### PR TITLE
perf: batch pricing upserts with `UpsertModelPricesBatch` to reduce round-trips during sync

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2474,6 +2474,59 @@ func (s *RDBConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables.
 	return nil
 }
 
+// pricingUpsertBatchSize bounds rows per multi-row INSERT on the PostgreSQL
+// pricing-sync path, sized well under PostgreSQL's 65535 bind-parameter ceiling
+// (TableModelPricing has ~76 columns, so ~860 rows would hit the limit; 500
+// leaves comfortable headroom). Only PostgreSQL batches — see
+// UpsertModelPricesBatch.
+const pricingUpsertBatchSize = 500
+
+// UpsertModelPricesBatch creates or updates many model pricing records with the
+// same semantics as UpsertModelPrices (pricingSyncUpdateColumns only, so
+// additional_attributes editorial metadata survives the sync). Callers must
+// dedup by (model, provider, mode) first: a conflict target may not appear
+// twice in one statement.
+//
+// The whole write runs in one transaction so the sync stays atomic. PostgreSQL
+// uses chunked multi-row ON CONFLICT statements to cut the per-model round-trips
+// that motivated batching against a remote DB. SQLite cannot batch these rows: a
+// multi-row VALUES list rejects the DEFAULT keyword GORM emits for the table's
+// many default:null columns ("near \"DEFAULT\": syntax error"), and its
+// bind-variable ceiling is lower. SQLite is a local file, so per-row writes are
+// ~free — it loops within the same transaction instead.
+func (s *RDBConfigStore) UpsertModelPricesBatch(ctx context.Context, pricing []tables.TableModelPricing, tx ...*gorm.DB) error {
+	if len(pricing) == 0 {
+		return nil
+	}
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	db := txDB.WithContext(ctx)
+
+	onConflict := clause.OnConflict{
+		Columns:   []clause.Column{{Name: "model"}, {Name: "provider"}, {Name: "mode"}},
+		DoUpdates: clause.AssignmentColumns(pricingSyncUpdateColumns),
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if tx.Dialector.Name() == "postgres" {
+			if err := tx.Clauses(onConflict).CreateInBatches(pricing, pricingUpsertBatchSize).Error; err != nil {
+				return s.parseGormError(err)
+			}
+			return nil
+		}
+		for i := range pricing {
+			if err := tx.Clauses(onConflict).Create(&pricing[i]).Error; err != nil {
+				return s.parseGormError(err)
+			}
+		}
+		return nil
+	})
+}
+
 // UpsertModelPricingAttributes writes only the additional_attributes column
 // for the pricing row keyed by (model, provider). The row must already exist
 // — callers may not seed pricing rows through this path; the management API

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2167,3 +2167,47 @@ func TestDeletePromptSession(t *testing.T) {
 		assert.Len(t, versions, 2)
 	})
 }
+
+// TestUpsertModelPricesBatch_SQLite guards the pricing-sync write path on
+// SQLite. Batching these rows into a multi-row INSERT makes GORM emit the
+// DEFAULT keyword for the table's many default:null columns, which SQLite
+// rejects ("near \"DEFAULT\": syntax error"), so UpsertModelPricesBatch must
+// fall back to per-row writes on SQLite. The rows below intentionally leave
+// cost columns nil to exercise exactly that case.
+func TestUpsertModelPricesBatch_SQLite(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableModelPricing{}))
+
+	ctx := context.Background()
+	cost := func(f float64) *float64 { return &f }
+
+	pricing := []tables.TableModelPricing{
+		{Model: "google/gemini-2.5-flash", Provider: "vertex", Mode: "chat", InputCostPerToken: cost(0.000001)},
+		{Model: "openai/gpt-4o", Provider: "openai", Mode: "chat"}, // all costs nil
+		{Model: "anthropic/claude-3", Provider: "anthropic", Mode: "chat", OutputCostPerToken: cost(0.000015)},
+	}
+
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, pricing))
+
+	got, err := s.GetModelPrices(ctx)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+
+	// Re-upsert with a changed cost to exercise the ON CONFLICT update path.
+	pricing[1].InputCostPerToken = cost(0.000005)
+	require.NoError(t, s.UpsertModelPricesBatch(ctx, pricing))
+
+	got, err = s.GetModelPrices(ctx)
+	require.NoError(t, err)
+	assert.Len(t, got, 3) // upsert, not duplicate insert
+
+	var updated *tables.TableModelPricing
+	for i := range got {
+		if got[i].Model == "openai/gpt-4o" {
+			updated = &got[i]
+		}
+	}
+	require.NotNil(t, updated)
+	require.NotNil(t, updated.InputCostPerToken)
+	assert.InDelta(t, 0.000005, *updated.InputCostPerToken, 1e-9)
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -369,6 +369,7 @@ type ConfigStore interface {
 	// Model pricing CRUD
 	GetModelPrices(ctx context.Context) ([]tables.TableModelPricing, error)
 	UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error
+	UpsertModelPricesBatch(ctx context.Context, pricing []tables.TableModelPricing, tx ...*gorm.DB) error
 	DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) error
 
 	// UpsertModelPricingAttributes writes only the additional_attributes column

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -18,7 +18,7 @@ const (
 	DefaultURL                    = "https://getbifrost.ai/datasheet"
 	DefaultModelParametersURL     = "https://getbifrost.ai/datasheet/model-parameters"
 	DefaultSyncInterval           = 24 * time.Hour
-	DefaultPricingTimeout         = 45 * time.Second
+	DefaultPricingTimeout         = 60 * time.Second
 	DefaultModelParametersTimeout = 45 * time.Second
 )
 

--- a/framework/modelcatalog/datasheet/sync.go
+++ b/framework/modelcatalog/datasheet/sync.go
@@ -13,7 +13,6 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
-	"gorm.io/gorm"
 )
 
 const (
@@ -51,22 +50,21 @@ func (s *Store) SyncFromURL(ctx context.Context) error {
 	}
 
 	if s.configStore != nil {
-		err = s.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-			seen := make(map[string]struct{})
-			for modelKey, entry := range pricingData {
-				pricing := convertEntryToTablePricing(modelKey, entry)
-				key := makeKey(pricing.Model, pricing.Provider, pricing.Mode)
-				if _, ok := seen[key]; ok {
-					continue
-				}
-				seen[key] = struct{}{}
-				if err := s.configStore.UpsertModelPrices(ctx, &pricing, tx); err != nil {
-					return fmt.Errorf("failed to create pricing record for model %s: %w", pricing.Model, err)
-				}
+		// Dedup by (model, provider, mode) before the write: the batched upsert
+		// below issues multi-row ON CONFLICT statements, and PostgreSQL rejects a
+		// statement whose VALUES list hits the same conflict target twice.
+		records := make([]configstoreTables.TableModelPricing, 0, len(pricingData))
+		seen := make(map[string]struct{}, len(pricingData))
+		for modelKey, entry := range pricingData {
+			pricing := convertEntryToTablePricing(modelKey, entry)
+			key := makeKey(pricing.Model, pricing.Provider, pricing.Mode)
+			if _, ok := seen[key]; ok {
+				continue
 			}
-			return nil
-		})
-		if err != nil {
+			seen[key] = struct{}{}
+			records = append(records, pricing)
+		}
+		if err := s.configStore.UpsertModelPricesBatch(ctx, records); err != nil {
 			return fmt.Errorf("failed to sync pricing data to database: %w", err)
 		}
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -846,7 +846,7 @@ func (h *ConfigHandler) forceSyncPricing(ctx *fasthttp.RequestCtx) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
-		"message": "pricing sync triggered",
+		"message": "pricing synced successfully",
 	})
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1100,6 +1100,10 @@ func (m *MockConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables
 	return nil
 }
 
+func (m *MockConfigStore) UpsertModelPricesBatch(ctx context.Context, pricing []tables.TableModelPricing, tx ...*gorm.DB) error {
+	return nil
+}
+
 func (m *MockConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) error {
 	return nil
 }

--- a/ui/app/workspace/config/views/modelSettingsView.tsx
+++ b/ui/app/workspace/config/views/modelSettingsView.tsx
@@ -97,7 +97,7 @@ export default function ModelSettingsView() {
 	const handleForceSync = async () => {
 		try {
 			await forcePricingSync().unwrap();
-			toast.success("Pricing sync triggered successfully.");
+			toast.success("Pricing synced successfully.");
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -80,7 +80,7 @@ export default function PricingConfigView() {
 	const handleForceSync = async () => {
 		try {
 			await forcePricingSync().unwrap();
-			toast.success("Pricing sync triggered successfully.");
+			toast.success("Pricing synced successfully.");
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}


### PR DESCRIPTION
## Summary

Pricing sync performance was degraded by issuing one database round-trip per model during a sync. For catalogs with thousands of models, this created significant latency. This PR replaces the per-row upsert loop with a batched multi-row `ON CONFLICT` upsert, collapsing the sync into a handful of round-trips.

## Changes

- Added `UpsertModelPricesBatch` to `RDBConfigStore` and the `ConfigStore` interface, which uses GORM's `CreateInBatches` with a 500-row batch size and `ON CONFLICT (model, provider, mode) DO UPDATE` semantics matching the existing single-row upsert
- Deduplication by `(model, provider, mode)` is now performed before the write rather than inside the transaction loop, since PostgreSQL rejects multi-row `ON CONFLICT` statements that target the same conflict key twice in a single statement
- `SyncFromURL` now builds the deduplicated slice upfront and delegates to `UpsertModelPricesBatch` inside a single transaction instead of calling `UpsertModelPrices` in a loop
- Increased `DefaultPricingTimeout` from 45s to 60s to accommodate larger catalogs
- Updated the force-sync success message from "pricing sync triggered" to "pricing synced successfully" in the API response and both UI toast notifications to better reflect that the sync completes synchronously
- Added `UpsertModelPricesBatch` stub to `MockConfigStore` in tests

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...
```

Trigger a pricing sync via the force-sync endpoint or UI button and verify:
- The sync completes without error
- The success toast reads "Pricing synced successfully." rather than "Pricing sync triggered successfully."
- Database pricing rows are correctly created or updated after the sync

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No changes to auth, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable