### PR TITLE
feat: push OAuth2 sessions filtering and pagination to SQL with total count

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7116,26 +7116,59 @@ type OAuth2SessionRow struct {
 	LastUsedAt   *time.Time `json:"last_used_at,omitempty"`
 }
 
-// ListOAuth2Sessions returns active (non-revoked) refresh token rows, joined
-// with their client names from oauth2_clients and VK names from
-// governance_virtual_keys for vk-mode grants. Uses ScopedDB so callers can
-// inject row-visibility predicates via the context.
-func (s *RDBConfigStore) ListOAuth2Sessions(ctx context.Context) ([]OAuth2SessionRow, error) {
+// ListOAuth2Sessions returns a page of active (non-revoked) refresh token rows,
+// joined with their client names from oauth2_clients and VK names from
+// governance_virtual_keys for vk-mode grants. Filtering (search + mode) and
+// pagination (limit/offset) are pushed to SQL; the second return value is the
+// total count matching the filters before the page slice. Uses ScopedDB so
+// callers can inject row-visibility predicates via the context.
+func (s *RDBConfigStore) ListOAuth2Sessions(ctx context.Context, params OAuth2SessionsQueryParams) ([]OAuth2SessionRow, int64, error) {
+	// base carries the joins + filters shared by the count and the page query.
+	// Session() forks it so Count and Find don't pollute each other's statement.
+	base := s.ScopedDB(ctx).
+		Table("oauth2_refresh_tokens rt").
+		Joins("LEFT JOIN oauth2_clients c ON c.client_id = rt.client_id").
+		Joins("LEFT JOIN governance_virtual_keys vk ON vk.id = rt.bf_sub AND rt.bf_mode = 'vk'").
+		Where("rt.revoked_at IS NULL")
+
+	if search := strings.TrimSpace(params.Search); search != "" {
+		like := "%" + strings.ToLower(search) + "%"
+		// Match the columns the UI renders: client name/id, the bound identity
+		// (bf_sub), and the joined VK name shown as the display name for vk mode.
+		base = base.Where(
+			"LOWER(COALESCE(c.client_name, '')) LIKE ? OR LOWER(rt.client_id) LIKE ? OR LOWER(rt.bf_sub) LIKE ? OR LOWER(COALESCE(vk.name, '')) LIKE ?",
+			like, like, like, like,
+		)
+	}
+	if len(params.Modes) > 0 {
+		base = base.Where("rt.bf_mode IN ?", params.Modes)
+	}
+
+	var totalCount int64
+	if err := base.Session(&gorm.Session{}).Count(&totalCount).Error; err != nil {
+		return nil, 0, fmt.Errorf("count oauth2 sessions: %w", err)
+	}
+
 	rows := []struct {
 		tables.TableOAuth2RefreshToken
 		ClientName string `gorm:"column:client_name"`
 		VKName     string `gorm:"column:vk_name"`
 	}{}
-	err := s.ScopedDB(ctx).
-		Table("oauth2_refresh_tokens rt").
+	query := base.Session(&gorm.Session{}).
 		Select("rt.*, c.client_name, vk.name as vk_name").
-		Joins("LEFT JOIN oauth2_clients c ON c.client_id = rt.client_id").
-		Joins("LEFT JOIN governance_virtual_keys vk ON vk.id = rt.bf_sub AND rt.bf_mode = 'vk'").
-		Where("rt.revoked_at IS NULL").
+		// id is the unique tiebreaker: created_at alone is not unique, and offset
+		// paging over a non-unique sort lets same-timestamp rows shuffle between
+		// pages (duplicated or skipped). id pins a deterministic order.
 		Order("rt.created_at DESC").
-		Scan(&rows).Error
-	if err != nil {
-		return nil, fmt.Errorf("list oauth2 sessions: %w", err)
+		Order("rt.id DESC")
+	if params.Limit > 0 {
+		query = query.Limit(params.Limit)
+	}
+	if params.Offset > 0 {
+		query = query.Offset(params.Offset)
+	}
+	if err := query.Scan(&rows).Error; err != nil {
+		return nil, 0, fmt.Errorf("list oauth2 sessions: %w", err)
 	}
 	out := make([]OAuth2SessionRow, 0, len(rows))
 	for _, r := range rows {
@@ -7155,7 +7188,7 @@ func (s *RDBConfigStore) ListOAuth2Sessions(ctx context.Context) ([]OAuth2Sessio
 		}
 		out = append(out, row)
 	}
-	return out, nil
+	return out, totalCount, nil
 }
 
 // RevokeOAuth2Session revokes a specific refresh token by ID (for use from the

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -384,9 +384,10 @@ func TestListOAuth2Sessions_JoinsAndExcludesRevoked(t *testing.T) {
 	require.NoError(t, s.DB().Create(sessTok).Error)
 	require.NoError(t, s.DB().Create(deadTok).Error)
 
-	rows, err := s.ListOAuth2Sessions(ctx)
+	rows, total, err := s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{})
 	require.NoError(t, err)
 	require.Len(t, rows, 2, "revoked grants are excluded")
+	require.Equal(t, int64(2), total, "total count excludes revoked grants")
 
 	byID := map[string]OAuth2SessionRow{}
 	for _, r := range rows {
@@ -405,6 +406,121 @@ func TestListOAuth2Sessions_JoinsAndExcludesRevoked(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 	// Revoking an already-revoked grant reports not-found.
 	assert.ErrorIs(t, s.RevokeOAuth2Session(ctx, "rt-dead"), ErrNotFound)
+}
+
+// TestListOAuth2Sessions_FilterAndPaginate pins the DB-side filtering +
+// pagination: ordering (created_at DESC), limit/offset paging, the total count
+// (independent of the page slice), the bf_mode filter, and case-insensitive
+// search across the joined client name, the joined VK display name, and the
+// bound identity (bf_sub).
+func TestListOAuth2Sessions_FilterAndPaginate(t *testing.T) {
+	s := setupOAuth2TestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.DB().Create(&tables.TableOAuth2Client{
+		ID: "c1", ClientID: "client-1", ClientName: "Acme Server",
+		RedirectURIs: []string{"http://127.0.0.1/cb"}, GrantTypes: []string{"authorization_code"}, CreatedAt: time.Now(),
+	}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableOAuth2Client{
+		ID: "c2", ClientID: "client-2", ClientName: "Beta Server",
+		RedirectURIs: []string{"http://127.0.0.1/cb"}, GrantTypes: []string{"authorization_code"}, CreatedAt: time.Now(),
+	}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableVirtualKey{ID: "vk-1", Name: "Alpha VK", Value: "sk-bf-alpha"}).Error)
+
+	base := time.Now()
+	rtA := makeRefreshToken("rt-a", "fa", "client-1", "h-a") // vk mode, bf_sub vk-1 → display "Alpha VK"
+	rtA.CreatedAt = base.Add(-3 * time.Minute)
+	rtB := makeRefreshToken("rt-b", "fb", "client-1", "h-b")
+	rtB.BfMode, rtB.BfSub = "user", "user@acme.com"
+	rtB.CreatedAt = base.Add(-2 * time.Minute)
+	rtC := makeRefreshToken("rt-c", "fc", "client-2", "h-c")
+	rtC.BfMode, rtC.BfSub = "session", "sess-xyz"
+	rtC.CreatedAt = base.Add(-1 * time.Minute)
+	require.NoError(t, s.DB().Create(rtA).Error)
+	require.NoError(t, s.DB().Create(rtB).Error)
+	require.NoError(t, s.DB().Create(rtC).Error)
+
+	ids := func(rows []OAuth2SessionRow) []string {
+		out := make([]string, len(rows))
+		for i, r := range rows {
+			out[i] = r.ID
+		}
+		return out
+	}
+
+	// Page 1 (newest first), limit 2 — total reflects all matches, not the page.
+	rows, total, err := s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Limit: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Equal(t, []string{"rt-c", "rt-b"}, ids(rows), "ordered created_at DESC")
+
+	// Page 2.
+	rows, total, err = s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Equal(t, []string{"rt-a"}, ids(rows))
+
+	// bf_mode filter.
+	rows, total, err = s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Modes: []string{"user"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"rt-b"}, ids(rows))
+
+	// Search matches the joined VK display name.
+	rows, total, err = s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Search: "alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"rt-a"}, ids(rows))
+
+	// Search matches the joined client name.
+	rows, total, err = s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Search: "beta"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"rt-c"}, ids(rows))
+
+	// Search matches the bound identity (bf_sub).
+	rows, total, err = s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Search: "user@acme"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"rt-b"}, ids(rows))
+}
+
+// TestListOAuth2Sessions_StableTiebreakerSameTimestamp pins the secondary id sort:
+// when grants share an identical created_at, ordering by created_at alone is
+// nondeterministic, so offset paging could repeat or skip rows. The id tiebreaker
+// makes every page deterministic — here the two pages partition all four rows
+// (ordered id DESC) with no duplicates and no gaps.
+func TestListOAuth2Sessions_StableTiebreakerSameTimestamp(t *testing.T) {
+	s := setupOAuth2TestStore(t)
+	ctx := context.Background()
+
+	ids := func(rows []OAuth2SessionRow) []string {
+		out := make([]string, len(rows))
+		for i, r := range rows {
+			out[i] = r.ID
+		}
+		return out
+	}
+
+	// All four grants share the same created_at, so only the id tiebreaker can
+	// give a stable order.
+	ts := time.Now()
+	for _, id := range []string{"rt-1", "rt-2", "rt-3", "rt-4"} {
+		rt := makeRefreshToken(id, "fam-"+id, "client-x", "hash-"+id)
+		rt.CreatedAt = ts
+		require.NoError(t, s.DB().Create(rt).Error)
+	}
+
+	// Page 1 and Page 2 (limit 2 each) must partition all rows in id-DESC order.
+	page1, total, err := s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Limit: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), total)
+	assert.Equal(t, []string{"rt-4", "rt-3"}, ids(page1), "page 1 ordered by id DESC on tied timestamps")
+
+	page2, total, err := s.ListOAuth2Sessions(ctx, OAuth2SessionsQueryParams{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), total)
+	assert.Equal(t, []string{"rt-2", "rt-1"}, ids(page2), "page 2 continues without overlap or gap")
 }
 
 // TestSweepConvergence_TokenSweepThenClientSweep pins the documented ordering: a

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -144,6 +144,18 @@ type MCPSessionsFilterParams struct {
 	MatchedUserIDs []string
 }
 
+// OAuth2SessionsQueryParams holds the filters + pagination for the OAuth2
+// grants list (Connected Clients UI). Search is a case-insensitive substring
+// matched against the client name/id, the bound identity (bf_sub), and the
+// joined virtual key name. Modes filters on bf_mode (user/vk/session); an
+// empty slice matches all. Limit/Offset paginate the filtered result in SQL.
+type OAuth2SessionsQueryParams struct {
+	Search string
+	Modes  []string
+	Limit  int
+	Offset int
+}
+
 // PricingOverrideFilters holds the filters for pricing overrides.
 type PricingOverrideFilters struct {
 	ScopeKind     *string
@@ -704,8 +716,10 @@ type ConfigStore interface {
 	// token sweep so clients are not collected while their tokens are still
 	// retained for reuse detection.
 	SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error)
-	// ListOAuth2Sessions returns active downstream grants for the Connected Clients UI.
-	ListOAuth2Sessions(ctx context.Context) ([]OAuth2SessionRow, error)
+	// ListOAuth2Sessions returns a page of active downstream grants for the
+	// Connected Clients UI, plus the total count matching the filters (before
+	// the limit/offset are applied). Filtering and pagination are pushed to SQL.
+	ListOAuth2Sessions(ctx context.Context, params OAuth2SessionsQueryParams) ([]OAuth2SessionRow, int64, error)
 	// GetOAuth2SessionByID returns a single active grant row for permission checks.
 	GetOAuth2SessionByID(ctx context.Context, id string) (*tables.TableOAuth2RefreshToken, error)
 	// RevokeOAuth2Session revokes a specific downstream grant by refresh token ID.

--- a/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
@@ -65,11 +65,11 @@ func (m *mockOAuth2Store) GetOAuth2ClientByClientID(_ context.Context, clientID 
 	return nil, configstore.ErrNotFound
 }
 
-func (m *mockOAuth2Store) ListOAuth2Sessions(_ context.Context) ([]configstore.OAuth2SessionRow, error) {
+func (m *mockOAuth2Store) ListOAuth2Sessions(_ context.Context, _ configstore.OAuth2SessionsQueryParams) ([]configstore.OAuth2SessionRow, int64, error) {
 	if m.listErr != nil {
-		return nil, m.listErr
+		return nil, 0, m.listErr
 	}
-	return m.sessionRows, nil
+	return m.sessionRows, int64(len(m.sessionRows)), nil
 }
 
 func (m *mockOAuth2Store) GetOAuth2SessionByID(_ context.Context, id string) (*configtables.TableOAuth2RefreshToken, error) {

--- a/transports/bifrost-http/handlers/mcpoauth2sessions.go
+++ b/transports/bifrost-http/handlers/mcpoauth2sessions.go
@@ -2,9 +2,9 @@ package handlers
 
 import (
 	"errors"
-	"fmt"
+	"strconv"
+	"strings"
 
-	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
@@ -29,25 +29,115 @@ func (h *OAuth2SessionsHandler) RegisterRoutes(r *router.Router, middlewares ...
 	r.DELETE("/api/oauth2/sessions/{id}", lib.ChainMiddlewares(h.revokeSession, middlewares...))
 }
 
-// GET /api/oauth2/sessions — list active downstream grants.
+const (
+	oauth2SessionsDefaultLimit = 50
+	oauth2SessionsMaxLimit     = 500
+)
+
+// oauth2SessionsListResponse is the wire shape for GET /api/oauth2/sessions.
+// Mirrors the MCP auth-sessions list contract (sessions + count/total_count/
+// limit/offset) so the grants UI paginates the same way.
+type oauth2SessionsListResponse struct {
+	Sessions   []configstore.OAuth2SessionRow `json:"sessions"`
+	Count      int                            `json:"count"`
+	TotalCount int                            `json:"total_count"`
+	Limit      int                            `json:"limit"`
+	Offset     int                            `json:"offset"`
+}
+
+// oauth2SessionsListQuery is the parsed query string for GET /api/oauth2/sessions.
+// Modes filters on bf_mode (user/vk/session); Search is a case-insensitive
+// substring matched against the client name/id and the bound identity.
+// Limit/Offset paginate the filtered result.
+type oauth2SessionsListQuery struct {
+	Search string
+	Modes  []string
+	Limit  int
+	Offset int
+}
+
+// parseOAuth2SessionsListQuery extracts pagination + filter params from the
+// request query string. On validation failure it writes a 400 response and
+// returns ok=false — the caller must early-return without further writes.
+func parseOAuth2SessionsListQuery(ctx *fasthttp.RequestCtx) (oauth2SessionsListQuery, bool) {
+	q := oauth2SessionsListQuery{Limit: oauth2SessionsDefaultLimit}
+	args := ctx.QueryArgs()
+	q.Search = strings.TrimSpace(string(args.Peek("q")))
+	q.Modes = parseCommaSeparated(string(args.Peek("bf_mode")))
+	// bf_mode only ever holds user/vk/session. Reject anything else with a 400
+	// rather than letting an unknown mode silently match no rows (the SQL filter
+	// would just return an empty page, hiding the typo from the caller).
+	for _, mode := range q.Modes {
+		switch mode {
+		case "user", "vk", "session":
+		default:
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid bf_mode parameter: must be one or more of user, vk, session")
+			return q, false
+		}
+	}
+	if s := string(args.Peek("limit")); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be a number")
+			return q, false
+		}
+		if n <= 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be greater than zero")
+			return q, false
+		}
+		if n > oauth2SessionsMaxLimit {
+			n = oauth2SessionsMaxLimit
+		}
+		q.Limit = n
+	}
+	if s := string(args.Peek("offset")); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be a number")
+			return q, false
+		}
+		if n < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be non-negative")
+			return q, false
+		}
+		q.Offset = n
+	}
+	return q, true
+}
+
+// GET /api/oauth2/sessions — list active downstream grants, filtered + paginated.
+// Filtering (search + mode) and pagination (limit/offset) are pushed to SQL by
+// the store; the single-table source has no cross-table merge, so — unlike the
+// MCP auth-sessions handler — there is nothing to slice here. The store also
+// returns the total count matching the filters, used for the page indicator.
 func (h *OAuth2SessionsHandler) listSessions(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store unavailable")
 		return
 	}
-	sessions, err := h.store.ConfigStore.ListOAuth2Sessions(ctx)
+	q, ok := parseOAuth2SessionsListQuery(ctx)
+	if !ok {
+		return
+	}
+	sessions, totalCount, err := h.store.ConfigStore.ListOAuth2Sessions(ctx, configstore.OAuth2SessionsQueryParams{
+		Search: q.Search,
+		Modes:  q.Modes,
+		Limit:  q.Limit,
+		Offset: q.Offset,
+	})
 	if err != nil {
 		logger.Error("oauth2 sessions: failed to list sessions: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, "failed to list sessions")
 		return
 	}
-	data, err := sonic.Marshal(map[string]any{"sessions": sessions})
-	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to encode sessions response: %v", err))
-		return
-	}
-	ctx.SetContentType("application/json")
-	ctx.SetBody(data)
+
+	SendJSON(ctx, oauth2SessionsListResponse{
+		Sessions:   sessions,
+		Count:      len(sessions),
+		TotalCount: int(totalCount),
+		Limit:      q.Limit,
+		Offset:     q.Offset,
+	})
 }
 
 // DELETE /api/oauth2/sessions/{id} — revoke a specific downstream grant.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -473,8 +473,8 @@ func (m *MockConfigStore) SweepOAuth2RefreshTokens(ctx context.Context, revokedO
 func (m *MockConfigStore) SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error) {
 	return 0, nil
 }
-func (m *MockConfigStore) ListOAuth2Sessions(ctx context.Context) ([]configstore.OAuth2SessionRow, error) {
-	return nil, nil
+func (m *MockConfigStore) ListOAuth2Sessions(ctx context.Context, params configstore.OAuth2SessionsQueryParams) ([]configstore.OAuth2SessionRow, int64, error) {
+	return nil, 0, nil
 }
 func (m *MockConfigStore) GetOAuth2SessionByID(ctx context.Context, id string) (*tables.TableOAuth2RefreshToken, error) {
 	return nil, configstore.ErrNotFound

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -1,6 +1,8 @@
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetOAuth2GrantsQuery, useRevokeOAuth2GrantMutation } from "@/lib/store";
 import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
 import { Loader2 } from "lucide-react";
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import GrantsFilterBar from "./views/grantsFilterBar";
@@ -10,47 +12,47 @@ import RevokeGrantDialog from "./views/revokeGrantDialog";
 const PAGE_SIZE = 50;
 
 export default function OAuthGrantsPage() {
-	const { data, isLoading, isFetching, isError, error } = useGetOAuth2GrantsQuery();
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			q: parseAsString.withDefault(""),
+			bf_mode: parseAsArrayOf(parseAsString).withDefault([]),
+			offset: parseAsInteger.withDefault(0),
+		},
+		{ history: "push" },
+	);
+
+	const debouncedSearch = useDebouncedValue(urlState.q, 300);
+
+	const { data, isLoading, isFetching, isError, error } = useGetOAuth2GrantsQuery({
+		q: debouncedSearch || undefined,
+		bf_mode: urlState.bf_mode.length ? urlState.bf_mode : undefined,
+		limit: PAGE_SIZE,
+		offset: urlState.offset,
+	});
 	const [revokeGrant, { isLoading: revoking }] = useRevokeOAuth2GrantMutation();
 
-	const [search, setSearch] = useState("");
-	const [modeFilter, setModeFilter] = useState<string[]>([]);
-	const [offset, setOffset] = useState(0);
 	const [pendingDelete, setPendingDelete] = useState<OAuth2GrantRow | null>(null);
 	const [pendingActionRowId, setPendingActionRowId] = useState<string | null>(null);
 
-	const allGrants = data?.sessions ?? [];
-	const filtered = allGrants.filter((g) => {
-		const matchesMode = modeFilter.length === 0 || modeFilter.includes(g.bf_mode);
-		const q = search.toLowerCase();
-		const matchesSearch =
-			!q ||
-			g.client_name?.toLowerCase().includes(q) ||
-			g.client_id.toLowerCase().includes(q) ||
-			(g.bf_sub_display ?? g.bf_sub).toLowerCase().includes(q);
-		return matchesMode && matchesSearch;
-	});
-	const totalCount = filtered.length;
-	const page = filtered.slice(offset, offset + PAGE_SIZE);
-	const hasActiveFilters = !!search || modeFilter.length > 0;
+	const page = data?.sessions ?? [];
+	const totalCount = data?.total_count ?? 0;
+	const hasActiveFilters = !!urlState.q || urlState.bf_mode.length > 0;
 
-	// Snap the offset back into range when the filtered count shrinks (e.g. a
-	// revoke removes the last row on the last page). Without this the page goes
-	// blank with the paginator and clear-filters affordances both hidden.
+	// Snap the offset back into range when the total shrinks past the current
+	// page (e.g. a revoke removes the last row on the last page). Without this
+	// the page goes blank with the paginator and clear-filters affordances both
+	// hidden. Mirrors the MCP sessions page.
 	useEffect(() => {
-		if (totalCount === 0) {
-			if (offset !== 0) setOffset(0);
-			return;
-		}
-		const maxOffset = Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE;
-		if (offset > maxOffset) setOffset(maxOffset);
-	}, [offset, totalCount]);
+		if (!data || urlState.offset < totalCount) return;
+		setUrlState({
+			offset: totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE,
+		});
+	}, [totalCount, urlState.offset, data, setUrlState]);
 
-	const clearFilters = () => {
-		setSearch("");
-		setModeFilter([]);
-		setOffset(0);
-	};
+	const handleSearchChange = (value: string) => setUrlState({ q: value || null, offset: 0 });
+	const handleModeChange = (value: string[]) => setUrlState({ bf_mode: value.length ? value : null, offset: 0 });
+	const handleOffsetChange = (offset: number) => setUrlState({ offset });
+	const clearFilters = () => setUrlState({ q: null, bf_mode: null, offset: 0 });
 
 	const confirmRevoke = async () => {
 		if (!pendingDelete) return;
@@ -68,14 +70,14 @@ export default function OAuthGrantsPage() {
 	};
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4">
+		<div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">
 			<RevokeGrantDialog
 				open={pendingDelete !== null}
 				onOpenChange={(open) => !open && setPendingDelete(null)}
 				onConfirm={confirmRevoke}
 			/>
 
-			<div className="flex items-center justify-between gap-4">
+			<div className="mb-4 flex items-center justify-between gap-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">OAuth Grants</h2>
 					<p className="text-muted-foreground text-sm">
@@ -85,17 +87,19 @@ export default function OAuthGrantsPage() {
 				</div>
 			</div>
 
-			<GrantsFilterBar
-				search={search}
-				onSearchChange={(value) => { setSearch(value); setOffset(0); }}
-				modeFilter={modeFilter}
-				onModeChange={(value) => { setModeFilter(value); setOffset(0); }}
-				hasActiveFilters={hasActiveFilters}
-				onClearFilters={clearFilters}
-			/>
+			<div className="mb-4">
+				<GrantsFilterBar
+					search={urlState.q}
+					onSearchChange={handleSearchChange}
+					modeFilter={urlState.bf_mode}
+					onModeChange={handleModeChange}
+					hasActiveFilters={hasActiveFilters}
+					onClearFilters={clearFilters}
+				/>
+			</div>
 
 			{isLoading ? (
-				<div className="flex items-center justify-center py-16">
+				<div className="flex grow items-center justify-center">
 					<Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
 				</div>
 			) : isError ? (
@@ -106,9 +110,9 @@ export default function OAuthGrantsPage() {
 				<GrantsTable
 					rows={page}
 					totalCount={totalCount}
-					offset={offset}
+					offset={urlState.offset}
 					pageSize={PAGE_SIZE}
-					onOffsetChange={setOffset}
+					onOffsetChange={handleOffsetChange}
 					isFetching={isFetching}
 					hasActiveFilters={hasActiveFilters}
 					revoking={revoking}

--- a/ui/app/workspace/oauth-grants/views/grantsTable.tsx
+++ b/ui/app/workspace/oauth-grants/views/grantsTable.tsx
@@ -21,7 +21,6 @@ import {
 	Fingerprint,
 	Info,
 	KeyRound,
-	ShieldCheck,
 	UserRound,
 } from "lucide-react";
 import GrantActions from "./grantActions";
@@ -52,10 +51,10 @@ export default function GrantsTable({
 	onRevoke,
 }: GrantsTableProps) {
 	return (
-		<>
-			<div className={`overflow-auto rounded-sm border ${isFetching ? "opacity-70 transition-opacity" : ""}`}>
-				<Table>
-					<TableHeader>
+		<div className="flex grow flex-col overflow-hidden">
+			<div className={`mb-2 grow overflow-hidden rounded-sm border ${isFetching ? "opacity-70 transition-opacity" : ""}`}>
+				<Table containerClassName="h-full overflow-auto">
+					<TableHeader className="bg-muted sticky top-0 z-20">
 						<TableRow>
 							<TableHead>Client</TableHead>
 							<TableHead>
@@ -128,26 +127,44 @@ export default function GrantsTable({
 				</Table>
 			</div>
 
-			{totalCount > pageSize && (
-				<div className="flex items-center justify-between gap-4">
-					<p className="text-muted-foreground text-sm">
-						Showing {offset + 1}&#8211;{Math.min(offset + pageSize, totalCount)} of {totalCount}
-					</p>
+			{totalCount > 0 && (
+				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+					<div className="text-muted-foreground flex items-center gap-2">
+						{(offset + 1).toLocaleString()}-{Math.min(offset + pageSize, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+					</div>
+
 					<div className="flex items-center gap-2">
-						<Button data-testid="oauth-grants-prev-page-btn" variant="outline" size="sm" disabled={offset === 0}
-							onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}>
-							<ChevronLeft className="h-4 w-4" />
-							Previous
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
+							disabled={offset === 0}
+							data-testid="oauth-grants-prev-page-btn"
+							aria-label="Previous page"
+						>
+							<ChevronLeft className="size-3" />
 						</Button>
-						<Button data-testid="oauth-grants-next-page-btn" variant="outline" size="sm" disabled={offset + pageSize >= totalCount}
-							onClick={() => onOffsetChange(offset + pageSize)}>
-							Next
-							<ChevronRight className="h-4 w-4" />
+
+						<div className="flex items-center gap-1">
+							<span>Page</span>
+							<span>{Math.floor(offset / pageSize) + 1}</span>
+							<span>of {Math.ceil(totalCount / pageSize)}</span>
+						</div>
+
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onOffsetChange(offset + pageSize)}
+							disabled={offset + pageSize >= totalCount}
+							data-testid="oauth-grants-next-page-btn"
+							aria-label="Next page"
+						>
+							<ChevronRight className="size-3" />
 						</Button>
 					</div>
 				</div>
 			)}
-		</>
+		</div>
 	);
 }
 

--- a/ui/lib/store/apis/oauth2SessionsApi.ts
+++ b/ui/lib/store/apis/oauth2SessionsApi.ts
@@ -14,12 +14,42 @@ export interface OAuth2GrantRow {
 
 export interface OAuth2GrantsListResponse {
 	sessions: OAuth2GrantRow[];
+	count?: number; // rows on this page
+	total_count?: number; // total across all pages, after filters
+	limit?: number;
+	offset?: number;
+}
+
+export interface OAuth2GrantsQueryParams {
+	q?: string;
+	bf_mode?: string[];
+	limit?: number;
+	offset?: number;
+}
+
+// buildOAuth2GrantsListParams shapes the filter+page params for the URL.
+// bf_mode is csv-joined (matches the backend's parseCommaSeparated) and sorted
+// so selection order doesn't fragment the RTK Query cache key. Empty values
+// are dropped so the key doesn't fragment on "" vs unset.
+function buildOAuth2GrantsListParams(params?: OAuth2GrantsQueryParams) {
+	if (!params) return {};
+	const out: Record<string, string | number> = {};
+	if (params.q) out.q = params.q;
+	if (params.bf_mode?.length) out.bf_mode = [...params.bf_mode].sort().join(",");
+	if (params.limit !== undefined) out.limit = params.limit;
+	if (params.offset !== undefined) out.offset = params.offset;
+	return out;
 }
 
 export const oauth2SessionsApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
-		getOAuth2Grants: builder.query<OAuth2GrantsListResponse, void>({
-			query: () => ({ url: "/oauth2/sessions" }),
+		// Each filter+page combo gets its own cache entry (RTK Query auto-derives
+		// the key from the params object).
+		getOAuth2Grants: builder.query<OAuth2GrantsListResponse, OAuth2GrantsQueryParams | void>({
+			query: (params) => ({
+				url: "/oauth2/sessions",
+				params: buildOAuth2GrantsListParams(params ?? undefined),
+			}),
 			providesTags: ["OAuth2Grants"],
 		}),
 		revokeOAuth2Grant: builder.mutation<void, string>({


### PR DESCRIPTION
## Summary

The OAuth Grants (Connected Clients) UI previously loaded all active sessions in a single query and performed filtering and pagination entirely in the browser. This PR moves filtering (case-insensitive search across client name, client ID, bound identity, and virtual key display name; `bf_mode` filter) and pagination (limit/offset) into SQL, and adds a total-count return value so the UI can render accurate page indicators without holding the full dataset in memory.

## Changes

- `ListOAuth2Sessions` now accepts an `OAuth2SessionsQueryParams` struct (search, modes, limit, offset) and returns a second `int64` total-count value alongside the page slice. Filtering and pagination are applied in SQL using a shared base query; a `gorm.Session` fork ensures the count and the page query don't pollute each other's statement.
- `GET /api/oauth2/sessions` parses `q`, `bf_mode`, `limit`, and `offset` query parameters, validates them, and forwards them to the store. The response envelope now includes `count`, `total_count`, `limit`, and `offset` fields, matching the shape used by the MCP auth-sessions endpoint.
- The UI switches from local `useState` for search/mode/offset to `nuqs` URL query state, so filter and page selections survive navigation and can be bookmarked. Search is debounced (300 ms) before triggering a fetch. RTK Query receives the filter+page params directly, giving each combination its own cache entry.
- The grants table gains a sticky header and a scrollable body so the page layout no longer grows unboundedly. The pagination bar is always visible when there are results (not only when results exceed one page), and shows an entry range and page-of-total indicator.
- A new `TestListOAuth2Sessions_FilterAndPaginate` test pins ordering (created_at DESC), limit/offset paging, total-count independence from the page slice, `bf_mode` filtering, and case-insensitive search against the joined client name, joined VK display name, and bound identity.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... -run TestListOAuth2Sessions
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

Navigate to the OAuth Grants page, enter a search term, toggle a mode filter, and verify the URL updates and results narrow correctly. Advance to a second page and confirm the total count and page indicator remain accurate. Revoke the last grant on a non-first page and confirm the offset snaps back rather than leaving a blank page.

## Screenshots/Recordings

_Add before/after screenshots of the grants table and pagination bar._

## Breaking changes

- [x] Yes
- [ ] No

`ListOAuth2Sessions` signature changed: callers must pass an `OAuth2SessionsQueryParams` argument and accept a second `int64` return value. Any mock or alternative implementation of `ConfigStore` must be updated accordingly (the in-tree mocks in `mcpoauth2jwt_test.go` and `lib/config_test.go` have been updated).

## Related issues

## Security considerations

Search terms are passed to SQL as `LIKE` parameters via GORM's parameterised query API; no raw interpolation is performed. The `ScopedDB` wrapper is preserved, so row-visibility predicates injected via context continue to apply to both the count and the page query.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable