### PR TITLE
[feat]: virtual-keys endpoint: add user_id filter and remove from_memory in-memory path

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,2 @@
+[feat]: add UserID filter to VirtualKeyQueryParams and GetVirtualKeysPaginated for created_by_user_id lookups [@jamesseiwert](https://github.com/jamesseiwert)
 [fix]: rebuild token usage from denormalized columns in hybrid log list [@G-XD](https://github.com/G-XD)

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3134,6 +3134,9 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
 	}
+	if params.UserID != "" {
+		baseQuery = baseQuery.Where("created_by_user_id = ?", params.UserID)
+	}
 
 	// Get total count before pagination
 	var totalCount int64

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -1872,6 +1872,61 @@ func TestGetVirtualKeysUsesInternalPagination(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("vk-page-%04d", totalVirtualKeys-1), virtualKeys[len(virtualKeys)-1].ID)
 }
 
+// TestGetVirtualKeysPaginatedFiltersByUserID verifies that the UserID filter
+// returns only virtual keys whose created_by_user_id matches.
+func TestGetVirtualKeysPaginatedFiltersByUserID(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	userA := "user-aaa"
+	userB := "user-bbb"
+
+	vk1 := &tables.TableVirtualKey{
+		ID:              "vk-user-a-1",
+		Name:            "Key for User A",
+		Value:           "vk-val-a-1",
+		IsActive:        schemas.Ptr(true),
+		CreatedByUserID: &userA,
+	}
+	vk2 := &tables.TableVirtualKey{
+		ID:              "vk-user-a-2",
+		Name:            "Another Key for User A",
+		Value:           "vk-val-a-2",
+		IsActive:        schemas.Ptr(true),
+		CreatedByUserID: &userA,
+	}
+	vk3 := &tables.TableVirtualKey{
+		ID:              "vk-user-b-1",
+		Name:            "Key for User B",
+		Value:           "vk-val-b-1",
+		IsActive:        schemas.Ptr(true),
+		CreatedByUserID: &userB,
+	}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk1))
+	require.NoError(t, store.CreateVirtualKey(ctx, vk2))
+	require.NoError(t, store.CreateVirtualKey(ctx, vk3))
+
+	results, total, err := store.GetVirtualKeysPaginated(ctx, VirtualKeyQueryParams{UserID: userA})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, results, 2)
+	for _, vk := range results {
+		require.NotNil(t, vk.CreatedByUserID)
+		require.Equal(t, userA, *vk.CreatedByUserID)
+	}
+
+	results, total, err = store.GetVirtualKeysPaginated(ctx, VirtualKeyQueryParams{UserID: userB})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Len(t, results, 1)
+	require.Equal(t, "vk-user-b-1", results[0].ID)
+
+	results, total, err = store.GetVirtualKeysPaginated(ctx, VirtualKeyQueryParams{UserID: "user-nonexistent"})
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total)
+	require.Empty(t, results)
+}
+
 // =============================================================================
 // Helper function tests
 // =============================================================================

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -21,6 +21,7 @@ type VirtualKeyQueryParams struct {
 	Search                             string
 	CustomerID                         string
 	TeamID                             string
+	UserID                             string // When set, filters to VKs created by this user (matches created_by_user_id)
 	SortBy                             string // name, budget_spent, created_at, status (default: created_at)
 	Order                              string // asc, desc (default: asc)
 	Export                             bool   // When true, skip default pagination limits (caller controls limit)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1109,47 +1109,13 @@ func (h *GovernanceHandler) reloadComplexityAnalyzerConfig(ctx context.Context, 
 
 // getVirtualKeys handles GET /api/governance/virtual-keys - Get all virtual keys with relationships
 func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
-	// Check if "from_memory" query parameter is set to true
-	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
-	if fromMemory {
-		data := h.governanceManager.GetGovernanceData(ctx)
-		if data == nil {
-			SendError(ctx, 500, "Governance data is not available")
-			return
-		}
-		// Convert map to slice to match the non-memory response format (array)
-		virtualKeys := make([]*configstoreTables.TableVirtualKey, 0, len(data.VirtualKeys))
-		for _, vk := range data.VirtualKeys {
-			virtualKeys = append(virtualKeys, vk)
-		}
-		sort.Slice(virtualKeys, func(i, j int) bool {
-			return virtualKeys[i].CreatedAt.Before(virtualKeys[j].CreatedAt)
-		})
-		byKey := buildVKModelConfigIndex(data.ModelConfigs)
-		hydratedVKs := make([]*configstoreTables.TableVirtualKey, len(virtualKeys))
-		for i, vk := range virtualKeys {
-			clone := *vk
-			pcs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
-			copy(pcs, vk.ProviderConfigs)
-			clone.ProviderConfigs = pcs
-			applyVKGovernanceFromModelConfigs(&clone, byKey)
-			hydratedVKs[i] = &clone
-		}
-		SendJSON(ctx, map[string]interface{}{
-			"virtual_keys": hydratedVKs,
-			"count":        len(hydratedVKs),
-			"total_count":  len(hydratedVKs),
-			"limit":        len(hydratedVKs),
-			"offset":       0,
-		})
-		return
-	}
 	// Check for pagination/filter parameters
 	limitStr := string(ctx.QueryArgs().Peek("limit"))
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	search := string(ctx.QueryArgs().Peek("search"))
 	customerID := string(ctx.QueryArgs().Peek("customer_id"))
 	teamID := string(ctx.QueryArgs().Peek("team_id"))
+	userID := string(ctx.QueryArgs().Peek("user_id"))
 	sortBy := string(ctx.QueryArgs().Peek("sort_by"))
 	order := string(ctx.QueryArgs().Peek("order"))
 	isExport := string(ctx.QueryArgs().Peek("export")) == "true"
@@ -1157,12 +1123,13 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 	excludeAssignedVirtualKeys := string(ctx.QueryArgs().Peek("exclude_assigned_virtual_keys")) == "true"
 	forUserAssignment := string(ctx.QueryArgs().Peek("for_user_assignment")) == "true"
 
-	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || sortBy != "" || isExport || excludeAccessProfileManagedVirtual || excludeAssignedVirtualKeys || forUserAssignment {
+	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || userID != "" || sortBy != "" || isExport || excludeAccessProfileManagedVirtual || excludeAssignedVirtualKeys || forUserAssignment {
 		// Paginated/filtered path
 		params := configstore.VirtualKeyQueryParams{
 			Search:                             search,
 			CustomerID:                         customerID,
 			TeamID:                             teamID,
+			UserID:                             userID,
 			SortBy:                             sortBy,
 			Order:                              order,
 			Export:                             isExport,

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -40,10 +40,12 @@ type mockConfigStoreForVK struct {
 	configstore.ConfigStore
 	getVirtualKeysCalls          int
 	getVirtualKeysPaginatedCalls int
+	lastPaginatedParams          configstore.VirtualKeyQueryParams
 }
 
-func (m *mockConfigStoreForVK) GetVirtualKeysPaginated(_ context.Context, _ configstore.VirtualKeyQueryParams) ([]configstoreTables.TableVirtualKey, int64, error) {
+func (m *mockConfigStoreForVK) GetVirtualKeysPaginated(_ context.Context, params configstore.VirtualKeyQueryParams) ([]configstoreTables.TableVirtualKey, int64, error) {
 	m.getVirtualKeysPaginatedCalls++
+	m.lastPaginatedParams = params
 	return nil, 0, nil
 }
 
@@ -2141,6 +2143,35 @@ func TestGetVirtualKeys_FromMemoryWithLimitUsesPaginatedConfigStore(t *testing.T
 	}
 	if store.getVirtualKeysCalls != 0 {
 		t.Fatalf("unexpected non-paginated call count %d", store.getVirtualKeysCalls)
+	}
+}
+
+// TestGetVirtualKeys_UserIDParamUsesPaginatedPath verifies that providing
+// user_id triggers the paginated DB path and passes UserID through to the
+// query params.
+func TestGetVirtualKeys_UserIDParamUsesPaginatedPath(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockConfigStoreForVK{}
+	h := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: &mockGovernanceManagerForVK{},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/governance/virtual-keys?user_id=user-abc-123")
+
+	h.getVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.getVirtualKeysPaginatedCalls != 1 {
+		t.Fatalf("expected GetVirtualKeysPaginated to be called once, got %d", store.getVirtualKeysPaginatedCalls)
+	}
+	if store.lastPaginatedParams.UserID != "user-abc-123" {
+		t.Fatalf("expected UserID %q, got %q", "user-abc-123", store.lastPaginatedParams.UserID)
 	}
 }
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,2 @@
+[feat]: virtual-keys endpoint: remove from_memory in-memory path, always use DB-backed store [@jamesseiwert](https://github.com/jamesseiwert)
+[feat]: virtual-keys endpoint: add user_id query param to filter by created_by_user_id [@jamesseiwert](https://github.com/jamesseiwert)


### PR DESCRIPTION
## Summary

- Remove the `from_memory` GovernanceManager block from `GET /api/governance/virtual-keys`, which returned all virtual keys from in-memory state with no filter or pagination support. The param is now a no-op and falls through to the regular DB-backed paths.
- Add a new `user_id` query parameter that filters results to virtual keys whose `created_by_user_id` matches the given value (Option A from the issue).
- Fix 2 pre-existing failing tests that already encoded the expected DB-backed behavior for the `from_memory` path.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run affected tests
go test ./transports/bifrost-http/handlers/ -run TestGetVirtualKeys -v
go test ./framework/configstore/ -run TestGetVirtualKeysPaginated -v
```

Filter by user ID (new):
```
GET /api/governance/virtual-keys?user_id=<user-uuid>
```

Filter by name substring combined with team (existing, now also works when from_memory param is present):
```
GET /api/governance/virtual-keys?team_id=<id>&search=USERID:<user-uuid>
```

## Breaking changes

- [x] No

`from_memory=true` continues to return the same logical dataset via the DB store. Response shape is identical.

## Related issues

Closes #4793

## Security considerations

No auth, secrets, or PII changes. The `user_id` filter is an exact match on `created_by_user_id`, a column already exposed in list responses.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable