### PR TITLE
feat: adds input output cost split for inference calls

### DIFF
--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -327,7 +327,7 @@ func (response *PerplexityChatResponse) ToBifrostChatResponse(model string) *sch
 		}
 
 		if response.Usage.Cost != nil {
-			usage.Cost = response.Usage.Cost
+			usage.Cost = response.Usage.Cost.toBifrostCost()
 		}
 
 		bifrostResponse.Usage = usage

--- a/core/providers/perplexity/perplexity_test.go
+++ b/core/providers/perplexity/perplexity_test.go
@@ -278,7 +278,7 @@ func TestWebSearchOption_JSONSerialization(t *testing.T) {
 func TestBifrostCost_DeserializationWithPerplexityFields(t *testing.T) {
 	t.Parallel()
 
-	t.Run("deserializes new cost breakdown fields", func(t *testing.T) {
+	t.Run("maps legacy flat shape onto nested", func(t *testing.T) {
 		jsonStr := `{
 			"input_tokens_cost": 0.001,
 			"output_tokens_cost": 0.002,
@@ -294,23 +294,29 @@ func TestBifrostCost_DeserializationWithPerplexityFields(t *testing.T) {
 			t.Fatalf("failed to unmarshal BifrostCost: %v", err)
 		}
 
-		if cost.InputTokensCost != 0.001 {
-			t.Errorf("expected input_tokens_cost 0.001, got %f", cost.InputTokensCost)
+		// The legacy flat shape maps onto the nested schema: the request surcharge
+		// folds into the input side; reasoning/citation/search are output-side
+		// categories. Detail fields carry the exact JSON values.
+		if cost.InputCostDetails == nil || cost.OutputCostDetails == nil {
+			t.Fatalf("expected nested cost details, got %+v", cost)
 		}
-		if cost.OutputTokensCost != 0.002 {
-			t.Errorf("expected output_tokens_cost 0.002, got %f", cost.OutputTokensCost)
+		if cost.InputCostDetails.TextCost != 0.001 {
+			t.Errorf("expected input text cost 0.001, got %f", cost.InputCostDetails.TextCost)
 		}
-		if cost.ReasoningTokensCost != 0.003 {
-			t.Errorf("expected reasoning_tokens_cost 0.003, got %f", cost.ReasoningTokensCost)
+		if cost.InputCostDetails.RequestCost != 0.006 {
+			t.Errorf("expected request cost 0.006, got %f", cost.InputCostDetails.RequestCost)
 		}
-		if cost.CitationTokensCost != 0.004 {
-			t.Errorf("expected citation_tokens_cost 0.004, got %f", cost.CitationTokensCost)
+		if cost.OutputCostDetails.TextCost != 0.002 {
+			t.Errorf("expected output text cost 0.002, got %f", cost.OutputCostDetails.TextCost)
 		}
-		if cost.SearchQueriesCost != 0.005 {
-			t.Errorf("expected search_queries_cost 0.005, got %f", cost.SearchQueriesCost)
+		if cost.OutputCostDetails.ReasoningCost != 0.003 {
+			t.Errorf("expected reasoning cost 0.003, got %f", cost.OutputCostDetails.ReasoningCost)
 		}
-		if cost.RequestCost != 0.006 {
-			t.Errorf("expected request_cost 0.006, got %f", cost.RequestCost)
+		if cost.OutputCostDetails.CitationCost != 0.004 {
+			t.Errorf("expected citation cost 0.004, got %f", cost.OutputCostDetails.CitationCost)
+		}
+		if cost.OutputCostDetails.SearchQueriesCost != 0.005 {
+			t.Errorf("expected search queries cost 0.005, got %f", cost.OutputCostDetails.SearchQueriesCost)
 		}
 		if cost.TotalCost != 0.021 {
 			t.Errorf("expected total_cost 0.021, got %f", cost.TotalCost)

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -94,5 +94,50 @@ type Usage struct {
 	CitationTokens    *int                 `json:"citation_tokens,omitempty"`
 	NumSearchQueries  *int                 `json:"num_search_queries,omitempty"`
 	ReasoningTokens   *int                 `json:"reasoning_tokens,omitempty"`
-	Cost              *schemas.BifrostCost `json:"cost,omitempty"`
+	Cost              *perplexityCost      `json:"cost,omitempty"`
+}
+
+// perplexityCost is Perplexity's raw cost object, a flat per-category shape. It
+// is mapped into the neutral schemas.BifrostCost via toBifrostCost rather than
+// deserialized into it directly, keeping the provider wire format out of the
+// core schema.
+type perplexityCost struct {
+	InputTokensCost     float64 `json:"input_tokens_cost"`
+	OutputTokensCost    float64 `json:"output_tokens_cost"`
+	ReasoningTokensCost float64 `json:"reasoning_tokens_cost"`
+	CitationTokensCost  float64 `json:"citation_tokens_cost"`
+	SearchQueriesCost   float64 `json:"search_queries_cost"`
+	RequestCost         float64 `json:"request_cost"`
+	TotalCost           float64 `json:"total_cost"`
+}
+
+// toBifrostCost maps Perplexity's flat cost onto the nested BifrostCost: the flat
+// request surcharge folds into the input side; reasoning/citation/search are
+// output-side categories.
+func (c *perplexityCost) toBifrostCost() *schemas.BifrostCost {
+	if c == nil {
+		return nil
+	}
+	inputCost := c.InputTokensCost + c.RequestCost
+	outputCost := c.OutputTokensCost + c.ReasoningTokensCost + c.CitationTokensCost + c.SearchQueriesCost
+	total := c.TotalCost
+	if total == 0 {
+		total = inputCost + outputCost
+	}
+	bc := &schemas.BifrostCost{InputCost: inputCost, OutputCost: outputCost, TotalCost: total}
+	if inputCost != 0 {
+		bc.InputCostDetails = &schemas.InputCostDetails{
+			TextCost:    c.InputTokensCost,
+			RequestCost: c.RequestCost,
+		}
+	}
+	if outputCost != 0 {
+		bc.OutputCostDetails = &schemas.OutputCostDetails{
+			TextCost:          c.OutputTokensCost,
+			ReasoningCost:     c.ReasoningTokensCost,
+			CitationCost:      c.CitationTokensCost,
+			SearchQueriesCost: c.SearchQueriesCost,
+		}
+	}
+	return bc
 }

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1947,14 +1947,23 @@ type ChatCompletionTokensDetails struct {
 	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
 }
 
+// BifrostCost splits a request's cost into an input side, an output side, and an
+// additional side, each with an optional per-category detail breakdown, mirroring
+// the token-usage shape (BifrostLLMUsage's PromptTokens/PromptTokensDetails +
+// CompletionTokens/CompletionTokensDetails). InputCost + OutputCost +
+// AdditionalCost == TotalCost. Flat, non-token request costs (per-request
+// surcharge, OCR per-page, container per-session) fold into the input side as
+// InputCostDetails.RequestCost. Internal sidecar costs that map to no token
+// category (guardrail judge calls, MCP tool executions) go on the additional
+// side as AdditionalCostDetails.
 type BifrostCost struct {
-	InputTokensCost     float64 `json:"input_tokens_cost,omitempty"`
-	OutputTokensCost    float64 `json:"output_tokens_cost,omitempty"`
-	ReasoningTokensCost float64 `json:"reasoning_tokens_cost,omitempty"`
-	CitationTokensCost  float64 `json:"citation_tokens_cost,omitempty"`
-	SearchQueriesCost   float64 `json:"search_queries_cost,omitempty"`
-	RequestCost         float64 `json:"request_cost,omitempty"`
-	TotalCost           float64 `json:"total_cost,omitempty"`
+	InputCost             float64                `json:"input_cost,omitempty"`
+	InputCostDetails      *InputCostDetails      `json:"input_cost_details,omitempty"`
+	OutputCost            float64                `json:"output_cost,omitempty"`
+	OutputCostDetails     *OutputCostDetails     `json:"output_cost_details,omitempty"`
+	AdditionalCost        float64                `json:"additional_cost,omitempty"`
+	AdditionalCostDetails *AdditionalCostDetails `json:"additional_cost_details,omitempty"`
+	TotalCost             float64                `json:"total_cost,omitempty"`
 }
 
 // MergeBifrostLLMUsage returns a usage value containing the sum of base and add.
@@ -2018,25 +2027,7 @@ func MergeBifrostLLMUsage(base, add *BifrostLLMUsage) *BifrostLLMUsage {
 		merged.CompletionTokensDetails.ImageTokens = sumOptionalInts(baseDetails.ImageTokens, addDetails.ImageTokens)
 	}
 
-	if base.Cost != nil || add.Cost != nil {
-		baseCost := base.Cost
-		addCost := add.Cost
-		if baseCost == nil {
-			baseCost = &BifrostCost{}
-		}
-		if addCost == nil {
-			addCost = &BifrostCost{}
-		}
-		merged.Cost = &BifrostCost{
-			InputTokensCost:     baseCost.InputTokensCost + addCost.InputTokensCost,
-			OutputTokensCost:    baseCost.OutputTokensCost + addCost.OutputTokensCost,
-			ReasoningTokensCost: baseCost.ReasoningTokensCost + addCost.ReasoningTokensCost,
-			CitationTokensCost:  baseCost.CitationTokensCost + addCost.CitationTokensCost,
-			SearchQueriesCost:   baseCost.SearchQueriesCost + addCost.SearchQueriesCost,
-			RequestCost:         baseCost.RequestCost + addCost.RequestCost,
-			TotalCost:           baseCost.TotalCost + addCost.TotalCost,
-		}
-	}
+	merged.Cost = base.Cost.Add(add.Cost)
 
 	return merged
 }
@@ -2069,7 +2060,41 @@ func sumOptionalInts(base, add *int) *int {
 	return &sum
 }
 
-// UnmarshalJSON implements custom JSON unmarshalling for BifrostCost.
+// InputCostDetails breaks InputCost down by category; sub-fields sum to InputCost.
+type InputCostDetails struct {
+	TextCost        float64 `json:"text_cost,omitempty"`
+	AudioCost       float64 `json:"audio_cost,omitempty"`
+	ImageCost       float64 `json:"image_cost,omitempty"`
+	CachedReadCost  float64 `json:"cached_read_cost,omitempty"`
+	CachedWriteCost float64 `json:"cached_write_cost,omitempty"`
+	// RequestCost is a flat per-request surcharge (also OCR per-page and
+	// container per-session), folded into the input side since it maps to no
+	// token category.
+	RequestCost float64 `json:"request_cost,omitempty"`
+}
+
+// OutputCostDetails breaks OutputCost down by category; sub-fields sum to OutputCost.
+type OutputCostDetails struct {
+	TextCost          float64 `json:"text_cost,omitempty"`
+	AudioCost         float64 `json:"audio_cost,omitempty"`
+	ImageCost         float64 `json:"image_cost,omitempty"`
+	ReasoningCost     float64 `json:"reasoning_cost,omitempty"`
+	CitationCost      float64 `json:"citation_cost,omitempty"`
+	SearchQueriesCost float64 `json:"search_queries_cost,omitempty"`
+}
+
+// AdditionalCostDetails breaks AdditionalCost down by category; sub-fields sum to
+// AdditionalCost. These are internal sidecar costs with no input/output token
+// category. Extend with new fields as more such cost sources are billed.
+type AdditionalCostDetails struct {
+	GuardrailCost float64 `json:"guardrail_cost,omitempty"` // Guardrail judge-call cost
+	MCPCost       float64 `json:"mcp_cost,omitempty"`       // MCP tool-execution cost
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for BifrostCost. It accepts
+// a bare float (treated as the total), the current nested shape, and the legacy
+// flat shape (input_tokens_cost, output_tokens_cost, ...) still emitted by
+// Perplexity and present in logs written before the nested shape existed.
 func (bc *BifrostCost) UnmarshalJSON(data []byte) error {
 	// First, try to unmarshal as a direct float
 	var costFloat float64
@@ -2078,16 +2103,139 @@ func (bc *BifrostCost) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Try to unmarshal as a full BifrostCost struct
-	// Use a type alias to avoid infinite recursion
+	// Nested shape. Use a type alias to avoid infinite recursion.
 	type Alias BifrostCost
-	var costStruct Alias
-	if err := Unmarshal(data, &costStruct); err == nil {
-		*bc = BifrostCost(costStruct)
-		return nil
+	var nested Alias
+	if err := Unmarshal(data, &nested); err != nil {
+		return fmt.Errorf("cost field is neither a float nor an object: %w", err)
 	}
+	*bc = BifrostCost(nested)
 
-	return fmt.Errorf("cost field is neither a float nor an object")
+	// Legacy flat shape backfill, only when the nested keys were absent.
+	if bc.InputCost == 0 && bc.OutputCost == 0 && bc.InputCostDetails == nil && bc.OutputCostDetails == nil {
+		var legacy legacyBifrostCost
+		if err := Unmarshal(data, &legacy); err == nil {
+			legacy.mergeInto(bc)
+		}
+	}
+	return nil
+}
+
+// legacyBifrostCost is the pre-nested flat cost shape, kept for deserializing
+// older logs and Perplexity's response. Pointers distinguish absent from zero.
+type legacyBifrostCost struct {
+	InputTokensCost     *float64 `json:"input_tokens_cost"`
+	OutputTokensCost    *float64 `json:"output_tokens_cost"`
+	CacheReadTokensCost *float64 `json:"cache_read_tokens_cost"`
+	ReasoningTokensCost *float64 `json:"reasoning_tokens_cost"`
+	CitationTokensCost  *float64 `json:"citation_tokens_cost"`
+	SearchQueriesCost   *float64 `json:"search_queries_cost"`
+	RequestCost         *float64 `json:"request_cost"`
+}
+
+// mergeInto maps the flat fields onto the nested shape: the per-request
+// surcharge folds into the input side; search/reasoning/citation are output-side
+// categories. TotalCost is left untouched (its "total_cost" key is unchanged).
+func (l legacyBifrostCost) mergeInto(bc *BifrostCost) {
+	if l.InputTokensCost == nil && l.OutputTokensCost == nil && l.RequestCost == nil &&
+		l.CacheReadTokensCost == nil && l.ReasoningTokensCost == nil &&
+		l.CitationTokensCost == nil && l.SearchQueriesCost == nil {
+		return // no legacy keys present
+	}
+	val := func(p *float64) float64 {
+		if p != nil {
+			return *p
+		}
+		return 0
+	}
+	inTok, outTok := val(l.InputTokensCost), val(l.OutputTokensCost)
+	cacheRead, request := val(l.CacheReadTokensCost), val(l.RequestCost)
+	reasoning, citation, search := val(l.ReasoningTokensCost), val(l.CitationTokensCost), val(l.SearchQueriesCost)
+
+	bc.InputCost = inTok + request
+	bc.OutputCost = outTok + reasoning + citation + search
+	if bc.InputCost != 0 || cacheRead != 0 {
+		bc.InputCostDetails = &InputCostDetails{
+			TextCost:       inTok - cacheRead,
+			CachedReadCost: cacheRead,
+			RequestCost:    request,
+		}
+	}
+	if bc.OutputCost != 0 {
+		bc.OutputCostDetails = &OutputCostDetails{
+			TextCost:          outTok,
+			ReasoningCost:     reasoning,
+			CitationCost:      citation,
+			SearchQueriesCost: search,
+		}
+	}
+}
+
+// Add returns the component-wise sum of two cost breakdowns, treating a nil
+// operand as zero. Returns nil only when both are nil.
+func (bc *BifrostCost) Add(other *BifrostCost) *BifrostCost {
+	if bc == nil {
+		return other
+	}
+	if other == nil {
+		return bc
+	}
+	return &BifrostCost{
+		InputCost:             bc.InputCost + other.InputCost,
+		InputCostDetails:      bc.InputCostDetails.add(other.InputCostDetails),
+		OutputCost:            bc.OutputCost + other.OutputCost,
+		OutputCostDetails:     bc.OutputCostDetails.add(other.OutputCostDetails),
+		AdditionalCost:        bc.AdditionalCost + other.AdditionalCost,
+		AdditionalCostDetails: bc.AdditionalCostDetails.add(other.AdditionalCostDetails),
+		TotalCost:             bc.TotalCost + other.TotalCost,
+	}
+}
+
+func (a *InputCostDetails) add(b *InputCostDetails) *InputCostDetails {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &InputCostDetails{
+		TextCost:        a.TextCost + b.TextCost,
+		AudioCost:       a.AudioCost + b.AudioCost,
+		ImageCost:       a.ImageCost + b.ImageCost,
+		CachedReadCost:  a.CachedReadCost + b.CachedReadCost,
+		CachedWriteCost: a.CachedWriteCost + b.CachedWriteCost,
+		RequestCost:     a.RequestCost + b.RequestCost,
+	}
+}
+
+func (a *OutputCostDetails) add(b *OutputCostDetails) *OutputCostDetails {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &OutputCostDetails{
+		TextCost:          a.TextCost + b.TextCost,
+		AudioCost:         a.AudioCost + b.AudioCost,
+		ImageCost:         a.ImageCost + b.ImageCost,
+		ReasoningCost:     a.ReasoningCost + b.ReasoningCost,
+		CitationCost:      a.CitationCost + b.CitationCost,
+		SearchQueriesCost: a.SearchQueriesCost + b.SearchQueriesCost,
+	}
+}
+
+func (a *AdditionalCostDetails) add(b *AdditionalCostDetails) *AdditionalCostDetails {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return &AdditionalCostDetails{
+		GuardrailCost: a.GuardrailCost + b.GuardrailCost,
+		MCPCost:       a.MCPCost + b.MCPCost,
+	}
 }
 
 // xAI reports request cost as cost_in_usd_ticks, where TICKS_IN_USD_CENT = 100_000_000, so 1 USD = 1e10 ticks.

--- a/core/schemas/usage_test.go
+++ b/core/schemas/usage_test.go
@@ -29,13 +29,13 @@ func TestMergeBifrostLLMUsage(t *testing.T) {
 			RejectedPredictionTokens: 8,
 		},
 		Cost: &BifrostCost{
-			InputTokensCost:     1,
-			OutputTokensCost:    2,
-			ReasoningTokensCost: 3,
-			CitationTokensCost:  4,
-			SearchQueriesCost:   5,
-			RequestCost:         6,
-			TotalCost:           21,
+			InputCost:             1,
+			InputCostDetails:      &InputCostDetails{TextCost: 1},
+			OutputCost:            2,
+			OutputCostDetails:     &OutputCostDetails{TextCost: 2},
+			AdditionalCost:        3,
+			AdditionalCostDetails: &AdditionalCostDetails{GuardrailCost: 3},
+			TotalCost:             6,
 		},
 	}
 	add := &BifrostLLMUsage{
@@ -64,13 +64,13 @@ func TestMergeBifrostLLMUsage(t *testing.T) {
 			RejectedPredictionTokens: 15,
 		},
 		Cost: &BifrostCost{
-			InputTokensCost:     10,
-			OutputTokensCost:    20,
-			ReasoningTokensCost: 30,
-			CitationTokensCost:  40,
-			SearchQueriesCost:   50,
-			RequestCost:         60,
-			TotalCost:           210,
+			InputCost:             10,
+			InputCostDetails:      &InputCostDetails{TextCost: 10},
+			OutputCost:            20,
+			OutputCostDetails:     &OutputCostDetails{TextCost: 20},
+			AdditionalCost:        30,
+			AdditionalCostDetails: &AdditionalCostDetails{GuardrailCost: 30},
+			TotalCost:             60,
 		},
 	}
 
@@ -99,13 +99,13 @@ func TestMergeBifrostLLMUsage(t *testing.T) {
 		merged.CompletionTokensDetails.RejectedPredictionTokens != 23 {
 		t.Fatalf("unexpected completion details: %+v", merged.CompletionTokensDetails)
 	}
-	if merged.Cost.InputTokensCost != 11 ||
-		merged.Cost.OutputTokensCost != 22 ||
-		merged.Cost.ReasoningTokensCost != 33 ||
-		merged.Cost.CitationTokensCost != 44 ||
-		merged.Cost.SearchQueriesCost != 55 ||
-		merged.Cost.RequestCost != 66 ||
-		merged.Cost.TotalCost != 231 {
+	if merged.Cost.InputCost != 11 ||
+		merged.Cost.OutputCost != 22 ||
+		merged.Cost.AdditionalCost != 33 ||
+		merged.Cost.TotalCost != 66 ||
+		merged.Cost.InputCostDetails.TextCost != 11 ||
+		merged.Cost.OutputCostDetails.TextCost != 22 ||
+		merged.Cost.AdditionalCostDetails.GuardrailCost != 33 {
 		t.Fatalf("unexpected cost: %+v", merged.Cost)
 	}
 }

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -15,8 +15,20 @@ import (
 // If scopes is nil, an empty LookupScopes is used; global and provider-scoped
 // overrides may still apply since the provider is derived from the response.
 func (s *Store) CalculateCost(result *schemas.BifrostResponse, scopes *LookupScopes) float64 {
-	if result == nil {
+	breakdown := s.CalculateCostBreakdown(result, scopes)
+	if breakdown == nil {
 		return 0
+	}
+	return breakdown.TotalCost
+}
+
+// CalculateCostBreakdown mirrors CalculateCost but returns the full per-category
+// cost breakdown (input / output / cache) instead of only the total. Returns nil
+// when there is no cost to record. CalculateCost is a thin wrapper over this that
+// returns breakdown.TotalCost, so both paths compute cost identically.
+func (s *Store) CalculateCostBreakdown(result *schemas.BifrostResponse, scopes *LookupScopes) *schemas.BifrostCost {
+	if result == nil {
+		return nil
 	}
 
 	var lookupScopes LookupScopes
@@ -28,7 +40,7 @@ func (s *Store) CalculateCost(result *schemas.BifrostResponse, scopes *LookupSco
 
 	// Handle semantic cache billing
 	cacheDebug := extraFields.CacheDebug
-	var requestCost float64
+	var requestCost *schemas.BifrostCost
 	if cacheDebug != nil {
 		requestCost = s.calculateCostWithCache(result, cacheDebug, lookupScopes)
 	} else {
@@ -39,7 +51,28 @@ func (s *Store) CalculateCost(result *schemas.BifrostResponse, scopes *LookupSco
 	if extraFields.GuardrailDebug == nil {
 		return requestCost
 	}
-	return requestCost + s.CalculateGuardrailCost(extraFields.GuardrailDebug, &lookupScopes)
+	guardrailCost := s.CalculateGuardrailCost(extraFields.GuardrailDebug, &lookupScopes)
+	if guardrailCost == 0 {
+		return requestCost
+	}
+	// Copy rather than mutate: requestCost may alias the provider-supplied
+	// usage.Cost. The judge call is a separate internal cost with no input/output
+	// token category, so it lands on the additional side (and the total).
+	merged := &schemas.BifrostCost{}
+	if requestCost != nil {
+		*merged = *requestCost
+		if requestCost.AdditionalCostDetails != nil {
+			d := *requestCost.AdditionalCostDetails
+			merged.AdditionalCostDetails = &d
+		}
+	}
+	if merged.AdditionalCostDetails == nil {
+		merged.AdditionalCostDetails = &schemas.AdditionalCostDetails{}
+	}
+	merged.AdditionalCost += guardrailCost
+	merged.AdditionalCostDetails.GuardrailCost += guardrailCost
+	merged.TotalCost += guardrailCost
+	return merged
 }
 
 // CalculateCostForUsage computes the dollar cost from a bare usage object plus
@@ -69,7 +102,7 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 	input := costInput{usage: usage}
 	input.tier = tierFromResponse(nil, usage.Speed, usage.InferenceGeo)
 
-	return s.computeCostFromInput(
+	breakdown := s.computeCostFromInput(
 		input,
 		schemas.RoutingInfo{
 			Provider:                provider,
@@ -79,6 +112,10 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 		normalizeStreamRequestType(requestType),
 		lookupScopes,
 	)
+	if breakdown == nil {
+		return 0
+	}
+	return breakdown.TotalCost
 }
 
 // CalculateGuardrailCost computes judge cost when no parent response is available.
@@ -210,7 +247,11 @@ func (s *Store) CalculateBatchCostDetailsForUsage(usage *schemas.BifrostLLMUsage
 		// the bare-usage batch path never sees a full response to read a served
 		// tier off, mirroring CalculateCostForUsage.
 		tier := tierFromResponse(nil, usage.Speed, usage.InferenceGeo)
-		cost := computeBatchTextCost(pricing, usage, tier)
+		breakdown := computeBatchTextCost(pricing, usage, tier)
+		cost := 0.0
+		if breakdown != nil {
+			cost = breakdown.TotalCost
+		}
 		// Flat per-request surcharge, mirroring computeCostFromInput: each row in
 		// a batch is its own distinct request, so a per-request fee applies once
 		// per row exactly as it would have applied once per synchronous call.
@@ -237,23 +278,49 @@ func cloneFloat64Pointer(value *float64) *float64 {
 }
 
 // calculateCostWithCache handles cost calculation when semantic cache debug info is present.
-func (s *Store) calculateCostWithCache(result *schemas.BifrostResponse, cacheDebug *schemas.BifrostCacheDebug, scopes LookupScopes) float64 {
+func (s *Store) calculateCostWithCache(result *schemas.BifrostResponse, cacheDebug *schemas.BifrostCacheDebug, scopes LookupScopes) *schemas.BifrostCost {
 	if cacheDebug.CacheHit {
 		// Direct cache hit — no LLM call, no cost
 		if cacheDebug.HitType != nil && *cacheDebug.HitType == "direct" {
-			return 0
+			return nil
 		}
-		// Semantic cache hit — only the embedding lookup cost
+		// Semantic cache hit — only the embedding lookup cost (an input cost)
 		if cacheDebug.ProviderUsed != nil && cacheDebug.ModelUsed != nil && cacheDebug.InputTokens != nil {
-			return s.computeCacheEmbeddingCost(cacheDebug, scopes)
+			c := s.computeCacheEmbeddingCost(cacheDebug, scopes)
+			if c == 0 {
+				return nil
+			}
+			return &schemas.BifrostCost{
+				InputCost:        c,
+				InputCostDetails: &schemas.InputCostDetails{TextCost: c},
+				TotalCost:        c,
+			}
 		}
-		return 0
+		return nil
 	}
 
-	// Cache miss — full LLM cost + embedding lookup cost
-	baseCost := s.calculateBaseCost(result, scopes)
+	// Cache miss — full LLM cost + embedding lookup cost (added on the input side)
+	base := s.calculateBaseCost(result, scopes)
 	embeddingCost := s.computeCacheEmbeddingCost(cacheDebug, scopes)
-	return baseCost + embeddingCost
+	if embeddingCost == 0 {
+		return base
+	}
+	// Copy rather than mutate: base may alias the provider-supplied usage.Cost.
+	merged := &schemas.BifrostCost{}
+	if base != nil {
+		*merged = *base
+		if base.InputCostDetails != nil {
+			d := *base.InputCostDetails
+			merged.InputCostDetails = &d
+		}
+	}
+	if merged.InputCostDetails == nil {
+		merged.InputCostDetails = &schemas.InputCostDetails{}
+	}
+	merged.InputCost += embeddingCost
+	merged.InputCostDetails.TextCost += embeddingCost
+	merged.TotalCost += embeddingCost
+	return merged
 }
 
 // computeCacheEmbeddingCost calculates the embedding cost for a semantic cache lookup.
@@ -287,18 +354,20 @@ func (s *Store) CalculateCacheEmbeddingCost(cacheDebug *schemas.BifrostCacheDebu
 }
 
 // computeContainerCreationCost returns the cost for creating a container from an already-resolved pricing entry.
-func computeContainerCreationCost(pricing *configstoreTables.TableModelPricing) float64 {
+func computeContainerCreationCost(pricing *configstoreTables.TableModelPricing) *schemas.BifrostCost {
 	if pricing == nil || pricing.CodeInterpreterCostPerSession == nil {
-		return 0
+		return nil
 	}
-	return *pricing.CodeInterpreterCostPerSession
+	// Container creation is a flat per-session cost, not a token cost, so it folds
+	// onto the input side as a flat request cost.
+	return totalOnlyCost(*pricing.CodeInterpreterCostPerSession)
 }
 
 // calculateBaseCost extracts usage from the response and routes to the appropriate compute function.
-func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes LookupScopes) float64 {
+func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes LookupScopes) *schemas.BifrostCost {
 	extraFields := result.GetExtraFields()
 	if extraFields == nil {
-		return 0
+		return nil
 	}
 
 	// Read routing info populated by core.bifrost at request time.
@@ -324,7 +393,7 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 	// succeeded) would otherwise be billed again on every poll, inflating logs, traces and
 	// governance budgets.
 	if requestType == schemas.VideoRetrieveRequest {
-		return 0
+		return nil
 	}
 
 	// Extract usage data from the response (passthrough and native paths unified)
@@ -332,16 +401,16 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 
 	// If provider already computed cost, use it
 	if input.usage != nil && input.usage.Cost != nil && input.usage.Cost.TotalCost > 0 {
-		return input.usage.Cost.TotalCost
+		return input.usage.Cost
 	}
 	// Image responses carry usage on imageUsage, never on input.usage.
 	if input.imageUsage != nil && input.imageUsage.Cost != nil && input.imageUsage.Cost.TotalCost > 0 {
-		return input.imageUsage.Cost.TotalCost
+		return input.imageUsage.Cost
 	}
 
 	// If no usage data at all, nothing to price
 	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
-		return 0
+		return nil
 	}
 
 	if result.PassthroughResponse != nil {
@@ -369,7 +438,7 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 // model it actually routed to, looked up fresh under the served model name so
 // regular per-token/tiered pricing applies to it exactly as if it had been
 // called directly.
-func (s *Store) calculateAzureModelRouterCost(result *schemas.BifrostResponse, input costInput, routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) float64 {
+func (s *Store) calculateAzureModelRouterCost(result *schemas.BifrostResponse, input costInput, routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) *schemas.BifrostCost {
 	pricingRequestType := requestType
 	if pricingRequestType == schemas.TextCompletionRequest {
 		pricingRequestType = schemas.ChatCompletionRequest
@@ -382,7 +451,7 @@ func (s *Store) calculateAzureModelRouterCost(result *schemas.BifrostResponse, i
 			Provider: routingInfo.Provider,
 			Model:    servedModel,
 		}
-		cost += s.computeCostFromInput(input, underlyingRoutingInfo, pricingRequestType, scopes)
+		cost = cost.Add(s.computeCostFromInput(input, underlyingRoutingInfo, pricingRequestType, scopes))
 	}
 
 	return cost
@@ -410,7 +479,7 @@ func azureModelRouterServedModel(result *schemas.BifrostResponse) string {
 // type and routes the extracted usage to the appropriate per-modality compute
 // function. Shared by calculateBaseCost (response-driven) and
 // CalculateCostForUsage (bare-usage-driven, for failed/cancelled requests).
-func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) float64 {
+func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.RoutingInfo, requestType schemas.RequestType, scopes LookupScopes) *schemas.BifrostCost {
 	// When a pricing model override is set (e.g. container creates always look
 	// up "container"), it replaces the lookup hierarchy entirely. Build a
 	// synthetic RoutingInfo that reuses Provider but pins the model fields to
@@ -426,11 +495,14 @@ func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.Routin
 
 	pricing := s.resolvePricing(routingInfo, requestType, scopes)
 	if pricing == nil {
-		return 0
+		return nil
 	}
 
-	// Route to the appropriate compute function
-	var cost float64
+	// Route to the appropriate compute function. Each returns a per-category
+	// breakdown: token-based modalities populate input / output (and cache, for
+	// text); non-token modalities (OCR per-page, container per-session) fold the
+	// flat charge onto the input side as InputCostDetails.RequestCost.
+	var cost *schemas.BifrostCost
 	switch requestType {
 	case schemas.ChatCompletionRequest, schemas.TextCompletionRequest, schemas.ResponsesRequest, schemas.RealtimeRequest, schemas.CompactionRequest:
 		cost = computeTextCost(pricing, input.usage, input.tier)
@@ -453,13 +525,22 @@ func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.Routin
 	case schemas.ContainerCreateRequest:
 		cost = computeContainerCreationCost(pricing)
 	default:
-		return 0
+		return nil
 	}
 
-	// Flat per-request surcharge, billed once on top of usage-based cost
-	// whenever the resolved pricing row carries one.
+	// Flat per-request surcharge, billed once on top of usage-based cost whenever
+	// the resolved pricing row carries one. It maps to no token category, so it
+	// folds into the input side (InputCostDetails.RequestCost) and the total.
 	if pricing.CostPerRequest != nil {
-		cost += *pricing.CostPerRequest
+		if cost == nil {
+			cost = &schemas.BifrostCost{}
+		}
+		if cost.InputCostDetails == nil {
+			cost.InputCostDetails = &schemas.InputCostDetails{}
+		}
+		cost.InputCost += *pricing.CostPerRequest
+		cost.InputCostDetails.RequestCost += *pricing.CostPerRequest
+		cost.TotalCost += *pricing.CostPerRequest
 	}
 	return cost
 }
@@ -647,9 +728,12 @@ func extractTranscriptionUsage(u *schemas.TranscriptionUsage) (*schemas.BifrostL
 // ---------------------------------------------------------------------------
 
 // computeTextCost handles chat, text completion, and responses requests.
-func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+// It returns a per-category cost breakdown; TotalCost equals the sum of every
+// component so callers that only need the total can read that field. Returns
+// nil when usage is nil.
+func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) *schemas.BifrostCost {
 	if usage == nil {
-		return 0
+		return nil
 	}
 
 	promptTokens := usage.PromptTokens
@@ -689,29 +773,34 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		cachedWriteTokensAbove1hr = cachedWriteTokens
 	}
 
-	// Input cost: non-cached tokens at regular rate
+	// Input cost components, tracked separately so the breakdown reports each
+	// category; together they sum to the input token cost.
 	nonCachedPrompt := promptTokens - cachedReadTokens - cachedWriteTokens
-	inputCost := float64(nonCachedPrompt) * inputRate
+	textInputCost := float64(nonCachedPrompt) * inputRate
 
-	// Add cached prompt tokens at cache read rate
+	cacheReadCost := 0.0
 	if cachedReadTokens > 0 {
-		inputCost += float64(cachedReadTokens) * cacheReadInputRate
+		cacheReadCost = float64(cachedReadTokens) * cacheReadInputRate
 	}
 
-	// Add cached write tokens at cache creation rate
+	cacheWriteCost := 0.0
 	if cachedWriteTokens > 0 {
 		if cachedWriteTokensAbove1hr > 0 {
-			inputCost += float64(cachedWriteTokensAbove1hr) * cacheCreationInputAbove1hrInputRate
+			cacheWriteCost += float64(cachedWriteTokensAbove1hr) * cacheCreationInputAbove1hrInputRate
 		}
-		inputCost += float64(cachedWriteTokens-cachedWriteTokensAbove1hr) * cacheCreationInputRate
+		cacheWriteCost += float64(cachedWriteTokens-cachedWriteTokensAbove1hr) * cacheCreationInputRate
 	}
 
-	outputCost := float64(completionTokens) * outputRate
+	textOutputCost := float64(completionTokens) * outputRate
 
-	// Audio token cost: when token details include audio tokens, price them
-	// at the dedicated audio rate and subtract from the text token costs above.
+	// Audio token cost: when token details include audio tokens, price them at
+	// the dedicated audio rate and drop them from the text token cost above.
 	// Realtime and audio-enabled chat models report audio tokens in details.
-	audioCost := 0.0
+	// AudioCost carries the full audio-token charge; TextCost keeps only
+	// non-audio tokens. The side totals are unchanged: what leaves TextCost at
+	// the text rate re-enters AudioCost at the audio rate.
+	inputAudioCost := 0.0
+	outputAudioCost := 0.0
 	inputAudioTokens := 0
 	outputAudioTokens := 0
 	if usage.PromptTokensDetails != nil {
@@ -731,14 +820,18 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		outputAudioTokens = completionTokens
 	}
 	if inputAudioTokens > 0 && pricing.InputCostPerAudioToken != nil {
-		// Subtract audio tokens charged at text rate, add at audio rate.
-		audioCost += float64(inputAudioTokens) * (*pricing.InputCostPerAudioToken - inputRate)
+		if inputAudioTokens > nonCachedPrompt {
+			inputAudioTokens = nonCachedPrompt
+		}
+		inputAudioCost = float64(inputAudioTokens) * *pricing.InputCostPerAudioToken
+		textInputCost -= float64(inputAudioTokens) * inputRate
 	}
 	if outputAudioTokens > 0 && pricing.OutputCostPerAudioToken != nil {
-		audioCost += float64(outputAudioTokens) * (*pricing.OutputCostPerAudioToken - outputRate)
+		outputAudioCost = float64(outputAudioTokens) * *pricing.OutputCostPerAudioToken
+		textOutputCost -= float64(outputAudioTokens) * outputRate
 	}
 
-	// Search query cost
+	// Search query cost (billed on the output side)
 	searchCost := 0.0
 	if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
 		searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
@@ -747,31 +840,59 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 	// Data residency (Anthropic inference_geo:"us") scales all token/cache costs
 	// by a flat multiplier; the per-search fee is not a token category, so it is
 	// excluded.
-	tokenCost := inputCost + outputCost + audioCost
 	if tier.inferenceGeoUS && pricing.InferenceGeoUSMultiplier != nil {
-		tokenCost *= *pricing.InferenceGeoUSMultiplier
+		m := *pricing.InferenceGeoUSMultiplier
+		textInputCost *= m
+		cacheReadCost *= m
+		cacheWriteCost *= m
+		inputAudioCost *= m
+		textOutputCost *= m
+		outputAudioCost *= m
 	}
 
-	return tokenCost + searchCost
+	inputCost := textInputCost + cacheReadCost + cacheWriteCost + inputAudioCost
+	outputCost := textOutputCost + outputAudioCost + searchCost
+
+	cost := &schemas.BifrostCost{
+		InputCost:  inputCost,
+		OutputCost: outputCost,
+		TotalCost:  inputCost + outputCost,
+	}
+	if textInputCost != 0 || inputAudioCost != 0 || cacheReadCost != 0 || cacheWriteCost != 0 {
+		cost.InputCostDetails = &schemas.InputCostDetails{
+			TextCost:        textInputCost,
+			AudioCost:       inputAudioCost,
+			CachedReadCost:  cacheReadCost,
+			CachedWriteCost: cacheWriteCost,
+		}
+	}
+	if textOutputCost != 0 || outputAudioCost != 0 || searchCost != 0 {
+		cost.OutputCostDetails = &schemas.OutputCostDetails{
+			TextCost:          textOutputCost,
+			AudioCost:         outputAudioCost,
+			SearchQueriesCost: searchCost,
+		}
+	}
+	return cost
 }
 
 // computeBatchTextCost handles token usage returned by batch result retrieval.
 // When the catalog has an explicit batch rate, that rate is used. When it does
 // not, the rate defaults to defaultBatchPricingRatio of the synchronous rate.
 // A model with neither rate is left unpriced.
-func computeBatchTextCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+func computeBatchTextCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) *schemas.BifrostCost {
 	if usage == nil {
-		return 0
+		return nil
 	}
 	// Falls back to defaultBatchPricingRatio of the standard rate when the
 	// catalog has no batch-specific rate; nil only when neither rate exists.
 	resolvedInputRate := resolveBatchRate(pricing.InputCostPerToken, pricing.InputCostPerTokenBatches)
 	resolvedOutputRate := resolveBatchRate(pricing.OutputCostPerToken, pricing.OutputCostPerTokenBatches)
 	if usage.PromptTokens > 0 && resolvedInputRate == nil {
-		return 0
+		return nil
 	}
 	if usage.CompletionTokens > 0 && resolvedOutputRate == nil {
-		return 0
+		return nil
 	}
 
 	inputCost := 0.0
@@ -868,26 +989,35 @@ func computeBatchTextCost(pricing *configstoreTables.TableModelPricing, usage *s
 
 	// Data residency (Anthropic inference_geo:"us") scales all token or cache costs
 	// by a flat multiplier, mirroring computeTextCost — batch and data residency
-	// are independent axes, so a batch request can still carry it.
-	tokenCost := inputCost + outputCost
+	// are independent axes, so a batch request can still carry it. Scale each side
+	// so the input/output split is preserved.
 	if tier.inferenceGeoUS && pricing.InferenceGeoUSMultiplier != nil {
-		tokenCost *= *pricing.InferenceGeoUSMultiplier
+		inputCost *= *pricing.InferenceGeoUSMultiplier
+		outputCost *= *pricing.InferenceGeoUSMultiplier
 	}
-	return tokenCost
+	return newInputOutputCost(inputCost, outputCost)
 }
 
 // computeEmbeddingCost handles embedding requests (input-only).
-func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) *schemas.BifrostCost {
 	if usage == nil {
-		return 0
+		return nil
 	}
-	return float64(usage.PromptTokens) * tieredInputRate(pricing, usage.PromptTokens, tier)
+	c := float64(usage.PromptTokens) * tieredInputRate(pricing, usage.PromptTokens, tier)
+	if c == 0 {
+		return nil
+	}
+	return &schemas.BifrostCost{
+		InputCost:        c,
+		InputCostDetails: &schemas.InputCostDetails{TextCost: c},
+		TotalCost:        c,
+	}
 }
 
 // computeRerankCost handles rerank requests.
-func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) *schemas.BifrostCost {
 	if usage == nil {
-		return 0
+		return nil
 	}
 	tierTokens := usage.PromptTokens
 	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
@@ -898,7 +1028,41 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 		searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
 	}
 
-	return inputCost + outputCost + searchCost
+	// Search queries are billed on the output side, matching computeTextCost.
+	outputTokensCost := outputCost + searchCost
+
+	var inputDetails *schemas.InputCostDetails
+	if inputCost != 0 {
+		inputDetails = &schemas.InputCostDetails{TextCost: inputCost}
+	}
+	var outputDetails *schemas.OutputCostDetails
+	if outputCost != 0 || searchCost != 0 {
+		outputDetails = &schemas.OutputCostDetails{TextCost: outputCost, SearchQueriesCost: searchCost}
+	}
+	return newInputOutputCostWithDetails(inputCost, outputTokensCost, inputDetails, outputDetails)
+}
+
+// newInputOutputCost builds a BifrostCost from separate input and output costs,
+// or returns nil when both are zero (nothing to record).
+func newInputOutputCost(inputCost, outputCost float64) *schemas.BifrostCost {
+	return newInputOutputCostWithDetails(inputCost, outputCost, nil, nil)
+}
+
+// newInputOutputCostWithDetails is newInputOutputCost with the nested per-category
+// breakdowns attached to each side. Details are passed through as-is (callers guard
+// them the same way computeTextCost does), so a nil side stays absent.
+func newInputOutputCostWithDetails(inputCost, outputCost float64, inputDetails *schemas.InputCostDetails, outputDetails *schemas.OutputCostDetails) *schemas.BifrostCost {
+	total := inputCost + outputCost
+	if total == 0 {
+		return nil
+	}
+	return &schemas.BifrostCost{
+		InputCost:         inputCost,
+		InputCostDetails:  inputDetails,
+		OutputCost:        outputCost,
+		OutputCostDetails: outputDetails,
+		TotalCost:         total,
+	}
 }
 
 // computeSpeechCost handles speech (TTS) requests.
@@ -909,7 +1073,7 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // input text rather than per token. PromptTokens from usage is treated as the character count
 // since TTS providers report their billable unit in that field.
 // Output falls back to per-second duration when no audio token rate is configured.
-func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) float64 {
+func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) *schemas.BifrostCost {
 	tierTokens := inputTierTokens(usage)
 
 	// Input: per-character rate takes precedence for TTS/audio models
@@ -927,13 +1091,22 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 	// Output: audio tokens first, then per-second fallback
 	outputCost := computeAudioOutputCost(pricing, usage, audioSeconds, tierTokens, tier)
 
-	return inputCost + outputCost
+	// Input is text (chars/tokens), output is audio.
+	var inputDetails *schemas.InputCostDetails
+	if inputCost != 0 {
+		inputDetails = &schemas.InputCostDetails{TextCost: inputCost}
+	}
+	var outputDetails *schemas.OutputCostDetails
+	if outputCost != 0 {
+		outputDetails = &schemas.OutputCostDetails{AudioCost: outputCost}
+	}
+	return newInputOutputCostWithDetails(inputCost, outputCost, inputDetails, outputDetails)
 }
 
 // computeTranscriptionCost handles transcription (STT) requests.
 // Input is audio, output is text (CompletionTokens).
 // Input and output are calculated independently — tokens first, then per-second fallback.
-func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
+func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) *schemas.BifrostCost {
 	tierTokens := inputTierTokens(usage)
 
 	// Input: audio tokens/details first, then per-second fallback
@@ -945,7 +1118,22 @@ func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usag
 		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 	}
 
-	return inputCost + outputCost
+	// Input is audio, output is text. When audio-token details carry a text-token
+	// portion (see computeAudioInputCost), split it out so AudioCost + TextCost
+	// reconcile with the authoritative input total.
+	var inputDetails *schemas.InputCostDetails
+	if inputCost != 0 {
+		textPortion := 0.0
+		if audioTokenDetails != nil && audioTokenDetails.TextTokens > 0 {
+			textPortion = float64(audioTokenDetails.TextTokens) * tieredInputRate(pricing, tierTokens, tier)
+		}
+		inputDetails = &schemas.InputCostDetails{AudioCost: inputCost - textPortion, TextCost: textPortion}
+	}
+	var outputDetails *schemas.OutputCostDetails
+	if outputCost != 0 {
+		outputDetails = &schemas.OutputCostDetails{TextCost: outputCost}
+	}
+	return newInputOutputCostWithDetails(inputCost, outputCost, inputDetails, outputDetails)
 }
 
 // computeAudioInputCost calculates input cost for audio: audio token details first,
@@ -994,9 +1182,9 @@ func computeAudioOutputCost(pricing *configstoreTables.TableModelPricing, usage 
 // Input and output are calculated independently — each tries token-based pricing first,
 // then per-pixel pricing, falling back to per-image count pricing.
 // imageQuality must be one of "low", "medium", "high", "auto" to use quality-specific rates; other values use base rates.
-func computeImageCost(pricing *configstoreTables.TableModelPricing, imageUsage *schemas.ImageUsage, imageSize string, imageQuality string, tier serviceTier) float64 {
+func computeImageCost(pricing *configstoreTables.TableModelPricing, imageUsage *schemas.ImageUsage, imageSize string, imageQuality string, tier serviceTier) *schemas.BifrostCost {
 	if imageUsage == nil {
-		return 0
+		return nil
 	}
 
 	tierTokens := imageInputTierTokens(imageUsage)
@@ -1004,7 +1192,7 @@ func computeImageCost(pricing *configstoreTables.TableModelPricing, imageUsage *
 	inputCost := computeImageInputCost(pricing, imageUsage, tierTokens, pixels, tier)
 	outputCost := computeImageOutputCost(pricing, imageUsage, tierTokens, pixels, imageQuality, tier)
 
-	return inputCost + outputCost
+	return newInputOutputCost(inputCost, outputCost)
 }
 
 // computeImageInputCost calculates input cost: tokens first, then per-pixel, then per-image count fallback.
@@ -1158,7 +1346,7 @@ func selectImageSizeTierRate(pricing *configstoreTables.TableModelPricing, pixel
 
 // computeVideoCost handles video generation requests.
 // Input and output are calculated independently — tokens first, then per-second fallback.
-func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, videoSeconds *int, tier serviceTier) float64 {
+func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, videoSeconds *int, tier serviceTier) *schemas.BifrostCost {
 	tierTokens := inputTierTokens(usage)
 
 	// Input: text prompt tokens first, then per-second fallback
@@ -1183,14 +1371,14 @@ func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schem
 		}
 	}
 
-	return inputCost + outputCost
+	return newInputOutputCost(inputCost, outputCost)
 }
 
 // computeOCRCost handles OCR requests, billing per page processed.
 // ocr_cost_per_page covers base processing; annotation_cost_per_page is added when set.
-func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPages *int, ocrIsAnnotated *bool) float64 {
+func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPages *int, ocrIsAnnotated *bool) *schemas.BifrostCost {
 	if ocrProcessedPages == nil {
-		return 0
+		return nil
 	}
 	pages := float64(*ocrProcessedPages)
 	cost := 0.0
@@ -1200,7 +1388,24 @@ func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPa
 	if ocrIsAnnotated != nil && *ocrIsAnnotated && pricing.AnnotationCostPerPage != nil {
 		cost += pages * *pricing.AnnotationCostPerPage
 	}
-	return cost
+	// OCR is billed per page, not per input/output token, so the flat charge
+	// folds onto the input side as a request cost.
+	return totalOnlyCost(cost)
+}
+
+
+// totalOnlyCost wraps a non-token-based cost (per-page, per-session) into a
+// BifrostCost, folding it onto the input side as a flat request cost, or nil
+// when there is nothing to record.
+func totalOnlyCost(c float64) *schemas.BifrostCost {
+	if c == 0 {
+		return nil
+	}
+	return &schemas.BifrostCost{
+		InputCost:        c,
+		InputCostDetails: &schemas.InputCostDetails{RequestCost: c},
+		TotalCost:        c,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -101,6 +101,49 @@ func derefF(f *float64) float64 {
 	return *f
 }
 
+// The compute* functions return a per-category cost breakdown
+// (*schemas.BifrostCost). These *Total wrappers return just the aggregate cost
+// for the many unit tests that assert on the total; tests that care about the
+// input/output/cache split assert on the breakdown object directly.
+func bcTotal(bd *schemas.BifrostCost) float64 {
+	if bd == nil {
+		return 0
+	}
+	return bd.TotalCost
+}
+
+func computeTextCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+	return bcTotal(computeTextCost(pricing, usage, tier))
+}
+
+func computeEmbeddingCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+	return bcTotal(computeEmbeddingCost(pricing, usage, tier))
+}
+
+func computeRerankCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+	return bcTotal(computeRerankCost(pricing, usage, tier))
+}
+
+func computeSpeechCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) float64 {
+	return bcTotal(computeSpeechCost(pricing, usage, audioSeconds, audioTextInputChars, tier))
+}
+
+func computeTranscriptionCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
+	return bcTotal(computeTranscriptionCost(pricing, usage, audioSeconds, audioTokenDetails, tier))
+}
+
+func computeImageCostTotal(pricing *configstoreTables.TableModelPricing, imageUsage *schemas.ImageUsage, imageSize string, imageQuality string, tier serviceTier) float64 {
+	return bcTotal(computeImageCost(pricing, imageUsage, imageSize, imageQuality, tier))
+}
+
+func computeVideoCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, videoSeconds *int, tier serviceTier) float64 {
+	return bcTotal(computeVideoCost(pricing, usage, videoSeconds, tier))
+}
+
+func computeContainerCreationCostTotal(pricing *configstoreTables.TableModelPricing) float64 {
+	return bcTotal(computeContainerCreationCost(pricing))
+}
+
 // =========================================================================
 // 1. computeTextCost — unit tests (pure function, no catalog)
 // =========================================================================
@@ -113,20 +156,20 @@ func TestComputeTextCost_BasicInputOutput(t *testing.T) {
 		CompletionTokens: 500,
 		TotalTokens:      1500,
 	}
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 	// 1000 * 0.000005 + 500 * 0.000015 = 0.005 + 0.0075 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
 
 func TestComputeTextCost_NilUsage(t *testing.T) {
 	p := chatPricing(0.000005, 0.000015)
-	assert.Equal(t, 0.0, computeTextCost(&p, nil, serviceTier{}))
+	assert.Equal(t, 0.0, computeTextCostTotal(&p, nil, serviceTier{}))
 }
 
 func TestComputeTextCost_ZeroTokens(t *testing.T) {
 	p := chatPricing(0.000005, 0.000015)
 	usage := &schemas.BifrostLLMUsage{}
-	assert.Equal(t, 0.0, computeTextCost(&p, usage, serviceTier{}))
+	assert.Equal(t, 0.0, computeTextCostTotal(&p, usage, serviceTier{}))
 }
 
 func TestComputeTextCost_WithCachedPromptTokens(t *testing.T) {
@@ -145,7 +188,7 @@ func TestComputeTextCost_WithCachedPromptTokens(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Both cached read and write tokens are input-side deductions from promptTokens.
 	// Input: (2000-1500-200)*0.000003 + 1500*0.0000003 + 200*0.00000375 = 0.0009 + 0.00045 + 0.00075 = 0.0021
@@ -193,7 +236,7 @@ func TestComputeTextCost_GPT56_StandardCacheWrite(t *testing.T) {
 			CachedWriteTokens: 28003,
 		},
 	}
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 	// input: (28006-28003)*0.000005 = 0.000015
 	// write: 28003*0.00000625 = 0.17501875
 	// output: 443*0.00003 = 0.01329
@@ -208,7 +251,7 @@ func TestComputeTextCost_GPT56_StandardCacheWriteAbove272k(t *testing.T) {
 		TotalTokens:         301000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedWriteTokens: 100000},
 	}
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 	// input: 200000*0.00001 = 2.0; write: 100000*0.0000125 = 1.25; output: 1000*0.000045 = 0.045
 	assert.InDelta(t, 2.0+1.25+0.045, cost, 1e-9)
 }
@@ -224,7 +267,7 @@ func TestComputeTextCost_GPT56_FlexTier(t *testing.T) {
 			CachedWriteTokens: 2000,
 		},
 	}
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 	// input: 4000*0.0000025 = 0.01; read: 4000*0.00000025 = 0.001
 	// write: 2000*0.000003125 = 0.00625; output: 1000*0.000015 = 0.015
 	assert.InDelta(t, 0.01+0.001+0.00625+0.015, cost, 1e-12)
@@ -241,7 +284,7 @@ func TestComputeTextCost_GPT56_FlexTierAbove272k(t *testing.T) {
 			CachedWriteTokens: 50000,
 		},
 	}
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 	// input: 150000*0.000005 = 0.75; read: 100000*0.0000005 = 0.05
 	// write: 50000*0.00000625 = 0.3125; output: 1000*0.0000225 = 0.0225
 	assert.InDelta(t, 0.75+0.05+0.3125+0.0225, cost, 1e-9)
@@ -258,7 +301,7 @@ func TestComputeTextCost_GPT56_PriorityTier(t *testing.T) {
 			CachedWriteTokens: 2000,
 		},
 	}
-	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 	// input: 4000*0.00001 = 0.04; read: 4000*0.000001 = 0.004
 	// write: 2000*0.0000125 = 0.025; output: 1000*0.00006 = 0.06
 	assert.InDelta(t, 0.04+0.004+0.025+0.06, cost, 1e-12)
@@ -270,8 +313,134 @@ func TestComputeTextCost_FlexFlatAbove272kWhenNoFlexTierColumn(t *testing.T) {
 	p := chatPricing(0.000005, 0.00003)
 	p.InputCostPerTokenFlex = bifrost.Ptr(0.0000025)
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 300000, TotalTokens: 300000}
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 	assert.InDelta(t, 300000*0.0000025, cost, 1e-9)
+}
+
+// TestComputeTextCost_Breakdown asserts the per-category split (input / output /
+// cache) that computeTextCost now returns, with cache reads as a subset of input.
+func TestComputeTextCost_Breakdown(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.CacheReadInputTokenCost = bifrost.Ptr(0.0000003)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  1500,
+			CachedWriteTokens: 200,
+		},
+	}
+
+	bd := computeTextCost(&p, usage, serviceTier{})
+	require.NotNil(t, bd)
+
+	// Input: (2000-1500-200)*3e-6 + 1500*3e-7 + 200*3.75e-6 = 0.0009 + 0.00045 + 0.00075 = 0.0021
+	assert.InDelta(t, 0.0021, bd.InputCost, 1e-12)
+	// Output: 500*1.5e-5 = 0.0075
+	assert.InDelta(t, 0.0075, bd.OutputCost, 1e-12)
+	// Cache read/write are input sub-categories surfaced in the details.
+	require.NotNil(t, bd.InputCostDetails)
+	assert.InDelta(t, 0.00045, bd.InputCostDetails.CachedReadCost, 1e-12) // 1500*3e-7
+	assert.InDelta(t, 0.00075, bd.InputCostDetails.CachedWriteCost, 1e-12) // 200*3.75e-6
+	// Detail components sum back to the input total.
+	assert.InDelta(t, bd.InputCost,
+		bd.InputCostDetails.TextCost+bd.InputCostDetails.CachedReadCost+bd.InputCostDetails.CachedWriteCost+bd.InputCostDetails.AudioCost, 1e-12)
+	// Total is input + output.
+	assert.InDelta(t, 0.0096, bd.TotalCost, 1e-12)
+	assert.InDelta(t, bd.InputCost+bd.OutputCost, bd.TotalCost, 1e-12)
+}
+
+// TestComputeTextCost_AudioBreakdown asserts audio tokens are charged in full at
+// the audio rate under AudioCost (never a negative rate delta), TextCost keeps
+// only non-audio tokens, and the side totals are unchanged whether the audio
+// rate is above or below the text rate.
+func TestComputeTextCost_AudioBreakdown(t *testing.T) {
+	const inputRate, outputRate = 0.000003, 0.000015
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 400,
+		TotalTokens:      2400,
+		PromptTokensDetails:     &schemas.ChatPromptTokensDetails{AudioTokens: 500},
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{AudioTokens: 100},
+	}
+
+	t.Run("audio rate above text rate", func(t *testing.T) {
+		p := chatPricing(inputRate, outputRate)
+		p.InputCostPerAudioToken = bifrost.Ptr(0.00001)
+		p.OutputCostPerAudioToken = bifrost.Ptr(0.00002)
+
+		bd := computeTextCost(&p, usage, serviceTier{})
+		require.NotNil(t, bd)
+		require.NotNil(t, bd.InputCostDetails)
+		require.NotNil(t, bd.OutputCostDetails)
+
+		// Input: 1500 text @ 3e-6 + 500 audio @ 1e-5.
+		assert.InDelta(t, 0.0045, bd.InputCostDetails.TextCost, 1e-12)
+		assert.InDelta(t, 0.005, bd.InputCostDetails.AudioCost, 1e-12)
+		assert.InDelta(t, 0.0095, bd.InputCost, 1e-12)
+		// Output: 300 text @ 1.5e-5 + 100 audio @ 2e-5.
+		assert.InDelta(t, 0.0045, bd.OutputCostDetails.TextCost, 1e-12)
+		assert.InDelta(t, 0.002, bd.OutputCostDetails.AudioCost, 1e-12)
+		assert.InDelta(t, 0.0065, bd.OutputCost, 1e-12)
+		// Details reconcile with the side totals.
+		assert.InDelta(t, bd.InputCost, bd.InputCostDetails.TextCost+bd.InputCostDetails.AudioCost, 1e-12)
+		assert.InDelta(t, bd.OutputCost, bd.OutputCostDetails.TextCost+bd.OutputCostDetails.AudioCost, 1e-12)
+	})
+
+	t.Run("audio rate below text rate stays non-negative", func(t *testing.T) {
+		p := chatPricing(inputRate, outputRate)
+		p.InputCostPerAudioToken = bifrost.Ptr(0.000001)  // below input text rate
+		p.OutputCostPerAudioToken = bifrost.Ptr(0.000005) // below output text rate
+
+		bd := computeTextCost(&p, usage, serviceTier{})
+		require.NotNil(t, bd)
+		require.NotNil(t, bd.InputCostDetails)
+		require.NotNil(t, bd.OutputCostDetails)
+
+		// AudioCost is the full audio-token charge, never a negative delta.
+		assert.InDelta(t, 0.0005, bd.InputCostDetails.AudioCost, 1e-12) // 500 * 1e-6
+		assert.InDelta(t, 0.0045, bd.InputCostDetails.TextCost, 1e-12)  // 1500 * 3e-6
+		assert.GreaterOrEqual(t, bd.InputCostDetails.AudioCost, 0.0)
+		assert.GreaterOrEqual(t, bd.OutputCostDetails.AudioCost, 0.0)
+		// Side totals match the delta-based aggregate they replaced.
+		assert.InDelta(t, 0.005, bd.InputCost, 1e-12) // 2000*3e-6 + 500*(1e-6 - 3e-6)
+		assert.InDelta(t, bd.InputCost, bd.InputCostDetails.TextCost+bd.InputCostDetails.AudioCost, 1e-12)
+		assert.InDelta(t, bd.OutputCost, bd.OutputCostDetails.TextCost+bd.OutputCostDetails.AudioCost, 1e-12)
+	})
+
+	t.Run("audio overlapping cached tokens keeps TextCost non-negative", func(t *testing.T) {
+		// Audio (500) exceeds the non-cached prompt (1000-700=300). Without the
+		// clamp, textInputCost would subtract 500 tokens it never held and go
+		// negative, understating InputCost/TotalCost.
+		u := &schemas.BifrostLLMUsage{
+			PromptTokens: 1000,
+			TotalTokens:  1000,
+			PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+				CachedReadTokens: 700,
+				AudioTokens:      500,
+			},
+		}
+		p := chatPricing(inputRate, outputRate)
+		p.InputCostPerAudioToken = bifrost.Ptr(0.00001)
+		p.CacheReadInputTokenCost = bifrost.Ptr(0.000001)
+
+		bd := computeTextCost(&p, u, serviceTier{})
+		require.NotNil(t, bd)
+		require.NotNil(t, bd.InputCostDetails)
+
+		// Audio clamps to the 300 non-cached tokens, so text drops to 0 (float
+		// subtraction leaves only rounding noise, never the -6e-4 the bug produced).
+		assert.GreaterOrEqual(t, bd.InputCostDetails.TextCost, -1e-12)
+		assert.InDelta(t, 0.0, bd.InputCostDetails.TextCost, 1e-12) // 300*3e-6 - 300*3e-6
+		assert.InDelta(t, 0.003, bd.InputCostDetails.AudioCost, 1e-12)      // 300 * 1e-5
+		assert.InDelta(t, 0.0007, bd.InputCostDetails.CachedReadCost, 1e-12) // 700 * 1e-6
+		assert.InDelta(t, 0.0037, bd.InputCost, 1e-12)
+		assert.InDelta(t, bd.InputCost,
+			bd.InputCostDetails.TextCost+bd.InputCostDetails.AudioCost+bd.InputCostDetails.CachedReadCost, 1e-12)
+	})
 }
 
 func TestComputeTextCost_FastMode(t *testing.T) {
@@ -287,11 +456,11 @@ func TestComputeTextCost_FastMode(t *testing.T) {
 	}
 
 	// Standard speed → standard rates.
-	standard := computeTextCost(&p, usage, serviceTier{})
+	standard := computeTextCostTotal(&p, usage, serviceTier{})
 	assert.InDelta(t, 1000*0.000005+500*0.000025, standard, 1e-12)
 
 	// Fast speed → fast rates.
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	assert.InDelta(t, 1000*0.00001+500*0.00005, fast, 1e-12)
 }
 
@@ -309,7 +478,7 @@ func TestComputeTextCost_FastMode_FlatAcrossContextWindow(t *testing.T) {
 		TotalTokens:      251000, // above the 200k tier
 	}
 
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	// Flat fast rate, not the above-200k rate.
 	assert.InDelta(t, 250000*0.00001+1000*0.00005, fast, 1e-9)
 }
@@ -322,7 +491,7 @@ func TestComputeTextCost_FastMode_FallsBackWhenUnconfigured(t *testing.T) {
 		CompletionTokens: 500,
 		TotalTokens:      1500,
 	}
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	assert.InDelta(t, 1000*0.000005+500*0.000025, fast, 1e-12)
 }
 
@@ -347,7 +516,7 @@ func TestComputeTextCost_FastMode_UsesFastCacheRates(t *testing.T) {
 		},
 	}
 
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	// non-cached 300*fast + read 1500*fastRead + write 200*fastWrite + output 500*fast
 	expected := 300*0.00001 + 1500*0.000001 + 200*0.0000125 + 500*0.00005
 	assert.InDelta(t, expected, fast, 1e-12)
@@ -372,7 +541,7 @@ func TestComputeTextCost_FastMode_CacheFallsBackToStandardWhenFastUnset(t *testi
 		},
 	}
 
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	// input/output use fast; cache uses standard.
 	expected := 300*0.00001 + 1500*0.0000005 + 200*0.00000625 + 500*0.00005
 	assert.InDelta(t, expected, fast, 1e-12)
@@ -402,7 +571,7 @@ func TestComputeTextCost_FastMode_Opus48CacheRegression(t *testing.T) {
 		},
 	}
 
-	fast := computeTextCost(&p, usage, serviceTier{isFast: true})
+	fast := computeTextCostTotal(&p, usage, serviceTier{isFast: true})
 	// 2*$10/M + 44667*$12.50/M (fast 5m cache) + 135*$50/M = $0.565108
 	expected := 2*0.00001 + 44667*0.0000125 + 135*0.00005
 	assert.InDelta(t, expected, fast, 1e-9)
@@ -433,11 +602,11 @@ func TestComputeTextCost_InferenceGeoUS_AppliesMultiplier(t *testing.T) {
 	tokenCost := 500*0.00001 + 200*0.000001 + 300*0.0000125 + 100*0.00005
 	searchCost := 2 * 0.01
 
-	got := computeTextCost(&p, usage, serviceTier{inferenceGeoUS: true})
+	got := computeTextCostTotal(&p, usage, serviceTier{inferenceGeoUS: true})
 	assert.InDelta(t, tokenCost*1.1+searchCost, got, 1e-9)
 
 	// Without US residency the multiplier is a no-op; the search fee is identical.
-	base := computeTextCost(&p, usage, serviceTier{})
+	base := computeTextCostTotal(&p, usage, serviceTier{})
 	assert.InDelta(t, tokenCost+searchCost, base, 1e-9)
 }
 
@@ -446,8 +615,8 @@ func TestComputeTextCost_InferenceGeoUS_AppliesMultiplier(t *testing.T) {
 func TestComputeTextCost_InferenceGeoUS_NoMultiplierColumn(t *testing.T) {
 	p := chatPricing(0.00001, 0.00005)
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 100}
-	withUS := computeTextCost(&p, usage, serviceTier{inferenceGeoUS: true})
-	without := computeTextCost(&p, usage, serviceTier{})
+	withUS := computeTextCostTotal(&p, usage, serviceTier{inferenceGeoUS: true})
+	without := computeTextCostTotal(&p, usage, serviceTier{})
 	assert.InDelta(t, without, withUS, 1e-9)
 }
 
@@ -484,7 +653,7 @@ func TestComputeTextCost_With1hrCacheCreationTokens(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Input (non-cached): (2000-1000)*0.000003 = 0.003
 	// Cache creation (1hr): 600*0.0000075 = 0.0045
@@ -520,8 +689,8 @@ func TestComputeTextCost_StandardCacheCreationPricingLesserThan1hr(t *testing.T)
 		},
 	}
 
-	costStandard := computeTextCost(&p, &usageStandard, serviceTier{})
-	cost1hr := computeTextCost(&p, &usage1hr, serviceTier{})
+	costStandard := computeTextCostTotal(&p, &usageStandard, serviceTier{})
+	cost1hr := computeTextCostTotal(&p, &usage1hr, serviceTier{})
 
 	assert.Less(t, costStandard, cost1hr, "standard cache creation should cost less than 1hr cache creation")
 }
@@ -546,7 +715,7 @@ func TestComputeTextCost_1hrCacheCreationFallsBackToStandardWhenAbove1hrRateAbse
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Input (non-cached): (2000-1000)*8e-7 = 0.0008
 	// Cache creation (1hr fallback → standard 0.000001): 1000*0.000001 = 0.001
@@ -572,7 +741,7 @@ func TestComputeTextCost_CacheWriteTokenDetailsNil_FallsBackToStandardCreationRa
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Input (non-cached): (2000-1000)*0.000003 = 0.003
 	// Cache creation (standard, no 1hr details): 1000*0.00000375 = 0.00375
@@ -600,7 +769,7 @@ func TestComputeTextCost_CacheWriteTokenDetails1hZero_FallsBackToStandardCreatio
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Input (non-cached): (2000-1000)*0.000003 = 0.003
 	// Cache creation (standard, 1h count is 0): 1000*0.00000375 = 0.00375
@@ -633,7 +802,7 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Input rate (>200k): 0.000006; output rate (>200k): 0.00003
 	// Input (non-cached): (210000-10000)*0.000006 = 200000*0.000006 = 1.20
@@ -667,7 +836,7 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove2
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Cache creation 1hr (no above_200k_1hr rate, uses above_1hr): 10000*0.000009 = 0.09
 	// Input (non-cached): 200000*0.000006 = 1.20
@@ -698,7 +867,7 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kW
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Cache creation (1hr → no 1hr rates → standard above_200k): 10000*0.000002 = 0.02
 	// Input (non-cached): 200000*0.0000016 = 0.32
@@ -719,7 +888,7 @@ func TestComputeTextCost_Tiered200k(t *testing.T) {
 		TotalTokens:      240000, // input is above 200k threshold
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses tiered rate since input > 200k
 	// 210000 * 0.000006 + 30000 * 0.00003 = 1.26 + 0.90 = 2.16
@@ -737,7 +906,7 @@ func TestComputeTextCost_Below200kUsesBaseRate(t *testing.T) {
 		TotalTokens:      1500, // Below 200k
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses base rate since input < 200k
 	// 1000 * 0.000003 + 500 * 0.000015 = 0.003 + 0.0075 = 0.0105
@@ -755,7 +924,7 @@ func TestComputeTextCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.
 		TotalTokens:      210000, // total is above 200k, input is not
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses base rates because long-context tiers are selected by input tokens.
 	// 180000 * 0.000003 + 30000 * 0.000015 = 0.54 + 0.45 = 0.99
@@ -775,7 +944,7 @@ func TestComputeTextCost_Tiered272k(t *testing.T) {
 		TotalTokens:      310000, // input is above 272k threshold
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses 272k tiered rate since input > 272k
 	// 280000 * 0.000009 + 30000 * 0.000045 = 2.52 + 1.35 = 3.87
@@ -795,7 +964,7 @@ func TestComputeTextCost_Between200kAnd272kUses200kRate(t *testing.T) {
 		TotalTokens:      260000, // input is between 200k and 272k
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses 200k tiered rate since input > 200k but <= 272k
 	// 230000 * 0.000006 + 30000 * 0.00003 = 1.38 + 0.90 = 2.28
@@ -818,7 +987,7 @@ func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Non-cached input: (280000-50000) * 0.000009 = 230000 * 0.000009 = 2.07
 	// Cached read: 50000 * 0.0000009 = 0.045
@@ -841,7 +1010,7 @@ func TestComputeTextCost_SearchQueryCost(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// 1000*0.000003 + 500*0.000015 + 3*0.01 = 0.003 + 0.0075 + 0.03 = 0.0405
 	assert.InDelta(t, 0.0405, cost, 1e-12)
@@ -860,7 +1029,7 @@ func TestComputeTextCost_NoCacheRateFallsBackToBaseInputRate(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Non-cached prompt: (1000-400)*0.000005 = 600*0.000005 = 0.003
 	// Cached prompt: 400 tokens at base input rate (no cache rate set) = 400*0.000005 = 0.002
@@ -883,7 +1052,7 @@ func TestComputeEmbeddingCost_Basic(t *testing.T) {
 		PromptTokens: 5000,
 		TotalTokens:  5000,
 	}
-	cost := computeEmbeddingCost(&p, usage, serviceTier{})
+	cost := computeEmbeddingCostTotal(&p, usage, serviceTier{})
 	// 5000 * 0.0000001 = 0.0005
 	assert.InDelta(t, 0.0005, cost, 1e-12)
 }
@@ -898,14 +1067,14 @@ func TestComputeEmbeddingCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *tes
 		TotalTokens:  210000,
 	}
 
-	cost := computeEmbeddingCost(&p, usage, serviceTier{})
+	cost := computeEmbeddingCostTotal(&p, usage, serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003, cost, 1e-9)
 }
 
 func TestComputeEmbeddingCost_NilUsage(t *testing.T) {
 	p := configstoreTables.TableModelPricing{InputCostPerToken: new(0.0000001)}
-	assert.Equal(t, 0.0, computeEmbeddingCost(&p, nil, serviceTier{}))
+	assert.Equal(t, 0.0, computeEmbeddingCostTotal(&p, nil, serviceTier{}))
 }
 
 // =========================================================================
@@ -922,7 +1091,7 @@ func TestComputeRerankCost_Basic(t *testing.T) {
 		CompletionTokens: 100,
 		TotalTokens:      2100,
 	}
-	cost := computeRerankCost(&p, usage, serviceTier{})
+	cost := computeRerankCostTotal(&p, usage, serviceTier{})
 	// 2000*0.000001 + 100*0.000002 = 0.002 + 0.0002 = 0.0022
 	assert.InDelta(t, 0.0022, cost, 1e-12)
 }
@@ -937,7 +1106,7 @@ func TestComputeRerankCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testin
 		TotalTokens:      210000,
 	}
 
-	cost := computeRerankCost(&p, usage, serviceTier{})
+	cost := computeRerankCostTotal(&p, usage, serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
@@ -954,13 +1123,125 @@ func TestComputeRerankCost_WithSearchCost(t *testing.T) {
 			NumSearchQueries: &numQueries,
 		},
 	}
-	cost := computeRerankCost(&p, usage, serviceTier{})
+	cost := computeRerankCostTotal(&p, usage, serviceTier{})
 	assert.InDelta(t, 0.005, cost, 1e-12)
+}
+
+// TestComputeRerankCost_BreakdownDetails asserts rerank surfaces the output-side
+// SearchQueriesCost (billed on output, matching computeTextCost) rather than
+// folding it into a bare OutputCost total.
+func TestComputeRerankCost_BreakdownDetails(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		InputCostPerToken:         bifrost.Ptr(0.001),
+		OutputCostPerToken:        bifrost.Ptr(0.002),
+		SearchContextCostPerQuery: bifrost.Ptr(0.001),
+	}
+	numQueries := 3
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     10,
+		CompletionTokens: 5,
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+			NumSearchQueries: &numQueries,
+		},
+	}
+	cost := computeRerankCost(&p, usage, serviceTier{})
+	require.NotNil(t, cost)
+	require.NotNil(t, cost.InputCostDetails)
+	require.NotNil(t, cost.OutputCostDetails)
+	assert.InDelta(t, 0.01, cost.InputCost, 1e-12)             // 10 * 0.001
+	assert.InDelta(t, 0.013, cost.OutputCost, 1e-12)           // 5*0.002 + 3*0.001
+	assert.InDelta(t, 0.023, cost.TotalCost, 1e-12)            // input + output
+	assert.InDelta(t, 0.01, cost.InputCostDetails.TextCost, 1e-12)
+	assert.InDelta(t, 0.01, cost.OutputCostDetails.TextCost, 1e-12)
+	assert.InDelta(t, 0.003, cost.OutputCostDetails.SearchQueriesCost, 1e-12)
+}
+
+// TestComputeSpeechCost_BreakdownDetails asserts TTS splits text input / audio output.
+func TestComputeSpeechCost_BreakdownDetails(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		InputCostPerToken:       bifrost.Ptr(0.000001),
+		OutputCostPerAudioToken: bifrost.Ptr(0.00005),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     200,
+		CompletionTokens: 100,
+		TotalTokens:      300,
+	}
+	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{})
+	require.NotNil(t, cost)
+	require.NotNil(t, cost.InputCostDetails)
+	require.NotNil(t, cost.OutputCostDetails)
+	assert.InDelta(t, 0.0002, cost.InputCostDetails.TextCost, 1e-12) // 200 * 0.000001
+	assert.InDelta(t, 0.005, cost.OutputCostDetails.AudioCost, 1e-12) // 100 * 0.00005
+	assert.Zero(t, cost.OutputCostDetails.TextCost)
+}
+
+// TestComputeTranscriptionCost_BreakdownDetails asserts STT splits audio input / text
+// output, and that a mixed audio+text input reconciles AudioCost + TextCost to the total.
+func TestComputeTranscriptionCost_BreakdownDetails(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		InputCostPerToken:      bifrost.Ptr(0.000005),
+		OutputCostPerToken:     bifrost.Ptr(0.000015),
+		InputCostPerAudioToken: bifrost.Ptr(0.00001),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+	}
+	audioDetails := &schemas.TranscriptionUsageInputTokenDetails{
+		AudioTokens: 1500,
+		TextTokens:  500,
+	}
+	cost := computeTranscriptionCost(&p, usage, nil, audioDetails, serviceTier{})
+	require.NotNil(t, cost)
+	require.NotNil(t, cost.InputCostDetails)
+	require.NotNil(t, cost.OutputCostDetails)
+	assert.InDelta(t, 0.015, cost.InputCostDetails.AudioCost, 1e-12) // 1500 * 0.00001
+	assert.InDelta(t, 0.0025, cost.InputCostDetails.TextCost, 1e-12) // 500 * 0.000005
+	assert.InDelta(t, 0.0075, cost.OutputCostDetails.TextCost, 1e-12) // 500 * 0.000015
+	// Details reconcile with the authoritative side totals.
+	assert.InDelta(t, cost.InputCost, cost.InputCostDetails.AudioCost+cost.InputCostDetails.TextCost, 1e-12)
 }
 
 func TestComputeRerankCost_NilUsage(t *testing.T) {
 	p := configstoreTables.TableModelPricing{InputCostPerToken: new(0.001)}
-	assert.Equal(t, 0.0, computeRerankCost(&p, nil, serviceTier{}))
+	assert.Equal(t, 0.0, computeRerankCostTotal(&p, nil, serviceTier{}))
+}
+
+// TestComputeCost_MultiModalBreakdown asserts that non-text modalities also
+// populate the input/output split (not just the total), so per-model quota
+// aggregation attributes their cost to the right buckets. Cache stays text-only.
+func TestComputeCost_MultiModalBreakdown(t *testing.T) {
+	// Embedding: input-only — the whole cost lands in InputTokensCost.
+	embPricing := configstoreTables.TableModelPricing{InputCostPerToken: bifrost.Ptr(0.0000001)}
+	emb := computeEmbeddingCost(&embPricing, &schemas.BifrostLLMUsage{PromptTokens: 5000, TotalTokens: 5000}, serviceTier{})
+	require.NotNil(t, emb)
+	assert.InDelta(t, 0.0005, emb.InputCost, 1e-12)
+	assert.Zero(t, emb.OutputCost)
+	assert.InDelta(t, emb.InputCost, emb.TotalCost, 1e-12)
+
+	// Rerank: input + output, and search queries billed on the output side.
+	rerankPricing := chatPricing(0.000002, 0.000004)
+	rr := computeRerankCost(&rerankPricing, &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500,
+	}, serviceTier{})
+	require.NotNil(t, rr)
+	assert.InDelta(t, 1000*0.000002, rr.InputCost, 1e-12)
+	assert.InDelta(t, 500*0.000004, rr.OutputCost, 1e-12)
+	assert.InDelta(t, rr.InputCost+rr.OutputCost, rr.TotalCost, 1e-12)
+
+	// Image: input + output tokens split.
+	imgPricing := chatPricing(0.000002, 0.000008)
+	img := computeImageCost(&imgPricing, &schemas.ImageUsage{
+		InputTokens:  1000,
+		OutputTokens: 200,
+		TotalTokens:  1200,
+	}, "", "", serviceTier{})
+	require.NotNil(t, img)
+	assert.InDelta(t, 1000*0.000002, img.InputCost, 1e-12)
+	assert.InDelta(t, 200*0.000008, img.OutputCost, 1e-12)
+	assert.InDelta(t, img.InputCost+img.OutputCost, img.TotalCost, 1e-12)
 }
 
 // =========================================================================
@@ -980,7 +1261,7 @@ func TestComputeSpeechCost_TokensPreferredOverDuration(t *testing.T) {
 		CompletionTokens: 200,
 		TotalTokens:      300,
 	}
-	cost := computeSpeechCost(&p, usage, &seconds, 0, serviceTier{})
+	cost := computeSpeechCostTotal(&p, usage, &seconds, 0, serviceTier{})
 	// Input: 100 text tokens * $0.0000025 = $0.00025
 	// Output: 200 audio tokens present → uses token rate $0.00001, NOT per-second
 	//         200 * $0.00001 = $0.002
@@ -997,7 +1278,7 @@ func TestComputeSpeechCost_OutputFallsBackToPerSecond(t *testing.T) {
 	}
 	seconds := 120
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 500}
-	cost := computeSpeechCost(&p, usage, &seconds, 0, serviceTier{})
+	cost := computeSpeechCostTotal(&p, usage, &seconds, 0, serviceTier{})
 	// Input: 500 * $0.000001 = $0.0005
 	// Output: no CompletionTokens → falls back to 120 * $0.0001 = $0.012
 	// Total: $0.0125
@@ -1016,7 +1297,7 @@ func TestComputeSpeechCost_OutputAudioTokenRate(t *testing.T) {
 		CompletionTokens: 100,
 		TotalTokens:      300,
 	}
-	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{})
+	cost := computeSpeechCostTotal(&p, usage, nil, 0, serviceTier{})
 	// Input: 200 * $0.000001 = $0.0002
 	// Output: 100 * $0.00005 = $0.005 (OutputCostPerAudioToken preferred)
 	// Total: $0.0052
@@ -1030,7 +1311,7 @@ func TestComputeSpeechCost_TokenFallback(t *testing.T) {
 		CompletionTokens: 500,
 		TotalTokens:      1500,
 	}
-	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{}) // No audio seconds → token fallback
+	cost := computeSpeechCostTotal(&p, usage, nil, 0, serviceTier{}) // No audio seconds → token fallback
 	// 1000*0.000005 + 500*0.000015 = 0.005 + 0.0075 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
@@ -1045,14 +1326,14 @@ func TestComputeSpeechCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testin
 		TotalTokens:      210000,
 	}
 
-	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{})
+	cost := computeSpeechCostTotal(&p, usage, nil, 0, serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeSpeechCost_NilUsageNilSeconds(t *testing.T) {
 	p := chatPricing(0.000005, 0.000015)
-	assert.Equal(t, 0.0, computeSpeechCost(&p, nil, nil, 0, serviceTier{}))
+	assert.Equal(t, 0.0, computeSpeechCostTotal(&p, nil, nil, 0, serviceTier{}))
 }
 
 // =========================================================================
@@ -1067,7 +1348,7 @@ func TestComputeTranscriptionCost_DurationBased(t *testing.T) {
 		InputCostPerSecond: bifrost.Ptr(0.00010278),
 	}
 	seconds := 300 // 5 minutes
-	cost := computeTranscriptionCost(&p, nil, &seconds, nil, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, nil, &seconds, nil, serviceTier{})
 	// 300 * 0.00010278 = 0.030834
 	assert.InDelta(t, 0.030834, cost, 1e-9)
 }
@@ -1087,7 +1368,7 @@ func TestComputeTranscriptionCost_AudioTokenDetails(t *testing.T) {
 		AudioTokens: 1500,
 		TextTokens:  500,
 	}
-	cost := computeTranscriptionCost(&p, usage, nil, audioDetails, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, usage, nil, audioDetails, serviceTier{})
 	// Audio: 1500*0.00001 = 0.015
 	// Text:  500*0.000005 = 0.0025
 	// Output: 500*0.000015 = 0.0075
@@ -1102,7 +1383,7 @@ func TestComputeTranscriptionCost_TokenFallback(t *testing.T) {
 		CompletionTokens: 200,
 		TotalTokens:      1200,
 	}
-	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, usage, nil, nil, serviceTier{})
 	// 1000*0.000005 + 200*0.000015 = 0.005 + 0.003 = 0.008
 	assert.InDelta(t, 0.008, cost, 1e-12)
 }
@@ -1117,7 +1398,7 @@ func TestComputeTranscriptionCost_TotalAbove200kButInputBelow200kUsesBaseRate(t 
 		TotalTokens:      210000,
 	}
 
-	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, usage, nil, nil, serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
@@ -1135,7 +1416,7 @@ func TestComputeTranscriptionCost_TokenDetailsPreferredOverDuration(t *testing.T
 		AudioTokens: 5000,
 		TextTokens:  1000,
 	}
-	cost := computeTranscriptionCost(&p, nil, &seconds, audioDetails, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, nil, &seconds, audioDetails, serviceTier{})
 	// Input: audio token details present → tokens preferred over per-second
 	//   5000 audio * $0.00001 = $0.05
 	//   1000 text  * $0.000005 = $0.005
@@ -1156,7 +1437,7 @@ func TestComputeTranscriptionCost_DurationFallbackWhenNoTokens(t *testing.T) {
 		CompletionTokens: 200,
 		TotalTokens:      200,
 	}
-	cost := computeTranscriptionCost(&p, usage, &seconds, nil, serviceTier{})
+	cost := computeTranscriptionCostTotal(&p, usage, &seconds, nil, serviceTier{})
 	// Input: no audio details, PromptTokens=0 → falls back to 60 * $0.0001 = $0.006
 	// Output: 200 * $0.000015 = $0.003
 	// Total: $0.009
@@ -1179,7 +1460,7 @@ func TestComputeImageCost_PerImage(t *testing.T) {
 			NImages: 2,
 		},
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// 2 * 0.052 = 0.104
 	assert.InDelta(t, 0.104, cost, 1e-12)
 }
@@ -1189,7 +1470,7 @@ func TestComputeImageCost_PerImageDefaultsToOne(t *testing.T) {
 		OutputCostPerImage: bifrost.Ptr(0.052),
 	}
 	usage := &schemas.ImageUsage{} // No token details → defaults to 1 image
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	assert.InDelta(t, 0.052, cost, 1e-12)
 }
 
@@ -1203,7 +1484,7 @@ func TestComputeImageCost_TokenBased(t *testing.T) {
 		OutputTokens: 500,
 		TotalTokens:  1500,
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// 1000*0.000005 + 500*0.000015 = 0.005 + 0.0075 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
@@ -1218,7 +1499,7 @@ func TestComputeImageCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing
 		TotalTokens:  210000,
 	}
 
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
@@ -1231,7 +1512,7 @@ func TestComputeImageCost_DerivesTierTokensFromTotalMinusOutputWhenInputMissing(
 		TotalTokens:  240000, // derived input = 210000, so output uses long-context rate
 	}
 
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 
 	assert.InDelta(t, 30000*0.00003, cost, 1e-9)
 }
@@ -1244,7 +1525,7 @@ func TestComputeImageCost_DoesNotUseBareTotalTokensAsInputTierTokens(t *testing.
 		TotalTokens: 210000, // no input/output split; total includes output, so do not use it as input
 	}
 
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 
 	assert.InDelta(t, 0.05, cost, 1e-9)
 }
@@ -1267,7 +1548,7 @@ func TestComputeImageCost_TokenBasedWithDetails(t *testing.T) {
 			ImageTokens: 800,
 		},
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// Input: (500+1500)*0.000005 = 2000*0.000005 = 0.01
 	// Output: (200+800)*0.000015 = 1000*0.000015 = 0.015
 	// Total: 0.025
@@ -1276,7 +1557,7 @@ func TestComputeImageCost_TokenBasedWithDetails(t *testing.T) {
 
 func TestComputeImageCost_NilUsage(t *testing.T) {
 	p := configstoreTables.TableModelPricing{OutputCostPerImage: new(0.05)}
-	assert.Equal(t, 0.0, computeImageCost(&p, nil, "", "", serviceTier{}))
+	assert.Equal(t, 0.0, computeImageCostTotal(&p, nil, "", "", serviceTier{}))
 }
 
 func TestComputeImageCost_InputAndOutputPerImage(t *testing.T) {
@@ -1288,7 +1569,7 @@ func TestComputeImageCost_InputAndOutputPerImage(t *testing.T) {
 		NumInputImages:      3,
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 2},
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// 3 input * $0.01 + 2 output * $0.05 = $0.03 + $0.10 = $0.13
 	assert.InDelta(t, 0.13, cost, 1e-12)
 }
@@ -1300,7 +1581,7 @@ func TestComputeImageCost_PerPixelOutput(t *testing.T) {
 	usage := &schemas.ImageUsage{
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 1},
 	}
-	cost := computeImageCost(&p, usage, "1024x1024", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "1024x1024", "", serviceTier{})
 	// 1024*1024 * 1 * 0.000000019 = 1048576 * 0.000000019 ≈ 0.01992
 	assert.InDelta(t, 1048576*0.000000019, cost, 1e-12)
 }
@@ -1314,7 +1595,7 @@ func TestComputeImageCost_PerPixelInputAndOutput(t *testing.T) {
 		NumInputImages:      2,
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 3},
 	}
-	cost := computeImageCost(&p, usage, "512x512", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "512x512", "", serviceTier{})
 	pixels := 512 * 512 // 262144
 	// Input: 262144 * 2 * 0.00000001 = 0.00524288
 	// Output: 262144 * 3 * 0.00000002 = 0.01572864
@@ -1334,7 +1615,7 @@ func TestComputeImageCost_TokensPreferredOverPixels(t *testing.T) {
 		OutputTokens: 500,
 		TotalTokens:  1500,
 	}
-	cost := computeImageCost(&p, usage, "1024x1024", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "1024x1024", "", serviceTier{})
 	// Tokens should win: 1000*0.000005 + 500*0.000015 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
@@ -1347,7 +1628,7 @@ func TestComputeImageCost_PixelsPreferredOverPerImage(t *testing.T) {
 	usage := &schemas.ImageUsage{
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 1},
 	}
-	cost := computeImageCost(&p, usage, "256x256", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "256x256", "", serviceTier{})
 	// Per-pixel should win: 65536 * 1 * 0.00000002 = 0.00131072
 	assert.InDelta(t, 65536*0.00000002, cost, 1e-12)
 }
@@ -1360,7 +1641,7 @@ func TestComputeImageCost_PerPixelFallsBackToPerImage_WhenNoSize(t *testing.T) {
 	usage := &schemas.ImageUsage{
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 2},
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// No size → pixels=0, falls through to per-image: 2 * $0.05 = $0.10
 	assert.InDelta(t, 0.10, cost, 1e-12)
 }
@@ -1377,14 +1658,14 @@ func TestComputeImageCost_QualityBasedRates(t *testing.T) {
 		OutputCostPerImageHighQuality:   bifrost.Ptr(0.04),
 		OutputCostPerImageAutoQuality:   bifrost.Ptr(0.05),
 	}
-	assert.InDelta(t, 0.02, computeImageCost(&p, usage, "", "low", serviceTier{}), 1e-12)
-	assert.InDelta(t, 0.03, computeImageCost(&p, usage, "", "medium", serviceTier{}), 1e-12)
-	assert.InDelta(t, 0.04, computeImageCost(&p, usage, "", "high", serviceTier{}), 1e-12)
-	assert.InDelta(t, 0.05, computeImageCost(&p, usage, "", "auto", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.02, computeImageCostTotal(&p, usage, "", "low", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.03, computeImageCostTotal(&p, usage, "", "medium", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.04, computeImageCostTotal(&p, usage, "", "high", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.05, computeImageCostTotal(&p, usage, "", "auto", serviceTier{}), 1e-12)
 	// "hd" does not match any quality case so perImageRate stays nil → size/base fallback.
-	assert.InDelta(t, 0.01, computeImageCost(&p, usage, "", "hd", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.01, computeImageCostTotal(&p, usage, "", "hd", serviceTier{}), 1e-12)
 	// Empty quality is treated as auto
-	assert.InDelta(t, 0.05, computeImageCost(&p, usage, "", "", serviceTier{}), 1e-12)
+	assert.InDelta(t, 0.05, computeImageCostTotal(&p, usage, "", "", serviceTier{}), 1e-12)
 }
 
 func TestComputeImageCost_MegapixelTier_SelectsCorrectBand(t *testing.T) {
@@ -1402,15 +1683,15 @@ func TestComputeImageCost_MegapixelTier_SelectsCorrectBand(t *testing.T) {
 	}
 
 	// 10MP output (between the 8MP and 16MP thresholds) → $0.02 tier.
-	cost := computeImageCost(&p, usage, "1x10000000", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "1x10000000", "", serviceTier{})
 	assert.InDelta(t, 0.02, cost, 1e-12)
 
 	// 2MP output (below the lowest 4MP threshold) → falls back to base rate.
-	cost = computeImageCost(&p, usage, "1x2000000", "", serviceTier{})
+	cost = computeImageCostTotal(&p, usage, "1x2000000", "", serviceTier{})
 	assert.InDelta(t, 0.005, cost, 1e-12)
 
 	// 70MP output (above every threshold) → top $0.12 tier.
-	cost = computeImageCost(&p, usage, "1x70000000", "", serviceTier{})
+	cost = computeImageCostTotal(&p, usage, "1x70000000", "", serviceTier{})
 	assert.InDelta(t, 0.12, cost, 1e-12)
 }
 
@@ -1429,11 +1710,11 @@ func TestComputeImageCost_MegapixelAndSquaredPixelTiers_Interleave(t *testing.T)
 	}
 
 	// 16.5MP: above the 16MP threshold but below 4096x4096 (16,777,216px) → $0.04.
-	cost := computeImageCost(&p, usage, "1x16500000", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "1x16500000", "", serviceTier{})
 	assert.InDelta(t, 0.04, cost, 1e-12)
 
 	// 17MP: above both thresholds → the larger (4096x4096) threshold wins → $0.30.
-	cost = computeImageCost(&p, usage, "1x17000000", "", serviceTier{})
+	cost = computeImageCostTotal(&p, usage, "1x17000000", "", serviceTier{})
 	assert.InDelta(t, 0.30, cost, 1e-12)
 }
 
@@ -1460,7 +1741,7 @@ func TestComputeVideoCost_DurationBased(t *testing.T) {
 	}
 	seconds := 30
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 500, TotalTokens: 500}
-	cost := computeVideoCost(&p, usage, &seconds, serviceTier{})
+	cost := computeVideoCostTotal(&p, usage, &seconds, serviceTier{})
 	// Output: 30 * 0.001 = 0.03
 	// Input:  500 * 0.000001 = 0.0005
 	// Total:  0.0305
@@ -1477,7 +1758,7 @@ func TestComputeVideoCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing
 		TotalTokens:      210000,
 	}
 
-	cost := computeVideoCost(&p, usage, nil, serviceTier{})
+	cost := computeVideoCostTotal(&p, usage, nil, serviceTier{})
 
 	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
@@ -1489,7 +1770,7 @@ func TestComputeVideoCost_OutputCostPerSecondFallback(t *testing.T) {
 		OutputCostPerSecond: bifrost.Ptr(0.002),
 	}
 	seconds := 10
-	cost := computeVideoCost(&p, nil, &seconds, serviceTier{})
+	cost := computeVideoCostTotal(&p, nil, &seconds, serviceTier{})
 	assert.InDelta(t, 0.02, cost, 1e-12)
 }
 
@@ -1499,7 +1780,7 @@ func TestComputeVideoCost_NilSeconds(t *testing.T) {
 		OutputCostPerVideoPerSecond: bifrost.Ptr(0.001),
 	}
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000}
-	cost := computeVideoCost(&p, usage, nil, serviceTier{})
+	cost := computeVideoCostTotal(&p, usage, nil, serviceTier{})
 	// Only input tokens: 1000 * 0.000001 = 0.001
 	assert.InDelta(t, 0.001, cost, 1e-12)
 }
@@ -1792,6 +2073,17 @@ func TestCalculateCostAddsGuardrailJudgeCost(t *testing.T) {
 	// Main: 100*0.000001 + 50*0.000002 = 0.0002.
 	// Judge: 20*0.000003 + 5*0.000004 = 0.00008.
 	assert.InDelta(t, 0.00028, s.CalculateCost(resp, nil), 1e-12)
+
+	// The judge cost lands on the additional side, not input/output, and the
+	// three reconcile to the total.
+	bd := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, bd)
+	assert.InDelta(t, 0.0001, bd.InputCost, 1e-12)
+	assert.InDelta(t, 0.0001, bd.OutputCost, 1e-12)
+	assert.InDelta(t, 0.00008, bd.AdditionalCost, 1e-12)
+	require.NotNil(t, bd.AdditionalCostDetails)
+	assert.InDelta(t, 0.00008, bd.AdditionalCostDetails.GuardrailCost, 1e-12)
+	assert.InDelta(t, bd.TotalCost, bd.InputCost+bd.OutputCost+bd.AdditionalCost, 1e-12)
 }
 
 // TestCalculateGuardrailCostPreservesUsageDetails verifies cache-aware judge pricing uses detailed usage.
@@ -2702,7 +2994,7 @@ func TestComputeTextCost_PriorityUsesInputOutputPriorityRate(t *testing.T) {
 		TotalTokens:      1500,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 
 	// Uses priority rates: 1000*0.000006 + 500*0.00003 = 0.006 + 0.015 = 0.021
 	assert.InDelta(t, 0.021, cost, 1e-12)
@@ -2719,7 +3011,7 @@ func TestComputeTextCost_NonPriorityIgnoresPriorityRate(t *testing.T) {
 		TotalTokens:      1500,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Uses base rates, ignores priority fields: 1000*0.000003 + 500*0.000015 = 0.003 + 0.0075 = 0.0105
 	assert.InDelta(t, 0.0105, cost, 1e-12)
@@ -2740,7 +3032,7 @@ func TestComputeTextCost_Priority272kTier(t *testing.T) {
 		TotalTokens:      310000,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 
 	// Uses 272k priority rates: 280000*0.000012 + 30000*0.00006 = 3.36 + 1.80 = 5.16
 	assert.InDelta(t, 5.16, cost, 1e-9)
@@ -2758,7 +3050,7 @@ func TestComputeTextCost_Priority272kTierFallsBackToNonPriority272k(t *testing.T
 		TotalTokens:      310000,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 
 	// Falls back to non-priority 272k rate: 280000*0.000009 + 30000*0.000045 = 2.52 + 1.35 = 3.87
 	assert.InDelta(t, 3.87, cost, 1e-9)
@@ -2780,7 +3072,7 @@ func TestComputeTextCost_PriorityCacheReadRate(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 
 	// Non-cached input: (1000-400)*0.000006 = 600*0.000006 = 0.0036
 	// Cached read (priority rate): 400*0.0000006 = 0.00024
@@ -2982,7 +3274,7 @@ func TestComputeTextCost_FlexUsesFlexRate(t *testing.T) {
 		TotalTokens:      1500,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 
 	// Flex rates: 1000*0.0000015 + 500*0.0000075 = 0.0015 + 0.00375 = 0.00525
 	assert.InDelta(t, 0.00525, cost, 1e-12)
@@ -2999,7 +3291,7 @@ func TestComputeTextCost_NonFlexIgnoresFlexRate(t *testing.T) {
 		TotalTokens:      1500,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 
 	// Base rates, flex fields ignored: 1000*0.000003 + 500*0.000015 = 0.003 + 0.0075 = 0.0105
 	assert.InDelta(t, 0.0105, cost, 1e-12)
@@ -3019,7 +3311,7 @@ func TestComputeTextCost_FlexIgnoresTokenTiers(t *testing.T) {
 		TotalTokens:      280000,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 
 	// Flex flat rate overrides 272k tier: 250000*0.0000015 + 30000*0.0000075 = 0.375 + 0.225 = 0.60
 	assert.InDelta(t, 0.60, cost, 1e-9)
@@ -3041,7 +3333,7 @@ func TestComputeTextCost_FlexCacheReadRate(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 
 	// Non-cached input: (1000-400)*0.0000015 = 600*0.0000015 = 0.0009
 	// Cached read (flex rate): 400*0.0000006 = 0.00024
@@ -3060,7 +3352,7 @@ func TestComputeTextCost_FlexFallsBackToBaseWhenNoFlexRate(t *testing.T) {
 		TotalTokens:      1500,
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+	cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 
 	// Base rates used as fallback: 1000*0.000003 + 500*0.000015 = 0.003 + 0.0075 = 0.0105
 	assert.InDelta(t, 0.0105, cost, 1e-12)
@@ -3159,7 +3451,7 @@ func TestCalculateCost_AllCachedTokens(t *testing.T) {
 		},
 	}
 
-	cost := computeTextCost(&p, usage, serviceTier{})
+	cost := computeTextCostTotal(&p, usage, serviceTier{})
 	// Non-cached: 0, cached: 1000*0.0000005 = 0.0005
 	assert.InDelta(t, 0.0005, cost, 1e-12)
 }
@@ -3311,7 +3603,7 @@ func TestComputeImageCost_MixedInputTokensOutputPerImage(t *testing.T) {
 		InputTokens:         500,
 		OutputTokensDetails: &schemas.ImageTokenDetails{NImages: 2},
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// Input: 500 tokens * $0.000005 = $0.0025
 	// Output: no output tokens → falls back to 2 images * $0.04 = $0.08
 	assert.InDelta(t, 0.0825, cost, 1e-12)
@@ -3328,7 +3620,7 @@ func TestComputeImageCost_MixedInputPerImageOutputTokens(t *testing.T) {
 		NumInputImages: 3,
 		OutputTokens:   1000,
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// Input: no input tokens → falls back to 3 images * $0.01 = $0.03
 	// Output: 1000 tokens * $0.000015 = $0.015
 	assert.InDelta(t, 0.045, cost, 1e-12)
@@ -3348,7 +3640,7 @@ func TestComputeImageCost_BothHaveTokens_IgnoresPerImage(t *testing.T) {
 		TotalTokens:    1000,
 		NumInputImages: 3,
 	}
-	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+	cost := computeImageCostTotal(&p, usage, "", "", serviceTier{})
 	// Input: 200 * $0.000005 = $0.001 (tokens present, per-image ignored)
 	// Output: 800 * $0.000015 = $0.012 (tokens present, per-image ignored)
 	assert.InDelta(t, 0.013, cost, 1e-12)
@@ -3395,11 +3687,11 @@ func TestComputeContainerCreationCost_Basic(t *testing.T) {
 		Mode:                          "chat",
 		CodeInterpreterCostPerSession: bifrost.Ptr(0.03),
 	}
-	assert.InDelta(t, 0.03, computeContainerCreationCost(&p), 1e-12)
+	assert.InDelta(t, 0.03, computeContainerCreationCostTotal(&p), 1e-12)
 }
 
 func TestComputeContainerCreationCost_NilPricing(t *testing.T) {
-	assert.Equal(t, 0.0, computeContainerCreationCost(nil))
+	assert.Equal(t, 0.0, computeContainerCreationCostTotal(nil))
 }
 
 func TestComputeContainerCreationCost_NilRate(t *testing.T) {
@@ -3408,7 +3700,7 @@ func TestComputeContainerCreationCost_NilRate(t *testing.T) {
 		Provider: "openai",
 		Mode:     "chat",
 	}
-	assert.Equal(t, 0.0, computeContainerCreationCost(&p))
+	assert.Equal(t, 0.0, computeContainerCreationCostTotal(&p))
 }
 
 // ---------------------------------------------------------------------------
@@ -3910,7 +4202,7 @@ func TestGoldenOpenAIPricing_GPT56Family(t *testing.T) {
 				},
 			}
 			p := tc.pricing
-			cost := computeTextCost(&p, usage, tc.tier)
+			cost := computeTextCostTotal(&p, usage, tc.tier)
 			nonCached := prompt - read - write
 			want := float64(nonCached)*tc.r.in + float64(read)*tc.r.cacheRead + float64(write)*tc.r.cacheWrite + float64(out)*tc.r.out
 			assert.InDelta(t, want, cost, 1e-9)
@@ -3933,7 +4225,7 @@ func TestGoldenOpenAIPricing_NoCacheWriteModels(t *testing.T) {
 			PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 100000, CachedWriteTokens: 50000},
 		}
 		p := gpt55
-		cost := computeTextCost(&p, usage, serviceTier{})
+		cost := computeTextCostTotal(&p, usage, serviceTier{})
 		// non-cached 150000*0.00001 + read 100000*0.000001 + write 50000*0.00001 (input fallback) + out 1000*0.000045
 		want := 150000*0.00001 + 100000*0.000001 + 50000*0.00001 + 1000*0.000045
 		assert.InDelta(t, want, cost, 1e-9)
@@ -3945,7 +4237,7 @@ func TestGoldenOpenAIPricing_NoCacheWriteModels(t *testing.T) {
 			PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 4000},
 		}
 		p := gpt55
-		cost := computeTextCost(&p, usage, serviceTier{isFlex: true})
+		cost := computeTextCostTotal(&p, usage, serviceTier{isFlex: true})
 		want := 6000*0.0000025 + 4000*0.00000025 + 1000*0.000015
 		assert.InDelta(t, want, cost, 1e-12)
 	})
@@ -3956,7 +4248,7 @@ func TestGoldenOpenAIPricing_NoCacheWriteModels(t *testing.T) {
 			PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 4000},
 		}
 		p := gpt55
-		cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
+		cost := computeTextCostTotal(&p, usage, serviceTier{isPriority: true})
 		want := 6000*0.0000125 + 4000*0.00000125 + 1000*0.000075
 		assert.InDelta(t, want, cost, 1e-9)
 	})
@@ -3968,7 +4260,7 @@ func TestGoldenOpenAIPricing_NoCacheWriteModels(t *testing.T) {
 			PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 50000},
 		}
 		p := gpt54mini
-		cost := computeTextCost(&p, usage, serviceTier{})
+		cost := computeTextCostTotal(&p, usage, serviceTier{})
 		want := 250000*0.00000075 + 50000*0.000000075 + 1000*0.0000045
 		assert.InDelta(t, want, cost, 1e-9)
 	})

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -59,6 +59,13 @@ func (mc *ModelCatalog) CalculateCost(result *schemas.BifrostResponse, scopes *P
 	return mc.datasheet.CalculateCost(result, (*datasheet.LookupScopes)(scopes))
 }
 
+// CalculateCostBreakdown computes the per-category cost breakdown (input /
+// output / cache) for a Bifrost response. Returns nil when there is no cost to
+// record. TotalCost equals what CalculateCost returns for the same response.
+func (mc *ModelCatalog) CalculateCostBreakdown(result *schemas.BifrostResponse, scopes *PricingLookupScopes) *schemas.BifrostCost {
+	return mc.datasheet.CalculateCostBreakdown(result, (*datasheet.LookupScopes)(scopes))
+}
+
 // CalculateCostForUsage computes the dollar cost from a bare usage object when
 // no full BifrostResponse is available — used to bill partial usage carried on
 // a failed/cancelled request (BifrostError.ExtraFields.BilledUsage).

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1773,6 +1773,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		if tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
 		}
+		// Attach the per-category cost split to the accumulated stream usage so
+		// log detail views can surface input / output / cache costs.
+		p.attachCostBreakdown(ctx, entry, result)
 		p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
 		p.scheduleDeferredUsageUpdate(ctx, requestID, entry.TokenUsageParsed != nil)
 		return result, bifrostErr, nil
@@ -1815,8 +1818,15 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	entry.CacheDebugParsed = cacheDebug
 	if p.pricingManager != nil {
 		pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
-		if cost := p.pricingManager.CalculateCost(result, pricingScopes); cost > 0 {
+		if breakdown := p.pricingManager.CalculateCostBreakdown(result, pricingScopes); breakdown != nil && breakdown.TotalCost > 0 {
+			cost := breakdown.TotalCost
 			entry.Cost = &cost
+			// Attach the per-category split (input / output / cache) to the
+			// stored usage so log detail views can surface it. Preserve any
+			// provider-supplied breakdown.
+			if entry.TokenUsageParsed != nil && entry.TokenUsageParsed.Cost == nil {
+				entry.TokenUsageParsed.Cost = breakdown
+			}
 		}
 		if bifrostErr == nil &&
 			requestType == schemas.BatchResultsRequest &&

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1853,6 +1853,21 @@ func normalizeLogRequestType(object string) schemas.RequestType {
 	}
 }
 
+// attachCostBreakdown fills entry.TokenUsageParsed.Cost with the per-category
+// cost split (input / output / cache) computed from result, so log detail views
+// can surface it alongside the total. It is a no-op when pricing is
+// unavailable, usage is missing, or a breakdown is already present (e.g.
+// provider-supplied or already attached on the non-streaming path).
+func (p *LoggerPlugin) attachCostBreakdown(ctx *schemas.BifrostContext, entry *logstore.Log, result *schemas.BifrostResponse) {
+	if p.pricingManager == nil || result == nil || entry.TokenUsageParsed == nil || entry.TokenUsageParsed.Cost != nil {
+		return
+	}
+	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(entry.Provider))
+	if breakdown := p.pricingManager.CalculateCostBreakdown(result, pricingScopes); breakdown != nil {
+		entry.TokenUsageParsed.Cost = breakdown
+	}
+}
+
 func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, error) {
 	if logEntry == nil {
 		return 0, fmt.Errorf("log entry cannot be nil")


### PR DESCRIPTION
## Summary

Replaces the flat `BifrostCost` shape (a single level of per-category float fields) with a nested input / output / additional breakdown that mirrors the existing token-usage structure (`PromptTokens` + `PromptTokensDetails` + `CompletionTokens` + `CompletionTokensDetails`). All internal compute functions now return `*schemas.BifrostCost` instead of `float64`, carrying the full per-category split alongside the total. The logging plugin attaches this breakdown to stored usage so log detail views can surface input, output, and cache costs rather than only the aggregate.

## Changes

- **`schemas.BifrostCost` restructured** into `InputCost` / `InputCostDetails`, `OutputCost` / `OutputCostDetails`, `AdditionalCost` / `AdditionalCostDetails`, and `TotalCost`. Detail structs carry per-category sub-fields (text, audio, image, cached read/write, reasoning, citation, search queries, guardrail, MCP).
- **Legacy flat shape preserved** via `UnmarshalJSON`: the old `input_tokens_cost`, `output_tokens_cost`, etc. keys are detected and mapped onto the nested shape, so logs written before this change and Perplexity's wire format continue to deserialize correctly.
- **`BifrostCost.Add`** method added for component-wise accumulation, replacing the inline merge logic in `core/mcp/agent.go`.
- **All `compute*` functions** in `framework/modelcatalog/datasheet/cost.go` now return `*schemas.BifrostCost` instead of `float64`. Non-token modalities (OCR per-page, container per-session) use a `totalOnlyCost` helper that folds the amount into the input side as a flat request cost. The per-request surcharge (`CostPerRequest`) folds into `InputCostDetails.RequestCost`. Guardrail judge costs land on `AdditionalCostDetails.GuardrailCost`.
- **`CalculateCostBreakdown`** added to `datasheet.Store` and exposed on `ModelCatalog`. `CalculateCost` becomes a thin wrapper returning `breakdown.TotalCost`, so both paths compute cost identically.
- **Perplexity provider** introduces a private `perplexityCost` type for the raw wire format and a `toBifrostCost()` mapper, keeping the provider's flat shape out of the core schema.
- **Logging plugin** calls `CalculateCostBreakdown` instead of `CalculateCost` and attaches the breakdown to `entry.TokenUsageParsed.Cost` on both streaming and non-streaming paths, preserving any provider-supplied breakdown.
- **Tests** updated throughout: existing total-only assertions use thin `*Total` wrapper helpers; new tests assert the input / output / cache split directly (`TestComputeTextCost_Breakdown`, `TestComputeCost_MultiModalBreakdown`, guardrail breakdown assertions in `TestCalculateCostAddsGuardrailJudgeCost`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./framework/modelcatalog/... ./plugins/logging/...
```

Key scenarios to verify:
- A chat completion response produces a `BifrostCost` where `InputCost + OutputCost + AdditionalCost == TotalCost`.
- A response with cached tokens populates `InputCostDetails.CachedReadCost` / `CachedWriteCost`.
- A Perplexity response with the legacy flat cost shape deserializes into the nested structure with reasoning/citation/search on the output side and the request surcharge on the input side.
- A log entry for a streamed response has `TokenUsageParsed.Cost` populated with the breakdown.
- Old JSON logs containing the flat `input_tokens_cost` shape round-trip correctly through `UnmarshalJSON`.

## Breaking changes

- [x] Yes
- [ ] No

`BifrostCost` field names have changed. Any code reading `InputTokensCost`, `OutputTokensCost`, `ReasoningTokensCost`, `CitationTokensCost`, `SearchQueriesCost`, or `RequestCost` directly from `BifrostCost` must be updated to use the nested `InputCost` / `InputCostDetails` / `OutputCost` / `OutputCostDetails` fields. JSON produced by the old shape is still accepted on read via the backward-compatible `UnmarshalJSON`, but JSON written by this version uses the new field names.

## Related issues

## Security considerations

None. No auth, secrets, PII, or sandboxing changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable