### PR TITLE
fix: append datasheet models for incomplete list models call

### DIFF
--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -9,6 +9,17 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 )
 
+// providersWithPartialListModels enumerates providers whose /v1/models response
+// is a strict subset of their callable catalog — Perplexity lists only
+// responses-API models and omits the Sonar chat family, which is still callable
+// via /chat/completions. For these, the datasheet (not the live list) is the
+// authoritative superset, so live must be unioned with the full allowed
+// datasheet set rather than only the deprecated backfill.
+var providersWithPartialListModels = map[schemas.ModelProvider]bool{
+	schemas.Perplexity: true,
+	schemas.Vertex:     true,
+}
+
 // GetModelsForProvider returns the effective allowed model set for the
 // provider. Filtered live entries are authoritative when present (they were
 // pre-gated by ListModelsPipeline against the key's allow/block/aliases);
@@ -20,7 +31,16 @@ func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []s
 	var out []string
 	if liveModels := mc.live.ModelsForProvider(provider); len(liveModels) > 0 {
 		out = liveModels
-		out = mc.appendAllowedDatasheetModels(out, mc.datasheet.DeprecatedDatasheetModelsForProvider(provider), allowed, blacklisted)
+		// Datasheet models to reconcile on top of the live list: normally just
+		// deprecated ones (dropped from list-models but still callable). For
+		// providers whose list-models is a partial subset, use the full
+		// datasheet so callable-but-unlisted models (e.g. Perplexity's Sonar
+		// chat family) aren't shadowed by the incomplete live list.
+		datasheetModelsToAppend := mc.datasheet.DeprecatedDatasheetModelsForProvider(provider)
+		if providersWithPartialListModels[provider] {
+			datasheetModelsToAppend = mc.datasheet.DatasheetModelsForProvider(provider)
+		}
+		out = mc.appendAllowedDatasheetModels(out, datasheetModelsToAppend, allowed, blacklisted)
 	} else if datasheetModels := mc.datasheet.DatasheetModelsForProvider(provider); len(datasheetModels) > 0 && allowed != nil {
 		out = make([]string, 0, len(datasheetModels))
 		for _, m := range datasheetModels {

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -154,6 +154,49 @@ func TestGetModelsForProvider_DeprecatedDatasheetModelsRespectAllowBlock(t *test
 	}
 }
 
+// TestGetModelsForProvider_PartialListModelsProviderUnionsDatasheet pins the
+// fix for Perplexity's partial /v1/models response: a callable-but-unlisted
+// datasheet model (the Sonar chat family) must survive once a live entry
+// exists, instead of being shadowed by the incomplete live list. The same
+// non-deprecated datasheet model stays excluded for a normal provider, whose
+// live list is treated as authoritative.
+func TestGetModelsForProvider_PartialListModelsProviderUnionsDatasheet(t *testing.T) {
+	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
+	pricingJSON := []byte(`{
+		"sonar": {"provider":"perplexity","mode":"chat","base_model":"sonar"},
+		"openai-unlisted": {"provider":"openai","mode":"chat","base_model":"openai-unlisted"}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing testdata: %v", err)
+	}
+	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + pricingPath})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing testdata: %v", err)
+	}
+
+	// Perplexity: live lists only a responses-API model; the unlisted "sonar"
+	// chat model must still be unioned in from the datasheet.
+	mcPerplexity := NewTestCatalogWithDatasheet(ds)
+	mcPerplexity.UpsertLive(schemas.Perplexity, "k1", false, []string{"listed-responses-model"})
+	gotPerplexity := mcPerplexity.GetModelsForProvider(schemas.Perplexity)
+	slices.Sort(gotPerplexity)
+	wantPerplexity := []string{"listed-responses-model", "sonar"}
+	if !slices.Equal(gotPerplexity, wantPerplexity) {
+		t.Errorf("GetModelsForProvider(Perplexity) = %v, want %v (unlisted datasheet model must be unioned)", gotPerplexity, wantPerplexity)
+	}
+
+	// OpenAI is not a partial-list-models provider: its non-deprecated unlisted
+	// datasheet model stays shadowed by the authoritative live list.
+	mcOpenAI := NewTestCatalogWithDatasheet(ds)
+	mcOpenAI.UpsertLive(schemas.OpenAI, "k1", false, []string{"live-model"})
+	gotOpenAI := mcOpenAI.GetModelsForProvider(schemas.OpenAI)
+	slices.Sort(gotOpenAI)
+	wantOpenAI := []string{"live-model"}
+	if !slices.Equal(gotOpenAI, wantOpenAI) {
+		t.Errorf("GetModelsForProvider(OpenAI) = %v, want %v (non-deprecated unlisted datasheet model must stay shadowed)", gotOpenAI, wantOpenAI)
+	}
+}
+
 // ptrBool returns a pointer to b, for building schemas.Key fixtures.
 func ptrBool(b bool) *bool { return &b }
 


### PR DESCRIPTION
## Summary

Perplexity's `/v1/models` endpoint returns only responses-API models, omitting the Sonar chat family (e.g. `sonar`) which remains callable via `/chat/completions`. Previously, when a live model list existed for Perplexity, the catalog treated it as authoritative and shadowed any unlisted-but-callable datasheet models, making the Sonar chat family invisible to the catalog. This fix introduces a provider-level flag for "partial list-models" providers and unions the full datasheet into the live list for those providers instead of only deprecated backfills.

## Changes

- Introduced `providersWithPartialListModels` — a map identifying providers (currently Perplexity and Vertex) whose `/v1/models` response is a strict subset of their callable catalog.
- In `GetModelsForProvider`, when a live list exists for a partial-list-models provider, the full datasheet model set is used for reconciliation rather than only deprecated models, ensuring callable-but-unlisted models are not dropped.
- For all other providers, the existing behavior is preserved: the live list is authoritative and only deprecated datasheet models are backfilled.
- Added a test (`TestGetModelsForProvider_PartialListModelsProviderUnionsDatasheet`) that pins both behaviors — Perplexity's unlisted `sonar` model is unioned in, while OpenAI's unlisted non-deprecated datasheet model remains shadowed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/...
```

Expected: `TestGetModelsForProvider_PartialListModelsProviderUnionsDatasheet` passes, confirming that:
- `GetModelsForProvider(Perplexity)` returns both `listed-responses-model` and `sonar` when only `listed-responses-model` is in the live list.
- `GetModelsForProvider(OpenAI)` returns only `live-model` when `openai-unlisted` exists in the datasheet but not the live list.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable