### PR TITLE
docs: clarify OAuth revocation behavior, `disable_vk_identity` flag, and token lifetime semantics

### DIFF
--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -226,10 +226,11 @@ Status values:
 - `pending` — admin hasn't authorized yet
 - `authorized` — token is valid and active
 - `failed` — authorization failed or token is invalid
+- `revoked` — the token was revoked (via DELETE); the config row is retained with no live token
 
 ### Automatic refresh
 
-Bifrost refreshes the access token automatically before expiration using the stored refresh token. No action required.
+Bifrost refreshes the access token automatically on its next use after it has expired, using the stored refresh token. No action required.
 
 ### Rotation
 
@@ -241,7 +242,7 @@ The MCP client edit flow lets you rotate `client_id` / `client_secret` while pre
 curl -X DELETE http://localhost:8080/api/oauth/config/oauth_cfg_abc123
 ```
 
-This revokes the token with the OAuth provider (if a revocation endpoint is configured), deletes the token from Bifrost, and removes the OAuth configuration.
+This deletes the stored token from Bifrost and marks the OAuth configuration `revoked` (the config row is kept, not deleted). Bifrost does **not** call the upstream provider's revocation endpoint — revoke at the provider's dashboard if you need the upstream token invalidated there.
 
 ---
 

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -14,7 +14,9 @@ If a single shared admin token is fine, use [OAuth 2.0](./oauth) instead.
 This auth type is only valid for **HTTP** and **SSE** connections.
 
 <Note>
-Bifrost is **not** an OAuth 2.1 Authorization Server. The MCP Gateway (`/mcp`) does not advertise its own `.well-known` endpoints or run a consent screen for inbound MCP clients. Identity is asserted by the caller via headers (or upstream SSO), and auth happens **lazily** — on the first tool call that needs an upstream token.
+This page covers **upstream** per-user OAuth — Bifrost holding a token *for* an upstream MCP service on behalf of each end-user, resolved **lazily** on the first tool call that needs it. Identity is asserted by the caller via headers (or upstream SSO).
+
+This is separate from Bifrost acting as an OAuth 2.1 Authorization Server *for inbound* `/mcp` clients (browser consent + `.well-known` discovery), which is covered in [Gateway Authentication](../gateway-auth).
 </Note>
 
 | | Server-level OAuth (`oauth`) | Per-user OAuth (`per_user_oauth`) |

--- a/docs/mcp/gateway-auth.mdx
+++ b/docs/mcp/gateway-auth.mdx
@@ -179,6 +179,8 @@ Revoking a grant stops its refresh token from rotating immediately, so the clien
 
 <Note>
 A revoked grant's current access token is a short-lived JWT that keeps working on `/mcp` until it expires (up to `access_token_ttl`, default `600` seconds). After that the client is fully cut off and must reconnect through the consent flow.
+
+This is deliberate: a holder of the virtual key or user credentials can always start a new authorized session, so invalidating the access token mid-flight adds little security while costing a per-request lookup. Lower `access_token_ttl` for a tighter window.
 </Note>
 
 <Info>
@@ -189,9 +191,11 @@ The **OAuth Grants** page lists credentials Bifrost **issued to clients** for in
 
 ## Token Lifetime & Revocation
 
-- **Access tokens** are JWTs valid for `access_token_ttl` (default 600s). They are validated statelessly on every `/mcp` request — signature, expiry, issuer, and audience.
-- **Refresh tokens** rotate on each use and have no fixed expiry. A token is invalidated by rotation, by the bound virtual key or user becoming inactive, or by an explicit revoke.
-- Because access tokens are validated statelessly, a revoke takes effect for renewals immediately but leaves an already-issued access token usable until it expires. Lower `access_token_ttl` to shorten that window.
+- **Access tokens** are JWTs valid for `access_token_ttl` (default 600s). On every `/mcp` request Bifrost validates the JWT — signature, expiry, issuer, and audience — and confirms the bound identity (the virtual key or user) still exists and is active. The identity check reads an in-memory cache, so in the common case it adds no database round-trip (vk-mode falls back to a single store lookup only on a cache miss).
+- **Refresh tokens** rotate on each use and have no fixed expiry. A token is invalidated by rotation, by the bound virtual key or user becoming inactive or deleted, or by an explicit revoke.
+- An explicit revoke marks the grant's refresh-token row revoked, so renewals stop immediately — but it does **not** remove the bound identity, so the identity check still passes and the already-issued access token keeps working until it expires. Lower `access_token_ttl` to shorten that window.
+- **Deleting** the bound virtual key or user is stronger than revoking a grant: it revokes the grant immediately *and* the identity check rejects the grant's already-issued access token on its next `/mcp` request, instead of letting it live out its TTL.
+- Enabling `disable_vk_identity` (require identity-provider login) cuts off all **virtual-key**–mode grants immediately — they are rejected at `/mcp` and denied on refresh — so those clients must re-authenticate as a user. Only applies in `oauth` mode with an identity provider configured.
 - Enabling `enforce_auth_on_inference` blocks session-mode (anonymous) tokens at `/mcp`, but does **not** delete or invalidate their grants — the grants remain in the database and become valid again if enforcement is later disabled. To remove a session-mode grant permanently, revoke it on the **OAuth Grants** page.
 
 ---

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -150,6 +150,14 @@ ClientConfig:
           minimum: 1
           default: 600
           description: Lifetime of the issued JWT Bearer token in seconds (default 600).
+        disable_vk_identity:
+          type: boolean
+          default: false
+          description: >
+            Require identity-provider login: virtual-key identity is removed from the consent
+            flow, and existing virtual-key-mode grants are rejected at /mcp and denied on refresh.
+            Only meaningful when mcp_server_auth_mode is 'oauth' and an identity provider is
+            configured. Anonymous session identity is governed separately by enforce_auth_on_inference.
       additionalProperties: false
 
 FrameworkConfig:

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7060,8 +7060,8 @@ func (s *RDBConfigStore) RevokeOAuth2RefreshTokensByFamilyID(ctx context.Context
 }
 
 // RevokeOAuth2RefreshTokensByMode revokes all active refresh tokens for a given
-// bf_mode. Used to invalidate session-mode grants when EnforceAuthOnInference
-// is toggled on, or to bulk-revoke all grants of a specific type.
+// bf_mode — a bulk-revoke utility for invalidating every grant of one identity
+// type (vk, user, or session).
 func (s *RDBConfigStore) RevokeOAuth2RefreshTokensByMode(ctx context.Context, bfMode string) error {
 	now := time.Now()
 	return s.DB().WithContext(ctx).

--- a/framework/configstore/tables/mcpoauth2server.go
+++ b/framework/configstore/tables/mcpoauth2server.go
@@ -72,10 +72,10 @@ type OAuth2ServerConfig struct {
 	// Refresh tokens have no hard expiry — they are invalidated only by:
 	//   - rotation on use (each /oauth2/token refresh call issues a new token
 	//     and immediately invalidates the previous one)
-	//   - bf_sub liveness check on refresh (VK deleted / user deactivated →
+	//   - bf_sub liveness check on refresh (VK or user deleted / deactivated →
 	//     invalid_grant, forcing re-authentication)
-	//   - explicit revocation via the Connected Clients UI
-	//   - EnforceAuthOnInference toggled on (revokes all session-mode grants)
+	//   - explicit revocation via the OAuth Grants UI
+	//   - DisableVKIdentity enabled (vk-mode grants denied on refresh)
 	// No RefreshTokenTTL field exists by design — there is no timer, only
 	// explicit invalidation paths.
 }


### PR DESCRIPTION
## Summary

This PR clarifies and corrects documentation around OAuth token lifecycle, revocation behavior, and the new `disable_vk_identity` configuration option. It also fixes inaccurate descriptions of how Bifrost handles upstream OAuth revocation, access token validation, and the distinction between revoking a grant versus deleting the bound identity.

## Changes

- Added `revoked` as a documented OAuth config status value, clarifying that the config row is retained with no live token after a DELETE call.
- Corrected the DELETE endpoint description: Bifrost does **not** call the upstream provider's revocation endpoint — it only deletes the stored token locally and marks the config `revoked`. Users must revoke at the provider's dashboard if upstream invalidation is needed.
- Clarified that access token refresh happens lazily on next use after expiration, not proactively before expiration.
- Updated the per-user OAuth note to clearly separate upstream per-user OAuth (tokens held for upstream MCP services) from Bifrost acting as an OAuth 2.1 Authorization Server for inbound `/mcp` clients, with a cross-reference to the Gateway Authentication page.
- Expanded the Token Lifetime & Revocation section to document:
  - The in-memory identity cache used during access token validation and its fallback behavior.
  - The distinction between revoking a grant (stops refresh, but existing access token lives out its TTL) versus deleting the bound virtual key or user (also rejects the already-issued access token on its next request).
  - The behavior of `disable_vk_identity`: rejects all virtual-key-mode grants at `/mcp` and on refresh, forcing re-authentication as a user.
- Added `disable_vk_identity` to the OpenAPI config schema with a description of its scope and conditions.
- Updated `RevokeOAuth2RefreshTokensByMode` comment to be more precise about its purpose as a bulk-revoke utility.
- Corrected internal comments in `OAuth2ServerConfig` to reference the OAuth Grants UI (not "Connected Clients UI") and `DisableVKIdentity` (not `EnforceAuthOnInference`) as the vk-mode revocation path.
- Added a note explaining why revoked grants leave short-lived access tokens usable until expiry, and why this is an intentional trade-off.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated documentation pages for accuracy against the actual Bifrost OAuth implementation:

- `docs/mcp/auth/oauth.mdx` — verify DELETE behavior and status values match implementation.
- `docs/mcp/auth/per-user-oauth.mdx` — verify the note correctly distinguishes upstream vs. inbound OAuth.
- `docs/mcp/gateway-auth.mdx` — verify token lifetime, revocation, and `disable_vk_identity` descriptions match behavior.
- `docs/openapi/schemas/management/config.yaml` — verify `disable_vk_identity` schema matches the Go struct definition.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The documentation now explicitly states that Bifrost does **not** call upstream OAuth provider revocation endpoints on DELETE. Operators who assumed upstream tokens were being invalidated must be made aware they need to revoke tokens directly at the provider's dashboard. The updated revocation lifecycle documentation also clarifies the security window left by short-lived access tokens after a grant revoke, and recommends lowering `access_token_ttl` for tighter control.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable