### PR TITLE
chore: test fixes

### DIFF
--- a/core/providers/anthropic/codeexecution_test.go
+++ b/core/providers/anthropic/codeexecution_test.go
@@ -323,8 +323,8 @@ func TestCodeExecution_BashStream(t *testing.T) {
 	// -> ctx bridge (mirrored from anthropic.go) lets the reverse converter skip a
 	// duplicate message_delta on response.completed.
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var emitted []*schemas.BifrostResponsesStreamResponse
 	seq := 0
@@ -519,8 +519,8 @@ var textEditorCodeExecStreamEvents = []string{
 func TestCodeExecution_TextEditorStream(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var emitted []*schemas.BifrostResponsesStreamResponse
 	seq := 0
@@ -791,8 +791,8 @@ func TestGenerateSyntheticInputJSONDeltas_UTF8(t *testing.T) {
 func TestCodeExecution_ProgrammaticStreamRoundTrip(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
-	state := acquireAnthropicResponsesStreamState()
-	defer releaseAnthropicResponsesStreamState(state)
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
 
 	var back []*AnthropicStreamEvent
 	seq := 0


### PR DESCRIPTION
## Summary

Exports the `acquireAnthropicResponsesStreamState` and `releaseAnthropicResponsesStreamState` functions by renaming them to `AcquireAnthropicResponsesStreamState` and `ReleaseAnthropicResponsesStreamState`, making them accessible from test files and external packages.

## Changes

- Renamed `acquireAnthropicResponsesStreamState` → `AcquireAnthropicResponsesStreamState` and `releaseAnthropicResponsesStreamState` → `ReleaseAnthropicResponsesStreamState` to export these functions, allowing test code to reference them directly without relying on unexported identifiers.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
```

All existing tests for `TestCodeExecution_BashStream`, `TestCodeExecution_TextEditorStream`, and `TestCodeExecution_ProgrammaticStreamRoundTrip` should continue to pass without modification.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. This change only affects the visibility of internal pool management functions used in tests.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable