### PR TITLE
docs: add `pending_verification` state and `initiate-verification` / `verify-headers` MCP client endpoints to OpenAPI spec

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -42917,7 +42917,7 @@
                           },
                           "oauth_config": {
                             "$ref": "#/components/schemas/OAuthConfigRequest",
-                            "description": "OAuth configuration for initiating OAuth flow.\nOnly include this when creating a client with auth_type \"oauth\".\nThis will trigger the OAuth flow and return an authorization URL.\n"
+                            "description": "OAuth configuration for initiating OAuth flow.\nRequired when creating a client with auth_type \"oauth\" or \"per_user_oauth\".\nThis will trigger the OAuth flow and return an authorization URL\n(see the pending_oauth response variant).\n"
                           },
                           "tools_to_execute": {
                             "type": "array",
@@ -43077,7 +43077,7 @@
                           },
                           "oauth_config": {
                             "$ref": "#/components/schemas/OAuthConfigRequest",
-                            "description": "OAuth configuration for initiating OAuth flow.\nOnly include this when creating a client with auth_type \"oauth\".\nThis will trigger the OAuth flow and return an authorization URL.\n"
+                            "description": "OAuth configuration for initiating OAuth flow.\nRequired when creating a client with auth_type \"oauth\" or \"per_user_oauth\".\nThis will trigger the OAuth flow and return an authorization URL\n(see the pending_oauth response variant).\n"
                           },
                           "tools_to_execute": {
                             "type": "array",
@@ -43237,7 +43237,7 @@
                           },
                           "oauth_config": {
                             "$ref": "#/components/schemas/OAuthConfigRequest",
-                            "description": "OAuth configuration for initiating OAuth flow.\nOnly include this when creating a client with auth_type \"oauth\".\nThis will trigger the OAuth flow and return an authorization URL.\n"
+                            "description": "OAuth configuration for initiating OAuth flow.\nRequired when creating a client with auth_type \"oauth\" or \"per_user_oauth\".\nThis will trigger the OAuth flow and return an authorization URL\n(see the pending_oauth response variant).\n"
                           },
                           "tools_to_execute": {
                             "type": "array",
@@ -43349,11 +43349,18 @@
         ],
         "responses": {
           "200": {
-            "description": "MCP client added successfully",
+            "description": "MCP client added successfully. For auth_type \"oauth\" and\n\"per_user_oauth\" the client is not created yet — the response is the\npending_oauth variant carrying authorize_url plus status_url /\ncomplete_url / next_steps hints; the client is created when the flow\nis completed via complete_url.\n",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SuccessResponse"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OAuthFlowInitiation"
+                    }
+                  ]
                 }
               }
             }
@@ -43691,7 +43698,7 @@
       "post": {
         "operationId": "reconnectMCPClient",
         "summary": "Reconnect MCP client",
-        "description": "Reconnects an MCP client that is in an error or disconnected state.",
+        "description": "Reconnects an MCP client that is in an error or disconnected state.\nNot applicable (400) to per-user auth clients (no shared upstream\nconnection) or to clients in pending_verification state — complete the\nadmin verification instead.\n",
         "tags": [
           "MCP"
         ],
@@ -43797,6 +43804,200 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/client/{id}/initiate-verification": {
+      "post": {
+        "operationId": "initiateMCPClientVerification",
+        "summary": "Initiate verification for a pending MCP client",
+        "description": "Starts the one-time admin OAuth authorization for an MCP client sitting\nin pending_verification state (declared via config.json with auth_type\n\"oauth\" or \"per_user_oauth\"). Runs OAuth metadata discovery (RFC 8414)\nand dynamic client registration (RFC 7591) against the client's\nconnection_string when the declared oauth_config omits those fields,\ncreates a fresh OAuth flow, and returns the authorization URL.\n\nComplete the flow like a create-time OAuth flow: open authorize_url in a\nbrowser, poll status_url until \"authorized\", then POST complete_url.\nSafe to call again if a previous attempt expired or was abandoned — each\ncall starts a fresh flow.\n",
+        "tags": [
+          "MCP",
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "MCP client ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth flow initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthFlowInitiation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client is not in pending_verification state, is not an OAuth-based auth type, has no pending bootstrap configuration, or has no connection_string",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/mcp/client/{id}/verify-headers": {
+      "post": {
+        "operationId": "verifyMCPClientHeaders",
+        "summary": "Verify a pending per-user-headers MCP client",
+        "description": "Completes the one-time admin verification for an MCP client sitting in\npending_verification state with auth_type \"per_user_headers\" (declared\nvia config.json). The admin supplies sample values for every declared\nper_user_header_keys entry; Bifrost opens an upstream connection with\nthem, discovers the tool list, persists it, and transitions the client\nto connected. The sample values are discarded — each end-user submits\ntheir own values at runtime. Synchronous; no browser flow.\n",
+        "tags": [
+          "MCP"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "MCP client ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "user_headers"
+                ],
+                "properties": {
+                  "user_headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Sample value for every header name declared in the client's\nper_user_header_keys. Used once for the verification\nconnection, then discarded — never persisted.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client verified; tools discovered and client connected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "success"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "tools_count": {
+                      "type": "integer",
+                      "description": "Number of tools discovered during verification"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client is not auth_type \"per_user_headers\", has no per_user_header_keys declared, or user_headers is missing required keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Client has already been verified (tools discovered); delete and recreate to re-verify",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Upstream verification failed with the supplied header values",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagementErrorResponse"
                 }
               }
             }
@@ -67432,6 +67633,16 @@
           }
         }
       },
+      "Conflict": {
+        "description": "Conflict with the current state of the resource",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            }
+          }
+        }
+      },
       "InternalError": {
         "description": "Internal server error",
         "content": {
@@ -80924,9 +81135,10 @@
               "disconnected",
               "error",
               "pending_tools",
+              "pending_verification",
               "disabled"
             ],
-            "description": "Connection state of an MCP client:\n- connected: Client is connected and ready to use\n- disconnected: Client is not connected (will be auto-recovered by health monitor)\n- error: Client is in an unrecoverable error state\n- pending_tools: Connected but tools not yet populated (per-user OAuth clients)\n- disabled: Client has been intentionally disabled; no connection or workers are active\n"
+            "description": "Connection state of an MCP client:\n- connected: Client is connected and ready to use\n- disconnected: Client is not connected (will be auto-recovered by health monitor)\n- error: Client is in an unrecoverable error state\n- pending_tools: Connected but tools not yet populated (per-user OAuth clients)\n- pending_verification: Declared (typically via config.json) but the one-time\n  admin verification has not been completed yet. Complete it via\n  POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /\n  per_user_oauth) or POST /api/mcp/client/{id}/verify-headers\n  (auth_type per_user_headers).\n- disabled: Client has been intentionally disabled; no connection or workers are active\n"
           },
           "vk_configs": {
             "type": "array",
@@ -81230,6 +81442,21 @@
           "mcp_client_id": {
             "type": "string",
             "description": "The MCP client ID that initiated this OAuth flow"
+          },
+          "complete_url": {
+            "type": "string",
+            "description": "Relative URL to POST once the flow is authorized\n(/api/mcp/client/{oauth_config_id}/complete-oauth). Note the path\nparameter is the oauth_config_id, not the MCP client ID.\n"
+          },
+          "status_url": {
+            "type": "string",
+            "description": "Relative URL to poll for the flow status\n(/api/oauth/config/{oauth_config_id}/status). Wait for\nstatus \"authorized\" before calling complete_url.\n"
+          },
+          "next_steps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Human-readable steps to complete the flow (authorize, poll, complete)"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -795,6 +795,10 @@ paths:
     $ref: './paths/management/mcp.yaml#/client-reconnect'
   /api/mcp/client/{id}/complete-oauth:
     $ref: './paths/management/mcp.yaml#/client-complete-oauth'
+  /api/mcp/client/{id}/initiate-verification:
+    $ref: './paths/management/mcp.yaml#/client-initiate-verification'
+  /api/mcp/client/{id}/verify-headers:
+    $ref: './paths/management/mcp.yaml#/client-verify-headers'
 
   # MCP — per-user sessions (OAuth tokens + headers credentials + pending flows)
   /api/mcp/sessions:
@@ -1178,6 +1182,12 @@ components:
             $ref: './schemas/inference/common.yaml#/BifrostError'
     NotFound:
       description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: './schemas/inference/common.yaml#/BifrostError'
+    Conflict:
+      description: Conflict with the current state of the resource
       content:
         application/json:
           schema:

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -182,11 +182,18 @@ client:
       - ManagementBearerAuth: []
     responses:
       '200':
-        description: MCP client added successfully
+        description: |
+          MCP client added successfully. For auth_type "oauth" and
+          "per_user_oauth" the client is not created yet — the response is the
+          pending_oauth variant carrying authorize_url plus status_url /
+          complete_url / next_steps hints; the client is created when the flow
+          is completed via complete_url.
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/SuccessResponse'
+              oneOf:
+                - $ref: '../../schemas/management/common.yaml#/SuccessResponse'
+                - $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '500':
@@ -261,7 +268,11 @@ client-reconnect:
   post:
     operationId: reconnectMCPClient
     summary: Reconnect MCP client
-    description: Reconnects an MCP client that is in an error or disconnected state.
+    description: |
+      Reconnects an MCP client that is in an error or disconnected state.
+      Not applicable (400) to per-user auth clients (no shared upstream
+      connection) or to clients in pending_verification state — complete the
+      admin verification instead.
     tags:
       - MCP
     parameters:
@@ -319,6 +330,121 @@ client-complete-oauth:
       '404':
         description: MCP client not found in pending OAuth clients or OAuth config not found
         $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+client-initiate-verification:
+  post:
+    operationId: initiateMCPClientVerification
+    summary: Initiate verification for a pending MCP client
+    description: |
+      Starts the one-time admin OAuth authorization for an MCP client sitting
+      in pending_verification state (declared via config.json with auth_type
+      "oauth" or "per_user_oauth"). Runs OAuth metadata discovery (RFC 8414)
+      and dynamic client registration (RFC 7591) against the client's
+      connection_string when the declared oauth_config omits those fields,
+      creates a fresh OAuth flow, and returns the authorization URL.
+
+      Complete the flow like a create-time OAuth flow: open authorize_url in a
+      browser, poll status_url until "authorized", then POST complete_url.
+      Safe to call again if a previous attempt expired or was abandoned — each
+      call starts a fresh flow.
+    tags:
+      - MCP
+      - OAuth
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: MCP client ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: OAuth flow initiated
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
+      '400':
+        description: Client is not in pending_verification state, is not an OAuth-based auth type, has no pending bootstrap configuration, or has no connection_string
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+client-verify-headers:
+  post:
+    operationId: verifyMCPClientHeaders
+    summary: Verify a pending per-user-headers MCP client
+    description: |
+      Completes the one-time admin verification for an MCP client sitting in
+      pending_verification state with auth_type "per_user_headers" (declared
+      via config.json). The admin supplies sample values for every declared
+      per_user_header_keys entry; Bifrost opens an upstream connection with
+      them, discovers the tool list, persists it, and transitions the client
+      to connected. The sample values are discarded — each end-user submits
+      their own values at runtime. Synchronous; no browser flow.
+    tags:
+      - MCP
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: MCP client ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [user_headers]
+            properties:
+              user_headers:
+                type: object
+                additionalProperties:
+                  type: string
+                description: |
+                  Sample value for every header name declared in the client's
+                  per_user_header_keys. Used once for the verification
+                  connection, then discarded — never persisted.
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Client verified; tools discovered and client connected
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [success]
+                message:
+                  type: string
+                tools_count:
+                  type: integer
+                  description: Number of tools discovered during verification
+      '400':
+        description: Client is not auth_type "per_user_headers", has no per_user_header_keys declared, or user_headers is missing required keys
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '409':
+        description: Client has already been verified (tools discovered); delete and recreate to re-verify
+        $ref: '../../openapi.yaml#/components/responses/Conflict'
+      '422':
+        description: Upstream verification failed with the supplied header values
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -18,13 +18,18 @@ MCPConnectionType:
 
 MCPConnectionState:
   type: string
-  enum: [connected, disconnected, error, pending_tools, disabled]
+  enum: [connected, disconnected, error, pending_tools, pending_verification, disabled]
   description: |
     Connection state of an MCP client:
     - connected: Client is connected and ready to use
     - disconnected: Client is not connected (will be auto-recovered by health monitor)
     - error: Client is in an unrecoverable error state
     - pending_tools: Connected but tools not yet populated (per-user OAuth clients)
+    - pending_verification: Declared (typically via config.json) but the one-time
+      admin verification has not been completed yet. Complete it via
+      POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /
+      per_user_oauth) or POST /api/mcp/client/{id}/verify-headers
+      (auth_type per_user_headers).
     - disabled: Client has been intentionally disabled; no connection or workers are active
 
 MCPStdioConfig:
@@ -126,8 +131,9 @@ MCPClientCreateRequestBase:
       $ref: '../../schemas/management/oauth.yaml#/OAuthConfigRequest'
       description: |
         OAuth configuration for initiating OAuth flow.
-        Only include this when creating a client with auth_type "oauth".
-        This will trigger the OAuth flow and return an authorization URL.
+        Required when creating a client with auth_type "oauth" or "per_user_oauth".
+        This will trigger the OAuth flow and return an authorization URL
+        (see the pending_oauth response variant).
     tools_to_execute:
       type: array
       items:

--- a/docs/openapi/schemas/management/oauth.yaml
+++ b/docs/openapi/schemas/management/oauth.yaml
@@ -66,6 +66,23 @@ OAuthFlowInitiation:
     mcp_client_id:
       type: string
       description: The MCP client ID that initiated this OAuth flow
+    complete_url:
+      type: string
+      description: |
+        Relative URL to POST once the flow is authorized
+        (/api/mcp/client/{oauth_config_id}/complete-oauth). Note the path
+        parameter is the oauth_config_id, not the MCP client ID.
+    status_url:
+      type: string
+      description: |
+        Relative URL to poll for the flow status
+        (/api/oauth/config/{oauth_config_id}/status). Wait for
+        status "authorized" before calling complete_url.
+    next_steps:
+      type: array
+      items:
+        type: string
+      description: Human-readable steps to complete the flow (authorize, poll, complete)
 
 OAuthConfigStatus:
   type: object


### PR DESCRIPTION
## Summary

This PR extends the MCP client API to support a `pending_verification` lifecycle state for clients declared via `config.json` that require a one-time admin verification step before becoming active. It introduces two new endpoints to complete that verification and clarifies the OAuth flow response shape for client creation.

## Changes

- Added `pending_verification` as a valid `MCPConnectionState` enum value, representing clients that have been declared (typically via `config.json`) but whose admin verification has not yet been completed.
- Added `POST /api/mcp/client/{id}/initiate-verification` — starts the one-time admin OAuth flow for clients with `auth_type` `oauth` or `per_user_oauth` in `pending_verification` state. Performs OAuth metadata discovery (RFC 8414) and dynamic client registration (RFC 7591) when the declared `oauth_config` omits those fields, then returns an `OAuthFlowInitiation` response. Safe to call repeatedly if a previous attempt expired.
- Added `POST /api/mcp/client/{id}/verify-headers` — completes admin verification for clients with `auth_type` `per_user_headers` in `pending_verification` state. The admin supplies sample header values; Bifrost opens an upstream connection, discovers tools, persists them, and transitions the client to `connected`. Sample values are discarded after use and never persisted.
- Updated the `POST /api/mcp/client` (create) response schema to `oneOf` `SuccessResponse` | `OAuthFlowInitiation`, reflecting that OAuth-based client creation returns a pending OAuth flow rather than immediate success.
- Updated `oauth_config` field description to clarify it is required (not optional) for `auth_type` `oauth` or `per_user_oauth`.
- Updated the reconnect endpoint description to note it returns `400` for per-user auth clients and clients in `pending_verification` state.
- Added `complete_url`, `status_url`, and `next_steps` fields to the `OAuthFlowInitiation` schema to guide callers through completing the OAuth flow.
- Added a `Conflict` (409) reusable response component.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the updated OpenAPI spec is valid and that the new endpoints, schemas, and state descriptions render correctly in your API documentation tooling.

```sh
# Validate the OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.yaml
```

- Confirm `pending_verification` appears in the `MCPConnectionState` enum.
- Confirm `POST /api/mcp/client/{id}/initiate-verification` and `POST /api/mcp/client/{id}/verify-headers` appear with correct request/response schemas.
- Confirm the create client `200` response shows `oneOf: [SuccessResponse, OAuthFlowInitiation]`.
- Confirm `OAuthFlowInitiation` includes `complete_url`, `status_url`, and `next_steps`.

## Breaking changes

- [x] Yes
- [ ] No

The `POST /api/mcp/client` `200` response schema has changed from a single `SuccessResponse` to `oneOf [SuccessResponse, OAuthFlowInitiation]`. Clients creating OAuth-based MCP clients must handle the `OAuthFlowInitiation` response variant and complete the OAuth flow via `complete_url` before the client is fully created.

## Related issues

## Security considerations

The `initiate-verification` and `verify-headers` endpoints are protected by `ManagementBearerAuth`. Sample header values supplied to `verify-headers` are explicitly never persisted, limiting exposure of admin-supplied credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable