### PR TITLE
feat: add `is_deprecated` field to model pricing and catalog API responses

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -151,12 +151,13 @@ type Model struct {
 	CanonicalSlug       *string            `json:"canonical_slug,omitempty"`
 	Name                *string            `json:"name,omitempty"`
 	NormalizedName      *string            `json:"normalized_name,omitempty"` // Human-readable name derived from the datasheet base_model (e.g. "Claude Sonnet 4.5")
-	Alias               *string            `json:"alias,omitempty"` // Provider API identifier this model alias maps to (e.g. Azure deployment name, Bedrock ARN)
+	Alias               *string            `json:"alias,omitempty"`           // Provider API identifier this model alias maps to (e.g. Azure deployment name, Bedrock ARN)
 	Created             *int64             `json:"created,omitempty"`
 	ContextLength       *int               `json:"context_length,omitempty"`
 	MaxInputTokens      *int               `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens     *int               `json:"max_output_tokens,omitempty"`
 	Architecture        *Architecture      `json:"architecture,omitempty"`
+	IsDeprecated        bool               `json:"is_deprecated,omitempty"`
 	Pricing             *Pricing           `json:"pricing,omitempty"`
 	TopProvider         *TopProvider       `json:"top_provider,omitempty"`
 	PerRequestLimits    *PerRequestLimits  `json:"per_request_limits,omitempty"`

--- a/docs/deployment-guides/how-to/security-best-practices.mdx
+++ b/docs/deployment-guides/how-to/security-best-practices.mdx
@@ -1,0 +1,221 @@
+---
+title: "Security best practices"
+description: "Best practices for hosting Bifrost on the public internet: strong dashboard credentials, enforced inference auth, locked-down CORS, and reverse-proxy security headers."
+icon: "shield-halved"
+---
+
+<Warning>
+**Read this before you expose Bifrost to the internet.** Bifrost includes secure defaults, but a public deployment is only as safe as the controls you actually turn on. By default the dashboard and inference endpoints are reachable by anyone who can route to the host. The items below are the minimum hardening for any gateway that is reachable from outside your private network.
+</Warning>
+
+Most of these controls live on the **Security Settings** page in the dashboard at `/workspace/config/security`, or in your `config.json` (inference and CORS controls under the `client` block; dashboard credentials under `governance.auth_config`). The rest live in the reverse proxy in front of Bifrost.
+
+---
+
+## 1. Use a strong dashboard password
+
+The dashboard can be protected with **Password protect the dashboard** on the Security Settings page (an admin username + password). Anyone who reaches the dashboard URL without credentials can read configuration, virtual keys, and logs, so this is the first thing to turn on for a public host.
+
+<Note>
+**Password policy is enforced starting OSS v1.6.0 and Enterprise v1.5.0.** On these versions Bifrost validates the password both in the UI and on the server before saving, and rejects weak values with HTTP 400. On **earlier versions there was no strength check at all**. If you are running an older build, choose a strong password manually (and upgrade as soon as you can).
+</Note>
+
+The enforced policy requires every dashboard password to have:
+
+- At least **12 characters**
+- At least one **uppercase** letter
+- At least one **lowercase** letter
+- At least one **number**
+- At least one **special character**
+
+```json
+{
+    "auth_config": {
+      "is_enabled": true,
+      "admin_username": "admin",
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD"
+    }
+}
+```
+
+<Tip>
+Reference the password from an environment variable or secret (`env.VAR_NAME`) instead of hardcoding a literal value in `config.json`. Env/secret references are stored as-is; literal passwords are hashed before storage.
+</Tip>
+
+For Enterprise deployments, prefer **SSO / OIDC** over a shared dashboard password so every operator who can change configuration is a known, traceable identity. See the [security hardening guide](/enterprise/moving-from-oss/security-hardening) and the SSO setup guides ([Okta](/enterprise/setting-up-okta), [Entra](/enterprise/setting-up-entra), [Keycloak](/enterprise/setting-up-keycloak), [Zitadel](/enterprise/setting-up-zitadel), [Google Workspace](/enterprise/setting-up-google-workspace)).
+
+---
+
+## 2. Enforce authentication on inference
+
+By default, inference endpoints (`/v1/chat/completions`, `/v1/embeddings`, `/v1/images/generations`, and related endpoints) accept anonymous requests. On a public host that means anyone who finds the URL can spend against your provider keys.
+
+Turn on the **Enable Auth on Inference** toggle on the Security Settings page (labeled **Enforce Virtual Keys on Inference** in OSS). This requires every inference call to present a valid credential, such as a [Virtual Key](/features/governance/virtual-keys), API key, or user token, which Bifrost resolves to scoped upstream provider keys. Your raw provider keys never leave the gateway.
+
+```json
+{
+  "client": {
+    "enforce_auth_on_inference": true
+  }
+}
+```
+
+<Note>
+This is the main setting. The older fields `enforce_governance_header` and `enforce_scim_auth` are deprecated. Don't use them in new deployments. Changing this setting requires a Bifrost restart in Enterprise.
+</Note>
+
+Once enforced, pair it with [budgets and rate limits](/features/governance/budget-and-limits) per virtual key so a runaway client can't burn through your provider spend even with valid credentials.
+
+---
+
+## 3. Review the rest of the Security Settings page
+
+The Security Settings page (`/workspace/config/security`) exposes several more controls worth checking before going public:
+
+| Setting | Config key | Recommendation for public hosts |
+|---|---|---|
+| **Allow Direct API Keys** | `allow_direct_keys` | Keep **off** (default). When on, callers can pass their own provider key in a header (`x-bf-direct-key: true`), bypassing your registered key pool. |
+| **Allowed Origins** | `allowed_origins` | Set an explicit list. Never `*` in production. A wildcard lets JavaScript from any page on the internet call your gateway. |
+| **Allowed Headers** | `allowed_headers` | Narrow to the minimum your callers need (e.g. `Authorization`, `Content-Type`, your virtual-key and tracing headers). |
+| **Required Headers** | `required_headers` | Optionally require headers on every request; missing ones are rejected with 400. |
+| **Whitelisted Routes** | `whitelisted_routes` | Only add routes that must bypass auth. System routes (`/health`, login, etc.) are always whitelisted. |
+
+```json
+{
+  "client": {
+    "allow_direct_keys": false,
+    "allowed_origins": [
+      "https://app.example.com",
+      "https://internal-dashboard.example.com"
+    ],
+    "allowed_headers": ["Authorization", "Content-Type", "X-Request-Id"]
+  }
+}
+```
+
+<Tip>
+Changing `allowed_origins` or `allowed_headers` requires a Bifrost restart to take effect.
+</Tip>
+
+Enterprise deployments should also tighten the provider-forwarded `x-bf-eh-*` header allowlist (`header_filter_config`). See [Tighten both header allowlists](/enterprise/moving-from-oss/security-hardening) for details.
+
+---
+
+## 4. Terminate TLS and serve from a reverse proxy
+
+Never expose Bifrost's HTTP port directly to the internet. Put a reverse proxy (NGINX, an Ingress controller, or a cloud load balancer) in front of it to terminate TLS, so all traffic, including dashboard logins, virtual keys, and prompts, is encrypted in transit.
+
+See the [Nginx reverse proxy guide](/deployment-guides/how-to/nginx-reverse-proxy) for streaming-safe proxy settings, and bind Bifrost itself to an internal interface so it is only reachable through the proxy.
+
+---
+
+## 5. Send security headers from the reverse proxy
+
+Add hardening response headers at the proxy layer to defend the dashboard against clickjacking, MIME sniffing, and protocol downgrade. Bifrost is served behind the proxy, so this is the right place to set them once for every response.
+
+<Tabs>
+  <Tab title="NGINX">
+    ```nginx
+    server {
+        listen 443 ssl;
+        server_name bifrost.example.com;
+
+        # Force HTTPS for one year, including subdomains
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # Clickjacking / iframe embedding protection
+        add_header X-Frame-Options "DENY" always;
+        add_header Content-Security-Policy "frame-ancestors 'none'" always;
+
+        # Block MIME-type sniffing
+        add_header X-Content-Type-Options "nosniff" always;
+
+        # Limit referrer leakage
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        location / {
+            proxy_pass http://bifrost_backend;
+            # ... streaming-safe proxy settings (see nginx guide)
+        }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Kubernetes (NGINX Ingress)">
+    ```yaml
+    ingress:
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
+          more_set_headers "X-Frame-Options: DENY";
+          more_set_headers "Content-Security-Policy: frame-ancestors 'none'";
+          more_set_headers "X-Content-Type-Options: nosniff";
+          more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+    ```
+  </Tab>
+</Tabs>
+
+| Header | Protects against |
+|---|---|
+| `Strict-Transport-Security` | Protocol downgrade / SSL-stripping attacks |
+| `X-Frame-Options` / `Content-Security-Policy: frame-ancestors` | Clickjacking and embedding the dashboard in a hostile iframe |
+| `X-Content-Type-Options: nosniff` | MIME-type sniffing |
+| `Referrer-Policy` | Leaking dashboard URLs to third-party sites |
+
+<Note>
+Use the `always` flag (NGINX) so headers are sent even on error responses. Only enable HSTS once you are confident HTTPS will stay on. Browsers cache it for the full `max-age`.
+</Note>
+
+---
+
+## 6. Restrict network exposure
+
+Network-level controls limit the impact of a misconfiguration:
+
+- **Don't publish the raw container port.** Expose only the reverse proxy; keep Bifrost on an internal network or `localhost` upstream.
+- **Firewall / security groups.** Allow inbound traffic only on `443` (and `80` for the ACME/HTTP-to-HTTPS redirect). Block everything else.
+- **Restrict the admin surface.** If only your team needs the dashboard, put it behind a VPN, an IP allowlist, or an identity-aware proxy rather than the open internet.
+- **Run as non-root.** The official `maximhq/bifrost` image already runs as an unprivileged user. Keep it that way and avoid mounting host paths writable.
+
+---
+
+## Hardening checklist
+
+<Steps>
+<Step title="Strong dashboard password (or SSO)">
+  12+ chars with mixed case, number, and symbol. Upgrade to OSS v1.6.0 / Enterprise v1.5.0+ so the policy is enforced.
+</Step>
+<Step title="Auth enforced on inference">
+  `enforce_auth_on_inference: true`: no anonymous path to a model.
+</Step>
+<Step title="Direct API keys disabled">
+  `allow_direct_keys: false` unless you have a specific reason.
+</Step>
+<Step title="CORS locked to your origins">
+  Explicit `allowed_origins`, never `*` in production.
+</Step>
+<Step title="TLS terminated at a reverse proxy">
+  No raw HTTP port exposed to the internet.
+</Step>
+<Step title="Security headers set at the proxy">
+  HSTS, frame-ancestors / X-Frame-Options, nosniff, Referrer-Policy.
+</Step>
+<Step title="Budgets and rate limits configured">
+  Per-virtual-key limits before the first real request.
+</Step>
+<Step title="Network exposure minimized">
+  Firewall to 443, admin surface behind VPN/allowlist where possible.
+</Step>
+</Steps>
+
+---
+
+## Related guides
+
+- [Nginx reverse proxy](/deployment-guides/how-to/nginx-reverse-proxy)
+- [Enterprise security hardening](/enterprise/moving-from-oss/security-hardening)
+- [Virtual keys](/features/governance/virtual-keys)
+- [Budgets and limits](/features/governance/budget-and-limits)
+- [Security at Bifrost](/security): how Bifrost itself is built and scanned

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -622,6 +622,7 @@
               "deployment-guides/how-to/install-make",
               "deployment-guides/how-to/multinode",
               "deployment-guides/how-to/nginx-reverse-proxy",
+              "deployment-guides/how-to/security-best-practices",
               "deployment-guides/how-to/airgapped",
               "deployment-guides/docker-tuning"
             ]

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -37001,6 +37001,10 @@
                           "provider": {
                             "type": "string"
                           },
+                          "is_deprecated": {
+                            "type": "boolean",
+                            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
+                          },
                           "accessible_by_keys": {
                             "type": "array",
                             "items": {
@@ -37148,6 +37152,10 @@
                                 }
                               }
                             }
+                          },
+                          "is_deprecated": {
+                            "type": "boolean",
+                            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
                           },
                           "accessible_by_keys": {
                             "type": "array",
@@ -61457,6 +61465,10 @@
                 }
               }
             }
+          },
+          "is_deprecated": {
+            "type": "boolean",
+            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
           },
           "pricing": {
             "type": "object",

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -433,6 +433,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_oauth2_issuance_tables"}, run: migrationAddOAuth2IssuanceTables},
 	{IDs: []string{"add_dump_errors_in_console_logs_column"}, run: migrationAddDumpErrorsInConsoleLogsColumn},
 	{IDs: []string{"add_bedrock_mantle_key_columns"}, run: migrationAddBedrockMantleKeyColumns},
+	{IDs: []string{"add_model_pricing_is_deprecated_column"}, run: migrationAddModelPricingIsDeprecatedColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -9626,6 +9627,36 @@ func migrationAddAdditionalAttributesToPricing(ctx context.Context, db *gorm.DB,
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_additional_attributes_to_pricing migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelPricingIsDeprecatedColumn adds is_deprecated to
+// governance_model_pricing so synced datasheets can mark models that should
+// remain listable but are no longer recommended for new use.
+func migrationAddModelPricingIsDeprecatedColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_model_pricing_is_deprecated_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableModelPricing{}, "IsDeprecated"); err != nil {
+				return fmt.Errorf("failed to add is_deprecated column: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, "IsDeprecated"); err != nil {
+				return fmt.Errorf("failed to drop is_deprecated column: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_model_pricing_is_deprecated_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1167,6 +1167,7 @@ func TestTriggerMigrations_FreshDB(t *testing.T) {
 	for _, table := range criticalTables {
 		assert.True(t, migrator.HasTable(table), "table should exist: %T", table)
 	}
+	assert.True(t, migrator.HasColumn(&tables.TableModelPricing{}, "is_deprecated"), "model pricing is_deprecated column should exist")
 }
 
 func TestTriggerMigrations_Idempotent(t *testing.T) {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2383,6 +2383,7 @@ var pricingSyncUpdateColumns = []string{
 	"max_input_tokens",
 	"max_output_tokens",
 	"architecture",
+	"is_deprecated",
 	// Costs - Text
 	"input_cost_per_token",
 	"output_cost_per_token",

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2750,6 +2750,51 @@ func (s *RDBConfigStore) UpsertModelParameters(ctx context.Context, params *tabl
 	return nil
 }
 
+const modelParametersUpsertBatchSize = 100
+
+// UpsertModelParametersBatch inserts or updates model parameters in batches.
+// The sync path uses this to avoid one DB round-trip per model parameter row.
+func (s *RDBConfigStore) UpsertModelParametersBatch(ctx context.Context, params []tables.TableModelParameters, tx ...*gorm.DB) error {
+	if len(params) == 0 {
+		return nil
+	}
+	deduped := make([]tables.TableModelParameters, 0, len(params))
+	seen := make(map[string]int, len(params))
+	for _, param := range params {
+		if idx, ok := seen[param.Model]; ok {
+			deduped[idx] = param
+			continue
+		}
+		seen[param.Model] = len(deduped)
+		deduped = append(deduped, param)
+	}
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	db := txDB.WithContext(ctx)
+
+	onConflict := clause.OnConflict{
+		Columns:   []clause.Column{{Name: "model"}},
+		UpdateAll: true,
+	}
+	upsert := func(tx *gorm.DB) error {
+		// Unlike TableModelPricing, TableModelParameters has no nullable default
+		// columns, so GORM's multi-row INSERT does not emit DEFAULT values that
+		// SQLite rejects.
+		if err := tx.Clauses(onConflict).CreateInBatches(deduped, modelParametersUpsertBatchSize).Error; err != nil {
+			return s.parseGormError(err)
+		}
+		return nil
+	}
+	if len(tx) > 0 {
+		return upsert(db)
+	}
+	return db.Transaction(upsert)
+}
+
 // PLUGINS METHODS
 
 func (s *RDBConfigStore) GetPlugins(ctx context.Context) ([]*tables.TablePlugin, error) {

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2246,3 +2246,40 @@ func TestUpsertModelPricesBatch_SQLite(t *testing.T) {
 	require.NotNil(t, updated.InputCostPerToken)
 	assert.InDelta(t, 0.000005, *updated.InputCostPerToken, 1e-9)
 }
+
+func TestUpsertModelParametersBatch_SQLite(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableModelParameters{}))
+
+	ctx := context.Background()
+	params := []tables.TableModelParameters{
+		{Model: "model-a", Data: `{"max_output_tokens":100}`},
+		{Model: "model-b", Data: `{"max_output_tokens":200}`},
+		{Model: "model-c", Data: `{"max_output_tokens":300}`},
+	}
+
+	require.NoError(t, s.UpsertModelParametersBatch(ctx, params))
+
+	got, err := s.GetModelParameters(ctx)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+
+	params[1].Data = `{"max_output_tokens":250}`
+	require.NoError(t, s.UpsertModelParametersBatch(ctx, params))
+
+	updated, err := s.GetModelParametersByModel(ctx, "model-b")
+	require.NoError(t, err)
+	assert.Equal(t, `{"max_output_tokens":250}`, updated.Data)
+
+	require.NoError(t, s.UpsertModelParametersBatch(ctx, []tables.TableModelParameters{
+		{Model: "model-b", Data: `{"max_output_tokens":260}`},
+		{Model: "model-b", Data: `{"max_output_tokens":270}`},
+	}))
+	updated, err = s.GetModelParametersByModel(ctx, "model-b")
+	require.NoError(t, err)
+	assert.Equal(t, `{"max_output_tokens":270}`, updated.Data)
+
+	got, err = s.GetModelParameters(ctx)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+}

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -88,6 +88,36 @@ func testComplexityAnalyzerConfig() *ComplexityAnalyzerConfig {
 	}
 }
 
+func TestRDBConfigStore_UpsertModelPricesSyncsIsDeprecated(t *testing.T) {
+	store := setupRDBTestStore(t)
+	require.NoError(t, store.DB().AutoMigrate(&tables.TableModelPricing{}))
+	ctx := context.Background()
+
+	require.NoError(t, store.UpsertModelPrices(ctx, &tables.TableModelPricing{
+		Model:        "deprecated-model",
+		Provider:     "openai",
+		Mode:         "chat",
+		IsDeprecated: true,
+	}))
+
+	prices, err := store.GetModelPrices(ctx)
+	require.NoError(t, err)
+	require.Len(t, prices, 1)
+	assert.True(t, prices[0].IsDeprecated)
+
+	require.NoError(t, store.UpsertModelPrices(ctx, &tables.TableModelPricing{
+		Model:        "deprecated-model",
+		Provider:     "openai",
+		Mode:         "chat",
+		IsDeprecated: false,
+	}))
+
+	prices, err = store.GetModelPrices(ctx)
+	require.NoError(t, err)
+	require.Len(t, prices, 1)
+	assert.False(t, prices[0].IsDeprecated)
+}
+
 func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -408,6 +408,7 @@ type ConfigStore interface {
 	GetModelParameters(ctx context.Context) ([]tables.TableModelParameters, error)
 	GetModelParametersByModel(ctx context.Context, model string) (*tables.TableModelParameters, error)
 	UpsertModelParameters(ctx context.Context, params *tables.TableModelParameters, tx ...*gorm.DB) error
+	UpsertModelParametersBatch(ctx context.Context, params []tables.TableModelParameters, tx ...*gorm.DB) error
 
 	// Key management
 	GetKeysByIDs(ctx context.Context, ids []string) ([]tables.TableKey, error)

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -18,6 +18,7 @@ type TableModelPricing struct {
 	MaxInputTokens  *int                  `gorm:"default:null" json:"max_input_tokens,omitempty"`
 	MaxOutputTokens *int                  `gorm:"default:null" json:"max_output_tokens,omitempty"`
 	Architecture    *schemas.Architecture `gorm:"type:text;serializer:json;default:null" json:"architecture,omitempty"`
+	IsDeprecated    bool                  `gorm:"default:false;column:is_deprecated" json:"is_deprecated"`
 
 	// Costs - Text
 	InputCostPerToken          *float64 `gorm:"default:null" json:"input_cost_per_token,omitempty"`

--- a/framework/modelcatalog/datasheet/capabilities_test.go
+++ b/framework/modelcatalog/datasheet/capabilities_test.go
@@ -189,9 +189,10 @@ func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
 	inputCost := float64(1)
 	outputCost := float64(2)
 	entry := Entry{
-		BaseModel: "gpt-4o",
-		Provider:  "openai",
-		Mode:      "chat",
+		BaseModel:    "gpt-4o",
+		Provider:     "openai",
+		Mode:         "chat",
+		IsDeprecated: true,
 		Options: Options{
 			InputCostPerToken:  &inputCost,
 			OutputCostPerToken: &outputCost,
@@ -218,6 +219,9 @@ func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
 	}
 	if roundTrip.Architecture == nil || roundTrip.Architecture.Modality == nil || *roundTrip.Architecture.Modality != modality {
 		t.Fatalf("expected architecture to round-trip, got %#v", roundTrip.Architecture)
+	}
+	if !roundTrip.IsDeprecated {
+		t.Fatalf("expected is_deprecated to round-trip")
 	}
 }
 

--- a/framework/modelcatalog/datasheet/params.go
+++ b/framework/modelcatalog/datasheet/params.go
@@ -15,7 +15,6 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/tidwall/gjson"
-	"gorm.io/gorm"
 )
 
 // LoadModelParamsFromDB bulk-loads model parameters from the DB into the
@@ -76,19 +75,14 @@ func (s *Store) SyncModelParamsFromURL(ctx context.Context) error {
 	}
 
 	if s.configStore != nil {
-		err = s.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-			for model, data := range paramsData {
-				params := &configstoreTables.TableModelParameters{
-					Model: model,
-					Data:  string(data),
-				}
-				if err := s.configStore.UpsertModelParameters(ctx, params, tx); err != nil {
-					return fmt.Errorf("failed to upsert model parameters for model %s: %w", model, err)
-				}
-			}
-			return nil
-		})
-		if err != nil {
+		records := make([]configstoreTables.TableModelParameters, 0, len(paramsData))
+		for model, data := range paramsData {
+			records = append(records, configstoreTables.TableModelParameters{
+				Model: model,
+				Data:  string(data),
+			})
+		}
+		if err := s.configStore.UpsertModelParametersBatch(ctx, records); err != nil {
 			return fmt.Errorf("failed to sync model parameters to database: %w", err)
 		}
 	}

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -282,6 +282,21 @@ func (s *Store) DatasheetModelsForProvider(provider schemas.ModelProvider) []str
 	return out
 }
 
+// DeprecatedDatasheetModelsForProvider returns deprecated models from the
+// datasheet view for provider. Deprecated models may disappear from provider
+// list-models APIs but must remain visible in Bifrost catalog listings.
+func (s *Store) DeprecatedDatasheetModelsForProvider(provider schemas.ModelProvider) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	models, ok := s.deprecatedByProvider[provider]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(models))
+	copy(out, models)
+	return out
+}
+
 // DatasheetProviders returns every provider that has at least one pricing
 // row in the datasheet view. Composer unions this with live + keyconfig to
 // enumerate "all known providers" for GetProvidersForModel.

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -45,6 +45,7 @@ type Entry struct {
 	MaxInputTokens  *int                  `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens *int                  `json:"max_output_tokens,omitempty"`
 	Architecture    *schemas.Architecture `json:"architecture,omitempty"`
+	IsDeprecated    bool                  `json:"is_deprecated,omitempty"`
 
 	// AdditionalAttributes carries editorial metadata stored on the pricing
 	// row (e.g. description). Populated from the DB read path only; the
@@ -552,6 +553,7 @@ func convertEntryToTablePricing(modelKey string, entry Entry) configstoreTables.
 		MaxInputTokens:  entry.MaxInputTokens,
 		MaxOutputTokens: entry.MaxOutputTokens,
 		Architecture:    entry.Architecture,
+		IsDeprecated:    entry.IsDeprecated,
 
 		InputCostPerToken:                         entry.InputCostPerToken,
 		OutputCostPerToken:                        entry.OutputCostPerToken,
@@ -709,6 +711,7 @@ func convertTablePricingToEntry(pricing *configstoreTables.TableModelPricing) *E
 		MaxInputTokens:       pricing.MaxInputTokens,
 		MaxOutputTokens:      pricing.MaxOutputTokens,
 		Architecture:         pricing.Architecture,
+		IsDeprecated:         pricing.IsDeprecated,
 		AdditionalAttributes: pricing.AdditionalAttributes,
 		Options:              options,
 	}

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -367,21 +367,6 @@ func (mc *ModelCatalog) ForceReloadPricing(ctx context.Context) error {
 		}
 	}()
 
-	// MCP library sync runs alongside but is non-fatal: a failure here must not
-	// block a pricing/params force-reload. It is logged and the last-sync
-	// timestamp is only advanced on success.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := mc.syncMCPLibrary(ctx); err != nil {
-			mc.logger.Warn("MCP library sync during force-reload failed: %v", err)
-			return
-		}
-		mc.syncMu.Lock()
-		mc.lastMCPLibrarySyncedAt = time.Now()
-		mc.syncMu.Unlock()
-	}()
-
 	wg.Wait()
 	if pricingErr != nil {
 		return pricingErr

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -20,6 +20,7 @@ func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []s
 	var out []string
 	if liveModels := mc.live.ModelsForProvider(provider); len(liveModels) > 0 {
 		out = liveModels
+		out = mc.appendAllowedDatasheetModels(out, mc.datasheet.DeprecatedDatasheetModelsForProvider(provider), allowed, blacklisted)
 	} else if datasheetModels := mc.datasheet.DatasheetModelsForProvider(provider); len(datasheetModels) > 0 && allowed != nil {
 		out = make([]string, 0, len(datasheetModels))
 		for _, m := range datasheetModels {
@@ -66,6 +67,31 @@ func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []s
 			out = append(out, m)
 		}
 	}
+	return out
+}
+
+func (mc *ModelCatalog) appendAllowedDatasheetModels(out []string, models []string, allowed schemas.WhiteList, blacklisted schemas.BlackList) []string {
+	if len(models) == 0 {
+		return out
+	}
+	seen := make(map[string]struct{}, len(out))
+	for _, m := range out {
+		seen[m] = struct{}{}
+	}
+	for _, m := range models {
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		if blacklisted.IsBlocked(m) {
+			continue
+		}
+		if allowed != nil && !allowed.IsAllowed(m) {
+			continue
+		}
+		seen[m] = struct{}{}
+		out = append(out, m)
+	}
+	slices.Sort(out)
 	return out
 }
 

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -1,10 +1,15 @@
 package modelcatalog
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
 )
 
 // TestUpsertLiveFromResponse_NilRespIsNoop guards the API surface: handing a
@@ -46,6 +51,111 @@ func TestUpsertLiveFromResponse_PopulatesFromResponse(t *testing.T) {
 		t.Errorf("GetModelsForProvider = %v, want %v", got, want)
 	}
 }
+
+func TestGetModelsForProvider_IncludesDeprecatedDatasheetModelsWhenLiveExists(t *testing.T) {
+	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
+	pricingJSON := []byte(`{
+		"deprecated-model": {"provider":"openai","mode":"chat","base_model":"deprecated-model","is_deprecated":true},
+		"current-model": {"provider":"openai","mode":"chat","base_model":"current-model"}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing testdata: %v", err)
+	}
+
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + pricingPath})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing testdata: %v", err)
+	}
+	mc := NewTestCatalogWithDatasheet(ds)
+	mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"live-model"})
+
+	got := mc.GetModelsForProvider(schemas.OpenAI)
+	slices.Sort(got)
+	want := []string{"deprecated-model", "live-model"}
+	if !slices.Equal(got, want) {
+		t.Errorf("GetModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+// deprecatedDatasheet returns a datasheet.Store loaded from a temp pricing
+// file containing one deprecated model and one current model, both openai.
+func deprecatedDatasheet(t *testing.T) *datasheet.Store {
+	t.Helper()
+	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
+	pricingJSON := []byte(`{
+		"deprecated-model": {"provider":"openai","mode":"chat","base_model":"deprecated-model","is_deprecated":true},
+		"current-model": {"provider":"openai","mode":"chat","base_model":"current-model"}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing testdata: %v", err)
+	}
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + pricingPath})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing testdata: %v", err)
+	}
+	return ds
+}
+
+// TestGetModelsForProvider_DeprecatedDatasheetModelsRespectAllowBlock pins the
+// allow/block gating that appendAllowedDatasheetModels applies to deprecated
+// datasheet models once a live entry exists. The unrestricted path is covered
+// by TestGetModelsForProvider_IncludesDeprecatedDatasheetModelsWhenLiveExists;
+// these sub-tests cover the keyconfig-restricted branches.
+func TestGetModelsForProvider_DeprecatedDatasheetModelsRespectAllowBlock(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []schemas.Key
+		want []string
+	}{
+		{
+			// deprecated-model sits in the keyconfig blocklist → excluded even
+			// though the key otherwise allows everything (wildcard).
+			name: "blocklisted deprecated model is excluded",
+			keys: []schemas.Key{
+				{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"*"}, BlacklistedModels: schemas.BlackList{"deprecated-model"}},
+			},
+			want: []string{"live-model"},
+		},
+		{
+			// explicit allowlist omits deprecated-model → excluded.
+			name: "deprecated model absent from allowlist is excluded",
+			keys: []schemas.Key{
+				{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"live-model"}},
+			},
+			want: []string{"live-model"},
+		},
+		{
+			// explicit allowlist names deprecated-model → included.
+			name: "deprecated model present in allowlist is included",
+			keys: []schemas.Key{
+				{ID: "k1", Enabled: ptrBool(true), Models: schemas.WhiteList{"live-model", "deprecated-model"}},
+			},
+			want: []string{"deprecated-model", "live-model"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kc := keyconfig.New(nil)
+			kc.Replace(map[schemas.ModelProvider][]schemas.Key{schemas.OpenAI: tt.keys})
+			mc := &ModelCatalog{
+				datasheet: deprecatedDatasheet(t),
+				live:      live.New(nil),
+				keyconf:   kc,
+				done:      make(chan struct{}),
+			}
+			mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"live-model"})
+
+			got := mc.GetModelsForProvider(schemas.OpenAI)
+			slices.Sort(got)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("GetModelsForProvider = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ptrBool returns a pointer to b, for building schemas.Key fixtures.
+func ptrBool(b bool) *bool { return &b }
 
 // TestExtractModelIDs_StripsOwningProviderPrefix verifies the canonical
 // shape returned by every provider's ListModels — an ID prefixed with its

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -259,6 +259,16 @@ type RecalculateCostResult struct {
 	Remaining    int64 `json:"remaining"`
 }
 
+// RecalculateCostProgress represents a progress event from a cost backfill operation.
+type RecalculateCostProgress struct {
+	TotalMatched int64  `json:"total_matched"`
+	Processed    int    `json:"processed"`
+	Updated      int    `json:"updated"`
+	Skipped      int    `json:"skipped"`
+	Remaining    *int64 `json:"remaining,omitempty"`
+	Done         bool   `json:"done"`
+}
+
 // LogMessage represents a message in the logging queue
 type LogMessage struct {
 	Operation          LogOperation

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1199,8 +1199,16 @@ func (p *LoggerPlugin) extractUniqueMCPKeyPairs(logs []logstore.MCPToolLog, extr
 	return result
 }
 
-// RecalculateCosts recomputes cost for log entries that are missing cost values
+// RecalculateCosts recomputes cost for all log entries that are missing cost values.
+// The limit controls batch size, not the total number of rows processed.
 func (p *LoggerPlugin) RecalculateCosts(ctx context.Context, filters logstore.SearchFilters, limit int) (*RecalculateCostResult, error) {
+	return p.RecalculateCostsWithProgress(ctx, filters, limit, nil)
+}
+
+// RecalculateCostsWithProgress recomputes cost for all log entries that are missing cost values
+// and invokes progress after each batch. The limit controls batch size, not the
+// total number of rows processed.
+func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters logstore.SearchFilters, limit int, progress func(RecalculateCostProgress)) (*RecalculateCostResult, error) {
 	if p.pricingManager == nil {
 		return nil, fmt.Errorf("pricing manager is not configured")
 	}
@@ -1221,32 +1229,71 @@ func (p *LoggerPlugin) RecalculateCosts(ctx context.Context, filters logstore.Se
 		Order:  "asc",
 	}
 
-	searchResult, err := p.store.SearchLogs(ctx, filters, pagination)
-	if err != nil {
-		return nil, fmt.Errorf("failed to search logs for cost recalculation: %w", err)
-	}
+	result := &RecalculateCostResult{}
+	seenInitialTotal := false
+	remainingOffset := 0
+	processed := 0
 
-	result := &RecalculateCostResult{
-		TotalMatched: searchResult.Stats.TotalRequests,
-	}
-
-	costUpdates := make(map[string]float64, len(searchResult.Logs))
-
-	for _, logEntry := range searchResult.Logs {
-		cost, calcErr := p.calculateCostForLog(&logEntry)
-		if calcErr != nil {
-			result.Skipped++
-			p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
-			continue
+	for {
+		pagination.Offset = remainingOffset
+		searchResult, err := p.store.SearchLogs(ctx, filters, pagination)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search logs for cost recalculation: %w", err)
 		}
-		costUpdates[logEntry.ID] = cost
-	}
-
-	if len(costUpdates) > 0 {
-		if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
-			return nil, fmt.Errorf("failed to bulk update costs: %w", err)
+		if !seenInitialTotal {
+			result.TotalMatched = searchResult.Stats.TotalRequests
+			seenInitialTotal = true
 		}
-		result.Updated = len(costUpdates)
+		if len(searchResult.Logs) == 0 {
+			break
+		}
+		processed += len(searchResult.Logs)
+
+		costUpdates := make(map[string]float64, len(searchResult.Logs))
+		stillMissingInBatch := 0
+
+		for _, logEntry := range searchResult.Logs {
+			cost, calcErr := p.calculateCostForLog(&logEntry)
+			if calcErr != nil {
+				result.Skipped++
+				stillMissingInBatch++
+				p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
+				continue
+			}
+			if cost <= 0 {
+				if isKnownZeroCostLog(&logEntry) {
+					costUpdates[logEntry.ID] = cost
+				} else {
+					result.Skipped++
+					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
+				}
+				// MissingCostOnly currently includes zero-cost rows, so advance past them
+				// whether they were skipped or updated to avoid recalculating forever.
+				stillMissingInBatch++
+				continue
+			}
+			costUpdates[logEntry.ID] = cost
+		}
+
+		if len(costUpdates) > 0 {
+			if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
+				return nil, fmt.Errorf("failed to bulk update costs: %w", err)
+			}
+			result.Updated += len(costUpdates)
+		}
+
+		remainingOffset += stillMissingInBatch
+		if progress != nil {
+			progress(RecalculateCostProgress{
+				TotalMatched: result.TotalMatched,
+				Processed:    processed,
+				Updated:      result.Updated,
+				Skipped:      result.Skipped,
+			})
+		}
+		if len(searchResult.Logs) < limit {
+			break
+		}
 	}
 
 	// Re-count how many logs still match the missing-cost filter after updates
@@ -1261,8 +1308,39 @@ func (p *LoggerPlugin) RecalculateCosts(ctx context.Context, filters logstore.Se
 	} else {
 		result.Remaining = remainingResult.Stats.TotalRequests
 	}
+	if progress != nil {
+		remaining := result.Remaining
+		progress(RecalculateCostProgress{
+			TotalMatched: result.TotalMatched,
+			Processed:    processed,
+			Updated:      result.Updated,
+			Skipped:      result.Skipped,
+			Remaining:    &remaining,
+			Done:         true,
+		})
+	}
 
 	return result, nil
+}
+
+func isKnownZeroCostLog(logEntry *logstore.Log) bool {
+	if logEntry == nil || logEntry.CacheDebugParsed == nil || !logEntry.CacheDebugParsed.CacheHit {
+		return false
+	}
+	return logEntry.CacheDebugParsed.HitType != nil && *logEntry.CacheDebugParsed.HitType == "direct"
+}
+
+func normalizeLogRequestType(object string) schemas.RequestType {
+	switch object {
+	case "chat.completion":
+		return schemas.ChatCompletionRequest
+	case "chat.completion.chunk":
+		return schemas.ChatCompletionStreamRequest
+	case "response":
+		return schemas.ResponsesRequest
+	default:
+		return schemas.RequestType(object)
+	}
 }
 
 func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, error) {
@@ -1285,7 +1363,7 @@ func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, err
 		return 0, fmt.Errorf("token usage not available for log %s", logEntry.ID)
 	}
 
-	requestType := schemas.RequestType(logEntry.Object)
+	requestType := normalizeLogRequestType(logEntry.Object)
 	if requestType == "" && (cacheDebug == nil || !cacheDebug.CacheHit) {
 		p.logger.Warn("skipping cost calculation for log %s: object type is empty (timestamp: %s)", logEntry.ID, logEntry.Timestamp)
 		return 0, fmt.Errorf("object type is empty for log %s", logEntry.ID)

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -360,6 +360,186 @@ func TestApplyErrorBillingFromBilledUsage_FillsTokensAndCostWhenUnparsed(t *test
 	}
 }
 
+func TestRecalculateCostsProcessesAllBatches(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:          store,
+		pricingManager: newTestPricingManager(t),
+		logger:         testLogger{},
+	}
+
+	now := time.Now().UTC()
+	for i := range 5 {
+		if err := store.Create(context.Background(), testRecalculateCostLog(
+			"req-recalc-batch-"+string(rune('a'+i)),
+			now.Add(time.Duration(i)*time.Second),
+			100+i,
+			50,
+		)); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	result, err := plugin.RecalculateCosts(context.Background(), logstore.SearchFilters{}, 2)
+	if err != nil {
+		t.Fatalf("RecalculateCosts() error = %v", err)
+	}
+	if result.TotalMatched != 5 || result.Updated != 5 || result.Skipped != 0 || result.Remaining != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	for _, id := range []string{"req-recalc-batch-a", "req-recalc-batch-b", "req-recalc-batch-c", "req-recalc-batch-d", "req-recalc-batch-e"} {
+		entry, err := store.FindByID(context.Background(), id)
+		if err != nil {
+			t.Fatalf("FindByID(%s) error = %v", id, err)
+		}
+		if entry.Cost == nil || *entry.Cost <= 0 {
+			t.Fatalf("expected positive cost for %s, got %v", id, entry.Cost)
+		}
+	}
+}
+
+func TestRecalculateCostsSkipsUnresolvableRowsAndContinues(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:          store,
+		pricingManager: newTestPricingManager(t),
+		logger:         testLogger{},
+	}
+
+	now := time.Now().UTC()
+	if err := store.Create(context.Background(), &logstore.Log{
+		ID:        "req-recalc-skip",
+		Timestamp: now,
+		Object:    string(schemas.ChatCompletionRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "gpt-4o",
+		Status:    "success",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	for i := range 3 {
+		if err := store.Create(context.Background(), testRecalculateCostLog(
+			"req-recalc-continue-"+string(rune('a'+i)),
+			now.Add(time.Duration(i+1)*time.Second),
+			100+i,
+			50,
+		)); err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+
+	result, err := plugin.RecalculateCosts(context.Background(), logstore.SearchFilters{}, 2)
+	if err != nil {
+		t.Fatalf("RecalculateCosts() error = %v", err)
+	}
+	if result.TotalMatched != 4 || result.Updated != 3 || result.Skipped != 1 || result.Remaining != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	skipped, err := store.FindByID(context.Background(), "req-recalc-skip")
+	if err != nil {
+		t.Fatalf("FindByID(req-recalc-skip) error = %v", err)
+	}
+	if skipped.Cost != nil {
+		t.Fatalf("expected skipped row cost to remain nil, got %v", skipped.Cost)
+	}
+	for _, id := range []string{"req-recalc-continue-a", "req-recalc-continue-b", "req-recalc-continue-c"} {
+		entry, err := store.FindByID(context.Background(), id)
+		if err != nil {
+			t.Fatalf("FindByID(%s) error = %v", id, err)
+		}
+		if entry.Cost == nil || *entry.Cost <= 0 {
+			t.Fatalf("expected positive cost for %s, got %v", id, entry.Cost)
+		}
+	}
+}
+
+func TestRecalculateCostsDoesNotWriteZeroForUnresolvedPricing(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:          store,
+		pricingManager: newTestPricingManager(t),
+		logger:         testLogger{},
+	}
+
+	entry := testRecalculateCostLog("req-recalc-unpriced", time.Now().UTC(), 100, 50)
+	entry.Model = "unknown-model"
+	if err := store.Create(context.Background(), entry); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	result, err := plugin.RecalculateCosts(context.Background(), logstore.SearchFilters{}, 2)
+	if err != nil {
+		t.Fatalf("RecalculateCosts() error = %v", err)
+	}
+	if result.TotalMatched != 1 || result.Updated != 0 || result.Skipped != 1 || result.Remaining != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), "req-recalc-unpriced")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.Cost != nil {
+		t.Fatalf("expected unresolved pricing to leave cost nil, got %v", *logEntry.Cost)
+	}
+}
+
+func TestRecalculateCostsNormalizesProviderObjectForPricing(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:          store,
+		pricingManager: newTestPricingManager(t),
+		logger:         testLogger{},
+	}
+
+	entry := testRecalculateCostLog("req-recalc-provider-object", time.Now().UTC(), 100, 50)
+	entry.Object = "chat.completion"
+	zeroCost := 0.0
+	entry.Cost = &zeroCost
+	if err := store.Create(context.Background(), entry); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	result, err := plugin.RecalculateCosts(context.Background(), logstore.SearchFilters{}, 2)
+	if err != nil {
+		t.Fatalf("RecalculateCosts() error = %v", err)
+	}
+	if result.TotalMatched != 1 || result.Updated != 1 || result.Skipped != 0 || result.Remaining != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), "req-recalc-provider-object")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.Cost == nil || *logEntry.Cost <= 0 {
+		t.Fatalf("expected legacy provider object to recalculate positive cost, got %v", logEntry.Cost)
+	}
+}
+
+func testRecalculateCostLog(id string, timestamp time.Time, promptTokens int, completionTokens int) *logstore.Log {
+	totalTokens := promptTokens + completionTokens
+	return &logstore.Log{
+		ID:               id,
+		Timestamp:        timestamp,
+		Object:           string(schemas.ChatCompletionRequest),
+		Provider:         string(schemas.OpenAI),
+		Model:            "gpt-4o",
+		Status:           "success",
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      totalTokens,
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      totalTokens,
+		},
+	}
+}
+
 func TestBuildInitialLogEntryPreservesMetadata(t *testing.T) {
 	metadata := map[string]any{"tenant": "acme"}
 	entry := buildInitialLogEntry(&PendingLogData{

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -123,6 +123,8 @@ type LogManager interface {
 
 	// RecalculateCosts recomputes missing costs for logs matching the filters
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
+	// RecalculateCostsWithProgress recomputes missing costs and emits batch progress updates
+	RecalculateCostsWithProgress(ctx context.Context, filters *logstore.SearchFilters, limit int, progress func(RecalculateCostProgress)) (*RecalculateCostResult, error)
 
 	// MCP Tool Log methods
 	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
@@ -367,6 +369,13 @@ func (p *PluginLogManager) RecalculateCosts(ctx context.Context, filters *logsto
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCosts(ctx, *filters, limit)
+}
+
+func (p *PluginLogManager) RecalculateCostsWithProgress(ctx context.Context, filters *logstore.SearchFilters, limit int, progress func(RecalculateCostProgress)) (*RecalculateCostResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.RecalculateCostsWithProgress(ctx, *filters, limit, progress)
 }
 
 // GetMCPToolLog retrieves a single MCP tool log entry by ID.

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -873,6 +873,7 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 				pricingEntry = h.config.ModelCatalog.GetPricingEntryForModel(*modelEntry.Alias, provider)
 			}
 			if pricingEntry != nil {
+				resp.Data[i].IsDeprecated = pricingEntry.IsDeprecated
 				if pricingEntry.BaseModel != "" && resp.Data[i].NormalizedName == nil {
 					resp.Data[i].NormalizedName = bifrost.Ptr(providerUtils.NormalizeBaseModelSlug(pricingEntry.BaseModel))
 				}

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1681,8 +1681,19 @@ func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
 		limit = 1000
 	}
 
-	filters := payload.Filters
+	filters := payload.Filters.SearchFilters
+	if payload.Filters.Period != "" {
+		if start, end := ResolvePeriod(payload.Filters.Period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
+		}
+	}
 	filters.MissingCostOnly = true
+
+	if strings.Contains(string(ctx.Request.Header.Peek("Accept")), "text/event-stream") {
+		h.streamRecalculateLogCosts(ctx, filters, limit)
+		return
+	}
 
 	result, err := h.logManager.RecalculateCosts(ctx, &filters, limit)
 	if err != nil {
@@ -1692,6 +1703,50 @@ func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+func (h *LoggingHandler) streamRecalculateLogCosts(ctx *fasthttp.RequestCtx, filters logstore.SearchFilters, limit int) {
+	ctx.SetContentType("text/event-stream")
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.Response.Header.Set("Connection", "keep-alive")
+	ctx.Response.Header.Set("X-Accel-Buffering", "no")
+
+	reader := lib.NewSSEStreamReader()
+	ctx.Response.SetBodyStream(reader, -1)
+
+	streamCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer reader.Done()
+		defer cancel()
+
+		result, err := h.logManager.RecalculateCostsWithProgress(streamCtx, &filters, limit, func(progress logging.RecalculateCostProgress) {
+			data, marshalErr := sonic.Marshal(progress)
+			if marshalErr != nil {
+				logger.Warn("failed to marshal recalculate cost progress: %v", marshalErr)
+				return
+			}
+			if !reader.SendEvent("progress", data) {
+				cancel()
+			}
+		})
+		if err != nil {
+			logger.Error("failed to recalculate log costs: %v", err)
+			data, marshalErr := sonic.Marshal(map[string]string{"message": fmt.Sprintf("Failed to recalculate costs: %v", err)})
+			if marshalErr != nil {
+				data = []byte(`{"message":"Failed to recalculate costs"}`)
+			}
+			reader.SendError(data)
+			return
+		}
+
+		data, marshalErr := sonic.Marshal(result)
+		if marshalErr != nil {
+			logger.Warn("failed to marshal recalculate cost result: %v", marshalErr)
+			reader.SendError([]byte(`{"message":"Failed to encode response"}`))
+			return
+		}
+		reader.SendEvent("done", data)
+	}()
 }
 
 // Helper functions
@@ -1823,8 +1878,13 @@ func parseMetadataFilters(ctx *fasthttp.RequestCtx, filters *logstore.SearchFilt
 }
 
 type recalculateCostRequest struct {
-	Filters logstore.SearchFilters `json:"filters"`
+	Filters recalculateCostFilters `json:"filters"`
 	Limit   *int                   `json:"limit,omitempty"`
+}
+
+type recalculateCostFilters struct {
+	logstore.SearchFilters
+	Period string `json:"period,omitempty"`
 }
 
 // parseMCPFiltersAndPagination parses MCP tool log filters and pagination from query parameters.

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/queryscope"
@@ -148,10 +149,73 @@ func TestGetDashboard(t *testing.T) {
 	}
 }
 
+func TestRecalculateLogCostsResolvesPeriodFilter(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	mgr := &dashboardLogManager{}
+	h := &LoggingHandler{logManager: mgr}
+
+	var req fasthttp.Request
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("/api/logs/recalculate-cost")
+	req.Header.SetContentType("application/json")
+	req.SetBodyString(`{"filters":{"period":"1h"}}`)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+	h.recalculateLogCosts(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", got, string(ctx.Response.Body()))
+	}
+	filters := mgr.lastRecalculateFilters
+	if filters.StartTime == nil || filters.EndTime == nil {
+		t.Fatalf("expected period to resolve start/end, got start=%v end=%v", filters.StartTime, filters.EndTime)
+	}
+	if !filters.EndTime.After(*filters.StartTime) {
+		t.Fatalf("expected end_time after start_time, got start=%s end=%s", filters.StartTime, filters.EndTime)
+	}
+	if !filters.MissingCostOnly {
+		t.Fatal("expected recalculation to force missing_cost_only")
+	}
+}
+
+func TestStreamRecalculateLogCostsUsesRequestContext(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	mgr := &dashboardLogManager{lastRecalculateContext: make(chan context.Context, 1)}
+	h := &LoggingHandler{logManager: mgr}
+
+	var req fasthttp.Request
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("/api/logs/recalculate-cost")
+	req.Header.SetContentType("application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.SetBodyString(`{"filters":{"period":"1h"}}`)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+	ctx.SetUserValue("request-scope", "preserved")
+
+	h.recalculateLogCosts(ctx)
+
+	select {
+	case recalculateCtx := <-mgr.lastRecalculateContext:
+		if got := recalculateCtx.Value("request-scope"); got != "preserved" {
+			t.Fatalf("expected request context value to be preserved, got %v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for recalculation context")
+	}
+}
+
 type dashboardLogManager struct {
-	failStats      bool
-	lastLLMFilters logstore.SearchFilters
-	lastMCPFilters logstore.MCPToolLogSearchFilters
+	failStats              bool
+	lastLLMFilters         logstore.SearchFilters
+	lastMCPFilters         logstore.MCPToolLogSearchFilters
+	lastRecalculateFilters logstore.SearchFilters
+	lastRecalculateContext chan context.Context
 }
 
 func (m *dashboardLogManager) GetLog(ctx context.Context, id string) (*logstore.Log, error) {
@@ -252,6 +316,14 @@ func (m *dashboardLogManager) GetDimensionLatencyHistogram(ctx context.Context, 
 func (m *dashboardLogManager) DeleteLog(ctx context.Context, id string) error     { return nil }
 func (m *dashboardLogManager) DeleteLogs(ctx context.Context, ids []string) error { return nil }
 func (m *dashboardLogManager) RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*loggingplugin.RecalculateCostResult, error) {
+	m.lastRecalculateFilters = *filters
+	return &loggingplugin.RecalculateCostResult{}, nil
+}
+func (m *dashboardLogManager) RecalculateCostsWithProgress(ctx context.Context, filters *logstore.SearchFilters, limit int, progress func(loggingplugin.RecalculateCostProgress)) (*loggingplugin.RecalculateCostResult, error) {
+	m.lastRecalculateFilters = *filters
+	if m.lastRecalculateContext != nil {
+		m.lastRecalculateContext <- ctx
+	}
 	return nil, nil
 }
 func (m *dashboardLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -624,6 +624,7 @@ func (h *ProviderHandler) listKeys(ctx *fasthttp.RequestCtx) {
 type ModelResponse struct {
 	Name             string   `json:"name"`
 	Provider         string   `json:"provider"`
+	IsDeprecated     bool     `json:"is_deprecated,omitempty"`
 	AccessibleByKeys []string `json:"accessible_by_keys,omitempty"`
 }
 
@@ -641,6 +642,7 @@ type ModelDetailsResponse struct {
 	MaxInputTokens       *int                  `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens      *int                  `json:"max_output_tokens,omitempty"`
 	Architecture         *schemas.Architecture `json:"architecture,omitempty"`
+	IsDeprecated         bool                  `json:"is_deprecated,omitempty"`
 	AdditionalAttributes map[string]string     `json:"additional_attributes,omitempty"`
 	AccessibleByKeys     []string              `json:"accessible_by_keys,omitempty"`
 }
@@ -694,8 +696,9 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 	responseModels := make([]ModelResponse, 0, len(allModels))
 	for _, model := range allModels {
 		entry := ModelResponse{
-			Name:     model.Name,
-			Provider: string(model.Provider),
+			Name:         model.Name,
+			Provider:     string(model.Provider),
+			IsDeprecated: h.isModelDeprecated(model.Name, model.Provider),
 		}
 		if len(model.AccessibleByKeys) > 0 {
 			entry.AccessibleByKeys = model.AccessibleByKeys
@@ -755,6 +758,7 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 			details.MaxInputTokens = capabilities.MaxInputTokens
 			details.MaxOutputTokens = capabilities.MaxOutputTokens
 			details.Architecture = capabilities.Architecture
+			details.IsDeprecated = capabilities.IsDeprecated
 			details.AdditionalAttributes = capabilities.AdditionalAttributes
 		}
 		responseModels = append(responseModels, details)
@@ -764,6 +768,15 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 		Models: responseModels,
 		Total:  total,
 	})
+}
+
+func (h *ProviderHandler) isModelDeprecated(model string, provider schemas.ModelProvider) bool {
+	modelCatalog := h.inMemoryStore.ModelCatalog
+	if modelCatalog == nil {
+		return false
+	}
+	capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
+	return capabilities != nil && capabilities.IsDeprecated
 }
 
 // parseModelListQuery normalizes the management model-list query string and resolves

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1207,6 +1207,10 @@ func (m *MockConfigStore) UpsertModelParameters(ctx context.Context, params *tab
 	return nil
 }
 
+func (m *MockConfigStore) UpsertModelParametersBatch(ctx context.Context, params []tables.TableModelParameters, tx ...*gorm.DB) error {
+	return nil
+}
+
 // Provider methods
 func (m *MockConfigStore) GetProvider(ctx context.Context, provider schemas.ModelProvider) (*tables.TableProvider, error) {
 	return nil, nil

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -3,12 +3,13 @@ import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
+import { parseAsSafeArrayOf } from "@/lib/queryParamsParser";
 import { useGetMCPAvailableFilterDataQuery } from "@/lib/store";
 import type { LogFilters, MCPToolLogFilters } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { useLocation } from "@tanstack/react-router";
-import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { type ChartType } from "./components/charts/chartTypeToggle";
 import { ModelFilterSelect } from "./components/charts/modelFilterSelect";
@@ -21,8 +22,6 @@ import { type ProviderUsageTabViewHandle, ProviderUsageTabView } from "./compone
 import type { DashboardData } from "./utils/exportUtils";
 
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
-
-const parseCsvParam = (value: string): string[] => (value ? value.split(",").filter(Boolean) : []);
 
 export default function DashboardPage() {
 	// MCP filter data
@@ -41,16 +40,16 @@ export default function DashboardPage() {
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
 			tab: parseAsString.withDefault("overview"),
-			virtual_key_ids: parseAsString.withDefault(""),
-			providers: parseAsString.withDefault(""),
-			models: parseAsString.withDefault(""),
-			selected_key_ids: parseAsString.withDefault(""),
-			objects: parseAsString.withDefault(""),
-			status: parseAsString.withDefault(""),
-			routing_rule_ids: parseAsString.withDefault(""),
-			routing_engine_used: parseAsString.withDefault(""),
-			stop_reasons: parseAsString.withDefault(""),
-			missing_cost_only: parseAsString.withDefault("false"),
+			virtual_key_ids: parseAsSafeArrayOf.withDefault([]),
+			providers: parseAsSafeArrayOf.withDefault([]),
+			models: parseAsSafeArrayOf.withDefault([]),
+			selected_key_ids: parseAsSafeArrayOf.withDefault([]),
+			objects: parseAsSafeArrayOf.withDefault([]),
+			status: parseAsSafeArrayOf.withDefault([]),
+			routing_rule_ids: parseAsSafeArrayOf.withDefault([]),
+			routing_engine_used: parseAsSafeArrayOf.withDefault([]),
+			stop_reasons: parseAsSafeArrayOf.withDefault([]),
+			missing_cost_only: parseAsBoolean.withDefault(false),
 			metadata_filters: parseAsString.withDefault(""),
 			volume_chart: parseAsString.withDefault("bar"),
 			token_chart: parseAsString.withDefault("bar"),
@@ -70,11 +69,11 @@ export default function DashboardPage() {
 			mcp_tool_names: parseAsString.withDefault(""),
 			mcp_server_labels: parseAsString.withDefault(""),
 			parent_request_id: parseAsString.withDefault(""),
-			user_ids: parseAsString.withDefault(""),
-			team_ids: parseAsString.withDefault(""),
-			customer_ids: parseAsString.withDefault(""),
-			business_unit_ids: parseAsString.withDefault(""),
-			aliases: parseAsString.withDefault(""),
+			user_ids: parseAsSafeArrayOf.withDefault([]),
+			team_ids: parseAsSafeArrayOf.withDefault([]),
+			customer_ids: parseAsSafeArrayOf.withDefault([]),
+			business_unit_ids: parseAsSafeArrayOf.withDefault([]),
+			aliases: parseAsSafeArrayOf.withDefault([]),
 		},
 		{
 			history: "push",
@@ -82,17 +81,13 @@ export default function DashboardPage() {
 		},
 	);
 
-	// Parse filter arrays from URL state
-	const selectedProviders = useMemo(() => parseCsvParam(urlState.providers), [urlState.providers]);
-	const selectedModels = useMemo(() => parseCsvParam(urlState.models), [urlState.models]);
-	const selectedKeyIds = useMemo(() => parseCsvParam(urlState.selected_key_ids), [urlState.selected_key_ids]);
-	const selectedVirtualKeyIds = useMemo(() => parseCsvParam(urlState.virtual_key_ids), [urlState.virtual_key_ids]);
-	const selectedTypes = useMemo(() => parseCsvParam(urlState.objects), [urlState.objects]);
-	const selectedStatuses = useMemo(() => parseCsvParam(urlState.status), [urlState.status]);
-	const selectedRoutingRuleIds = useMemo(() => parseCsvParam(urlState.routing_rule_ids), [urlState.routing_rule_ids]);
-	const selectedRoutingEngines = useMemo(() => parseCsvParam(urlState.routing_engine_used), [urlState.routing_engine_used]);
-	const selectedStopReasons = useMemo(() => parseCsvParam(urlState.stop_reasons), [urlState.stop_reasons]);
-	const missingCostOnly = useMemo(() => urlState.missing_cost_only === "true", [urlState.missing_cost_only]);
+	// Parse string-backed MCP filter values from URL state
+	const selectedMcpToolNames = useMemo(() => (urlState.mcp_tool_names ? [urlState.mcp_tool_names] : []), [urlState.mcp_tool_names]);
+	const selectedMcpServerLabels = useMemo(
+		() => (urlState.mcp_server_labels ? [urlState.mcp_server_labels] : []),
+		[urlState.mcp_server_labels],
+	);
+
 	const metadataFilters = useMemo(() => {
 		if (!urlState.metadata_filters) return undefined;
 		try {
@@ -102,15 +97,6 @@ export default function DashboardPage() {
 		}
 	}, [urlState.metadata_filters]);
 
-	const selectedMcpToolNames = useMemo(() => parseCsvParam(urlState.mcp_tool_names), [urlState.mcp_tool_names]);
-	const selectedMcpServerLabels = useMemo(() => parseCsvParam(urlState.mcp_server_labels), [urlState.mcp_server_labels]);
-
-	const selectedUserIds = useMemo(() => parseCsvParam(urlState.user_ids), [urlState.user_ids]);
-	const selectedTeamIds = useMemo(() => parseCsvParam(urlState.team_ids), [urlState.team_ids]);
-	const selectedCustomerIds = useMemo(() => parseCsvParam(urlState.customer_ids), [urlState.customer_ids]);
-	const selectedBusinessUnitIds = useMemo(() => parseCsvParam(urlState.business_unit_ids), [urlState.business_unit_ids]);
-	const selectedAliases = useMemo(() => parseCsvParam(urlState.aliases), [urlState.aliases]);
-
 	const filters: LogFilters = useMemo(
 		() => ({
 			...(urlState.period
@@ -119,54 +105,54 @@ export default function DashboardPage() {
 						start_time: dateUtils.toISOString(urlState.start_time),
 						end_time: dateUtils.toISOString(urlState.end_time),
 					}),
-			...(selectedProviders.length > 0 && { providers: selectedProviders }),
-			...(selectedModels.length > 0 && { models: selectedModels }),
-			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
-			...(selectedVirtualKeyIds.length > 0 && {
-				virtual_key_ids: selectedVirtualKeyIds,
+			...(urlState.providers.length > 0 && { providers: urlState.providers }),
+			...(urlState.models.length > 0 && { models: urlState.models }),
+			...(urlState.selected_key_ids.length > 0 && { selected_key_ids: urlState.selected_key_ids }),
+			...(urlState.virtual_key_ids.length > 0 && {
+				virtual_key_ids: urlState.virtual_key_ids,
 			}),
-			...(selectedTypes.length > 0 && { objects: selectedTypes }),
-			...(selectedStatuses.length > 0 && { status: selectedStatuses }),
-			...(selectedRoutingRuleIds.length > 0 && {
-				routing_rule_ids: selectedRoutingRuleIds,
+			...(urlState.objects.length > 0 && { objects: urlState.objects }),
+			...(urlState.status.length > 0 && { status: urlState.status }),
+			...(urlState.routing_rule_ids.length > 0 && {
+				routing_rule_ids: urlState.routing_rule_ids,
 			}),
-			...(selectedRoutingEngines.length > 0 && {
-				routing_engine_used: selectedRoutingEngines,
+			...(urlState.routing_engine_used.length > 0 && {
+				routing_engine_used: urlState.routing_engine_used,
 			}),
-			...(selectedStopReasons.length > 0 && { stop_reasons: selectedStopReasons }),
-			...(missingCostOnly && { missing_cost_only: true }),
+			...(urlState.stop_reasons.length > 0 && { stop_reasons: urlState.stop_reasons }),
+			...(urlState.missing_cost_only && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
 					metadata_filters: metadataFilters,
 				}),
 			...(urlState.parent_request_id && { parent_request_id: urlState.parent_request_id }),
-			...(selectedUserIds.length > 0 && { user_ids: selectedUserIds }),
-			...(selectedTeamIds.length > 0 && { team_ids: selectedTeamIds }),
-			...(selectedCustomerIds.length > 0 && { customer_ids: selectedCustomerIds }),
-			...(selectedBusinessUnitIds.length > 0 && { business_unit_ids: selectedBusinessUnitIds }),
-			...(selectedAliases.length > 0 && { aliases: selectedAliases }),
+			...(urlState.user_ids.length > 0 && { user_ids: urlState.user_ids }),
+			...(urlState.team_ids.length > 0 && { team_ids: urlState.team_ids }),
+			...(urlState.customer_ids.length > 0 && { customer_ids: urlState.customer_ids }),
+			...(urlState.business_unit_ids.length > 0 && { business_unit_ids: urlState.business_unit_ids }),
+			...(urlState.aliases.length > 0 && { aliases: urlState.aliases }),
 		}),
 		[
 			urlState.period,
 			urlState.start_time,
 			urlState.end_time,
 			urlState.parent_request_id,
-			selectedProviders,
-			selectedModels,
-			selectedKeyIds,
-			selectedVirtualKeyIds,
-			selectedTypes,
-			selectedStatuses,
-			selectedRoutingRuleIds,
-			selectedRoutingEngines,
-			selectedStopReasons,
-			missingCostOnly,
+			urlState.providers,
+			urlState.models,
+			urlState.selected_key_ids,
+			urlState.virtual_key_ids,
+			urlState.objects,
+			urlState.status,
+			urlState.routing_rule_ids,
+			urlState.routing_engine_used,
+			urlState.stop_reasons,
+			urlState.missing_cost_only,
 			metadataFilters,
-			selectedUserIds,
-			selectedTeamIds,
-			selectedCustomerIds,
-			selectedBusinessUnitIds,
-			selectedAliases,
+			urlState.user_ids,
+			urlState.team_ids,
+			urlState.customer_ids,
+			urlState.business_unit_ids,
+			urlState.aliases,
 		],
 	);
 
@@ -184,9 +170,9 @@ export default function DashboardPage() {
 			...(selectedMcpServerLabels.length > 0 && {
 				server_labels: selectedMcpServerLabels,
 			}),
-			...(selectedStatuses.length > 0 && { status: selectedStatuses }),
-			...(selectedVirtualKeyIds.length > 0 && {
-				virtual_key_ids: selectedVirtualKeyIds,
+			...(urlState.status.length > 0 && { status: urlState.status }),
+			...(urlState.virtual_key_ids.length > 0 && {
+				virtual_key_ids: urlState.virtual_key_ids,
 			}),
 		}),
 		[
@@ -195,8 +181,8 @@ export default function DashboardPage() {
 			urlState.end_time,
 			selectedMcpToolNames,
 			selectedMcpServerLabels,
-			selectedStatuses,
-			selectedVirtualKeyIds,
+			urlState.status,
+			urlState.virtual_key_ids,
 		],
 	);
 
@@ -290,7 +276,7 @@ export default function DashboardPage() {
 		[setUrlState],
 	);
 
-	// Adapter: converts a full LogFilters object to dashboard's CSV-based URL state
+	// Adapter: converts a full LogFilters object to dashboard URL state
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
 			const newStartTime = newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined;
@@ -300,30 +286,29 @@ export default function DashboardPage() {
 				...(timeChanged && { period: "" }),
 				start_time: newStartTime,
 				end_time: newEndTime,
-				period: urlState.period,
-				providers: (newFilters.providers || []).join(","),
-				models: (newFilters.models || []).join(","),
-				selected_key_ids: (newFilters.selected_key_ids || []).join(","),
-				virtual_key_ids: (newFilters.virtual_key_ids || []).join(","),
-				objects: (newFilters.objects || []).join(","),
-				status: (newFilters.status || []).join(","),
-				routing_rule_ids: (newFilters.routing_rule_ids || []).join(","),
-				routing_engine_used: (newFilters.routing_engine_used || []).join(","),
-				stop_reasons: (newFilters.stop_reasons || []).join(","),
-				missing_cost_only: String(newFilters.missing_cost_only ?? false),
+				providers: newFilters.providers || [],
+				models: newFilters.models || [],
+				selected_key_ids: newFilters.selected_key_ids || [],
+				virtual_key_ids: newFilters.virtual_key_ids || [],
+				objects: newFilters.objects || [],
+				status: newFilters.status || [],
+				routing_rule_ids: newFilters.routing_rule_ids || [],
+				routing_engine_used: newFilters.routing_engine_used || [],
+				stop_reasons: newFilters.stop_reasons || [],
+				missing_cost_only: newFilters.missing_cost_only ?? false,
 				metadata_filters:
 					newFilters.metadata_filters && Object.keys(newFilters.metadata_filters).length > 0
 						? JSON.stringify(newFilters.metadata_filters)
 						: "",
 				parent_request_id: newFilters.parent_request_id || "",
-				user_ids: (newFilters.user_ids || []).join(","),
-				team_ids: (newFilters.team_ids || []).join(","),
-				customer_ids: (newFilters.customer_ids || []).join(","),
-				business_unit_ids: (newFilters.business_unit_ids || []).join(","),
-				aliases: (newFilters.aliases || []).join(","),
+				user_ids: newFilters.user_ids || [],
+				team_ids: newFilters.team_ids || [],
+				customer_ids: newFilters.customer_ids || [],
+				business_unit_ids: newFilters.business_unit_ids || [],
+				aliases: newFilters.aliases || [],
 			});
 		},
-		[setUrlState, urlState.start_time, urlState.end_time, urlState.period],
+		[setUrlState, urlState.start_time, urlState.end_time],
 	);
 
 	// Date range for picker

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -5,8 +5,10 @@ import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
-import { getErrorMessage, useRecalculateLogCostsMutation } from "@/lib/store";
-import type { LogFilters as LogFiltersType } from "@/lib/types/logs";
+import { getErrorMessage } from "@/lib/store";
+import { getActiveTempToken } from "@/lib/store/apis/tempToken";
+import type { LogFilters as LogFiltersType, RecalculateCostProgress, RecalculateCostResponse } from "@/lib/types/logs";
+import { getApiBaseUrl } from "@/lib/utils/port";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -50,7 +52,6 @@ export function LogsHeaderView({
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const filtersRef = useRef<LogFiltersType>(filters);
-	const [recalculateCosts] = useRecalculateLogCostsMutation();
 
 	const [timezone, setTimezone] = useTimezonePreference();
 
@@ -77,19 +78,37 @@ export function LogsHeaderView({
 	}, []);
 
 	const handleRecalculateCosts = useCallback(async () => {
-		try {
-			const response = await recalculateCosts({ filters }).unwrap();
-			await fetchLogs();
-			await fetchStats();
-			setOpenMoreActionsPopover(false);
-			toast.success(`Recalculated costs for ${response.updated} logs`, {
+		setOpenMoreActionsPopover(false);
+		const toastId = "logs-recalculate-costs";
+		const recalculatePromise = recalculateCostsWithProgress(filters, (progress) => {
+			const total = progress.total_matched || 0;
+			const processed = Math.min(progress.processed, total || progress.processed);
+			toast.loading("Recalculating log costs...", {
+				id: toastId,
+				description:
+					total > 0
+						? `${processed}/${total} checked, ${progress.updated} updated, ${progress.skipped} skipped`
+						: "Finding logs with missing costs",
+			});
+		});
+
+		toast.promise(recalculatePromise, {
+			id: toastId,
+			loading: "Recalculating log costs...",
+			success: (response) => ({
+				message: `Recalculated costs for ${response.updated} logs`,
 				description: `${response.updated} logs updated, ${response.skipped} logs skipped, ${response.remaining} logs remaining`,
 				duration: 5000,
-			});
-		} catch (err) {
-			toast.error(getErrorMessage(err));
-		}
-	}, [filters, recalculateCosts, fetchLogs, fetchStats]);
+			}),
+			error: (err) => getErrorMessage(err),
+		});
+
+		try {
+			await recalculatePromise;
+			await fetchLogs();
+			await fetchStats();
+		} catch {}
+	}, [filters, fetchLogs, fetchStats]);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
@@ -190,4 +209,107 @@ export function LogsHeaderView({
 			/>
 		</div>
 	);
+}
+
+async function recalculateCostsWithProgress(
+	filters: LogFiltersType,
+	onProgress: (progress: RecalculateCostProgress) => void,
+): Promise<RecalculateCostResponse> {
+	const headers: Record<string, string> = {
+		Accept: "text/event-stream",
+		"Content-Type": "application/json",
+	};
+	const tempToken = getActiveTempToken();
+	if (tempToken) {
+		headers["X-Bifrost-Temp-Token"] = tempToken;
+	}
+
+	const response = await fetch(`${getApiBaseUrl()}/logs/recalculate-cost`, {
+		method: "POST",
+		credentials: "include",
+		headers,
+		body: JSON.stringify({ filters }),
+	});
+
+	if (!response.ok) {
+		throw await readRecalculateCostError(response);
+	}
+	if (!response.body) {
+		throw new Error("Recalculate cost stream is unavailable");
+	}
+
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let finalResult: RecalculateCostResponse | undefined;
+
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+		const events = buffer.split("\n\n");
+		buffer = events.pop() || "";
+		for (const eventBlock of events) {
+			const parsed = parseSSEEvent(eventBlock);
+			if (!parsed || parsed.data === "[DONE]") continue;
+			if (parsed.event === "error") {
+				throw parseRecalculateCostStreamError(parsed.data);
+			}
+			if (parsed.event === "progress") {
+				onProgress(JSON.parse(parsed.data) as RecalculateCostProgress);
+				continue;
+			}
+			if (parsed.event === "done") {
+				finalResult = JSON.parse(parsed.data) as RecalculateCostResponse;
+			}
+		}
+	}
+
+	buffer += decoder.decode();
+	if (buffer.trim()) {
+		const parsed = parseSSEEvent(buffer);
+		if (parsed?.event === "error") {
+			throw parseRecalculateCostStreamError(parsed.data);
+		}
+		if (parsed?.event === "done") {
+			finalResult = JSON.parse(parsed.data) as RecalculateCostResponse;
+		}
+	}
+
+	if (!finalResult) {
+		throw new Error("Recalculate cost stream ended before a final result was received");
+	}
+	return finalResult;
+}
+
+function parseSSEEvent(block: string): { event: string; data: string } | undefined {
+	let event = "message";
+	const data: string[] = [];
+	for (const rawLine of block.split("\n")) {
+		const line = rawLine.trimEnd();
+		if (line.startsWith("event: ")) {
+			event = line.slice(7);
+		} else if (line.startsWith("data: ")) {
+			data.push(line.slice(6));
+		}
+	}
+	if (data.length === 0) return undefined;
+	return { event, data: data.join("\n") };
+}
+
+async function readRecalculateCostError(response: Response): Promise<Error> {
+	try {
+		return parseRecalculateCostStreamError(await response.text());
+	} catch {
+		return new Error(`Failed to recalculate costs (${response.status})`);
+	}
+}
+
+function parseRecalculateCostStreamError(data: string): Error {
+	try {
+		const parsed = JSON.parse(data) as { error?: { message?: string }; message?: string };
+		return new Error(parsed.error?.message || parsed.message || "Failed to recalculate costs");
+	} catch {
+		return new Error(data || "Failed to recalculate costs");
+	}
 }

--- a/ui/app/workspace/model-catalog/views/overviewTab.tsx
+++ b/ui/app/workspace/model-catalog/views/overviewTab.tsx
@@ -1,7 +1,13 @@
 import FullPageLoader from "@/components/fullPageLoader";
 import { ProviderNames } from "@/lib/constants/logs";
-import { useGetModelsQuery, useGetProvidersQuery, useLazyGetLogsModelHistogramQuery, useLazyGetLogsStatsQuery } from "@/lib/store";
-import { KnownProvider } from "@/lib/types/config";
+import {
+	useGetModelsQuery,
+	useGetProvidersQuery,
+	useLazyGetLogsModelHistogramQuery,
+	useLazyGetLogsStatsQuery,
+	useLazyGetProviderKeysQuery,
+} from "@/lib/store";
+import { KnownProvider, ModelProviderKey } from "@/lib/types/config";
 import { LogStats } from "@/lib/types/logs";
 import { useEffect, useMemo, useState } from "react";
 import { ModelCatalogEmptyState } from "./modelCatalogEmptyState";
@@ -9,6 +15,37 @@ import ModelCatalogTable, { ModelCatalogRow } from "./modelCatalogTable";
 
 interface OverviewTabProps {
 	hasAccess: boolean;
+}
+
+function buildAliasDisplayMap(keys: ModelProviderKey[]) {
+	const displayByValue = new Map<string, string[]>();
+
+	for (const key of keys) {
+		for (const [aliasName, rawConfig] of Object.entries(key.aliases ?? {})) {
+			const config = rawConfig as unknown;
+			const modelValues =
+				typeof config === "string"
+					? [config]
+					: typeof config === "object" && config !== null
+						? [(config as { model_id?: string }).model_id, (config as { model_name?: string }).model_name].filter(
+								(value): value is string => Boolean(value),
+							)
+						: [];
+
+			for (const modelValue of modelValues) {
+				const aliases = displayByValue.get(modelValue) ?? [];
+				if (!aliases.includes(aliasName)) {
+					displayByValue.set(modelValue, [...aliases, aliasName]);
+				}
+			}
+		}
+	}
+
+	return displayByValue;
+}
+
+function getDisplayModels(models: string[], displayByValue: Map<string, string[]>) {
+	return models.flatMap((model) => displayByValue.get(model) ?? [model]);
 }
 
 export default function OverviewTab({ hasAccess }: OverviewTabProps) {
@@ -28,6 +65,7 @@ export default function OverviewTab({ hasAccess }: OverviewTabProps) {
 	const [triggerGlobalStats, { data: globalStats }] = useLazyGetLogsStatsQuery();
 	const [triggerStats] = useLazyGetLogsStatsQuery();
 	const [triggerModelHistogram] = useLazyGetLogsModelHistogramQuery();
+	const [triggerProviderKeys] = useLazyGetProviderKeysQuery();
 
 	useEffect(() => {
 		if (!hasAccess) return;
@@ -79,12 +117,19 @@ export default function OverviewTab({ hasAccess }: OverviewTabProps) {
 		const monthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
 		Promise.all(
-			providers.map((p) =>
-				triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
-					.unwrap()
-					.then((data): [string, string[]] => [p.name, data.models ?? []])
-					.catch((): [string, string[]] => [p.name, []]),
-			),
+			providers.map(async (p): Promise<[string, string[]]> => {
+				const [models, keys] = await Promise.all([
+					triggerModelHistogram({ filters: { providers: [p.name], start_time: monthAgo, end_time: now } })
+						.unwrap()
+						.then((data) => data.models ?? [])
+						.catch(() => []),
+					triggerProviderKeys(p.name)
+						.unwrap()
+						.catch(() => []),
+				]);
+
+				return [p.name, getDisplayModels(models, buildAliasDisplayMap(keys))];
+			}),
 		).then((results) => {
 			if (!cancelled) {
 				setModelsUsedMap(new Map(results));
@@ -94,7 +139,7 @@ export default function OverviewTab({ hasAccess }: OverviewTabProps) {
 		return () => {
 			cancelled = true;
 		};
-	}, [providers, triggerModelHistogram]);
+	}, [providers, triggerModelHistogram, triggerProviderKeys]);
 
 	const rows: ModelCatalogRow[] = useMemo(() => {
 		if (!providers) return [];

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -784,6 +784,15 @@ export interface RecalculateCostResponse {
 	remaining: number;
 }
 
+export interface RecalculateCostProgress {
+	total_matched: number;
+	processed: number;
+	updated: number;
+	skipped: number;
+	remaining?: number;
+	done: boolean;
+}
+
 // Responses API types (for responses_output field)
 
 // Message roles for responses


### PR DESCRIPTION
## Summary

Adds an `is_deprecated` flag to the model pricing datasheet and surfaces it throughout the catalog and API responses. This allows models that are no longer recommended for new use to remain visible in Bifrost listings, supporting migration and compatibility workflows without removing them from the catalog entirely.

## Changes

- Added `IsDeprecated bool` field to `TableModelPricing`, `datasheet.Entry`, and `schemas.Model`.
- Added a database migration (`add_model_pricing_is_deprecated_column`) to add the `is_deprecated` column to `governance_model_pricing`, with rollback support.
- Included `is_deprecated` in the `pricingSyncUpdateColumns` list so the field is kept in sync during datasheet upserts.
- Added `DeprecatedDatasheetModelsForProvider` to the datasheet store, which returns only deprecated models for a given provider.
- Updated `GetModelsForProvider` in the model catalog so that when live models exist for a provider, deprecated datasheet-only models are appended to the result (respecting allowlists and blocklists). Previously, deprecated models would be silently dropped when a live model list was available.
- Exposed `is_deprecated` in the `/models` list and detail responses for both the inference and provider handlers.
- Updated the OpenAPI spec to document the `is_deprecated` field across all relevant response shapes.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...
```

- Verify that after migration, the `governance_model_pricing` table has an `is_deprecated` column defaulting to `false`.
- Sync a datasheet that includes a model with `"is_deprecated": true` and confirm it appears in `/v1/models` and `/v1/providers/models` responses with `"is_deprecated": true`.
- Confirm that a deprecated model not returned by the provider's live list-models API still appears in `GetModelsForProvider` results.
- Confirm that a deprecated model on the blocklist is excluded from results.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The `is_deprecated` flag is read-only metadata derived from the pricing datasheet and does not affect authentication, authorization, or secret handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable