### PR TITLE
fix: unify request-time reset side effects

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -51,6 +51,11 @@ type LocalGovernanceStore struct {
 	// Model catalog for cross-provider model matching (optional)
 	modelCatalog *modelcatalog.ModelCatalog
 
+	// Reset hooks allow wrappers to observe request-time local resets.
+	resetHooksMu      sync.RWMutex
+	onBudgetsReset    func([]*configstoreTables.TableBudget)
+	onRateLimitsReset func([]*configstoreTables.TableRateLimit)
+
 	// Logger
 	logger schemas.Logger
 }
@@ -135,8 +140,8 @@ type GovernanceStore interface {
 	UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error
 	UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory reset checks (return items that need DB sync)
-	ResetExpiredRateLimitsInMemory(ctx context.Context) []*configstoreTables.TableRateLimit
-	ResetExpiredBudgetsInMemory(ctx context.Context) []*configstoreTables.TableBudget
+	ResetExpiredRateLimitsInMemory(ctx context.Context, rateLimitIDs ...string) []*configstoreTables.TableRateLimit
+	ResetExpiredBudgetsInMemory(ctx context.Context, budgetIDs ...string) []*configstoreTables.TableBudget
 	// DB sync for expired items
 	ResetExpiredRateLimits(ctx context.Context, resetRateLimits []*configstoreTables.TableRateLimit) error
 	ResetExpiredBudgets(ctx context.Context, resetBudgets []*configstoreTables.TableBudget) error
@@ -235,6 +240,26 @@ func NewLocalGovernanceStore(ctx context.Context, logger schemas.Logger, configS
 
 	store.logger.Info("governance store initialized successfully")
 	return store, nil
+}
+
+// SetResetHooks configures callbacks that run after successful local resets.
+func (gs *LocalGovernanceStore) SetResetHooks(onBudgetsReset func([]*configstoreTables.TableBudget), onRateLimitsReset func([]*configstoreTables.TableRateLimit)) {
+	gs.resetHooksMu.Lock()
+	defer gs.resetHooksMu.Unlock()
+	gs.onBudgetsReset = onBudgetsReset
+	gs.onRateLimitsReset = onRateLimitsReset
+}
+
+func (gs *LocalGovernanceStore) getBudgetsResetHook() func([]*configstoreTables.TableBudget) {
+	gs.resetHooksMu.RLock()
+	defer gs.resetHooksMu.RUnlock()
+	return gs.onBudgetsReset
+}
+
+func (gs *LocalGovernanceStore) getRateLimitsResetHook() func([]*configstoreTables.TableRateLimit) {
+	gs.resetHooksMu.RLock()
+	defer gs.resetHooksMu.RUnlock()
+	return gs.onRateLimitsReset
 }
 
 // LoadBudget loads a budget by its ID from the local store.
@@ -392,16 +417,11 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 		if !ok || old == nil {
 			return nil
 		}
-		clone := *old
-		now := time.Now()
-		if clone.ResetDuration != "" {
-			if duration, err := configstoreTables.ParseDuration(clone.ResetDuration); err == nil {
-				if now.Sub(clone.LastReset) >= duration {
-					clone.CurrentUsage = 0
-					clone.LastReset = now
-				}
-			}
+		if gs.budgetResetTarget(old, time.Now()) != nil {
+			gs.ResetExpiredBudgetsInMemory(ctx, budgetID)
+			continue
 		}
+		clone := *old
 		clone.CurrentUsage += cost
 		if gs.budgets.CompareAndSwap(budgetID, raw, &clone) {
 			return nil
@@ -425,24 +445,11 @@ func (gs *LocalGovernanceStore) BumpRateLimitUsage(ctx context.Context, rateLimi
 		if !ok || old == nil {
 			return nil
 		}
+		if tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(old, time.Now()); tokenNewLastReset != nil || requestNewLastReset != nil {
+			gs.ResetExpiredRateLimitsInMemory(ctx, rateLimitID)
+			continue
+		}
 		clone := *old
-		now := time.Now()
-		if clone.TokenResetDuration != nil {
-			if duration, err := configstoreTables.ParseDuration(*clone.TokenResetDuration); err == nil {
-				if now.Sub(clone.TokenLastReset) >= duration {
-					clone.TokenCurrentUsage = 0
-					clone.TokenLastReset = now
-				}
-			}
-		}
-		if clone.RequestResetDuration != nil {
-			if duration, err := configstoreTables.ParseDuration(*clone.RequestResetDuration); err == nil {
-				if now.Sub(clone.RequestLastReset) >= duration {
-					clone.RequestCurrentUsage = 0
-					clone.RequestLastReset = now
-				}
-			}
-		}
 		if shouldUpdateTokens {
 			clone.TokenCurrentUsage += tokensUsed
 		}
@@ -1725,125 +1732,169 @@ func (gs *LocalGovernanceStore) UpdateUserRateLimitUsageInMemory(ctx context.Con
 	return nil
 }
 
-// ResetExpiredBudgetsInMemory checks and resets budgets that have exceeded their reset duration.
-// Decision of whether to reset is computed per-budget from the snapshot observed via Range; the
-// actual CAS is delegated to ResetBudgetAt, which skips already-reset snapshots and never drops
-// a concurrent usage increment.
-func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context) []*configstoreTables.TableBudget {
-	now := time.Now()
-	var resetBudgets []*configstoreTables.TableBudget
-	gs.budgets.Range(func(key, value any) bool {
-		budget, ok := value.(*configstoreTables.TableBudget)
-		if !ok || budget == nil {
-			return true
-		}
-		calendarAligned := budget.IsCalendarAligned
-		var shouldReset bool
-		var newLastReset time.Time
-		if calendarAligned {
-			currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
-			if currentPeriodStart.After(budget.LastReset) {
-				shouldReset = true
-				newLastReset = currentPeriodStart
-			}
-		} else {
-			duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
-			if err != nil {
-				gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
-				return true
-			}
-			if now.Sub(budget.LastReset) >= duration {
-				shouldReset = true
-				newLastReset = now
-			}
-		}
-		if !shouldReset {
-			return true
-		}
-		resetBudget, ok := gs.ResetBudgetAt(ctx, budget.ID, newLastReset)
-		if !ok {
-			// Another resetter got there first, or a concurrent usage update
-			// already advanced LastReset past ours; nothing to do.
-			return true
-		}
-		oldUsage := budget.CurrentUsage
-		gs.LastDBUsagesBudgetsMu.Lock()
-		gs.LastDBUsagesBudgets[resetBudget.ID] = 0
-		gs.LastDBUsagesBudgetsMu.Unlock()
-		resetBudgets = append(resetBudgets, resetBudget)
-		gs.updateBudgetReferences(ctx, resetBudget)
-		gs.logger.Debug(fmt.Sprintf("Reset budget %s (was %.2f, reset to 0)",
-			resetBudget.ID, oldUsage))
-		return true
-	})
-	return resetBudgets
-}
-
-// ResetExpiredRateLimitsInMemory performs background reset of expired rate limits for both provider-level and VK-level.
-// Decision of whether each counter needs resetting is computed per-rate-limit from the snapshot observed via Range;
-// the actual CAS is delegated to ResetRateLimitAt, which skips already-reset snapshots and never drops a concurrent
-// increment.
-func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Context) []*configstoreTables.TableRateLimit {
-	now := time.Now()
-	var resetRateLimits []*configstoreTables.TableRateLimit
-	// resolvePeriodStart returns the next LastReset target for a counter whose
-	// reset-duration setting is resetDuration and whose current LastReset is
-	// lastReset. Returns nil when no reset is due (or the duration is invalid).
-	resolvePeriodStart := func(resetDuration *string, calendarAligned bool, lastReset time.Time) *time.Time {
-		if resetDuration == nil {
-			return nil
-		}
-		if calendarAligned {
-			period := configstoreTables.GetCalendarPeriodStart(*resetDuration, now)
-			if period.After(lastReset) {
-				return &period
-			}
-			return nil
-		}
-		duration, err := configstoreTables.ParseDuration(*resetDuration)
-		if err != nil {
-			gs.logger.Error("invalid rate limit reset duration %s: %v", *resetDuration, err)
-			return nil
-		}
-		if now.Sub(lastReset) >= duration {
-			t := now
-			return &t
+// budgetResetTarget returns the LastReset value to write when budget is expired.
+func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.TableBudget, now time.Time) *time.Time {
+	if budget == nil || budget.ResetDuration == "" {
+		return nil
+	}
+	if budget.IsCalendarAligned {
+		currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
+		if currentPeriodStart.After(budget.LastReset) {
+			return &currentPeriodStart
 		}
 		return nil
 	}
-	gs.rateLimits.Range(func(key, value any) bool {
+	duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
+	if err != nil {
+		gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
+		return nil
+	}
+	if now.Sub(budget.LastReset) >= duration {
+		return &now
+	}
+	return nil
+}
+
+// resetExpiredBudgetFromSnapshot applies the local side effects for an expired budget snapshot.
+func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Context, budget *configstoreTables.TableBudget, now time.Time) *configstoreTables.TableBudget {
+	newLastReset := gs.budgetResetTarget(budget, now)
+	if newLastReset == nil {
+		return nil
+	}
+	resetBudget, ok := gs.ResetBudgetAt(ctx, budget.ID, *newLastReset)
+	if !ok {
+		return nil
+	}
+	oldUsage := budget.CurrentUsage
+	gs.LastDBUsagesBudgetsMu.Lock()
+	gs.LastDBUsagesBudgets[resetBudget.ID] = 0
+	gs.LastDBUsagesBudgetsMu.Unlock()
+	gs.updateBudgetReferences(ctx, resetBudget)
+	gs.logger.Debug(fmt.Sprintf("Reset budget %s (was %.2f, reset to 0)", resetBudget.ID, oldUsage))
+	return resetBudget
+}
+
+// ResetExpiredBudgetsInMemory checks and resets budgets that have exceeded their reset duration.
+// With no budgetIDs it scans every budget; with IDs it only checks those budgets.
+func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context, budgetIDs ...string) []*configstoreTables.TableBudget {
+	now := time.Now()
+	var resetBudgets []*configstoreTables.TableBudget
+	resetOne := func(value any) {
+		budget, ok := value.(*configstoreTables.TableBudget)
+		if !ok || budget == nil {
+			return
+		}
+		if resetBudget := gs.resetExpiredBudgetFromSnapshot(ctx, budget, now); resetBudget != nil {
+			resetBudgets = append(resetBudgets, resetBudget)
+		}
+	}
+	if len(budgetIDs) == 0 {
+		gs.budgets.Range(func(key, value any) bool {
+			resetOne(value)
+			return true
+		})
+	} else {
+		for _, budgetID := range budgetIDs {
+			if value, ok := gs.budgets.Load(budgetID); ok {
+				resetOne(value)
+			}
+		}
+	}
+	if len(resetBudgets) > 0 {
+		if onBudgetsReset := gs.getBudgetsResetHook(); onBudgetsReset != nil {
+			onBudgetsReset(resetBudgets)
+		}
+	}
+	return resetBudgets
+}
+
+// rateLimitResetTarget returns the LastReset value to write when a rate-limit counter is expired.
+func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, calendarAligned bool, lastReset time.Time, now time.Time) *time.Time {
+	if resetDuration == nil {
+		return nil
+	}
+	if calendarAligned {
+		period := configstoreTables.GetCalendarPeriodStart(*resetDuration, now)
+		if period.After(lastReset) {
+			return &period
+		}
+		return nil
+	}
+	duration, err := configstoreTables.ParseDuration(*resetDuration)
+	if err != nil {
+		gs.logger.Error("invalid rate limit reset duration %s: %v", *resetDuration, err)
+		return nil
+	}
+	if now.Sub(lastReset) >= duration {
+		return &now
+	}
+	return nil
+}
+
+// rateLimitResetTargets returns reset targets for the token and request counters.
+func (gs *LocalGovernanceStore) rateLimitResetTargets(rateLimit *configstoreTables.TableRateLimit, now time.Time) (*time.Time, *time.Time) {
+	if rateLimit == nil {
+		return nil, nil
+	}
+	calendarAligned := rateLimit.IsCalendarAligned
+	return gs.rateLimitResetTarget(rateLimit.TokenResetDuration, calendarAligned, rateLimit.TokenLastReset, now), gs.rateLimitResetTarget(rateLimit.RequestResetDuration, calendarAligned, rateLimit.RequestLastReset, now)
+}
+
+// resetExpiredRateLimitFromSnapshot applies the local side effects for an expired rate-limit snapshot.
+func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Context, rateLimit *configstoreTables.TableRateLimit, now time.Time) *configstoreTables.TableRateLimit {
+	tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(rateLimit, now)
+	if tokenNewLastReset == nil && requestNewLastReset == nil {
+		return nil
+	}
+	resetRateLimit, ok := gs.ResetRateLimitAt(ctx, rateLimit.ID, tokenNewLastReset, requestNewLastReset)
+	if !ok {
+		return nil
+	}
+	if tokenNewLastReset != nil {
+		gs.LastDBUsagesRateLimitsTokensMu.Lock()
+		gs.LastDBUsagesTokensRateLimits[resetRateLimit.ID] = 0
+		gs.LastDBUsagesRateLimitsTokensMu.Unlock()
+	}
+	if requestNewLastReset != nil {
+		gs.LastDBUsagesRateLimitsRequestsMu.Lock()
+		gs.LastDBUsagesRequestsRateLimits[resetRateLimit.ID] = 0
+		gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
+	}
+	gs.updateRateLimitReferences(ctx, resetRateLimit)
+	return resetRateLimit
+}
+
+// ResetExpiredRateLimitsInMemory performs background reset of expired rate limits for both provider-level and VK-level.
+// With no rateLimitIDs it scans every rate limit; with IDs it only checks those rate limits.
+func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Context, rateLimitIDs ...string) []*configstoreTables.TableRateLimit {
+	now := time.Now()
+	var resetRateLimits []*configstoreTables.TableRateLimit
+	resetOne := func(value any) {
 		rateLimit, ok := value.(*configstoreTables.TableRateLimit)
 		if !ok || rateLimit == nil {
+			return
+		}
+		if resetRateLimit := gs.resetExpiredRateLimitFromSnapshot(ctx, rateLimit, now); resetRateLimit != nil {
+			resetRateLimits = append(resetRateLimits, resetRateLimit)
+		}
+	}
+	if len(rateLimitIDs) == 0 {
+		gs.rateLimits.Range(func(key, value any) bool {
+			resetOne(value)
 			return true
+		})
+	} else {
+		for _, rateLimitID := range rateLimitIDs {
+			if value, ok := gs.rateLimits.Load(rateLimitID); ok {
+				resetOne(value)
+			}
 		}
-		calendarAligned := rateLimit.IsCalendarAligned
-		tokenNewLastReset := resolvePeriodStart(rateLimit.TokenResetDuration, calendarAligned, rateLimit.TokenLastReset)
-		requestNewLastReset := resolvePeriodStart(rateLimit.RequestResetDuration, calendarAligned, rateLimit.RequestLastReset)
-		if tokenNewLastReset == nil && requestNewLastReset == nil {
-			return true
+	}
+	if len(resetRateLimits) > 0 {
+		if onRateLimitsReset := gs.getRateLimitsResetHook(); onRateLimitsReset != nil {
+			onRateLimitsReset(resetRateLimits)
 		}
-		resetRateLimit, ok := gs.ResetRateLimitAt(ctx, rateLimit.ID, tokenNewLastReset, requestNewLastReset)
-		if !ok {
-			return true
-		}
-		// Clear DB-baseline markers only for the counters we actually reset in
-		// this call. Baseline locks stay independent of the primary sync.Map
-		// CAS — they guard a separate map whose values just need consistency,
-		// not atomicity with the counter mutation.
-		if tokenNewLastReset != nil {
-			gs.LastDBUsagesRateLimitsTokensMu.Lock()
-			gs.LastDBUsagesTokensRateLimits[resetRateLimit.ID] = 0
-			gs.LastDBUsagesRateLimitsTokensMu.Unlock()
-		}
-		if requestNewLastReset != nil {
-			gs.LastDBUsagesRateLimitsRequestsMu.Lock()
-			gs.LastDBUsagesRequestsRateLimits[resetRateLimit.ID] = 0
-			gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
-		}
-		resetRateLimits = append(resetRateLimits, resetRateLimit)
-		gs.updateRateLimitReferences(ctx, resetRateLimit)
-		return true
-	})
+	}
 	return resetRateLimits
 }
 
@@ -1936,7 +1987,9 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 	type rateLimitUpdate struct {
 		ID                  string
 		TokenCurrentUsage   int64
+		TokenLastReset      time.Time
 		RequestCurrentUsage int64
+		RequestLastReset    time.Time
 	}
 	var rateLimitUpdates []rateLimitUpdate
 	gs.rateLimits.Range(func(key, value interface{}) bool {
@@ -1947,7 +2000,9 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 		update := rateLimitUpdate{
 			ID:                  rateLimit.ID,
 			TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
+			TokenLastReset:      rateLimit.TokenLastReset,
 			RequestCurrentUsage: rateLimit.RequestCurrentUsage,
+			RequestLastReset:    rateLimit.RequestLastReset,
 		}
 		if tokenBaseline, exists := tokenBaselines[rateLimit.ID]; exists {
 			update.TokenCurrentUsage += tokenBaseline
@@ -1974,7 +2029,9 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 					Where("id = ?", update.ID).
 					Updates(map[string]interface{}{
 						"token_current_usage":   update.TokenCurrentUsage,
+						"token_last_reset":      update.TokenLastReset,
 						"request_current_usage": update.RequestCurrentUsage,
+						"request_last_reset":    update.RequestLastReset,
 					})
 
 				if result.Error != nil {
@@ -2044,7 +2101,10 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 					Session(&gorm.Session{SkipHooks: true}).
 					Model(&configstoreTables.TableBudget{}).
 					Where("id = ?", inMemoryBudget.ID).
-					Update("current_usage", newUsage)
+					Updates(map[string]interface{}{
+						"current_usage": newUsage,
+						"last_reset":    inMemoryBudget.LastReset,
+					})
 
 				if result.Error != nil {
 					return fmt.Errorf("failed to update budget %s: %w", inMemoryBudget.ID, result.Error)

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
-	"gorm.io/gorm"
 )
 
 // UsageUpdate contains data for VK-level usage tracking
@@ -307,126 +306,69 @@ func (t *UsageTracker) PerformStartupResets(ctx context.Context) error {
 	}
 
 	t.logger.Debug("performing startup reset check for expired rate limits and budgets")
-	now := time.Now()
-
-	var resetRateLimits []*configstoreTables.TableRateLimit
 	var errs []string
-	var vksWithRateLimits int
-	var vksWithoutRateLimits int
+	for _, err := range t.validateStartupResetDurations(ctx) {
+		errs = append(errs, err.Error())
+	}
 
 	// ==== RESET EXPIRED RATE LIMITS ====
-	// Check ALL virtual keys (both active and inactive) for expired rate limits.
-	// Reuse the already-loaded in-memory governance data instead of issuing a
-	// second full database load of every virtual key. The store is populated at
-	// startup (loadFromDatabase) before this runs, so re-querying all VKs from
-	// the DB here was redundant and, at large key counts, added seconds of
-	// startup latency for no additional information.
-	vkLoadStart := time.Now()
-	var allVKs []configstoreTables.TableVirtualKey
-	if govData := t.store.GetGovernanceData(ctx); govData != nil {
-		allVKs = make([]configstoreTables.TableVirtualKey, 0, len(govData.VirtualKeys))
-		for _, vk := range govData.VirtualKeys {
-			if vk != nil {
-				allVKs = append(allVKs, *vk)
-			}
-		}
+	// Reuse the shared in-memory reset path so startup, ticker, and request-time
+	// resets all apply the same LastDB baseline and reset-hook side effects.
+	rateLimitResetStart := time.Now()
+	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx)
+	t.logger.Info("[startup-timing] PerformStartupResets in-memory reset of %d rate limits took %v", len(resetRateLimits), time.Since(rateLimitResetStart))
+	if err := t.store.ResetExpiredRateLimits(ctx, resetRateLimits); err != nil {
+		errs = append(errs, fmt.Sprintf("failed to reset expired rate limits: %s", err.Error()))
 	}
-	t.logger.Debug(fmt.Sprintf("startup reset: checking %d virtual keys (active + inactive) for expired rate limits", len(allVKs)))
-	t.logger.Info("[startup-timing] PerformStartupResets read %d keys from in-memory store in %v", len(allVKs), time.Since(vkLoadStart))
-
-	scanStart := time.Now()
-	for i := range allVKs {
-		vk := &allVKs[i] // Get pointer to VK for modifications
-		if vk.RateLimit == nil {
-			vksWithoutRateLimits++
-			continue
-		}
-
-		vksWithRateLimits++
-
-		// Operate on a detached copy so the persisted reset never mutates the
-		// live in-memory rate limit (which background workers may read).
-		rlCopy := *vk.RateLimit
-		rateLimit := &rlCopy
-		rateLimitUpdated := false
-
-		// Check token limits
-		if rateLimit.TokenResetDuration != nil {
-			if duration, err := configstoreTables.ParseDuration(*rateLimit.TokenResetDuration); err == nil {
-				timeSinceReset := now.Sub(rateLimit.TokenLastReset)
-				if timeSinceReset >= duration {
-					rateLimit.TokenCurrentUsage = 0
-					rateLimit.TokenLastReset = now
-					rateLimitUpdated = true
-				}
-			} else {
-				errs = append(errs, fmt.Sprintf("invalid token reset duration for VK %s: %s", vk.ID, *rateLimit.TokenResetDuration))
-			}
-		}
-
-		// Check request limits
-		if rateLimit.RequestResetDuration != nil {
-			if duration, err := configstoreTables.ParseDuration(*rateLimit.RequestResetDuration); err == nil {
-				timeSinceReset := now.Sub(rateLimit.RequestLastReset)
-				if timeSinceReset >= duration {
-					rateLimit.RequestCurrentUsage = 0
-					rateLimit.RequestLastReset = now
-					rateLimitUpdated = true
-				}
-			} else {
-				errs = append(errs, fmt.Sprintf("invalid request reset duration for VK %s: %s", vk.ID, *rateLimit.RequestResetDuration))
-			}
-		}
-
-		if rateLimitUpdated {
-			resetRateLimits = append(resetRateLimits, rateLimit)
-		}
-	}
-	t.logger.Info("[startup-timing] PerformStartupResets VK scan loop took %v (%d with rate limits, %d without, %d to reset)", time.Since(scanStart), vksWithRateLimits, vksWithoutRateLimits, len(resetRateLimits))
 
 	// DB reset is also handled by this function
+	budgetResetStart := time.Now()
 	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx)
+	t.logger.Info("[startup-timing] PerformStartupResets in-memory reset of %d budgets took %v", len(resetBudgets), time.Since(budgetResetStart))
 	if err := t.store.ResetExpiredBudgets(ctx, resetBudgets); err != nil {
 		errs = append(errs, fmt.Sprintf("failed to reset expired budgets: %s", err.Error()))
 	}
-
-	// ==== PERSIST RESETS TO DATABASE ====
-	// Use selective updates to avoid overwriting config fields (max_limit, reset_duration)
-	dbWriteStart := time.Now()
-	if t.configStore != nil && len(resetRateLimits) > 0 {
-		if err := t.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-			for _, rateLimit := range resetRateLimits {
-				// Build update map with only the fields that were reset
-				updates := make(map[string]interface{})
-				updates["token_current_usage"] = rateLimit.TokenCurrentUsage
-				updates["token_last_reset"] = rateLimit.TokenLastReset
-				updates["request_current_usage"] = rateLimit.RequestCurrentUsage
-				updates["request_last_reset"] = rateLimit.RequestLastReset
-
-				// Direct UPDATE only resets usage and last_reset fields
-				// This prevents overwriting max_limit or reset_duration that may have been changed during startup
-				result := tx.WithContext(ctx).
-					Session(&gorm.Session{SkipHooks: true}).
-					Model(&configstoreTables.TableRateLimit{}).
-					Where("id = ?", rateLimit.ID).
-					Updates(updates)
-
-				if result.Error != nil {
-					return fmt.Errorf("failed to reset rate limit %s: %w", rateLimit.ID, result.Error)
-				}
-			}
-			return nil
-		}); err != nil {
-			errs = append(errs, fmt.Sprintf("failed to persist rate limit resets: %s", err.Error()))
-		}
-	}
-	t.logger.Info("[startup-timing] PerformStartupResets DB persist of %d rate-limit resets took %v", len(resetRateLimits), time.Since(dbWriteStart))
 	if len(errs) > 0 {
 		t.logger.Error("startup reset encountered %d errors: %v", len(errs), errs)
 		return fmt.Errorf("startup reset completed with %d errors", len(errs))
 	}
 
 	return nil
+}
+
+func (t *UsageTracker) validateStartupResetDurations(ctx context.Context) []error {
+	data := t.store.GetGovernanceData(ctx)
+	if data == nil {
+		return nil
+	}
+
+	var errs []error
+	for _, budget := range data.Budgets {
+		if budget == nil || budget.ResetDuration == "" || budget.IsCalendarAligned {
+			continue
+		}
+		if _, err := configstoreTables.ParseDuration(budget.ResetDuration); err != nil {
+			errs = append(errs, fmt.Errorf("invalid budget reset duration for budget %s: %w", budget.ID, err))
+		}
+	}
+
+	for _, rateLimit := range data.RateLimits {
+		if rateLimit == nil || rateLimit.IsCalendarAligned {
+			continue
+		}
+		if rateLimit.TokenResetDuration != nil {
+			if _, err := configstoreTables.ParseDuration(*rateLimit.TokenResetDuration); err != nil {
+				errs = append(errs, fmt.Errorf("invalid token reset duration for rate limit %s: %w", rateLimit.ID, err))
+			}
+		}
+		if rateLimit.RequestResetDuration != nil {
+			if _, err := configstoreTables.ParseDuration(*rateLimit.RequestResetDuration); err != nil {
+				errs = append(errs, fmt.Errorf("invalid request reset duration for rate limit %s: %w", rateLimit.ID, err))
+			}
+		}
+	}
+
+	return errs
 }
 
 // Cleanup stops all background workers and flushes pending operations


### PR DESCRIPTION
## Summary

Fixes governance reset consistency by making request-time resets use the same
first-class reset path as background/startup resets.

Previously, request-time budget/rate-limit bumps could perform a partial reset
of the live usage counters without running all reset side effects. In
particular, the request path could advance `LastReset` and reset current usage
before the periodic reset worker ran. Since the worker uses `LastReset` to
decide whether a reset is still due, it could then skip the reset later.

That created two problems:

1. `LastDB` baselines could remain stale while current usage had already moved
   into a new reset window.
2. Reset hooks used by higher-level governance stores could be bypassed for
   request-time resets.

This PR unifies request-time, ticker, and startup reset behavior so they all go
through the same in-memory reset functions and apply the same
baseline/reset-hook side effects.

## Changes

- Added targeted reset support to the in-memory reset functions:
  - `ResetExpiredBudgetsInMemory(ctx, budgetIDs ...string)`
  - `ResetExpiredRateLimitsInMemory(ctx, rateLimitIDs ...string)`
- Updated `BumpBudgetUsage` to call the shared targeted budget reset path when
  the budget window is expired before applying the new usage increment.
- Updated `BumpRateLimitUsage` to call the shared targeted rate-limit reset path
  when token/request windows are expired before applying the new usage
  increment.
- Added reset hooks on `LocalGovernanceStore` so wrappers can observe
  request-time resets and run their own reset side effects.
- Refactored startup rate-limit reset to use the shared full-map reset path
  instead of manually scanning virtual keys and resetting detached rate-limit
  copies.
- Kept startup optimized by continuing to operate on already-loaded in-memory
  state rather than reloading virtual keys from the DB.

Notable design decisions and trade-offs:

- The reset functions now support both modes:
  - no IDs: scan all budgets/rate limits, used by ticker/startup reset flows
  - specific IDs: check only those entries, used by request-time bump flows
- Request-time resets remain immediate. We did not remove reset checks from the
  bump path because doing so would make the first requests after a reset
  boundary depend on the reset worker interval and could evaluate them against
  stale old-window usage.
- Startup rate-limit reset now scans the in-memory rate-limit map instead of
  walking virtual keys. This preserves the original startup optimization of
  avoiding a second DB load while aligning startup with ticker semantics.
- Startup rate-limit reset may now cover any expired rate limit loaded in the
  store, not only top-level virtual-key rate limits. This matches the periodic
  reset path and makes startup behavior more consistent with runtime behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validated the governance package tests:

```sh
go test ./plugins/governance
```

Expected outcome:

```text
ok github.com/maximhq/bifrost/plugins/governance
```

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable. This is a backend governance reset-path change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No direct security implications. This change only affects governance usage reset
accounting and reset side-effect consistency.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
