### PR TITLE
feat: scope pre-authenticated user requests to their representative virtual key in headers/both auth modes

### DIFF
--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -630,6 +630,42 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 
 	discoveryEnabled := authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
 
+	// --- Pre-authenticated user path ---
+	// An upstream auth layer that authenticated the caller as a user stamps the
+	// user id onto the request context. In headers/both modes, scope the request
+	// to that user's virtual key — the same representative-VK scoping a user-mode
+	// token gets — so a user authenticated by a bearer token is treated like a
+	// virtual key. oauth-strict accepts only Bifrost-issued tokens and is excluded.
+	if h.identityResolver != nil &&
+		(authMode == tables.MCPServerAuthModeHeaders || authMode == tables.MCPServerAuthModeBoth) {
+		if userID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string); userID != "" {
+			// The user identity is the sole credential; reject a stray virtual key
+			// header so it is not also attributed to the request.
+			if headerVK := getVKFromRequest(ctx); headerVK != "" {
+				return nil, fmt.Errorf("conflicting credentials: a user token and a virtual key header were both provided; send only one")
+			}
+			vkID, err := h.identityResolver.ResolveUserVirtualKey(ctx, userID)
+			if err != nil {
+				return nil, err
+			}
+			if vkID == "" {
+				return nil, fmt.Errorf("no MCP access grant for the authenticated user")
+			}
+			vk, err := h.getVirtualKeyByID(ctx, vkID)
+			if err != nil {
+				return nil, err
+			}
+			if !vk.IsActiveValue() {
+				return nil, fmt.Errorf("virtual key is inactive")
+			}
+			vkServer, err := h.ensureVKMCPServerByValue(ctx, vk.Value)
+			if err != nil {
+				return nil, err
+			}
+			return &mcpAuthResult{mcpServer: vkServer}, nil
+		}
+	}
+
 	// --- JWT path ---
 	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {
 		// An OAuth token is the sole identity for the request. Reject when a

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -267,6 +267,124 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 	})
 }
 
+// TestGetMCPServerForRequest_PreAuthenticatedUserPath covers the path where an
+// upstream auth layer has already authenticated the caller as a user and stamped
+// the user id onto the request context (BifrostContextKeyUserID). In headers/both
+// modes the request is scoped to the user's representative virtual key, just like
+// a user-mode token; oauth-strict ignores it (Bifrost-issued tokens only).
+func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
+	SetLogger(&mockLogger{})
+	key, _ := newTestSigningKey(t)
+
+	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-user-rep", IsActive: new(true)}
+	newStore := func() *mockOAuth2Store {
+		return &mockOAuth2Store{
+			signingKey: key,
+			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
+		}
+	}
+
+	for _, mode := range []configtables.MCPServerAuthMode{
+		configtables.MCPServerAuthModeHeaders,
+		configtables.MCPServerAuthModeBoth,
+	} {
+		t.Run(string(mode)+" mode: stamped user id is scoped to the user's virtual key", func(t *testing.T) {
+			cfg := newTestOAuth2Config(newStore(), mode, true)
+			h := newTestMCPHandler(cfg)
+			h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
+			vkServer := server.NewMCPServer("vk", "v0")
+			h.vkMCPServers[activeVK.Value] = vkServer
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+
+			res, err := h.getMCPServerForRequest(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			// Served the user's scoped VK server, NOT the global (unscoped) one.
+			assert.Equal(t, vkServer, res.mcpServer)
+			assert.NotEqual(t, h.globalMCPServer, res.mcpServer)
+			// Identity stays the user; no VK identity or JWT claims are attributed.
+			assert.Nil(t, res.jwtVK)
+			assert.Nil(t, res.jwtClaims)
+		})
+	}
+
+	t.Run("user with no virtual key is rejected (strict VK parity)", func(t *testing.T) {
+		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeBoth, true)
+		h := newTestMCPHandler(cfg)
+		h.identityResolver = &fakeResolver{userVKID: ""} // no AP-managed VK
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		_, err := h.getMCPServerForRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no MCP access grant")
+	})
+
+	t.Run("stamped user id with a header VK is rejected as conflicting", func(t *testing.T) {
+		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeBoth, true)
+		h := newTestMCPHandler(cfg)
+		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
+		h.vkMCPServers[activeVK.Value] = server.NewMCPServer("vk", "v0")
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-header")
+
+		_, err := h.getMCPServerForRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflicting credentials")
+	})
+
+	t.Run("inactive representative virtual key is rejected", func(t *testing.T) {
+		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-x", IsActive: new(false)}
+		store := &mockOAuth2Store{
+			signingKey: key,
+			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK},
+		}
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true)
+		h := newTestMCPHandler(cfg)
+		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		_, err := h.getMCPServerForRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "inactive")
+	})
+
+	t.Run("oauth-strict mode ignores the stamped user id", func(t *testing.T) {
+		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeOAuth, true)
+		h := newTestMCPHandler(cfg)
+		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		// No bearer JWT, and header credentials are rejected in oauth-strict: the
+		// user-id check does not run, so this falls through to the strict rejection.
+		_, err := h.getMCPServerForRequest(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OAuth JWT")
+	})
+
+	t.Run("no resolver: stamped user id is ignored", func(t *testing.T) {
+		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeHeaders, false)
+		h := newTestMCPHandler(cfg)
+		// identityResolver is nil (pure OSS, no IdP); enforce=false → anonymous.
+
+		ctx := &fasthttp.RequestCtx{}
+		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		res, err := h.getMCPServerForRequest(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, h.globalMCPServer, res.mcpServer)
+	})
+}
+
 // TestGetMCPServerForRequest_HeaderAndAnonPath covers the legacy header-VK path,
 // anonymous access, and oauth-strict header rejection.
 func TestGetMCPServerForRequest_HeaderAndAnonPath(t *testing.T) {


### PR DESCRIPTION
## Summary

When an upstream auth layer (e.g. an IdP proxy or middleware) has already authenticated a caller as a user and stamped their user ID onto the request context via `BifrostContextKeyUserID`, the MCP server handler previously had no way to act on that identity. This PR adds a pre-authenticated user path that resolves the stamped user ID to their representative virtual key and scopes the request accordingly — giving pre-authenticated users the same access as a user-mode OAuth token, without requiring a Bifrost-issued JWT.

## Changes

- Added a pre-authenticated user path in `getMCPServerForRequest` that runs before the JWT path. When `identityResolver` is set and the auth mode is `headers` or `both`, a stamped `BifrostContextKeyUserID` is resolved to the user's virtual key via `ResolveUserVirtualKey`. The request is then scoped to that VK's MCP server, matching the behavior of a user-mode token.
- Conflicting credentials (a stamped user ID alongside a virtual key header) are explicitly rejected to prevent ambiguous attribution.
- Inactive representative virtual keys are rejected.
- `oauth-strict` mode (`MCPServerAuthModeOAuth`) intentionally ignores the stamped user ID, as that mode accepts only Bifrost-issued tokens.
- When `identityResolver` is `nil` (OSS deployments without an IdP), the stamped user ID is silently ignored and the request falls through to the normal anonymous/header path.
- Added comprehensive tests covering all branches: `headers` and `both` modes resolving correctly, missing VK grants, conflicting credentials, inactive VKs, `oauth-strict` bypass, and nil resolver fallthrough.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestGetMCPServerForRequest_PreAuthenticatedUserPath -v
go test ./transports/bifrost-http/handlers/...
```

Expected: all pre-authenticated user path tests pass, and no regressions in existing JWT or header/anon path tests.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- A request carrying both a stamped user ID and a virtual key header is rejected outright to prevent credential confusion attacks.
- The pre-authenticated path is only active when `identityResolver` is non-nil, meaning it requires an explicit integration with an upstream IdP layer; it cannot be triggered in vanilla OSS deployments.
- `oauth-strict` mode is unaffected, preserving its guarantee that only Bifrost-issued tokens are accepted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable