### PR TITLE
fix(anthropic): strip unsupported JSON Schema keywords from strict tool input_schema

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -29,6 +29,12 @@ func convertFunctionToolToAnthropic(tool schemas.ChatTool) AnthropicTool {
 	}
 
 	if anthropicTool.InputSchema != nil {
+		// Anthropic only rejects these JSON Schema keywords under strict
+		// (grammar-constrained) tool input validation; non-strict tool calls
+		// accept them without complaint, so only sanitize when strict is on.
+		if tool.Function.Strict != nil && *tool.Function.Strict {
+			anthropicTool.InputSchema = SanitizeToolSchemaForAnthropic(anthropicTool.InputSchema)
+		}
 		anthropicTool.InputSchema = anthropicTool.InputSchema.Normalized()
 	}
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -6688,8 +6688,10 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 	// Agent SDK) may send non-deterministic property orderings across turns,
 	// which breaks Anthropic's prefix-based prompt caching since tool
 	// definitions are part of the serialized request prefix.
-	// Normalized() returns a shallow copy with sorted key slices, so the
-	// caller-owned tool.ResponsesToolFunction.Parameters is never mutated.
+	// anthropicTool.InputSchema is already an owned copy at this point (from
+	// the DeepCopyToolFunctionParameters call above), so both Sanitize's
+	// in-place mutation and Normalized()'s shallow copy operate on it safely
+	// without touching the caller-owned tool.ResponsesToolFunction.Parameters.
 	if anthropicTool.InputSchema != nil {
 		if anthropicTool.Strict != nil && *anthropicTool.Strict {
 			anthropicTool.InputSchema = SanitizeToolSchemaForAnthropic(anthropicTool.InputSchema)

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -6668,7 +6668,10 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 		anthropicTool.Strict = tool.ResponsesToolFunction.Strict
 	}
 	if tool.ResponsesToolFunction != nil && tool.ResponsesToolFunction.Parameters != nil {
-		anthropicTool.InputSchema = tool.ResponsesToolFunction.Parameters
+		// Deep-copy before sanitizing: SanitizeToolSchemaForAnthropic mutates
+		// nested OrderedMap trees in place, and the caller-owned
+		// tool.ResponsesToolFunction.Parameters must never be mutated.
+		anthropicTool.InputSchema = schemas.DeepCopyToolFunctionParameters(tool.ResponsesToolFunction.Parameters)
 	} else {
 		// Anthropic requires input_schema for custom tools, provide empty object schema if missing
 		anthropicTool.InputSchema = &schemas.ToolFunctionParameters{
@@ -6677,13 +6680,20 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 		}
 	}
 
-	// Normalize tool schema key ordering to ensure deterministic serialization.
-	// Clients (e.g. Claude Agent SDK) may send non-deterministic property orderings
-	// across turns, which breaks Anthropic's prefix-based prompt caching since tool
+	// Strip JSON Schema keywords Anthropic's input_schema does not support
+	// (see SanitizeToolSchemaForAnthropic) — only under strict (grammar-
+	// constrained) tool input validation, since non-strict tool calls accept
+	// these keywords without complaint — then normalize tool schema key
+	// ordering to ensure deterministic serialization. Clients (e.g. Claude
+	// Agent SDK) may send non-deterministic property orderings across turns,
+	// which breaks Anthropic's prefix-based prompt caching since tool
 	// definitions are part of the serialized request prefix.
 	// Normalized() returns a shallow copy with sorted key slices, so the
 	// caller-owned tool.ResponsesToolFunction.Parameters is never mutated.
 	if anthropicTool.InputSchema != nil {
+		if anthropicTool.Strict != nil && *anthropicTool.Strict {
+			anthropicTool.InputSchema = SanitizeToolSchemaForAnthropic(anthropicTool.InputSchema)
+		}
 		anthropicTool.InputSchema = anthropicTool.InputSchema.Normalized()
 	}
 

--- a/core/providers/anthropic/schemasanitize.go
+++ b/core/providers/anthropic/schemasanitize.go
@@ -1,0 +1,256 @@
+package anthropic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// anthropicUnsupportedSchemaKeywords lists JSON Schema validation keywords
+// that Anthropic's tool input_schema (and structured-output schema) rejects
+// outright, wherever they appear in the schema tree.
+//
+// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
+var anthropicUnsupportedSchemaKeywords = []string{
+	"minItems", "maxItems",
+	"minLength", "maxLength",
+	"minimum", "maximum",
+	"exclusiveMinimum", "exclusiveMaximum",
+}
+
+// anthropicConstraintDescriptionTemplates renders a removed constraint's value
+// into a human-readable note appended to the affected schema node's
+// description, mirroring the transformation Anthropic's own SDKs perform.
+var anthropicConstraintDescriptionTemplates = map[string]string{
+	"minItems":         "minimum number of items: %v",
+	"maxItems":         "maximum number of items: %v",
+	"minLength":        "minimum length: %v",
+	"maxLength":        "maximum length: %v",
+	"minimum":          "minimum value: %v",
+	"maximum":          "maximum value: %v",
+	"exclusiveMinimum": "exclusive minimum value: %v",
+	"exclusiveMaximum": "exclusive maximum value: %v",
+}
+
+// constraintEntry captures a single removed JSON Schema keyword and its value,
+// in removal order, so the generated description note is deterministic.
+type constraintEntry struct {
+	keyword string
+	value   interface{}
+}
+
+// buildConstraintNote renders removed constraints into a single description
+// suffix, e.g. "Note: maximum number of items: 5, minimum length: 1."
+func buildConstraintNote(entries []constraintEntry) string {
+	parts := make([]string, 0, len(entries))
+	for _, e := range entries {
+		tmpl := anthropicConstraintDescriptionTemplates[e.keyword]
+		parts = append(parts, fmt.Sprintf(tmpl, e.value))
+	}
+	return "Note: " + strings.Join(parts, ", ") + "."
+}
+
+// appendDescriptionNote appends note to an existing description, separating
+// with a space if a description was already present.
+func appendDescriptionNote(existing string, note string) string {
+	if existing == "" {
+		return note
+	}
+	return existing + " " + note
+}
+
+// asSchemaNode coerces a raw JSON-Schema-node value (decoded either as
+// *schemas.OrderedMap via the ordered-key JSON path, or as a plain
+// map[string]interface{} when constructed programmatically) into an
+// *schemas.OrderedMap that can be mutated in place. Returns nil for any other
+// (non-object) schema shape, e.g. `true`/`false` schemas.
+func asSchemaNode(v interface{}) *schemas.OrderedMap {
+	switch t := v.(type) {
+	case *schemas.OrderedMap:
+		return t
+	case map[string]interface{}:
+		return schemas.OrderedMapFromMap(t)
+	default:
+		return nil
+	}
+}
+
+// sanitizeSchemaNode recursively strips anthropicUnsupportedSchemaKeywords
+// from a raw JSON Schema node (an object schema decoded into an OrderedMap)
+// and from every nested node reachable via "properties", "items", "$defs",
+// "definitions", "anyOf", "oneOf", and "allOf". Removed constraints are folded
+// into the node's own "description" key so the model still sees the intent.
+//
+// Mutates om in place and returns it for convenience; safe to call with nil.
+func sanitizeSchemaNode(om *schemas.OrderedMap) *schemas.OrderedMap {
+	if om == nil {
+		return nil
+	}
+
+	var entries []constraintEntry
+	for _, kw := range anthropicUnsupportedSchemaKeywords {
+		if val, ok := om.Get(kw); ok {
+			entries = append(entries, constraintEntry{keyword: kw, value: val})
+			om.Delete(kw)
+		}
+	}
+	if len(entries) > 0 {
+		existing := ""
+		if v, ok := om.Get("description"); ok {
+			if s, ok2 := v.(string); ok2 {
+				existing = s
+			}
+		}
+		om.Set("description", appendDescriptionNote(existing, buildConstraintNote(entries)))
+	}
+
+	if propsVal, ok := om.Get("properties"); ok {
+		if props := asSchemaNode(propsVal); props != nil {
+			sanitizeNamedNodeMap(props)
+			om.Set("properties", props)
+		}
+	}
+	if itemsVal, ok := om.Get("items"); ok {
+		if node := asSchemaNode(itemsVal); node != nil {
+			om.Set("items", sanitizeSchemaNode(node))
+		}
+	}
+	for _, key := range []string{"$defs", "definitions"} {
+		if val, ok := om.Get(key); ok {
+			if defs := asSchemaNode(val); defs != nil {
+				sanitizeNamedNodeMap(defs)
+				om.Set(key, defs)
+			}
+		}
+	}
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		if val, ok := om.Get(key); ok {
+			if arr, ok := val.([]interface{}); ok {
+				for i, item := range arr {
+					if node := asSchemaNode(item); node != nil {
+						arr[i] = sanitizeSchemaNode(node)
+					}
+				}
+				om.Set(key, arr)
+			}
+		}
+	}
+	// additionalProperties may itself be a schema (not just a bool) per JSON
+	// Schema — e.g. {"additionalProperties": {"type": "string", "maxLength": 32}}
+	// constrains any extra properties. Sanitize it like any other nested node;
+	// a bool value falls through asSchemaNode as nil and is left untouched.
+	if addlVal, ok := om.Get("additionalProperties"); ok {
+		if node := asSchemaNode(addlVal); node != nil {
+			om.Set("additionalProperties", sanitizeSchemaNode(node))
+		}
+	}
+
+	return om
+}
+
+// sanitizeNamedNodeMap sanitizes every value in a name->schema-node map
+// (used for "properties" and "$defs"/"definitions" containers) in place.
+func sanitizeNamedNodeMap(named *schemas.OrderedMap) {
+	if named == nil {
+		return
+	}
+	for _, k := range named.Keys() {
+		v, ok := named.Get(k)
+		if !ok {
+			continue
+		}
+		if node := asSchemaNode(v); node != nil {
+			named.Set(k, sanitizeSchemaNode(node))
+		}
+	}
+}
+
+// SanitizeToolSchemaForAnthropic returns a copy of params with every JSON
+// Schema keyword unsupported by Anthropic's tool input_schema removed,
+// recursively, from the top-level schema and from every nested
+// property/items/defs/anyOf/oneOf/allOf schema. Removed numeric/string/array
+// constraints are folded into the affected node's description so the model
+// still sees the intent as guidance, mirroring the transformation Anthropic's
+// own SDKs perform for structured outputs.
+//
+// See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations
+//
+// params is expected to already be an owned copy (e.g. via
+// schemas.DeepCopyToolFunctionParameters) — nested OrderedMap trees are
+// mutated in place as they are sanitized.
+func SanitizeToolSchemaForAnthropic(params *schemas.ToolFunctionParameters) *schemas.ToolFunctionParameters {
+	if params == nil {
+		return nil
+	}
+	out := *params
+
+	var entries []constraintEntry
+	if out.MinItems != nil {
+		entries = append(entries, constraintEntry{"minItems", *out.MinItems})
+		out.MinItems = nil
+	}
+	if out.MaxItems != nil {
+		entries = append(entries, constraintEntry{"maxItems", *out.MaxItems})
+		out.MaxItems = nil
+	}
+	if out.MinLength != nil {
+		entries = append(entries, constraintEntry{"minLength", *out.MinLength})
+		out.MinLength = nil
+	}
+	if out.MaxLength != nil {
+		entries = append(entries, constraintEntry{"maxLength", *out.MaxLength})
+		out.MaxLength = nil
+	}
+	if out.Minimum != nil {
+		entries = append(entries, constraintEntry{"minimum", *out.Minimum})
+		out.Minimum = nil
+	}
+	if out.Maximum != nil {
+		entries = append(entries, constraintEntry{"maximum", *out.Maximum})
+		out.Maximum = nil
+	}
+	if out.ExclusiveMinimum != nil {
+		entries = append(entries, constraintEntry{"exclusiveMinimum", *out.ExclusiveMinimum})
+		out.ExclusiveMinimum = nil
+	}
+	if out.ExclusiveMaximum != nil {
+		entries = append(entries, constraintEntry{"exclusiveMaximum", *out.ExclusiveMaximum})
+		out.ExclusiveMaximum = nil
+	}
+	if len(entries) > 0 {
+		existing := ""
+		if out.Description != nil {
+			existing = *out.Description
+		}
+		combined := appendDescriptionNote(existing, buildConstraintNote(entries))
+		out.Description = &combined
+	}
+
+	if out.Properties != nil {
+		sanitizeNamedNodeMap(out.Properties)
+	}
+	out.Items = sanitizeSchemaNode(out.Items)
+	if out.Defs != nil {
+		sanitizeNamedNodeMap(out.Defs)
+	}
+	if out.Definitions != nil {
+		sanitizeNamedNodeMap(out.Definitions)
+	}
+	for i := range out.AnyOf {
+		sanitizeSchemaNode(&out.AnyOf[i])
+	}
+	for i := range out.OneOf {
+		sanitizeSchemaNode(&out.OneOf[i])
+	}
+	for i := range out.AllOf {
+		sanitizeSchemaNode(&out.AllOf[i])
+	}
+	// additionalProperties may itself carry a schema (AdditionalPropertiesMap)
+	// constraining extra properties — sanitize it like any other nested node.
+	if out.AdditionalProperties != nil && out.AdditionalProperties.AdditionalPropertiesMap != nil {
+		sanitizeSchemaNode(out.AdditionalProperties.AdditionalPropertiesMap)
+	}
+
+	return &out
+}

--- a/core/providers/anthropic/schemasanitize_test.go
+++ b/core/providers/anthropic/schemasanitize_test.go
@@ -81,8 +81,12 @@ func TestSanitizeToolSchemaForAnthropic_NestedContainers(t *testing.T) {
 				schemas.KV("maxItems", int64(5)),
 				schemas.KV("items", schemas.NewOrderedMapFromPairs(schemas.KV("type", "string"))),
 			)),
-			// exclusiveMinimum/Maximum only ever appear in the raw nested tree,
-			// since ToolFunctionParameters has no top-level field for them.
+			// exclusiveMinimum/Maximum here are nested inside a property's raw
+			// schema node (an *OrderedMap), not the top-level typed struct
+			// fields covered by TestSanitizeToolSchemaForAnthropic_TopLevel —
+			// property-level schemas are never typed, only the top-level
+			// ToolFunctionParameters struct is, so the recursive node
+			// sanitizer must catch these independently of the top-level fields.
 			schemas.KV("score", schemas.NewOrderedMapFromPairs(
 				schemas.KV("type", "number"),
 				schemas.KV("exclusiveMinimum", 0.0),
@@ -166,10 +170,17 @@ func TestSanitizeToolSchemaForAnthropic_NestedContainers(t *testing.T) {
 	}
 }
 
-// TestSanitizeToolSchemaForAnthropic_DoesNotMutateCaller verifies the
-// function returns an independent copy: a caller passing a schema that
-// needs no changes must still get back a distinct struct, not an alias.
-func TestSanitizeToolSchemaForAnthropic_DoesNotMutateCaller(t *testing.T) {
+// TestSanitizeToolSchemaForAnthropic_ReturnsDistinctTopLevelCopy verifies the
+// top-level struct returned is a distinct copy, not an alias — so scalar
+// fields on the caller's original (e.g. Description) are never overwritten in
+// place. This does NOT cover nested OrderedMap trees (Properties, Items,
+// etc.): those are intentionally mutated in place, by design (see
+// SanitizeToolSchemaForAnthropic's doc comment) — callers must pass an owned
+// copy (e.g. via schemas.DeepCopyToolFunctionParameters) if they need the
+// original nested data preserved, which is what both chat.go and responses.go
+// do; that specific invariant is covered by
+// TestConvertResponsesFunctionToolToAnthropic_DeepCopiesBeforeSanitizing.
+func TestSanitizeToolSchemaForAnthropic_ReturnsDistinctTopLevelCopy(t *testing.T) {
 	desc := "unchanged"
 	params := &schemas.ToolFunctionParameters{Type: "string", Description: &desc}
 

--- a/core/providers/anthropic/schemasanitize_test.go
+++ b/core/providers/anthropic/schemasanitize_test.go
@@ -1,0 +1,285 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestSanitizeToolSchemaForAnthropic_Nil(t *testing.T) {
+	if got := SanitizeToolSchemaForAnthropic(nil); got != nil {
+		t.Fatalf("expected nil, got %#v", got)
+	}
+}
+
+// TestSanitizeToolSchemaForAnthropic_TopLevel covers the description-note
+// synthesis behavior for the 8 top-level constraint fields: stripped +
+// fresh note, stripped + appended to an existing description, and a no-op
+// pass-through when nothing needs stripping.
+func TestSanitizeToolSchemaForAnthropic_TopLevel(t *testing.T) {
+	t.Run("strips all constraints and synthesizes a description", func(t *testing.T) {
+		minItems, maxItems := int64(1), int64(5)
+		minLength, maxLength := int64(2), int64(50)
+		minimum, maximum := 0.0, 100.0
+		exclusiveMinimum, exclusiveMaximum := -1.0, 101.0
+
+		out := SanitizeToolSchemaForAnthropic(&schemas.ToolFunctionParameters{
+			Type: "array", MinItems: &minItems, MaxItems: &maxItems,
+			MinLength: &minLength, MaxLength: &maxLength,
+			Minimum: &minimum, Maximum: &maximum,
+			ExclusiveMinimum: &exclusiveMinimum, ExclusiveMaximum: &exclusiveMaximum,
+		})
+
+		if out.MinItems != nil || out.MaxItems != nil || out.MinLength != nil || out.MaxLength != nil ||
+			out.Minimum != nil || out.Maximum != nil || out.ExclusiveMinimum != nil || out.ExclusiveMaximum != nil {
+			t.Fatalf("expected all 8 constraint fields to be stripped, got %+v", out)
+		}
+		const expected = "Note: minimum number of items: 1, maximum number of items: 5, minimum length: 2, maximum length: 50, minimum value: 0, maximum value: 100, exclusive minimum value: -1, exclusive maximum value: 101."
+		if out.Description == nil || *out.Description != expected {
+			t.Errorf("description mismatch:\n got:  %v\nwant: %q", out.Description, expected)
+		}
+	})
+
+	t.Run("appends note to an existing description", func(t *testing.T) {
+		maxItems := int64(3)
+		desc := "A list of tags."
+		out := SanitizeToolSchemaForAnthropic(&schemas.ToolFunctionParameters{
+			Type: "array", Description: &desc, MaxItems: &maxItems,
+		})
+		const expected = "A list of tags. Note: maximum number of items: 3."
+		if out.Description == nil || *out.Description != expected {
+			t.Errorf("description mismatch: got %v, want %q", out.Description, expected)
+		}
+	})
+
+	t.Run("leaves a clean schema's description untouched", func(t *testing.T) {
+		desc := "A plain string field."
+		out := SanitizeToolSchemaForAnthropic(&schemas.ToolFunctionParameters{Type: "string", Description: &desc})
+		if out.Description == nil || *out.Description != desc {
+			t.Errorf("expected description unchanged, got %v", out.Description)
+		}
+	})
+}
+
+// TestSanitizeToolSchemaForAnthropic_NestedContainers reproduces the exact
+// failure in https://github.com/maximhq/bifrost/issues/4691 (an OpenAI-style
+// array property carrying `maxItems`, forwarded to Anthropic, 400s with
+// "tools.1.custom: For 'array' type, property 'maxItems' is not supported")
+// and exercises every kind of nested container the recursive sanitizer must
+// walk in one representative schema: properties, items, $defs,
+// anyOf/oneOf/allOf, and schema-valued vs. bool-valued additionalProperties.
+func TestSanitizeToolSchemaForAnthropic_NestedContainers(t *testing.T) {
+	params := &schemas.ToolFunctionParameters{
+		Type: "object",
+		Properties: schemas.NewOrderedMapFromPairs(
+			// issue #4691: array property with min/maxItems + nested items schema.
+			schemas.KV("tags", schemas.NewOrderedMapFromPairs(
+				schemas.KV("type", "array"),
+				schemas.KV("minItems", int64(1)),
+				schemas.KV("maxItems", int64(5)),
+				schemas.KV("items", schemas.NewOrderedMapFromPairs(schemas.KV("type", "string"))),
+			)),
+			// exclusiveMinimum/Maximum only ever appear in the raw nested tree,
+			// since ToolFunctionParameters has no top-level field for them.
+			schemas.KV("score", schemas.NewOrderedMapFromPairs(
+				schemas.KV("type", "number"),
+				schemas.KV("exclusiveMinimum", 0.0),
+				schemas.KV("exclusiveMaximum", 1.0),
+			)),
+			// additionalProperties may itself be a schema (not a bool).
+			schemas.KV("metadata", schemas.NewOrderedMapFromPairs(
+				schemas.KV("type", "object"),
+				schemas.KV("additionalProperties", schemas.NewOrderedMapFromPairs(
+					schemas.KV("type", "number"),
+					schemas.KV("maximum", 10.0),
+				)),
+			)),
+		),
+		// $defs / Pydantic-Zod-style refs.
+		Defs: schemas.NewOrderedMapFromPairs(
+			schemas.KV("Tag", schemas.NewOrderedMapFromPairs(
+				schemas.KV("type", "string"),
+				schemas.KV("maxLength", int64(32)),
+			)),
+		),
+		// Union schemas.
+		AnyOf: []schemas.OrderedMap{
+			*schemas.NewOrderedMapFromPairs(schemas.KV("type", "array"), schemas.KV("minItems", int64(1))),
+			*schemas.NewOrderedMapFromPairs(schemas.KV("type", "null")),
+		},
+		// Top-level additionalProperties, bool-valued (common case): must be left alone.
+		AdditionalProperties: &schemas.AdditionalPropertiesStruct{AdditionalPropertiesBool: schemas.Ptr(false)},
+	}
+
+	out := SanitizeToolSchemaForAnthropic(params)
+
+	get := func(om *schemas.OrderedMap, key string) *schemas.OrderedMap {
+		v, _ := om.Get(key)
+		node, _ := v.(*schemas.OrderedMap)
+		return node
+	}
+
+	tags := get(out.Properties, "tags")
+	if _, ok := tags.Get("minItems"); ok {
+		t.Error("expected 'minItems' stripped from nested array property")
+	}
+	if _, ok := tags.Get("maxItems"); ok {
+		t.Error("expected 'maxItems' stripped from nested array property")
+	}
+	if items := get(tags, "items"); items == nil {
+		t.Error("expected nested 'items' schema to survive")
+	} else if typ, _ := items.Get("type"); typ != "string" {
+		t.Errorf("expected items.type to remain 'string', got %v", typ)
+	}
+
+	score := get(out.Properties, "score")
+	if _, ok := score.Get("exclusiveMinimum"); ok {
+		t.Error("expected 'exclusiveMinimum' stripped from nested property")
+	}
+	if _, ok := score.Get("exclusiveMaximum"); ok {
+		t.Error("expected 'exclusiveMaximum' stripped from nested property")
+	}
+
+	if nestedAddl := get(get(out.Properties, "metadata"), "additionalProperties"); nestedAddl == nil {
+		t.Error("expected nested schema-valued additionalProperties to survive")
+	} else if _, ok := nestedAddl.Get("maximum"); ok {
+		t.Error("expected 'maximum' stripped from nested additionalProperties schema")
+	}
+
+	if tag := get(out.Defs, "Tag"); tag == nil {
+		t.Error("expected $defs entry to survive")
+	} else if _, ok := tag.Get("maxLength"); ok {
+		t.Error("expected 'maxLength' stripped from $defs entry")
+	}
+
+	if _, ok := out.AnyOf[0].Get("minItems"); ok {
+		t.Error("expected 'minItems' stripped from anyOf[0]")
+	}
+	if typ, _ := out.AnyOf[1].Get("type"); typ != "null" {
+		t.Errorf("expected anyOf[1] left untouched, got %v", typ)
+	}
+
+	if out.AdditionalProperties.AdditionalPropertiesBool == nil || *out.AdditionalProperties.AdditionalPropertiesBool != false {
+		t.Error("expected bool-valued top-level additionalProperties left untouched")
+	}
+}
+
+// TestSanitizeToolSchemaForAnthropic_DoesNotMutateCaller verifies the
+// function returns an independent copy: a caller passing a schema that
+// needs no changes must still get back a distinct struct, not an alias.
+func TestSanitizeToolSchemaForAnthropic_DoesNotMutateCaller(t *testing.T) {
+	desc := "unchanged"
+	params := &schemas.ToolFunctionParameters{Type: "string", Description: &desc}
+
+	out := SanitizeToolSchemaForAnthropic(params)
+	if out == params {
+		t.Fatal("expected a distinct copy, not the same pointer")
+	}
+	if params.Description == nil || *params.Description != "unchanged" {
+		t.Fatal("expected caller's original Description to be left untouched")
+	}
+}
+
+// TestConvertFunctionToolToAnthropic is an end-to-end regression test for
+// issue #4691, gated on `strict`: Anthropic only rejects these keywords under
+// strict (grammar-constrained) tool-input validation — verified live, a
+// non-strict call with `maxItems` is accepted by the real API unchanged — so
+// the sanitizer must strip for strict tools and leave non-strict ones alone.
+func TestConvertFunctionToolToAnthropic(t *testing.T) {
+	buildTool := func(strict *bool) schemas.ChatTool {
+		return schemas.ChatTool{
+			Type: schemas.ChatToolTypeFunction,
+			Function: &schemas.ChatToolFunction{
+				Name:   "list_files",
+				Strict: strict,
+				Parameters: &schemas.ToolFunctionParameters{
+					Type: "object",
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("paths", schemas.NewOrderedMapFromPairs(
+							schemas.KV("type", "array"),
+							schemas.KV("maxItems", int64(5)),
+							schemas.KV("items", schemas.NewOrderedMapFromPairs(schemas.KV("type", "string"))),
+						)),
+					),
+				},
+			},
+		}
+	}
+
+	t.Run("strict tool: maxItems stripped from struct and wire bytes", func(t *testing.T) {
+		anthropicTool := convertFunctionToolToAnthropic(buildTool(schemas.Ptr(true)))
+
+		pathsVal, _ := anthropicTool.InputSchema.Properties.Get("paths")
+		paths := pathsVal.(*schemas.OrderedMap)
+		if _, ok := paths.Get("maxItems"); ok {
+			t.Fatal("expected 'maxItems' stripped from the converted Anthropic tool schema")
+		}
+
+		// Also assert at the wire level: Anthropic never sees the Go struct,
+		// only the serialized JSON bytes actually sent over HTTP.
+		raw, err := json.Marshal(anthropicTool)
+		if err != nil {
+			t.Fatalf("failed to marshal AnthropicTool: %v", err)
+		}
+		if strings.Contains(string(raw), `"maxItems"`) {
+			t.Errorf("wire payload must not contain \"maxItems\", but it does:\n%s", raw)
+		}
+	})
+
+	t.Run("non-strict tool: schema left untouched", func(t *testing.T) {
+		anthropicTool := convertFunctionToolToAnthropic(buildTool(nil))
+
+		pathsVal, _ := anthropicTool.InputSchema.Properties.Get("paths")
+		paths := pathsVal.(*schemas.OrderedMap)
+		if _, ok := paths.Get("maxItems"); !ok {
+			t.Fatal("expected 'maxItems' preserved for a non-strict tool schema")
+		}
+	})
+}
+
+// TestConvertResponsesFunctionToolToAnthropic_DeepCopiesBeforeSanitizing
+// guards the Responses-API tool path: since SanitizeToolSchemaForAnthropic
+// mutates OrderedMap trees in place, the conversion must deep-copy the
+// caller-owned schemas.ResponsesToolFunction.Parameters before sanitizing it,
+// otherwise a caller that reuses the same *ToolFunctionParameters across
+// providers would see it silently stripped for non-Anthropic use too.
+func TestConvertResponsesFunctionToolToAnthropic_DeepCopiesBeforeSanitizing(t *testing.T) {
+	maxItems := int64(5)
+	originalParams := &schemas.ToolFunctionParameters{
+		Type: "object",
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("tags", schemas.NewOrderedMapFromPairs(
+				schemas.KV("type", "array"),
+				schemas.KV("maxItems", maxItems),
+			)),
+		),
+	}
+
+	name := "list_tags"
+	tool := schemas.ResponsesTool{
+		Type: schemas.ResponsesToolTypeFunction,
+		Name: &name,
+		ResponsesToolFunction: &schemas.ResponsesToolFunction{
+			Parameters: originalParams,
+			Strict:     schemas.Ptr(true),
+		},
+	}
+
+	anthropicTool := convertBifrostToolToAnthropic("claude-sonnet-4-20250514", &tool, schemas.Anthropic, false)
+	if anthropicTool == nil {
+		t.Fatal("expected a non-nil AnthropicTool")
+	}
+
+	convertedTags, _ := anthropicTool.InputSchema.Properties.Get("tags")
+	if _, ok := convertedTags.(*schemas.OrderedMap).Get("maxItems"); ok {
+		t.Fatal("expected 'maxItems' to be stripped from the converted schema")
+	}
+
+	// The caller's original schema must be untouched.
+	originalTags, _ := originalParams.Properties.Get("tags")
+	if _, ok := originalTags.(*schemas.OrderedMap).Get("maxItems"); !ok {
+		t.Fatal("expected caller-owned original Parameters to remain unmodified (no deep copy before sanitize)")
+	}
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -567,8 +567,10 @@ type ToolFunctionParameters struct {
 	MaxLength *int64  `json:"maxLength,omitempty"` // Maximum string length
 
 	// Number validation fields
-	Minimum *float64 `json:"minimum,omitempty"` // Minimum number value
-	Maximum *float64 `json:"maximum,omitempty"` // Maximum number value
+	Minimum          *float64 `json:"minimum,omitempty"`          // Minimum number value
+	Maximum          *float64 `json:"maximum,omitempty"`          // Maximum number value
+	ExclusiveMinimum *float64 `json:"exclusiveMinimum,omitempty"` // Exclusive minimum number value
+	ExclusiveMaximum *float64 `json:"exclusiveMaximum,omitempty"` // Exclusive maximum number value
 
 	// Misc fields
 	Title    *string     `json:"title,omitempty"`    // Schema title
@@ -729,7 +731,7 @@ func (t *ToolFunctionParameters) hasDefinedSchemaFields() bool {
 	if t.Format != nil || t.Pattern != nil || t.MinLength != nil || t.MaxLength != nil {
 		return true
 	}
-	if t.Minimum != nil || t.Maximum != nil {
+	if t.Minimum != nil || t.Maximum != nil || t.ExclusiveMinimum != nil || t.ExclusiveMaximum != nil {
 		return true
 	}
 	return t.Title != nil || t.Default != nil || t.Nullable != nil

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1173,6 +1173,14 @@ func DeepCopyToolFunctionParameters(original *ToolFunctionParameters) *ToolFunct
 		maximum := *original.Maximum
 		copyParams.Maximum = &maximum
 	}
+	if original.ExclusiveMinimum != nil {
+		exclusiveMinimum := *original.ExclusiveMinimum
+		copyParams.ExclusiveMinimum = &exclusiveMinimum
+	}
+	if original.ExclusiveMaximum != nil {
+		exclusiveMaximum := *original.ExclusiveMaximum
+		copyParams.ExclusiveMaximum = &exclusiveMaximum
+	}
 	if original.Title != nil {
 		title := *original.Title
 		copyParams.Title = &title


### PR DESCRIPTION
Fixes #4691

Anthropic's strict tool schema validation rejects several JSON Schema keywords that OpenAI's strict mode supports, causing a 400 for clients emitting OpenAI-shaped `strict: true` tools. This PR strips the unsupported keywords before sending to Anthropic (folding each into the field's `description` so the constraint isn't silently lost), keeping tool schemas OpenAI-compatible.

Unsupported keywords stripped:
```json
["maxItems", "minItems", "minLength", "maxLength", "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"]
```

## Checklist

- [x] Added tests
- [x] Reproduced against live Anthropic API
