### PR TITLE
retry on query cache fix

### DIFF
--- a/framework/postgresconn/postgresconn.go
+++ b/framework/postgresconn/postgresconn.go
@@ -99,30 +99,28 @@ func BuildDSN(config *Config) string {
 
 // Open opens a *gorm.DB against the configured Postgres instance.
 func Open(dsn string, config *Config, logger gormlogger.Interface) (*gorm.DB, error) {
-	if config.PasswordCommand == nil {
-		return gorm.Open(postgres.New(postgres.Config{DSN: dsn}), &gorm.Config{
-			Logger: logger,
-		})
-	}
-
 	pgxConfig, err := pgx.ParseConfig(dsn)
 	if err != nil {
 		return nil, err
 	}
-	sqlDB := stdlib.OpenDB(*pgxConfig, stdlib.OptionBeforeConnect(func(ctx context.Context, connConfig *pgx.ConnConfig) error {
-		password, err := RunPasswordCommand(ctx, config.PasswordCommand)
-		if err != nil {
-			return err
-		}
-		connConfig.Password = password
-		return nil
-	}))
-	return openGormFromSQLDB(sqlDB, logger)
+	var opts []stdlib.OptionOpenDB
+	if config.PasswordCommand != nil {
+		opts = append(opts, stdlib.OptionBeforeConnect(func(ctx context.Context, connConfig *pgx.ConnConfig) error {
+			password, err := RunPasswordCommand(ctx, config.PasswordCommand)
+			if err != nil {
+				return err
+			}
+			connConfig.Password = password
+			return nil
+		}))
+	}
+	return openGormFromSQLDB(stdlib.OpenDB(*pgxConfig, opts...), logger)
 }
 
-// openGormFromSQLDB opens a GORM connection over an existing sql.DB.
+// openGormFromSQLDB opens a GORM connection over an existing sql.DB, wrapping
+// it so cached-plan invalidation errors after schema changes are retried.
 func openGormFromSQLDB(sqlDB *sql.DB, logger gormlogger.Interface) (*gorm.DB, error) {
-	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: newRetryConnPool(sqlDB)}), &gorm.Config{
 		Logger: logger,
 	})
 	if err != nil {

--- a/framework/postgresconn/retrypool.go
+++ b/framework/postgresconn/retrypool.go
@@ -1,0 +1,91 @@
+package postgresconn
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// maxCachedPlanRetries bounds retries of statements that fail with SQLSTATE
+// 0A000 ("cached plan must not change result type"). Each pooled connection
+// caches prepared statements independently and a retry may land on another
+// stale connection; every failed attempt invalidates that connection's cache
+// entry, so bounded retries converge quickly after a schema change.
+const maxCachedPlanRetries = 3
+
+// execQuerier is the subset of *sql.DB the retry wrapper delegates queries to.
+type execQuerier interface {
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// retryConnPool is a gorm.ConnPool that retries statements failing with the
+// Postgres "cached plan must not change result type" error, raised when DDL
+// (e.g. a migration's ADD COLUMN on another instance during a rolling upgrade)
+// invalidates a connection's cached prepared statement. The error is raised at
+// plan-validation time, before the statement executes, so retrying writes is
+// safe; pgx drops the stale cache entry on failure, so the retry re-prepares
+// against the current schema.
+//
+// BeginTx returns a raw *sql.Tx, so statements inside explicit transactions
+// intentionally bypass the retry: after an error the transaction is aborted
+// and must be retried as a whole by the caller.
+type retryConnPool struct {
+	delegate execQuerier
+	db       *sql.DB
+}
+
+func newRetryConnPool(db *sql.DB) *retryConnPool {
+	return &retryConnPool{delegate: db, db: db}
+}
+
+func (r *retryConnPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return r.delegate.PrepareContext(ctx, query)
+}
+
+func (r *retryConnPool) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	result, err := r.delegate.ExecContext(ctx, query, args...)
+	for attempt := 0; attempt < maxCachedPlanRetries && isCachedPlanError(err); attempt++ {
+		result, err = r.delegate.ExecContext(ctx, query, args...)
+	}
+	return result, err
+}
+
+func (r *retryConnPool) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	rows, err := r.delegate.QueryContext(ctx, query, args...)
+	for attempt := 0; attempt < maxCachedPlanRetries && isCachedPlanError(err); attempt++ {
+		rows, err = r.delegate.QueryContext(ctx, query, args...)
+	}
+	return rows, err
+}
+
+// QueryRowContext cannot retry: *sql.Row surfaces its error only at Scan time.
+func (r *retryConnPool) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return r.delegate.QueryRowContext(ctx, query, args...)
+}
+
+// BeginTx implements gorm.TxBeginner.
+func (r *retryConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return r.db.BeginTx(ctx, opts)
+}
+
+// GetDBConn implements gorm.GetDBConnector so gorm.DB.DB() keeps resolving the
+// underlying *sql.DB for pool tuning and close.
+func (r *retryConnPool) GetDBConn() (*sql.DB, error) {
+	return r.db, nil
+}
+
+// isCachedPlanError reports whether err is the Postgres cached-plan
+// invalidation error. SQLSTATE 0A000 (feature_not_supported) covers other
+// errors too, so the message is matched as well.
+func isCachedPlanError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) &&
+		pgErr.Code == "0A000" &&
+		strings.Contains(pgErr.Message, "cached plan must not change result type")
+}

--- a/framework/postgresconn/retrypool_test.go
+++ b/framework/postgresconn/retrypool_test.go
@@ -1,0 +1,146 @@
+package postgresconn
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func cachedPlanErr() *pgconn.PgError {
+	return &pgconn.PgError{Code: "0A000", Message: "cached plan must not change result type"}
+}
+
+func TestIsCachedPlanError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "cached plan error", err: cachedPlanErr(), want: true},
+		{name: "wrapped cached plan error", err: fmt.Errorf("exec failed: %w", cachedPlanErr()), want: true},
+		{name: "other 0A000 error", err: &pgconn.PgError{Code: "0A000", Message: "LISTEN is not supported"}, want: false},
+		{name: "other sqlstate with matching message", err: &pgconn.PgError{Code: "42P05", Message: "cached plan must not change result type"}, want: false},
+		{name: "non-pg error", err: errors.New("cached plan must not change result type"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCachedPlanError(tt.err); got != tt.want {
+				t.Errorf("isCachedPlanError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// stubExecQuerier fails the first failures calls with err, then succeeds.
+type stubExecQuerier struct {
+	failures int
+	err      error
+	calls    int
+}
+
+func (s *stubExecQuerier) attempt() error {
+	s.calls++
+	if s.calls <= s.failures {
+		return s.err
+	}
+	return nil
+}
+
+func (s *stubExecQuerier) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return nil, s.attempt()
+}
+
+func (s *stubExecQuerier) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return nil, s.attempt()
+}
+
+func (s *stubExecQuerier) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return nil, s.attempt()
+}
+
+func (s *stubExecQuerier) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	s.calls++
+	return nil
+}
+
+func TestRetryConnPoolRetriesCachedPlanErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		failures  int
+		err       error
+		wantErr   bool
+		wantCalls int
+	}{
+		{name: "success without retry", failures: 0, err: nil, wantErr: false, wantCalls: 1},
+		{name: "success after one retry", failures: 1, err: cachedPlanErr(), wantErr: false, wantCalls: 2},
+		{name: "success on last retry", failures: maxCachedPlanRetries, err: cachedPlanErr(), wantErr: false, wantCalls: maxCachedPlanRetries + 1},
+		{name: "retries exhausted", failures: maxCachedPlanRetries + 1, err: cachedPlanErr(), wantErr: true, wantCalls: maxCachedPlanRetries + 1},
+		{name: "non-retryable error", failures: 1, err: errors.New("connection refused"), wantErr: true, wantCalls: 1},
+	}
+	ops := []struct {
+		name string
+		run  func(pool *retryConnPool) error
+	}{
+		{name: "ExecContext", run: func(pool *retryConnPool) error {
+			_, err := pool.ExecContext(context.Background(), "UPDATE t SET a = $1", 1)
+			return err
+		}},
+		{name: "QueryContext", run: func(pool *retryConnPool) error {
+			_, err := pool.QueryContext(context.Background(), "SELECT * FROM t")
+			return err
+		}},
+	}
+	for _, op := range ops {
+		for _, tt := range tests {
+			t.Run(op.name+"/"+tt.name, func(t *testing.T) {
+				stub := &stubExecQuerier{failures: tt.failures, err: tt.err}
+				pool := &retryConnPool{delegate: stub}
+				err := op.run(pool)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("err = %v, wantErr %v", err, tt.wantErr)
+				}
+				if tt.wantErr && !errors.Is(err, tt.err) {
+					t.Errorf("err = %v, want %v", err, tt.err)
+				}
+				if stub.calls != tt.wantCalls {
+					t.Errorf("calls = %d, want %d", stub.calls, tt.wantCalls)
+				}
+			})
+		}
+	}
+}
+
+func TestRetryConnPoolDoesNotRetryPrepareOrQueryRow(t *testing.T) {
+	stub := &stubExecQuerier{failures: 1, err: cachedPlanErr()}
+	pool := &retryConnPool{delegate: stub}
+	if _, err := pool.PrepareContext(context.Background(), "SELECT 1"); !errors.Is(err, stub.err) {
+		t.Errorf("PrepareContext err = %v, want %v", err, stub.err)
+	}
+	if stub.calls != 1 {
+		t.Errorf("PrepareContext calls = %d, want 1", stub.calls)
+	}
+
+	stub = &stubExecQuerier{failures: 1, err: cachedPlanErr()}
+	pool = &retryConnPool{delegate: stub}
+	pool.QueryRowContext(context.Background(), "SELECT 1")
+	if stub.calls != 1 {
+		t.Errorf("QueryRowContext calls = %d, want 1", stub.calls)
+	}
+}
+
+func TestRetryConnPoolGetDBConn(t *testing.T) {
+	db := &sql.DB{}
+	pool := newRetryConnPool(db)
+	got, err := pool.GetDBConn()
+	if err != nil {
+		t.Fatalf("GetDBConn() error = %v", err)
+	}
+	if got != db {
+		t.Errorf("GetDBConn() = %p, want %p", got, db)
+	}
+}


### PR DESCRIPTION
## Summary

During rolling upgrades, a migration running on one instance can invalidate prepared-statement caches on other instances, causing Postgres to return `SQLSTATE 0A000` ("cached plan must not change result type"). This PR introduces a retrying connection pool wrapper that transparently re-executes statements that fail with this error, so application code does not need to handle it explicitly.

## Changes

- Introduced `retryConnPool`, a `gorm.ConnPool` implementation that wraps `*sql.DB` and retries `ExecContext` and `QueryContext` calls that fail with the cached-plan invalidation error, up to `maxCachedPlanRetries` (3) times. Each failed attempt causes pgx to drop the stale cache entry, so retries re-prepare against the current schema and converge quickly.
- `QueryRowContext` is not retried because `*sql.Row` surfaces its error only at `Scan` time. `PrepareContext` is also not retried. Statements inside explicit transactions bypass the retry intentionally — after an error the transaction is aborted and must be retried as a whole by the caller.
- Unified the `Open` code path so both the password-command and no-password-command cases go through `stdlib.OpenDB` and `openGormFromSQLDB`, eliminating the separate early-return branch.
- Added `isCachedPlanError` which matches both the `0A000` SQLSTATE code and the specific message to avoid false positives from other `feature_not_supported` errors.
- Added `retrypool_test.go` covering `isCachedPlanError`, retry behavior for `ExecContext` and `QueryContext` across success, partial failure, and exhausted-retry scenarios, non-retry behavior for `PrepareContext` and `QueryRowContext`, and `GetDBConn` resolution.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/postgresconn/...
```

To validate end-to-end, run a rolling upgrade scenario where a migration adds a column while the application is serving traffic and confirm that queries no longer fail with "cached plan must not change result type".

## Breaking changes

- [x] No

## Security considerations

The retry logic re-executes the original query and arguments unchanged. No credentials, PII, or secrets are introduced or logged. Password-command behaviour is unaffected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable