### PR TITLE
fix(gemini): preserve file upload mime type

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: preserve Gemini file upload MIME types for GenAI file URI completions
 - fix: Gemini video reference fields map to instances [@vojthor](https://github.com/vojthor)
 - fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
 - fix: recover from idle-timeout timer-goroutine panic that could crash the process

--- a/core/providers/gemini/fileupload_test.go
+++ b/core/providers/gemini/fileupload_test.go
@@ -1,0 +1,123 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileUploadSendsContentTypeToGemini(t *testing.T) {
+	const contentType = "application/pdf"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/upload/v1beta/files" {
+			http.Error(w, fmt.Sprintf("unexpected path: %s", r.URL.Path), http.StatusNotFound)
+			return
+		}
+		if got := r.Header.Get("x-goog-api-key"); got != "dummy-key" {
+			http.Error(w, fmt.Sprintf("unexpected api key: %s", got), http.StatusUnauthorized)
+			return
+		}
+
+		reader, err := r.MultipartReader()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to read multipart body: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		var sawMetadata, sawFile bool
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				http.Error(w, fmt.Sprintf("failed to read multipart part: %v", err), http.StatusBadRequest)
+				return
+			}
+			body, err := io.ReadAll(part)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("failed to read multipart part body: %v", err), http.StatusBadRequest)
+				return
+			}
+
+			switch part.FormName() {
+			case "metadata":
+				sawMetadata = true
+				var metadata struct {
+					File struct {
+						DisplayName string `json:"displayName"`
+						MIMEType    string `json:"mimeType"`
+					} `json:"file"`
+				}
+				if err := json.Unmarshal(body, &metadata); err != nil {
+					http.Error(w, fmt.Sprintf("failed to unmarshal metadata: %v", err), http.StatusBadRequest)
+					return
+				}
+				if metadata.File.DisplayName != "tiny.pdf" {
+					http.Error(w, fmt.Sprintf("unexpected displayName: %s", metadata.File.DisplayName), http.StatusBadRequest)
+					return
+				}
+				if metadata.File.MIMEType != contentType {
+					http.Error(w, fmt.Sprintf("unexpected metadata mimeType: %s", metadata.File.MIMEType), http.StatusBadRequest)
+					return
+				}
+			case "file":
+				sawFile = true
+				if part.FileName() != "tiny.pdf" {
+					http.Error(w, fmt.Sprintf("unexpected filename: %s", part.FileName()), http.StatusBadRequest)
+					return
+				}
+				if got := part.Header.Get("Content-Type"); got != contentType {
+					http.Error(w, fmt.Sprintf("unexpected file part content type: %s", got), http.StatusBadRequest)
+					return
+				}
+				if string(body) != "ok" {
+					http.Error(w, fmt.Sprintf("unexpected file body: %s", string(body)), http.StatusBadRequest)
+					return
+				}
+			}
+		}
+		if !sawMetadata || !sawFile {
+			http.Error(w, "missing metadata or file multipart part", http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"file":{"name":"files/test","displayName":"tiny.pdf","mimeType":"application/pdf","sizeBytes":"2","createTime":"2026-07-01T00:00:00Z","state":"ACTIVE","uri":"https://generativelanguage.googleapis.com/v1beta/files/test"}}`))
+	}))
+	defer ts.Close()
+
+	provider := NewGeminiProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL + "/v1beta"},
+	}, testNoopLogger{})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}
+	resp, bifrostErr := provider.FileUpload(ctx, key, &schemas.BifrostFileUploadRequest{
+		Provider:    schemas.Gemini,
+		File:        []byte("ok"),
+		Filename:    "tiny.pdf",
+		Purpose:     schemas.FilePurposeUserData,
+		ContentType: schemas.Ptr(contentType),
+	})
+
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, resp)
+	assert.Equal(t, "files/test", resp.ID)
+	assert.Equal(t, "tiny.pdf", resp.Filename)
+	assert.Equal(t, "https://generativelanguage.googleapis.com/v1beta/files/test", resp.StorageURI)
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 	"time"
@@ -3442,6 +3443,16 @@ func (provider *GeminiProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to marshal metadata", err)
 	}
+	contentType := ""
+	if request.ContentType != nil {
+		contentType = strings.TrimSpace(*request.ContentType)
+	}
+	if contentType != "" {
+		metadataJSON, err = providerUtils.SetJSONField(metadataJSON, "file.mimeType", contentType)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to marshal metadata", err)
+		}
+	}
 	if _, err := metadataField.Write(metadataJSON); err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to write metadata", err)
 	}
@@ -3451,7 +3462,15 @@ func (provider *GeminiProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 	if filename == "" {
 		filename = "file.bin"
 	}
-	part, err := writer.CreateFormFile("file", filename)
+	var part io.Writer
+	if contentType != "" {
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", multipart.FileContentDisposition("file", filename))
+		header.Set("Content-Type", contentType)
+		part, err = writer.CreatePart(header)
+	} else {
+		part, err = writer.CreateFormFile("file", filename)
+	}
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to create form file", err)
 	}


### PR DESCRIPTION
## Summary

Fixes Gemini file uploads losing the caller-provided MIME type when Bifrost handles uploads through the GenAI-compatible resumable upload route.

The GenAI transport already extracts `X-Goog-Upload-Header-Content-Type` and passes it into the core `FileUpload` request. The Gemini provider ignored that value, so uploads were sent to Gemini with only a display name in metadata and a generic multipart file part. Gemini could accept the upload, but the resulting file metadata could lack a useful `mimeType`, and later file URI completions could fail with a generic Google 400.

## When This Happens

A client can upload a PDF through Bifrost's GenAI-compatible route like this:

```http
POST /genai/upload/v1beta/files
X-Goog-Upload-Protocol: resumable
X-Goog-Upload-Command: start
X-Goog-Upload-Header-Content-Type: application/pdf
```

The transport turns that into a core Gemini `FileUpload` request with `ContentType=application/pdf`.

Before the fix, the provider sent metadata like:

```json
{
  "file": {
    "displayName": "tiny.pdf"
  }
}
```

and created the multipart file part through `CreateFormFile`, which uses `application/octet-stream` for the file part.

That makes the uploaded Gemini file ambiguous. A later `generateContent` request with the uploaded file URI can fail even when the request includes `mimeType=application/pdf`:

```json
{
  "fileData": {
    "fileUri": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
    "mimeType": "application/pdf"
  }
}
```

Google returns a generic error:

```text
400 Request contains an invalid argument.
```

After the fix, Bifrost sends the uploaded file part with the caller-provided MIME type:

```http
Content-Type: application/pdf
```

Google may still return generic file metadata from the File API, but the later `generateContent` request no longer fails with the invalid-argument error.

## Reproduction

A self-contained uv repro lives at:

```sh
examples/reproductions/gemini-file-upload-mime-type
```

The same repro is also published in the issue reproduction repo:

[https://github.com/talismanai/bifrost-issue/tree/main/cases/gemini-file-upload-mime-type](https://github.com/talismanai/bifrost-issue/tree/main/cases/gemini-file-upload-mime-type)

That case contains the run instructions, sample script, expected before/after output, and the local Bifrost configuration used to reproduce the issue against `dev` and verify this branch.

The script creates a tiny PDF, uploads it through Bifrost's GenAI resumable upload route, retrieves the file metadata, calls `generateContent` with the uploaded URI, prints each response, and deletes the file.

```sh
cd examples/reproductions/gemini-file-upload-mime-type
BIFROST_URL="http://localhost:8080" BIFROST_API_KEY="..." uv run python repro.py
```

Optional:

```sh
MODEL="gemini-2.5-flash"
```

## Changes

- Preserve `BifrostFileUploadRequest.ContentType` on the Gemini upload multipart file part.
- Use Gemini-compatible multipart content disposition when a MIME type is provided.
- Keep the previous `CreateFormFile` behavior when no MIME type is provided.
- Add a focused Gemini provider regression test that validates both metadata and multipart file part content type.
- Add a minimal uv reproduction project for the GenAI upload and file URI completion path.
- Update `core/changelog.md`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
cd core && go test ./providers/gemini
cd examples/reproductions/gemini-file-upload-mime-type && uv run python -m py_compile repro.py && uv lock --check
git diff --check
```

Live local verification with the Gemini key from the downstream integration test env:

- upstream `dev`: upload finalizes, file metadata is generic, `generateContent` returns `400 Request contains an invalid argument`
- this branch: upload finalizes, file metadata may still be generic, `generateContent` returns `200` and extracts `ok` from the PDF

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new auth, secret, or data exposure paths. This only preserves an existing caller-provided MIME type in the Gemini upload metadata and multipart file part. The repro reads credentials from environment variables only.

## Checklist

- [x] I read the contribution guidelines and followed the applicable parts
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed for the touched Go packages
- [ ] I verified the full CI pipeline passes locally if applicable



