### PR TITLE
feat: lower `auth_code_ttl` default to 300s and enforce 900s maximum

### DIFF
--- a/docs/mcp/gateway-auth.mdx
+++ b/docs/mcp/gateway-auth.mdx
@@ -117,7 +117,7 @@ curl -X PUT http://localhost:8080/api/config \
       "mcp_server_auth_mode": "both",
       "oauth2_server_config": {
         "issuer_url": "https://bifrost.example.com",
-        "auth_code_ttl": 600,
+        "auth_code_ttl": 300,
         "access_token_ttl": 600
       }
     }
@@ -133,7 +133,7 @@ curl -X PUT http://localhost:8080/api/config \
     "mcp_server_auth_mode": "both",
     "oauth2_server_config": {
       "issuer_url": "https://bifrost.example.com",
-      "auth_code_ttl": 600,
+      "auth_code_ttl": 300,
       "access_token_ttl": 600
     }
   }
@@ -144,7 +144,7 @@ curl -X PUT http://localhost:8080/api/config \
 |-------|------|----------|-------------|
 | `mcp_server_auth_mode` | string | No | `headers` (default), `both`, or `oauth`. |
 | `oauth2_server_config.issuer_url` | string | No | Stable public URL advertised as the issuer in discovery docs and the JWT `iss` claim. Required for multi-host deployments; single-host can omit it (falls back to the request `Host`). Supports `env.MY_VAR` syntax. |
-| `oauth2_server_config.auth_code_ttl` | integer | No | Authorization code lifetime in seconds (default `600`). |
+| `oauth2_server_config.auth_code_ttl` | integer | No | Authorization code lifetime in seconds (default `300`, max `900` = 15 minutes). |
 | `oauth2_server_config.access_token_ttl` | integer | No | Issued JWT lifetime in seconds (default `600`). |
 
 </Tab>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -71571,8 +71571,9 @@
                   "auth_code_ttl": {
                     "type": "integer",
                     "minimum": 1,
-                    "default": 600,
-                    "description": "Lifetime of the single-use authorization code in seconds (default 600)."
+                    "maximum": 900,
+                    "default": 300,
+                    "description": "Lifetime of the single-use authorization code in seconds (default 300, max 900 = 15 minutes)."
                   },
                   "access_token_ttl": {
                     "type": "integer",
@@ -71891,8 +71892,9 @@
                   "auth_code_ttl": {
                     "type": "integer",
                     "minimum": 1,
-                    "default": 600,
-                    "description": "Lifetime of the single-use authorization code in seconds (default 600)."
+                    "maximum": 900,
+                    "default": 300,
+                    "description": "Lifetime of the single-use authorization code in seconds (default 300, max 900 = 15 minutes)."
                   },
                   "access_token_ttl": {
                     "type": "integer",

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -143,8 +143,9 @@ ClientConfig:
         auth_code_ttl:
           type: integer
           minimum: 1
-          default: 600
-          description: Lifetime of the single-use authorization code in seconds (default 600).
+          maximum: 900
+          default: 300
+          description: Lifetime of the single-use authorization code in seconds (default 300, max 900 = 15 minutes).
         access_token_ttl:
           type: integer
           minimum: 1

--- a/framework/configstore/tables/mcpoauth2server.go
+++ b/framework/configstore/tables/mcpoauth2server.go
@@ -13,7 +13,8 @@ import (
 type MCPServerAuthMode string
 
 const (
-	DefaultAuthCodeTTL    = 600 // 10 minutes
+	DefaultAuthCodeTTL    = 300 // 5 minutes
+	MaxAuthCodeTTL        = 900 // 15 minutes — hard ceiling; enforced at config save and at code issuance
 	DefaultAccessTokenTTL = 600 // 10 minutes
 )
 
@@ -49,10 +50,11 @@ type OAuth2ServerConfig struct {
 	IssuerURL *schemas.SecretVar `json:"issuer_url,omitempty"`
 
 	// AuthCodeTTL is the lifetime of the one-time authorization code issued by
-	// /oauth2/authorize and exchanged at /oauth2/token (seconds, default 600).
+	// /oauth2/authorize and exchanged at /oauth2/token (seconds, default 300).
 	// The code is single-use — it is invalidated the moment it is exchanged or
 	// expires. Short TTL is intentional: if the window lapses the user simply
-	// re-authenticates.
+	// re-authenticates. Capped at MaxAuthCodeTTL (900s); larger stored values
+	// are rejected at config save and clamped to the cap at issuance.
 	AuthCodeTTL int `json:"auth_code_ttl"`
 
 	// AccessTokenTTL is the lifetime of the issued JWT Bearer token (seconds,

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -342,6 +342,58 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	currentConfig := h.store.ClientConfig
 	updatedConfig := currentConfig
 
+	// Validate MCP auth-mode / OAuth2 server settings before any live mutation
+	// below (drop-excess flag, MCP tool-manager reload, compat plugin reload,
+	// in-memory MCP config). A late rejection would return 400 while runtime
+	// state had already changed but DB persistence was skipped, diverging
+	// in-memory, core, and DB state.
+
+	// Validate the inbound MCP auth mode against the allowed enum
+	// (config.schema.json is the source of truth: headers | both | oauth).
+	switch payload.ClientConfig.MCPServerAuthMode {
+	case "", configstoreTables.MCPServerAuthModeHeaders, configstoreTables.MCPServerAuthModeBoth, configstoreTables.MCPServerAuthModeOAuth:
+		// valid; empty means the field was omitted from a partial update
+	default:
+		SendError(ctx, fasthttp.StatusBadRequest, "mcp_server_auth_mode must be one of: headers, both, oauth")
+		return
+	}
+
+	// oauth2_server_config only applies when discovery is enabled (both | oauth).
+	// Evaluate against the effective mode so a partial update that supplies only
+	// the config cannot smuggle it in while the stored mode is headers.
+	effectiveAuthMode := payload.ClientConfig.MCPServerAuthMode
+	if effectiveAuthMode == "" {
+		effectiveAuthMode = currentConfig.MCPServerAuthMode
+	}
+	effectiveOAuth2Config := currentConfig.OAuth2ServerConfig
+	if payload.ClientConfig.OAuth2ServerConfig != nil {
+		effectiveOAuth2Config = payload.ClientConfig.OAuth2ServerConfig
+	}
+
+	// disable_vk_identity only makes sense in oauth mode: in both mode virtual
+	// keys can still authenticate via headers, so suppressing them in the consent
+	// flow alone would be misleading. Evaluate the merged config so a partial
+	// update that switches the mode away from oauth (without resending the config)
+	// cannot leave a previously stored disable_vk_identity active.
+	if effectiveOAuth2Config != nil &&
+		effectiveOAuth2Config.DisableVKIdentity &&
+		effectiveAuthMode != configstoreTables.MCPServerAuthModeOAuth {
+		SendError(ctx, fasthttp.StatusBadRequest, "disable_vk_identity is only valid when mcp_server_auth_mode is oauth")
+		return
+	}
+
+	// Cap auth_code_ttl so a leaked one-time code can't stay valid for long.
+	// This is an unconditional invariant on the stored value — enforced in every
+	// mode (not just both | oauth), mirroring the load-time validateClientConfig
+	// check — so a save can never persist a value that would then fail boot on the
+	// next restart. A zero/omitted value falls back to the default at issuance and
+	// is left alone here.
+	if effectiveOAuth2Config != nil &&
+		effectiveOAuth2Config.AuthCodeTTL > configstoreTables.MaxAuthCodeTTL {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("auth_code_ttl must not exceed %d seconds (15 minutes)", configstoreTables.MaxAuthCodeTTL))
+		return
+	}
+
 	var restartReasons []string
 
 	if payload.ClientConfig.DropExcessRequests != currentConfig.DropExcessRequests {
@@ -538,46 +590,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	// Validation is performed up front in this handler so a failure here cannot leave the process in a partial state.
 	updatedConfig.MCPExternalClientURL = payload.ClientConfig.MCPExternalClientURL
 
-	// Validate the inbound MCP auth mode against the allowed enum before persisting
-	// (config.schema.json is the source of truth: headers | both | oauth).
-	switch payload.ClientConfig.MCPServerAuthMode {
-	case "", configstoreTables.MCPServerAuthModeHeaders, configstoreTables.MCPServerAuthModeBoth, configstoreTables.MCPServerAuthModeOAuth:
-		// valid; empty means the field was omitted from a partial update
-	default:
-		SendError(ctx, fasthttp.StatusBadRequest, "mcp_server_auth_mode must be one of: headers, both, oauth")
-		return
-	}
-
-	// oauth2_server_config only applies when discovery is enabled (both | oauth).
-	// Evaluate against the effective mode so a partial update that supplies only
-	// the config cannot smuggle it in while the stored mode is headers.
-	effectiveAuthMode := payload.ClientConfig.MCPServerAuthMode
-	if effectiveAuthMode == "" {
-		effectiveAuthMode = currentConfig.MCPServerAuthMode
-	}
-	if payload.ClientConfig.OAuth2ServerConfig != nil && effectiveAuthMode == configstoreTables.MCPServerAuthModeHeaders {
-		SendError(ctx, fasthttp.StatusBadRequest, "oauth2_server_config is only valid when mcp_server_auth_mode is both or oauth")
-		return
-	}
-
-	// disable_vk_identity only makes sense in oauth mode: in both mode virtual
-	// keys can still authenticate via headers, so suppressing them in the consent
-	// flow alone would be misleading. Evaluate the merged config so a partial
-	// update that switches the mode away from oauth (without resending the config)
-	// cannot leave a previously stored disable_vk_identity active.
-	effectiveOAuth2Config := currentConfig.OAuth2ServerConfig
-	if payload.ClientConfig.OAuth2ServerConfig != nil {
-		effectiveOAuth2Config = payload.ClientConfig.OAuth2ServerConfig
-	}
-	if effectiveOAuth2Config != nil &&
-		effectiveOAuth2Config.DisableVKIdentity &&
-		effectiveAuthMode != configstoreTables.MCPServerAuthModeOAuth {
-		SendError(ctx, fasthttp.StatusBadRequest, "disable_vk_identity is only valid when mcp_server_auth_mode is oauth")
-		return
-	}
-
 	// Only update each field when explicitly provided so partial /api/config
 	// payloads do not clear stored values (matches the MCP field handling above).
+	// The enum, disable_vk_identity, and auth_code_ttl validations for these
+	// fields run up front (before any live mutation) so a rejection can't leave
+	// runtime and DB state diverged.
 	if payload.ClientConfig.MCPServerAuthMode != "" {
 		updatedConfig.MCPServerAuthMode = payload.ClientConfig.MCPServerAuthMode
 	}

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -247,6 +247,11 @@ func (h *OAuth2IssuanceHandler) handleAuthorize(ctx *fasthttp.RequestCtx) {
 	authCodeTTL := cfg.AuthCodeTTL
 	if authCodeTTL <= 0 {
 		authCodeTTL = configtables.DefaultAuthCodeTTL
+	} else if authCodeTTL > configtables.MaxAuthCodeTTL {
+		// Defense in depth: the API rejects an over-max value at save and config
+		// load rejects it at startup, so this should be unreachable — but clamp
+		// anyway so a code can never be minted with a lifetime above the cap.
+		authCodeTTL = configtables.MaxAuthCodeTTL
 	}
 
 	req := &configtables.TableOAuth2AuthorizeRequest{

--- a/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance_test.go
@@ -618,3 +618,90 @@ func TestHandleToken_RefreshUserLiveness(t *testing.T) {
 		assert.NotContains(t, string(ctx.Response.Body()), "user is no longer active")
 	})
 }
+
+// putConfigCtx builds an initialized PUT /api/config request carrying a JSON body.
+func putConfigCtx(body string) *fasthttp.RequestCtx {
+	var req fasthttp.Request
+	req.Header.SetMethod("PUT")
+	req.Header.SetContentType("application/json")
+	req.SetBodyString(body)
+	return initCtx(&req)
+}
+
+// TestUpdateConfig_RejectsAuthCodeTTLAboveMax covers the API-layer guard: a save
+// with auth_code_ttl above the cap is rejected with 400 in every mode — including
+// headers, so the API can never persist a value the load-time validator would
+// later reject at boot — before any live runtime mutation. The handler returns at
+// the validation, so configManager is never invoked (left nil).
+func TestUpdateConfig_RejectsAuthCodeTTLAboveMax(t *testing.T) {
+	for _, mode := range []configtables.MCPServerAuthMode{
+		configtables.MCPServerAuthModeOAuth,
+		configtables.MCPServerAuthModeBoth,
+		configtables.MCPServerAuthModeHeaders,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			SetLogger(&mockLogger{})
+			store := newRealOAuth2Store(t)
+			cfg := newTestOAuth2Config(store, mode, false)
+			h := &ConfigHandler{store: cfg}
+
+			body := `{"client_config":{"mcp_server_auth_mode":"` + string(mode) +
+				`","oauth2_server_config":{"auth_code_ttl":5000,"access_token_ttl":600}}}`
+			ctx := putConfigCtx(body)
+			h.updateConfig(ctx)
+
+			require.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode())
+			assert.Contains(t, string(ctx.Response.Body()), "auth_code_ttl must not exceed")
+		})
+	}
+}
+
+// TestHandleAuthorize_AuthCodeTTLResolution covers the issuance-layer resolution
+// of the configured auth_code_ttl into the authorization code's ExpiresAt:
+// over-cap is clamped to the max, zero falls back to the default, and an in-range
+// value is used verbatim. The three expected values are far enough apart that the
+// generous timing tolerance cannot mask the wrong branch.
+func TestHandleAuthorize_AuthCodeTTLResolution(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured int
+		wantTTL    int
+	}{
+		{"above cap is clamped", 5000, configtables.MaxAuthCodeTTL},
+		{"zero falls back to default", 0, configtables.DefaultAuthCodeTTL},
+		{"in-range used verbatim", 120, 120},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, store, cfg := newIssuanceHandler(t)
+			cfg.ClientConfig.OAuth2ServerConfig.AuthCodeTTL = tc.configured
+			cid := seedClient(t, store, []string{"http://127.0.0.1:1234/cb"})
+
+			v := url.Values{}
+			v.Set("client_id", cid)
+			v.Set("redirect_uri", "http://127.0.0.1:1234/cb")
+			v.Set("response_type", "code")
+			v.Set("code_challenge", "challenge")
+			v.Set("code_challenge_method", "S256")
+			v.Set("resource", testMCPResource)
+			v.Set("state", "xyz")
+
+			before := time.Now()
+			ctx := getCtx("/oauth2/authorize?" + v.Encode())
+			h.handleAuthorize(ctx)
+			require.Equal(t, fasthttp.StatusFound, ctx.Response.StatusCode())
+
+			loc := string(ctx.Response.Header.Peek("Location"))
+			u, err := url.Parse(loc)
+			require.NoError(t, err)
+			flowID := u.Query().Get("flow")
+			require.NotEmpty(t, flowID)
+
+			req, err := store.GetOAuth2AuthorizeRequestByID(context.Background(), flowID)
+			require.NoError(t, err)
+
+			wantDeadline := before.Add(time.Duration(tc.wantTTL) * time.Second)
+			assert.WithinDuration(t, wantDeadline, req.ExpiresAt, 30*time.Second)
+		})
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -877,6 +877,12 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	}
 	// 4. Client config (store → file → defaults)
 	loadClientConfig(ctx, config, &configData)
+	// Reject an out-of-range client config (e.g. auth_code_ttl above the cap)
+	// loudly at startup instead of silently correcting it, so in-memory, core,
+	// and DB state cannot diverge.
+	if err := validateClientConfig(config.ClientConfig); err != nil {
+		return nil, err
+	}
 	config.SetHeaderMatcher(NewHeaderMatcher(config.ClientConfig.HeaderFilterConfig))
 	// 5. Providers (store → file → auto-detect)
 	if err := loadProviders(ctx, config, &configData); err != nil {
@@ -1084,6 +1090,23 @@ func applyClientConfigDefaults(cc *configstore.ClientConfig) {
 	if cc.EnableLogging == nil {
 		cc.EnableLogging = new(true)
 	}
+}
+
+// validateClientConfig checks invariants on a fully-merged client config that
+// must hold regardless of the source (config.json, DB, or defaults). It returns
+// an error rather than silently correcting a value so an out-of-range setting
+// fails loudly at startup instead of diverging in-memory state from what the
+// operator wrote — and stays wrong (re-warned, unpersisted) on every restart.
+func validateClientConfig(cc *configstore.ClientConfig) error {
+	// The /api/config handler rejects an over-max auth_code_ttl, but config.json
+	// and any DB row written before the cap existed bypass that path. Fail fast
+	// here, the point where every config source converges, so a leaked one-time
+	// code can never be minted with a lifetime above the ceiling. A zero/omitted
+	// value is valid — it resolves to the default at issuance.
+	if oc := cc.OAuth2ServerConfig; oc != nil && oc.AuthCodeTTL > configstoreTables.MaxAuthCodeTTL {
+		return fmt.Errorf("oauth2_server_config.auth_code_ttl %d exceeds the maximum of %d seconds (15 minutes)", oc.AuthCodeTTL, configstoreTables.MaxAuthCodeTTL)
+	}
+	return nil
 }
 
 // sanitizeMCPExternalOAuthURLs validates the MCP external OAuth URL overrides

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2045,6 +2045,62 @@ func createConfigFile(t *testing.T, dir string, data *ConfigData) {
 	}
 }
 
+// TestValidateClientConfig_AuthCodeTTL covers the load-time invariant check that
+// backs the "fail loudly instead of silently clamp" behavior: an auth_code_ttl
+// above the cap is rejected, while nil/zero/in-range/at-cap values pass.
+func TestValidateClientConfig_AuthCodeTTL(t *testing.T) {
+	oauth := func(ttl int) *configstore.ClientConfig {
+		return &configstore.ClientConfig{OAuth2ServerConfig: &tables.OAuth2ServerConfig{AuthCodeTTL: ttl}}
+	}
+	tests := []struct {
+		name    string
+		cc      *configstore.ClientConfig
+		wantErr bool
+	}{
+		{"no oauth config", &configstore.ClientConfig{}, false},
+		{"zero ttl resolves to default at issuance", oauth(0), false},
+		{"in-range ttl", oauth(300), false},
+		{"exactly at cap", oauth(tables.MaxAuthCodeTTL), false},
+		{"one over cap", oauth(tables.MaxAuthCodeTTL + 1), true},
+		{"far over cap", oauth(5000), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateClientConfig(tc.cc)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "auth_code_ttl")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestLoadConfig_AuthCodeTTLAboveMaxFailsBoot verifies an over-cap auth_code_ttl
+// in config.json makes LoadConfig fail rather than silently clamping the value.
+func TestLoadConfig_AuthCodeTTLAboveMaxFailsBoot(t *testing.T) {
+	initTestLogger()
+	tempDir := createTempDir(t)
+	createConfigFile(t, tempDir, &ConfigData{
+		Client: &configstore.ClientConfig{
+			MCPServerAuthMode: tables.MCPServerAuthModeOAuth,
+			OAuth2ServerConfig: &tables.OAuth2ServerConfig{
+				AuthCodeTTL:    5000,
+				AccessTokenTTL: tables.DefaultAccessTokenTTL,
+			},
+		},
+	})
+
+	ctx := context.Background()
+	config, err := LoadConfig(ctx, tempDir)
+	if config != nil {
+		defer config.Close(ctx)
+	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "auth_code_ttl")
+}
+
 // TestConfigDataSourceOfTruthDefaultsToSplit verifies omitted source_of_truth uses split mode.
 func TestConfigDataSourceOfTruthDefaultsToSplit(t *testing.T) {
 	var configData ConfigData

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -306,8 +306,9 @@
             "auth_code_ttl": {
               "type": "integer",
               "minimum": 1,
-              "default": 600,
-              "description": "Lifetime of the single-use authorization code in seconds (default: 600)."
+              "maximum": 900,
+              "default": 300,
+              "description": "Lifetime of the single-use authorization code in seconds (default: 300, max: 900 = 15 minutes)."
             },
             "access_token_ttl": {
               "type": "integer",

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -44,7 +44,7 @@ export default function MCPView() {
 		mcp_tool_execution_timeout: "30",
 		mcp_code_mode_binding_level: "server",
 		mcp_tool_sync_interval: "10",
-    oauth2_auth_code_ttl: "600",
+    oauth2_auth_code_ttl: "300",
     oauth2_access_token_ttl: "600",
 	});
 
@@ -59,7 +59,7 @@ export default function MCPView() {
         // Coerce a stored 0 (which the backend treats as "use default") to the
         // displayed default so the inputs never show a confusing 0.
         oauth2_auth_code_ttl: (
-          config?.oauth2_server_config?.auth_code_ttl || 600
+          config?.oauth2_server_config?.auth_code_ttl || 300
         ).toString(),
         oauth2_access_token_ttl: (
           config?.oauth2_server_config?.access_token_ttl || 600
@@ -86,8 +86,8 @@ export default function MCPView() {
       (localConfig.mcp_server_auth_mode ?? "headers") !==
         (config.mcp_server_auth_mode ?? "headers") ||
       issuerURLChanged ||
-      (localConfig.oauth2_server_config?.auth_code_ttl ?? 600) !==
-        (config.oauth2_server_config?.auth_code_ttl ?? 600) ||
+      (localConfig.oauth2_server_config?.auth_code_ttl ?? 300) !==
+        (config.oauth2_server_config?.auth_code_ttl ?? 300) ||
       (localConfig.oauth2_server_config?.access_token_ttl ?? 600) !==
         (config.oauth2_server_config?.access_token_ttl ?? 600) ||
       (localConfig.oauth2_server_config?.disable_vk_identity ?? false) !==
@@ -176,7 +176,7 @@ export default function MCPView() {
   const handleAuthCodeTTLChange = useCallback((value: string) => {
     setLocalValues((prev) => ({ ...prev, oauth2_auth_code_ttl: value }));
     const num = Number.parseInt(value);
-    if (!isNaN(num) && num >= 60) {
+    if (!isNaN(num) && num >= 1) {
       setLocalConfig((prev) => ({
         ...prev,
         oauth2_server_config: { ...prev.oauth2_server_config, auth_code_ttl: num },
@@ -230,8 +230,13 @@ export default function MCPView() {
         localValues.oauth2_access_token_ttl,
       );
 
-      if (oauthModeActive && (isNaN(authCodeTTL) || authCodeTTL < 60)) {
-        toast.error("Authorization code TTL must be at least 60 seconds.");
+      if (
+        oauthModeActive &&
+        (isNaN(authCodeTTL) || authCodeTTL < 1 || authCodeTTL > 900)
+      ) {
+        toast.error(
+          "Authorization code TTL must be between 1 and 900 seconds (15 minutes).",
+        );
         return;
       }
 
@@ -590,14 +595,16 @@ export default function MCPView() {
                       </label>
                       <p className="text-muted-foreground text-xs">
                         How long the one-time code is valid after the consent
-                        page redirects back to the MCP client (default: 600).
+                        page redirects back to the MCP client (default: 300, max
+                        900 = 15 min).
                       </p>
                       <Input
                         id="oauth2-auth-code-ttl"
                         data-testid="oauth2-auth-code-ttl-input"
                         type="number"
                         className="w-28"
-                        min="60"
+                        min="1"
+                        max="900"
                         value={localValues.oauth2_auth_code_ttl}
                         onChange={(e) => handleAuthCodeTTLChange(e.target.value)}
                         disabled={!hasSettingsUpdateAccess}


### PR DESCRIPTION
## Summary

Reduces the default OAuth2 authorization code TTL from 600 seconds to 300 seconds and enforces a hard maximum of 900 seconds (15 minutes). This limits the window during which a leaked one-time authorization code could be exploited.

## Changes

- `DefaultAuthCodeTTL` reduced from 600s to 300s; `MaxAuthCodeTTL` constant introduced at 900s
- API handler (`/api/config`) now rejects `auth_code_ttl` values exceeding 900s when OAuth or both auth modes are active, returning a 400 error
- `applyClientConfigDefaults` clamps any over-max value loaded from `config.json` or the database (bypassing the API), with a warning log
- Authorization code issuance clamps the TTL as a final defense-in-depth layer, even if a value was written directly to storage
- UI updated to reflect the new default (300) and maximum (900), including input validation, placeholder text, and the `max` attribute on the number input
- OpenAPI spec and JSON schema updated with `maximum: 900`, `default: 300`, and revised descriptions
- Documentation examples and parameter table updated to reflect the new default and maximum

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Verify the cap is enforced at the API layer
curl -X PUT http://localhost:8080/api/config \
  -H "Content-Type: application/json" \
  -d '{"mcp_server_auth_mode":"oauth","oauth2_server_config":{"auth_code_ttl":901}}'
# Expected: 400 Bad Request

# Verify a valid value is accepted
curl -X PUT http://localhost:8080/api/config \
  -H "Content-Type: application/json" \
  -d '{"mcp_server_auth_mode":"oauth","oauth2_server_config":{"auth_code_ttl":300}}'
# Expected: 200 OK

# Run backend tests
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

The default `auth_code_ttl` drops from 600s to 300s. Any deployment relying on the previous default will now issue shorter-lived authorization codes. Stored values above 900s will be clamped at load time with a warning log and rejected via the API going forward.

## Security considerations

Authorization codes are single-use but represent a brief window of exploitability if intercepted. Reducing the default TTL to 5 minutes and capping the maximum at 15 minutes limits the exposure window for leaked codes. The cap is enforced at three layers: API validation, config load, and code issuance, ensuring no path can produce a code with a TTL exceeding 900 seconds.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable