### PR TITLE
fix: Anthropic - default unrecognized Claude models to adaptive thinking

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,4 +1,5 @@
 - fix: preserve Gemini file upload MIME types for GenAI file URI completions
+- fix: Anthropic - default unrecognized Claude models to adaptive thinking instead of downgrading to budget_tokens [@adrianlyjak](https://github.com/adrianlyjak)
 - fix: Gemini video reference fields map to instances [@vojthor](https://github.com/vojthor)
 - fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,5 +1,5 @@
-- fix: preserve Gemini file upload MIME types for GenAI file URI completions
 - fix: Anthropic - default unrecognized Claude models to adaptive thinking instead of downgrading to budget_tokens [@adrianlyjak](https://github.com/adrianlyjak)
+- fix: preserve Gemini file upload MIME types for GenAI file URI completions
 - fix: Gemini video reference fields map to instances [@vojthor](https://github.com/vojthor)
 - fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -770,14 +770,115 @@ func IsSonnet5Plus(model string) bool {
 	return strings.Contains(strings.ToLower(model), "sonnet-5")
 }
 
+// claudeOpusSonnet4Minor extracts the minor version of a Claude Opus/Sonnet 4.x
+// model from a lowercased model id. It returns (minor, true) when m names such a
+// model, or (0, false) otherwise. Adaptive thinking arrived at the .6 minor, so
+// callers treat minor < 6 as pre-adaptive (legacy) and minor == 6 as dual-mode.
+//
+// Handles every id form Anthropic/Bedrock/Vertex use:
+//
+//	claude-opus-4-6-20250514      -> 6
+//	claude-sonnet-4-5-20250929    -> 5
+//	claude-sonnet-4-20250514      -> 0   (bare 4.0, dated)
+//	anthropic.claude-opus-4-v1    -> 0   (bare 4.0, bedrock)
+//	claude-opus-4                 -> 0   (bare 4.0, alias)
+//	claude-opus-4.6               -> 6
+//	claude-opus-4-16              -> 16
+//
+// A numeric run of 4+ digits immediately after the major (e.g. a 2025xxxx date)
+// is treated as no explicit minor (bare 4.0 -> minor 0).
+func claudeOpusSonnet4Minor(m string) (int, bool) {
+	for _, fam := range []string{"opus-4", "sonnet-4"} {
+		idx := strings.Index(m, fam)
+		if idx == -1 {
+			continue
+		}
+		rest := m[idx+len(fam):]
+		if rest == "" {
+			return 0, true // bare "…-4"
+		}
+		if rest[0] != '-' && rest[0] != '.' {
+			return 0, true // "…-4v1" etc. — treat as bare 4.0
+		}
+		// Read the numeric run right after the separator.
+		j := 1
+		for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+			j++
+		}
+		digits := rest[1:j]
+		if digits == "" {
+			return 0, true // "…-4-v1" (separator then non-digit)
+		}
+		if len(digits) >= 4 {
+			return 0, true // date run (e.g. -20250514) — bare 4.0
+		}
+		n := 0
+		for _, c := range digits {
+			n = n*10 + int(c-'0')
+		}
+		return n, true
+	}
+	return 0, false
+}
+
+// isLegacyBudgetTokensOnlyModel reports whether a lowercased Claude model id
+// predates adaptive thinking and therefore only accepts budget_tokens extended
+// thinking (and still accepts temperature/top_p/top_k). This is the closed set
+// of legacy Claude models: Haiku (any), Claude 2.x/3.x, and Opus/Sonnet 4.x
+// below the .6 adaptive cutoff. Every other Claude model is assumed to support
+// adaptive thinking — the fail-open default so a new/unknown Claude model is not
+// downgraded to budget_tokens (which post-4.7 models reject with a 400).
+func isLegacyBudgetTokensOnlyModel(m string) bool {
+	// Haiku has never supported adaptive thinking. NOTE: this blanket match
+	// will very likely need to be narrowed to specific legacy Haiku versions
+	// once a new Haiku ships — Anthropic's trajectory (Opus 4.7+, Sonnet 5,
+	// Fable/Mythos) points at adaptive-only becoming the default for new
+	// models across every tier, Haiku included.
+	if strings.Contains(m, "haiku") {
+		return true
+	}
+	// Pre-Claude-4 generations.
+	if strings.Contains(m, "claude-2") || strings.Contains(m, "claude-instant") {
+		return true
+	}
+	if strings.Contains(m, "claude-3") {
+		return true
+	}
+	// Opus/Sonnet 4.x below the .6 adaptive cutoff (incl. bare 4.0).
+	if minor, ok := claudeOpusSonnet4Minor(m); ok && minor < 6 {
+		return true
+	}
+	return false
+}
+
+// isDualModeThinkingModel reports whether a lowercased Claude model id supports
+// BOTH adaptive thinking and budget_tokens extended thinking (and still accepts
+// sampling params) — adaptive is available but not the only mode. Only Opus 4.6
+// and Sonnet 4.6 qualify.
+func isDualModeThinkingModel(m string) bool {
+	minor, ok := claudeOpusSonnet4Minor(m)
+	return ok && minor == 6
+}
+
 // IsAdaptiveOnlyThinkingModel returns true for models where budget_tokens
 // extended thinking is removed (adaptive is the only thinking-on mode) and
-// temperature/top_p/top_k are rejected with a 400. Covers Opus 4.7+, Sonnet 5+,
-// and the Fable/Mythos family. Use this — not IsOpus47Plus — for the thinking and
-// sampling-parameter gates so Fable is handled correctly. (Fast mode is gated
-// on IsOpus47Plus instead, since Fable does not support speed:"fast".)
+// temperature/top_p/top_k are rejected with a 400. This covers Opus 4.7+,
+// Sonnet 5+, the Fable/Mythos family, and — by fail-open default — any new or
+// unrecognized Claude model. The only models excluded are known legacy models
+// (see isLegacyBudgetTokensOnlyModel) and the dual-mode Opus 4.6 / Sonnet 4.6,
+// which still accept budget_tokens and sampling params.
+//
+// Use this — not IsOpus47Plus — for the thinking and sampling-parameter gates so
+// the whole adaptive-only family is handled correctly. (Fast mode is gated on
+// IsOpus47Plus instead, since Fable does not support speed:"fast".)
 func IsAdaptiveOnlyThinkingModel(model string) bool {
-	return IsOpus47Plus(model) || IsSonnet5Plus(model) || IsFableFamily(model)
+	m := strings.ToLower(model)
+	if !SupportsAdaptiveThinking(m) {
+		return false // legacy (budget_tokens-only) or non-Claude
+	}
+	// Opus 4.6 / Sonnet 4.6 accept budget_tokens and sampling params too, so
+	// adaptive is available but not the only thinking-on mode.
+	return !isDualModeThinkingModel(m)
 }
 
 // SupportsNativeEffort returns true if the model supports Anthropic's native output_config.effort parameter.
@@ -885,20 +986,25 @@ func SupportsFastMode(model string) bool {
 }
 
 // SupportsAdaptiveThinking returns true if the model supports thinking.type: "adaptive".
-// Currently supported on Claude Opus 4.6, Claude Sonnet 4.6, Claude Sonnet 5+, Claude
-// Opus 4.7+, and the Claude Fable/Mythos family. On Opus 4.7+, Sonnet 5+, and
-// Fable/Mythos adaptive is the only thinking-on mode; on Opus 4.6 and Sonnet 4.6 it
+// It fails open: a Claude model is assumed to support adaptive thinking unless it is
+// a known legacy (budget_tokens-only) model — Haiku (any), Claude 2.x/3.x, or
+// Opus/Sonnet 4.x below the .6 cutoff (see isLegacyBudgetTokensOnlyModel). This
+// reverses the previous allowlist so a new/unrecognized Claude model (e.g. a future
+// claude-opus-5) is routed to adaptive thinking instead of being downgraded to
+// budget_tokens, which every Claude model since Opus 4.7 rejects with a 400.
+//
+// On Opus 4.7+, Sonnet 5+, Fable/Mythos, and unknown models adaptive is the only
+// thinking-on mode (see IsAdaptiveOnlyThinkingModel); on Opus 4.6 and Sonnet 4.6 it
 // coexists with the deprecated budget_tokens-based extended thinking. On Fable/Mythos
 // adaptive is always on and thinking:{type:"disabled"} is rejected (see IsFableFamily).
+//
+// Empty and non-Claude model strings return false.
 func SupportsAdaptiveThinking(model string) bool {
-	if IsOpus47Plus(model) || IsSonnet5Plus(model) || IsFableFamily(model) {
-		return true
-	}
-	model = strings.ToLower(model)
-	if !strings.Contains(model, "4-6") && !strings.Contains(model, "4.6") {
+	m := strings.ToLower(model)
+	if !strings.Contains(m, "claude") {
 		return false
 	}
-	return strings.Contains(model, "opus") || strings.Contains(model, "sonnet")
+	return !isLegacyBudgetTokensOnlyModel(m)
 }
 
 // Computer-use tool generations.

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -824,24 +824,29 @@ func claudeOpusSonnet4Minor(m string) (int, bool) {
 // isLegacyBudgetTokensOnlyModel reports whether a lowercased Claude model id
 // predates adaptive thinking and therefore only accepts budget_tokens extended
 // thinking (and still accepts temperature/top_p/top_k). This is the closed set
-// of legacy Claude models: Haiku (any), Claude 2.x/3.x, and Opus/Sonnet 4.x
-// below the .6 adaptive cutoff. Every other Claude model is assumed to support
+// of legacy Claude models: Claude 2.x/3.x (incl. 3.x Haiku), Haiku 4.5, and
+// Opus/Sonnet 4.x below the .6 adaptive cutoff. Every other Claude model is
+// assumed to support
 // adaptive thinking — the fail-open default so a new/unknown Claude model is not
 // downgraded to budget_tokens (which post-4.7 models reject with a 400).
 func isLegacyBudgetTokensOnlyModel(m string) bool {
-	// Haiku has never supported adaptive thinking. NOTE: this blanket match
-	// will very likely need to be narrowed to specific legacy Haiku versions
-	// once a new Haiku ships — Anthropic's trajectory (Opus 4.7+, Sonnet 5,
-	// Fable/Mythos) points at adaptive-only becoming the default for new
-	// models across every tier, Haiku included.
-	if strings.Contains(m, "haiku") {
-		return true
-	}
-	// Pre-Claude-4 generations.
+	// Pre-Claude-4 generations, including every 3.x Haiku (claude-3-haiku,
+	// claude-3-5-haiku).
 	if strings.Contains(m, "claude-2") || strings.Contains(m, "claude-instant") {
 		return true
 	}
 	if strings.Contains(m, "claude-3") {
+		return true
+	}
+	// Haiku 4.5 is the latest Haiku and is budget_tokens-only. Match the known
+	// legacy Haiku versions explicitly rather than any "haiku" so a future
+	// adaptive-only Haiku — e.g. claude-haiku-5, following Anthropic's trajectory
+	// of adaptive-by-default for new models across every tier (Opus 4.7+, Sonnet
+	// 5, Fable/Mythos) — fails open to adaptive like any other new/unknown model
+	// instead of being downgraded to budget_tokens (which adaptive-only models
+	// reject with a 400). Narrow this set when a new legacy Haiku ships; a new
+	// adaptive Haiku needs no change here.
+	if strings.Contains(m, "haiku-4-5") || strings.Contains(m, "haiku-4.5") {
 		return true
 	}
 	// Opus/Sonnet 4.x below the .6 adaptive cutoff (incl. bare 4.0).
@@ -987,8 +992,9 @@ func SupportsFastMode(model string) bool {
 
 // SupportsAdaptiveThinking returns true if the model supports thinking.type: "adaptive".
 // It fails open: a Claude model is assumed to support adaptive thinking unless it is
-// a known legacy (budget_tokens-only) model — Haiku (any), Claude 2.x/3.x, or
-// Opus/Sonnet 4.x below the .6 cutoff (see isLegacyBudgetTokensOnlyModel). This
+// a known legacy (budget_tokens-only) model — Claude 2.x/3.x (incl. 3.x Haiku),
+// Haiku 4.5, or Opus/Sonnet 4.x below the .6 cutoff (see
+// isLegacyBudgetTokensOnlyModel). This
 // reverses the previous allowlist so a new/unrecognized Claude model (e.g. a future
 // claude-opus-5) is routed to adaptive thinking instead of being downgraded to
 // budget_tokens, which every Claude model since Opus 4.7 rejects with a 400.

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -2291,6 +2292,24 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		{"claude-haiku-4-6-20250514", false}, // haiku does not support adaptive
 		{"claude-haiku-4-7-20260401", false}, // haiku, not opus
 		{"claude-haiku-4-8-20260601", false}, // haiku, not opus
+		{"claude-haiku-4-9-20270101", false}, // future haiku still legacy
+		// Fail-open: new/unrecognized Claude models default to adaptive.
+		{"claude-opus-5", true},
+		{"claude-opus-5-20270101", true},
+		{"claude-sonnet-6", true},
+		{"claude-opus-4-9", true},                  // future Opus 4.x minor >= 6
+		{"claude-sonnet-7-20270101", true},
+		{"global.anthropic.claude-opus-5", true},
+		// Legacy stays budget_tokens-only (must NOT flip to adaptive).
+		{"claude-sonnet-4-20250514", false}, // bare Sonnet 4.0 (dated)
+		{"claude-opus-4-20250514", false},   // bare Opus 4.0 (dated)
+		{"claude-opus-4-1", false},
+		{"claude-opus-4-0", false},
+		{"anthropic.claude-opus-4-v1", false}, // bare Opus 4.0 (bedrock)
+		{"claude-3-7-sonnet", false},
+		{"claude-3-5-sonnet-20241022", false},
+		{"claude-3-opus", false},
+		{"claude-2.1", false},
 		{"", false},
 	}
 
@@ -2398,6 +2417,18 @@ func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
 		// Other.
 		{"claude-opus-4-5", false},
 		{"claude-haiku-4-5", false},
+		// Fail-open: new/unrecognized Claude models are adaptive-only.
+		{"claude-opus-5", true},
+		{"claude-sonnet-6", true},
+		{"claude-opus-4-9", true}, // future Opus 4.x minor >= 6
+		{"global.anthropic.claude-opus-5", true},
+		// Legacy / bare-4 stay non-adaptive.
+		{"claude-sonnet-4-20250514", false}, // bare Sonnet 4.0 (dated)
+		{"claude-opus-4-1", false},
+		{"anthropic.claude-opus-4-v1", false},
+		{"claude-3-7-sonnet", false},
+		{"claude-2.1", false},
+		{"claude-haiku-4-9", false},
 		{"", false},
 	}
 
@@ -2405,6 +2436,50 @@ func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
 		t.Run(tt.model, func(t *testing.T) {
 			if got := IsAdaptiveOnlyThinkingModel(tt.model); got != tt.expected {
 				t.Errorf("IsAdaptiveOnlyThinkingModel(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestClaudeOpusSonnet4Minor(t *testing.T) {
+	tests := []struct {
+		model     string
+		wantMinor int
+		wantOK    bool
+	}{
+		// Explicit minors (hyphen and dot forms, with/without date suffix).
+		{"claude-opus-4-6-20250514", 6, true},
+		{"claude-opus-4.6", 6, true},
+		{"claude-sonnet-4-6-20250514", 6, true},
+		{"claude-opus-4-7-20260401", 7, true},
+		{"claude-opus-4-8", 8, true},
+		{"claude-opus-4-5-20241022", 5, true},
+		{"claude-sonnet-4-5-20250929", 5, true},
+		{"claude-opus-4-1-20250805", 1, true},
+		{"claude-opus-4-16", 16, true}, // multi-digit future minor
+		// Bare 4.0 forms → minor 0.
+		{"claude-sonnet-4-20250514", 0, true}, // dated
+		{"claude-opus-4-20250514", 0, true},   // dated
+		{"anthropic.claude-opus-4-v1", 0, true},
+		{"us.anthropic.claude-sonnet-4-v1:0", 0, true},
+		{"claude-opus-4-0", 0, true},
+		{"claude-opus-4", 0, true},   // alias, end of string
+		{"claude-sonnet-4", 0, true}, // alias, end of string
+		// Not an Opus/Sonnet 4.x model.
+		{"claude-sonnet-5", 0, false},
+		{"claude-opus-5", 0, false},
+		{"claude-3-7-sonnet", 0, false},
+		{"claude-3-5-sonnet-20241022", 0, false},
+		{"claude-haiku-4-5", 0, false},
+		{"claude-fable-5", 0, false},
+		{"", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			gotMinor, gotOK := claudeOpusSonnet4Minor(strings.ToLower(tt.model))
+			if gotOK != tt.wantOK || (gotOK && gotMinor != tt.wantMinor) {
+				t.Errorf("claudeOpusSonnet4Minor(%q) = (%d, %v), want (%d, %v)",
+					tt.model, gotMinor, gotOK, tt.wantMinor, tt.wantOK)
 			}
 		})
 	}

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2295,19 +2295,6 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		{"anthropic.claude-haiku-4-5-20251001-v1:0", false},
 		{"claude-3-5-haiku-20241022", false},
 		{"claude-3-haiku", false},
-		// A future/adaptive Haiku fails open like every other new model — the
-		// blanket "haiku" denylist would have wrongly downgraded these.
-		{"claude-haiku-5", true},
-		{"claude-haiku-5-20270101", true},
-		{"claude-haiku-4-6-20250514", true},
-		{"claude-haiku-4-9-20270101", true},
-		// Fail-open: new/unrecognized Claude models default to adaptive.
-		{"claude-opus-5", true},
-		{"claude-opus-5-20270101", true},
-		{"claude-sonnet-6", true},
-		{"claude-opus-4-9", true},                  // future Opus 4.x minor >= 6
-		{"claude-sonnet-7-20270101", true},
-		{"global.anthropic.claude-opus-5", true},
 		// Legacy stays budget_tokens-only (must NOT flip to adaptive).
 		{"claude-sonnet-4-20250514", false}, // bare Sonnet 4.0 (dated)
 		{"claude-opus-4-20250514", false},   // bare Opus 4.0 (dated)
@@ -2425,20 +2412,12 @@ func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
 		// Other.
 		{"claude-opus-4-5", false},
 		{"claude-haiku-4-5", false},
-		// Fail-open: new/unrecognized Claude models are adaptive-only.
-		{"claude-opus-5", true},
-		{"claude-sonnet-6", true},
-		{"claude-opus-4-9", true}, // future Opus 4.x minor >= 6
-		{"global.anthropic.claude-opus-5", true},
 		// Legacy / bare-4 stay non-adaptive.
 		{"claude-sonnet-4-20250514", false}, // bare Sonnet 4.0 (dated)
 		{"claude-opus-4-1", false},
 		{"anthropic.claude-opus-4-v1", false},
 		{"claude-3-7-sonnet", false},
 		{"claude-2.1", false},
-		// A future/adaptive Haiku fails open (Haiku 4.5 legacy case above).
-		{"claude-haiku-4-9", true},
-		{"claude-haiku-5", true},
 		{"", false},
 	}
 

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2289,10 +2289,18 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		{"global.anthropic.claude-fable-5", true},
 		{"claude-opus-4-5-20241022", false},
 		{"claude-sonnet-4-5-20241022", false},
-		{"claude-haiku-4-6-20250514", false}, // haiku does not support adaptive
-		{"claude-haiku-4-7-20260401", false}, // haiku, not opus
-		{"claude-haiku-4-8-20260601", false}, // haiku, not opus
-		{"claude-haiku-4-9-20270101", false}, // future haiku still legacy
+		// Haiku 4.5 (the latest Haiku) and 3.x Haiku stay budget_tokens-only.
+		{"claude-haiku-4-5", false},
+		{"claude-haiku-4-5-20251001", false},
+		{"anthropic.claude-haiku-4-5-20251001-v1:0", false},
+		{"claude-3-5-haiku-20241022", false},
+		{"claude-3-haiku", false},
+		// A future/adaptive Haiku fails open like every other new model — the
+		// blanket "haiku" denylist would have wrongly downgraded these.
+		{"claude-haiku-5", true},
+		{"claude-haiku-5-20270101", true},
+		{"claude-haiku-4-6-20250514", true},
+		{"claude-haiku-4-9-20270101", true},
 		// Fail-open: new/unrecognized Claude models default to adaptive.
 		{"claude-opus-5", true},
 		{"claude-opus-5-20270101", true},
@@ -2428,7 +2436,9 @@ func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
 		{"anthropic.claude-opus-4-v1", false},
 		{"claude-3-7-sonnet", false},
 		{"claude-2.1", false},
-		{"claude-haiku-4-9", false},
+		// A future/adaptive Haiku fails open (Haiku 4.5 legacy case above).
+		{"claude-haiku-4-9", true},
+		{"claude-haiku-5", true},
 		{"", false},
 	}
 


### PR DESCRIPTION
## Summary

`SupportsAdaptiveThinking` / `IsAdaptiveOnlyThinkingModel` were allowlists — an unrecognized Claude model id fell through to `false` and got downgraded to `budget_tokens` extended thinking. Every Claude model since Opus 4.7 (including Sonnet 5) rejects `budget_tokens` and sampling params with a 400, so a new/unlisted model would 400 on first use instead of working.

## Changes

- Reversed the default: an unrecognized Claude model is now assumed to support adaptive thinking instead of being downgraded.
- Added a small closed legacy denylist (Haiku 4.5, Claude 2.x/3.x, Opus/Sonnet 4.x below the `.6` minor) via a new `claudeOpusSonnet4Minor` parser, so every currently-known model keeps its exact prior behavior — only genuinely new/unrecognized Claude ids flip to adaptive.
- Bedrock reuses the same helpers, so it inherits the fix with no separate change needed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go build ./...
go test ./providers/anthropic/... ./providers/bedrock/...
go vet ./providers/anthropic/... ./providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

All currently-known model ids (Haiku 4.5, Claude 2.x/3.x, Opus/Sonnet 4.0–4.5, dual-mode 4.6, adaptive-only 4.7+/5+/Fable/Mythos) keep identical behavior. Only genuinely new/unrecognized Claude model ids change (adaptive instead of a 400).

## Related issues

Closes #4828

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/raising-a-pr.mdx` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated `core/changelog.md`
- [x] I verified builds succeed (Go)
- [ ] UI build/tests (not applicable — no UI changes)
