### PR TITLE
docs: add `env.`/`vault.` reference support for OAuth `client_id`/`client_secret` and update OpenAPI `EnvVar` schema

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -295,7 +295,7 @@ Auth-type-specific fields:
 
 | Field | Auth type | Description |
 |-------|-----------|-------------|
-| `oauth_config` | `oauth`, `per_user_oauth` | Optional inline OAuth provider block. The whole block can be omitted, and any inner field (`client_id`, `client_secret`, `authorize_url`, `token_url`, `registration_url`, `scopes`) can be omitted individually — RFC 8414 metadata discovery + RFC 7591 dynamic client registration fill the gaps off `connection_string` at admin-click time. |
+| `oauth_config` | `oauth`, `per_user_oauth` | Optional inline OAuth provider block. The whole block can be omitted, and any inner field (`client_id`, `client_secret`, `authorize_url`, `token_url`, `registration_url`, `scopes`) can be omitted individually — RFC 8414 metadata discovery + RFC 7591 dynamic client registration fill the gaps off `connection_string` at admin-click time. `client_id` / `client_secret` support `env.VAR_NAME` and `vault.path` references (resolved at runtime, reference stored); the other fields take literal values (encrypted at rest, redacted in API responses). |
 | `per_user_header_keys` | `per_user_headers` | Required, non-empty. Array of header names each end-user must supply. |
 
 The schema enforces these pairings: `oauth_config` is rejected on non-OAuth auth types, and `per_user_header_keys` is rejected on any auth type other than `per_user_headers` — a misplaced block fails `$schema` validation instead of being silently ignored.

--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -149,6 +149,10 @@ Declare the client with an inline `oauth_config` block:
 
 The `oauth_config` block itself is optional, and every inner field is optional. `authorize_url` / `token_url` come from RFC 8414 discovery off `connection_string` when the upstream supports it, and `client_id` / `client_secret` can be obtained via RFC 7591 Dynamic Client Registration. The minimum viable declaration is `{ "auth_type": "oauth", "connection_string": "..." }`.
 
+<Note>
+`client_id` and `client_secret` support `env.VAR_NAME` and `vault.path` references — `"client_secret": "env.GITHUB_SECRET"` resolves from the environment at runtime, and the reference (not the resolved secret) is what gets stored. Plain values also work (encrypted at rest, redacted in API responses). The other fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
+</Note>
+
 At boot the client lands in **`pending_verification`** state because the OAuth flow still needs a live admin browser session to complete. From the MCP Gateway UI, open the client and click **Authorize** — the same browser popup the Web UI Create flow uses. On success the OAuth tokens are stored, the tool list is discovered, and the client transitions to `connected`.
 
 The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (this time `{id}` *is* the MCP client ID) returns the same `authorize_url` / `status_url` / `complete_url` payload as the create flow above — open `authorize_url` in a browser, poll `status_url`, then POST `complete_url`. Safe to call again if a previous attempt expired or was abandoned.

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -82,6 +82,10 @@ Declare the client with an inline `oauth_config` block:
 
 The `oauth_config` block itself is optional, and every inner field is optional. `authorize_url` / `token_url` come from RFC 8414 discovery off `connection_string` when the upstream supports it, and `client_id` / `client_secret` can be obtained via RFC 7591 Dynamic Client Registration. The minimum viable declaration is `{ "auth_type": "per_user_oauth", "connection_string": "..." }`.
 
+<Note>
+`client_id` and `client_secret` support `env.VAR_NAME` and `vault.path` references — `"client_secret": "env.GITHUB_SECRET"` resolves from the environment at runtime, and the reference (not the resolved secret) is what gets stored. Plain values also work (encrypted at rest, redacted in API responses). The other fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
+</Note>
+
 At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `connected` with the tool list discovered, and the admin's temp token is discarded.
 
 The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (`{id}` = MCP client ID) returns `authorize_url` plus `status_url` / `complete_url` hints — open `authorize_url` in a browser for the one-time admin login, poll `status_url` until `authorized`, then POST `complete_url` to run verification and tool discovery.

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -266,7 +266,7 @@ All five auth types can be declared in `config.json`. The three that need an adm
         "auth_type": "oauth",
         "oauth_config": {
           "client_id": "your-client-id",
-          "client_secret": "your-client-secret",
+          "client_secret": "env.GOOGLE_OAUTH_CLIENT_SECRET",
           "scopes": ["drive.readonly"]
         },
         "tools_to_execute": ["*"]

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -80447,13 +80447,21 @@
             "description": "API key value (redacted in responses)",
             "properties": {
               "value": {
-                "type": "string"
+                "type": "string",
+                "description": "Resolved value (redacted in GET responses for secret fields)"
               },
-              "env_var": {
-                "type": "string"
+              "ref": {
+                "type": "string",
+                "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
               },
-              "from_env": {
-                "type": "boolean"
+              "type": {
+                "type": "string",
+                "enum": [
+                  "plain_text",
+                  "env",
+                  "vault"
+                ],
+                "description": "Source type of the value"
               }
             }
           },
@@ -80492,76 +80500,116 @@
             "properties": {
               "endpoint": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "api_version": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "client_id": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "client_secret": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "tenant_id": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -80580,61 +80628,93 @@
             "properties": {
               "project_id": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "project_number": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "region": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "auth_credentials": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               }
@@ -80646,76 +80726,116 @@
             "properties": {
               "access_key": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "secret_key": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "session_token": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "region": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
               "arn": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -80749,16 +80869,24 @@
             "properties": {
               "url": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -80776,16 +80904,24 @@
             "properties": {
               "url": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               }
@@ -80800,16 +80936,24 @@
             "properties": {
               "url": {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               }
@@ -81385,12 +81529,60 @@
         "description": "OAuth configuration for MCP client creation",
         "properties": {
           "client_id": {
-            "type": "string",
-            "description": "OAuth client ID. Optional if client supports dynamic client registration (RFC 7591).\nIf not provided, the server_url must be set for OAuth discovery and dynamic registration.\n"
+            "allOf": [
+              {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              }
+            ],
+            "description": "OAuth client ID. Optional if client supports dynamic client registration (RFC 7591).\nIf not provided, the server_url must be set for OAuth discovery and dynamic registration.\nSupports env./vault. references.\n"
           },
           "client_secret": {
-            "type": "string",
-            "description": "OAuth client secret. Optional for public clients using PKCE or clients obtained via dynamic registration.\n"
+            "allOf": [
+              {
+                "type": "object",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
+                  },
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
+                  }
+                }
+              }
+            ],
+            "description": "OAuth client secret. Optional for public clients using PKCE or clients obtained via dynamic registration.\nSupports env./vault. references.\n"
           },
           "authorize_url": {
             "type": "string",
@@ -83511,16 +83703,24 @@
           },
           "value": {
             "type": "object",
-            "description": "Environment variable configuration",
+            "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
             "properties": {
               "value": {
-                "type": "string"
+                "type": "string",
+                "description": "Resolved value (redacted in GET responses for secret fields)"
               },
-              "env_var": {
-                "type": "string"
+              "ref": {
+                "type": "string",
+                "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
               },
-              "from_env": {
-                "type": "boolean"
+              "type": {
+                "type": "string",
+                "enum": [
+                  "plain_text",
+                  "env",
+                  "vault"
+                ],
+                "description": "Source type of the value"
               }
             }
           },
@@ -83568,16 +83768,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83590,16 +83798,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83612,16 +83828,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83634,16 +83858,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83656,16 +83888,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83678,16 +83918,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83700,16 +83948,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83722,16 +83978,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83744,16 +84008,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83766,16 +84038,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83788,16 +84068,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83810,16 +84098,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },
@@ -83832,16 +84128,24 @@
             "oneOf": [
               {
                 "type": "object",
-                "description": "Environment variable configuration",
+                "description": "A secret-capable value. Serialized as an object with the resolved `value` plus\nreference metadata; on input, a bare string is also accepted — plain text,\n`env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and\nonly the reference is persisted).\n",
                 "properties": {
                   "value": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resolved value (redacted in GET responses for secret fields)"
                   },
-                  "env_var": {
-                    "type": "string"
+                  "ref": {
+                    "type": "string",
+                    "description": "Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values"
                   },
-                  "from_env": {
-                    "type": "boolean"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
+                    "description": "Source type of the value"
                   }
                 }
               },

--- a/docs/openapi/schemas/management/common.yaml
+++ b/docs/openapi/schemas/management/common.yaml
@@ -25,11 +25,19 @@ MessageResponse:
 
 EnvVar:
   type: object
-  description: Environment variable configuration
+  description: |
+    A secret-capable value. Serialized as an object with the resolved `value` plus
+    reference metadata; on input, a bare string is also accepted — plain text,
+    `env.VAR_NAME`, or `vault.path/to/secret` (references resolve at runtime and
+    only the reference is persisted).
   properties:
-        value:
-          type: string
-        env_var:
-          type: string
-        from_env:
-          type: boolean
+    value:
+      type: string
+      description: Resolved value (redacted in GET responses for secret fields)
+    ref:
+      type: string
+      description: Source reference (`env.VAR_NAME` or `vault.path`); empty for plain-text values
+    type:
+      type: string
+      enum: [plain_text, env, vault]
+      description: Source type of the value

--- a/docs/openapi/schemas/management/oauth.yaml
+++ b/docs/openapi/schemas/management/oauth.yaml
@@ -16,14 +16,18 @@ OAuthConfigRequest:
   description: OAuth configuration for MCP client creation
   properties:
     client_id:
-      type: string
+      allOf:
+        - $ref: '../../schemas/management/common.yaml#/EnvVar'
       description: |
         OAuth client ID. Optional if client supports dynamic client registration (RFC 7591).
         If not provided, the server_url must be set for OAuth discovery and dynamic registration.
+        Supports env./vault. references.
     client_secret:
-      type: string
+      allOf:
+        - $ref: '../../schemas/management/common.yaml#/EnvVar'
       description: |
         OAuth client secret. Optional for public clients using PKCE or clients obtained via dynamic registration.
+        Supports env./vault. references.
     authorize_url:
       type: string
       description: |

--- a/examples/configs/withmcpbootstrapauth/config.json
+++ b/examples/configs/withmcpbootstrapauth/config.json
@@ -22,7 +22,7 @@
         "auth_type": "oauth",
         "oauth_config": {
           "client_id": "your-google-oauth-client-id",
-          "client_secret": "your-google-oauth-client-secret",
+          "client_secret": "env.GOOGLE_OAUTH_CLIENT_SECRET",
           "scopes": ["https://www.googleapis.com/auth/drive.readonly"]
         },
         "tools_to_execute": ["*"]

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4848,11 +4848,11 @@
           "properties": {
             "client_id": {
               "type": "string",
-              "description": "OAuth client ID (optional — Dynamic Client Registration is used when omitted)"
+              "description": "OAuth client ID (optional — Dynamic Client Registration is used when omitted; can use env. or vault. prefix)"
             },
             "client_secret": {
               "type": "string",
-              "description": "OAuth client secret (optional — omit for PKCE public clients or DCR)"
+              "description": "OAuth client secret (optional — omit for PKCE public clients or DCR; can use env. or vault. prefix)"
             },
             "authorize_url": {
               "type": "string",


### PR DESCRIPTION
## Summary

Documents and formalizes support for `env.VAR_NAME` and `vault.path` references in OAuth `client_id` and `client_secret` fields, allowing secrets to be sourced from environment variables or Vault at runtime rather than stored as plain text. Updates the OpenAPI schema to replace the old `env_var`/`from_env` boolean pattern with a cleaner `ref`/`type` model that explicitly enumerates `plain_text`, `env`, and `vault` as source types.

## Changes

- Added a `<Note>` callout to both `oauth.mdx` and `per-user-oauth.mdx` explaining that `client_id` and `client_secret` accept `env.VAR_NAME` and `vault.path` references, that only the reference (not the resolved value) is persisted, and that the remaining `oauth_config` fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
- Updated the `schema-reference.mdx` `oauth_config` table row to document the same reference behavior inline.
- Updated the `connecting-to-servers.mdx` example and the `withmcpbootstrapauth/config.json` example config to use `env.GOOGLE_OAUTH_CLIENT_SECRET` instead of a hardcoded secret string.
- Replaced the `EnvVar` schema shape (`value`, `env_var`, `from_env: boolean`) with a new shape (`value`, `ref`, `type: plain_text | env | vault`) across `common.yaml`, `oauth.yaml`, and the compiled `openapi.json`. The new shape makes the source type explicit and self-describing rather than inferred from a boolean flag.
- Updated `config.schema.json` descriptions for `client_id` and `client_secret` to note the `env.` and `vault.` prefix support.
- Promoted `client_id` and `client_secret` in `OAuthConfigRequest` from plain `string` to `$ref: EnvVar` (via `allOf`) to reflect that they now carry reference metadata in API responses.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify that the OAuth and per-user-OAuth docs render the new `<Note>` block correctly. Confirm the OpenAPI spec renders `client_id` and `client_secret` under `OAuthConfigRequest` as objects with `value`, `ref`, and `type` fields rather than plain strings. Confirm the example config no longer contains a hardcoded secret value.

## Breaking changes

- [x] Yes
- [ ] No

The `EnvVar` schema shape has changed: `env_var` (string) and `from_env` (boolean) are replaced by `ref` (string) and `type` (enum). Any API clients or tooling that reads or writes these fields by name will need to be updated to use the new field names.

## Security considerations

The primary motivation is to prevent OAuth client secrets from being stored or logged as plain text. With `env.` and `vault.` references, only the reference string is persisted; the actual secret is resolved at runtime. GET responses redact the resolved `value` for secret fields, and the `ref` field exposes only the reference path, not the secret itself.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable