### PR TITLE
fix: cost for image generation or image edit streaming

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -3322,7 +3322,6 @@ func HandleOpenAIImageGenerationStreaming(
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
 		lastChunkTime := startTime
-		var collectedUsage *schemas.ImageUsage
 		// Track chunk indices per image - similar to how speech/transcription track chunkIndex
 		imageChunkIndices := make(map[int]int) // image index -> chunk index
 		// Track images that have started (via partial chunks) but not yet completed
@@ -3391,15 +3390,6 @@ func HandleOpenAIImageGenerationStreaming(
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
 				return
-			}
-
-			// Collect usage from completed event
-			if response.Usage != nil {
-				collectedUsage = &schemas.ImageUsage{
-					InputTokens:  response.Usage.InputTokens,
-					OutputTokens: response.Usage.OutputTokens,
-					TotalTokens:  response.Usage.TotalTokens,
-				}
 			}
 
 			// Determine if this is the final chunk
@@ -3508,16 +3498,15 @@ func HandleOpenAIImageGenerationStreaming(
 			}
 
 			if isCompleted {
-				if collectedUsage != nil {
-					// Set NImages based on maximum image index seen (maxImageIndex + 1 since indices are 0-based)
-					if maxImageIndex >= 0 {
-						nImages := maxImageIndex + 1
-						collectedUsage.OutputTokensDetails = &schemas.ImageTokenDetails{
-							NImages: nImages,
-						}
+				if response.Usage != nil && maxImageIndex >= 0 {
+					if response.Usage.OutputTokensDetails == nil {
+						response.Usage.OutputTokensDetails = &schemas.ImageTokenDetails{}
 					}
-					chunk.Usage = collectedUsage
+					if response.Usage.OutputTokensDetails.NImages == 0 {
+						response.Usage.OutputTokensDetails.NImages = maxImageIndex + 1
+					}
 				}
+				chunk.Usage = response.Usage
 				// For completed chunk, use total latency from start
 				chunk.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 				chunk.BackfillParams(&schemas.BifrostRequest{
@@ -4683,7 +4672,6 @@ func HandleOpenAIImageEditStreamRequest(
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
 		lastChunkTime := startTime
-		var collectedUsage *schemas.ImageUsage
 		// Track chunk indices per image - similar to how speech/transcription track chunkIndex
 		imageChunkIndices := make(map[int]int) // image index -> chunk index
 		// Track images that have started (via partial chunks) but not yet completed
@@ -4753,15 +4741,6 @@ func HandleOpenAIImageEditStreamRequest(
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
 				return
-			}
-
-			// Collect usage from completed event
-			if response.Usage != nil {
-				collectedUsage = &schemas.ImageUsage{
-					InputTokens:  response.Usage.InputTokens,
-					OutputTokens: response.Usage.OutputTokens,
-					TotalTokens:  response.Usage.TotalTokens,
-				}
 			}
 
 			// Determine if this is the final chunk
@@ -4870,16 +4849,15 @@ func HandleOpenAIImageEditStreamRequest(
 			}
 
 			if isCompleted {
-				if collectedUsage != nil {
-					// Set NImages based on maximum image index seen (maxImageIndex + 1 since indices are 0-based)
-					if maxImageIndex >= 0 {
-						nImages := maxImageIndex + 1
-						collectedUsage.OutputTokensDetails = &schemas.ImageTokenDetails{
-							NImages: nImages,
-						}
+				if response.Usage != nil && maxImageIndex >= 0 {
+					if response.Usage.OutputTokensDetails == nil {
+						response.Usage.OutputTokensDetails = &schemas.ImageTokenDetails{}
 					}
-					chunk.Usage = collectedUsage
+					if response.Usage.OutputTokensDetails.NImages == 0 {
+						response.Usage.OutputTokensDetails.NImages = maxImageIndex + 1
+					}
 				}
+				chunk.Usage = response.Usage
 				// For completed chunk, use total latency from start
 				chunk.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 				chunk.BackfillParams(&schemas.BifrostRequest{

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -60,7 +60,7 @@ type BifrostImageGenerationResponse struct {
 	*ImageGenerationResponseParameters
 
 	Usage       *ImageUsage                `json:"usage,omitempty"`
-	ExtraFields BifrostResponseExtraFields `json:"extra_fields,omitempty"`
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }
 
 // BackfillParams populates response fields from the original request that are needed
@@ -119,22 +119,6 @@ func (r *BifrostImageGenerationResponse) BackfillParams(req *BifrostRequest) {
 		}
 		r.ImageGenerationResponseParameters.AspectRatio = aspectRatio
 	}
-}
-
-// getModelFromRequest extracts the model from any image-related request.
-func getModelFromRequest(req *BifrostRequest) string {
-	if req == nil {
-		return ""
-	}
-	switch {
-	case req.ImageGenerationRequest != nil:
-		return req.ImageGenerationRequest.Model
-	case req.ImageEditRequest != nil:
-		return req.ImageEditRequest.Model
-	case req.ImageVariationRequest != nil:
-		return req.ImageVariationRequest.Model
-	}
-	return ""
 }
 
 // getNumInputImagesSizeQualityAndAspectRatioFromRequest extracts request params for cost
@@ -218,7 +202,7 @@ type ImageUsage struct {
 	TotalTokens         int                `json:"total_tokens,omitempty"`
 	OutputTokens        int                `json:"output_tokens,omitempty"` // Always image tokens unless OutputTokensDetails is not nil
 	OutputTokensDetails *ImageTokenDetails `json:"output_tokens_details,omitempty"`
-	NumInputImages      int                `json:"num_input_images,omitempty"` // Number of input images from the request (populated by Bifrost)
+	NumInputImages      int                `json:"-"` // Number of input images from the request (populated by Bifrost)
 }
 
 type ImageTokenDetails struct {
@@ -267,7 +251,7 @@ type BifrostImageGenerationStreamResponse struct {
 	Error             *BifrostError              `json:"error,omitempty"`
 	RawRequest        string                     `json:"-"`
 	RawResponse       string                     `json:"-"`
-	ExtraFields       BifrostResponseExtraFields `json:"extra_fields,omitempty"`
+	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
 }
 
 // BackfillParams populates response fields from the original request that are needed


### PR DESCRIPTION
## Summary

Eliminates the intermediate `collectedUsage` variable in image generation and image edit streaming handlers, instead using `response.Usage` directly on the completed event. Also preserves any `OutputTokensDetails` already present in the response rather than unconditionally overwriting it, and hides `NumInputImages` from JSON serialization.

## Changes

- Removed the `collectedUsage` accumulator variable from both `HandleOpenAIImageGenerationStreaming` and `HandleOpenAIImageEditStreamRequest`. Usage data is now read directly from `response.Usage` when the completed event is received, avoiding an unnecessary copy.
- Updated the `NImages` backfill logic to only initialize `OutputTokensDetails` if it is `nil`, and only set `NImages` if it is not already populated — preserving any details the provider may have already returned.
- Changed `NumInputImages` in `ImageUsage` to use `json:"-"` so it is no longer included in serialized responses (it is an internal Bifrost field).
- Changed `ExtraFields` in `BifrostImageGenerationResponse` and `BifrostImageGenerationStreamResponse` to always serialize (`json:"extra_fields"` instead of `json:"extra_fields,omitempty"`).
- Removed the unused `getModelFromRequest` helper function from `schemas/images.go`.  
  
Closes #4777

## Type of change

- [x] Refactor
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./...
```

Trigger a streaming image generation and image edit request and verify that:

- Usage fields are correctly populated on the completed chunk.
- `NImages` reflects the number of images generated.
- `num_input_images` no longer appears in the JSON response.
- `extra_fields` is always present in the response body.

## Breaking changes

- [x]  No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable