### PR TITLE
fixes plan cache issue with migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -8884,24 +8884,51 @@ func migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx context.Cont
 			// Gating on the legacy column would make ordering brittle: any
 			// reordering that drops the column before this runs would silently
 			// turn the refresh into a no-op and leave stale hashes behind.
-			// Read via an explicit, schema-derived column projection rather
-			// than GORM's default Find (SELECT *). Earlier migrations in this
-			// same run add and drop config_client columns; reusing a cached
-			// SELECT * plan whose projection has since drifted is what trips
-			// PostgreSQL's "cached plan must not change result type"
-			// (SQLSTATE 0A000) — an error that is unrecoverable inside a
-			// migration's transaction. An explicit column list is a distinct,
-			// previously-uncached query: it prepares fresh against the current
-			// schema and has a fixed result type. Same class of guard as
-			// migrate_calendar_aligned. The projection is derived from the
-			// TableClientConfig schema so it cannot drift from the struct.
+			// Read via an explicit column projection rather than GORM's default
+			// Find (SELECT *). Earlier migrations in this same run add and drop
+			// config_client columns; reusing a cached SELECT * plan whose
+			// projection has since drifted is what trips PostgreSQL's "cached
+			// plan must not change result type" (SQLSTATE 0A000), an error that
+			// is unrecoverable inside a migration's transaction. An explicit
+			// column list is a distinct, previously-uncached query: it prepares
+			// fresh against the current schema and has a fixed result type. Same
+			// class of guard as migrate_calendar_aligned.
+			//
+			// Derive the projection from the LIVE table columns intersected with
+			// the struct, not from the struct alone. TableClientConfig can be
+			// ahead of applied DDL: a declared column (e.g.
+			// dump_errors_in_console_logs, added by a later migration step) does
+			// not exist yet on upgrade, and naming a missing column in the SELECT
+			// fails with 42703. Intersecting with the columns that physically
+			// exist makes that impossible for any current or future column. Keep
+			// the read on .Find (not a raw Scan) so the AfterFind hook still
+			// deserializes the *_json columns into the virtual fields the hash
+			// depends on; a raw Scan bypasses AfterFind and would corrupt them.
+			existingCols, err := mg.ColumnTypes(&tables.TableClientConfig{})
+			if err != nil {
+				return fmt.Errorf("inspect config_client columns for hash recompute: %w", err)
+			}
+			present := make(map[string]struct{}, len(existingCols))
+			for _, ct := range existingCols {
+				present[ct.Name()] = struct{}{}
+			}
 			schemaStmt := &gorm.Statement{DB: tx}
 			if err := schemaStmt.Parse(&tables.TableClientConfig{}); err != nil {
 				return fmt.Errorf("parse config_client schema for hash recompute: %w", err)
 			}
+			projection := make([]string, 0, len(schemaStmt.Schema.DBNames))
+			for _, name := range schemaStmt.Schema.DBNames {
+				if _, ok := present[name]; ok {
+					projection = append(projection, name)
+				}
+			}
+			if len(projection) == 0 {
+				logger.Info("[configstore] %s: no columns in common between config_client and TableClientConfig, skipping hash recompute", migrationName)
+				return nil
+			}
 			var clientConfigs []tables.TableClientConfig
 			if err := tx.Model(&tables.TableClientConfig{}).
-				Select(schemaStmt.Schema.DBNames).
+				Select(projection).
 				Find(&clientConfigs).Error; err != nil {
 				return fmt.Errorf("fetch client configs for hash recompute: %w", err)
 			}

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2600,3 +2600,81 @@ func TestMigrationMigrateProviderGovernanceToModelConfigs(t *testing.T) {
 		Count(&count).Error)
 	assert.Equal(t, int64(1), count, "re-run must not duplicate the wildcard config")
 }
+
+// TestMigrationRefreshConfigHash_ColumnAheadOfTable is the focused regression test
+// for issue #4797: the config-hash recompute must not fail when the
+// TableClientConfig struct declares a column the physical table does not have yet.
+//
+// On upgrade from a pre-1.6 schema, config_client lacks dump_errors_in_console_logs
+// (added by a later migration step). The old recompute derived its SELECT projection
+// from the struct, so it named the missing column and failed with 42703 on Postgres
+// (or "no such column" on SQLite). The fix intersects the struct columns with the
+// live table columns before selecting.
+func TestMigrationRefreshConfigHash_ColumnAheadOfTable(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create config_client with the full current schema, then seed a row before
+	// dropping the column (GORM's struct-derived INSERT would fail once the column
+	// is gone). PrometheusLabels / AllowedOrigins exercise the AfterFind path the
+	// recompute depends on to compute the hash.
+	require.NoError(t, db.AutoMigrate(&tables.TableClientConfig{}))
+	seed := &tables.TableClientConfig{
+		ConfigHash:       "stale-hash",
+		PrometheusLabels: []string{"team", "env"},
+		AllowedOrigins:   []string{"https://example.com"},
+	}
+	require.NoError(t, db.Create(seed).Error)
+
+	// Simulate the pre-1.6 table: struct is ahead of the applied DDL.
+	require.NoError(t, db.Migrator().DropColumn(&tables.TableClientConfig{}, "dump_errors_in_console_logs"))
+	require.False(t, db.Migrator().HasColumn(&tables.TableClientConfig{}, "dump_errors_in_console_logs"),
+		"precondition: dump_errors_in_console_logs must be absent to reproduce the bug")
+
+	// Pre-fix this returned the 42703 / "no such column" error; post-fix the
+	// projection skips the absent column and the recompute succeeds.
+	require.NoError(t, migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx, db, testMigrationLogger))
+
+	// The stale hash was recomputed. Read via raw SQL to avoid the same
+	// struct-vs-table drift on the read path.
+	var gotHash string
+	require.NoError(t, db.Raw("SELECT config_hash FROM config_client WHERE id = ?", seed.ID).Scan(&gotHash).Error)
+	assert.NotEmpty(t, gotHash, "config_hash should have been recomputed")
+	assert.NotEqual(t, "stale-hash", gotHash, "config_hash should differ from the seeded stale value")
+}
+
+// TestFullMigration_UpgradeFromPreDumpErrorsSchema runs the entire ordered chain
+// against a config_client that predates dump_errors_in_console_logs, reproducing
+// the real upgrade path from issue #4797.
+//
+// A fresh triggerMigrations run cannot reproduce the bug because init's CreateTable
+// builds config_client from the current struct (with the column). We instead
+// pre-create the table and drop the column so the chain hits the recompute step
+// (which runs before add_dump_errors_in_console_logs_column) while the column is
+// still missing.
+func TestFullMigration_UpgradeFromPreDumpErrorsSchema(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.AutoMigrate(&tables.TableClientConfig{}))
+	seed := &tables.TableClientConfig{
+		ConfigHash:       "stale-hash",
+		PrometheusLabels: []string{"team"},
+	}
+	require.NoError(t, db.Create(seed).Error)
+	require.NoError(t, db.Migrator().DropColumn(&tables.TableClientConfig{}, "dump_errors_in_console_logs"))
+	require.False(t, db.Migrator().HasColumn(&tables.TableClientConfig{}, "dump_errors_in_console_logs"))
+
+	// The full chain must complete: init skips CreateTable (table exists), the
+	// recompute runs against the column-less table, and add_dump_errors re-adds it.
+	require.NoError(t, triggerMigrations(ctx, db, testMigrationLogger),
+		"full migration chain should complete on a pre-dump-errors config_client")
+
+	assert.True(t, db.Migrator().HasColumn(&tables.TableClientConfig{}, "dump_errors_in_console_logs"),
+		"chain should have re-added dump_errors_in_console_logs")
+
+	var gotHash string
+	require.NoError(t, db.Raw("SELECT config_hash FROM config_client WHERE id = ?", seed.ID).Scan(&gotHash).Error)
+	assert.NotEmpty(t, gotHash)
+	assert.NotEqual(t, "stale-hash", gotHash, "config_hash should have been recomputed by the chain")
+}


### PR DESCRIPTION
## Summary

Fixes a regression (#4797) where the config-hash recompute migration failed on upgrade from a pre-1.6 schema. The `TableClientConfig` struct declares `dump_errors_in_console_logs`, but on older schemas this column does not yet exist on the physical table when the recompute step runs. The previous implementation derived its `SELECT` projection solely from the struct, causing PostgreSQL to return error `42703` (undefined column) and SQLite to return "no such column".

## Changes

- The recompute step in `migrationRefreshConfigHashAfterMCPExternalServerURLRemoval` now intersects the struct's declared column names with the columns that physically exist on the live table before building the `SELECT` projection. This prevents naming absent columns regardless of future struct additions.
- The `AfterFind` hook path is preserved by keeping `.Find` rather than switching to a raw `Scan`, ensuring `*_json` columns are still deserialized correctly for hash computation.
- Two regression tests added:
  - `TestMigrationRefreshConfigHash_ColumnAheadOfTable`: focused test that drops `dump_errors_in_console_logs` from the table and confirms the recompute step succeeds and produces a fresh hash.
  - `TestFullMigration_UpgradeFromPreDumpErrorsSchema`: end-to-end test that runs the full migration chain against a column-less table, confirming the column is re-added and the hash is recomputed.
- `git fetch --tags` in the migration test CI script is commented out to avoid tag-fetch side effects during test runs.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/configstore/... -run TestMigrationRefreshConfigHash_ColumnAheadOfTable
go test ./framework/configstore/... -run TestFullMigration_UpgradeFromPreDumpErrorsSchema
```

Both tests should pass. Prior to this fix, both would fail with a "no such column: dump_errors_in_console_logs" (SQLite) or `42703` (PostgreSQL) error.

## Breaking changes

- [x] No

## Related issues

Closes #4797

## Security considerations

None. This change only affects the column projection used during a read inside a migration transaction.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable