### PR TITLE
feat: use `schemas.SecretVar` for virtual key values to support env store

### DIFF
--- a/core/schemas/vault.go
+++ b/core/schemas/vault.go
@@ -80,25 +80,30 @@ var (
 // RemoveOwnedVaultSecretVars best-effort deletes the vault secret for every
 // SecretVar / *SecretVar field in model whose VaultRef starts with
 // ownedPrefix+"/". Refs outside that prefix are user-provided and are left alone.
-func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model interface{}) {
+// Returns one error per field whose deletion failed; callers should log these but
+// must not treat them as fatal (the DB row is already deleted).
+func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model interface{}) []error {
 	if VaultRemoveHook == nil {
-		return
+		return nil
 	}
 	rv := reflect.ValueOf(model)
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
 	}
 	if rv.Kind() != reflect.Struct {
-		return
+		return nil
 	}
 	rt := rv.Type()
+	var errs []error
 	for i := 0; i < rt.NumField(); i++ {
 		fv := rv.Field(i)
 		if fv.Type() == secretVarMapType {
 			iter := fv.MapRange()
 			for iter.Next() {
 				e := iter.Value().Interface().(SecretVar)
-				removeOwnedVaultSecretVar(ctx, ownedPrefix, &e)
+				if err := removeOwnedVaultSecretVar(ctx, ownedPrefix, &e); err != nil {
+					errs = append(errs, err)
+				}
 			}
 			continue
 		}
@@ -111,25 +116,28 @@ func RemoveOwnedVaultSecretVars(ctx context.Context, ownedPrefix string, model i
 				field = fv.Interface().(*SecretVar)
 			}
 		}
-		removeOwnedVaultSecretVar(ctx, ownedPrefix, field)
+		if err := removeOwnedVaultSecretVar(ctx, ownedPrefix, field); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return errs
 }
 
 // removeOwnedVaultSecretVar removes a single SecretVar's vault secret if it is a
 // vault-backed, non-fragment reference under ownedPrefix. Fragment refs (#key)
 // point at shared, externally-managed secrets and are never auto-deleted.
-func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) {
+func removeOwnedVaultSecretVar(ctx context.Context, ownedPrefix string, field *SecretVar) error {
 	path := field.GetRef()
 	if path == "" {
-		return
+		return nil
 	}
 	if strings.IndexByte(path, '#') >= 0 {
-		return
+		return nil
 	}
 	if !strings.HasPrefix(path, ownedPrefix+"/") {
-		return
+		return nil
 	}
-	_ = VaultRemoveHook(ctx, path)
+	return VaultRemoveHook(ctx, path)
 }
 
 // StoreVaultSecretVar pushes a single plaintext SecretVar value into the vault at path

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -863,8 +863,9 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 	hash.Write([]byte(vk.Name))
 	// Hash Description
 	hash.Write([]byte(vk.Description))
-	// Hash Value
-	hash.Write([]byte(vk.Value))
+	// Hash the resolved value so that secret rotation (vault/env change) is
+	// detected as a config change and triggers a re-sync.
+	hash.Write([]byte(vk.Value.GetValue()))
 	// Hash IsActive (nil treated as DB default true)
 	if vk.IsActiveValue() {
 		hash.Write([]byte("isActive:true"))

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -428,7 +428,7 @@ func TestEncryptPlaintextVirtualKeys_EncryptsAndDecryptsCorrectly(t *testing.T) 
 	// GORM hooks should decrypt on read
 	var found tables.TableVirtualKey
 	require.NoError(t, db.Where("id = ?", "vk-batch-1").First(&found).Error)
-	assert.Equal(t, "vk-batch-secret", found.Value)
+	assert.Equal(t, "vk-batch-secret", found.Value.GetValue())
 }
 
 func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T) {
@@ -1342,7 +1342,7 @@ func TestEncryptPlaintextRows_SkipsAlreadyEncryptedVirtualKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-already-enc",
 		Name:     "already-encrypted-vk",
-		Value:    "vk-secret-already",
+		Value:    *schemas.NewSecretVar("vk-secret-already"),
 		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1250,7 +1250,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:        "vk-test-001",
 		Name:      "test-virtual-key",
-		Value:     "vk-secret-value-12345",
+		Value:     *schemas.NewSecretVar("vk-secret-value-12345"),
 		IsActive:  bifrost.Ptr(true),
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -1266,7 +1266,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 
 	assert.Equal(t, "vk-test-001", vks[0].ID)
 	assert.Equal(t, "test-virtual-key", vks[0].Name)
-	assert.Equal(t, "vk-secret-value-12345", vks[0].Value) // AfterFind decrypts
+	assert.Equal(t, "vk-secret-value-12345", vks[0].Value.GetValue()) // AfterFind decrypts
 	assert.True(t, vks[0].IsActiveValue())
 
 	// Verify encryption at raw DB level
@@ -1396,7 +1396,7 @@ func TestFullMigration_EncryptPlaintextRows(t *testing.T) {
 	var vk tables.TableVirtualKey
 	err = db.Where("id = ?", "vk-plain-1").First(&vk).Error
 	require.NoError(t, err)
-	assert.Equal(t, "vk-plain-secret", vk.Value)
+	assert.Equal(t, "vk-plain-secret", vk.Value.Val)
 }
 
 func TestFullMigration_EndToEnd(t *testing.T) {
@@ -1438,7 +1438,7 @@ func TestFullMigration_EndToEnd(t *testing.T) {
 		{"vk-2", "vk-beta", "vk-beta-secret"},
 	} {
 		err := store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
-			ID: vk.id, Name: vk.name, Value: vk.value,
+			ID: vk.id, Name: vk.name, Value: *schemas.NewSecretVar(vk.value),
 			IsActive: bifrost.Ptr(true), CreatedAt: now, UpdatedAt: now,
 		})
 		require.NoError(t, err, "CreateVirtualKey %s", vk.name)

--- a/framework/configstore/rdb_deadlock_postgres_test.go
+++ b/framework/configstore/rdb_deadlock_postgres_test.go
@@ -162,7 +162,7 @@ func TestPostgresVirtualKeyBudgetConcurrentMutationsDoNotDeadlock(t *testing.T) 
 				if err := store.UpdateVirtualKey(ctx, &tables.TableVirtualKey{
 					ID:       vkID,
 					Name:     "PG VK Budget",
-					Value:    "pg-vk-budget-value",
+					Value:    *schemas.NewSecretVar("pg-vk-budget-value"),
 					IsActive: schemas.Ptr(true),
 				}, tx); err != nil {
 					return err
@@ -247,7 +247,7 @@ func seedProviderGraph(ctx context.Context, store *RDBConfigStore) error {
 	if err := store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 		ID:       "pg-vk",
 		Name:     "PG VK",
-		Value:    fmt.Sprintf("pg-vk-value-%d", time.Now().UnixNano()),
+		Value:    *schemas.NewSecretVar(fmt.Sprintf("pg-vk-value-%d", time.Now().UnixNano())),
 		IsActive: schemas.Ptr(true),
 	}); err != nil && !isUniqueRace(err) {
 		return err
@@ -271,7 +271,7 @@ func seedVirtualKeyBudget(ctx context.Context, t *testing.T, store *RDBConfigSto
 	require.NoError(t, store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "PG VK Budget",
-		Value:    "pg-vk-budget-value",
+		Value:    *schemas.NewSecretVar("pg-vk-budget-value"),
 		IsActive: schemas.Ptr(true),
 	}))
 	require.NoError(t, store.CreateBudget(ctx, &tables.TableBudget{

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/require"
 )
@@ -39,7 +40,7 @@ func seedMCPSessionsFixture(t *testing.T, store *RDBConfigStore) {
 	vk := &tables.TableVirtualKey{
 		ID:    "vk-alpha",
 		Name:  "Alpha VK",
-		Value: "sk-bf-alpha",
+		Value: *schemas.NewSecretVar("sk-bf-alpha"),
 	}
 	require.NoError(t, store.DB().WithContext(ctx).Create(vk).Error)
 

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -370,7 +371,7 @@ func TestListOAuth2Sessions_JoinsAndExcludesRevoked(t *testing.T) {
 		ID: "crow", ClientID: "client-1", ClientName: "Test Client",
 		RedirectURIs: []string{"http://127.0.0.1/cb"}, GrantTypes: []string{"authorization_code"}, CreatedAt: time.Now(),
 	}).Error)
-	require.NoError(t, s.DB().Create(&tables.TableVirtualKey{ID: "vk-1", Name: "Alpha VK", Value: "sk-bf-alpha"}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableVirtualKey{ID: "vk-1", Name: "Alpha VK", Value: *schemas.NewSecretVar("sk-bf-alpha")}).Error)
 
 	vkTok := makeRefreshToken("rt-vk", "f1", "client-1", "h-vk")
 	vkTok.BfSub = "vk-1" // joins to governance_virtual_keys.id
@@ -425,7 +426,7 @@ func TestListOAuth2Sessions_FilterAndPaginate(t *testing.T) {
 		ID: "c2", ClientID: "client-2", ClientName: "Beta Server",
 		RedirectURIs: []string{"http://127.0.0.1/cb"}, GrantTypes: []string{"authorization_code"}, CreatedAt: time.Now(),
 	}).Error)
-	require.NoError(t, s.DB().Create(&tables.TableVirtualKey{ID: "vk-1", Name: "Alpha VK", Value: "sk-bf-alpha"}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableVirtualKey{ID: "vk-1", Name: "Alpha VK", Value: *schemas.NewSecretVar("sk-bf-alpha")}).Error)
 
 	base := time.Now()
 	rtA := makeRefreshToken("rt-a", "fa", "client-1", "h-a") // vk mode, bf_sub vk-1 → display "Alpha VK"

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -866,7 +866,7 @@ func TestCreateVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-test",
 		Name:     "Test Virtual Key",
-		Value:    "vk-test-value-123",
+		Value:    *schemas.NewSecretVar("vk-test-value-123"),
 		IsActive: schemas.Ptr(true),
 	}
 
@@ -877,7 +877,7 @@ func TestCreateVirtualKey(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "vk-test", result.ID)
 	assert.Equal(t, "Test Virtual Key", result.Name)
-	assert.Equal(t, "vk-test-value-123", result.Value)
+	assert.Equal(t, "vk-test-value-123", result.Value.Val)
 	assert.True(t, result.IsActiveValue())
 }
 
@@ -911,7 +911,7 @@ func TestCreateVirtualKey_WithBudgetAndRateLimit(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:          vkID,
 		Name:        "VK With References",
-		Value:       "vk-refs-value",
+		Value:       *schemas.NewSecretVar("vk-refs-value"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -939,7 +939,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 	vk1 := &tables.TableVirtualKey{
 		ID:       "vk-1",
 		Name:     "Same Name",
-		Value:    "vk-value-1",
+		Value:    *schemas.NewSecretVar("vk-value-1"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk1)
@@ -948,7 +948,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 	vk2 := &tables.TableVirtualKey{
 		ID:       "vk-2",
 		Name:     "Same Name", // Duplicate name
-		Value:    "vk-value-2",
+		Value:    *schemas.NewSecretVar("vk-value-2"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk2)
@@ -962,7 +962,7 @@ func TestGetVirtualKeyByValue(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-lookup",
 		Name:     "Lookup Key",
-		Value:    "vk-unique-value-xyz",
+		Value:    *schemas.NewSecretVar("vk-unique-value-xyz"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -980,7 +980,7 @@ func TestUpdateVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-update",
 		Name:     "Original Name",
-		Value:    "vk-update-value",
+		Value:    *schemas.NewSecretVar("vk-update-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1005,7 +1005,7 @@ func TestDeleteVirtualKey(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-delete",
 		Name:     "Delete Me",
-		Value:    "vk-delete-value",
+		Value:    *schemas.NewSecretVar("vk-delete-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1025,7 +1025,7 @@ func TestDeleteVirtualKey_RevokesInboundVKGrants(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-grant",
 		Name:     "Grant VK",
-		Value:    "vk-grant-value",
+		Value:    *schemas.NewSecretVar("vk-grant-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	require.NoError(t, store.CreateVirtualKey(ctx, vk))
@@ -1059,7 +1059,7 @@ func TestDeleteVirtualKey_CleansUpScopedModelConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-scoped",
 		Name:     "Scoped VK",
-		Value:    "vk-scoped-value",
+		Value:    *schemas.NewSecretVar("vk-scoped-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	require.NoError(t, store.CreateVirtualKey(ctx, vk))
@@ -1113,7 +1113,7 @@ func TestDeleteVirtualKey_CleansUpMultiBudgetScopedModelConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-multibudget",
 		Name:     "MultiBudget VK",
-		Value:    "vk-multibudget-value",
+		Value:    *schemas.NewSecretVar("vk-multibudget-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	require.NoError(t, store.CreateVirtualKey(ctx, vk))
@@ -1236,7 +1236,7 @@ func TestCreateVirtualKeyProviderConfig(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-for-pc",
 		Name:     "VK For Provider Config",
-		Value:    "vk-pc-value",
+		Value:    *schemas.NewSecretVar("vk-pc-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1279,7 +1279,7 @@ func TestCreateVirtualKeyProviderConfig_WithKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-with-keys",
 		Name:     "VK With Keys",
-		Value:    "vk-keys-value",
+		Value:    *schemas.NewSecretVar("vk-keys-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1319,7 +1319,7 @@ func TestCreateVirtualKeyProviderConfig_UnresolvedKeys(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-unresolved",
 		Name:     "VK Unresolved",
-		Value:    "vk-unresolved-value",
+		Value:    *schemas.NewSecretVar("vk-unresolved-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
@@ -1361,7 +1361,7 @@ func TestUpdateProvider_RemovesStaleVirtualKeyProviderConfigKeyAssociations(t *t
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-update-provider-cleanup",
 		Name:     "VK Update Provider Cleanup",
-		Value:    "vk-update-provider-cleanup-value",
+		Value:    *schemas.NewSecretVar("vk-update-provider-cleanup-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1410,7 +1410,7 @@ func TestDeleteProvider_RemovesVirtualKeyProviderConfigs(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:       "vk-delete-provider-cleanup",
 		Name:     "VK Delete Provider Cleanup",
-		Value:    "vk-delete-provider-cleanup-value",
+		Value:    *schemas.NewSecretVar("vk-delete-provider-cleanup-value"),
 		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
@@ -1806,7 +1806,7 @@ func TestFullVirtualKeyFlow(t *testing.T) {
 	vk := &tables.TableVirtualKey{
 		ID:          integrationVKID,
 		Name:        "Integration Virtual Key",
-		Value:       "vk-integration-xyz",
+		Value:       *schemas.NewSecretVar("vk-integration-xyz"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -1857,7 +1857,7 @@ func TestGetVirtualKeysUsesInternalPagination(t *testing.T) {
 		vk := &tables.TableVirtualKey{
 			ID:        fmt.Sprintf("vk-page-%04d", i),
 			Name:      fmt.Sprintf("Virtual Key %04d", i),
-			Value:     fmt.Sprintf("vk-value-%04d", i),
+			Value:     *schemas.NewSecretVar(fmt.Sprintf("vk-value-%04d", i)),
 			IsActive:  schemas.Ptr(true),
 			CreatedAt: createdAt,
 			UpdatedAt: createdAt,

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -408,7 +408,7 @@ func TestTableVirtualKey_EncryptDecrypt(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-1",
 		Name:     "test-vk",
-		Value:    "vk-secret-value-xyz",
+		Value:    *schemas.NewSecretVar("vk-secret-value-xyz"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -424,7 +424,7 @@ func TestTableVirtualKey_EncryptDecrypt(t *testing.T) {
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-1").Error)
-	assert.Equal(t, "vk-secret-value-xyz", found.Value)
+	assert.Equal(t, "vk-secret-value-xyz", found.Value.GetValue())
 	assert.Equal(t, expectedHash, found.ValueHash)
 }
 
@@ -434,7 +434,7 @@ func TestTableVirtualKey_HashComputedBeforeEncryption(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-hash",
 		Name:     "hash-test",
-		Value:    "plaintext-value",
+		Value:    *schemas.NewSecretVar("plaintext-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -892,21 +892,21 @@ func TestTableVirtualKey_UpdatePreservesDecryption(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-update",
 		Name:     "update-vk",
-		Value:    "original-vk-value",
+		Value:    *schemas.NewSecretVar("original-vk-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)
 
 	var found TableVirtualKey
 	require.NoError(t, db.First(&found, "id = ?", "vk-update").Error)
-	assert.Equal(t, "original-vk-value", found.Value)
+	assert.Equal(t, "original-vk-value", found.Value.GetValue())
 
-	found.Value = "updated-vk-value"
+	found.Value = *schemas.NewSecretVar("updated-vk-value")
 	require.NoError(t, db.Save(&found).Error)
 
 	var found2 TableVirtualKey
 	require.NoError(t, db.First(&found2, "id = ?", "vk-update").Error)
-	assert.Equal(t, "updated-vk-value", found2.Value)
+	assert.Equal(t, "updated-vk-value", found2.Value.GetValue())
 
 	raw := rawRow(t, db, "governance_virtual_keys", "vk-update")
 	assert.Equal(t, "encrypted", raw["encryption_status"])
@@ -1315,7 +1315,7 @@ func TestTableVirtualKey_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	vk := &TableVirtualKey{
 		ID:       "vk-dis-1",
 		Name:     "disabled-vk",
-		Value:    "vk-plaintext-value",
+		Value:    *schemas.NewSecretVar("vk-plaintext-value"),
 		IsActive: bifrost.Ptr(true),
 	}
 
@@ -1331,7 +1331,7 @@ func TestTableVirtualKey_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	// GORM read should return same plaintext
 	var found TableVirtualKey
 	require.NoError(t, db.Where("id = ?", "vk-dis-1").First(&found).Error)
-	assert.Equal(t, "vk-plaintext-value", found.Value)
+	assert.Equal(t, "vk-plaintext-value", found.Value.GetValue())
 }
 
 func TestSessionsTable_EncryptionDisabled_StoresPlaintext(t *testing.T) {

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -209,7 +209,7 @@ type TableVirtualKey struct {
 	ID              string                          `gorm:"primaryKey;type:varchar(255)" json:"id"`
 	Name            string                          `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
 	Description     string                          `gorm:"type:text" json:"description,omitempty"`
-	Value           string                          `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`
+	Value           schemas.SecretVar               `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`
 	IsActive        *bool                           `gorm:"default:true" json:"is_active,omitempty"`                                     // Nil means true (DB default); false means inactive
 	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs      []TableVirtualKeyMCPConfig      `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"mcp_configs"`
@@ -254,6 +254,28 @@ func (vk *TableVirtualKey) IsActiveValue() bool {
 	return *vk.IsActive
 }
 
+// VaultPathKey implements schemas.VaultPathKeyer so vault callbacks can compute the
+// vault base path for this model automatically.
+func (vk *TableVirtualKey) VaultPathKey() string { return vk.ID }
+
+// VaultStoreSelfManaged marks TableVirtualKey as storing its own vault secrets from
+// within BeforeSave, so the global vault callback skips it.
+func (vk *TableVirtualKey) VaultStoreSelfManaged() {}
+
+// MarshalJSON serializes TableVirtualKey with Value emitted as a resolved plain string,
+// never as a SecretVar object. This ensures all REST API responses return "bfvk-xxx"
+// rather than {"value":"bfvk-xxx","type":"plain_text"}.
+func (vk TableVirtualKey) MarshalJSON() ([]byte, error) {
+	type Alias TableVirtualKey
+	return json.Marshal(&struct {
+		Alias
+		Value string `json:"value"`
+	}{
+		Alias: Alias(vk),
+		Value: vk.Value.GetValue(),
+	})
+}
+
 // BeforeSave is a GORM hook that enforces mutual exclusion (team vs customer), computes
 // a SHA-256 hash of the plaintext value for indexed lookups, and encrypts the virtual key
 // value before writing to the database.
@@ -263,13 +285,23 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 		return fmt.Errorf("virtual key cannot belong to both team and customer")
 	}
 
-	// Hash must be computed before encryption (from plaintext value)
-	if vk.Value != "" {
-		vk.ValueHash = encrypt.HashSHA256(vk.Value)
-
+	// Hash must be computed before encryption (from plaintext value).
+	if vk.Value.IsSet() {
+		resolved := vk.Value.GetValue()
+		if resolved == "" {
+			return fmt.Errorf("virtual key %s: env/vault ref %q could not be resolved", vk.ID, vk.Value.GetRawRef())
+		}
+		vk.ValueHash = encrypt.HashSHA256(resolved)
 	}
-	if encrypt.IsEnabled() && vk.Value != "" {
-		if err := encryptString(&vk.Value); err != nil {
+	// Store plaintext SecretVar into vault and rewrite to vault ref before encrypting.
+	if schemas.VaultStoreWriteEnabled() {
+		base := schemas.VaultBasePath(vk.TableName(), vk.VaultPathKey())
+		if err := schemas.StoreOwnedVaultSecretVars(tx.Statement.Context, base, vk); err != nil {
+			return fmt.Errorf("failed to store virtual key secrets to vault: %w", err)
+		}
+	}
+	if encrypt.IsEnabled() && vk.Value.IsSet() {
+		if err := encryptSecretVar(&vk.Value); err != nil {
 			return fmt.Errorf("failed to encrypt virtual key value: %w", err)
 		}
 		vk.EncryptionStatus = EncryptionStatusEncrypted
@@ -285,7 +317,7 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	switch vk.EncryptionStatus {
 	case EncryptionStatusEncrypted:
-		if err := decryptString(&vk.Value); err != nil {
+		if err := decryptSecretVar(&vk.Value); err != nil {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
 		}
 	}

--- a/framework/configstore/vault_callbacks.go
+++ b/framework/configstore/vault_callbacks.go
@@ -1,6 +1,7 @@
 package configstore
 
 import (
+	"log"
 	"reflect"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -59,7 +60,10 @@ func vaultRemoveCallback(tx *gorm.DB) {
 	forEachModel(tx, func(model interface{}, keyer schemas.VaultPathKeyer) {
 		tableName := tx.Statement.Table
 		base := schemas.VaultBasePath(tableName, keyer.VaultPathKey())
-		schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, model)
+		errs := schemas.RemoveOwnedVaultSecretVars(tx.Statement.Context, base, model)
+		for _, err := range errs {
+			log.Printf("vault: failed to remove secret for %s/%s: %v", tableName, keyer.VaultPathKey(), err)
+		}
 	})
 }
 

--- a/framework/configstore/vault_callbacks_test.go
+++ b/framework/configstore/vault_callbacks_test.go
@@ -136,6 +136,45 @@ func TestVaultCallbacks_SelfManagedStoresPlaintext(t *testing.T) {
 	}
 }
 
+// TestVaultCallbacks_SelfManagedRemovesVaultSecrets verifies that deleting a TableKey
+// (a self-managed model) removes all its owned vault secrets via the global remove callback.
+func TestVaultCallbacks_SelfManagedRemovesVaultSecrets(t *testing.T) {
+	stored, removed := stubVaultHooks(t)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	RegisterVaultCallbacks(db)
+	require.NoError(t, db.AutoMigrate(&tables.TableKey{}))
+
+	keyID := "key-delete-test"
+	key := &tables.TableKey{
+		Name:     "k-delete",
+		KeyID:    keyID,
+		Provider: "openai",
+		Value:    schemas.SecretVar{Val: "sk-secret-value"},
+		Models:   schemas.WhiteList{"*"},
+	}
+	require.NoError(t, db.Create(key).Error)
+
+	valuePath := fmt.Sprintf("bifrost/config_keys/%s/value", keyID)
+	require.Equal(t, "sk-secret-value", stored[valuePath], "value not stored to vault on create")
+
+	// Load fresh to get the vault ref populated in SecretVar fields.
+	var toDelete tables.TableKey
+	require.NoError(t, db.First(&toDelete, "key_id = ?", keyID).Error)
+	require.Equal(t, "vault."+valuePath, toDelete.Value.GetRawRef(), "loaded key should carry vault ref")
+
+	require.NoError(t, db.Delete(&toDelete).Error)
+
+	found := false
+	for _, p := range *removed {
+		if p == valuePath {
+			found = true
+		}
+	}
+	require.True(t, found, "expected vault remove for %q, got %v", valuePath, *removed)
+}
+
 func TestVaultCallbacks_NoOpWhenDisabled(t *testing.T) {
 	// No hooks installed -> VaultStoreEnabled() is false -> callbacks no-op.
 	prevStore := schemas.VaultStoreHook

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -45,7 +45,7 @@ func newTestAsyncExecutor(t *testing.T) *AsyncJobExecutor {
 
 	govStore := &testGovernanceStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"sk-bf-test": {ID: "vk-123", Value: "sk-bf-test"},
+			"sk-bf-test": {ID: "vk-123", Value: *schemas.NewSecretVar("sk-bf-test")},
 		},
 	}
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -899,6 +899,12 @@ func (gs *LocalGovernanceStore) GetVirtualKeyByID(ctx context.Context, vkID stri
 // ID-keyed secondary index, keeping the two in lock-step. Every writer to
 // virtualKeys must go through here so the ID index never diverges.
 func (gs *LocalGovernanceStore) storeVirtualKey(value string, vk *configstoreTables.TableVirtualKey) {
+	if value == "" {
+		if vk != nil {
+			gs.logger.Warn("skipping virtual key %s with unresolvable value (env/vault ref could not be resolved)", vk.ID)
+		}
+		return
+	}
 	gs.virtualKeys.Store(value, vk)
 	if vk != nil && vk.ID != "" {
 		gs.virtualKeysByID.Store(vk.ID, vk)
@@ -2419,7 +2425,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// Build virtual keys map and track active VKs
 	for i := range virtualKeys {
 		vk := &virtualKeys[i]
-		gs.storeVirtualKey(vk.Value, vk)
+		gs.storeVirtualKey(vk.Value.GetValue(), vk)
 	}
 
 	// Build model configs map.
@@ -2915,7 +2921,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 		}
 	}
 
-	gs.storeVirtualKey(clone.Value, &clone)
+	gs.storeVirtualKey(clone.Value.GetValue(), &clone)
 }
 
 // UpdateVirtualKeyInMemory updates an existing virtual key in the in-memory store (lock-free)
@@ -2926,8 +2932,8 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 
 	// Do not update the current usage of the rate limit, as it will be updated by the usage tracker.
 	// But update if max limit or reset duration changes.
-	existingVKKey := vk.Value
-	existingVKValue, exists := gs.virtualKeys.Load(vk.Value)
+	existingVKKey := vk.Value.GetValue()
+	existingVKValue, exists := gs.virtualKeys.Load(vk.Value.GetValue())
 	if exists && existingVKValue != nil {
 		if existingVK, ok := existingVKValue.(*configstoreTables.TableVirtualKey); !ok || existingVK == nil || existingVK.ID != vk.ID {
 			exists = false
@@ -3090,10 +3096,10 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 				}
 			}
 		}
-		if existingVKKey != "" && existingVKKey != vk.Value {
+		if existingVKKey != "" && existingVKKey != vk.Value.GetValue() {
 			gs.deleteVirtualKeyByValue(existingVKKey)
 		}
-		gs.storeVirtualKey(vk.Value, &clone)
+		gs.storeVirtualKey(vk.Value.GetValue(), &clone)
 	} else {
 		gs.CreateVirtualKeyInMemory(ctx, vk)
 	}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -656,7 +656,7 @@ func TestGovernanceStore_UpdateVirtualKeyInMemory_RotatedValueRemovesOldLookup(t
 	require.NoError(t, err)
 
 	updated := *vk
-	updated.Value = "sk-bf-new"
+	updated.Value = *schemas.NewSecretVar("sk-bf-new")
 	store.UpdateVirtualKeyInMemory(context.Background(), &updated, nil, nil, nil)
 
 	oldVK, oldFound := store.GetVirtualKey(context.Background(), "sk-bf-old")

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -80,7 +80,7 @@ func (ml *MockLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas
 func buildVirtualKey(id, value, name string, isActive bool) *configstoreTables.TableVirtualKey {
 	return &configstoreTables.TableVirtualKey{
 		ID:       id,
-		Value:    value,
+		Value:    *schemas.NewSecretVar(value),
 		Name:     name,
 		IsActive: &isActive,
 	}

--- a/tests/cmd/seed/seed.go
+++ b/tests/cmd/seed/seed.go
@@ -613,9 +613,9 @@ func seedGovernance(ctx context.Context, db *gorm.DB, prefix string, now time.Ti
 		}
 	}
 	for _, vk := range []tables.TableVirtualKey{
-		{ID: prefix + "-vk-user-team", Name: "E2E User Team VK", Value: prefix + "-vk-user-team-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
-		{ID: prefix + "-vk-team-only", Name: "E2E Team Only VK", Value: prefix + "-vk-team-only-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
-		{ID: prefix + "-vk-outside", Name: "E2E Outside VK", Value: prefix + "-vk-outside-secret", IsActive: &active, TeamID: &outsideTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-user-team", Name: "E2E User Team VK", Value: *schemas.NewSecretVar(prefix + "-vk-user-team-secret"), IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-team-only", Name: "E2E Team Only VK", Value: *schemas.NewSecretVar(prefix + "-vk-team-only-secret"), IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-outside", Name: "E2E Outside VK", Value: *schemas.NewSecretVar(prefix + "-vk-outside-secret"), IsActive: &active, TeamID: &outsideTeam, CreatedAt: now, UpdatedAt: now},
 	} {
 		if err := db.WithContext(ctx).Where("id = ?", vk.ID).Assign(vk).FirstOrCreate(&vk).Error; err != nil {
 			return err

--- a/tests/cmd/seedvks/main.go
+++ b/tests/cmd/seedvks/main.go
@@ -135,7 +135,7 @@ func generateBatch(prefix string, start, n int, now time.Time) []configstoreTabl
 		rows = append(rows, configstoreTables.TableVirtualKey{
 			ID:        uuid.NewString(),
 			Name:      fmt.Sprintf("%s-%d", prefix, idx),
-			Value:     virtualKeyPrefix + uuid.NewString(),
+			Value:     *schemas.NewSecretVar(virtualKeyPrefix + uuid.NewString()),
 			CreatedAt: now,
 			UpdatedAt: now,
 		})

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1291,7 +1291,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		vk = configstoreTables.TableVirtualKey{
 			ID:              uuid.NewString(),
 			Name:            req.Name,
-			Value:           governance.GenerateVirtualKey(),
+			Value:           *schemas.NewSecretVar(governance.GenerateVirtualKey()),
 			Description:     req.Description,
 			TeamID:          req.TeamID,
 			CustomerID:      req.CustomerID,
@@ -1904,9 +1904,9 @@ func (h *GovernanceHandler) rotateVirtualKeyByID(ctx context.Context, vkID strin
 	if err != nil {
 		return nil, err
 	}
-	oldValue := vk.Value
-	vk.Value = governance.GenerateVirtualKey()
-	if vk.Value == oldValue {
+	oldValue := vk.Value.GetValue()
+	vk.Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
+	if vk.Value.GetValue() == oldValue {
 		return nil, fmt.Errorf("generated virtual key matched existing value")
 	}
 	if err := h.configStore.UpdateVirtualKey(ctx, vk); err != nil {

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1040,7 +1040,7 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 			"vk-1": {
 				ID:          "vk-1",
 				Name:        "Production",
-				Value:       "sk-bf-old",
+				Value:       *schemas.NewSecretVar("sk-bf-old"),
 				Description: "existing description",
 				TeamID:      &teamID,
 				RateLimitID: &rateLimitID,
@@ -1076,11 +1076,11 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 	}
 
 	updated := store.virtualKeys["vk-1"]
-	if updated.Value == "sk-bf-old" {
+	if updated.Value.GetValue() == "sk-bf-old" {
 		t.Fatal("expected virtual key value to rotate")
 	}
-	if !strings.HasPrefix(updated.Value, governance.VirtualKeyPrefix) {
-		t.Fatalf("expected rotated value to use %q prefix, got %q", governance.VirtualKeyPrefix, updated.Value)
+	if !strings.HasPrefix(updated.Value.GetValue(), governance.VirtualKeyPrefix) {
+		t.Fatalf("expected rotated value to use %q prefix, got %q", governance.VirtualKeyPrefix, updated.Value.GetValue())
 	}
 	if updated.ID != "vk-1" || updated.Name != "Production" || updated.Description != "existing description" {
 		t.Fatalf("rotation changed non-value fields: %#v", updated)
@@ -1105,8 +1105,8 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
-	if resp.VirtualKey.Value != updated.Value {
-		t.Fatalf("response value = %q, want %q", resp.VirtualKey.Value, updated.Value)
+	if resp.VirtualKey.Value.GetValue() != updated.Value.GetValue() {
+		t.Fatalf("response value = %q, want %q", resp.VirtualKey.Value.GetValue(), updated.Value.GetValue())
 	}
 }
 
@@ -1138,7 +1138,7 @@ func TestRotateVirtualKey_UpdateFailureDoesNotReload(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old")},
 		},
 		updateErr: errors.New("database unavailable"),
 	}
@@ -1153,8 +1153,8 @@ func TestRotateVirtualKey_UpdateFailureDoesNotReload(t *testing.T) {
 	if ctx.Response.StatusCode() != 500 {
 		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
 	}
-	if store.virtualKeys["vk-1"].Value != "sk-bf-old" {
-		t.Fatalf("expected value to remain unchanged, got %q", store.virtualKeys["vk-1"].Value)
+	if store.virtualKeys["vk-1"].Value.GetValue() != "sk-bf-old" {
+		t.Fatalf("expected value to remain unchanged, got %q", store.virtualKeys["vk-1"].Value.GetValue())
 	}
 	if len(manager.reloadIDs) != 0 {
 		t.Fatalf("expected no reloads, got %#v", manager.reloadIDs)
@@ -1166,7 +1166,7 @@ func TestRotateVirtualKey_ReloadFailureReturnsErrorAfterUpdate(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store, reloadErr: errors.New("reload failed")}
@@ -1183,7 +1183,7 @@ func TestRotateVirtualKey_ReloadFailureReturnsErrorAfterUpdate(t *testing.T) {
 	if store.updates != 1 {
 		t.Fatalf("expected one update, got %d", store.updates)
 	}
-	if store.virtualKeys["vk-1"].Value == "sk-bf-old" {
+	if store.virtualKeys["vk-1"].Value.GetValue() == "sk-bf-old" {
 		t.Fatal("expected value to rotate before reload failure")
 	}
 	if len(manager.reloadIDs) != 1 || manager.reloadIDs[0] != "vk-1" {
@@ -1199,8 +1199,8 @@ func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
-			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: *schemas.NewSecretVar("sk-bf-old-2")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store}
@@ -1220,7 +1220,7 @@ func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 	if len(manager.reloadIDs) != 2 || manager.reloadIDs[0] != "vk-1" || manager.reloadIDs[1] != "vk-2" {
 		t.Fatalf("expected reloads for vk-1 and vk-2, got %#v", manager.reloadIDs)
 	}
-	if store.virtualKeys["vk-1"].Value == "sk-bf-old-1" || store.virtualKeys["vk-2"].Value == "sk-bf-old-2" {
+	if store.virtualKeys["vk-1"].Value.GetValue() == "sk-bf-old-1" || store.virtualKeys["vk-2"].Value.GetValue() == "sk-bf-old-2" {
 		t.Fatalf("expected successful IDs to rotate: %#v", store.virtualKeys)
 	}
 
@@ -1256,7 +1256,7 @@ func TestRotateVirtualKeys_RejectsInvalidRequests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := &mockRotateConfigStore{
 				virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-					"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
+					"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
 				},
 			}
 			manager := &mockRotateGovernanceManager{store: store}
@@ -1288,8 +1288,8 @@ func TestRotateVirtualKeys_TrimsAndDeduplicatesIDs(t *testing.T) {
 
 	store := &mockRotateConfigStore{
 		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
-			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
-			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+			"vk-1": {ID: "vk-1", Name: "One", Value: *schemas.NewSecretVar("sk-bf-old-1")},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: *schemas.NewSecretVar("sk-bf-old-2")},
 		},
 	}
 	manager := &mockRotateGovernanceManager{store: store}
@@ -1742,7 +1742,7 @@ func TestGetVirtualKeyQuota_EndToEndWithRealStore(t *testing.T) {
 	vk := &configstoreTables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "Prod",
-		Value:    "sk-bf-e2e-secret",
+		Value:    *schemas.NewSecretVar("sk-bf-e2e-secret"),
 		IsActive: &active,
 		ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 			{VirtualKeyID: vkID, Provider: "openai", AllowAllKeys: true, AllowedModels: schemas.WhiteList{"*"}},
@@ -1908,7 +1908,7 @@ func TestGetVirtualKeyQuota_WindowClampedToBudgetCreation(t *testing.T) {
 	vk := &configstoreTables.TableVirtualKey{
 		ID:       vkID,
 		Name:     "Clamp",
-		Value:    "sk-bf-clamp-secret",
+		Value:    *schemas.NewSecretVar("sk-bf-clamp-secret"),
 		IsActive: &active,
 	}
 	if err := store.CreateVirtualKey(ctx, vk); err != nil {

--- a/transports/bifrost-http/handlers/list_models_vk_test.go
+++ b/transports/bifrost-http/handlers/list_models_vk_test.go
@@ -28,7 +28,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSetsActiveVKProviders(t *testing
 	h := &CompletionHandler{
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
-				Value:    "sk-bf-active",
+				Value:    *schemas.NewSecretVar("sk-bf-active"),
 				IsActive: new(true),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},
@@ -124,7 +124,7 @@ func TestApplyListModelsVirtualKeyProviderFilterSkipsInactiveVK(t *testing.T) {
 	h := &CompletionHandler{
 		config: &lib.Config{
 			ConfigStore: &mockListModelsVKConfigStore{vk: &configstoreTables.TableVirtualKey{
-				Value:    "sk-bf-inactive",
+				Value:    *schemas.NewSecretVar("sk-bf-inactive"),
 				IsActive: new(false),
 				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
 					{Provider: "openai"},

--- a/transports/bifrost-http/handlers/mcpoauth2consent_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2consent_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	configtables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -152,8 +153,8 @@ func TestConsentAvailableModes(t *testing.T) {
 }
 
 func TestConsentFlowSubmit_VK(t *testing.T) {
-	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-active", IsActive: new(true)}
-	inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-2", Value: "sk-bf-inactive", IsActive: new(false)}
+	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
+	inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-2", Value: *schemas.NewSecretVar("sk-bf-inactive"), IsActive: new(false)}
 
 	t.Run("active VK mints a code", func(t *testing.T) {
 		store := newConsentStore()
@@ -175,7 +176,7 @@ func TestConsentFlowSubmit_VK(t *testing.T) {
 
 	t.Run("inactive VK is rejected", func(t *testing.T) {
 		store := newConsentStore()
-		store.vksByValue[inactiveVK.Value] = inactiveVK
+		store.vksByValue[inactiveVK.Value.GetValue()] = inactiveVK
 		seedPendingFlow(store, "flow-1", time.Now().Add(time.Minute))
 		h := newConsentHandler(store, nil, false)
 		ctx := consentCtx("flow-1", `{"mode":"vk","value":"sk-bf-inactive"}`)
@@ -203,7 +204,7 @@ func TestConsentFlowSubmit_VK(t *testing.T) {
 
 	t.Run("double submit returns 410 on the second attempt", func(t *testing.T) {
 		store := newConsentStore()
-		store.vksByValue[activeVK.Value] = activeVK
+		store.vksByValue[activeVK.Value.GetValue()] = activeVK
 		seedPendingFlow(store, "flow-1", time.Now().Add(time.Minute))
 		h := newConsentHandler(store, nil, false)
 
@@ -272,11 +273,11 @@ func TestConsentFlowSubmit_User(t *testing.T) {
 }
 
 func TestConsentFlowSubmit_VKUserBinding(t *testing.T) {
-	boundVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-bound", IsActive: new(true)}
+	boundVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-bound"), IsActive: new(true)}
 
 	t.Run("bound VK upgrades to user when logged-in user matches", func(t *testing.T) {
 		store := newConsentStore()
-		store.vksByValue[boundVK.Value] = boundVK
+		store.vksByValue[boundVK.Value.GetValue()] = boundVK
 		seedPendingFlow(store, "flow-1", time.Now().Add(time.Minute))
 		h := newConsentHandler(store, &fakeResolver{userModeAvailable: true, userID: "owner-1", vkBoundUserID: "owner-1"}, false)
 		ctx := consentCtx("flow-1", `{"mode":"vk","value":"sk-bf-bound"}`)
@@ -288,7 +289,7 @@ func TestConsentFlowSubmit_VKUserBinding(t *testing.T) {
 
 	t.Run("bound VK rejected when logged-in user differs", func(t *testing.T) {
 		store := newConsentStore()
-		store.vksByValue[boundVK.Value] = boundVK
+		store.vksByValue[boundVK.Value.GetValue()] = boundVK
 		seedPendingFlow(store, "flow-1", time.Now().Add(time.Minute))
 		h := newConsentHandler(store, &fakeResolver{userModeAvailable: true, userID: "intruder", vkBoundUserID: "owner-1"}, false)
 		ctx := consentCtx("flow-1", `{"mode":"vk","value":"sk-bf-bound"}`)
@@ -298,7 +299,7 @@ func TestConsentFlowSubmit_VKUserBinding(t *testing.T) {
 
 	t.Run("bound VK rejected when not signed in", func(t *testing.T) {
 		store := newConsentStore()
-		store.vksByValue[boundVK.Value] = boundVK
+		store.vksByValue[boundVK.Value.GetValue()] = boundVK
 		seedPendingFlow(store, "flow-1", time.Now().Add(time.Minute))
 		h := newConsentHandler(store, &fakeResolver{userModeAvailable: true, userID: "", vkBoundUserID: "owner-1"}, false)
 		ctx := consentCtx("flow-1", `{"mode":"vk","value":"sk-bf-bound"}`)

--- a/transports/bifrost-http/handlers/mcpoauth2jwt.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt.go
@@ -144,7 +144,7 @@ func injectJWTContext(bifrostCtx *schemas.BifrostContext, claims *jwtMCPClaims, 
 		// the VK row ID (BifrostContextKeyGovernanceVirtualKeyID) on the connect
 		// path before the per-user credential resolver needs it — the same way the
 		// x-bf-vk header path does, which never stamps the row ID at ingress either.
-		bifrostCtx.SetValue(schemas.BifrostContextKeyVirtualKey, vk.Value)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyVirtualKey, vk.Value.GetValue())
 	case schemas.MCPAuthModeSession:
 		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPSessionID, sub)
 	default:

--- a/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
@@ -400,7 +400,7 @@ func TestCachedSigningKey_ConfigFaults(t *testing.T) {
 }
 
 func TestInjectJWTContext(t *testing.T) {
-	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-active"}
+	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active")}
 
 	t.Run("user mode sets user id", func(t *testing.T) {
 		bc := schemas.NewBifrostContext(context.Background(), time.Time{})

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -348,7 +348,7 @@ func (h *MCPServerHandler) SyncAllMCPServers(ctx context.Context) error {
 func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) *server.MCPServer {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	vkServer, ok := h.vkMCPServers[vk.Value]
+	vkServer, ok := h.vkMCPServers[vk.Value.GetValue()]
 	if !ok {
 		// Add new server
 		vkServer = server.NewMCPServer(
@@ -357,11 +357,11 @@ func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) *server.M
 			server.WithToolCapabilities(true),
 		)
 		server.WithToolFilter(h.makeIncludeClientsFilter())(vkServer)
-		h.vkMCPServers[vk.Value] = vkServer
+		h.vkMCPServers[vk.Value.GetValue()] = vkServer
 	}
 	availableTools, toolFilter := h.fetchToolsForVK(vk)
 	h.syncServer(vkServer, availableTools, toolFilter)
-	h.vkMCPServers[vk.Value] = vkServer
+	h.vkMCPServers[vk.Value.GetValue()] = vkServer
 	logger.Debug("Synced MCP server for virtual key '%s' with %d tools", vk.Name, len(availableTools))
 	return vkServer
 }
@@ -658,7 +658,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 			if !vk.IsActiveValue() {
 				return nil, fmt.Errorf("virtual key is inactive")
 			}
-			vkServer, err := h.ensureVKMCPServerByValue(ctx, vk.Value)
+			vkServer, err := h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
 			if err != nil {
 				return nil, err
 			}
@@ -749,7 +749,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*mc
 				return nil, fmt.Errorf("virtual key is inactive")
 			}
 			res.jwtVK = vk
-			vkServer, serverErr := h.ensureVKMCPServerByValue(ctx, vk.Value)
+			vkServer, serverErr := h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
 			if serverErr != nil {
 				return nil, serverErr
 			}
@@ -836,7 +836,7 @@ func (h *MCPServerHandler) userScopedServer(ctx *fasthttp.RequestCtx, claims *jw
 	if !vk.IsActiveValue() {
 		return nil, fmt.Errorf("virtual key is inactive")
 	}
-	return h.ensureVKMCPServerByValue(ctx, vk.Value)
+	return h.ensureVKMCPServerByValue(ctx, vk.Value.GetValue())
 }
 
 // ensureVKMCPServerByValue returns the per-VK server from cache or creates it.

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -98,7 +98,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 	key, priv := newTestSigningKey(t)
 
 	t.Run("oauth mode: valid vk JWT with active key is accepted", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-active", IsActive: new(true)}
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
@@ -106,7 +106,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, false)
 		h := newTestMCPHandler(cfg)
 		// Pre-seed the per-VK server so the accepted path does not build one.
-		h.vkMCPServers[activeVK.Value] = server.NewMCPServer("vk", "v0")
+		h.vkMCPServers[activeVK.Value.GetValue()] = server.NewMCPServer("vk", "v0")
 
 		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
 			c["bf_mode"] = string(schemas.MCPAuthModeVK)
@@ -125,7 +125,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 	})
 
 	t.Run("vk JWT with inactive key is rejected", func(t *testing.T) {
-		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-x", IsActive: new(false)}
+		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK},
@@ -181,7 +181,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 	})
 
 	t.Run("user JWT is scoped to the user's representative virtual key", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-user-rep", IsActive: new(true)}
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
@@ -192,7 +192,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 		// scoped path does not build a real one.
 		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
 		vkServer := server.NewMCPServer("vk", "v0")
-		h.vkMCPServers[activeVK.Value] = vkServer
+		h.vkMCPServers[activeVK.Value.GetValue()] = vkServer
 
 		raw := mintTestToken(t, priv, key.KID, func(c jwt.MapClaims) {
 			c["bf_mode"] = string(schemas.MCPAuthModeUser)
@@ -212,7 +212,7 @@ func TestGetMCPServerForRequest_JWTPath(t *testing.T) {
 	})
 
 	t.Run("user JWT is rejected when the user is no longer active", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-user-rep", IsActive: new(true)}
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": activeVK},
@@ -366,7 +366,7 @@ func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
 	SetLogger(&mockLogger{})
 	key, _ := newTestSigningKey(t)
 
-	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-user-rep", IsActive: new(true)}
+	activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-user-rep"), IsActive: new(true)}
 	newStore := func() *mockOAuth2Store {
 		return &mockOAuth2Store{
 			signingKey: key,
@@ -383,7 +383,7 @@ func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
 			h := newTestMCPHandler(cfg)
 			h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
 			vkServer := server.NewMCPServer("vk", "v0")
-			h.vkMCPServers[activeVK.Value] = vkServer
+			h.vkMCPServers[activeVK.Value.GetValue()] = vkServer
 
 			ctx := &fasthttp.RequestCtx{}
 			ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
@@ -417,7 +417,7 @@ func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
 		cfg := newTestOAuth2Config(newStore(), configtables.MCPServerAuthModeBoth, true)
 		h := newTestMCPHandler(cfg)
 		h.identityResolver = &fakeResolver{userVKID: "vk-row-1"}
-		h.vkMCPServers[activeVK.Value] = server.NewMCPServer("vk", "v0")
+		h.vkMCPServers[activeVK.Value.GetValue()] = server.NewMCPServer("vk", "v0")
 
 		ctx := &fasthttp.RequestCtx{}
 		ctx.SetUserValue(schemas.BifrostContextKeyUserID, "user-1")
@@ -429,7 +429,7 @@ func TestGetMCPServerForRequest_PreAuthenticatedUserPath(t *testing.T) {
 	})
 
 	t.Run("inactive representative virtual key is rejected", func(t *testing.T) {
-		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-x", IsActive: new(false)}
+		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByID:    map[string]*configtables.TableVirtualKey{"vk-row-1": inactiveVK},
@@ -482,14 +482,14 @@ func TestGetMCPServerForRequest_HeaderAndAnonPath(t *testing.T) {
 	key, _ := newTestSigningKey(t)
 
 	t.Run("headers mode: active header VK connects", func(t *testing.T) {
-		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-active", IsActive: new(true)}
+		activeVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-active"), IsActive: new(true)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByValue: map[string]*configtables.TableVirtualKey{"sk-bf-active": activeVK},
 		}
 		cfg := newTestOAuth2Config(store, configtables.MCPServerAuthModeHeaders, true)
 		h := newTestMCPHandler(cfg)
-		h.vkMCPServers[activeVK.Value] = server.NewMCPServer("vk", "v0")
+		h.vkMCPServers[activeVK.Value.GetValue()] = server.NewMCPServer("vk", "v0")
 
 		ctx := &fasthttp.RequestCtx{}
 		ctx.Request.Header.Set(string(schemas.BifrostContextKeyVirtualKey), "sk-bf-active")
@@ -501,7 +501,7 @@ func TestGetMCPServerForRequest_HeaderAndAnonPath(t *testing.T) {
 	})
 
 	t.Run("inactive header VK is rejected at the shared chokepoint", func(t *testing.T) {
-		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: "sk-bf-x", IsActive: new(false)}
+		inactiveVK := &configtables.TableVirtualKey{ID: "vk-row-1", Value: *schemas.NewSecretVar("sk-bf-x"), IsActive: new(false)}
 		store := &mockOAuth2Store{
 			signingKey: key,
 			vksByValue: map[string]*configtables.TableVirtualKey{"sk-bf-x": inactiveVK},

--- a/transports/bifrost-http/handlers/requestpayload_test.go
+++ b/transports/bifrost-http/handlers/requestpayload_test.go
@@ -40,7 +40,7 @@ func TestPrepareRequestInvalidPayloadDoesNotExposeDecoderDetails(t *testing.T) {
 		t.Fatal("expected error for invalid payload")
 	}
 	msg := err.Error()
-	if msg != "invalid request payload" {
+	if msg != "Invalid request payload" {
 		t.Fatalf("error = %q, want generic invalid payload message", msg)
 	}
 	if strings.Contains(msg, "cannot unmarshal") || strings.Contains(msg, "model") || strings.Contains(msg, "Go struct field") {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2285,26 +2285,18 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 				if forceFileSync || existingVirtualKey.ConfigHash != fileVKHash {
 					logger.Debug("config hash mismatch for virtual key %s, syncing from config file", existingVirtualKey.ID)
 					configData.Governance.VirtualKeys[i].ConfigHash = fileVKHash
-					// This is added for backward compatibility with existing configs
-					if configData.Governance.VirtualKeys[i].Value == "" && existingVirtualKey.Value != "" {
+					// Preserve stored value when config doesn't supply one
+					if configData.Governance.VirtualKeys[i].Value.ShouldPreserveStored() && existingVirtualKey.Value.IsSet() {
 						configData.Governance.VirtualKeys[i].Value = existingVirtualKey.Value
 					}
-					// Process environment variable for virtual key value
-					if strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, "env.") {
-						// Resolving the environment variable value
-						envValue, err := envutils.ProcessEnvValue(configData.Governance.VirtualKeys[i].Value)
-						if err != nil {
-							logger.Warn("failed to process environment variable for virtual key %s: %v", newVirtualKey.ID, err)
-							continue
-						}
-						configData.Governance.VirtualKeys[i].Value = envValue
+					resolvedVal := configData.Governance.VirtualKeys[i].Value.GetValue()
+					if resolvedVal == "" && configData.Governance.VirtualKeys[i].Value.IsFromSecret() {
+						logger.Warn("virtual key %s: env/vault ref %q could not be resolved, skipping update", newVirtualKey.ID, configData.Governance.VirtualKeys[i].Value.GetRawRef())
+						break
 					}
-					// If the virtual key value is not a valid virtual key, we will generate a new one
-					if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, governance.VirtualKeyPrefix) {
-						if configData.Governance.VirtualKeys[i].Value != "" {
-							logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
-						}
-						configData.Governance.VirtualKeys[i].Value = governance.GenerateVirtualKey()
+					if !strings.HasPrefix(resolvedVal, governance.VirtualKeyPrefix) {
+						logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
+						configData.Governance.VirtualKeys[i].Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
 					}
 					// Resolve MCP client names to IDs for config file mcp_configs
 					configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(
@@ -2322,22 +2314,14 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			if configData.Governance.VirtualKeys[i].ID == "" {
 				configData.Governance.VirtualKeys[i].ID = uuid.NewString()
 			}
-			// if the virtual key value is env.VIRTUAL_KEY_VALUE, then we will need to resolve the environment variable
-			// Process environment variable for virtual key value
-			if strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, "env.") {
-				// Resolving the environment variable value
-				envValue, err := envutils.ProcessEnvValue(configData.Governance.VirtualKeys[i].Value)
-				if err != nil {
-					logger.Warn("failed to process environment variable for virtual key %s: %v", newVirtualKey.ID, err)
-					continue
-				}
-				configData.Governance.VirtualKeys[i].Value = envValue
+			resolvedVal := configData.Governance.VirtualKeys[i].Value.GetValue()
+			if resolvedVal == "" && configData.Governance.VirtualKeys[i].Value.IsFromSecret() {
+				logger.Warn("virtual key %s: env/vault ref %q could not be resolved, skipping", newVirtualKey.ID, configData.Governance.VirtualKeys[i].Value.GetRawRef())
+				continue
 			}
-			if !strings.HasPrefix(configData.Governance.VirtualKeys[i].Value, governance.VirtualKeyPrefix) {
-				if configData.Governance.VirtualKeys[i].Value != "" {
-					logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
-				}
-				configData.Governance.VirtualKeys[i].Value = governance.GenerateVirtualKey()
+			if !strings.HasPrefix(resolvedVal, governance.VirtualKeyPrefix) {
+				logger.Warn("virtual key %s has a value in the config file that does not have %s prefix. We are generating a new one for you.", newVirtualKey.ID, governance.VirtualKeyPrefix)
+				configData.Governance.VirtualKeys[i].Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
 			}
 			// Resolve MCP client names to IDs for config file mcp_configs
 			configData.Governance.VirtualKeys[i].MCPConfigs = resolveMCPConfigClientIDs(
@@ -4364,29 +4348,6 @@ func (c *Config) GetRawConfigString() string {
 	return string(data)
 }
 
-// processEnvValue checks and replaces environment variable references in configuration values.
-// Returns the processed value and the environment variable name if it was an env reference.
-// Supports the "env.VARIABLE_NAME" syntax for referencing environment variables.
-// This enables secure configuration management without hardcoding sensitive values.
-//
-// Examples:
-//   - "env.OPENAI_API_KEY" -> actual value from OPENAI_API_KEY environment variable
-//   - "sk-1234567890" -> returned as-is (no env prefix)
-func (c *Config) processEnvValue(value string) (string, string, error) {
-	v := strings.TrimSpace(value)
-	if !strings.HasPrefix(v, "env.") {
-		return value, "", nil // do not trim non-env values
-	}
-	envKey := strings.TrimSpace(strings.TrimPrefix(v, "env."))
-	if envKey == "" {
-		return "", "", fmt.Errorf("environment variable name missing in %q", value)
-	}
-	if envValue, ok := os.LookupEnv(envKey); ok {
-		return envValue, envKey, nil
-	}
-	return "", envKey, fmt.Errorf("environment variable %s not found", envKey)
-}
-
 // GetProviderConfigRaw retrieves the raw, unredacted provider configuration from memory.
 // This method is for internal use only, particularly by the account implementation.
 //
@@ -6119,7 +6080,7 @@ func (c *Config) autoDetectProviders(ctx context.Context) {
 
 	for provider, envVars := range providerEnvVars {
 		for _, envVar := range envVars {
-			if apiKey := os.Getenv(envVar); apiKey != "" {
+			if os.Getenv(envVar) != "" {
 				// Generate a unique ID for the auto-detected key
 				keyID := uuid.NewString()
 				// Create default provider configuration
@@ -6128,7 +6089,7 @@ func (c *Config) autoDetectProviders(ctx context.Context) {
 						{
 							ID:     keyID,
 							Name:   fmt.Sprintf("%s_auto_detected", envVar),
-							Value:  *schemas.NewSecretVar(apiKey),
+							Value:  *schemas.NewSecretVar("env." + envVar),
 							Models: schemas.WhiteList{"*"},
 							Weight: 1.0,
 						},

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2332,7 +2332,7 @@ func makeVirtualKey(id, name, value string) tables.TableVirtualKey {
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 	}
 }
@@ -2343,7 +2343,7 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key with team",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -2355,7 +2355,7 @@ func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.Table
 		ID:          id,
 		Name:        name,
 		Description: "Test virtual key with customer",
-		Value:       value,
+		Value:       *schemas.NewSecretVar(value),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
@@ -2367,7 +2367,7 @@ func makeVirtualKeyWithProviderConfigs(id, name, value string, providerConfigs [
 		ID:              id,
 		Name:            name,
 		Description:     "Test virtual key with provider configs",
-		Value:           value,
+		Value:           *schemas.NewSecretVar(value),
 		IsActive:        schemas.Ptr(true),
 		ProviderConfigs: providerConfigs,
 	}
@@ -7226,7 +7226,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7246,7 +7246,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "different-id", // Different ID - should be skipped
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7265,7 +7265,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "different-name", // Different name
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7284,7 +7284,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_different", // Different value
+		Value:       *schemas.NewSecretVar("vk_different"), // Different value
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7303,7 +7303,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(false), // Different IsActive
 		TeamID:      &teamID,
 	}
@@ -7323,7 +7323,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &differentTeamID, // Different TeamID
 	}
@@ -7342,7 +7342,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Different description", // Different description
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7362,7 +7362,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &customerID, // CustomerID set
@@ -7383,7 +7383,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &differentCustomerID, // Different CustomerID
@@ -7404,7 +7404,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID, // RateLimitID set
@@ -7425,7 +7425,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &differentRateLimitID, // Different RateLimitID
@@ -7452,7 +7452,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7484,7 +7484,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7512,7 +7512,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -7549,7 +7549,7 @@ func TestGenerateVirtualKeyHash_AllowAllKeysAndBlacklistedModels(t *testing.T) {
 		return tables.TableVirtualKey{
 			ID:       "vk-1",
 			Name:     "test-vk",
-			Value:    "vk_abc123",
+			Value:    *schemas.NewSecretVar("vk_abc123"),
 			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -7617,7 +7617,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7643,7 +7643,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7669,7 +7669,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -7700,7 +7700,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7717,7 +7717,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &dbTeamID,
 		ConfigHash:  fileHash, // Same hash as file
@@ -7750,7 +7750,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "old-name", // Old name
 		Description: "Old description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7767,7 +7767,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "new-name", // Updated name
 		Description: "New description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &fileTeamID,
 	}
@@ -7798,7 +7798,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard123",
+		Value:       *schemas.NewSecretVar("vk_dashboard123"),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 		RateLimitID: &rateLimitID,
@@ -7816,7 +7816,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 			ID:          "vk-file",
 			Name:        "file-vk",
 			Description: "From config.json",
-			Value:       "vk_file123",
+			Value:       *schemas.NewSecretVar("vk_file123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -7846,7 +7846,7 @@ func TestVirtualKeyHashComparison_NewVirtualKey(t *testing.T) {
 		ID:          "vk-new",
 		Name:        "new-vk",
 		Description: "New virtual key from config.json",
-		Value:       "vk_new123",
+		Value:       *schemas.NewSecretVar("vk_new123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7888,7 +7888,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 	}
 
@@ -7903,7 +7903,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -7923,7 +7923,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
@@ -7947,7 +7947,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
@@ -7973,7 +7973,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Base description",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
@@ -8036,7 +8036,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID,
@@ -8066,7 +8066,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		TeamID:      &reloadTeamID,
 		RateLimitID: &reloadRateLimitID,
@@ -8806,7 +8806,7 @@ func TestSQLite_VirtualKey_HashMismatch_FileSync(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "modified-name",
 			Description: "Modified description",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -8859,7 +8859,7 @@ func TestSQLite_VirtualKey_DBOnlyVK_Preserved(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard456",
+		Value:       *schemas.NewSecretVar("vk_dashboard456"),
 		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
@@ -8908,7 +8908,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK with provider configs",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -8946,7 +8946,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "VK with provider configs",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9001,7 +9001,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigs(t *testing.T) {
 			ID:          "vk-2",
 			Name:        "vk-with-providers",
 			Description: "VK with provider configs added via merge",
-			Value:       "vk_providers456",
+			Value:       *schemas.NewSecretVar("vk_providers456"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9114,7 +9114,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			ID:          "vk-2",
 			Name:        "vk-with-provider-keys",
 			Description: "VK with provider configs referencing keys",
-			Value:       "vk_keys456",
+			Value:       *schemas.NewSecretVar("vk_keys456"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9172,7 +9172,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9189,7 +9189,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9221,7 +9221,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9262,7 +9262,7 @@ func TestSQLite_VKProviderConfig_NewConfig(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "vk-with-provider-config",
 			Description: "VK with provider configs",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9329,7 +9329,7 @@ func TestSQLite_VKProviderConfig_KeyIDsWildcardFlipsAllowAllKeys(t *testing.T) {
 		{
 			ID:       "vk-1",
 			Name:     "wildcard-vk",
-			Value:    "vk_test123",
+			Value:    *schemas.NewSecretVar("vk_test123"),
 			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9363,7 +9363,7 @@ func TestSQLite_VKProviderConfig_KeyIDsWildcardFlipsAllowAllKeys(t *testing.T) {
 		{
 			ID:       "vk-1",
 			Name:     "wildcard-vk",
-			Value:    "vk_test123",
+			Value:    *schemas.NewSecretVar("vk_test123"),
 			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9420,7 +9420,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "vk-with-provider-ref",
 			Description: "VK with provider config",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -9472,7 +9472,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9490,7 +9490,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9522,7 +9522,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9555,7 +9555,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9571,7 +9571,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9587,7 +9587,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9630,7 +9630,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -9718,7 +9718,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				ID:          "vk-1",
 				Name:        "test-vk-1",
 				Description: "Test virtual key 1",
-				Value:       "vk_test123",
+				Value:       *schemas.NewSecretVar("vk_test123"),
 				IsActive:    schemas.Ptr(true),
 				RateLimitID: &rateLimitID,
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -9733,7 +9733,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				ID:          "vk-2",
 				Name:        "test-vk-2",
 				Description: "Test virtual key 2",
-				Value:       "vk_test456",
+				Value:       *schemas.NewSecretVar("vk_test456"),
 				IsActive:    schemas.Ptr(true),
 			},
 		},
@@ -9973,7 +9973,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 		ID:          "vk-dashboard",
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
-		Value:       "vk_dashboard456",
+		Value:       *schemas.NewSecretVar("vk_dashboard456"),
 		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
@@ -10036,7 +10036,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 	}
 
@@ -10045,7 +10045,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -10060,7 +10060,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -10075,7 +10075,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -10090,7 +10090,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -10154,7 +10154,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -10195,7 +10195,7 @@ func TestSQLite_VirtualKey_WithMCPConfigs(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK with MCP config",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10284,7 +10284,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10355,7 +10355,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
@@ -10451,7 +10451,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -10515,7 +10515,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -10606,7 +10606,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10691,7 +10691,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
@@ -10776,7 +10776,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 		},
 	}
@@ -10812,7 +10812,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
@@ -10844,7 +10844,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
@@ -10921,7 +10921,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test",
-		Value:       "vk_test123",
+		Value:       *schemas.NewSecretVar("vk_test123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool1", "tool2"}},
@@ -10946,7 +10946,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "test-vk",
 			Description: "Test",
-			Value:       "vk_test123",
+			Value:       *schemas.NewSecretVar("vk_test123"),
 			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool3", "tool4", "tool5"}}, // Different tools
@@ -11018,7 +11018,7 @@ func TestSQLite_VK_ProviderAndMCPConfigs_Combined(t *testing.T) {
 			ID:          "vk-1",
 			Name:        "combined-vk",
 			Description: "VK with both provider and MCP configs",
-			Value:       "vk_combined123",
+			Value:       *schemas.NewSecretVar("vk_combined123"),
 			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -11439,7 +11439,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11471,7 +11471,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11503,7 +11503,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11563,7 +11563,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11581,7 +11581,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11599,7 +11599,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11645,7 +11645,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11668,7 +11668,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11691,7 +11691,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11742,7 +11742,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11771,7 +11771,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11800,7 +11800,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11857,7 +11857,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11874,7 +11874,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11891,7 +11891,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
@@ -11936,7 +11936,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -11978,7 +11978,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		ID:          "vk-1",
 		Name:        "test-vk",
 		Description: "Test virtual key",
-		Value:       "vk_abc123",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
 		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -12147,7 +12147,7 @@ func TestLoadConfig_Governance_FirstImportUsesMergeIDHandling(t *testing.T) {
 			{Name: "Generated Team"},
 		},
 		VirtualKeys: []tables.TableVirtualKey{
-			{ID: "vk-explicit", Name: "Explicit VK", Value: "sk-bf-explicit"},
+			{ID: "vk-explicit", Name: "Explicit VK", Value: *schemas.NewSecretVar("sk-bf-explicit")},
 			{Name: "Generated VK"},
 		},
 		ComplexityAnalyzerConfig: testFileComplexityAnalyzerConfig(),
@@ -12206,11 +12206,11 @@ func TestLoadConfig_Governance_FirstImportUsesMergeIDHandling(t *testing.T) {
 	}
 	require.NotNil(t, explicitVK)
 	require.Equal(t, "vk-explicit", explicitVK.ID)
-	require.Equal(t, "sk-bf-explicit", explicitVK.Value)
+	require.Equal(t, "sk-bf-explicit", explicitVK.Value.GetValue())
 	require.NotNil(t, generatedVK)
 	_, err = uuid.Parse(generatedVK.ID)
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(generatedVK.Value, "sk-bf-"))
+	require.True(t, strings.HasPrefix(generatedVK.Value.GetValue(), "sk-bf-"))
 	require.NotNil(t, config.GovernanceConfig.ComplexityAnalyzerConfig)
 	require.NotNil(t, govConfig.ComplexityAnalyzerConfig)
 	require.Equal(t, govConfig.ComplexityAnalyzerConfig, config.GovernanceConfig.ComplexityAnalyzerConfig)
@@ -14232,7 +14232,7 @@ func TestUpdateGovernanceConfigInStore_RejectsSharedGovernanceIDs(t *testing.T) 
 		require.NoError(t, cfg.ConfigStore.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 			ID:       "vk-rl-owner",
 			Name:     "vk-rl-owner",
-			Value:    "vk-rl-owner-value",
+			Value:    *schemas.NewSecretVar("vk-rl-owner-value"),
 			IsActive: schemas.Ptr(true),
 		}))
 		require.NoError(t, cfg.ConfigStore.CreateVirtualKeyProviderConfig(ctx, &tables.TableVirtualKeyProviderConfig{
@@ -15362,7 +15362,7 @@ func TestVKProviderConfig_WeightZeroPreserved(t *testing.T) {
 	vk := tables.TableVirtualKey{
 		ID:       "vk-zero-weight",
 		Name:     "test-vk",
-		Value:    "vk_test123",
+		Value:    *schemas.NewSecretVar("vk_test123"),
 		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
@@ -15420,7 +15420,7 @@ func TestSQLite_VKProviderConfig_WeightZero_RoundTrip(t *testing.T) {
 		{
 			ID:       "vk-zero-weight",
 			Name:     "test-vk",
-			Value:    "vk_abc123",
+			Value:    *schemas.NewSecretVar("vk_abc123"),
 			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
@@ -18546,11 +18546,11 @@ func TestSQLite_GetVirtualKeysPaginated(t *testing.T) {
 	}
 
 	vks := []tables.TableVirtualKey{
-		{ID: "vk-1", Name: "alpha-key", Value: "val-1", IsActive: schemas.Ptr(true), TeamID: &team1},
-		{ID: "vk-2", Name: "beta-key", Value: "val-2", IsActive: schemas.Ptr(true), TeamID: &team2},
-		{ID: "vk-3", Name: "alpha-test", Value: "val-3", IsActive: schemas.Ptr(true), CustomerID: &cust1},
-		{ID: "vk-4", Name: "gamma-key", Value: "val-4", IsActive: schemas.Ptr(true), CustomerID: &cust2},
-		{ID: "vk-5", Name: "delta-key", Value: "val-5", IsActive: schemas.Ptr(true), TeamID: &team1},
+		{ID: "vk-1", Name: "alpha-key", Value: *schemas.NewSecretVar("val-1"), IsActive: schemas.Ptr(true), TeamID: &team1},
+		{ID: "vk-2", Name: "beta-key", Value: *schemas.NewSecretVar("val-2"), IsActive: schemas.Ptr(true), TeamID: &team2},
+		{ID: "vk-3", Name: "alpha-test", Value: *schemas.NewSecretVar("val-3"), IsActive: schemas.Ptr(true), CustomerID: &cust1},
+		{ID: "vk-4", Name: "gamma-key", Value: *schemas.NewSecretVar("val-4"), IsActive: schemas.Ptr(true), CustomerID: &cust2},
+		{ID: "vk-5", Name: "delta-key", Value: *schemas.NewSecretVar("val-5"), IsActive: schemas.Ptr(true), TeamID: &team1},
 	}
 	for i := range vks {
 		err := store.CreateVirtualKey(ctx, &vks[i])

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -407,8 +407,8 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	}
 	if governanceData := governancePlugin.GetGovernanceStore().GetGovernanceData(ctx); governanceData != nil {
 		for _, existingVK := range governanceData.VirtualKeys {
-			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value != "" && existingVK.Value != virtualKey.Value {
-				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value)
+			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value.IsSet() && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
+				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
 				break
 			}
 		}
@@ -452,7 +452,7 @@ func (s *BifrostHTTPServer) RemoveVirtualKey(ctx context.Context, id string) err
 		return nil
 	}
 	governancePlugin.GetGovernanceStore().DeleteVirtualKeyInMemory(ctx, id)
-	s.MCPServerHandler.DeleteVKMCPServer(preloadedVk.Value)
+	s.MCPServerHandler.DeleteVKMCPServer(preloadedVk.Value.GetValue())
 	return nil
 }
 

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -166,9 +166,10 @@ export function isRedacted(value: string): boolean {
 	}
 
 	// Check if it's an environment variable reference
-	if (value.startsWith("env.")) {
+	if (value.startsWith("env.") || value.startsWith("vault.")) {
 		return true;
 	}
+	
 
 	// Check for exact redaction pattern: 4 chars + 24 asterisks + 4 chars (total 32)
 	if (value.length === 32) {
@@ -216,7 +217,7 @@ export function isValidVertexAuthCredentials(value: string): boolean {
 	}
 
 	// If environment variable, validate format
-	if (value.startsWith("env.")) {
+	if (value.startsWith("env.") || value.startsWith("vault.")) {
 		return value.length > 4;
 	}
 


### PR DESCRIPTION
## Summary

`TableVirtualKey.Value` was a plain `string`, which meant the raw secret was passed around in-memory with no type-level distinction between a resolved plaintext value, an environment-variable reference, or a future vault reference. This PR changes the field type to `schemas.SecretVar`, a wrapper that carries the value's origin (plain text, env var, vault ref) and exposes it only through `GetValue()`. All call sites are updated to construct values via `schemas.NewSecretVar(...)` and read them via `.GetValue()`.

## Changes

- `TableVirtualKey.Value` changed from `string` to `schemas.SecretVar` across the model definition, GORM hooks (`BeforeSave`, `AfterFind`), and all consumers.
- `BeforeSave` now calls `encryptSecretVar` / `decryptSecretVar` helpers instead of operating on a raw string, and integrates with the vault write path via `StoreOwnedVaultSecretVars` when vault storage is enabled.
- `MarshalJSON` is added to `TableVirtualKey` so REST API responses continue to emit `value` as a plain string rather than a `SecretVar` object.
- `VaultPathKey` and `VaultStoreSelfManaged` are implemented on `TableVirtualKey` so the global vault callback skips it and `BeforeSave` manages vault writes directly.
- Config-file merge logic in `mergeGovernanceConfig` is simplified: env-var and vault references are resolved automatically by `SecretVar`, removing the explicit `env.` prefix handling and the separate `envutils.ProcessEnvValue` calls. Plain-text values still enforce the virtual-key prefix or trigger auto-generation.
- `GenerateVirtualKeyHash` updated to hash `vk.Value.GetValue()` instead of the raw field.
- All in-memory governance store operations (`rebuildInMemoryStructures`, `CreateVirtualKeyInMemory`, `UpdateVirtualKeyInMemory`) updated to key the sync map on `.GetValue()`.
- MCP server handler, JWT injection, server reload/remove paths, and HTTP governance handler all updated to call `.GetValue()` when the string value is needed.
- All tests updated to construct `TableVirtualKey` with `*schemas.NewSecretVar(...)` and assert against `.GetValue()`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/logstore/...
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

Verify that:
- Virtual keys created via the REST API return `"value": "sk-bf-..."` (plain string) in the response body.
- Virtual keys stored with encryption enabled are encrypted at rest and decrypted transparently on read.
- Config-file virtual keys with `env.VAR_NAME` values resolve correctly without the explicit prefix-stripping logic.
- Virtual key rotation produces a new value with the `sk-bf-` prefix and the old MCP server entry is evicted.

## Breaking changes

- [x] Yes
- [ ] No

Any code outside this repository that directly assigns or reads `TableVirtualKey.Value` as a `string` must be updated to use `*schemas.NewSecretVar(value)` for writes and `.GetValue()` for reads. JSON serialization of `TableVirtualKey` is unchanged — `value` is still emitted as a plain string.

## Security considerations

The `SecretVar` wrapper makes the origin of a secret explicit at the type level, reducing the risk of accidentally treating an unresolved env-var reference as a usable key value. Vault write integration in `BeforeSave` ensures that when vault storage is enabled, the plaintext is written to vault before encryption, keeping the database free of unprotected secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable