### PR TITLE
feat: add `x-goog-api-key` as a supported VK header on the MCP auth path

### DIFF
--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -82,7 +82,7 @@ Per-user auth keys every credential against an **identity**. The mode is derived
 | Mode      | How it's set                                                                                            | Notes                                              |
 | --------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | `user`    | Bifrost's auth middleware populates `BifrostContextKeyUserID` (signed-in user via SSO), **or** the caller sends a VK that is owned by a user — Bifrost auto-promotes the VK's owner onto the context  | Enterprise SSO and enterprise user-owned VKs only |
-| `vk`      | Caller sends `x-bf-vk` (or `Authorization: Bearer …` / `x-api-key`) and the VK resolves but is **not** owned by a user                | Typical non-enterprise pattern, or enterprise VKs that aren't tied to a person  |
+| `vk`      | Caller sends `x-bf-vk` (or `Authorization: Bearer …` / `x-api-key` / `x-goog-api-key`) and the VK resolves but is **not** owned by a user                | Typical non-enterprise pattern, or enterprise VKs that aren't tied to a person  |
 | `session` | Caller sends `x-bf-mcp-session-id: <any-opaque-value>` and re-sends the same value on later calls      | Useful when there is no VK and no SSO              |
 
 Priority: `user` > `vk` > `session`. If multiple are present (e.g., a user-owned VK both resolves a VK ID **and** promotes a user ID), Bifrost picks the highest-priority and ignores the rest for credential lookup. This means a user-owned VK always lands in `user` mode — the credential and any auth flow are bound to the user, not the VK.

--- a/docs/mcp/auth/per-user-headers.mdx
+++ b/docs/mcp/auth/per-user-headers.mdx
@@ -258,7 +258,7 @@ The admin sample values you supplied (`user_headers`) didn't pass upstream auth.
 
 <Accordion title="End-users see `requires an identity` even though they sent a VK">
 
-The VK isn't resolving. Confirm the VK exists and the caller is sending it under one of `x-bf-vk`, `Authorization: Bearer …`, or `x-api-key`. If you're behind a proxy that strips `Authorization`, switch the caller to `x-bf-vk`.
+The VK isn't resolving. Confirm the VK exists and the caller is sending it under one of `x-bf-vk`, `Authorization: Bearer …`, `x-api-key`, or `x-goog-api-key`. If you're behind a proxy that strips `Authorization`, switch the caller to `x-bf-vk`.
 </Accordion>
 
 <Accordion title="`Headers submission flow has expired`">

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -135,6 +135,12 @@ When using Virtual Keys, each VK gets its own MCP server with filtered tools bas
 **Authenticate with Virtual Key:**
 
 ```bash
+# Via x-bf-vk header
+curl -X POST http://localhost:8080/mcp \
+  -H "x-bf-vk: vk_your_virtual_key" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
+
 # Via Authorization header
 curl -X POST http://localhost:8080/mcp \
   -H "Authorization: Bearer vk_your_virtual_key" \
@@ -147,9 +153,9 @@ curl -X POST http://localhost:8080/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 
-# Via x-bf-vk header
+# Via x-goog-api-key header
 curl -X POST http://localhost:8080/mcp \
-  -H "x-bf-vk: vk_your_virtual_key" \
+  -H "x-goog-api-key: vk_your_virtual_key" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
 ```
@@ -315,7 +321,7 @@ When at least one upstream MCP server is configured with `per_user_oauth` or `pe
 
 In `headers` mode, inbound MCP clients identify themselves via headers:
 
-- `x-bf-vk: <vk>` (or `Authorization: Bearer <vk>` / `x-api-key: <vk>`) — VK-mode identity
+- `x-bf-vk: <vk>` (or `Authorization: Bearer <vk>` / `x-api-key: <vk>` / `x-goog-api-key: <vk>`) — VK-mode identity
 - `x-bf-mcp-session-id: <opaque-string>` — session-mode identity (client-asserted, must be re-sent on every call)
 - Enterprise SSO — user-mode identity, attached automatically by the auth middleware
 

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -669,7 +669,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 	// --- JWT path ---
 	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {
 		// An OAuth token is the sole identity for the request. Reject when a
-		// header-based virtual key (x-bf-vk / x-api-key / Bearer vk) is also
+		// header-based virtual key (x-bf-vk / x-api-key / x-goog-api-key / Bearer vk) is also
 		// presented: mixing credential sources is ambiguous, and for user- and
 		// session-mode tokens — which carry no virtual key — a stray header VK
 		// would otherwise leak onto the context and be attributed to the request.
@@ -784,7 +784,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 		if discoveryEnabled {
 			ctx.Response.Header.Set("WWW-Authenticate", wwwAuthenticateValue(ctx, h.config))
 		}
-		return nil, fmt.Errorf("virtual key required to access mcp server; set one of x-bf-vk, Authorization: Bearer <vk>, or x-api-key in your MCP client config")
+		return nil, fmt.Errorf("virtual key required to access mcp server; set one of x-bf-vk, Authorization: Bearer <vk>, x-api-key, or x-goog-api-key in your MCP client config")
 	}
 
 	vkServer, err := h.ensureVKMCPServerByValue(ctx, vk)
@@ -877,6 +877,17 @@ func (h *MCPServerHandler) ensureVKMCPServer(ctx context.Context, vkValue string
 	return h.SyncVKMCPServer(vk), nil
 }
 
+// getVKFromRequest extracts a virtual key from the request headers, checking
+// each supported header in priority order and returning the first match:
+//  1. x-bf-vk        — taken verbatim (no prefix check)
+//  2. Authorization  — "Bearer <vk>", where <vk> must start with the VK prefix
+//  3. x-api-key      — must start with the VK prefix
+//  4. x-goog-api-key — must start with the VK prefix
+//
+// The prefix gate (governance.VirtualKeyPrefix) on the latter three lets real
+// provider credentials pass through untouched, so only Bifrost virtual keys are
+// picked up here. This header set mirrors the inference path, keeping MCP and
+// inference at parity. Returns "" when no header carries a virtual key.
 func getVKFromRequest(ctx *fasthttp.RequestCtx) string {
 	if value := strings.TrimSpace(string(ctx.Request.Header.Peek(string(schemas.BifrostContextKeyVirtualKey)))); value != "" {
 		return value
@@ -895,6 +906,12 @@ func getVKFromRequest(ctx *fasthttp.RequestCtx) string {
 	if apiKey := strings.TrimSpace(string(ctx.Request.Header.Peek("x-api-key"))); apiKey != "" {
 		if strings.HasPrefix(strings.ToLower(apiKey), governance.VirtualKeyPrefix) {
 			return apiKey
+		}
+	}
+
+	if googAPIKey := strings.TrimSpace(string(ctx.Request.Header.Peek("x-goog-api-key"))); googAPIKey != "" {
+		if strings.HasPrefix(strings.ToLower(googAPIKey), governance.VirtualKeyPrefix) {
+			return googAPIKey
 		}
 	}
 

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -25,6 +25,72 @@ func newTestMCPHandler(cfg *lib.Config) *MCPServerHandler {
 	}
 }
 
+// TestGetVKFromRequest verifies the VK value is extracted from each supported
+// header, in priority order, and that non-VK values are ignored. This mirrors
+// the inference-path header set (x-bf-vk, Authorization Bearer, x-api-key,
+// x-goog-api-key) so MCP and inference stay at parity.
+func TestGetVKFromRequest(t *testing.T) {
+	const vk = "sk-bf-test-virtual-key"
+
+	cases := []struct {
+		name   string
+		setup  func(*fasthttp.RequestCtx)
+		wantVK string
+	}{
+		{
+			name:   "x-bf-vk header",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("x-bf-vk", vk) },
+			wantVK: vk,
+		},
+		{
+			name:   "Authorization Bearer header",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("Authorization", "Bearer "+vk) },
+			wantVK: vk,
+		},
+		{
+			name:   "x-api-key header",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("x-api-key", vk) },
+			wantVK: vk,
+		},
+		{
+			name:   "x-goog-api-key header",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("x-goog-api-key", vk) },
+			wantVK: vk,
+		},
+		{
+			name:   "no header returns empty string",
+			setup:  func(*fasthttp.RequestCtx) {},
+			wantVK: "",
+		},
+		{
+			name:   "non-VK Bearer token returns empty string",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("Authorization", "Bearer regular-api-key-123") },
+			wantVK: "",
+		},
+		{
+			name:   "non-VK x-goog-api-key returns empty string",
+			setup:  func(ctx *fasthttp.RequestCtx) { ctx.Request.Header.Set("x-goog-api-key", "regular-google-key") },
+			wantVK: "",
+		},
+		{
+			name: "x-bf-vk takes priority over x-goog-api-key",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("x-bf-vk", vk)
+				ctx.Request.Header.Set("x-goog-api-key", "sk-bf-other")
+			},
+			wantVK: vk,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			tc.setup(ctx)
+			assert.Equal(t, tc.wantVK, getVKFromRequest(ctx))
+		})
+	}
+}
+
 // TestGetMCPServerForRequest_JWTPath covers the JWT branch of /mcp auth across
 // modes and identity kinds: the security contract for OAuth-authenticated calls.
 func TestGetMCPServerForRequest_JWTPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `x-goog-api-key` as a supported header for passing Bifrost virtual keys to the MCP server, bringing the MCP authentication path into parity with the inference path.

## Changes

- Extended `getVKFromRequest` in `mcpserver.go` to check the `x-goog-api-key` header (with the same VK prefix gate applied to `x-api-key` and `Authorization: Bearer`) so that clients using Google-style API key headers can authenticate with Bifrost virtual keys
- Updated error messages and inline comments throughout `mcpserver.go` to reference `x-goog-api-key` alongside the existing supported headers
- Added `TestGetVKFromRequest` unit tests covering all four supported headers, priority ordering, and rejection of non-VK values in `x-goog-api-key` and `Authorization: Bearer`
- Updated `docs/mcp/gateway.mdx` to replace the `x-bf-vk` curl example with an `x-goog-api-key` example and added a dedicated `x-bf-vk` example, showing all supported authentication methods
- Updated `docs/mcp/auth/overview.mdx` and `docs/mcp/auth/per-user-headers.mdx` to include `x-goog-api-key` in the list of accepted VK headers

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestGetVKFromRequest -v
```

To validate end-to-end, start the MCP server and authenticate using the `x-goog-api-key` header with a valid virtual key:

```sh
curl -X POST http://localhost:8080/mcp \
  -H "x-goog-api-key: vk_your_virtual_key" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
```

Expected: a valid `tools/list` response. A non-VK value in `x-goog-api-key` (i.e., one not prefixed with the VK prefix) should be ignored and fall through to the next header or return an auth error.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The `x-goog-api-key` header is gated by the same `governance.VirtualKeyPrefix` check used for `x-api-key` and `Authorization: Bearer`, ensuring that real provider credentials passed via this header are not mistakenly interpreted as Bifrost virtual keys and are left untouched.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable