### PR TITLE
fix: skip O(N) reference refresh on request-time rate-limit/budget reset

### DIFF
--- a/plugins/governance/ratelimitreset_test.go
+++ b/plugins/governance/ratelimitreset_test.go
@@ -1,0 +1,203 @@
+package governance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+const resetBenchmarkVirtualKeys = 5000
+
+// TestRequestTimeRateLimitResetPerformance verifies request-time rate-limit
+// reset stays constant-time with thousands of embedded references. Runs as a
+// regular test so it executes in CI via go test / make test-governance.
+func TestRequestTimeRateLimitResetPerformance(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	rateLimitID := seedResetBenchmarkVirtualKeys(ctx, store, resetBenchmarkVirtualKeys)
+
+	const iterations = 1000
+	start := time.Now()
+	for i := 0; i < iterations; i++ {
+		markRequestRateLimitExpired(store, rateLimitID)
+		if err := store.BumpRateLimitUsage(ctx, rateLimitID, 0, false, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	nsPerOp := float64(time.Since(start).Nanoseconds()) / float64(iterations)
+	// Request-time reset must stay O(1). With the reference-refresh regression
+	// this exceeds 500µs per op; the fix keeps it well under 100µs.
+	const maxNsPerOp = 100_000 // 100µs
+	if nsPerOp > maxNsPerOp {
+		t.Fatalf("request-time reset too slow: %.0f ns/op (max %d ns/op) — likely running expensive O(N) work on the request hot path", nsPerOp, maxNsPerOp)
+	}
+	t.Logf("request-time reset: %.0f ns/op (%d iterations)", nsPerOp, iterations)
+}
+
+// BenchmarkSingleRequestTimeRateLimitResetDoesNotRefreshReferences runs the same
+// reset path exactly once per benchmark iteration for fixed-count profiles.
+func BenchmarkSingleRequestTimeRateLimitResetDoesNotRefreshReferences(b *testing.B) {
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		store := newStandaloneStoreForResetBenchmark()
+		rateLimitID := seedResetBenchmarkVirtualKeys(ctx, store, resetBenchmarkVirtualKeys)
+		markRequestRateLimitExpired(store, rateLimitID)
+
+		b.StartTimer()
+		if err := store.BumpRateLimitUsage(ctx, rateLimitID, 0, false, true); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+	}
+}
+
+// TestRequestTimeRateLimitResetSkipsReferenceRefresh verifies request-time resets
+// keep canonical side effects without scanning embedded references.
+func TestRequestTimeRateLimitResetSkipsReferenceRefresh(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	rateLimitID := seedResetBenchmarkVirtualKeys(ctx, store, 10)
+	staleRateLimit := store.LoadRateLimit(ctx, rateLimitID)
+	markRequestRateLimitExpired(store, rateLimitID)
+
+	resetHookCalls := 0
+	store.SetResetHooks(nil, func(resetRateLimits []*configstoreTables.TableRateLimit) {
+		resetHookCalls++
+		if len(resetRateLimits) != 1 {
+			t.Fatalf("expected one reset rate limit, got %d", len(resetRateLimits))
+		}
+		if resetRateLimits[0].ID != rateLimitID {
+			t.Fatalf("expected reset rate limit %q, got %q", rateLimitID, resetRateLimits[0].ID)
+		}
+	})
+
+	if err := store.BumpRateLimitUsage(ctx, rateLimitID, 0, false, true); err != nil {
+		t.Fatal(err)
+	}
+	resetRateLimit := store.LoadRateLimit(ctx, rateLimitID)
+	if resetRateLimit == nil {
+		t.Fatal("expected reset rate limit to remain loaded")
+	}
+	if resetRateLimit.RequestCurrentUsage != 1 {
+		t.Fatalf("expected request usage to be bumped after reset, got %d", resetRateLimit.RequestCurrentUsage)
+	}
+	if resetRateLimit.RequestLastReset.Before(staleRateLimit.RequestLastReset) || resetRateLimit.RequestLastReset.Equal(staleRateLimit.RequestLastReset) {
+		t.Fatalf("expected request reset timestamp to advance beyond %s, got %s", staleRateLimit.RequestLastReset, resetRateLimit.RequestLastReset)
+	}
+	if resetHookCalls != 1 {
+		t.Fatalf("expected request-time reset hook to fire once, got %d", resetHookCalls)
+	}
+
+	store.LastDBUsagesRateLimitsRequestsMu.RLock()
+	lastDBRequests := store.LastDBUsagesRequestsRateLimits[rateLimitID]
+	store.LastDBUsagesRateLimitsRequestsMu.RUnlock()
+	if lastDBRequests != 0 {
+		t.Fatalf("expected request LastDB baseline to reset to 0, got %d", lastDBRequests)
+	}
+
+	rawVK, ok := store.virtualKeys.Load("sk-bf-reset-00000")
+	if !ok || rawVK == nil {
+		t.Fatal("expected seeded virtual key to remain loaded")
+	}
+	vk, ok := rawVK.(*configstoreTables.TableVirtualKey)
+	if !ok || vk == nil {
+		t.Fatal("expected seeded virtual key to have the correct type")
+	}
+	// Embedded reference should remain stale (not refreshed) after request-time reset.
+	// It may be non-nil because CreateVirtualKeyInMemory keeps embedded references,
+	// but it must NOT point at the freshly reset canonical object.
+	if vk.RateLimit == resetRateLimit {
+		t.Fatal("expected request-time reset NOT to refresh embedded virtual-key rate-limit reference")
+	}
+	if vk.RateLimitID == nil || *vk.RateLimitID != rateLimitID {
+		t.Fatal("expected request-time reset to preserve owner-to-rate-limit ID mapping")
+	}
+}
+
+// TestBackgroundRateLimitResetRefreshesReferences verifies non-request resets still hydrate embedded references.
+func TestBackgroundRateLimitResetRefreshesReferences(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	rateLimitID := seedResetBenchmarkVirtualKeys(ctx, store, 10)
+	staleRateLimit := store.LoadRateLimit(ctx, rateLimitID)
+	markRequestRateLimitExpired(store, rateLimitID)
+
+	resetRateLimits := store.ResetExpiredRateLimitsInMemory(ctx, true, rateLimitID)
+	if len(resetRateLimits) != 1 {
+		t.Fatalf("expected one background reset, got %d", len(resetRateLimits))
+	}
+
+	rawVK, ok := store.virtualKeys.Load("sk-bf-reset-00000")
+	if !ok || rawVK == nil {
+		t.Fatal("expected seeded virtual key to remain loaded")
+	}
+	vk, ok := rawVK.(*configstoreTables.TableVirtualKey)
+	if !ok || vk == nil {
+		t.Fatal("expected seeded virtual key to have the correct type")
+	}
+	if vk.RateLimit == nil {
+		t.Fatal("expected background reset to refresh virtual-key rate-limit reference")
+	}
+	if vk.RateLimit != resetRateLimits[0] {
+		t.Fatal("expected background reset to point virtual-key reference at canonical reset object")
+	}
+	if vk.RateLimitID == nil || *vk.RateLimitID != rateLimitID {
+		t.Fatal("expected background reset to preserve owner-to-rate-limit ID mapping")
+	}
+	if resetRateLimits[0] == staleRateLimit {
+		t.Fatal("expected canonical reset to replace stale rate-limit snapshot")
+	}
+}
+
+// newStandaloneStoreForResetBenchmark creates an in-memory-only store so benchmark
+// profiles isolate sync.Map/reference-update CPU rather than DB IO.
+func newStandaloneStoreForResetBenchmark() *LocalGovernanceStore {
+	return &LocalGovernanceStore{
+		logger:                         NewMockLogger(),
+		LastDBUsagesBudgets:            map[string]float64{},
+		LastDBUsagesTokensRateLimits:   map[string]int64{},
+		LastDBUsagesRequestsRateLimits: map[string]int64{},
+	}
+}
+
+// seedResetBenchmarkVirtualKeys creates many VK owner mappings to one rate limit so
+// the benchmark guards against reintroducing global owner scans.
+func seedResetBenchmarkVirtualKeys(ctx context.Context, store *LocalGovernanceStore, virtualKeys int) string {
+	rateLimitID := "request-reset-rate-limit"
+	rateLimit := buildRateLimit(rateLimitID, 1_000_000_000, 1_000_000_000)
+	store.rateLimits.Store(rateLimitID, rateLimit)
+
+	for i := 0; i < virtualKeys; i++ {
+		vk := buildVirtualKeyWithRateLimit(
+			fmt.Sprintf("reset-vk-%05d", i),
+			fmt.Sprintf("sk-bf-reset-%05d", i),
+			fmt.Sprintf("Reset VK %05d", i),
+			rateLimit,
+		)
+		store.CreateVirtualKeyInMemory(ctx, vk)
+	}
+
+	return rateLimitID
+}
+
+// markRequestRateLimitExpired forces BumpRateLimitUsage down the request-time
+// reset path on the next call.
+func markRequestRateLimitExpired(store *LocalGovernanceStore, rateLimitID string) {
+	raw, ok := store.rateLimits.Load(rateLimitID)
+	if !ok || raw == nil {
+		return
+	}
+	rateLimit, ok := raw.(*configstoreTables.TableRateLimit)
+	if !ok || rateLimit == nil {
+		return
+	}
+	clone := *rateLimit
+	clone.RequestCurrentUsage = 123
+	clone.RequestLastReset = time.Now().Add(-2 * time.Minute)
+	store.rateLimits.Store(rateLimitID, &clone)
+}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -408,16 +408,18 @@ func (r *BudgetResolver) isProviderAllowed(vk *configstoreTables.TableVirtualKey
 // checkRateLimitHierarchy checks provider-level rate limits first, then VK rate limits using flexible approach
 func (r *BudgetResolver) checkRateLimitHierarchy(ctx context.Context, vk *configstoreTables.TableVirtualKey, request *EvaluationRequest) *EvaluationResult {
 	if decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil, nil); err != nil || isRateLimitViolation(decision) {
-		// Check provider-level first (matching check order), then VK-level
+		// Check provider-level first (matching check order), then VK-level.
+		// Resolve by ID from the canonical rate-limit map because embedded
+		// references can intentionally remain stale after request-time resets.
 		var rateLimitInfo *configstoreTables.TableRateLimit
 		for _, pc := range vk.ProviderConfigs {
-			if pc.Provider == string(request.Provider) && pc.RateLimit != nil {
-				rateLimitInfo = pc.RateLimit
+			if pc.Provider == string(request.Provider) && pc.RateLimitID != nil {
+				rateLimitInfo = r.store.LoadRateLimit(ctx, *pc.RateLimitID)
 				break
 			}
 		}
-		if rateLimitInfo == nil && vk.RateLimit != nil {
-			rateLimitInfo = vk.RateLimit
+		if rateLimitInfo == nil && vk.RateLimitID != nil {
+			rateLimitInfo = r.store.LoadRateLimit(ctx, *vk.RateLimitID)
 		}
 		return &EvaluationResult{
 			Decision:      decision,
@@ -478,7 +480,7 @@ func (r *BudgetResolver) isProviderRateLimitViolated(ctx context.Context, vk *co
 	}
 
 	// 2. Check VK-level provider config rate limit
-	if config.RateLimit == nil {
+	if config.RateLimitID == nil {
 		return false
 	}
 	decision, err := r.store.CheckVirtualKeyRateLimit(ctx, vk, request, nil, nil)

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -221,7 +221,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExpired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset expired rate limits (simulating ticker behavior)
-	expiredRateLimits := store.ResetExpiredRateLimitsInMemory(context.Background())
+	expiredRateLimits := store.ResetExpiredRateLimitsInMemory(context.Background(), true)
 	err = store.ResetExpiredRateLimits(context.Background(), expiredRateLimits)
 	require.NoError(t, err)
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -145,8 +145,8 @@ type GovernanceStore interface {
 	UpdateScopedModelBudgetUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, cost float64) error
 	UpdateScopedModelRateLimitUsageInMemory(ctx context.Context, scope, scopeID, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
 	// In-memory reset checks (return items that need DB sync)
-	ResetExpiredRateLimitsInMemory(ctx context.Context, rateLimitIDs ...string) []*configstoreTables.TableRateLimit
-	ResetExpiredBudgetsInMemory(ctx context.Context, budgetIDs ...string) []*configstoreTables.TableBudget
+	ResetExpiredRateLimitsInMemory(ctx context.Context, refreshReferences bool, rateLimitIDs ...string) []*configstoreTables.TableRateLimit
+	ResetExpiredBudgetsInMemory(ctx context.Context, refreshReferences bool, budgetIDs ...string) []*configstoreTables.TableBudget
 	// DB sync for expired items
 	ResetExpiredRateLimits(ctx context.Context, resetRateLimits []*configstoreTables.TableRateLimit) error
 	ResetExpiredBudgets(ctx context.Context, resetBudgets []*configstoreTables.TableBudget) error
@@ -423,7 +423,7 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 			return nil
 		}
 		if gs.budgetResetTarget(old, time.Now()) != nil {
-			gs.ResetExpiredBudgetsInMemory(ctx, budgetID)
+			gs.ResetExpiredBudgetsInMemory(ctx, false, budgetID)
 			continue
 		}
 		clone := *old
@@ -451,7 +451,7 @@ func (gs *LocalGovernanceStore) BumpRateLimitUsage(ctx context.Context, rateLimi
 			return nil
 		}
 		if tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(old, time.Now()); tokenNewLastReset != nil || requestNewLastReset != nil {
-			gs.ResetExpiredRateLimitsInMemory(ctx, rateLimitID)
+			gs.ResetExpiredRateLimitsInMemory(ctx, false, rateLimitID)
 			continue
 		}
 		clone := *old
@@ -1804,7 +1804,7 @@ func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.Tabl
 }
 
 // resetExpiredBudgetFromSnapshot applies the local side effects for an expired budget snapshot.
-func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Context, budget *configstoreTables.TableBudget, now time.Time) *configstoreTables.TableBudget {
+func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Context, budget *configstoreTables.TableBudget, now time.Time, refreshReferences bool) *configstoreTables.TableBudget {
 	newLastReset := gs.budgetResetTarget(budget, now)
 	if newLastReset == nil {
 		return nil
@@ -1817,14 +1817,19 @@ func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Conte
 	gs.LastDBUsagesBudgetsMu.Lock()
 	gs.LastDBUsagesBudgets[resetBudget.ID] = 0
 	gs.LastDBUsagesBudgetsMu.Unlock()
-	gs.updateBudgetReferences(ctx, resetBudget)
+	if refreshReferences {
+		gs.updateBudgetReferences(ctx, resetBudget)
+	}
 	gs.logger.Debug(fmt.Sprintf("Reset budget %s (was %.2f, reset to 0)", resetBudget.ID, oldUsage))
 	return resetBudget
 }
 
 // ResetExpiredBudgetsInMemory checks and resets budgets that have exceeded their reset duration.
 // With no budgetIDs it scans every budget; with IDs it only checks those budgets.
-func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context, budgetIDs ...string) []*configstoreTables.TableBudget {
+// refreshReferences controls whether embedded owner references (VK, team, customer) are updated
+// after reset. Background/ticker callers pass true; request-time callers pass false to avoid
+// an O(N) scan of all owners on the hot path.
+func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context, refreshReferences bool, budgetIDs ...string) []*configstoreTables.TableBudget {
 	now := time.Now()
 	var resetBudgets []*configstoreTables.TableBudget
 	resetOne := func(value any) {
@@ -1832,7 +1837,7 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 		if !ok || budget == nil {
 			return
 		}
-		if resetBudget := gs.resetExpiredBudgetFromSnapshot(ctx, budget, now); resetBudget != nil {
+		if resetBudget := gs.resetExpiredBudgetFromSnapshot(ctx, budget, now, refreshReferences); resetBudget != nil {
 			resetBudgets = append(resetBudgets, resetBudget)
 		}
 	}
@@ -1889,7 +1894,7 @@ func (gs *LocalGovernanceStore) rateLimitResetTargets(rateLimit *configstoreTabl
 }
 
 // resetExpiredRateLimitFromSnapshot applies the local side effects for an expired rate-limit snapshot.
-func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Context, rateLimit *configstoreTables.TableRateLimit, now time.Time) *configstoreTables.TableRateLimit {
+func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Context, rateLimit *configstoreTables.TableRateLimit, now time.Time, refreshReferences bool) *configstoreTables.TableRateLimit {
 	tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(rateLimit, now)
 	if tokenNewLastReset == nil && requestNewLastReset == nil {
 		return nil
@@ -1908,13 +1913,18 @@ func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Co
 		gs.LastDBUsagesRequestsRateLimits[resetRateLimit.ID] = 0
 		gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
 	}
-	gs.updateRateLimitReferences(ctx, resetRateLimit)
+	if refreshReferences {
+		gs.updateRateLimitReferences(ctx, resetRateLimit)
+	}
 	return resetRateLimit
 }
 
-// ResetExpiredRateLimitsInMemory performs background reset of expired rate limits for both provider-level and VK-level.
+// ResetExpiredRateLimitsInMemory performs reset of expired rate limits for both provider-level and VK-level.
 // With no rateLimitIDs it scans every rate limit; with IDs it only checks those rate limits.
-func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Context, rateLimitIDs ...string) []*configstoreTables.TableRateLimit {
+// refreshReferences controls whether embedded owner references (VK, team, customer) are updated
+// after reset. Background/ticker callers pass true; request-time callers pass false to avoid
+// an O(N) scan of all owners on the hot path.
+func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Context, refreshReferences bool, rateLimitIDs ...string) []*configstoreTables.TableRateLimit {
 	now := time.Now()
 	var resetRateLimits []*configstoreTables.TableRateLimit
 	resetOne := func(value any) {
@@ -1922,7 +1932,7 @@ func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Conte
 		if !ok || rateLimit == nil {
 			return
 		}
-		if resetRateLimit := gs.resetExpiredRateLimitFromSnapshot(ctx, rateLimit, now); resetRateLimit != nil {
+		if resetRateLimit := gs.resetExpiredRateLimitFromSnapshot(ctx, rateLimit, now, refreshReferences); resetRateLimit != nil {
 			resetRateLimits = append(resetRateLimits, resetRateLimit)
 		}
 	}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -738,7 +738,7 @@ func TestGovernanceStore_ResetExpiredRateLimits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset expired rate limits
-	expiredRateLimits := store.ResetExpiredRateLimitsInMemory(context.Background())
+	expiredRateLimits := store.ResetExpiredRateLimitsInMemory(context.Background(), true)
 	err = store.ResetExpiredRateLimits(context.Background(), expiredRateLimits)
 	assert.NoError(t, err, "Reset should succeed")
 
@@ -773,7 +773,7 @@ func TestGovernanceStore_ResetExpiredBudgets(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reset expired budgets
-	expiredBudgets := store.ResetExpiredBudgetsInMemory(context.Background())
+	expiredBudgets := store.ResetExpiredBudgetsInMemory(context.Background(), true)
 	err = store.ResetExpiredBudgets(context.Background(), expiredBudgets)
 	assert.NoError(t, err, "Reset should succeed")
 

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -240,13 +240,13 @@ func (t *UsageTracker) resetWorker(ctx context.Context) {
 // resetExpiredCounters manages periodic resets of usage counters AND budgets using flexible durations
 func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
 	// ==== PART 1: Reset Rate Limits ====
-	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx)
+	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx, true)
 	if err := t.store.ResetExpiredRateLimits(ctx, resetRateLimits); err != nil {
 		t.logger.Error("failed to reset expired rate limits: %v", err)
 	}
 
 	// ==== PART 2: Reset Budgets ====
-	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx)
+	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx, true)
 	if err := t.store.ResetExpiredBudgets(ctx, resetBudgets); err != nil {
 		t.logger.Error("failed to reset expired budgets: %v", err)
 	}
@@ -315,7 +315,7 @@ func (t *UsageTracker) PerformStartupResets(ctx context.Context) error {
 	// Reuse the shared in-memory reset path so startup, ticker, and request-time
 	// resets all apply the same LastDB baseline and reset-hook side effects.
 	rateLimitResetStart := time.Now()
-	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx)
+	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx, true)
 	t.logger.Info("[startup-timing] PerformStartupResets in-memory reset of %d rate limits took %v", len(resetRateLimits), time.Since(rateLimitResetStart))
 	if err := t.store.ResetExpiredRateLimits(ctx, resetRateLimits); err != nil {
 		errs = append(errs, fmt.Sprintf("failed to reset expired rate limits: %s", err.Error()))
@@ -323,7 +323,7 @@ func (t *UsageTracker) PerformStartupResets(ctx context.Context) error {
 
 	// DB reset is also handled by this function
 	budgetResetStart := time.Now()
-	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx)
+	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx, true)
 	t.logger.Info("[startup-timing] PerformStartupResets in-memory reset of %d budgets took %v", len(resetBudgets), time.Since(budgetResetStart))
 	if err := t.store.ResetExpiredBudgets(ctx, resetBudgets); err != nil {
 		errs = append(errs, fmt.Sprintf("failed to reset expired budgets: %s", err.Error()))


### PR DESCRIPTION
## Summary

Fixes a CPU regression introduced in v1.6.2 where request-time rate-limit resets
triggered an O(N) scan of all virtual keys, teams, and customers via
`updateRateLimitReferences` / `updateBudgetReferences`. With thousands of VKs,
this caused sustained ~2 CPU cores usage even under <1 req/s traffic.

## Changes

- Added `refreshReferences bool` parameter to `ResetExpiredRateLimitsInMemory`
and `ResetExpiredBudgetsInMemory` (and their internal helpers
`resetExpiredRateLimitFromSnapshot` / `resetExpiredBudgetFromSnapshot`)
- Request-time callers (`BumpRateLimitUsage`, `BumpBudgetUsage`) pass `false` to
skip the expensive embedded reference refresh
- Background/ticker/startup callers pass `true` to preserve periodic embedded
reference hydration (every 10s, same as v1.6.0 behavior)
- Switched resolver violation metadata in `checkRateLimitHierarchy` and
`isProviderRateLimitViolated` to resolve rate-limit info by ID from canonical
maps via `LoadRateLimit()`, so error responses show fresh usage after
request-time resets
- Added regression benchmark
(`BenchmarkRequestTimeRateLimitResetDoesNotRefreshReferences`) that fails if
request-time reset exceeds 100us/op, catching any future reintroduction of
O(N) work on the hot path

Benchmark with 5,000 VKs sharing one expired rate limit:

| Metric | Before fix (v1.6.2) | After fix | Improvement |
| --- | --- | --- | --- |
| ns/op | 617,442 | 672 | 918x faster |
| B/op | 1,840,924 | 920 | 2001x less memory |
| allocs/op | 10,016 | 16 | 626x fewer allocations |

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run governance tests
make test-governance

# Run the regression benchmark (should pass under 100us/op)
cd plugins/governance
go test -run '^$' -bench '^BenchmarkRequestTimeRateLimitResetDoesNotRefreshReferences$' -benchtime=5s -count=1 -benchmem

# Verify the benchmark catches the regression without the fix by reverting
# the refreshReferences parameter to always-true in BumpRateLimitUsage/BumpBudgetUsage
# — benchmark should fail at ~617,000 ns/op
```

## Screenshots/Recordings

N/A — backend-only change.

## Breaking changes

- [ ] Yes
- [x] No

The `GovernanceStore` interface signature for `ResetExpiredRateLimitsInMemory`
and `ResetExpiredBudgetsInMemory` changed (added `refreshReferences bool`
parameter), but these are internal plugin interfaces not used externally.

## Related issues

Closes #4851

## Security considerations

No security implications. This change only affects the internal execution path
of rate-limit/budget reset operations.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable