### PR TITLE
chore: reorder migrations to place OAuth2, console logs, and Bedrock Mantle steps before MCP/Azure steps

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -408,6 +408,10 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"backfill_vk_provider_config_blacklisted_models"}, run: migrationBackfillVirtualKeyBlacklistedModels},
 	{IDs: []string{"add_created_by_user_id_column_for_virtual_keys"}, run: migrationAddCreatedByUserIDColumnForVirtualKeys},
 	{IDs: []string{"re_add_allow_direct_keys_column"}, run: migrationReAddAllowDirectKeysColumn},
+	{IDs: []string{"add_dump_errors_in_console_logs_column"}, run: migrationAddDumpErrorsInConsoleLogsColumn},
+	{IDs: []string{"add_oauth2_server_tables"}, run: migrationAddOAuth2ServerTables},
+	{IDs: []string{"add_oauth2_issuance_tables"}, run: migrationAddOAuth2IssuanceTables},
+	{IDs: []string{"add_bedrock_mantle_key_columns"}, run: migrationAddBedrockMantleKeyColumns},
 	{IDs: []string{"refresh_config_hash_after_mcp_external_server_url_removal"}, run: migrationRefreshConfigHashAfterMCPExternalServerURLRemoval},
 	{IDs: []string{"drop_azure_api_version_column"}, run: migrationDropAzureAPIVersionColumn},
 	{IDs: []string{"add_mcp_per_user_header_credentials_table"}, run: migrationAddPerUserHeadersTables},
@@ -429,10 +433,6 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_customer_name_unique_constraint_dedup", "add_customer_name_unique_constraint_index"}, run: migrationAddCustomerNameUniqueConstraint},
 	{IDs: []string{"null_legacy_customer_budget_id_refs"}, run: migrationNullLegacyCustomerBudgetID},
 	{IDs: []string{"add_skills_repo_tables"}, run: migrationAddSkillsRepoTables},
-	{IDs: []string{"add_oauth2_server_tables"}, run: migrationAddOAuth2ServerTables},
-	{IDs: []string{"add_oauth2_issuance_tables"}, run: migrationAddOAuth2IssuanceTables},
-	{IDs: []string{"add_dump_errors_in_console_logs_column"}, run: migrationAddDumpErrorsInConsoleLogsColumn},
-	{IDs: []string{"add_bedrock_mantle_key_columns"}, run: migrationAddBedrockMantleKeyColumns},
 	{IDs: []string{"add_model_pricing_is_deprecated_column"}, run: migrationAddModelPricingIsDeprecatedColumn},
 }
 


### PR DESCRIPTION
## Summary

Reorders database migration steps to ensure `add_dump_errors_in_console_logs_column`, `add_oauth2_server_tables`, `add_oauth2_issuance_tables`, and `add_bedrock_mantle_key_columns` run earlier in the migration sequence, before the MCP external server URL removal and Azure API version column drop steps, rather than at the end of the list.

## Changes

- Moved four migration steps (`add_dump_errors_in_console_logs_column`, `add_oauth2_server_tables`, `add_oauth2_issuance_tables`, `add_bedrock_mantle_key_columns`) to an earlier position in the migration order to reflect their correct dependency ordering relative to subsequent migrations.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

Verify that the migration sequence runs without errors on a fresh database and on an existing database that has already applied some or all of these migrations. Since migration steps are tracked by ID, previously applied migrations should be skipped regardless of their position in the list.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable