### PR TITLE
fix: small latency return fixes

### DIFF
--- a/core/providers/azure/realtime.go
+++ b/core/providers/azure/realtime.go
@@ -121,7 +121,7 @@ func (provider *AzureProvider) ExchangeRealtimeWebRTCSDP(
 	}
 	req.SetBody(bodyBuf.Bytes())
 
-	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
 	defer wait()
 	if bifrostErr != nil {
 		return "", bifrostErr
@@ -129,7 +129,7 @@ func (provider *AzureProvider) ExchangeRealtimeWebRTCSDP(
 
 	answerBody := resp.Body()
 	if resp.StatusCode() < fasthttp.StatusOK || resp.StatusCode() >= fasthttp.StatusMultipleChoices {
-		return "", provider.realtimeWebRTCUpstreamError(ctx, resp.StatusCode(), answerBody)
+		return "", providerUtils.SetErrorLatency(provider.realtimeWebRTCUpstreamError(ctx, resp.StatusCode(), answerBody), latency)
 	}
 
 	return string(answerBody), nil

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -887,13 +887,13 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	responseBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return nil, &schemas.BifrostError{
+		return nil, providerUtils.SetErrorLatency(&schemas.BifrostError{
 			IsBifrostError: true,
 			Error: &schemas.ErrorField{
 				Message: "error reading request",
 				Error:   err,
 			},
-		}
+		}, latency)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2443,10 +2443,10 @@ func (provider *GeminiProvider) VideoDownload(ctx *schemas.BifrostContext, key s
 		if resp.StatusCode() != fasthttp.StatusOK {
 			// log full error
 			provider.logger.Error("failed to download video: " + string(resp.Body()))
-			return nil, providerUtils.NewBifrostOperationError(
+			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(
 				fmt.Sprintf("failed to download video: HTTP %d", resp.StatusCode()),
 				nil,
-			)
+			), latency)
 		}
 		body, err := providerUtils.CheckAndDecodeBody(resp)
 		if err != nil {

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -209,10 +209,10 @@ func (provider *HuggingFaceProvider) completeRequestWithModelAliasCache(
 			// Retry the request
 			responseBody, latency, providerResponseHeaders, err = provider.completeRequest(ctx, updatedJSONData, url, key, isHFInferenceAudioRequest, isHFInferenceImageRequest)
 			if err != nil {
-				return nil, 0, nil, err
+				return nil, latency, nil, err
 			}
 		} else {
-			return nil, 0, nil, err
+			return nil, latency, nil, err
 		}
 	}
 

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -114,7 +114,7 @@ func (provider *OpenAIProvider) exchangeWebRTCSDP(
 	}
 	req.SetBody(bodyBuf.Bytes())
 
-	_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
 	defer wait()
 	if bifrostErr != nil {
 		return "", bifrostErr
@@ -122,7 +122,7 @@ func (provider *OpenAIProvider) exchangeWebRTCSDP(
 
 	answerBody := resp.Body()
 	if resp.StatusCode() < fasthttp.StatusOK || resp.StatusCode() >= fasthttp.StatusMultipleChoices {
-		return "", provider.realtimeWebRTCUpstreamError(ctx, resp.StatusCode(), answerBody)
+		return "", providerUtils.SetErrorLatency(provider.realtimeWebRTCUpstreamError(ctx, resp.StatusCode(), answerBody), latency)
 	}
 
 	return string(answerBody), nil

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -333,7 +333,7 @@ func (provider *ReplicateProvider) listDeploymentsByKey(ctx *schemas.BifrostCont
 		providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
 
 		// Make request
-		_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+		latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
 
 		// Release resources
 		wait()
@@ -346,7 +346,7 @@ func (provider *ReplicateProvider) listDeploymentsByKey(ctx *schemas.BifrostCont
 
 		// Handle error response
 		if resp.StatusCode() != fasthttp.StatusOK {
-			errorResponse := parseReplicateError(resp.Body(), resp.StatusCode())
+			errorResponse := providerUtils.SetErrorLatency(parseReplicateError(resp.Body(), resp.StatusCode()), latency)
 			fasthttp.ReleaseResponse(resp)
 			return nil, errorResponse
 		}
@@ -2721,9 +2721,9 @@ func (provider *ReplicateProvider) VideoDownload(ctx *schemas.BifrostContext, ke
 		return nil, bifrostErr
 	}
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, providerUtils.NewBifrostOperationError(
+		return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(
 			fmt.Sprintf("failed to download video: HTTP %d", resp.StatusCode()),
-			nil)
+			nil), latency)
 	}
 
 	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)

--- a/core/providers/runware/runware.go
+++ b/core/providers/runware/runware.go
@@ -277,14 +277,14 @@ func (provider *RunwareProvider) sendTaskArray(ctx *schemas.BifrostContext, key 
 	lat, bErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
 	defer wait()
 	if bErr != nil {
-		return reqBody, nil, 0, bErr
+		return reqBody, nil, lat, bErr
 	}
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return reqBody, nil, 0, providerUtils.SetErrorLatency(parseRunwareError(resp), lat)
+		return reqBody, nil, lat, providerUtils.SetErrorLatency(parseRunwareError(resp), lat)
 	}
 	decoded, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
-		return reqBody, nil, 0, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+		return reqBody, nil, lat, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err), lat)
 	}
 	// Copy out: the fasthttp response buffer is released when this function returns.
 	return reqBody, append([]byte(nil), decoded...), lat, nil
@@ -405,7 +405,7 @@ func (provider *RunwareProvider) VideoDownload(ctx *schemas.BifrostContext, key 
 		return nil, bifrostErr
 	}
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to download video: HTTP %d", resp.StatusCode()), nil)
+		return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to download video: HTTP %d", resp.StatusCode()), nil), latency)
 	}
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -269,7 +269,7 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 			providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 			req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 
-			_, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+			latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
 			if bifrostErr != nil {
 				wait()
 				respBody := append([]byte(nil), resp.Body()...)
@@ -307,9 +307,9 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 
 				var errorResp VertexError
 				if err := sonic.Unmarshal(respBody, &errorResp); err != nil {
-					return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), nil, respBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+					return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err), nil, respBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 				}
-				return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorResp.Error.Message, nil, statusCode, nil, nil), nil, respBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+				return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorResp.Error.Message, nil, statusCode, nil, nil), nil, respBody, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 			}
 
 			// Parse Vertex's publisher models response
@@ -2583,9 +2583,9 @@ func (provider *VertexProvider) VideoDownload(ctx *schemas.BifrostContext, key s
 		}
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerUtils.ExtractProviderResponseHeaders(resp))
 		if resp.StatusCode() != fasthttp.StatusOK {
-			return nil, providerUtils.NewBifrostOperationError(
+			return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(
 				fmt.Sprintf("failed to download video: HTTP %d", resp.StatusCode()),
-				nil)
+				nil), latency)
 		}
 		body, err := providerUtils.CheckAndDecodeBody(resp)
 		if err != nil {
@@ -4162,7 +4162,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
 			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
 		}
-		return nil, providerUtils.EnrichError(ctx, parseVertexError(resp), jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, parseVertexError(resp), jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 
 	responseBody, isLargeResp, decodeErr := providerUtils.FinalizeResponseWithLargeDetection(ctx, resp, provider.logger)


### PR DESCRIPTION
## Summary

Latency values captured from HTTP requests were being discarded or zeroed out when errors occurred, meaning error responses had no timing information attached. This PR ensures that latency is consistently propagated and attached to `BifrostError` instances across all affected providers.

## Changes

- Captured the `latency` return value from `MakeRequestWithContext` in Azure and OpenAI realtime WebRTC SDP exchange functions, and attached it to upstream errors via `SetErrorLatency`.
- Fixed Bedrock's `listModelsByKey` to wrap the read error with `SetErrorLatency` instead of returning a bare `BifrostError`.
- Fixed Gemini, Replicate, Runware, and Vertex `VideoDownload` functions to attach latency to errors returned on non-200 status codes.
- Fixed Replicate's `listDeploymentsByKey` to attach latency to parsed error responses.
- Fixed Runware's `sendTaskArray` to return the captured `lat` value instead of `0` on all error paths.
- Fixed HuggingFace's `completeRequestWithModelAliasCache` to return the actual `latency` value instead of `0` on retry error paths.
- Updated Vertex's `listModelsByKey` and `CountTokens` to pass `latency` through to `EnrichError`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./...
```

Trigger requests to each affected provider that result in an error response (e.g., invalid credentials, bad model name) and verify that the returned `BifrostError` includes a non-zero latency value reflecting the actual round-trip time.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects error metadata propagation and does not touch authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable