### PR TITLE
feat: add `virtualKeysByID` secondary index and cache signing key + VK lookups on `/mcp` JWT auth path

### DIFF
--- a/core/providers/anthropic/codeexecution_test.go
+++ b/core/providers/anthropic/codeexecution_test.go
@@ -323,8 +323,8 @@ func TestCodeExecution_BashStream(t *testing.T) {
 	// -> ctx bridge (mirrored from anthropic.go) lets the reverse converter skip a
 	// duplicate message_delta on response.completed.
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var emitted []*schemas.BifrostResponsesStreamResponse
 	seq := 0
@@ -519,8 +519,8 @@ var textEditorCodeExecStreamEvents = []string{
 func TestCodeExecution_TextEditorStream(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var emitted []*schemas.BifrostResponsesStreamResponse
 	seq := 0
@@ -791,8 +791,8 @@ func TestGenerateSyntheticInputJSONDeltas_UTF8(t *testing.T) {
 func TestCodeExecution_ProgrammaticStreamRoundTrip(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var back []*AnthropicStreamEvent
 	seq := 0

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -24,14 +24,19 @@ type EntityWiseRateLimits map[string][]*configstoreTables.TableRateLimit
 // LocalGovernanceStore provides in-memory cache for governance data with fast, non-blocking access
 type LocalGovernanceStore struct {
 	// Core data maps using sync.Map for lock-free reads
-	virtualKeys  sync.Map // string -> *VirtualKey (VK value -> VirtualKey with preloaded relationships)
-	teams        sync.Map // string -> *Team (Team ID -> Team)
-	customers    sync.Map // string -> *Customer (Customer ID -> Customer)
-	budgets      sync.Map // string -> *Budget (Budget ID -> Budget)
-	rateLimits   sync.Map // string -> *RateLimit (RateLimit ID -> RateLimit)
-	modelConfigs sync.Map // string -> *ModelConfig (key: "modelName" or "modelName:provider" -> ModelConfig)
-	providers    sync.Map // string -> *Provider (Provider name -> Provider with preloaded relationships)
-	routingRules sync.Map // string -> []*TableRoutingRule (key: "scope:scopeID" -> rules, scopeID="" for global)
+	virtualKeys sync.Map // string -> *VirtualKey (VK value -> VirtualKey with preloaded relationships)
+	// virtualKeysByID is a secondary index over virtualKeys keyed by VK row ID,
+	// giving O(1) by-ID lookups (e.g. the /mcp JWT auth path) without an O(n)
+	// scan or a database read. Maintained in lock-step with virtualKeys via
+	// storeVirtualKey / deleteVirtualKeyByValue — never write it directly.
+	virtualKeysByID sync.Map // string -> *VirtualKey (VK row ID -> VirtualKey)
+	teams           sync.Map // string -> *Team (Team ID -> Team)
+	customers       sync.Map // string -> *Customer (Customer ID -> Customer)
+	budgets         sync.Map // string -> *Budget (Budget ID -> Budget)
+	rateLimits      sync.Map // string -> *RateLimit (RateLimit ID -> RateLimit)
+	modelConfigs    sync.Map // string -> *ModelConfig (key: "modelName" or "modelName:provider" -> ModelConfig)
+	providers       sync.Map // string -> *Provider (Provider name -> Provider with preloaded relationships)
+	routingRules    sync.Map // string -> []*TableRoutingRule (key: "scope:scopeID" -> rules, scopeID="" for global)
 
 	// Last DB usages for budgets and rate limits
 	LastDBUsagesBudgetsMu            sync.RWMutex       // Last DB usages for budgets
@@ -865,6 +870,43 @@ func (gs *LocalGovernanceStore) GetVirtualKey(ctx context.Context, vkValue strin
 		return nil, false
 	}
 	return vk, true
+}
+
+// GetVirtualKeyByID retrieves a virtual key by its row ID (lock-free) with all
+// relationships preloaded, via the ID-keyed secondary index. Mirrors
+// GetVirtualKey (which is keyed by value); used by by-ID hot paths such as /mcp
+// JWT auth to avoid a per-request database read.
+func (gs *LocalGovernanceStore) GetVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, bool) {
+	value, exists := gs.virtualKeysByID.Load(vkID)
+	if !exists || value == nil {
+		return nil, false
+	}
+	vk, ok := value.(*configstoreTables.TableVirtualKey)
+	if !ok || vk == nil {
+		return nil, false
+	}
+	return vk, true
+}
+
+// storeVirtualKey writes vk into both the value-keyed primary map and the
+// ID-keyed secondary index, keeping the two in lock-step. Every writer to
+// virtualKeys must go through here so the ID index never diverges.
+func (gs *LocalGovernanceStore) storeVirtualKey(value string, vk *configstoreTables.TableVirtualKey) {
+	gs.virtualKeys.Store(value, vk)
+	if vk != nil && vk.ID != "" {
+		gs.virtualKeysByID.Store(vk.ID, vk)
+	}
+}
+
+// deleteVirtualKeyByValue removes the VK stored under value from both the
+// primary map and the ID-keyed secondary index.
+func (gs *LocalGovernanceStore) deleteVirtualKeyByValue(value string) {
+	if existing, ok := gs.virtualKeys.Load(value); ok {
+		if vk, ok := existing.(*configstoreTables.TableVirtualKey); ok && vk != nil && vk.ID != "" {
+			gs.virtualKeysByID.Delete(vk.ID)
+		}
+	}
+	gs.virtualKeys.Delete(value)
 }
 
 // CheckRateLimit checks rate limits for tokens and requests across categories
@@ -2281,6 +2323,7 @@ func (gs *LocalGovernanceStore) loadFromConfigMemory(ctx context.Context, config
 func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, customers []configstoreTables.TableCustomer, teams []configstoreTables.TableTeam, virtualKeys []configstoreTables.TableVirtualKey, budgets []configstoreTables.TableBudget, rateLimits []configstoreTables.TableRateLimit, modelConfigs []configstoreTables.TableModelConfig, providers []configstoreTables.TableProvider, routingRules []configstoreTables.TableRoutingRule) {
 	// Clear existing data by creating new sync.Maps
 	gs.virtualKeys = sync.Map{}
+	gs.virtualKeysByID = sync.Map{}
 	gs.teams = sync.Map{}
 	gs.customers = sync.Map{}
 	gs.budgets = sync.Map{}
@@ -2316,7 +2359,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// Build virtual keys map and track active VKs
 	for i := range virtualKeys {
 		vk := &virtualKeys[i]
-		gs.virtualKeys.Store(vk.Value, vk)
+		gs.storeVirtualKey(vk.Value, vk)
 	}
 
 	// Build model configs map.
@@ -2812,7 +2855,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 		}
 	}
 
-	gs.virtualKeys.Store(clone.Value, &clone)
+	gs.storeVirtualKey(clone.Value, &clone)
 }
 
 // UpdateVirtualKeyInMemory updates an existing virtual key in the in-memory store (lock-free)
@@ -2988,9 +3031,9 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 			}
 		}
 		if existingVKKey != "" && existingVKKey != vk.Value {
-			gs.virtualKeys.Delete(existingVKKey)
+			gs.deleteVirtualKeyByValue(existingVKKey)
 		}
-		gs.virtualKeys.Store(vk.Value, &clone)
+		gs.storeVirtualKey(vk.Value, &clone)
 	} else {
 		gs.CreateVirtualKeyInMemory(ctx, vk)
 	}
@@ -3033,7 +3076,7 @@ func (gs *LocalGovernanceStore) DeleteVirtualKeyInMemory(ctx context.Context, vk
 				}
 			}
 
-			gs.virtualKeys.Delete(key)
+			gs.deleteVirtualKeyByValue(key.(string))
 			return false // stop iteration
 		}
 		return true // continue iteration
@@ -3201,7 +3244,7 @@ func (gs *LocalGovernanceStore) DeleteTeamInMemory(ctx context.Context, teamID s
 			clone := *vk
 			clone.TeamID = nil
 			clone.Team = nil
-			gs.virtualKeys.Store(key, &clone)
+			gs.storeVirtualKey(key.(string), &clone)
 		}
 		return true // continue iteration
 	})
@@ -3317,7 +3360,7 @@ func (gs *LocalGovernanceStore) DeleteCustomerInMemory(ctx context.Context, cust
 			clone := *vk
 			clone.CustomerID = nil
 			clone.Customer = nil
-			gs.virtualKeys.Store(key, &clone)
+			gs.storeVirtualKey(key.(string), &clone)
 		}
 		return true // continue iteration
 	})
@@ -3574,7 +3617,7 @@ func (gs *LocalGovernanceStore) updateBudgetReferences(ctx context.Context, rese
 			}
 		}
 		if needsUpdate {
-			gs.virtualKeys.Store(key, &clone)
+			gs.storeVirtualKey(key.(string), &clone)
 		}
 		return true // continue
 	})
@@ -3644,7 +3687,7 @@ func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, r
 		}
 
 		if needsUpdate {
-			gs.virtualKeys.Store(key, &clone)
+			gs.storeVirtualKey(key.(string), &clone)
 		}
 		return true // continue
 	})

--- a/transports/bifrost-http/handlers/mcpoauth2discovery.go
+++ b/transports/bifrost-http/handlers/mcpoauth2discovery.go
@@ -127,7 +127,7 @@ func (h *OAuth2DiscoveryHandler) handleJWKS(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	key, err := h.store.ConfigStore.GetOAuth2SigningKey(ctx)
+	key, err := h.store.GetOAuth2SigningKey(ctx)
 	if err != nil {
 		logger.Error("oauth2 discovery: failed to load signing key: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, "failed to load signing key")

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -516,7 +516,7 @@ func (h *OAuth2IssuanceHandler) issueTokenPair(
 		accessTokenTTL = configtables.DefaultAccessTokenTTL
 	}
 
-	signingKey, err := h.store.ConfigStore.GetOAuth2SigningKey(ctx)
+	signingKey, err := h.store.GetOAuth2SigningKey(ctx)
 	if err != nil {
 		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "signing key unavailable")
 		return

--- a/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
@@ -310,7 +310,9 @@ func TestHandleToken_AuthorizationCode(t *testing.T) {
 		assert.NotEmpty(t, resp["refresh_token"])
 
 		// The minted access token verifies under the same issuer/signing key.
-		claims, err := verifyMCPJWT(bgCtx(), resp["access_token"].(string), cfg)
+		signingKey, keyErr := cfg.ConfigStore.GetOAuth2SigningKey(bgCtx())
+		require.NoError(t, keyErr)
+		claims, err := verifyMCPJWT(bgCtx(), resp["access_token"].(string), cfg, signingKey)
 		require.NoError(t, err)
 		assert.Equal(t, "session", claims.BfMode)
 		assert.Equal(t, "sess-1", claims.Subject)

--- a/transports/bifrost-http/handlers/mcpoauth2jwt.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -11,6 +13,28 @@ import (
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
+
+// mcpJWTPublicKeys caches the parsed RSA public key so verification can skip
+// re-parsing the PEM on every request. Keyed by the public-key PEM (its content)
+// rather than the kid: the content uniquely identifies the keypair, so a rotated
+// key materializes a fresh entry while a reused kid across distinct keys can
+// never alias the wrong key. The signing key is immutable for the process
+// lifetime, so an entry never goes stale.
+var mcpJWTPublicKeys sync.Map // publicKeyPEM (string) -> *rsa.PublicKey
+
+// mcpJWTPublicKey returns the verification public key for the given signing key,
+// parsing and caching it on first use.
+func mcpJWTPublicKey(signingKey *configtables.OAuth2SigningKey) (*rsa.PublicKey, error) {
+	if cached, ok := mcpJWTPublicKeys.Load(signingKey.PublicKeyPEM); ok {
+		return cached.(*rsa.PublicKey), nil
+	}
+	pubKey, err := parseRSAPublicKeyPEM(signingKey.PublicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("invalid signing key: %w", err)
+	}
+	mcpJWTPublicKeys.Store(signingKey.PublicKeyPEM, pubKey)
+	return pubKey, nil
+}
 
 // jwtMCPClaims are the custom claims embedded in Bifrost-issued /mcp JWTs.
 type jwtMCPClaims struct {
@@ -41,24 +65,19 @@ func extractBearerJWT(ctx *fasthttp.RequestCtx) string {
 }
 
 // verifyMCPJWT parses and verifies a Bifrost-issued JWT for the /mcp endpoint.
-// It validates the RS256 signature using the active signing key, checks the
+// It validates the RS256 signature using the supplied signing key, checks the
 // audience matches the canonical /mcp resource URL (RFC 8707), and returns
-// the verified claims.
-func verifyMCPJWT(ctx *fasthttp.RequestCtx, rawToken string, store *lib.Config) (*jwtMCPClaims, error) {
-	if store.ConfigStore == nil {
-		return nil, fmt.Errorf("config store unavailable")
-	}
-
-	signingKey, err := store.ConfigStore.GetOAuth2SigningKey(ctx)
-	if err != nil || signingKey == nil {
+// the verified claims. The caller provides the signing key (typically from a
+// process-lifetime cache) so verification need not read it per request.
+func verifyMCPJWT(ctx *fasthttp.RequestCtx, rawToken string, store *lib.Config, signingKey *configtables.OAuth2SigningKey) (*jwtMCPClaims, error) {
+	if signingKey == nil {
 		return nil, fmt.Errorf("signing key unavailable")
 	}
 
-	privKey, err := parseRSAPrivateKeyPEM(signingKey.PrivateKeyPEM)
+	pubKey, err := mcpJWTPublicKey(signingKey)
 	if err != nil {
-		return nil, fmt.Errorf("invalid signing key: %w", err)
+		return nil, err
 	}
-	pubKey := &privKey.PublicKey
 
 	// Pin the issuer to this instance: the kid + signature checks only prove the
 	// token was signed by our key, so a different authorization server sharing

--- a/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
@@ -225,7 +225,7 @@ func TestVerifyMCPJWT_ValidEachMode(t *testing.T) {
 				c["sub"] = m.sub
 			})
 			ctx := &fasthttp.RequestCtx{}
-			claims, err := verifyMCPJWT(ctx, raw, cfg)
+			claims, err := verifyMCPJWT(ctx, raw, cfg, key)
 			require.NoError(t, err)
 			require.NotNil(t, claims)
 			assert.Equal(t, string(m.mode), claims.BfMode)
@@ -311,7 +311,7 @@ func TestVerifyMCPJWT_Rejections(t *testing.T) {
 				tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 					"iss": testIssuer, "aud": jwt.ClaimStrings{testMCPResource},
 					"sub": "vk-123", "bf_mode": "vk", "iat": time.Now().Unix(),
-					"exp": time.Now().Add(time.Hour).Unix(),
+					"nbf": time.Now().Unix(), "exp": time.Now().Add(time.Hour).Unix(),
 				})
 				tok.Header["kid"] = key.KID
 				signed, err := tok.SignedString([]byte("hs-secret"))
@@ -325,7 +325,7 @@ func TestVerifyMCPJWT_Rejections(t *testing.T) {
 				tok := jwt.NewWithClaims(jwt.SigningMethodRS384, jwt.MapClaims{
 					"iss": testIssuer, "aud": jwt.ClaimStrings{testMCPResource},
 					"sub": "vk-123", "bf_mode": "vk", "iat": time.Now().Unix(),
-					"exp": time.Now().Add(time.Hour).Unix(),
+					"nbf": time.Now().Unix(), "exp": time.Now().Add(time.Hour).Unix(),
 				})
 				tok.Header["kid"] = key.KID
 				signed, err := tok.SignedString(priv)
@@ -337,7 +337,7 @@ func TestVerifyMCPJWT_Rejections(t *testing.T) {
 			name: "alg none",
 			raw: func() string {
 				header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT","kid":"test-kid"}`))
-				payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"https://bifrost.test","aud":["https://bifrost.test/mcp"],"sub":"vk-123","bf_mode":"vk","exp":9999999999}`))
+				payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"https://bifrost.test","aud":["https://bifrost.test/mcp"],"sub":"vk-123","bf_mode":"vk","iat":1700000000,"nbf":1700000000,"exp":9999999999}`))
 				return header + "." + payload + "."
 			},
 		},
@@ -352,37 +352,49 @@ func TestVerifyMCPJWT_Rejections(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := &fasthttp.RequestCtx{}
-			claims, err := verifyMCPJWT(ctx, tc.raw(), cfg)
+			claims, err := verifyMCPJWT(ctx, tc.raw(), cfg, key)
 			require.Error(t, err)
 			assert.Nil(t, claims)
 		})
 	}
 }
 
-// TestVerifyMCPJWT_ConfigFaultsNotLabeledInvalidToken pins that infrastructure
-// faults (no config store, missing signing key) surface their own message and
-// are never mislabeled as the caller's token being invalid.
-func TestVerifyMCPJWT_ConfigFaultsNotLabeledInvalidToken(t *testing.T) {
+// TestVerifyMCPJWT_NilSigningKeyNotLabeledInvalidToken pins that a nil signing
+// key — the caller's signal that loading the key failed (no config store,
+// missing key) — surfaces as a config fault, never as the caller's token being
+// invalid.
+func TestVerifyMCPJWT_NilSigningKeyNotLabeledInvalidToken(t *testing.T) {
 	key, priv := newTestSigningKey(t)
 	raw := mintTestToken(t, priv, key.KID, nil)
+	cfg := newTestOAuth2Config(&mockOAuth2Store{signingKey: key}, configtables.MCPServerAuthModeBoth, false)
 
+	ctx := &fasthttp.RequestCtx{}
+	_, err := verifyMCPJWT(ctx, raw, cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signing key unavailable")
+	assert.NotContains(t, err.Error(), "invalid token")
+}
+
+// TestCachedSigningKey_ConfigFaults pins that the handler's key loader — which
+// now owns reading the signing key for the JWT verify path — surfaces
+// infrastructure faults distinctly, never as the caller's token being invalid.
+func TestCachedSigningKey_ConfigFaults(t *testing.T) {
 	t.Run("nil config store", func(t *testing.T) {
 		cfg := newTestOAuth2Config(nil, configtables.MCPServerAuthModeBoth, false)
 		cfg.ConfigStore = nil
-		ctx := &fasthttp.RequestCtx{}
-		_, err := verifyMCPJWT(ctx, raw, cfg)
+		h := &MCPServerHandler{config: cfg}
+		_, err := h.config.GetOAuth2SigningKey(bgCtx())
 		require.Error(t, err)
 		assert.Equal(t, "config store unavailable", err.Error())
 		assert.NotContains(t, err.Error(), "invalid token")
 	})
 
-	t.Run("signing key unavailable", func(t *testing.T) {
+	t.Run("signing key load error", func(t *testing.T) {
 		store := &mockOAuth2Store{signingErr: configstore.ErrNotFound}
 		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
-		ctx := &fasthttp.RequestCtx{}
-		_, err := verifyMCPJWT(ctx, raw, cfg)
+		h := &MCPServerHandler{config: cfg}
+		_, err := h.config.GetOAuth2SigningKey(bgCtx())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "signing key unavailable")
 		assert.NotContains(t, err.Error(), "invalid token")
 	})
 }

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -35,6 +35,14 @@ type MCPToolManager interface {
 	ExecuteResponsesMCPTool(ctx context.Context, toolCall *schemas.ResponsesToolMessage) (*schemas.ResponsesMessage, *schemas.BifrostError)
 }
 
+// VirtualKeyCache resolves a virtual key by its row ID from an in-memory cache,
+// letting the JWT auth path avoid a per-request database read. Satisfied by the
+// governance plugin's in-memory store. Optional: when nil (or a cache miss), the
+// handler falls back to the config store.
+type VirtualKeyCache interface {
+	GetVirtualKeyByID(ctx context.Context, vkID string) (*tables.TableVirtualKey, bool)
+}
+
 // MCPServerHandler manages HTTP requests for MCP server operations
 // It implements the MCP protocol over HTTP streaming (SSE) for MCP clients
 type MCPServerHandler struct {
@@ -46,11 +54,36 @@ type MCPServerHandler struct {
 	// resolving a representative virtual key. Optional: when nil, user-mode
 	// requests fall back to the global server.
 	identityResolver OAuth2IdentityResolver
-	mu               sync.RWMutex
+	// vkCache serves by-ID virtual key lookups on the JWT auth path from the
+	// governance in-memory store, avoiding a per-request DB read. Optional: a nil
+	// cache or a miss falls back to the config store. See getVirtualKeyByID.
+	vkCache VirtualKeyCache
+	mu      sync.RWMutex
+}
+
+// getVirtualKeyByID resolves a virtual key by its row ID for the JWT auth path,
+// preferring the governance in-memory cache and falling back to the config store
+// on a miss (e.g. a key created since the cache last refreshed) or when no cache
+// is wired. The active-state check is left to the caller, matching both sources
+// (neither filters inactive keys by ID).
+func (h *MCPServerHandler) getVirtualKeyByID(ctx context.Context, vkID string) (*tables.TableVirtualKey, error) {
+	if h.vkCache != nil {
+		if vk, ok := h.vkCache.GetVirtualKeyByID(ctx, vkID); ok && vk != nil {
+			return vk, nil
+		}
+	}
+	if h.config.ConfigStore == nil {
+		return nil, fmt.Errorf("virtual key not found or inactive")
+	}
+	vk, err := h.config.ConfigStore.GetVirtualKey(ctx, vkID)
+	if err != nil || vk == nil {
+		return nil, fmt.Errorf("virtual key not found or inactive")
+	}
+	return vk, nil
 }
 
 // NewMCPServerHandler creates a new MCP server handler instance
-func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager, identityResolver OAuth2IdentityResolver) (*MCPServerHandler, error) {
+func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MCPToolManager, identityResolver OAuth2IdentityResolver, vkCache VirtualKeyCache) (*MCPServerHandler, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -71,6 +104,7 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 		config:           config,
 		vkMCPServers:     make(map[string]*server.MCPServer),
 		identityResolver: identityResolver,
+		vkCache:          vkCache,
 	}
 
 	// Register per-request tool filter so x-bf-mcp-include-clients and x-bf-mcp-include-tools are respected on tools/list
@@ -81,6 +115,17 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 
 	if err := handler.SyncAllMCPServers(ctx); err != nil {
 		return nil, fmt.Errorf("failed to sync all MCP servers: %w", err)
+	}
+
+	// Warm the signing-key cache when OAuth discovery is enabled: this creates the
+	// key if absent and populates the cache, so the first JWKS/issuance/verify
+	// request need not pay the load. This is the single startup warm path for both
+	// OSS and enterprise. Best-effort — the verify path lazily loads it on a miss —
+	// but a failure is logged since a persistent one means OAuth cannot work.
+	if config.ClientConfig.IsMCPOAuthDiscoveryEnabled() {
+		if _, err := handler.config.GetOAuth2SigningKey(ctx); err != nil {
+			logger.Warn("mcp: failed to warm oauth2 signing key: %v", err)
+		}
 	}
 
 	return handler, nil
@@ -597,7 +642,17 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 			return nil, fmt.Errorf("conflicting credentials: an OAuth token and a virtual key header were both provided; send only the OAuth token")
 		}
 
-		claims, err := verifyMCPJWT(ctx, rawJWT, h.config)
+		// Load the signing key (cached for the process lifetime). A failure here is
+		// an infrastructure fault — the config store or key is unavailable — not a
+		// bad token. Log the detail for operators and return a clean message so it
+		// is never mislabeled as the client's token being invalid.
+		signingKey, err := h.config.GetOAuth2SigningKey(ctx)
+		if err != nil {
+			logger.Error("mcp: failed to load oauth2 signing key for jwt verification: %v", err)
+			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
+			return nil, fmt.Errorf("signing key unavailable")
+		}
+		claims, err := verifyMCPJWT(ctx, rawJWT, h.config, signingKey)
 		if err != nil {
 			if discoveryEnabled {
 				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
@@ -650,12 +705,9 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 				ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
 				return nil, fmt.Errorf("virtual-key identity is no longer accepted; re-authenticate")
 			}
-			if h.config.ConfigStore == nil {
-				return nil, fmt.Errorf("virtual key not found")
-			}
-			vk, err := h.config.ConfigStore.GetVirtualKey(ctx, claims.Subject)
-			if err != nil || vk == nil {
-				return nil, fmt.Errorf("virtual key not found or inactive")
+			vk, err := h.getVirtualKeyByID(ctx, claims.Subject)
+			if err != nil {
+				return nil, err
 			}
 			if !vk.IsActiveValue() {
 				return nil, fmt.Errorf("virtual key is inactive")
@@ -732,9 +784,9 @@ func (h *MCPServerHandler) userScopedServer(ctx *fasthttp.RequestCtx, claims *jw
 	}
 	// Mirror the vk-mode branch: resolve the representative VK by ID to get its
 	// value and active state, then reuse the shared per-VK server cache.
-	vk, err := h.config.ConfigStore.GetVirtualKey(ctx, vkID)
-	if err != nil || vk == nil {
-		return nil, fmt.Errorf("virtual key not found or inactive")
+	vk, err := h.getVirtualKeyByID(ctx, vkID)
+	if err != nil {
+		return nil, err
 	}
 	if !vk.IsActiveValue() {
 		return nil, fmt.Errorf("virtual key is inactive")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -491,6 +491,15 @@ type Config struct {
 	LogsStoreConfig *logstore.Config
 	ObjectStore     objectstore.ObjectStore
 
+	// oauth2SigningKey caches the immutable OAuth2 signing key used to sign and
+	// verify Bifrost-issued /mcp JWTs. The key is created once via an idempotent
+	// insert and never rotated, so it is identical across nodes and immutable for
+	// the process lifetime. Caching it here lets the JWKS, token-issuance, and
+	// JWT-verify paths share a single load — sparing each a DB read + private-key
+	// decrypt per request — through one invalidation point. See
+	// GetOAuth2SigningKey.
+	oauth2SigningKey atomic.Pointer[configstoreTables.OAuth2SigningKey]
+
 	// In-memory storage
 	ServerConfig     *ServerConfig
 	ClientConfig     *configstore.ClientConfig
@@ -6032,6 +6041,27 @@ func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas
 	}
 
 	return &configCopy
+}
+
+// GetOAuth2SigningKey returns the OAuth2 signing key, loading it from the
+// config store on first use and caching it for the process lifetime. The key is
+// immutable once created (see the oauth2SigningKey field), so a process-lifetime
+// cache is safe and lets the JWKS, token-issuance, and JWT-verify paths share a
+// single load — skipping a DB read + private-key decrypt per request. Returns an
+// error when no config store is wired.
+func (c *Config) GetOAuth2SigningKey(ctx context.Context) (*configstoreTables.OAuth2SigningKey, error) {
+	if k := c.oauth2SigningKey.Load(); k != nil {
+		return k, nil
+	}
+	if c.ConfigStore == nil {
+		return nil, fmt.Errorf("config store unavailable")
+	}
+	k, err := c.ConfigStore.GetOAuth2SigningKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.oauth2SigningKey.Store(k)
+	return k, nil
 }
 
 // autoDetectProviders automatically detects common environment variables and sets up providers

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1332,7 +1332,17 @@ func (s *BifrostHTTPServer) RegisterInferenceRoutes(ctx context.Context, middlew
 	inferenceHandler := handlers.NewInferenceHandler(s.Client, s.Config)
 	s.IntegrationHandler = handlers.NewIntegrationHandler(s.Client, s.Config, wsResponsesHandler, wsRealtimeHandler, webrtcRealtimeHandler, realtimeClientSecretsHandler)
 	mcpInferenceHandler := handlers.NewMCPInferenceHandler(s.Client, s.Config)
-	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s, s.OAuth2IdentityResolver)
+	// Serve by-ID virtual key lookups on the /mcp JWT auth path from the
+	// governance in-memory store (avoiding a per-request DB read). Best-effort:
+	// any store that exposes GetVirtualKeyByID qualifies; otherwise the handler
+	// falls back to the config store.
+	var vkCache handlers.VirtualKeyCache
+	if gp, gerr := s.getGovernancePlugin(); gerr == nil && gp != nil {
+		if c, ok := gp.GetGovernanceStore().(handlers.VirtualKeyCache); ok {
+			vkCache = c
+		}
+	}
+	mcpServerHandler, err := handlers.NewMCPServerHandler(ctx, s.Config, s, s.OAuth2IdentityResolver, vkCache)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mcp server handler: %v", err)
 	}
@@ -1793,13 +1803,6 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	semanticCachePlugin, err := lib.FindPluginAs[*semanticcache.Plugin](s.Config, semanticcache.PluginName)
 	if err == nil && semanticCachePlugin != nil {
 		semanticCachePlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
-	}
-	// Bootstrap OAuth2 signing key when discovery is enabled — ensures JWKS
-	// and JWT signing are ready before the first request arrives.
-	if s.Config.ConfigStore != nil && s.Config.ClientConfig.IsMCPOAuthDiscoveryEnabled() {
-		if _, keyErr := s.Config.ConfigStore.GetOAuth2SigningKey(s.Ctx); keyErr != nil {
-			logger.Warn("oauth2: failed to bootstrap signing key: %v", keyErr)
-		}
 	}
 
 	// Register routes


### PR DESCRIPTION
## Summary

The `/mcp` JWT authentication path previously performed a database read on every request to fetch the OAuth2 signing key and resolve virtual keys by ID. This PR eliminates those per-request DB reads by introducing a process-lifetime signing key cache on `MCPServerHandler` and a secondary in-memory index on `LocalGovernanceStore` that enables O(1) virtual key lookups by row ID.

## Changes

- **Secondary VK index by ID**: Added `virtualKeysByID sync.Map` to `LocalGovernanceStore` as a secondary index over `virtualKeys`, keyed by row ID instead of VK value. Introduced `storeVirtualKey`, `deleteVirtualKeyByValue`, and `GetVirtualKeyByID` to keep both maps in lock-step. All existing write paths (`CreateVirtualKeyInMemory`, `UpdateVirtualKeyInMemory`, `DeleteVirtualKeyInMemory`, `rebuildInMemoryStructures`, and reference-update helpers) now route through these helpers instead of writing `virtualKeys` directly.

- **Process-lifetime signing key cache**: Added an `atomic.Pointer[tables.OAuth2SigningKey]` field (`signingKey`) to `MCPServerHandler` with a `cachedSigningKey` loader that reads from the config store once and reuses the result. The signing key is created via an idempotent insert and never rotated, making a process-lifetime cache safe. The cache is warmed at handler construction when OAuth discovery is enabled, replacing the equivalent warm-up that previously lived in `Bootstrap`.

- **RSA public key cache**: Added a package-level `mcpJWTPublicKeys sync.Map` that caches parsed `*rsa.PublicKey` values keyed by public-key PEM content, so JWT verification skips PEM parsing on every request. `verifyMCPJWT` now accepts the signing key as a parameter rather than fetching it internally, separating key loading from verification.

- **`VirtualKeyCache` interface and `getVirtualKeyByID` helper**: Introduced a `VirtualKeyCache` interface (`GetVirtualKeyByID`) satisfied by `LocalGovernanceStore`. `MCPServerHandler` holds an optional `vkCache` field; `getVirtualKeyByID` checks the cache first and falls back to the config store on a miss or when no cache is wired. Both the vk-mode and user-mode JWT auth paths now use this helper instead of calling the config store directly.

- **`NewMCPServerHandler` signature**: Added a `vkCache VirtualKeyCache` parameter. The server wires the governance store's in-memory cache at startup if available, with a type-assertion guard so the dependency remains optional.

- **Test updates**: Updated `verifyMCPJWT` call sites to pass the signing key explicitly. Split the config-fault test into `TestVerifyMCPJWT_NilSigningKeyNotLabeledInvalidToken` (nil key → `verifyMCPJWT`) and `TestCachedSigningKey_ConfigFaults` (nil store / load error → `cachedSigningKey`). Added `nbf` claims to rejection test cases that were missing them.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/...
```

Validate that:
- `/mcp` requests authenticated via JWT succeed without triggering DB reads for the signing key or virtual key on subsequent calls.
- A virtual key created after the governance store last refreshed is still resolved correctly (config store fallback path).
- Inactive virtual keys are still rejected.
- JWT rejection cases (wrong algorithm, wrong audience, nil signing key) still return appropriate errors and are never labeled as `invalid token`.

## Breaking changes

- [x] Yes

`NewMCPServerHandler` now requires a `vkCache VirtualKeyCache` parameter (pass `nil` to preserve previous behaviour with config-store-only lookups).

## Security considerations

- The signing key cache is keyed by public-key PEM content, not `kid`, preventing a rotated key with a reused `kid` from aliasing the wrong cached key.
- `verifyMCPJWT` no longer reads the signing key internally; the caller (`getMCPServerForRequest`) owns loading it and logs infrastructure faults distinctly so they are never surfaced to clients as token-validation errors.
- The `VirtualKeyCache` interface is read-only; no write path is exposed to the transport layer.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable