### PR TITLE
feat: adds denormalized cost columns for logs

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -291,6 +291,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_video_edit_input_column"}, run: migrationAddVideoEditInputColumn},
 	{IDs: []string{"logs_add_upstream_and_overhead_latency_columns"}, run: migrationAddUpstreamAndOverheadLatencyColumns},
 	{IDs: []string{"logs_add_batch_debug_column"}, run: migrationAddBatchDebugColumn},
+	{IDs: []string{"logs_add_cost_breakdown_columns"}, run: migrationAddCostBreakdownColumns},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -3029,6 +3030,45 @@ func migrationAddCanonicalModelColumns(ctx context.Context, db *gorm.DB, logger 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding canonical model columns: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddCostBreakdownColumns adds the denormalized input/output/additional
+// cost columns (input_cost, output_cost, additional_cost) to the logs table. The
+// total cost already lives in the cost column; these split it so per-model quota
+// usage can be summed by category in SQL (input + output + additional == total).
+// New rows populate them on write from the TokenUsage cost breakdown; existing
+// rows keep 0 (their total cost column is unaffected).
+func migrationAddCostBreakdownColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_cost_breakdown_columns"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range []string{"input_cost", "output_cost", "additional_cost"} {
+				if err := addColumnIfNotExists(tx, logger, &Log{}, column); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range []string{"input_cost", "output_cost", "additional_cost"} {
+				if err := dropColumnIfExists(tx, logger, &Log{}, column); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding cost breakdown columns: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -242,26 +242,32 @@ type Log struct {
 	CacheDebug              string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.BifrostCacheDebug
 	GuardrailDebug          string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.BifrostGuardrailDebug
 	Latency                 *float64  `gorm:"index:idx_logs_latency" json:"latency,omitempty"`
-	UpstreamLatency         *float64  `gorm:"index:idx_logs_upstream_latency" json:"upstream_latency,omitempty"`                          // Provider socket time across all attempts, ms; nil = unmeasured
-	OverheadLatency         *float64  `gorm:"index:idx_logs_overhead_latency" json:"overhead_latency,omitempty"`                          // Bifrost overhead (total minus upstream), ms; nil = unmeasured
-	TokenUsage              string    `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.LLMUsage
-	Cost                    *float64  `gorm:"index" json:"cost,omitempty"`                                                                // Cost in dollars (total cost of the request - includes cache lookup cost)
-	Status                  string    `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
-	StopReason              *string   `gorm:"type:varchar(50);index:idx_logs_stop_reason" json:"stop_reason,omitempty"`                   // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
-	ErrorDetails            string    `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.BifrostError
-	Stream                  bool      `gorm:"default:false" json:"stream"`                                                                // true if this was a streaming response
-	ContentSummary          string    `gorm:"type:text" json:"content_summary,omitempty"`                                                 // Last user message preview; UI log-list display fallback when payload fields are offloaded to object storage
-	RawRequest              string    `gorm:"type:text" json:"raw_request"`                                                               // Populated when `send-back-raw-request` is on
-	RawResponse             string    `gorm:"type:text" json:"raw_response"`                                                              // Populated when `send-back-raw-response` is on
-	PassthroughRequestBody  string    `gorm:"type:text" json:"passthrough_request_body,omitempty"`                                        // Raw body for passthrough requests (UTF-8)
-	PassthroughResponseBody string    `gorm:"type:text" json:"passthrough_response_body,omitempty"`                                       // Raw body for passthrough responses (UTF-8)
-	RoutingEngineLogs       string    `gorm:"type:text" json:"routing_engine_logs,omitempty"`                                             // Formatted routing engine decision logs
-	PluginLogs              string    `gorm:"type:text" json:"plugin_logs,omitempty"`                                                     // JSON serialized plugin log entries grouped by plugin name
-	Metadata                *string   `gorm:"type:text" json:"-"`                                                                         // JSON serialized map[string]interface{}
-	IsLargePayloadRequest   bool      `gorm:"default:false" json:"is_large_payload_request"`
-	IsLargePayloadResponse  bool      `gorm:"default:false" json:"is_large_payload_response"`
-	HasObject               bool      `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
-	ContentHidden           bool      `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
+	UpstreamLatency         *float64  `gorm:"index:idx_logs_upstream_latency" json:"upstream_latency,omitempty"` // Provider socket time across all attempts, ms; nil = unmeasured
+	OverheadLatency         *float64  `gorm:"index:idx_logs_overhead_latency" json:"overhead_latency,omitempty"` // Bifrost overhead (total minus upstream), ms; nil = unmeasured
+	TokenUsage              string    `gorm:"type:text" json:"-"`                                                // JSON serialized *schemas.LLMUsage
+	// Denormalized cost split for per-category quota aggregation. input + output +
+	// additional reconcile to the cost column. Additional holds internal sidecar
+	// costs with no input/output token category (guardrail, MCP).
+	InputCost               float64  `gorm:"default:0" json:"-"`
+	OutputCost              float64  `gorm:"default:0" json:"-"`
+	AdditionalCost          float64  `gorm:"default:0" json:"-"`
+	Cost                    *float64 `gorm:"index" json:"cost,omitempty"`                                                                // Cost in dollars (total cost of the request - includes cache lookup cost)
+	Status                  string   `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
+	StopReason              *string  `gorm:"type:varchar(50);index:idx_logs_stop_reason" json:"stop_reason,omitempty"`                   // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
+	ErrorDetails            string   `gorm:"type:text" json:"-"`                                                                         // JSON serialized *schemas.BifrostError
+	Stream                  bool     `gorm:"default:false" json:"stream"`                                                                // true if this was a streaming response
+	ContentSummary          string   `gorm:"type:text" json:"content_summary,omitempty"`                                                 // Last user message preview; UI log-list display fallback when payload fields are offloaded to object storage
+	RawRequest              string   `gorm:"type:text" json:"raw_request"`                                                               // Populated when `send-back-raw-request` is on
+	RawResponse             string   `gorm:"type:text" json:"raw_response"`                                                              // Populated when `send-back-raw-response` is on
+	PassthroughRequestBody  string   `gorm:"type:text" json:"passthrough_request_body,omitempty"`                                        // Raw body for passthrough requests (UTF-8)
+	PassthroughResponseBody string   `gorm:"type:text" json:"passthrough_response_body,omitempty"`                                       // Raw body for passthrough responses (UTF-8)
+	RoutingEngineLogs       string   `gorm:"type:text" json:"routing_engine_logs,omitempty"`                                             // Formatted routing engine decision logs
+	PluginLogs              string   `gorm:"type:text" json:"plugin_logs,omitempty"`                                                     // JSON serialized plugin log entries grouped by plugin name
+	Metadata                *string  `gorm:"type:text" json:"-"`                                                                         // JSON serialized map[string]interface{}
+	IsLargePayloadRequest   bool     `gorm:"default:false" json:"is_large_payload_request"`
+	IsLargePayloadResponse  bool     `gorm:"default:false" json:"is_large_payload_response"`
+	HasObject               bool     `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
+	ContentHidden           bool     `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
 
 	// Aggregates over this log's child rows (rows whose parent_request_id equals
 	// this log's ID, i.e. fallback attempts). Populated only on roots_only list
@@ -660,6 +666,20 @@ func (l *Log) SerializeFields() error {
 		if l.TokenUsageParsed.PromptTokensDetails != nil {
 			l.CachedReadTokens = l.TokenUsageParsed.PromptTokensDetails.CachedReadTokens
 		}
+		// Denormalize the input/output/additional cost split so it can be summed in SQL.
+		if l.TokenUsageParsed.Cost != nil {
+			l.InputCost = l.TokenUsageParsed.Cost.InputCost
+			l.OutputCost = l.TokenUsageParsed.Cost.OutputCost
+			l.AdditionalCost = l.TokenUsageParsed.Cost.AdditionalCost
+		}
+	}
+
+	// Some providers report only an opaque total (e.g. xAI usd-ticks, Runware),
+	// leaving the per-category split empty. Attribute the total to the input side
+	// so the denormalized columns still reconcile to the cost column
+	// (input + output + additional == total) instead of summing short.
+	if l.InputCost == 0 && l.OutputCost == 0 && l.AdditionalCost == 0 && l.Cost != nil && *l.Cost > 0 {
+		l.InputCost = *l.Cost
 	}
 
 	if l.ErrorDetailsParsed != nil {

--- a/framework/logstore/tables_test.go
+++ b/framework/logstore/tables_test.go
@@ -3,9 +3,90 @@ package logstore
 import (
 	"testing"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSerializeFieldsDenormalizesCostBreakdown(t *testing.T) {
+	log := &Log{
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     1000,
+			CompletionTokens: 500,
+			TotalTokens:      1500,
+			PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+				CachedReadTokens: 400,
+			},
+			Cost: &schemas.BifrostCost{
+				InputCost:  0.0021,
+				OutputCost: 0.0075,
+				InputCostDetails: &schemas.InputCostDetails{
+					TextCost:       0.00165,
+					CachedReadCost: 0.00045,
+				},
+				AdditionalCost: 0.0003,
+				AdditionalCostDetails: &schemas.AdditionalCostDetails{
+					GuardrailCost: 0.0003,
+				},
+				TotalCost: 0.0099,
+			},
+		},
+	}
+	require.NoError(t, log.SerializeFields())
+
+	// Token denorm still works.
+	assert.Equal(t, 1000, log.PromptTokens)
+	assert.Equal(t, 400, log.CachedReadTokens)
+	// Input/output/additional cost split is denormalized for SQL aggregation.
+	assert.InDelta(t, 0.0021, log.InputCost, 1e-12)
+	assert.InDelta(t, 0.0075, log.OutputCost, 1e-12)
+	assert.InDelta(t, 0.0003, log.AdditionalCost, 1e-12)
+}
+
+func TestSerializeFieldsLeavesCostBreakdownZeroWhenNoCost(t *testing.T) {
+	log := &Log{
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     10,
+			CompletionTokens: 5,
+			TotalTokens:      15,
+		},
+	}
+	require.NoError(t, log.SerializeFields())
+	assert.Zero(t, log.InputCost)
+	assert.Zero(t, log.OutputCost)
+	assert.Zero(t, log.AdditionalCost)
+}
+
+// TestSerializeFieldsAttributesOpaqueTotalToInput covers providers that report
+// only a total with no per-category split (xAI usd-ticks, Runware): the
+// denormalized columns must still reconcile to the cost column by attributing
+// the total to the input side.
+func TestSerializeFieldsAttributesOpaqueTotalToInput(t *testing.T) {
+	total := 0.0042
+	log := &Log{
+		Cost: &total,
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens: 100,
+			// Opaque total only, no input/output/additional split.
+			Cost: &schemas.BifrostCost{TotalCost: total},
+		},
+	}
+	require.NoError(t, log.SerializeFields())
+	assert.InDelta(t, total, log.InputCost, 1e-12)
+	assert.Zero(t, log.OutputCost)
+	assert.Zero(t, log.AdditionalCost)
+	assert.InDelta(t, total, log.InputCost+log.OutputCost+log.AdditionalCost, 1e-12)
+}
+
+// TestSerializeFieldsOpaqueTotalNoUsageCarrier covers the same opaque-total
+// reconciliation when there is no usage carrier at all (e.g. OCR rows before the
+// plugin denormalizes): the total on the cost column still lands on input.
+func TestSerializeFieldsOpaqueTotalNoUsageCarrier(t *testing.T) {
+	total := 0.01
+	log := &Log{Cost: &total}
+	require.NoError(t, log.SerializeFields())
+	assert.InDelta(t, total, log.InputCost, 1e-12)
+}
 
 func TestDeserializeFieldsReconstructsTokenUsageFromDenormalizedColumns(t *testing.T) {
 	log := &Log{


### PR DESCRIPTION
## Summary

Adds three denormalized cost columns (`input_cost`, `output_cost`, `additional_cost`) to the `logs` table so that per-model quota usage can be aggregated by cost category directly in SQL (`input + output + additional == total`). The existing `cost` column (total) is unchanged; these new columns split it for finer-grained reporting.

## Changes

- Added `InputCost`, `OutputCost`, and `AdditionalCost` fields to the `Log` struct, defaulting to `0`, excluded from JSON responses.
- In `SerializeFields`, the cost breakdown is populated from `TokenUsageParsed.Cost` when available.
- For providers that report only an opaque total with no per-category split (e.g. xAI usd-ticks, Runware), the total is attributed entirely to `InputCost` so the denormalized columns always reconcile to the `cost` column.
- Added migration `logs_add_cost_breakdown_columns` to add the three columns to existing databases. Existing rows retain `0` for the new columns; their `cost` column is unaffected.
- Added unit tests covering: full cost breakdown denormalization, no-cost case, opaque-total-only provider, and opaque-total with no usage carrier.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that:
- `TestSerializeFieldsDenormalizesCostBreakdown` passes and `input_cost + output_cost + additional_cost` equals the total cost.
- `TestSerializeFieldsAttributesOpaqueTotalToInput` passes and the full total lands on `input_cost` when no per-category split exists.
- `TestSerializeFieldsOpaqueTotalNoUsageCarrier` passes for rows with no usage carrier.
- The migration `logs_add_cost_breakdown_columns` runs cleanly against an existing database and the three new columns are present with a default of `0`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The new columns are excluded from JSON API responses (`json:"-"`).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable