### PR TITLE
fix: billing on failed responses stream requests anthropic and bedrock

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -616,6 +616,81 @@ func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
 	usage.TotalTokens += cached
 }
 
+func accumulateAnthropicResponsesUsage(usage *schemas.ResponsesResponseUsage, billedUsage *schemas.BifrostLLMUsage, usageToProcess *AnthropicUsage) {
+	if usage == nil || usageToProcess == nil {
+		return
+	}
+	if usageToProcess.InputTokens > usage.InputTokens {
+		usage.InputTokens = usageToProcess.InputTokens
+		if billedUsage != nil {
+			billedUsage.PromptTokens = usageToProcess.InputTokens
+		}
+	}
+	if usageToProcess.OutputTokens > usage.OutputTokens {
+		usage.OutputTokens = usageToProcess.OutputTokens
+		if billedUsage != nil {
+			billedUsage.CompletionTokens = usageToProcess.OutputTokens
+		}
+	}
+	calculatedTotal := usage.InputTokens + usage.OutputTokens
+	if calculatedTotal > usage.TotalTokens {
+		usage.TotalTokens = calculatedTotal
+		if billedUsage != nil {
+			billedUsage.TotalTokens = calculatedTotal
+		}
+	}
+	// Handle cached tokens if present
+	if usageToProcess.CacheReadInputTokens > 0 {
+		if usage.InputTokensDetails == nil {
+			usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+		}
+		if billedUsage != nil && billedUsage.PromptTokensDetails == nil {
+			billedUsage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
+			usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+			if billedUsage != nil {
+				billedUsage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+			}
+		}
+	}
+	// Handle cached tokens if present
+	if usageToProcess.CacheCreationInputTokens > 0 {
+		if usage.InputTokensDetails == nil {
+			usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+		}
+		if billedUsage != nil && billedUsage.PromptTokensDetails == nil {
+			billedUsage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
+			usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+			if billedUsage != nil {
+				billedUsage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+			}
+		}
+		if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+			if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+				usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			if billedUsage != nil && billedUsage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+				billedUsage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+				usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+				if billedUsage != nil {
+					billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+				}
+			}
+			if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+				usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+				if billedUsage != nil {
+					billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+				}
+			}
+		}
+	}
+}
+
 // HandleAnthropicChatCompletionStreaming handles streaming for Anthropic-compatible APIs.
 // This shared function reduces code duplication between providers that use the same SSE event format.
 func HandleAnthropicChatCompletionStreaming(
@@ -1347,6 +1422,25 @@ func HandleAnthropicResponsesStream(
 
 		// Track minimal state needed for response format
 		usage := &schemas.ResponsesResponseUsage{}
+		billedUsage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream cancel/timeout
+		// can bill for Anthropic Responses usage already reported by message_start
+		// or message_delta events before the stream was interrupted.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, billedUsage)
+
+		usageNormalized := false
+		normalizeBilledUsage := func() {
+			if usageNormalized {
+				return
+			}
+			usageNormalized = true
+			normalizeCachedUsage(billedUsage)
+		}
+		defer func() {
+			if ctx.Err() != nil {
+				normalizeBilledUsage()
+			}
+		}()
 
 		// Create stream state for stateful conversions
 		streamState := AcquireAnthropicResponsesStreamState()
@@ -1402,49 +1496,10 @@ func HandleAnthropicResponsesStream(
 			}
 
 			if usageToProcess != nil {
-				// Collect usage information and send at the end of the stream
-				// Here in some cases usage comes before final message
-				// So we need to check if the response.Usage is nil and then if usage != nil
-				// then add up all tokens
-				if usageToProcess.InputTokens > usage.InputTokens {
-					usage.InputTokens = usageToProcess.InputTokens
-				}
-				if usageToProcess.OutputTokens > usage.OutputTokens {
-					usage.OutputTokens = usageToProcess.OutputTokens
-				}
-				calculatedTotal := usage.InputTokens + usage.OutputTokens
-				if calculatedTotal > usage.TotalTokens {
-					usage.TotalTokens = calculatedTotal
-				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheReadInputTokens > 0 {
-					if usage.InputTokensDetails == nil {
-						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-					}
-					if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
-						usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
-					}
-				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheCreationInputTokens > 0 {
-					if usage.InputTokensDetails == nil {
-						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-					}
-					if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
-						usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-					}
-					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-						if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
-							usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-						}
-						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-						}
-						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
-						}
-					}
-				}
+				// Collect usage information and send at the end of the stream.
+				// Also mirror it into billedUsage so cancellation/timeout paths can
+				// charge for provider-reported usage before the final chunk arrives.
+				accumulateAnthropicResponsesUsage(usage, billedUsage, usageToProcess)
 			}
 
 			responses, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(ctx, chunkIndex, streamState)

--- a/core/providers/anthropic/cancelbilling_test.go
+++ b/core/providers/anthropic/cancelbilling_test.go
@@ -43,3 +43,61 @@ func TestNormalizeCachedUsage_NoCacheDetailsIsNoOp(t *testing.T) {
 func TestNormalizeCachedUsage_NilSafe(t *testing.T) {
 	normalizeCachedUsage(nil) // must not panic
 }
+
+func TestAccumulateAnthropicResponsesUsage_MirrorsCacheIntoBilledUsage(t *testing.T) {
+	responseUsage := &schemas.ResponsesResponseUsage{}
+	billedUsage := &schemas.BifrostLLMUsage{}
+	upstreamUsage := &AnthropicUsage{
+		InputTokens:              2,
+		CacheReadInputTokens:     1300,
+		CacheCreationInputTokens: 78456,
+		CacheCreation: AnthropicUsageCacheCreation{
+			Ephemeral1hInputTokens: 78456,
+		},
+		OutputTokens: 3,
+	}
+
+	accumulateAnthropicResponsesUsage(responseUsage, billedUsage, upstreamUsage)
+
+	if responseUsage.InputTokens != 2 || responseUsage.OutputTokens != 3 || responseUsage.TotalTokens != 5 {
+		t.Fatalf("unexpected response usage before final normalization: %+v", responseUsage)
+	}
+	if responseUsage.InputTokensDetails == nil {
+		t.Fatal("expected response cache details")
+	}
+	if responseUsage.InputTokensDetails.CachedReadTokens != 1300 {
+		t.Fatalf("response cached read = %d, want 1300", responseUsage.InputTokensDetails.CachedReadTokens)
+	}
+	if responseUsage.InputTokensDetails.CachedWriteTokens != 78456 {
+		t.Fatalf("response cached write = %d, want 78456", responseUsage.InputTokensDetails.CachedWriteTokens)
+	}
+	if responseUsage.InputTokensDetails.CachedWriteTokenDetails == nil ||
+		responseUsage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h != 78456 {
+		t.Fatalf("response cached write details = %+v, want 1h=78456", responseUsage.InputTokensDetails.CachedWriteTokenDetails)
+	}
+
+	if billedUsage.PromptTokens != 2 || billedUsage.CompletionTokens != 3 || billedUsage.TotalTokens != 5 {
+		t.Fatalf("unexpected billed usage before normalization: %+v", billedUsage)
+	}
+	if billedUsage.PromptTokensDetails == nil {
+		t.Fatal("expected billed cache details")
+	}
+	if billedUsage.PromptTokensDetails.CachedReadTokens != 1300 {
+		t.Fatalf("billed cached read = %d, want 1300", billedUsage.PromptTokensDetails.CachedReadTokens)
+	}
+	if billedUsage.PromptTokensDetails.CachedWriteTokens != 78456 {
+		t.Fatalf("billed cached write = %d, want 78456", billedUsage.PromptTokensDetails.CachedWriteTokens)
+	}
+	if billedUsage.PromptTokensDetails.CachedWriteTokenDetails == nil ||
+		billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h != 78456 {
+		t.Fatalf("billed cached write details = %+v, want 1h=78456", billedUsage.PromptTokensDetails.CachedWriteTokenDetails)
+	}
+
+	normalizeCachedUsage(billedUsage)
+	if billedUsage.PromptTokens != 79758 {
+		t.Fatalf("normalized billed prompt = %d, want 79758", billedUsage.PromptTokens)
+	}
+	if billedUsage.TotalTokens != 79761 {
+		t.Fatalf("normalized billed total = %d, want 79761", billedUsage.TotalTokens)
+	}
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1246,6 +1246,80 @@ func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
 	usage.PromptTokens += usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
 }
 
+func accumulateBedrockResponsesUsage(usage *schemas.ResponsesResponseUsage, billedUsage *schemas.BifrostLLMUsage, usageToProcess *BedrockTokenUsage) {
+	if usage == nil || usageToProcess == nil {
+		return
+	}
+	if usageToProcess.InputTokens > usage.InputTokens {
+		usage.InputTokens = usageToProcess.InputTokens
+		if billedUsage != nil {
+			billedUsage.PromptTokens = usageToProcess.InputTokens
+		}
+	}
+	if usageToProcess.OutputTokens > usage.OutputTokens {
+		usage.OutputTokens = usageToProcess.OutputTokens
+		if billedUsage != nil {
+			billedUsage.CompletionTokens = usageToProcess.OutputTokens
+		}
+	}
+	if usageToProcess.TotalTokens > usage.TotalTokens {
+		usage.TotalTokens = usageToProcess.TotalTokens
+		if billedUsage != nil {
+			billedUsage.TotalTokens = usageToProcess.TotalTokens
+		}
+	}
+	if usageToProcess.CacheReadInputTokens > 0 {
+		if usage.InputTokensDetails == nil {
+			usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+		}
+		if billedUsage != nil && billedUsage.PromptTokensDetails == nil {
+			billedUsage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
+			usage.InputTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+			if billedUsage != nil {
+				billedUsage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+			}
+		}
+	}
+	if usageToProcess.CacheWriteInputTokens > 0 {
+		if usage.InputTokensDetails == nil {
+			usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+		}
+		if billedUsage != nil && billedUsage.PromptTokensDetails == nil {
+			billedUsage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheWriteInputTokens > usage.InputTokensDetails.CachedWriteTokens {
+			usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheWriteInputTokens
+			if billedUsage != nil {
+				billedUsage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheWriteInputTokens
+			}
+		}
+		if usageToProcess.CacheDetails != nil {
+			if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+				usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			if billedUsage != nil && billedUsage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+				billedUsage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			for _, cacheDetail := range *usageToProcess.CacheDetails {
+				if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+					usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+					if billedUsage != nil {
+						billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+					}
+				}
+				if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+					usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+					if billedUsage != nil {
+						billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+					}
+				}
+			}
+		}
+	}
+}
+
 // ChatCompletionStream performs a streaming chat completion request to Bedrock's API.
 // OpenAI-family and Gemma 4 models route via the Bedrock Mantle OpenAI-compatible endpoint.
 // All other models (including Anthropic/Claude) use the Bedrock Converse streaming API.
@@ -1693,6 +1767,26 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 
 		// Process AWS Event Stream format
 		usage := &schemas.ResponsesResponseUsage{}
+		billedUsage := &schemas.BifrostLLMUsage{}
+		// Register the accumulating usage handle so a mid-stream cancel/timeout
+		// can bill for Bedrock Responses usage already reported by stream events
+		// before the stream was interrupted.
+		ctx.SetValue(schemas.BifrostContextKeyStreamAccumulatedUsage, billedUsage)
+
+		usageNormalized := false
+		normalizeUsage := func() {
+			if usageNormalized {
+				return
+			}
+			usageNormalized = true
+			normalizeCachedUsage(billedUsage)
+		}
+		defer func() {
+			if ctx.Err() != nil {
+				normalizeUsage()
+			}
+		}()
+
 		var streamTrace *BedrockConverseTrace
 		chunkIndex := 0
 
@@ -1803,45 +1897,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 				if streamEvent.Usage != nil {
 					// Accumulate usage information instead of overwriting
 					// In some cases usage comes in multiple events, so we need to take the maximum values
-					if streamEvent.Usage.InputTokens > usage.InputTokens {
-						usage.InputTokens = streamEvent.Usage.InputTokens
-					}
-					if streamEvent.Usage.OutputTokens > usage.OutputTokens {
-						usage.OutputTokens = streamEvent.Usage.OutputTokens
-					}
-					if streamEvent.Usage.TotalTokens > usage.TotalTokens {
-						usage.TotalTokens = streamEvent.Usage.TotalTokens
-					}
-					// Handle cached tokens if present
-					if streamEvent.Usage.CacheReadInputTokens > 0 {
-						if usage.InputTokensDetails == nil {
-							usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-						}
-						if streamEvent.Usage.CacheReadInputTokens > usage.InputTokensDetails.CachedReadTokens {
-							usage.InputTokensDetails.CachedReadTokens = streamEvent.Usage.CacheReadInputTokens
-						}
-					}
-					if streamEvent.Usage.CacheWriteInputTokens > 0 {
-						if usage.InputTokensDetails == nil {
-							usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
-						}
-						if streamEvent.Usage.CacheWriteInputTokens > usage.InputTokensDetails.CachedWriteTokens {
-							usage.InputTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
-						}
-						if streamEvent.Usage.CacheDetails != nil {
-							if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
-								usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-							}
-							for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
-								if cacheDetail.TTL == BedrockCacheWriteTTL5m {
-									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
-								}
-								if cacheDetail.TTL == BedrockCacheWriteTTL1h {
-									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
-								}
-							}
-						}
-					}
+					accumulateBedrockResponsesUsage(usage, billedUsage, streamEvent.Usage)
 				}
 
 				// Handle structured output: intercept tool calls for the structured output tool

--- a/core/providers/bedrock/cancelbilling_test.go
+++ b/core/providers/bedrock/cancelbilling_test.go
@@ -39,3 +39,63 @@ func TestNormalizeCachedUsage_NoCacheDetailsIsNoOp(t *testing.T) {
 func TestNormalizeCachedUsage_NilSafe(t *testing.T) {
 	normalizeCachedUsage(nil) // must not panic
 }
+
+func TestAccumulateBedrockResponsesUsage_MirrorsCacheIntoBilledUsage(t *testing.T) {
+	responseUsage := &schemas.ResponsesResponseUsage{}
+	billedUsage := &schemas.BifrostLLMUsage{}
+	cacheDetails := []BedrockCacheWriteDetails{
+		{TTL: BedrockCacheWriteTTL1h, InputTokens: 700},
+	}
+	upstreamUsage := &BedrockTokenUsage{
+		InputTokens:           10,
+		OutputTokens:          5,
+		TotalTokens:           1515,
+		CacheReadInputTokens:  800,
+		CacheWriteInputTokens: 700,
+		CacheDetails:          &cacheDetails,
+	}
+
+	accumulateBedrockResponsesUsage(responseUsage, billedUsage, upstreamUsage)
+
+	if responseUsage.InputTokens != 10 || responseUsage.OutputTokens != 5 || responseUsage.TotalTokens != 1515 {
+		t.Fatalf("unexpected response usage: %+v", responseUsage)
+	}
+	if responseUsage.InputTokensDetails == nil {
+		t.Fatal("expected response cache details")
+	}
+	if responseUsage.InputTokensDetails.CachedReadTokens != 800 {
+		t.Fatalf("response cached read = %d, want 800", responseUsage.InputTokensDetails.CachedReadTokens)
+	}
+	if responseUsage.InputTokensDetails.CachedWriteTokens != 700 {
+		t.Fatalf("response cached write = %d, want 700", responseUsage.InputTokensDetails.CachedWriteTokens)
+	}
+	if responseUsage.InputTokensDetails.CachedWriteTokenDetails == nil ||
+		responseUsage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h != 700 {
+		t.Fatalf("response cached write details = %+v, want 1h=700", responseUsage.InputTokensDetails.CachedWriteTokenDetails)
+	}
+
+	if billedUsage.PromptTokens != 10 || billedUsage.CompletionTokens != 5 || billedUsage.TotalTokens != 1515 {
+		t.Fatalf("unexpected billed usage before normalization: %+v", billedUsage)
+	}
+	if billedUsage.PromptTokensDetails == nil {
+		t.Fatal("expected billed cache details")
+	}
+	if billedUsage.PromptTokensDetails.CachedReadTokens != 800 {
+		t.Fatalf("billed cached read = %d, want 800", billedUsage.PromptTokensDetails.CachedReadTokens)
+	}
+	if billedUsage.PromptTokensDetails.CachedWriteTokens != 700 {
+		t.Fatalf("billed cached write = %d, want 700", billedUsage.PromptTokensDetails.CachedWriteTokens)
+	}
+	if billedUsage.PromptTokensDetails.CachedWriteTokenDetails == nil ||
+		billedUsage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h != 700 {
+		t.Fatalf("billed cached write details = %+v, want 1h=700", billedUsage.PromptTokensDetails.CachedWriteTokenDetails)
+	}
+
+	normalizeCachedUsage(billedUsage)
+	if billedUsage.PromptTokens != 1510 {
+		t.Fatalf("normalized billed prompt = %d, want 1510", billedUsage.PromptTokens)
+	}
+	if billedUsage.TotalTokens != 1515 {
+		t.Fatalf("normalized billed total = %d, want 1515", billedUsage.TotalTokens)
+	}
+}


### PR DESCRIPTION
## Summary

When a streaming Responses API request is cancelled or times out mid-stream, usage tokens reported by intermediate events (e.g. `message_start`, `message_delta` for Anthropic, or early Bedrock Converse events) were being discarded. This meant callers could not be billed for provider-reported usage that arrived before the stream was interrupted. This PR fixes that by maintaining a mirrored `BifrostLLMUsage` struct that is updated in lockstep with the in-flight `ResponsesResponseUsage` and registered on the context so cancellation/timeout paths can retrieve and apply it.

## Changes

- Extracted `accumulateAnthropicResponsesUsage` and `accumulateBedrockResponsesUsage` helper functions that simultaneously update both the streaming `ResponsesResponseUsage` and a parallel `BifrostLLMUsage` (including all cache token detail fields: read, write, 5m, and 1h TTL buckets).
- In both `HandleAnthropicResponsesStream` and `BedrockProvider.ResponsesStream`, a `billedUsage` pointer is now registered on the context via `BifrostContextKeyStreamAccumulatedUsage` at stream start, so any mid-stream interruption can access already-accumulated usage.
- A deferred closure normalises cached token counts into `billedUsage` (via `normalizeCachedUsage`) when the context is cancelled, ensuring prompt token totals are correct even for partial streams.
- The inline usage-accumulation blocks in both streaming handlers are replaced with calls to the new helper functions, removing the duplication.
- Tests are added for both `accumulateAnthropicResponsesUsage` and `accumulateBedrockResponsesUsage`, verifying that all token fields (including cache read/write details and TTL buckets) are mirrored correctly and that post-normalization totals are accurate.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/bedrock/...
```

Specifically, the new test cases `TestAccumulateAnthropicResponsesUsage_MirrorsCacheIntoBilledUsage` and `TestAccumulateBedrockResponsesUsage_MirrorsCacheIntoBilledUsage` validate that:
1. All token fields (input, output, total, cached read, cached write, 5m/1h TTL buckets) are mirrored from upstream usage into `BifrostLLMUsage`.
2. After `normalizeCachedUsage` is applied, prompt token totals correctly include cached token contributions.

To validate the cancellation path end-to-end, initiate a Responses streaming request and cancel the context mid-stream; the usage reported on the context key `BifrostContextKeyStreamAccumulatedUsage` should reflect tokens seen up to the point of cancellation.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing implications. Usage data is internal billing metadata only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable