### PR TITLE
fix: cancelled state in logs

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -802,7 +802,7 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	}
 
 	initialData.RoutingEngineUsed = routingEngines
-	initialData.Status = "processing"
+	initialData.Status = logStatusProcessing
 
 	// Store input data in pendingLogs for later combination with PostLLMHook output.
 	// No DB write here - the write is deferred to PostLLMHook to halve total writes.
@@ -814,7 +814,7 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		RoutingEnginesUsed: routingEngines,
 		InitialData:        initialData,
 		CreatedAt:          time.Now(),
-		Status:             "processing",
+		Status:             logStatusProcessing,
 	}
 	// Seed LastActivity so the first idle-eviction check has a baseline even if no
 	// PostLLMHook chunk has fired yet.
@@ -906,7 +906,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry := &logstore.Log{
 				ID:        requestID,
 				Provider:  string(bifrostErr.ExtraFields.Provider),
-				Status:    "error",
+				Status:    logStatusForError(bifrostErr),
 				Object:    string(requestType),
 				Stream:    bifrost.IsStreamRequestType(requestType),
 				Timestamp: time.Now().UTC(),
@@ -1037,7 +1037,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	// Path A: Error with nil result
 	if result == nil && bifrostErr != nil {
-		entry.Status = "error"
+		entry.Status = logStatusForError(bifrostErr)
 		applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 		if bifrost.IsStreamRequestType(requestType) {
 			entry.Stream = true
@@ -1100,7 +1100,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 
 		if bifrostErr != nil {
-			entry.Status = "error"
+			entry.Status = logStatusForError(bifrostErr)
 			entry.Stream = true
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 			if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
@@ -1141,7 +1141,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 		} else if streamResponse == nil {
 			// tracer or traceID not available, or accumulator returned nil - still write what we have
-			entry.Status = "success"
+			entry.Status = logStatusSuccess
 			entry.Stream = true
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 		} else if isFinalChunk {
@@ -1150,7 +1150,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
 		}
 		if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
-			entry.Status = "error"
+			entry.Status = logStatusForError(entry.ErrorDetailsParsed)
 		}
 		// Backfill passthrough status_code from response (streaming path)
 		if result != nil && result.PassthroughResponse != nil {
@@ -1162,7 +1162,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 			// Flip status for passthrough error responses (4xx/5xx from provider)
 			if isPassthroughErrorResponse(result) {
-				entry.Status = "error"
+				entry.Status = logStatusError
 			}
 			// Compute cost for streaming passthrough using StreamUsage set by the accumulator.
 			if entry.Cost == nil && p.pricingManager != nil && result.PassthroughResponse.PassthroughUsage != nil {
@@ -1183,7 +1183,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	// Path C: Non-streaming response
 	if bifrostErr != nil {
-		entry.Status = "error"
+		entry.Status = logStatusForError(bifrostErr)
 		applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 		// Serialize error details immediately since bifrostErr may be released
 		// back to the pool before the async batch writer processes this entry.
@@ -1198,7 +1198,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			applyRealtimeRawRequestBackfill(entry, bifrostErr.ExtraFields.RawRequest, contentLoggingEnabled, shouldStoreRaw)
 		}
 	} else if result != nil {
-		entry.Status = "success"
+		entry.Status = logStatusSuccess
 		extraFields := result.GetExtraFields()
 		applyModelAlias(entry, extraFields.OriginalModelRequested, extraFields.ResolvedModelUsed)
 		if requestType == schemas.RealtimeRequest {
@@ -1208,7 +1208,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 		// Flip status for passthrough error responses (4xx/5xx from provider)
 		if isPassthroughErrorResponse(result) {
-			entry.Status = "error"
+			entry.Status = logStatusError
 		}
 	}
 	applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -16,6 +16,52 @@ import (
 
 const realtimeMissingTranscriptText = "[Audio transcription unavailable]"
 
+const (
+	logStatusProcessing = "processing"
+	logStatusSuccess    = "success"
+	logStatusError      = "error"
+	logStatusCancelled  = "cancelled"
+)
+
+func logStatusForError(err *schemas.BifrostError) string {
+	if isCancelledLogError(err) {
+		return logStatusCancelled
+	}
+	return logStatusError
+}
+
+func isCancelledLogError(err *schemas.BifrostError) bool {
+	if err == nil {
+		return false
+	}
+	if err.StatusCode != nil && *err.StatusCode == 499 {
+		return true
+	}
+	if err.Error == nil || err.Error.Type == nil {
+		return false
+	}
+	switch *err.Error.Type {
+	case schemas.RequestCancelled:
+		return true
+	case schemas.RequestTimedOut:
+		return isContextTimeoutLogError(err)
+	default:
+		return false
+	}
+}
+
+func isContextTimeoutLogError(err *schemas.BifrostError) bool {
+	if err == nil || err.Error == nil {
+		return false
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error.Message))
+	if message == "" || message == strings.ToLower(schemas.ErrProviderRequestTimedOut) {
+		return false
+	}
+	return strings.Contains(message, "by context") ||
+		strings.Contains(message, "context deadline exceeded")
+}
+
 // insertInitialLogEntry creates a new log entry in the database using GORM
 func (p *LoggerPlugin) insertInitialLogEntry(
 	ctx context.Context,
@@ -33,7 +79,7 @@ func (p *LoggerPlugin) insertInitialLogEntry(
 		Provider:      data.Provider,
 		Model:         data.Model,
 		FallbackIndex: fallbackIndex,
-		Status:        "processing",
+		Status:        logStatusProcessing,
 		Stream:        false,
 		CreatedAt:     timestamp,
 		// Set parsed fields for serialization
@@ -339,7 +385,8 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 
 	// Handle error case first
 	if streamResponse.Data.ErrorDetails != nil {
-		entry.Status = "error"
+		entry.Status = logStatusForError(streamResponse.Data.ErrorDetails)
+		entry.ErrorDetailsParsed = streamResponse.Data.ErrorDetails
 		// Serialize error details immediately to avoid use-after-free with pooled errors
 		if data, err := sonic.Marshal(streamResponse.Data.ErrorDetails); err == nil {
 			entry.ErrorDetails = string(data)
@@ -347,7 +394,7 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		latF := float64(streamResponse.Data.Latency)
 		entry.Latency = &latF
 	} else {
-		entry.Status = "success"
+		entry.Status = logStatusSuccess
 		latF := float64(streamResponse.Data.Latency)
 		entry.Latency = &latF
 	}

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/streaming"
 )
 
 type testLogger struct{}
@@ -188,7 +189,7 @@ func TestPostLLMHookStreamingErrorPreservesHeaderMetadata(t *testing.T) {
 // TestPostLLMHookCancelledStreamLogsCost verifies #3357 at the logging layer: a
 // streaming request cancelled mid-flight (result==nil) whose error carries the
 // partial usage the provider already processed (BifrostError.ExtraFields.BilledUsage)
-// must produce a log row with status="error", the consumed tokens, AND an
+// must produce a log row with status="cancelled", the consumed tokens, AND an
 // accurate cost computed from the datasheet rates.
 func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
 	store := newTestStore(t)
@@ -255,8 +256,8 @@ func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindByID() error = %v", err)
 	}
-	if entry.Status != "error" {
-		t.Fatalf("expected error status, got %q", entry.Status)
+	if entry.Status != "cancelled" {
+		t.Fatalf("expected cancelled status, got %q", entry.Status)
 	}
 	if entry.TokenUsageParsed == nil {
 		t.Fatalf("expected token usage recorded from BilledUsage on the cancel path")
@@ -271,6 +272,168 @@ func TestPostLLMHookCancelledStreamLogsCost(t *testing.T) {
 	want := float64(promptTokens)*2.5e-6 + float64(completionTokens)*1e-5
 	if diff := *entry.Cost - want; diff < -1e-9 || diff > 1e-9 {
 		t.Fatalf("logged cost %v does not match datasheet-computed cost %v", *entry.Cost, want)
+	}
+}
+
+func TestPostLLMHookContextTimeoutLogsCancelledStatus(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-context-timeout")
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+			Params:   &schemas.ChatParameters{},
+		},
+	}
+	if _, _, err = plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook() error = %v", err)
+	}
+
+	statusCode := 504
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "Request timed out by context: context deadline exceeded",
+			Type:    schemas.Ptr(schemas.RequestTimedOut),
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ChatCompletionRequest,
+			Provider:               schemas.OpenAI,
+			OriginalModelRequested: "gpt-4o",
+			ResolvedModelUsed:      "gpt-4o",
+		},
+	}
+	if _, _, err = plugin.PostLLMHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostLLMHook() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	entry, err := store.FindByID(context.Background(), "req-context-timeout")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if entry.Status != "cancelled" {
+		t.Fatalf("expected cancelled status, got %q", entry.Status)
+	}
+}
+
+func TestPostLLMHookProviderTimeoutRemainsErrorStatus(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-provider-timeout")
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+			Params:   &schemas.ChatParameters{},
+		},
+	}
+	if _, _, err = plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook() error = %v", err)
+	}
+
+	statusCode := 504
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: schemas.ErrProviderRequestTimedOut,
+			Type:    schemas.Ptr(schemas.RequestTimedOut),
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ChatCompletionRequest,
+			Provider:               schemas.OpenAI,
+			OriginalModelRequested: "gpt-4o",
+			ResolvedModelUsed:      "gpt-4o",
+		},
+	}
+	if _, _, err = plugin.PostLLMHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostLLMHook() error = %v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	entry, err := store.FindByID(context.Background(), "req-provider-timeout")
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if entry.Status != "error" {
+		t.Fatalf("expected error status, got %q", entry.Status)
+	}
+}
+
+func TestLogStatusForErrorDoesNotTreatGenericDeadlineMessageAsCancelled(t *testing.T) {
+	statusCode := 504
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: "provider request hit project deadline exceeded limit",
+			Type:    schemas.Ptr(schemas.RequestTimedOut),
+		},
+	}
+
+	if got := logStatusForError(bifrostErr); got != "error" {
+		t.Fatalf("expected generic provider deadline message to remain error, got %q", got)
+	}
+}
+
+func TestApplyStreamingOutputToEntryPreservesAccumulatorCancelledStatus(t *testing.T) {
+	plugin := &LoggerPlugin{}
+	entry := &logstore.Log{}
+	statusCode := 499
+	streamResponse := &streaming.ProcessedStreamResponse{
+		Data: &streaming.AccumulatedData{
+			ErrorDetails: &schemas.BifrostError{
+				IsBifrostError: true,
+				StatusCode:     &statusCode,
+				Error: &schemas.ErrorField{
+					Message: "Request cancelled: client disconnected",
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+				},
+			},
+			Latency: 42,
+		},
+	}
+
+	plugin.applyStreamingOutputToEntry(entry, streamResponse, false, true)
+	if entry.Status != "cancelled" {
+		t.Fatalf("expected initial cancelled status, got %q", entry.Status)
+	}
+	if entry.ErrorDetails == "" {
+		t.Fatalf("expected serialized error details to be set")
+	}
+	if entry.ErrorDetailsParsed == nil {
+		t.Fatalf("expected parsed error details to be set")
+	}
+
+	// Match the downstream Path B re-derivation in PostLLMHook. If
+	// ErrorDetailsParsed is missing, this collapses accumulator-originated
+	// cancellations back to "error".
+	if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
+		entry.Status = logStatusForError(entry.ErrorDetailsParsed)
+	}
+	if entry.Status != "cancelled" {
+		t.Fatalf("expected downstream reclassification to preserve cancelled status, got %q", entry.Status)
 	}
 }
 


### PR DESCRIPTION
## Summary

Requests cancelled by the client (e.g. context deadline exceeded, HTTP 499) were being logged with `status="error"`, making it impossible to distinguish genuine provider/network failures from client-initiated cancellations. This PR introduces a dedicated `"cancelled"` log status for those cases.

## Changes

- Introduced log status constants (`logStatusProcessing`, `logStatusSuccess`, `logStatusError`, `logStatusCancelled`) to replace raw string literals throughout `main.go` and `operations.go`.
- Added `logStatusForError(*schemas.BifrostError) string` which returns `"cancelled"` when the error represents a client cancellation (HTTP 499, `RequestCancelled` error type, or a `RequestTimedOut` whose message indicates the timeout was driven by a context deadline), and `"error"` otherwise.
- Provider-side timeouts (where the message matches `ErrProviderRequestTimedOut`) continue to produce `status="error"` — only context-driven timeouts are treated as cancellations.
- Updated the existing cancelled-stream test assertion from `"error"` to `"cancelled"`.
- Added two new tests: `TestPostLLMHookContextTimeoutLogsCancelledStatus` (context deadline → `"cancelled"`) and `TestPostLLMHookProviderTimeoutRemainsErrorStatus` (provider timeout → `"error"`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/logging/...
```

Expected: all tests pass, including the two new timeout-status tests and the updated cancelled-stream test.

## Breaking changes

- [x] Yes
- [ ] No

Any downstream consumers filtering log rows by `status="error"` to catch cancelled requests will need to also handle `status="cancelled"`. Existing `"error"` rows for true provider/network failures are unaffected.

## Related issues

Closes #3357

## Security considerations

None — this change only affects how log status strings are assigned; no auth, secrets, or PII handling is modified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable