### PR TITLE
fix(anthropic): preserve file id document sources

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: preserve Anthropic uploaded file references in document sources [@mmacvicar](https://github.com/mmacvicar)
 - fix: Gemini video reference fields map to instances [@vojthor](https://github.com/vojthor)
 - fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -76,6 +78,64 @@ func TestToAnthropicChatRequest_PreservesPropertyOrder(t *testing.T) {
 		if keys[i] != k {
 			t.Errorf("property %d: expected %q, got %q (full order: %v)", i, k, keys[i], keys)
 		}
+	}
+}
+
+func TestToAnthropicChatRequest_OpenAICompatibleFileIDUsesFileSource(t *testing.T) {
+	body := `{
+		"model": "anthropic/claude-sonnet-4-5-20250929",
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "Read the attached PDF."},
+				{
+					"type": "file",
+					"file": {
+						"file_id": "file_abc123",
+						"filename": "tiny.pdf",
+						"format": "application/pdf"
+					}
+				}
+			]
+		}]
+	}`
+
+	var openAIReq openai.OpenAIChatRequest
+	if err := sonic.Unmarshal([]byte(body), &openAIReq); err != nil {
+		t.Fatalf("unmarshal OpenAI-compatible request: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq := openAIReq.ToBifrostChatRequest(ctx)
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("convert to Anthropic request: %v", err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected one message, got %d", len(result.Messages))
+	}
+	blocks := result.Messages[0].Content.ContentBlocks
+	if len(blocks) != 2 {
+		t.Fatalf("expected two content blocks, got %d", len(blocks))
+	}
+
+	documentBlock := blocks[1]
+	if documentBlock.Type != AnthropicContentBlockTypeDocument {
+		t.Fatalf("expected document block, got %q", documentBlock.Type)
+	}
+	if documentBlock.Title == nil || *documentBlock.Title != "tiny.pdf" {
+		t.Fatalf("expected document title tiny.pdf, got %v", documentBlock.Title)
+	}
+	if documentBlock.Source == nil || documentBlock.Source.SourceObj == nil {
+		t.Fatalf("expected document source object, got %#v", documentBlock.Source)
+	}
+	source := documentBlock.Source.SourceObj
+	if source.Type != "file" {
+		t.Fatalf("expected source type file, got %q", source.Type)
+	}
+	if source.FileID == nil || *source.FileID != "file_abc123" {
+		t.Fatalf("expected source file_id file_abc123, got %v", source.FileID)
 	}
 }
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -2184,6 +2184,13 @@ func ConvertToAnthropicDocumentBlock(block schemas.ChatContentBlock) AnthropicCo
 		documentBlock.Title = file.Filename
 	}
 
+	// Handle uploaded file references from OpenAI-compatible file blocks.
+	if file.FileID != nil && *file.FileID != "" {
+		documentBlock.Source.SourceObj.Type = "file"
+		documentBlock.Source.SourceObj.FileID = file.FileID
+		return documentBlock
+	}
+
 	// Handle file URL
 	if file.FileURL != nil && *file.FileURL != "" {
 		documentBlock.Source.SourceObj.Type = "url"


### PR DESCRIPTION
## Summary

Fixes Anthropic document conversion when Bifrost receives an OpenAI-compatible chat completion request that references an uploaded Anthropic file by `file_id`.

## When This Happens

When the routed model is Anthropic and the message contains a file content block like below on OpenAI-compatible routes such as `/litellm/v1/chat/completions` or `/v1/chat/completions`, Bifrost converts that OpenAI-compatible file block into an Anthropic document block. Before this fix, uploaded `file_id` references were not copied into the Anthropic document source object, and `source.type` was not set to `file`, causing Anthropic to reject the request.

OpenAI-compatible input:

```json
{
  "type": "file",
  "file": {
    "file_id": "file_abc123",
    "filename": "tiny.pdf"
  }
}
```

The failure happens while converting the OpenAI-compatible chat request into Anthropic Messages API content blocks. Before the fix, Bifrost produced an Anthropic document block with an initialized but invalid source object:

```json
{
  "type": "document",
  "title": "tiny.pdf",
  "source": {
    "type": ""
  }
}
```

Anthropic rejects this because `document.source.type` must be one of its supported source tags, for example `file`, `base64`, `url`, or `text`. After the fix, Bifrost preserves the uploaded file reference in Anthropic's expected file-source shape:

```json
{
  "type": "document",
  "title": "tiny.pdf",
  "source": {
    "type": "file",
    "file_id": "file_abc123"
  }
}
```

## Reproduction

A self-contained reproduction case is documented here:

[talismanai/bifrost-issue: anthropic-file-id-openai-route](https://github.com/talismanai/bifrost-issue/tree/main/cases/anthropic-file-id-openai-route)

That case contains the run instructions, a self-contained uv sample script, and the Bifrost configuration used for local validation. The script uploads a tiny PDF to `POST /v1/files?provider=anthropic`, calls `POST /litellm/v1/chat/completions` with the uploaded `file_id`, prints the response, and deletes the uploaded file.

```sh
git clone git@github.com:talismanai/bifrost-issue.git
cd bifrost-issue/cases/anthropic-file-id-openai-route
BIFROST_URL="http://localhost:8080" BIFROST_API_KEY="..." uv run python repro.py
```

## Changes

- Map `ChatInputFile.FileID` to Anthropic `source: {type: "file", file_id: ...}`.
- Add a regression test for the LiteLLM/OpenAI-compatible payload shape.
- Update `core/changelog.md`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./providers/anthropic ./providers/openai
go vet ./providers/anthropic
git diff --check
```

For end-to-end validation, run the external reproduction case linked above against a local Bifrost gateway configured with an Anthropic key and the `anthropic-beta: files-api-2025-04-14` header.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new auth, secret, or data exposure paths. This only preserves an existing uploaded file ID in the downstream Anthropic request body. The external repro reads credentials from environment variables only.

## Checklist

- [x] I read the contribution guidelines and followed the applicable parts
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed for the touched Go packages
- [ ] I verified the full CI pipeline passes locally if applicable
