### PR TITLE
feat: add pagination and filtering to MCP clients list endpoint

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -37001,10 +37001,6 @@
                           "provider": {
                             "type": "string"
                           },
-                          "is_deprecated": {
-                            "type": "boolean",
-                            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
-                          },
                           "accessible_by_keys": {
                             "type": "array",
                             "items": {
@@ -37152,10 +37148,6 @@
                                 }
                               }
                             }
-                          },
-                          "is_deprecated": {
-                            "type": "boolean",
-                            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
                           },
                           "accessible_by_keys": {
                             "type": "array",
@@ -38078,9 +38070,106 @@
       "get": {
         "operationId": "getMCPClients",
         "summary": "List MCP clients",
-        "description": "Returns a list of all configured MCP clients with their tools and connection state.",
+        "description": "Returns a paginated list of configured MCP clients with their tools and connection state.\nSupports case-insensitive name search and exact-match filtering by connection type, auth type,\ncode-mode, and enabled/disabled status. Multi-value filters accept a comma-separated list and\nuse OR semantics within a field.\n",
         "tags": [
           "MCP"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of clients to return (1–100, default 25).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 25
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of clients to skip.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive search by client name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "server",
+            "in": "query",
+            "description": "Filter to a single client by its exact client_id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "connection_type",
+            "in": "query",
+            "description": "Comma-separated connection types to include (OR semantics).",
+            "schema": {
+              "type": "string",
+              "example": "http,sse"
+            }
+          },
+          {
+            "name": "auth_type",
+            "in": "query",
+            "description": "Comma-separated auth types to include (OR semantics).",
+            "schema": {
+              "type": "string",
+              "example": "oauth,per_user_oauth"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "Comma-separated runtime connection states to include (OR semantics),\nresolved against live engine state. `connected` matches clients the engine\ncurrently reports as connected; `disconnected` matches everything else.\n",
+            "schema": {
+              "type": "string",
+              "example": "connected"
+            }
+          },
+          {
+            "name": "all_virtual_keys",
+            "in": "query",
+            "description": "When true, include clients that are open to all virtual keys (allow_on_all_virtual_keys). ORs with virtual_keys.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "virtual_keys",
+            "in": "query",
+            "description": "Comma-separated virtual key IDs; includes clients explicitly assigned to any of them. ORs with all_virtual_keys.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "code_mode",
+            "in": "query",
+            "description": "Filter by code-mode clients. Omit for no filter.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "disabled",
+            "in": "query",
+            "description": "Filter by disabled status — true returns disabled clients, false returns enabled clients. Omit for no filter.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
         ],
         "security": [
           {
@@ -38093,10 +38182,50 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MCPClient"
+                  "type": "object",
+                  "description": "Paginated list of MCP clients.",
+                  "required": [
+                    "clients",
+                    "count",
+                    "total_count",
+                    "limit",
+                    "offset"
+                  ],
+                  "properties": {
+                    "clients": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/MCPClient"
+                      }
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Number of clients returned in this page"
+                    },
+                    "total_count": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Total number of clients matching the query (before pagination)"
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Page size used for the response"
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "description": "Page offset used for the response"
+                    }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
                 }
               }
             }
@@ -61466,10 +61595,6 @@
               }
             }
           },
-          "is_deprecated": {
-            "type": "boolean",
-            "description": "True when the model is marked deprecated in the Bifrost pricing datasheet. Deprecated models remain listable for migration and compatibility workflows."
-          },
           "pricing": {
             "type": "object",
             "properties": {
@@ -71580,6 +71705,11 @@
                     "minimum": 1,
                     "default": 600,
                     "description": "Lifetime of the issued JWT Bearer token in seconds (default 600)."
+                  },
+                  "disable_vk_identity": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Require identity-provider login: virtual-key identity is removed from the consent flow, and existing virtual-key-mode grants are rejected at /mcp and denied on refresh. Only meaningful when mcp_server_auth_mode is 'oauth' and an identity provider is configured. Anonymous session identity is governed separately by enforce_auth_on_inference.\n"
                   }
                 },
                 "additionalProperties": false
@@ -71901,6 +72031,11 @@
                     "minimum": 1,
                     "default": 600,
                     "description": "Lifetime of the issued JWT Bearer token in seconds (default 600)."
+                  },
+                  "disable_vk_identity": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Require identity-provider login: virtual-key identity is removed from the consent flow, and existing virtual-key-mode grants are rejected at /mcp and denied on refresh. Only meaningful when mcp_server_auth_mode is 'oauth' and an identity provider is configured. Anonymous session identity is governed separately by enforce_auth_on_inference.\n"
                   }
                 },
                 "additionalProperties": false

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -76,9 +76,79 @@ clients:
   get:
     operationId: getMCPClients
     summary: List MCP clients
-    description: Returns a list of all configured MCP clients with their tools and connection state.
+    description: |
+      Returns a paginated list of configured MCP clients with their tools and connection state.
+      Supports case-insensitive name search and exact-match filtering by connection type, auth type,
+      code-mode, and enabled/disabled status. Multi-value filters accept a comma-separated list and
+      use OR semantics within a field.
     tags:
       - MCP
+    parameters:
+      - name: limit
+        in: query
+        description: Maximum number of clients to return (1–100, default 25).
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 25
+      - name: offset
+        in: query
+        description: Number of clients to skip.
+        schema:
+          type: integer
+          minimum: 0
+      - name: search
+        in: query
+        description: Case-insensitive search by client name.
+        schema:
+          type: string
+      - name: server
+        in: query
+        description: Filter to a single client by its exact client_id.
+        schema:
+          type: string
+      - name: connection_type
+        in: query
+        description: Comma-separated connection types to include (OR semantics).
+        schema:
+          type: string
+          example: http,sse
+      - name: auth_type
+        in: query
+        description: Comma-separated auth types to include (OR semantics).
+        schema:
+          type: string
+          example: oauth,per_user_oauth
+      - name: state
+        in: query
+        description: |
+          Comma-separated runtime connection states to include (OR semantics),
+          resolved against live engine state. `connected` matches clients the engine
+          currently reports as connected; `disconnected` matches everything else.
+        schema:
+          type: string
+          example: connected
+      - name: all_virtual_keys
+        in: query
+        description: When true, include clients that are open to all virtual keys (allow_on_all_virtual_keys). ORs with virtual_keys.
+        schema:
+          type: boolean
+      - name: virtual_keys
+        in: query
+        description: Comma-separated virtual key IDs; includes clients explicitly assigned to any of them. ORs with all_virtual_keys.
+        schema:
+          type: string
+      - name: code_mode
+        in: query
+        description: Filter by code-mode clients. Omit for no filter.
+        schema:
+          type: boolean
+      - name: disabled
+        in: query
+        description: Filter by disabled status — true returns disabled clients, false returns enabled clients. Omit for no filter.
+        schema:
+          type: boolean
     security:
       - ManagementBearerAuth: []
     responses:
@@ -87,9 +157,9 @@ clients:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '../../schemas/management/mcp.yaml#/MCPClient'
+              $ref: '../../schemas/management/mcp.yaml#/MCPClientsListResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -530,6 +530,34 @@ MCPClient:
         $ref: '#/MCPVKConfigResponse'
       description: Virtual key assignments for this MCP client
 
+MCPClientsListResponse:
+  type: object
+  description: Paginated list of MCP clients.
+  required:
+    - clients
+    - count
+    - total_count
+    - limit
+    - offset
+  properties:
+    clients:
+      type: array
+      items:
+        $ref: '#/MCPClient'
+    count:
+      type: integer
+      description: Number of clients returned in this page
+    total_count:
+      type: integer
+      format: int64
+      description: Total number of clients matching the query (before pagination)
+    limit:
+      type: integer
+      description: Page size used for the response
+    offset:
+      type: integer
+      description: Page offset used for the response
+
 ExecuteToolRequest:
   oneOf:
     - title: Chat (Default)


### PR DESCRIPTION
## Summary

The `GET /management/mcp/clients` endpoint has been upgraded from returning a flat array to a paginated response with filtering and search support. The `is_deprecated` field has also been removed from model schemas, and a new `disable_vk_identity` option has been added to the MCP server OAuth configuration.

## Changes

- **Paginated MCP clients list**: The `getMCPClients` endpoint now returns a `MCPClientsListResponse` object containing `clients`, `count`, `total_count`, `limit`, and `offset` fields instead of a bare array.
- **Query parameters for filtering**: Added `limit`, `offset`, `search`, `server`, `connection_type`, `auth_type`, `state`, `all_virtual_keys`, `virtual_keys`, `code_mode`, and `disabled` query parameters to the endpoint. Multi-value filters use comma-separated OR semantics.
- **`400` error response**: Added a `BadRequest` response to the `getMCPClients` endpoint for invalid query parameters.
- **Removed `is_deprecated` field**: Dropped the `is_deprecated` boolean from model schemas in both inline path definitions and the shared `MCPClient` component schema.
- **`disable_vk_identity` option**: Added a new boolean field to the MCP server OAuth configuration that forces identity-provider login by removing virtual-key identity from the consent flow and rejecting existing virtual-key-mode grants.
- **New `MCPClientsListResponse` schema**: Introduced a reusable schema definition for the paginated clients list response.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the updated OpenAPI spec is valid and that the `getMCPClients` endpoint reflects the new paginated contract:

```sh
# Validate the OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.json

# Confirm pagination fields are present in the response schema
curl -s -H "Authorization: Bearer <token>" \
  "https://<host>/management/mcp/clients?limit=10&offset=0&search=my-client" | \
  jq '{count: .count, total_count: .total_count, limit: .limit, offset: .offset}'

# Confirm filtering works
curl -s -H "Authorization: Bearer <token>" \
  "https://<host>/management/mcp/clients?connection_type=http,sse&disabled=false"
```

**New config field — `disable_vk_identity`:**
- Only meaningful when `mcp_server_auth_mode` is `oauth` and an identity provider is configured.
- When `true`, virtual-key identity is removed from the consent flow and existing virtual-key-mode grants are rejected at `/mcp` and denied on refresh.

## Breaking changes

- [x] Yes
- [ ] No

The `getMCPClients` response shape has changed from an array to a paginated object. Callers that previously iterated directly over the response array must now access `.clients` instead.

## Related issues

## Security considerations

The new `disable_vk_identity` flag enforces identity-provider login for MCP OAuth flows, preventing virtual-key credentials from being used as a substitute for user identity. This strengthens the authentication posture for deployments that require explicit IdP-backed user consent.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable