### PR TITLE
fix: fixes Bedrock error type extraction

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -189,16 +189,74 @@ func isStreamTransportError(err error) bool {
 	return errors.As(err, &opErr) || errors.As(err, &dnsErr)
 }
 
-// retryableBedrockExceptions maps AWS Bedrock EventStream exception types to
-// their HTTP status code equivalents. These exceptions are transient and should
-// be retried — the retry gate in executeRequestWithRetries checks StatusCode
-// against transientServerStatusCodes (500, 502, 503, 504) for same-key retries
-// and perKeyFailureStatusCodes (429) for rotation-triggered retries.
+// retryableBedrockExceptions maps AWS Bedrock EventStream exception types (the
+// camelCase shape names AWS uses for ConverseStream / InvokeModelWithResponseStream
+// in-stream exception members) to a retryable HTTP status code. These exceptions
+// are transient and should be retried — the retry gate in executeRequestWithRetries
+// checks StatusCode against transientServerStatusCodes (500, 502, 503, 504) for
+// same-key retries and perKeyFailureStatusCodes (429) for rotation-triggered retries.
+//
+// Some AWS exceptions have a native status code the gate does not recognize
+// (modelStreamErrorException=424, modelTimeoutException=408); they are mapped to
+// the nearest gate-recognized transient code so the retry still fires. The client
+// still sees the original exception type — only the internal retry hint is mapped.
+//
+// modelNotReadyException is an HTTP-level error (not an in-stream member) but is
+// kept here because AWS auto-retries it; it is harmless when it never matches a
+// stream event. validationException / accessDeniedException / resourceNotFoundException
+// are intentionally absent — they are terminal request-bound errors.
 var retryableBedrockExceptions = map[string]int{
 	"throttlingException":         429,
 	"serviceUnavailableException": 503,
 	"modelNotReadyException":      503,
 	"internalServerException":     500,
+	"modelStreamErrorException":   503, // native 424; AWS guidance: "Retry your request"
+	"modelTimeoutException":       504, // native 408; processing timeout, transient
+}
+
+// newBedrockStreamException builds a BifrostError from an AWS EventStream
+// exception message (any :message-type other than "event"). It preserves the
+// upstream exception type — the payload's "__type" when present, else the
+// :exception-type header value (excType) — so downstream conversion
+// (ToBedrockError) forwards it instead of falling back to "InternalServerError".
+//
+// Retryable exceptions are emitted with IsBifrostError:false and the equivalent
+// HTTP status so the retry gate in executeRequestWithRetries handles them;
+// non-retryable ones are terminal (IsBifrostError:true). providerName is an
+// optional label prefix for the message.
+func newBedrockStreamException(providerName, excType string, payload []byte) *schemas.BifrostError {
+	errMsg := string(payload)
+	var bedrockErr BedrockError
+	if err := sonic.Unmarshal(payload, &bedrockErr); err == nil && bedrockErr.Message != "" {
+		errMsg = bedrockErr.Message
+	}
+
+	fwdType := bedrockErr.Type
+	if fwdType == "" {
+		fwdType = excType
+	}
+
+	prefix := "stream"
+	if providerName != "" {
+		prefix = providerName + " stream"
+	}
+
+	streamErr := &schemas.BifrostError{
+		IsBifrostError: false,
+		Error: &schemas.ErrorField{
+			Message: fmt.Sprintf("%s %s: %s", prefix, excType, errMsg),
+		},
+	}
+	if fwdType != "" {
+		streamErr.Type = &fwdType
+	}
+	if statusCode, ok := retryableBedrockExceptions[excType]; ok {
+		sc := statusCode
+		streamErr.StatusCode = &sc
+	} else {
+		streamErr.IsBifrostError = true
+	}
+	return streamErr
 }
 
 // completeRequest sends a request to Bedrock's API and handles the response.
@@ -1079,27 +1137,8 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 								excType = v
 							}
 						}
-						errMsg := string(message.Payload)
-						var bedrockErr BedrockError
-						if err := sonic.Unmarshal(message.Payload, &bedrockErr); err == nil && bedrockErr.Message != "" {
-							errMsg = bedrockErr.Message
-						}
-						// Retryable AWS exceptions must not set IsBifrostError:true — that would
-						// bypass the retry gate in executeRequestWithRetries. Instead emit
-						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
-						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
-							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
-								IsBifrostError: false,
-								StatusCode:     &statusCode,
-								Error: &schemas.ErrorField{
-									Message: fmt.Sprintf("%s stream %s: %s", providerName, excType, errMsg),
-								},
-							}, responseChan, provider.logger, postHookSpanFinalizer)
-						} else {
-							err := fmt.Errorf("%s stream %s: %s", providerName, excType, errMsg)
-							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						}
+						streamErr := newBedrockStreamException(string(providerName), excType, message.Payload)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, streamErr, responseChan, provider.logger, postHookSpanFinalizer)
 						return
 					}
 				}
@@ -1368,23 +1407,8 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 								excType = v
 							}
 						}
-						errMsg := string(message.Payload)
-						err := fmt.Errorf("stream %s: %s", excType, errMsg)
-						// Retryable AWS exceptions must not set IsBifrostError:true — that would
-						// bypass the retry gate in executeRequestWithRetries. Instead emit
-						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
-						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
-							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
-								IsBifrostError: false,
-								StatusCode:     &statusCode,
-								Error: &schemas.ErrorField{
-									Message: err.Error(),
-								},
-							}, responseChan, provider.logger, postHookSpanFinalizer)
-						} else {
-							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						}
+						streamErr := newBedrockStreamException("", excType, message.Payload)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, streamErr, responseChan, provider.logger, postHookSpanFinalizer)
 						return
 					}
 				}
@@ -1771,23 +1795,8 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 								excType = v
 							}
 						}
-						errMsg := string(message.Payload)
-						err := fmt.Errorf("stream %s: %s", excType, errMsg)
-						// Retryable AWS exceptions must not set IsBifrostError:true — that would
-						// bypass the retry gate in executeRequestWithRetries. Instead emit
-						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
-						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
-							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
-								IsBifrostError: false,
-								StatusCode:     &statusCode,
-								Error: &schemas.ErrorField{
-									Message: err.Error(),
-								},
-							}, responseChan, provider.logger, postHookSpanFinalizer)
-						} else {
-							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, provider.logger, postHookSpanFinalizer)
-						}
+						streamErr := newBedrockStreamException("", excType, message.Payload)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, streamErr, responseChan, provider.logger, postHookSpanFinalizer)
 						return
 					}
 				}

--- a/core/providers/bedrock/errors.go
+++ b/core/providers/bedrock/errors.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"net/http"
+	"strings"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -28,6 +29,21 @@ func parseBedrockHTTPError(statusCode int, headers http.Header, body []byte) *sc
 		}
 		bifrostErr.Error.Message = errorResp.Message
 		bifrostErr.Error.Code = errorResp.Code
+	}
+
+	if bifrostErr.Type == nil {
+		exceptionType := errorResp.Type
+		if exceptionType == "" {
+			if hv := headers.Get("X-Amzn-Errortype"); hv != "" {
+				if i := strings.IndexAny(hv, ":#"); i >= 0 {
+					hv = hv[:i]
+				}
+				exceptionType = strings.TrimSpace(hv)
+			}
+		}
+		if exceptionType != "" {
+			bifrostErr.Type = &exceptionType
+		}
 	}
 
 	return bifrostErr

--- a/core/providers/bedrock/errors_test.go
+++ b/core/providers/bedrock/errors_test.go
@@ -1,0 +1,201 @@
+package bedrock
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseBedrockHTTPError_PreservesExceptionType verifies that the upstream
+// AWS exception type (the JSON "__type" field) is preserved on the resulting
+// BifrostError. Without this, a retired/unsupported model error surfaces as a
+// generic "InternalServerError" once it is converted back for the streaming
+// EventStream path.
+func TestParseBedrockHTTPError_PreservesExceptionType(t *testing.T) {
+	// Shape AWS Bedrock returns for an EOL/unsupported model.
+	body := []byte(`{"__type":"ValidationException","message":"Invocation of model ID anthropic.claude-v2 with on-demand throughput isn't supported."}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, http.Header{}, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Type, "exception type must be preserved from __type")
+	assert.Equal(t, "ValidationException", *bifrostErr.Type)
+	require.NotNil(t, bifrostErr.Error)
+	assert.Equal(t, "Invocation of model ID anthropic.claude-v2 with on-demand throughput isn't supported.", bifrostErr.Error.Message)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, http.StatusBadRequest, *bifrostErr.StatusCode)
+}
+
+// TestParseBedrockHTTPError_TypeFromHeader covers the real end-of-life model
+// case: AWS reports the exception type only in the X-Amzn-Errortype response
+// header while the body carries just {"message": ...}. The type must still be
+// recovered from the header.
+func TestParseBedrockHTTPError_TypeFromHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Amzn-Errortype", "ValidationException")
+	body := []byte(`{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, headers, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Type, "type must be recovered from X-Amzn-Errortype header")
+	assert.Equal(t, "ValidationException", *bifrostErr.Type)
+	require.NotNil(t, bifrostErr.Error)
+	assert.Contains(t, bifrostErr.Error.Message, "reached the end of its life")
+}
+
+// TestParseBedrockHTTPError_HeaderTypeQualifierStripped ensures the trailing
+// ":<url>" / "#<shape>" qualifier AWS sometimes appends to X-Amzn-Errortype is
+// removed.
+func TestParseBedrockHTTPError_HeaderTypeQualifierStripped(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Amzn-Errortype", "ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/")
+	body := []byte(`{"message":"bad model"}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, headers, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, "ValidationException", *bifrostErr.Type)
+}
+
+// TestParseBedrockHTTPError_BodyTypePreferredOverHeader ensures the body's
+// "__type" wins when both the body and header carry a type.
+func TestParseBedrockHTTPError_BodyTypePreferredOverHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Amzn-Errortype", "SomethingElse")
+	body := []byte(`{"__type":"ValidationException","message":"bad model"}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, headers, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, "ValidationException", *bifrostErr.Type)
+}
+
+// TestParseBedrockHTTPError_RoundTripToBedrockError is the regression test for
+// the actual bug: the exception type must survive the parse -> ToBedrockError
+// round trip used by the streaming error converter, rather than falling back to
+// "InternalServerError". Modeled on the EOL case where the type is header-only.
+func TestParseBedrockHTTPError_RoundTripToBedrockError(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Amzn-Errortype", "ValidationException")
+	body := []byte(`{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, headers, body)
+	bedrockErr := ToBedrockError(bifrostErr)
+
+	require.NotNil(t, bedrockErr)
+	assert.Equal(t, "ValidationException", bedrockErr.Type, "must forward AWS exception type, not fall back to InternalServerError")
+	assert.Contains(t, bedrockErr.Message, "reached the end of its life")
+}
+
+// TestNewBedrockStreamException_TypeFromBody verifies an in-stream exception
+// event whose payload carries a "__type" forwards that type and surfaces the
+// clean message.
+func TestNewBedrockStreamException_TypeFromBody(t *testing.T) {
+	payload := []byte(`{"__type":"ValidationException","message":"This model version has reached the end of its life."}`)
+
+	streamErr := newBedrockStreamException("bedrock", "validationException", payload)
+
+	require.NotNil(t, streamErr)
+	require.NotNil(t, streamErr.Type)
+	assert.Equal(t, "ValidationException", *streamErr.Type, "payload __type is preferred over the header excType")
+	assert.True(t, streamErr.IsBifrostError, "non-retryable exceptions are terminal")
+	assert.Nil(t, streamErr.StatusCode)
+	require.NotNil(t, streamErr.Error)
+	assert.Contains(t, streamErr.Error.Message, "reached the end of its life")
+
+	// Must survive conversion to the streaming EventStream exception payload.
+	bedrockErr := ToBedrockError(streamErr)
+	assert.Equal(t, "ValidationException", bedrockErr.Type)
+}
+
+// TestNewBedrockStreamException_TypeFromHeader verifies the type falls back to
+// the :exception-type header value (excType) when the payload has no "__type".
+func TestNewBedrockStreamException_TypeFromHeader(t *testing.T) {
+	payload := []byte(`{"message":"bad input"}`)
+
+	streamErr := newBedrockStreamException("", "validationException", payload)
+
+	require.NotNil(t, streamErr)
+	require.NotNil(t, streamErr.Type)
+	assert.Equal(t, "validationException", *streamErr.Type)
+
+	bedrockErr := ToBedrockError(streamErr)
+	assert.Equal(t, "validationException", bedrockErr.Type, "must not fall back to InternalServerError")
+}
+
+// TestNewBedrockStreamException_Retryable verifies each retryable AWS in-stream
+// exception is marked with IsBifrostError:false and a gate-recognized transient
+// status so the retry fires, while still forwarding the original type. Covers the
+// two exceptions whose native status (424 / 408) the retry gate does not
+// recognize and which must be mapped to a transient code.
+func TestNewBedrockStreamException_Retryable(t *testing.T) {
+	// status codes the retry gate honors (transientServerStatusCodes ∪ perKeyFailureStatusCodes).
+	gateRetryable := map[int]bool{500: true, 502: true, 503: true, 504: true, 429: true}
+
+	cases := []struct {
+		excType string
+		status  int
+	}{
+		{"internalServerException", 500},
+		{"throttlingException", 429},
+		{"serviceUnavailableException", 503},
+		{"modelNotReadyException", 503},
+		{"modelStreamErrorException", 503}, // native 424 -> mapped
+		{"modelTimeoutException", 504},     // native 408 -> mapped
+	}
+
+	for _, c := range cases {
+		t.Run(c.excType, func(t *testing.T) {
+			streamErr := newBedrockStreamException("", c.excType, []byte(`{"message":"transient"}`))
+
+			require.NotNil(t, streamErr)
+			assert.False(t, streamErr.IsBifrostError, "retryable exceptions must keep IsBifrostError:false for the retry gate")
+			require.NotNil(t, streamErr.StatusCode)
+			assert.Equal(t, c.status, *streamErr.StatusCode)
+			assert.True(t, gateRetryable[*streamErr.StatusCode], "mapped status must be one the retry gate honors")
+			require.NotNil(t, streamErr.Type)
+			assert.Equal(t, c.excType, *streamErr.Type, "original exception type must still be forwarded")
+		})
+	}
+}
+
+// TestNewBedrockStreamException_Terminal verifies non-retryable AWS in-stream
+// exceptions are terminal (IsBifrostError:true, no retry status) yet still
+// forward the type so the client sees the real exception rather than
+// InternalServerError.
+func TestNewBedrockStreamException_Terminal(t *testing.T) {
+	for _, excType := range []string{"validationException", "accessDeniedException", "resourceNotFoundException"} {
+		t.Run(excType, func(t *testing.T) {
+			streamErr := newBedrockStreamException("", excType, []byte(`{"message":"bad request"}`))
+
+			require.NotNil(t, streamErr)
+			assert.True(t, streamErr.IsBifrostError, "non-retryable exceptions must be terminal")
+			assert.Nil(t, streamErr.StatusCode)
+			require.NotNil(t, streamErr.Type)
+			assert.Equal(t, excType, *streamErr.Type)
+
+			assert.Equal(t, excType, ToBedrockError(streamErr).Type)
+		})
+	}
+}
+
+// TestParseBedrockHTTPError_NoTypeFallsBack ensures that when AWS provides no
+// "__type" we don't fabricate one; ToBedrockError still applies its
+// InternalServerError fallback for a typeless error.
+func TestParseBedrockHTTPError_NoTypeFallsBack(t *testing.T) {
+	body := []byte(`{"message":"something went wrong"}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusInternalServerError, http.Header{}, body)
+	require.NotNil(t, bifrostErr)
+	assert.Nil(t, bifrostErr.Type, "no __type present, so none should be set")
+
+	bedrockErr := ToBedrockError(bifrostErr)
+	require.NotNil(t, bedrockErr)
+	assert.Equal(t, "InternalServerError", bedrockErr.Type)
+	assert.Equal(t, "something went wrong", bedrockErr.Message)
+}


### PR DESCRIPTION
## Summary

AWS Bedrock EventStream exceptions were losing their original exception type during error handling, causing downstream consumers to see a generic `InternalServerError` instead of the real exception (e.g., `ValidationException` for an end-of-life model). Additionally, two retryable in-stream exceptions (`modelStreamErrorException` and `modelTimeoutException`) were missing from the retry map, so they were treated as terminal errors rather than being retried.

## Changes

- Extracted duplicated inline EventStream exception handling from `TextCompletionStream`, `ChatCompletionStream`, and `ResponsesStream` into a single `newBedrockStreamException` helper. The helper preserves the upstream exception type from the payload's `__type` field, falling back to the `:exception-type` header value (`excType`), so `ToBedrockError` forwards the real type instead of falling back to `InternalServerError`.
- Added `modelStreamErrorException` (mapped to 503, native 424) and `modelTimeoutException` (mapped to 504, native 408) to `retryableBedrockExceptions`. Their native status codes are not recognized by the retry gate, so they are remapped to the nearest gate-recognized transient code while the original exception type is still forwarded to the client.
- Updated `parseBedrockHTTPError` to populate `BifrostError.Type` from the JSON `__type` field or, when absent, from the `X-Amzn-Errortype` response header (stripping any trailing `:<url>` or `#<shape>` qualifier AWS appends). This fixes the same type-loss bug for the HTTP (non-streaming) path.
- Added `errors_test.go` covering: `__type` preservation, header fallback, header qualifier stripping, body-over-header precedence, the full parse→`ToBedrockError` round trip, retryable exception mapping (including the two remapped codes), terminal exception handling, and the no-type fallback.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

The new `errors_test.go` covers all changed paths. Key cases to verify:

- A `ValidationException` for an EOL model (type in header only) round-trips through `parseBedrockHTTPError` → `ToBedrockError` and returns `"ValidationException"`, not `"InternalServerError"`.
- `modelStreamErrorException` and `modelTimeoutException` stream events produce `IsBifrostError:false` with status codes `503` and `504` respectively, triggering the retry gate.
- `validationException`, `accessDeniedException`, and `resourceNotFoundException` stream events produce `IsBifrostError:true` with no status code (terminal).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable