### PR TITLE
docs: clarify two-layer token refresh behavior and disabled-client refresh token expiry

### DIFF
--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -230,7 +230,12 @@ Status values:
 
 ### Automatic refresh
 
-Bifrost refreshes the access token automatically on its next use after it has expired, using the stored refresh token. No action required.
+Bifrost refreshes access tokens automatically using the stored refresh token, in two layers:
+
+- **In the background** — a worker periodically refreshes tokens that are about to expire, so active clients always have a valid token ready.
+- **On use** — if a token is already expired when a request needs it, Bifrost refreshes it inline before forwarding the request.
+
+Background refresh only runs while the MCP client is enabled. Disabling a client pauses it; on re-enable, the token is refreshed on first use. If a client stays disabled long enough for the provider to expire the idle refresh token, re-authorization is required.
 
 ### Rotation
 
@@ -335,6 +340,7 @@ See [Reverse Proxy configuration →](../../deployment-guides/config-json/client
 <Accordion title="Token refresh fails / tools say `oauth token expired`">
 
 - Check that the refresh token is still valid (some providers expire refresh tokens after long idle)
+- If the client was disabled for a long stretch, background refresh was paused for it — the refresh token may have expired at the provider in the meantime
 - Verify scopes are still sufficient
 - Re-authorize: `DELETE /api/oauth/config/{id}` then create a new client
 </Accordion>


### PR DESCRIPTION
## Summary

Documents the two-layer automatic token refresh behavior in Bifrost's OAuth flow, clarifying how background refresh and on-use refresh work together, and what happens when an MCP client is disabled.

## Changes

- Expanded the "Automatic refresh" section to describe both the background worker (proactive refresh before expiry) and the inline fallback (refresh on first use after expiry)
- Added a note explaining that background refresh is paused when a client is disabled, and that re-authorization may be required if the provider expires the idle refresh token during that time
- Added a corresponding troubleshooting bullet under the "Token refresh fails" accordion to surface this as a known cause of expired token errors

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered docs to confirm the updated "Automatic refresh" section and troubleshooting accordion entry are accurate and clearly worded.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable