### PR TITLE
feat: add audit logs public API docs

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -180,6 +180,10 @@
     {
       "name": "Skills",
       "description": "Skills Repository management, marketplace, and download endpoints"
+    },
+    {
+      "name": "Audit Logs",
+      "description": "CADF-compliant audit log search, export, and signature verification endpoints"
     }
   ],
   "paths": {
@@ -48242,6 +48246,630 @@
         }
       }
     },
+    "/api/audit-logs": {
+      "get": {
+        "operationId": "getAuditLogs",
+        "summary": "List audit logs",
+        "description": "Retrieves CADF-compliant audit log events with filtering, search, and\npagination via query parameters. Most filter dimensions accept either a\nsingle value (singular parameter, e.g. `action`) or a JSON-encoded array\nof values (plural parameter, e.g. `actions`); when both are supplied the\nplural array takes precedence.\n",
+        "tags": [
+          "Audit Logs"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for offset-based pagination (default 1).",
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of events to return per page (default 100, max 1000).",
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 1000
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for cursor-based pagination (from `next_cursor`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across audit event fields.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "description": "Filter by a single CADF action.",
+            "schema": {
+              "$ref": "#/components/schemas/AuditAction"
+            }
+          },
+          {
+            "name": "actions",
+            "in": "query",
+            "description": "JSON array of CADF actions to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "[\"create\",\"update\"]"
+          },
+          {
+            "name": "outcome",
+            "in": "query",
+            "description": "Filter by a single outcome.",
+            "schema": {
+              "$ref": "#/components/schemas/AuditOutcome"
+            }
+          },
+          {
+            "name": "outcomes",
+            "in": "query",
+            "description": "JSON array of outcomes to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "[\"success\",\"failure\"]"
+          },
+          {
+            "name": "event_type",
+            "in": "query",
+            "description": "Filter by a single event type.",
+            "schema": {
+              "$ref": "#/components/schemas/AuditEventType"
+            }
+          },
+          {
+            "name": "event_types",
+            "in": "query",
+            "description": "JSON array of event types to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "[\"activity\",\"control\"]"
+          },
+          {
+            "name": "initiator_id",
+            "in": "query",
+            "description": "Filter by a single initiator ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "initiator_ids",
+            "in": "query",
+            "description": "JSON array of initiator IDs to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "initiator_type",
+            "in": "query",
+            "description": "Filter by a single initiator resource type.",
+            "schema": {
+              "$ref": "#/components/schemas/AuditResourceType"
+            }
+          },
+          {
+            "name": "initiator_types",
+            "in": "query",
+            "description": "JSON array of initiator resource types to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target_id",
+            "in": "query",
+            "description": "Filter by a single target ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target_ids",
+            "in": "query",
+            "description": "JSON array of target IDs to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "target_type",
+            "in": "query",
+            "description": "Filter by a single target resource type.",
+            "schema": {
+              "$ref": "#/components/schemas/AuditResourceType"
+            }
+          },
+          {
+            "name": "target_types",
+            "in": "query",
+            "description": "JSON array of target resource types to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Filter events at or after this time (RFC3339 or `YYYY-MM-DD`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "Filter events at or before this time (RFC3339 or `YYYY-MM-DD`; a date is treated as end-of-day).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "description": "Relative time window that overrides `start_date`/`end_date` when set (e.g. `24h`, `7d`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_method",
+            "in": "query",
+            "description": "Filter by a single HTTP request method.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_methods",
+            "in": "query",
+            "description": "JSON array of HTTP request methods to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_path",
+            "in": "query",
+            "description": "Filter by a single request path prefix.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_paths",
+            "in": "query",
+            "description": "JSON array of request path prefixes to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_ip",
+            "in": "query",
+            "description": "Filter by a single client IP address.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_ips",
+            "in": "query",
+            "description": "JSON array of client IP addresses to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "JSON array of tags to filter by (any match).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "[\"security\",\"auth\"]"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Field to sort by (default `event_time`).",
+            "schema": {
+              "type": "string",
+              "default": "event_time"
+            }
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "description": "Sort direction.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogsResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/audit-logs/filterdata": {
+      "get": {
+        "operationId": "getAuditLogsFilterData",
+        "summary": "Get audit log filter data",
+        "description": "Returns the distinct values available for each audit log filter dimension,\nused to populate filter dropdowns in the dashboard.\n",
+        "tags": [
+          "Audit Logs"
+        ],
+        "parameters": [
+          {
+            "name": "dimensions",
+            "in": "query",
+            "description": "Comma-separated list of dimensions to return. When omitted, all\ndimensions are returned. Unknown dimensions are ignored.\n",
+            "schema": {
+              "type": "string",
+              "example": "actions,outcomes,initiators"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Optional case-insensitive substring filter applied to dimension values.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditFilterDataResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/audit-logs/export": {
+      "get": {
+        "operationId": "exportAuditLogs",
+        "summary": "Export audit logs",
+        "description": "Streams audit log events matching the supplied filters as a downloadable\nfile. Accepts the same filter query parameters as `GET /api/audit-logs`.\nThe response is returned as an attachment with a generated filename.\n",
+        "tags": [
+          "Audit Logs"
+        ],
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Export format. Defaults to `json` when omitted or unrecognized.\n- `json`: a JSON array of events\n- `jsonl`: JSON Lines, one event per line\n- `syslog`: RFC 5424 syslog format\n",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "jsonl",
+                "syslog"
+              ],
+              "default": "json"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across audit event fields.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "actions",
+            "in": "query",
+            "description": "JSON array of CADF actions to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "outcomes",
+            "in": "query",
+            "description": "JSON array of outcomes to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "event_types",
+            "in": "query",
+            "description": "JSON array of event types to filter by (OR match).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Filter events at or after this time (RFC3339 or `YYYY-MM-DD`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "Filter events at or before this time (RFC3339 or `YYYY-MM-DD`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "description": "Relative time window that overrides `start_date`/`end_date` when set (e.g. `24h`, `7d`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A streamed export of the matching audit logs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/x-ndjson": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/audit-logs/{id}": {
+      "get": {
+        "operationId": "getAuditLogById",
+        "summary": "Get audit log by ID",
+        "description": "Retrieves a single audit log event by its unique ID.",
+        "tags": [
+          "Audit Logs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the audit log event.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditLogResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/audit-logs/{id}/verify": {
+      "get": {
+        "operationId": "verifyAuditLogSignature",
+        "summary": "Verify audit log signature",
+        "description": "Recomputes the HMAC-SHA256 signature for a single audit log event and\ncompares it (in constant time) against the stored signature to detect\ntampering.\n",
+        "tags": [
+          "Audit Logs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the audit log event to verify.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditVerifyResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp/tool-groups": {
       "get": {
         "operationId": "listMCPToolGroups",
@@ -71516,7 +72144,70 @@
                     "additionalProperties": false
                   }
                 ],
+<<<<<<< HEAD
                 "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy. Overrides the host derived from the incoming request. Supports env var syntax (\"env.MY_VAR\"). Configurable via UI, API, or config.json.\n"
+=======
+                "description": "Public base URL Bifrost uses as the redirect_uri when acting as an OAuth client to upstream MCP servers (Notion, Jira, etc.). Set when Bifrost's callback endpoint is reached via a different URL than its server-side metadata. Supports env var syntax (\"env.MY_VAR\").\n"
+              },
+              "mcp_server_auth_mode": {
+                "type": "string",
+                "enum": [
+                  "headers",
+                  "both",
+                  "oauth"
+                ],
+                "default": "headers",
+                "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
+              },
+              "oauth2_server_config": {
+                "type": "object",
+                "description": "OAuth2 authorization server settings for /mcp. Only relevant when mcp_server_auth_mode is 'both' or 'oauth'.\n",
+                "properties": {
+                  "issuer_url": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "description": "Plain URL or env var reference (e.g. \"env.MY_VAR\")"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          },
+                          "env_var": {
+                            "type": "string"
+                          },
+                          "from_env": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Stable public URL advertised as the OAuth2 AS issuer in discovery documents and the JWT iss claim. Required for multi-host deployments; single-host can omit it (falls back to the request Host header). Supports env var syntax (\"env.MY_VAR\").\n"
+                  },
+                  "auth_code_ttl": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 900,
+                    "default": 300,
+                    "description": "Lifetime of the single-use authorization code in seconds (default 300, max 900 = 15 minutes)."
+                  },
+                  "access_token_ttl": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 600,
+                    "description": "Lifetime of the issued JWT Bearer token in seconds (default 600)."
+                  },
+                  "disable_vk_identity": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Require identity-provider login: virtual-key identity is removed from the consent flow, and existing virtual-key-mode grants are rejected at /mcp and denied on refresh. Only meaningful when mcp_server_auth_mode is 'oauth' and an identity provider is configured. Anonymous session identity is governed separately by enforce_auth_on_inference.\n"
+                  }
+                },
+                "additionalProperties": false
+>>>>>>> 871a3f5a2 (feat: audit logs public API docs)
               }
             }
           },
@@ -71784,6 +72475,65 @@
                   }
                 ],
                 "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy. Overrides the host derived from the incoming request. Supports env var syntax (\"env.MY_VAR\"). Configurable via UI, API, or config.json.\n"
+              },
+              "mcp_server_auth_mode": {
+                "type": "string",
+                "enum": [
+                  "headers",
+                  "both",
+                  "oauth"
+                ],
+                "default": "headers",
+                "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
+              },
+              "oauth2_server_config": {
+                "type": "object",
+                "description": "OAuth2 authorization server settings for /mcp. Only relevant when mcp_server_auth_mode is 'both' or 'oauth'.\n",
+                "properties": {
+                  "issuer_url": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "description": "Plain URL or env var reference (e.g. \"env.MY_VAR\")"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          },
+                          "env_var": {
+                            "type": "string"
+                          },
+                          "from_env": {
+                            "type": "boolean"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "Stable public URL advertised as the OAuth2 AS issuer in discovery documents and the JWT iss claim. Required for multi-host deployments; single-host can omit it (falls back to the request Host header). Supports env var syntax (\"env.MY_VAR\").\n"
+                  },
+                  "auth_code_ttl": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 900,
+                    "default": 300,
+                    "description": "Lifetime of the single-use authorization code in seconds (default 300, max 900 = 15 minutes)."
+                  },
+                  "access_token_ttl": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 600,
+                    "description": "Lifetime of the issued JWT Bearer token in seconds (default 600)."
+                  },
+                  "disable_vk_identity": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Require identity-provider login: virtual-key identity is removed from the consent flow, and existing virtual-key-mode grants are rejected at /mcp and denied on refresh. Only meaningful when mcp_server_auth_mode is 'oauth' and an identity provider is configured. Anonymous session identity is governed separately by enforce_auth_on_inference.\n"
+                  }
+                },
+                "additionalProperties": false
               }
             }
           },
@@ -78015,6 +78765,399 @@
             "example": "Cache cleared successfully"
           }
         }
+      },
+      "AuditEventType": {
+        "type": "string",
+        "description": "Classifies the audit event.",
+        "enum": [
+          "activity",
+          "monitor",
+          "control"
+        ]
+      },
+      "AuditAction": {
+        "type": "string",
+        "description": "The CADF action performed.",
+        "enum": [
+          "create",
+          "read",
+          "update",
+          "delete",
+          "authenticate",
+          "authorize",
+          "access",
+          "enable",
+          "disable",
+          "start",
+          "stop",
+          "backup",
+          "restore",
+          "export",
+          "import"
+        ]
+      },
+      "AuditOutcome": {
+        "type": "string",
+        "description": "The CADF outcome of the action.",
+        "enum": [
+          "success",
+          "failure",
+          "pending"
+        ]
+      },
+      "AuditResourceType": {
+        "type": "string",
+        "description": "The type of resource involved in an audit event (initiator or target).",
+        "enum": [
+          "user",
+          "api_key",
+          "system",
+          "provider",
+          "virtual_key",
+          "team",
+          "customer",
+          "role",
+          "permission",
+          "guardrail",
+          "mcp_client",
+          "mcp_tool_group",
+          "plugin",
+          "config",
+          "session",
+          "inference"
+        ]
+      },
+      "AuditResource": {
+        "type": "object",
+        "description": "A CADF resource (initiator, target, or observer).",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the resource."
+          },
+          "typeURI": {
+            "type": "string",
+            "description": "Resource type URI (e.g., \"bifrost/user\", \"bifrost/api_key\")."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the resource."
+          },
+          "host": {
+            "type": "string",
+            "description": "Hostname or IP address associated with the resource."
+          }
+        },
+        "required": [
+          "id",
+          "typeURI"
+        ]
+      },
+      "AuditReason": {
+        "type": "object",
+        "description": "The CADF reason for an outcome (especially for failures).",
+        "properties": {
+          "reasonCode": {
+            "type": "string",
+            "description": "Machine-readable code (e.g., \"401\", \"FORBIDDEN\")."
+          },
+          "reasonType": {
+            "type": "string",
+            "description": "Category of reason (e.g., \"HTTP\", \"policy\")."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable description."
+          }
+        }
+      },
+      "AuditAttachment": {
+        "type": "object",
+        "description": "Additional CADF data attached to an event.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Identifies the attachment."
+          },
+          "contentType": {
+            "type": "string",
+            "description": "MIME type of the content."
+          },
+          "content": {
+            "type": "string",
+            "description": "Attachment data (typically a JSON string)."
+          }
+        },
+        "required": [
+          "name",
+          "contentType",
+          "content"
+        ]
+      },
+      "AuditEvent": {
+        "type": "object",
+        "description": "A CADF-compliant audit event.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for this event (UUID)."
+          },
+          "typeURI": {
+            "type": "string",
+            "description": "Event type URI (e.g., \"http://schemas.bifrost.io/audit/api/v1\")."
+          },
+          "eventType": {
+            "$ref": "#/components/schemas/AuditEventType"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the event occurred (RFC 3339)."
+          },
+          "action": {
+            "$ref": "#/components/schemas/AuditAction"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/AuditOutcome"
+          },
+          "initiator": {
+            "$ref": "#/components/schemas/AuditResource"
+          },
+          "target": {
+            "$ref": "#/components/schemas/AuditResource"
+          },
+          "observer": {
+            "$ref": "#/components/schemas/AuditResource"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/AuditReason"
+          },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditAttachment"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "description": "Searchable labels for categorization.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "requestMethod": {
+            "type": "string",
+            "description": "HTTP method (GET, POST, etc.)."
+          },
+          "requestPath": {
+            "type": "string",
+            "description": "HTTP request path."
+          },
+          "requestIP": {
+            "type": "string",
+            "description": "Client IP address."
+          },
+          "userAgent": {
+            "type": "string",
+            "description": "HTTP User-Agent header."
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Request duration in milliseconds."
+          },
+          "signature": {
+            "type": "string",
+            "description": "HMAC-SHA256 signature for tamper detection."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the record was created in the database."
+          }
+        },
+        "required": [
+          "id",
+          "typeURI",
+          "eventType",
+          "eventTime",
+          "action",
+          "outcome",
+          "initiator",
+          "target",
+          "observer",
+          "signature",
+          "createdAt"
+        ]
+      },
+      "AuditLogsResult": {
+        "type": "object",
+        "description": "A paginated result of audit logs.",
+        "properties": {
+          "audit_logs": {
+            "type": "array",
+            "description": "The list of audit events.",
+            "items": {
+              "$ref": "#/components/schemas/AuditEvent"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Total count of events matching the filter."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Page size."
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "Whether there are more results."
+          },
+          "next_cursor": {
+            "type": "string",
+            "description": "Opaque cursor for the next page (cursor-based pagination)."
+          }
+        },
+        "required": [
+          "audit_logs",
+          "total",
+          "page",
+          "limit",
+          "total_pages",
+          "has_more"
+        ]
+      },
+      "AuditLogResponse": {
+        "type": "object",
+        "description": "Response wrapper for a single audit log entry.",
+        "properties": {
+          "audit_log": {
+            "$ref": "#/components/schemas/AuditEvent"
+          }
+        },
+        "required": [
+          "audit_log"
+        ]
+      },
+      "AuditFilterKeyPair": {
+        "type": "object",
+        "description": "An id/name pair used for initiator and target filter dropdowns.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "AuditFilterDataResponse": {
+        "type": "object",
+        "description": "Distinct values available for each audit log filter dimension.",
+        "properties": {
+          "actions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "outcomes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "event_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "initiator_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "target_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "request_methods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "initiators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditFilterKeyPair"
+            }
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AuditFilterKeyPair"
+            }
+          },
+          "request_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "request_ips": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AuditVerifyResult": {
+        "type": "object",
+        "description": "The result of an audit log signature verification.",
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "description": "Whether the stored signature matches the recomputed signature."
+          },
+          "computed": {
+            "type": "string",
+            "description": "The signature recomputed from the stored event fields."
+          },
+          "stored": {
+            "type": "string",
+            "description": "The signature persisted with the event."
+          }
+        },
+        "required": [
+          "valid",
+          "computed",
+          "stored"
+        ]
       }
     }
   }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -144,6 +144,8 @@ tags:
     description: Vault secret management endpoints
   - name: Skills
     description: Skills Repository management, marketplace, and download endpoints
+  - name: Audit Logs
+    description: CADF-compliant audit log search, export, and signature verification endpoints
 
 paths:
   # ==================== Unified Inference API ====================
@@ -916,6 +918,18 @@ paths:
   /api/users/{target_user_id}/access-profiles/virtual-keys/{vk_id}:
     $ref: './paths/management/accessprofiles.yaml#/users-access-profile-virtual-key-by-id'
 
+  # Audit Logs
+  /api/audit-logs:
+    $ref: './paths/management/auditlogs.yaml#/audit-logs'
+  /api/audit-logs/filterdata:
+    $ref: './paths/management/auditlogs.yaml#/audit-logs-filterdata'
+  /api/audit-logs/export:
+    $ref: './paths/management/auditlogs.yaml#/audit-logs-export'
+  /api/audit-logs/{id}:
+    $ref: './paths/management/auditlogs.yaml#/audit-logs-by-id'
+  /api/audit-logs/{id}/verify:
+    $ref: './paths/management/auditlogs.yaml#/audit-logs-verify'
+
   # MCP Tool Groups
   /api/mcp/tool-groups:
     $ref: './paths/management/mcptoolgroups.yaml#/mcp-tool-groups'
@@ -1630,3 +1644,31 @@ components:
     # Cache
     ClearCacheResponse:
       $ref: './schemas/management/cache.yaml#/ClearCacheResponse'
+
+    # Audit Logs
+    AuditEventType:
+      $ref: './schemas/management/auditlogs.yaml#/AuditEventType'
+    AuditAction:
+      $ref: './schemas/management/auditlogs.yaml#/AuditAction'
+    AuditOutcome:
+      $ref: './schemas/management/auditlogs.yaml#/AuditOutcome'
+    AuditResourceType:
+      $ref: './schemas/management/auditlogs.yaml#/AuditResourceType'
+    AuditResource:
+      $ref: './schemas/management/auditlogs.yaml#/AuditResource'
+    AuditReason:
+      $ref: './schemas/management/auditlogs.yaml#/AuditReason'
+    AuditAttachment:
+      $ref: './schemas/management/auditlogs.yaml#/AuditAttachment'
+    AuditEvent:
+      $ref: './schemas/management/auditlogs.yaml#/AuditEvent'
+    AuditLogsResult:
+      $ref: './schemas/management/auditlogs.yaml#/AuditLogsResult'
+    AuditLogResponse:
+      $ref: './schemas/management/auditlogs.yaml#/AuditLogResponse'
+    AuditFilterKeyPair:
+      $ref: './schemas/management/auditlogs.yaml#/AuditFilterKeyPair'
+    AuditFilterDataResponse:
+      $ref: './schemas/management/auditlogs.yaml#/AuditFilterDataResponse'
+    AuditVerifyResult:
+      $ref: './schemas/management/auditlogs.yaml#/AuditVerifyResult'

--- a/docs/openapi/paths/management/auditlogs.yaml
+++ b/docs/openapi/paths/management/auditlogs.yaml
@@ -1,0 +1,365 @@
+audit-logs:
+  get:
+    operationId: getAuditLogs
+    summary: List audit logs
+    description: |
+      Retrieves CADF-compliant audit log events with filtering, search, and
+      pagination via query parameters. Most filter dimensions accept either a
+      single value (singular parameter, e.g. `action`) or a JSON-encoded array
+      of values (plural parameter, e.g. `actions`); when both are supplied the
+      plural array takes precedence.
+    tags:
+      - Audit Logs
+    parameters:
+      - name: page
+        in: query
+        description: Page number for offset-based pagination (default 1).
+        schema:
+          type: integer
+          default: 1
+          minimum: 1
+      - name: limit
+        in: query
+        description: Number of events to return per page (default 100, max 1000).
+        schema:
+          type: integer
+          default: 100
+          maximum: 1000
+      - name: cursor
+        in: query
+        description: Opaque cursor for cursor-based pagination (from `next_cursor`).
+        schema:
+          type: string
+      - name: search
+        in: query
+        description: Free-text search across audit event fields.
+        schema:
+          type: string
+      - name: action
+        in: query
+        description: Filter by a single CADF action.
+        schema:
+          $ref: '../../schemas/management/auditlogs.yaml#/AuditAction'
+      - name: actions
+        in: query
+        description: JSON array of CADF actions to filter by (OR match).
+        schema:
+          type: string
+        example: '["create","update"]'
+      - name: outcome
+        in: query
+        description: Filter by a single outcome.
+        schema:
+          $ref: '../../schemas/management/auditlogs.yaml#/AuditOutcome'
+      - name: outcomes
+        in: query
+        description: JSON array of outcomes to filter by (OR match).
+        schema:
+          type: string
+        example: '["success","failure"]'
+      - name: event_type
+        in: query
+        description: Filter by a single event type.
+        schema:
+          $ref: '../../schemas/management/auditlogs.yaml#/AuditEventType'
+      - name: event_types
+        in: query
+        description: JSON array of event types to filter by (OR match).
+        schema:
+          type: string
+        example: '["activity","control"]'
+      - name: initiator_id
+        in: query
+        description: Filter by a single initiator ID.
+        schema:
+          type: string
+      - name: initiator_ids
+        in: query
+        description: JSON array of initiator IDs to filter by (OR match).
+        schema:
+          type: string
+      - name: initiator_type
+        in: query
+        description: Filter by a single initiator resource type.
+        schema:
+          $ref: '../../schemas/management/auditlogs.yaml#/AuditResourceType'
+      - name: initiator_types
+        in: query
+        description: JSON array of initiator resource types to filter by (OR match).
+        schema:
+          type: string
+      - name: target_id
+        in: query
+        description: Filter by a single target ID.
+        schema:
+          type: string
+      - name: target_ids
+        in: query
+        description: JSON array of target IDs to filter by (OR match).
+        schema:
+          type: string
+      - name: target_type
+        in: query
+        description: Filter by a single target resource type.
+        schema:
+          $ref: '../../schemas/management/auditlogs.yaml#/AuditResourceType'
+      - name: target_types
+        in: query
+        description: JSON array of target resource types to filter by (OR match).
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: Filter events at or after this time (RFC3339 or `YYYY-MM-DD`).
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: Filter events at or before this time (RFC3339 or `YYYY-MM-DD`; a date is treated as end-of-day).
+        schema:
+          type: string
+      - name: period
+        in: query
+        description: Relative time window that overrides `start_date`/`end_date` when set (e.g. `24h`, `7d`).
+        schema:
+          type: string
+      - name: request_method
+        in: query
+        description: Filter by a single HTTP request method.
+        schema:
+          type: string
+      - name: request_methods
+        in: query
+        description: JSON array of HTTP request methods to filter by (OR match).
+        schema:
+          type: string
+      - name: request_path
+        in: query
+        description: Filter by a single request path prefix.
+        schema:
+          type: string
+      - name: request_paths
+        in: query
+        description: JSON array of request path prefixes to filter by (OR match).
+        schema:
+          type: string
+      - name: request_ip
+        in: query
+        description: Filter by a single client IP address.
+        schema:
+          type: string
+      - name: request_ips
+        in: query
+        description: JSON array of client IP addresses to filter by (OR match).
+        schema:
+          type: string
+      - name: tags
+        in: query
+        description: JSON array of tags to filter by (any match).
+        schema:
+          type: string
+        example: '["security","auth"]'
+      - name: sort_by
+        in: query
+        description: Field to sort by (default `event_time`).
+        schema:
+          type: string
+          default: event_time
+      - name: sort_order
+        in: query
+        description: Sort direction.
+        schema:
+          type: string
+          enum: [asc, desc]
+          default: desc
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/auditlogs.yaml#/AuditLogsResult'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+audit-logs-filterdata:
+  get:
+    operationId: getAuditLogsFilterData
+    summary: Get audit log filter data
+    description: |
+      Returns the distinct values available for each audit log filter dimension,
+      used to populate filter dropdowns in the dashboard.
+    tags:
+      - Audit Logs
+    parameters:
+      - name: dimensions
+        in: query
+        description: |
+          Comma-separated list of dimensions to return. When omitted, all
+          dimensions are returned. Unknown dimensions are ignored.
+        schema:
+          type: string
+          example: actions,outcomes,initiators
+        # Valid dimensions: actions, outcomes, event_types, initiator_types,
+        # target_types, request_methods, initiators, targets, request_paths,
+        # request_ips, tags
+      - name: q
+        in: query
+        description: Optional case-insensitive substring filter applied to dimension values.
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/auditlogs.yaml#/AuditFilterDataResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+audit-logs-export:
+  get:
+    operationId: exportAuditLogs
+    summary: Export audit logs
+    description: |
+      Streams audit log events matching the supplied filters as a downloadable
+      file. Accepts the same filter query parameters as `GET /api/audit-logs`.
+      The response is returned as an attachment with a generated filename.
+    tags:
+      - Audit Logs
+    parameters:
+      - name: format
+        in: query
+        description: |
+          Export format. Defaults to `json` when omitted or unrecognized.
+          - `json`: a JSON array of events
+          - `jsonl`: JSON Lines, one event per line
+          - `syslog`: RFC 5424 syslog format
+        schema:
+          type: string
+          enum: [json, jsonl, syslog]
+          default: json
+      - name: search
+        in: query
+        description: Free-text search across audit event fields.
+        schema:
+          type: string
+      - name: actions
+        in: query
+        description: JSON array of CADF actions to filter by (OR match).
+        schema:
+          type: string
+      - name: outcomes
+        in: query
+        description: JSON array of outcomes to filter by (OR match).
+        schema:
+          type: string
+      - name: event_types
+        in: query
+        description: JSON array of event types to filter by (OR match).
+        schema:
+          type: string
+      - name: start_date
+        in: query
+        description: Filter events at or after this time (RFC3339 or `YYYY-MM-DD`).
+        schema:
+          type: string
+      - name: end_date
+        in: query
+        description: Filter events at or before this time (RFC3339 or `YYYY-MM-DD`).
+        schema:
+          type: string
+      - name: period
+        in: query
+        description: Relative time window that overrides `start_date`/`end_date` when set (e.g. `24h`, `7d`).
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: A streamed export of the matching audit logs.
+        content:
+          application/json:
+            schema:
+              type: string
+          application/x-ndjson:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+audit-logs-by-id:
+  get:
+    operationId: getAuditLogById
+    summary: Get audit log by ID
+    description: Retrieves a single audit log event by its unique ID.
+    tags:
+      - Audit Logs
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier of the audit log event.
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/auditlogs.yaml#/AuditLogResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+audit-logs-verify:
+  get:
+    operationId: verifyAuditLogSignature
+    summary: Verify audit log signature
+    description: |
+      Recomputes the HMAC-SHA256 signature for a single audit log event and
+      compares it (in constant time) against the stored signature to detect
+      tampering.
+    tags:
+      - Audit Logs
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: The unique identifier of the audit log event to verify.
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/auditlogs.yaml#/AuditVerifyResult'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/schemas/management/auditlogs.yaml
+++ b/docs/openapi/schemas/management/auditlogs.yaml
@@ -1,0 +1,301 @@
+# Audit Logs API schemas
+
+AuditEventType:
+  type: string
+  description: Classifies the audit event.
+  enum: [activity, monitor, control]
+
+AuditAction:
+  type: string
+  description: The CADF action performed.
+  enum:
+    - create
+    - read
+    - update
+    - delete
+    - authenticate
+    - authorize
+    - access
+    - enable
+    - disable
+    - start
+    - stop
+    - backup
+    - restore
+    - export
+    - import
+
+AuditOutcome:
+  type: string
+  description: The CADF outcome of the action.
+  enum: [success, failure, pending]
+
+AuditResourceType:
+  type: string
+  description: The type of resource involved in an audit event (initiator or target).
+  enum:
+    - user
+    - api_key
+    - system
+    - provider
+    - virtual_key
+    - team
+    - customer
+    - role
+    - permission
+    - guardrail
+    - mcp_client
+    - mcp_tool_group
+    - plugin
+    - config
+    - session
+    - inference
+
+AuditResource:
+  type: object
+  description: A CADF resource (initiator, target, or observer).
+  properties:
+    id:
+      type: string
+      description: Unique identifier of the resource.
+    typeURI:
+      type: string
+      description: Resource type URI (e.g., "bifrost/user", "bifrost/api_key").
+    name:
+      type: string
+      description: Human-readable name of the resource.
+    host:
+      type: string
+      description: Hostname or IP address associated with the resource.
+  required:
+    - id
+    - typeURI
+
+AuditReason:
+  type: object
+  description: The CADF reason for an outcome (especially for failures).
+  properties:
+    reasonCode:
+      type: string
+      description: Machine-readable code (e.g., "401", "FORBIDDEN").
+    reasonType:
+      type: string
+      description: Category of reason (e.g., "HTTP", "policy").
+    message:
+      type: string
+      description: Human-readable description.
+
+AuditAttachment:
+  type: object
+  description: Additional CADF data attached to an event.
+  properties:
+    name:
+      type: string
+      description: Identifies the attachment.
+    contentType:
+      type: string
+      description: MIME type of the content.
+    content:
+      type: string
+      description: Attachment data (typically a JSON string).
+  required:
+    - name
+    - contentType
+    - content
+
+AuditEvent:
+  type: object
+  description: A CADF-compliant audit event.
+  properties:
+    id:
+      type: string
+      description: Unique identifier for this event (UUID).
+    typeURI:
+      type: string
+      description: Event type URI (e.g., "http://schemas.bifrost.io/audit/api/v1").
+    eventType:
+      $ref: '#/AuditEventType'
+    eventTime:
+      type: string
+      format: date-time
+      description: When the event occurred (RFC 3339).
+    action:
+      $ref: '#/AuditAction'
+    outcome:
+      $ref: '#/AuditOutcome'
+    initiator:
+      $ref: '#/AuditResource'
+    target:
+      $ref: '#/AuditResource'
+    observer:
+      $ref: '#/AuditResource'
+    reason:
+      $ref: '#/AuditReason'
+    attachments:
+      type: array
+      items:
+        $ref: '#/AuditAttachment'
+    tags:
+      type: array
+      description: Searchable labels for categorization.
+      items:
+        type: string
+    requestMethod:
+      type: string
+      description: HTTP method (GET, POST, etc.).
+    requestPath:
+      type: string
+      description: HTTP request path.
+    requestIP:
+      type: string
+      description: Client IP address.
+    userAgent:
+      type: string
+      description: HTTP User-Agent header.
+    duration:
+      type: integer
+      format: int64
+      description: Request duration in milliseconds.
+    signature:
+      type: string
+      description: HMAC-SHA256 signature for tamper detection.
+    createdAt:
+      type: string
+      format: date-time
+      description: When the record was created in the database.
+  required:
+    - id
+    - typeURI
+    - eventType
+    - eventTime
+    - action
+    - outcome
+    - initiator
+    - target
+    - observer
+    - signature
+    - createdAt
+
+AuditLogsResult:
+  type: object
+  description: A paginated result of audit logs.
+  properties:
+    audit_logs:
+      type: array
+      description: The list of audit events.
+      items:
+        $ref: '#/AuditEvent'
+    total:
+      type: integer
+      format: int64
+      description: Total count of events matching the filter.
+    page:
+      type: integer
+      description: Current page number.
+    limit:
+      type: integer
+      description: Page size.
+    total_pages:
+      type: integer
+      description: Total number of pages.
+    has_more:
+      type: boolean
+      description: Whether there are more results.
+    next_cursor:
+      type: string
+      description: Opaque cursor for the next page (cursor-based pagination).
+  required:
+    - audit_logs
+    - total
+    - page
+    - limit
+    - total_pages
+    - has_more
+
+AuditLogResponse:
+  type: object
+  description: Response wrapper for a single audit log entry.
+  properties:
+    audit_log:
+      $ref: '#/AuditEvent'
+  required:
+    - audit_log
+
+AuditFilterKeyPair:
+  type: object
+  description: An id/name pair used for initiator and target filter dropdowns.
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+  required:
+    - id
+    - name
+
+AuditFilterDataResponse:
+  type: object
+  description: Distinct values available for each audit log filter dimension.
+  properties:
+    actions:
+      type: array
+      items:
+        type: string
+    outcomes:
+      type: array
+      items:
+        type: string
+    event_types:
+      type: array
+      items:
+        type: string
+    initiator_types:
+      type: array
+      items:
+        type: string
+    target_types:
+      type: array
+      items:
+        type: string
+    request_methods:
+      type: array
+      items:
+        type: string
+    initiators:
+      type: array
+      items:
+        $ref: '#/AuditFilterKeyPair'
+    targets:
+      type: array
+      items:
+        $ref: '#/AuditFilterKeyPair'
+    request_paths:
+      type: array
+      items:
+        type: string
+    request_ips:
+      type: array
+      items:
+        type: string
+    tags:
+      type: array
+      items:
+        type: string
+
+AuditVerifyResult:
+  type: object
+  description: The result of an audit log signature verification.
+  properties:
+    valid:
+      type: boolean
+      description: Whether the stored signature matches the recomputed signature.
+    computed:
+      type: string
+      description: The signature recomputed from the stored event fields.
+    stored:
+      type: string
+      description: The signature persisted with the event.
+  required:
+    - valid
+    - computed
+    - stored


### PR DESCRIPTION
## Summary

Adds public OpenAPI documentation for the Audit Logs API, exposing CADF-compliant audit log search, export, and signature verification endpoints under the `Audit Logs` tag.

## Changes

- Added a new `Audit Logs` tag to both `openapi.json` and `openapi.yaml` with the description "CADF-compliant audit log search, export, and signature verification endpoints."
- Introduced five new API paths:
  - `GET /api/audit-logs` — paginated, filterable list of audit events supporting both offset- and cursor-based pagination, free-text search, and singular/plural filter parameters for actions, outcomes, event types, initiator/target IDs and types, request metadata, tags, and time ranges.
  - `GET /api/audit-logs/filterdata` — returns distinct values for each filter dimension to populate dashboard dropdowns, with optional dimension selection and substring filtering.
  - `GET /api/audit-logs/export` — streams matching audit events as a downloadable file in `json`, `jsonl`, or RFC 5424 `syslog` format.
  - `GET /api/audit-logs/{id}` — retrieves a single audit event by UUID.
  - `GET /api/audit-logs/{id}/verify` — recomputes the HMAC-SHA256 signature for an event and compares it in constant time against the stored signature to detect tampering.
- Added new schema definitions: `AuditEventType`, `AuditAction`, `AuditOutcome`, `AuditResourceType`, `AuditResource`, `AuditReason`, `AuditAttachment`, `AuditEvent`, `AuditLogsResult`, `AuditLogResponse`, `AuditFilterKeyPair`, `AuditFilterDataResponse`, and `AuditVerifyResult`.
- Created dedicated source files `docs/openapi/paths/management/auditlogs.yaml` and `docs/openapi/schemas/management/auditlogs.yaml` and wired them into the root `openapi.yaml`.
- The compiled `openapi.json` also includes unresolved merge conflict markers from a concurrent branch adding `mcp_server_auth_mode` and `oauth2_server_config` fields; these should be resolved before merging.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the OpenAPI spec renders correctly and all `$ref` paths resolve without errors:

```sh
# Install a validator if not already present
npm install -g @redocly/cli

# Lint the YAML source
redocly lint docs/openapi/openapi.yaml

# Confirm the compiled JSON is consistent with the YAML source
# (resolve the merge conflict markers in openapi.json first)
```

Verify the five new audit log endpoints appear under the "Audit Logs" tag in the rendered docs and that all schema references resolve correctly.

## Screenshots/Recordings

N/A — documentation-only change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

All five audit log endpoints are protected by `ManagementBearerAuth`. The signature verification endpoint (`/api/audit-logs/{id}/verify`) uses constant-time comparison to prevent timing attacks when validating HMAC-SHA256 signatures.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable