### PR TITLE
feat: allow Elevenlabs as a custom-provider base type

### DIFF
--- a/core/providers/elevenlabs/custom_provider_test.go
+++ b/core/providers/elevenlabs/custom_provider_test.go
@@ -1,0 +1,87 @@
+package elevenlabs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testLogger is a minimal logger implementation for testing.
+type testLogger struct{}
+
+func (l *testLogger) Debug(msg string, args ...any)                     {}
+func (l *testLogger) Info(msg string, args ...any)                      {}
+func (l *testLogger) Warn(msg string, args ...any)                      {}
+func (l *testLogger) Error(msg string, args ...any)                     {}
+func (l *testLogger) Fatal(msg string, args ...any)                     {}
+func (l *testLogger) SetLevel(level schemas.LogLevel)                   {}
+func (l *testLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
+func (l *testLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+const customElevenlabsProviderName = schemas.ModelProvider("custom-elevenlabs")
+
+func TestElevenlabsProvider_CustomAliasListModelsReportsAliasMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`[{"model_id":"eleven_multilingual_v2","name":"Eleven Multilingual v2"}]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	provider := NewElevenlabsProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: string(customElevenlabsProviderName),
+			BaseProviderType:  schemas.Elevenlabs,
+		},
+	}, &testLogger{})
+
+	assert.Equal(t, customElevenlabsProviderName, provider.GetProviderKey())
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	request := &schemas.BifrostListModelsRequest{
+		Provider: customElevenlabsProviderName,
+	}
+
+	response, bifrostErr := provider.ListModels(ctx, []schemas.Key{{}}, request)
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, response)
+}
+
+func TestElevenlabsProvider_CustomAliasHonorsAllowedRequests(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("request should not reach the server when the operation is disallowed")
+	}))
+	defer server.Close()
+
+	provider := NewElevenlabsProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: string(customElevenlabsProviderName),
+			BaseProviderType:  schemas.Elevenlabs,
+			AllowedRequests: &schemas.AllowedRequests{
+				Speech: true,
+			},
+		},
+	}, &testLogger{})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	request := &schemas.BifrostListModelsRequest{
+		Provider: customElevenlabsProviderName,
+	}
+
+	response, bifrostErr := provider.ListModels(ctx, []schemas.Key{{}}, request)
+	require.Nil(t, response)
+	require.NotNil(t, bifrostErr)
+}

--- a/core/providers/elevenlabs/custom_provider_test.go
+++ b/core/providers/elevenlabs/custom_provider_test.go
@@ -49,12 +49,15 @@ func TestElevenlabsProvider_CustomAliasListModelsReportsAliasMetadata(t *testing
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	request := &schemas.BifrostListModelsRequest{
-		Provider: customElevenlabsProviderName,
+		Provider:   customElevenlabsProviderName,
+		Unfiltered: true,
 	}
 
 	response, bifrostErr := provider.ListModels(ctx, []schemas.Key{{}}, request)
 	require.Nil(t, bifrostErr)
 	require.NotNil(t, response)
+	require.Len(t, response.Data, 1)
+	assert.Equal(t, "custom-elevenlabs/eleven_multilingual_v2", response.Data[0].ID)
 }
 
 func TestElevenlabsProvider_CustomAliasHonorsAllowedRequests(t *testing.T) {

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -85,8 +85,13 @@ func (provider *ElevenlabsProvider) listModelsByKey(ctx *schemas.BifrostContext,
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	// Build URL using centralized URL construction
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/models"))
+	// Build URL using centralized URL construction, honoring custom provider RequestPathOverrides
+	requestPath, isCompleteURL := providerUtils.GetRequestPath(ctx, "/v1/models", provider.customProviderConfig, schemas.ListModelsRequest)
+	if isCompleteURL {
+		req.SetRequestURI(requestPath)
+	} else {
+		req.SetRequestURI(provider.networkConfig.BaseURL + requestPath)
+	}
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -75,6 +75,7 @@ var SupportedBaseProviders = []ModelProvider{
 	Anthropic,
 	Bedrock,
 	Cohere,
+	Elevenlabs,
 	Gemini,
 	OpenAI,
 	HuggingFace,

--- a/tests/e2e/features/providers/pages/providers.page.ts
+++ b/tests/e2e/features/providers/pages/providers.page.ts
@@ -379,6 +379,7 @@ export class ProvidersPage extends BasePage {
       gemini: 'Gemini',
       cohere: 'Cohere',
       bedrock: 'AWS Bedrock',
+      elevenlabs: 'Elevenlabs',
     }
     return labels[type] || type
   }

--- a/tests/e2e/features/providers/providers.spec.ts
+++ b/tests/e2e/features/providers/providers.spec.ts
@@ -195,6 +195,25 @@ test.describe("Providers", () => {
       await expect(providerItem).toBeVisible({ timeout: 15000 });
     });
 
+    test("should create a custom ElevenLabs-compatible provider", async ({
+      providersPage,
+    }) => {
+      const providerData = createCustomProviderData({
+        name: `test-elevenlabs-${Date.now()}`,
+        baseProviderType: "elevenlabs",
+        baseUrl: "https://api.elevenlabs.io",
+      });
+
+      // Track for cleanup
+      createdProviders.push(providerData.name);
+
+      await providersPage.createProvider(providerData);
+
+      // Wait for provider to appear in sidebar
+      const providerItem = providersPage.getProviderItem(providerData.name);
+      await expect(providerItem).toBeVisible({ timeout: 15000 });
+    });
+
     test("should cancel custom provider creation", async ({
       providersPage,
     }) => {

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -169,6 +169,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 													<SelectItem value="cohere">Cohere</SelectItem>
 													<SelectItem value="bedrock">AWS Bedrock</SelectItem>
 													<SelectItem value="replicate">Replicate</SelectItem>
+													<SelectItem value="elevenlabs">Elevenlabs</SelectItem>
 												</SelectContent>
 											</Select>
 										</FormControl>

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -52,6 +52,12 @@ const ProviderEndpoints: Partial<Record<BaseProvider, Partial<Record<RequestType
 		responses_stream: "/v2/chat",
 		embedding: "/v2/embed",
 	},
+	elevenlabs: {
+		list_models: "/v1/models",
+		speech: "/v1/text-to-speech/{voice_id}",
+		speech_stream: "/v1/text-to-speech/{voice_id}/stream",
+		transcription: "/v1/speech-to-text",
+	},
 };
 
 // Helper function to get the appropriate placeholder

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -117,6 +117,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 										<SelectItem value="cohere">Cohere</SelectItem>
 										<SelectItem value="gemini">Gemini</SelectItem>
 										<SelectItem value="replicate">Replicate</SelectItem>
+										<SelectItem value="elevenlabs">Elevenlabs</SelectItem>
 									</SelectContent>
 								</Select>
 								<FormDescription>The underlying provider this custom provider will use</FormDescription>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -203,6 +203,7 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 		"responses_stream",
 		"embedding",
 	],
+	elevenlabs: ["list_models", "speech", "speech_stream", "transcription"],
 };
 
 export const IS_ENTERPRISE = process.env.BIFROST_IS_ENTERPRISE === "true";

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -7,7 +7,7 @@ import { SecretVar } from "./schemas";
 export type KnownProvider = (typeof KnownProvidersNames)[number];
 
 // Base provider names - all supported base providers
-export type BaseProvider = "openai" | "anthropic" | "cohere" | "gemini" | "bedrock" | "replicate" | "fireworks";
+export type BaseProvider = "openai" | "anthropic" | "cohere" | "gemini" | "bedrock" | "replicate" | "fireworks" | "elevenlabs";
 
 // Branded type for custom provider names to prevent collision with known providers
 export type CustomProviderName = string & { readonly __brand: "CustomProviderName" };


### PR DESCRIPTION
Users can register Elevenlabs as a custom-provider base type, aliasing an Elevenlabs-compatible endpoint the same way OpenAI/Mistral/Anthropic/Cohere/Gemini/Bedrock/Replicate already work.

## Details

- Adds `Elevenlabs` to `SupportedBaseProviders`.
- Adds `RequestPathOverrides` support for `ListModels` (matching Speech/Transcription) so custom Elevenlabs providers can override all their request paths, not just some.
- UI Updated — custom-provider create/edit forms recognize Elevenlabs and gate "Allowed Request Types" to the 4 operations it actually supports.

## Checklist

- [x] Added tests
- [x] Reproduced against live ElevenLabs API — created a custom Elevenlabs provider, added a real key, confirmed `ListModels` and `Speech` round-trip to the real ElevenLabs API
