### PR TITLE
feat: revoke VK-mode OAuth2 grants on VK deletion and add user-liveness checks at refresh and request time

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3392,6 +3392,16 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
 			return err
 		}
+		// Revoke gateway-issued OAuth2 grants bound to this VK (vk-mode tokens are
+		// keyed by vk_id in bf_sub). They are revoked rather than deleted so they
+		// stop minting access tokens on refresh and drop off the active-grants
+		// view, while remaining available for reuse detection until the sweep.
+		now := time.Now()
+		if err := txDB.WithContext(ctx).Model(&tables.TableOAuth2RefreshToken{}).
+			Where("bf_mode = ? AND bf_sub = ? AND revoked_at IS NULL", string(schemas.MCPAuthModeVK), id).
+			Update("revoked_at", &now).Error; err != nil {
+			return err
+		}
 		// Delete per-user MCP header credentials tied to this VK
 		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableMCPPerUserHeaderCredential{}).Error; err != nil {
 			return err

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -55,6 +55,7 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TableOauthUserToken{},
 		&tables.TableMCPPerUserHeaderCredential{},
 		&tables.TableMCPPerUserHeaderFlow{},
+		&tables.TableOAuth2RefreshToken{},
 	)
 	require.NoError(t, err, "Failed to migrate test database")
 
@@ -985,6 +986,40 @@ func TestDeleteVirtualKey(t *testing.T) {
 
 	_, err = store.GetVirtualKey(ctx, "vk-delete")
 	assert.Error(t, err, "Should not find deleted virtual key")
+}
+
+func TestDeleteVirtualKey_RevokesInboundVKGrants(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	vk := &tables.TableVirtualKey{
+		ID:       "vk-grant",
+		Name:     "Grant VK",
+		Value:    "vk-grant-value",
+		IsActive: schemas.Ptr(true),
+	}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	// An active vk-mode inbound grant bound to this VK (vk-mode rows key bf_sub
+	// to the VK id).
+	rt := &tables.TableOAuth2RefreshToken{
+		ID:        "rt-vk-grant",
+		TokenHash: "hash-vk-grant",
+		FamilyID:  "fam-vk-grant",
+		ClientID:  "client-1",
+		BfMode:    string(schemas.MCPAuthModeVK),
+		BfSub:     vk.ID,
+		Scope:     "mcp",
+		Resource:  "https://example.test/mcp",
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(rt).Error)
+
+	require.NoError(t, store.DeleteVirtualKey(ctx, vk.ID))
+
+	var got tables.TableOAuth2RefreshToken
+	require.NoError(t, store.DB().WithContext(ctx).First(&got, "id = ?", "rt-vk-grant").Error)
+	assert.NotNil(t, got.RevokedAt, "vk-mode grant should be revoked when its VK is deleted")
 }
 
 func TestDeleteVirtualKey_CleansUpScopedModelConfigs(t *testing.T) {

--- a/transports/bifrost-http/handlers/mcpoauth2consent.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent.go
@@ -41,6 +41,13 @@ type OAuth2IdentityResolver interface {
 	// carry no virtual key of their own. When a user maps to several equivalent
 	// virtual keys, any one of them may be returned.
 	ResolveUserVirtualKey(ctx context.Context, userID string) (vkID string, err error)
+	// IsUserActive reports whether the given user identity still exists and is
+	// usable. Returns (false, nil) when the user is gone or deactivated; an
+	// error is reserved for transient lookup failures that should be retried.
+	// Used to cut off a deleted user's grant at request and refresh time rather
+	// than waiting for the access token to expire, mirroring the virtual-key
+	// liveness check.
+	IsUserActive(ctx context.Context, userID string) (active bool, err error)
 }
 
 // OAuth2ConsentHandler serves the two consent flow APIs:

--- a/transports/bifrost-http/handlers/mcpoauth2consent_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent_test.go
@@ -22,6 +22,8 @@ type fakeResolver struct {
 	vkBindErr         error
 	userVKID          string
 	userVKErr         error
+	userInactive      bool // when true, IsUserActive reports the user as gone
+	userActiveErr     error
 }
 
 func (f *fakeResolver) IsUserModeAvailable() bool { return f.userModeAvailable }
@@ -33,6 +35,9 @@ func (f *fakeResolver) ResolveVKUserUpgrade(_ context.Context, _ string) (string
 }
 func (f *fakeResolver) ResolveUserVirtualKey(_ context.Context, _ string) (string, error) {
 	return f.userVKID, f.userVKErr
+}
+func (f *fakeResolver) IsUserActive(_ context.Context, _ string) (bool, error) {
+	return !f.userInactive, f.userActiveErr
 }
 
 func newConsentStore() *mockOAuth2Store {

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -458,6 +458,24 @@ func (h *OAuth2IssuanceHandler) handleTokenRefresh(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	// bf_sub liveness check: for user-mode tokens, verify the user still exists
+	// and is active, mirroring the VK-mode check above. A deleted or deactivated
+	// user should not be able to silently obtain new access tokens via refresh.
+	// The user is verified against the same in-memory source used on the /mcp
+	// request path. A transient lookup failure stays retriable (server_error) —
+	// only a gone/deactivated user invalidates the grant.
+	if schemas.MCPAuthMode(rt.BfMode) == schemas.MCPAuthModeUser && h.identityResolver != nil {
+		active, err := h.identityResolver.IsUserActive(ctx, rt.BfSub)
+		if err != nil {
+			sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "failed to verify user")
+			return
+		}
+		if !active {
+			sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "user is no longer active")
+			return
+		}
+	}
+
 	// RFC 8707: resource (audience URI) is distinct from scope. When the client
 	// omits it on refresh, carry forward the original resource captured at
 	// authorization — never substitute the scope string. When the client does

--- a/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
@@ -569,3 +569,52 @@ func TestHandleToken_RefreshVKIdentityDisabled(t *testing.T) {
 		assert.Contains(t, body, "no longer active")
 	})
 }
+
+func TestHandleToken_RefreshUserLiveness(t *testing.T) {
+	seedUserRefresh := func(t *testing.T, store configstore.ConfigStore, plain string) {
+		t.Helper()
+		seedConsentedRequest(t, store, "fam-user", "client-1", "auth-code-user", pkceChallenge("v"), "user", "user-1", time.Now().Add(time.Minute))
+		rt := &configtables.TableOAuth2RefreshToken{
+			ID: "rt-user", TokenHash: hashSHA256Hex(plain), FamilyID: "fam-user", ClientID: "client-1",
+			BfMode: "user", BfSub: "user-1", Scope: "mcp", Resource: testMCPResource, CreatedAt: time.Now(),
+		}
+		require.NoError(t, store.ConsumeOAuth2AuthorizeRequest(context.Background(), "fam-user", rt))
+	}
+
+	refreshReq := func() *fasthttp.RequestCtx {
+		return formPostCtx(url.Values{
+			"grant_type": {"refresh_token"}, "refresh_token": {"refresh-user-1"}, "client_id": {"client-1"},
+		}.Encode())
+	}
+
+	t.Run("user refresh rejected when the user is no longer active", func(t *testing.T) {
+		store := newRealOAuth2Store(t)
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
+		// Resolver reports the user as gone: refresh must be denied rather than
+		// minting a new access token, mirroring the VK-mode liveness check.
+		h := NewOAuth2IssuanceHandler(cfg, nil, &fakeResolver{userModeAvailable: true, userInactive: true})
+		seedClient(t, store, []string{"http://127.0.0.1/cb"})
+		seedUserRefresh(t, store, "refresh-user-1")
+
+		ctx := refreshReq()
+		h.handleToken(ctx)
+		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+		body := string(ctx.Response.Body())
+		assert.Contains(t, body, "invalid_grant")
+		assert.Contains(t, body, "user is no longer active")
+	})
+
+	t.Run("user refresh succeeds when the user is active", func(t *testing.T) {
+		store := newRealOAuth2Store(t)
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
+		// Active user (default resolver) must pass the liveness check and rotate.
+		h := NewOAuth2IssuanceHandler(cfg, nil, &fakeResolver{userModeAvailable: true})
+		seedClient(t, store, []string{"http://127.0.0.1/cb"})
+		seedUserRefresh(t, store, "refresh-user-1")
+
+		ctx := refreshReq()
+		h.handleToken(ctx)
+		require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode(), string(ctx.Response.Body()))
+		assert.NotContains(t, string(ctx.Response.Body()), "user is no longer active")
+	})
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -811,6 +811,15 @@ func (h *MCPServerHandler) userScopedServer(ctx *fasthttp.RequestCtx, claims *jw
 	if schemas.MCPAuthMode(claims.BfMode) != schemas.MCPAuthModeUser {
 		return nil, nil
 	}
+	// Reject deleted or deactivated users at request time, mirroring the vk-mode
+	// IsActiveValue() cutoff, rather than letting an already-issued access token
+	// keep working until it expires. Placed before the no-virtual-key early
+	// return below so a removed user cannot fall through to the global server.
+	if active, err := h.identityResolver.IsUserActive(ctx, claims.Subject); err != nil {
+		return nil, fmt.Errorf("failed to verify user: %w", err)
+	} else if !active {
+		return nil, fmt.Errorf("user is no longer active")
+	}
 	vkID, err := h.identityResolver.ResolveUserVirtualKey(ctx, claims.Subject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve virtual key for user: %w", err)

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -145,6 +145,30 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 		assert.Nil(t, res.jwtVK)
 	})
 
+	t.Run("user JWT is rejected when the user is no longer active", func(t *testing.T) {
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-user-rep", IsActive: new(true)}
+		store := &mockOAuth2Store{
+			signingKey: key,
+			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
+		}
+		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)
+		h := newTestMCPHandler(cfg)
+		// The resolver still maps the user to a VK, but reports the user as gone.
+		// The request must be rejected at request time rather than falling through
+		// to the global (unscoped) server until the access token expires.
+		h.identityResolver = &fakeResolver{userVKID: "vk-row-1", userInactive: true}
+
+		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
+			c["bf_mode"] = string(schemas.MCPAuthModeUser)
+			c["sub"] = "user-1"
+		})
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.Header.Set("Authorization", "Bearer "+raw)
+
+		_, err := h.getMCPServerForRequest(ctx)
+		require.Error(t, err)
+	})
+
 	t.Run("user JWT falls back to the global server when the user has no virtual key", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
 		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, false)


### PR DESCRIPTION
## Summary

When a user identity is deleted or deactivated, their gateway-issued OAuth2 grants and active MCP requests should be cut off immediately rather than continuing to work until the access token naturally expires. This PR adds a user liveness check (`IsUserActive`) that mirrors the existing virtual-key liveness check, enforcing it at both request time and token refresh time.

## Changes

- Added `IsUserActive` to the `OAuth2IdentityResolver` interface, returning `(false, nil)` for a gone/deactivated user and reserving errors for transient failures.
- Added a user liveness check in `userScopedServer` on the MCP request path — a deleted user is rejected before any virtual key resolution, preventing fallthrough to the global server until the access token expires.
- Added a user liveness check in `handleTokenRefresh` — a deleted or deactivated user receives `invalid_grant` on refresh rather than silently receiving a new access token.
- When a virtual key is deleted, any gateway-issued OAuth2 refresh tokens in `vk` mode bound to that VK are now revoked (setting `revoked_at`) rather than deleted, so they stop minting access tokens on refresh and fall off the active-grants view while remaining available for reuse detection until the sweep.
- Migrated `TableOAuth2RefreshToken` in the test setup and added tests covering VK deletion grant revocation, user-inactive refresh rejection, active-user refresh success, and user-inactive MCP request rejection.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/handlers/...
```

Key scenarios to verify:
- Deleting a virtual key sets `revoked_at` on any associated `vk`-mode refresh tokens rather than leaving them active.
- A refresh request for a `user`-mode token where `IsUserActive` returns `false` receives a `400 invalid_grant` response with `"user is no longer active"`.
- A refresh request for a `user`-mode token where the user is active completes successfully with a `200` and a rotated token.
- An MCP request bearing a `user`-mode JWT where `IsUserActive` returns `false` is rejected with an error rather than falling through to the global server.

## Breaking changes

- [x] Yes
- [ ] No

Any implementation of the `OAuth2IdentityResolver` interface must now implement the `IsUserActive(ctx context.Context, userID string) (bool, error)` method.

## Security considerations

This closes a window where a deleted or deactivated user could continue to access MCP resources and silently rotate refresh tokens until their access token expired. The fix ensures revocation is enforced at both the request and refresh layers, consistent with how virtual key deactivation is already handled.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable