### PR TITLE
test: add Postman e2e collection and runner for virtual key expiry validation and enforcement

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -871,6 +872,10 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 		hash.Write([]byte("isActive:true"))
 	} else {
 		hash.Write([]byte("isActive:false"))
+	}
+	// Hash ExpiresAt only when set, so rows created before expiry existed keep their hash
+	if vk.ExpiresAt != nil {
+		hash.Write([]byte("expiresAt:" + vk.ExpiresAt.UTC().Format(time.RFC3339Nano)))
 	}
 	// Hash TeamID
 	if vk.TeamID != nil {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -435,6 +435,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_bedrock_mantle_key_columns"}, run: migrationAddBedrockMantleKeyColumns},
 	{IDs: []string{"add_model_pricing_is_deprecated_column"}, run: migrationAddModelPricingIsDeprecatedColumn},
 	{IDs: []string{"add_mcp_client_tool_execution_timeout_column"}, run: migrationAddMCPClientToolExecutionTimeoutColumn},
+	{IDs: []string{"add_virtual_key_expires_at_column"}, run: migrationAddVirtualKeyExpiresAtColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10285,6 +10286,29 @@ func migrationAddMCPClientToolExecutionTimeoutColumn(ctx context.Context, db *go
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 			return dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_execution_timeout")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}
+
+// migrationAddVirtualKeyExpiresAtColumn adds nullable expires_at to governance_virtual_keys.
+// No index: expiry is checked in-memory from the already-loaded VK, never queried by column.
+func migrationAddVirtualKeyExpiresAtColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_virtual_key_expires_at_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &tables.TableVirtualKey{}, "expires_at")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &tables.TableVirtualKey{}, "expires_at")
 		},
 	}})
 	if err := m.Migrate(); err != nil {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3376,7 +3376,7 @@ func (s *RDBConfigStore) UpdateVirtualKey(ctx context.Context, virtualKey *table
 	} else {
 		virtualKey.ID = existing.ID
 		if err := txDB.WithContext(ctx).
-			Select("name", "description", "value", "is_active", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "config_hash", "updated_at", "encryption_status", "value_hash").
+			Select("name", "description", "value", "is_active", "expires_at", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "config_hash", "updated_at", "encryption_status", "value_hash").
 			Updates(virtualKey).Error; err != nil {
 			return s.parseGormError(err)
 		}

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -211,6 +211,7 @@ type TableVirtualKey struct {
 	Description     string                          `gorm:"type:text" json:"description,omitempty"`
 	Value           schemas.SecretVar               `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`
 	IsActive        *bool                           `gorm:"default:true" json:"is_active,omitempty"`                                     // Nil means true (DB default); false means inactive
+	ExpiresAt       *time.Time                      `gorm:"type:timestamp;null" json:"expires_at,omitempty"`                             // Optional expiry; nil means never expires
 	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs      []TableVirtualKeyMCPConfig      `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"mcp_configs"`
 
@@ -274,6 +275,15 @@ func (vk TableVirtualKey) MarshalJSON() ([]byte, error) {
 		Alias: Alias(vk),
 		Value: vk.Value.GetValue(),
 	})
+}
+
+// IsExpiredAt reports whether the virtual key has passed its expiry.
+// now == expires_at is treated as expired; nil ExpiresAt means never expires.
+func (vk *TableVirtualKey) IsExpiredAt(now time.Time) bool {
+	if vk == nil || vk.ExpiresAt == nil {
+		return false
+	}
+	return !now.UTC().Before(vk.ExpiresAt.UTC())
 }
 
 // BeforeSave is a GORM hook that enforces mutual exclusion (team vs customer), computes

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1204,7 +1204,7 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 	if virtualKeyValue != "" {
 		var ok bool
 		virtualKey, ok = p.store.GetVirtualKey(ctx, virtualKeyValue)
-		if !ok || virtualKey == nil || !virtualKey.IsActiveValue() {
+		if !ok || virtualKey == nil || !virtualKey.IsActiveValue() || virtualKey.IsExpiredAt(time.Now().UTC()) {
 			return nil
 		}
 	}
@@ -1440,7 +1440,7 @@ func (p *GovernancePlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.
 	// This runs independently of EvaluateGovernanceRequest to enforce execution-time allow-list.
 	if virtualKeyValue != "" {
 		vk, ok := p.store.GetVirtualKey(ctx, virtualKeyValue)
-		if !ok || vk == nil || !vk.IsActiveValue() {
+		if !ok || vk == nil {
 			// VK became invalid after initial check - fail closed for security
 			ctx.SetValue(governanceRejectedContextKey, true)
 			return req, &schemas.MCPPluginShortCircuit{Error: &schemas.BifrostError{
@@ -1448,6 +1448,26 @@ func (p *GovernancePlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.
 				StatusCode: bifrost.Ptr(403),
 				Error: &schemas.ErrorField{
 					Message: "Virtual key not found",
+				},
+			}}, nil
+		}
+		if !vk.IsActiveValue() {
+			ctx.SetValue(governanceRejectedContextKey, true)
+			return req, &schemas.MCPPluginShortCircuit{Error: &schemas.BifrostError{
+				Type:       bifrost.Ptr(string(DecisionVirtualKeyBlocked)),
+				StatusCode: bifrost.Ptr(403),
+				Error: &schemas.ErrorField{
+					Message: "Virtual key is inactive",
+				},
+			}}, nil
+		}
+		if vk.IsExpiredAt(time.Now().UTC()) {
+			ctx.SetValue(governanceRejectedContextKey, true)
+			return req, &schemas.MCPPluginShortCircuit{Error: &schemas.BifrostError{
+				Type:       bifrost.Ptr(string(DecisionVirtualKeyBlocked)),
+				StatusCode: bifrost.Ptr(403),
+				Error: &schemas.ErrorField{
+					Message: "Virtual key has expired",
 				},
 			}}, nil
 		}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -4,6 +4,7 @@ package governance
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -269,6 +270,12 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		return &EvaluationResult{
 			Decision: DecisionVirtualKeyBlocked,
 			Reason:   "Virtual key is inactive",
+		}
+	}
+	if vk.IsExpiredAt(time.Now().UTC()) {
+		return &EvaluationResult{
+			Decision: DecisionVirtualKeyBlocked,
+			Reason:   "Virtual key has expired",
 		}
 	}
 	// 2. Check provider filtering

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -576,3 +576,93 @@ func TestBudgetResolver_EvaluateRequest_PassthroughModelFiltering(t *testing.T) 
 		})
 	}
 }
+
+// TestBudgetResolver_EvaluateVirtualKeyRequest_ActiveNoExpiry verifies that a VK
+// with no expiry is allowed.
+func TestBudgetResolver_EvaluateVirtualKeyRequest_ActiveNoExpiry(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+	}
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := &schemas.BifrostContext{}
+
+	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
+	assertDecision(t, DecisionAllow, result)
+}
+
+// TestBudgetResolver_EvaluateVirtualKeyRequest_FutureExpiry verifies that a VK
+// with a future expiry is allowed.
+func TestBudgetResolver_EvaluateVirtualKeyRequest_FutureExpiry(t *testing.T) {
+	logger := NewMockLogger()
+	future := time.Now().UTC().Add(time.Hour)
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
+	vk.ExpiresAt = &future
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+	}
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := &schemas.BifrostContext{}
+
+	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
+	assertDecision(t, DecisionAllow, result)
+}
+
+// TestBudgetResolver_EvaluateVirtualKeyRequest_ExpiredKey verifies that an
+// active VK with a past expiry is blocked with DecisionVirtualKeyBlocked.
+func TestBudgetResolver_EvaluateVirtualKeyRequest_ExpiredKey(t *testing.T) {
+	logger := NewMockLogger()
+	past := time.Now().UTC().Add(-time.Second)
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
+	vk.ExpiresAt = &past
+	vk.ProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"*"}),
+	}
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := &schemas.BifrostContext{}
+
+	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
+	assertDecision(t, DecisionVirtualKeyBlocked, result)
+	assert.Contains(t, result.Reason, "expired")
+}
+
+// TestBudgetResolver_EvaluateVirtualKeyRequest_InactiveWithFutureExpiry verifies
+// that an inactive VK is blocked as inactive, not expired, even when it has a
+// future expiry.
+func TestBudgetResolver_EvaluateVirtualKeyRequest_InactiveWithFutureExpiry(t *testing.T) {
+	logger := NewMockLogger()
+	future := time.Now().UTC().Add(time.Hour)
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", false)
+	vk.ExpiresAt = &future
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	resolver := NewBudgetResolver(store, nil, logger, nil)
+	ctx := &schemas.BifrostContext{}
+
+	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
+	assertDecision(t, DecisionVirtualKeyBlocked, result)
+	assert.Contains(t, result.Reason, "inactive")
+}

--- a/tests/cmd/e2eseed/go.mod
+++ b/tests/cmd/e2eseed/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/maximhq/bifrost/core v1.6.1 // indirect
+	github.com/maximhq/bifrost/core v1.6.2 // indirect
 	github.com/maximhq/bifrost/framework v1.3.16 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect

--- a/tests/cmd/seed/go.mod
+++ b/tests/cmd/seed/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/maximhq/bifrost/core v1.6.1
+	github.com/maximhq/bifrost/core v1.6.2
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/tests/cmd/seedvks/go.mod
+++ b/tests/cmd/seedvks/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.6.1
+	github.com/maximhq/bifrost/core v1.6.2
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1

--- a/tests/e2e/api/collections/bifrost-v1-vk-expiry.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-vk-expiry.postman_collection.json
@@ -1,0 +1,1899 @@
+{
+  "info": {
+    "name": "Bifrost V1 - Virtual Key Expiry",
+    "description": "Virtual key expiry tests. Covers create/update validation (future-only timestamps, RFC3339 parsing, empty-string clear, omit-leaves-unchanged) and runtime enforcement (unexpired passes, expired blocks with 403 virtual_key_blocked, inactive wins before expired, clearing expiry restores access). Self-provisions VKs and cleans up.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "provider",
+      "value": "openai",
+      "type": "string"
+    },
+    {
+      "key": "chat_model",
+      "value": "gpt-4o",
+      "type": "string"
+    },
+    {
+      "key": "vk_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "vk_value",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "vk2_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "mcp_client_name",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "mcp_tool_name",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "mcp_candidates",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "short_expiry_epoch",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Setup",
+      "item": [
+        {
+          "name": "Create VK without expiry",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var timestamp = Date.now();",
+                  "var uniqueName = 'VK Expiry Test ' + timestamp;",
+                  "var provider = pm.variables.get('provider') || 'openai';",
+                  "pm.request.body.raw = JSON.stringify({name: uniqueName, provider_configs: [{provider: provider, weight: 1.0, allowed_models: ['*'], key_ids: ['*']}]});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var code = pm.response.code;",
+                  "pm.test('Create VK returns 200 or 201', function() { pm.expect(code).to.be.oneOf([200, 201]); });",
+                  "if (code === 200 || code === 201) {",
+                  "  var jsonData = pm.response.json();",
+                  "  var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "  pm.test('VK has id and value', function() {",
+                  "    pm.expect(vk).to.be.an('object');",
+                  "    pm.expect(vk.id).to.be.a('string').and.not.be.empty;",
+                  "    pm.expect(vk.value).to.be.a('string').and.not.be.empty;",
+                  "  });",
+                  "  pm.test('VK without expiry has no expires_at', function() {",
+                  "    pm.expect(vk.expires_at == null).to.be.true;",
+                  "  });",
+                  "  pm.collectionVariables.set('vk_id', vk.id);",
+                  "  pm.collectionVariables.set('vk_value', vk.value);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\": \"VK Expiry Test\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Discover MCP tool candidates for enforcement tests",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Executable tool names are registered as '<client>-<tool>'. Collect",
+                  "// candidates from connected clients, restricted to read-only-looking,",
+                  "// argument-free-callable tools so probing them is side-effect free.",
+                  "// Per-user-auth clients fail before the governance gate, so candidates",
+                  "// are verified with a live probe in the next request.",
+                  "pm.test('List MCP clients returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var clients = (jsonData && jsonData.clients) || [];",
+                  "var SAFE_TOOL = /(echo|greet|public|info|ping|health|status)/i;",
+                  "var candidates = [];",
+                  "clients.forEach(function(cl) {",
+                  "  if (cl.state !== 'connected' || !cl.config || !cl.config.name) return;",
+                  "  (cl.tools || []).forEach(function(t) {",
+                  "    if (t.name && SAFE_TOOL.test(t.name) && candidates.length < 5) {",
+                  "      candidates.push({client: cl.config.name, tool: cl.config.name + '-' + t.name});",
+                  "    }",
+                  "  });",
+                  "});",
+                  "pm.collectionVariables.set('mcp_candidates', JSON.stringify(candidates));",
+                  "if (!candidates.length) {",
+                  "  pm.test('Skipped: no connected MCP client with a safe probe tool', function() { pm.expect(true).to.be.true; });",
+                  "} else {",
+                  "  console.log('MCP candidates: ' + candidates.map(function(c) { return c.tool; }).join(', '));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/mcp/clients",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mcp",
+                "clients"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Grant VK access to MCP candidate clients",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var candidates = JSON.parse(pm.collectionVariables.get('mcp_candidates') || '[]');",
+                  "var clientNames = candidates.map(function(c) { return c.client; }).filter(function(v, i, a) { return a.indexOf(v) === i; });",
+                  "// No usable MCP client: turn this into a harmless no-op update.",
+                  "if (!clientNames.length) {",
+                  "  pm.request.body.raw = JSON.stringify({description: 'no MCP client available'});",
+                  "} else {",
+                  "  pm.request.body.raw = JSON.stringify({mcp_configs: clientNames.map(function(n) { return {mcp_client_name: n, tools_to_execute: ['*']}; })});",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Grant MCP access returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Probe MCP candidates and pick a working tool",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// A candidate only counts if a real execution with the fresh VK returns",
+                  "// 200 \u2014 this filters out per-user-auth clients, whose connection fails",
+                  "// before the governance gate the expiry tests need to reach.",
+                  "var candidates = JSON.parse(pm.collectionVariables.get('mcp_candidates') || '[]');",
+                  "pm.collectionVariables.set('mcp_tool_name', '');",
+                  "if (!candidates.length) {",
+                  "  pm.test('Skipped: no MCP candidates to probe', function() { pm.expect(true).to.be.true; });",
+                  "} else {",
+                  "  var baseUrl = pm.variables.get('base_url');",
+                  "  var vkValue = pm.collectionVariables.get('vk_value');",
+                  "  function probe(i) {",
+                  "    if (i >= candidates.length) {",
+                  "      pm.test('Skipped: no MCP candidate executed successfully', function() { pm.expect(true).to.be.true; });",
+                  "      return;",
+                  "    }",
+                  "    pm.sendRequest({",
+                  "      url: baseUrl + '/v1/mcp/tool/execute',",
+                  "      method: 'POST',",
+                  "      header: {'Content-Type': 'application/json', 'x-bf-vk': vkValue},",
+                  "      body: {mode: 'raw', raw: JSON.stringify({id: 'probe_' + i, type: 'function', function: {name: candidates[i].tool, arguments: '{}'}})}",
+                  "    }, function(err, res) {",
+                  "      if (!err && res.code === 200) {",
+                  "        pm.collectionVariables.set('mcp_tool_name', candidates[i].tool);",
+                  "        pm.test('Selected MCP tool for enforcement tests: ' + candidates[i].tool, function() { pm.expect(true).to.be.true; });",
+                  "      } else {",
+                  "        probe(i + 1);",
+                  "      }",
+                  "    });",
+                  "  }",
+                  "  probe(0);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/mcp/clients",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "mcp",
+                "clients"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Create Validation",
+      "item": [
+        {
+          "name": "Create VK with past expiry is rejected",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var uniqueName = 'VK Expiry Past ' + Date.now();",
+                  "var pastExpiry = new Date(Date.now() - 3600000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({name: uniqueName, expires_at: pastExpiry});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Create with past expiry returns 400', function() { pm.expect(pm.response.code).to.equal(400); });",
+                  "pm.test('Error mentions future timestamp', function() { pm.expect(pm.response.text()).to.include('future'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\": \"VK Expiry Past\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create VK with future expiry persists it",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var uniqueName = 'VK Expiry Future ' + Date.now();",
+                  "var futureExpiry = new Date(Date.now() + 3600000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({name: uniqueName, expires_at: futureExpiry});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var code = pm.response.code;",
+                  "pm.test('Create with future expiry returns 200 or 201', function() { pm.expect(code).to.be.oneOf([200, 201]); });",
+                  "if (code === 200 || code === 201) {",
+                  "  var jsonData = pm.response.json();",
+                  "  var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "  pm.test('Response echoes expires_at about 1h from now', function() {",
+                  "    pm.expect(vk).to.be.an('object');",
+                  "    pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "    var exp = new Date(vk.expires_at).getTime();",
+                  "    pm.expect(exp).to.be.greaterThan(Date.now() + 50 * 60000);",
+                  "    pm.expect(exp).to.be.lessThan(Date.now() + 70 * 60000);",
+                  "  });",
+                  "  if (vk && vk.id) { pm.collectionVariables.set('vk2_id', vk.id); }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\": \"VK Expiry Future\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Update Semantics",
+      "item": [
+        {
+          "name": "Set future expiry via update",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var futureExpiry = new Date(Date.now() + 3600000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({expires_at: futureExpiry});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Set expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reflects the new expiry",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('expires_at is about 1h from now', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  var exp = new Date(vk.expires_at).getTime();",
+                  "  pm.expect(exp).to.be.greaterThan(Date.now() + 50 * 60000);",
+                  "  pm.expect(exp).to.be.lessThan(Date.now() + 70 * 60000);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "List endpoint includes expires_at",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('List VKs returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var list = (jsonData && jsonData.virtual_keys) || [];",
+                  "var mine = list.filter(function(v) { return v.id === pm.collectionVariables.get('vk_id'); })[0];",
+                  "if (mine) {",
+                  "  pm.test('Listed VK carries its expires_at', function() {",
+                  "    pm.expect(mine.expires_at).to.be.a('string').and.not.be.empty;",
+                  "    pm.expect(new Date(mine.expires_at).getTime()).to.be.greaterThan(Date.now());",
+                  "  });",
+                  "} else {",
+                  "  pm.test('Skipped: VK not on this list page', function() { pm.expect(true).to.be.true; });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys?limit=500&offset=0",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "500"
+                },
+                {
+                  "key": "offset",
+                  "value": "0"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update without expires_at leaves expiry unchanged",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Update without expires_at returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\": \"expiry untouched\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET still has the expiry",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('expires_at survives an unrelated update', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  pm.expect(new Date(vk.expires_at).getTime()).to.be.greaterThan(Date.now());",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Extend expiry to 2h",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var extended = new Date(Date.now() + 7200000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({expires_at: extended});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Extend expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reflects the extended expiry",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('expires_at moved out to about 2h from now', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  var exp = new Date(vk.expires_at).getTime();",
+                  "  pm.expect(exp).to.be.greaterThan(Date.now() + 110 * 60000);",
+                  "  pm.expect(exp).to.be.lessThan(Date.now() + 130 * 60000);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Set expiry with timezone offset",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// now+1h expressed in a +05:30 offset instead of Z; the backend must",
+                  "// store the same instant.",
+                  "var target = Date.now() + 3600000;",
+                  "var shifted = new Date(target + 330 * 60000);",
+                  "var offsetTimestamp = shifted.toISOString().slice(0, 19) + '+05:30';",
+                  "pm.request.body.raw = JSON.stringify({expires_at: offsetTimestamp});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Offset timestamp is accepted', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET normalizes offset expiry to the same instant",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('Stored expiry equals the +05:30 instant (about 1h from now)', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  var exp = new Date(vk.expires_at).getTime();",
+                  "  pm.expect(exp).to.be.greaterThan(Date.now() + 50 * 60000);",
+                  "  pm.expect(exp).to.be.lessThan(Date.now() + 70 * 60000);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update with invalid timestamp is rejected",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Invalid timestamp returns 400', function() { pm.expect(pm.response.code).to.equal(400); });",
+                  "pm.test('Error mentions RFC3339', function() { pm.expect(pm.response.text()).to.include('RFC3339'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"expires_at\": \"not-a-timestamp\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update with past expiry is rejected",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var pastExpiry = new Date(Date.now() - 60000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({expires_at: pastExpiry});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Past expiry returns 400', function() { pm.expect(pm.response.code).to.equal(400); });",
+                  "pm.test('Error mentions future timestamp', function() { pm.expect(pm.response.text()).to.include('future'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Clear expiry with empty string",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Clear expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"expires_at\": \"\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET shows no expiry after clear",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('expires_at is cleared', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at == null).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Enforcement",
+      "item": [
+        {
+          "name": "Re-set future expiry",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var futureExpiry = new Date(Date.now() + 3600000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({expires_at: futureExpiry});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Set expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Inference with unexpired VK is not blocked as expired",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The provider call itself may fail in some environments; this test only",
+                  "// guards that governance does not reject an unexpired VK.",
+                  "pm.test('Response carries no expiry rejection', function() {",
+                  "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
+                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "MCP tool execution with unexpired VK is not blocked",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get('mcp_tool_name')) { pm.test('Skipped: no connected MCP client with tools', function() { pm.expect(true).to.be.true; }); } else {",
+                  "  pm.test('Unexpired VK MCP execution carries no governance rejection', function() {",
+                  "    pm.expect(pm.response.text(), 'body: ' + pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\": \"call_expiry_test\", \"type\": \"function\", \"function\": {\"name\": \"{{mcp_tool_name}}\", \"arguments\": \"{}\"}}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/mcp/tool/execute",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "mcp",
+                "tool",
+                "execute"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Set short expiry",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Record the absolute expiry instant so the wait before the blocked-request",
+                  "// checks can anchor to it instead of guessing a fixed window.",
+                  "var shortExpiryEpoch = Date.now() + 5000;",
+                  "pm.collectionVariables.set('short_expiry_epoch', String(shortExpiryEpoch));",
+                  "pm.request.body.raw = JSON.stringify({expires_at: new Date(shortExpiryEpoch).toISOString()});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Set short expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Inference after expiry is blocked",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Wait until the wall clock is safely past the expiry instant recorded by",
+                  "// 'Set short expiry'. Anchoring to the absolute epoch means PUT round-trip",
+                  "// time or a slow runner can never shrink the wait below the expiry boundary.",
+                  "// Newman's sandbox waits for pending timers before sending the request.",
+                  "var deadline = Number(pm.collectionVariables.get('short_expiry_epoch') || 0) + 2000;",
+                  "(function waitForExpiry() {",
+                  "  if (Date.now() < deadline) {",
+                  "    setTimeout(waitForExpiry, 250);",
+                  "  }",
+                  "})();"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Expired VK inference returns 403', function() {",
+                  "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
+                  "});",
+                  "pm.test('Rejection is virtual_key_blocked with expired reason', function() {",
+                  "  pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "MCP tool execution with expired VK is blocked",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get('mcp_tool_name')) { pm.test('Skipped: no connected MCP client with tools', function() { pm.expect(true).to.be.true; }); } else {",
+                  "  pm.test('Expired VK MCP execution returns 403', function() {",
+                  "    pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
+                  "  });",
+                  "  pm.test('Rejection is virtual_key_blocked with expired reason', function() {",
+                  "    pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "    pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\": \"call_expiry_test\", \"type\": \"function\", \"function\": {\"name\": \"{{mcp_tool_name}}\", \"arguments\": \"{}\"}}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/mcp/tool/execute",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "mcp",
+                "tool",
+                "execute"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Expired VK stays visible via GET",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET expired VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('Expired VK is still active with a past expires_at', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.is_active).to.not.equal(false);",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  pm.expect(new Date(vk.expires_at).getTime()).to.be.lessThan(Date.now());",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Editing an expired VK without touching expiry succeeds",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The stored expiry is already in the past; an update that omits expires_at",
+                  "// must not re-validate it (omit means leave unchanged).",
+                  "pm.test('Unrelated edit of expired VK returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"description\": \"edited after expiry\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Deactivate expired VK",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Deactivate returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"is_active\": false}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Inactive wins before expired",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Inactive+expired VK inference returns 403', function() {",
+                  "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
+                  "});",
+                  "pm.test('Rejection reason is inactive, not expired', function() {",
+                  "  pm.expect(pm.response.text().toLowerCase()).to.include('inactive');",
+                  "  pm.expect(pm.response.text().toLowerCase()).to.not.include('expired');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "MCP tool execution with inactive VK is blocked as inactive",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.collectionVariables.get('mcp_tool_name')) { pm.test('Skipped: no connected MCP client with tools', function() { pm.expect(true).to.be.true; }); } else {",
+                  "  pm.test('Inactive VK MCP execution returns 403', function() {",
+                  "    pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
+                  "  });",
+                  "  pm.test('Rejection reason is inactive, not expired', function() {",
+                  "    pm.expect(pm.response.text().toLowerCase()).to.include('inactive');",
+                  "    pm.expect(pm.response.text().toLowerCase()).to.not.include('expired');",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\": \"call_expiry_test\", \"type\": \"function\", \"function\": {\"name\": \"{{mcp_tool_name}}\", \"arguments\": \"{}\"}}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/mcp/tool/execute",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "mcp",
+                "tool",
+                "execute"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Reactivate expired VK (expiry untouched)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Reactivate returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"is_active\": true}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Reactivated but still expired VK stays blocked",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Reactivation must not implicitly un-expire the key.",
+                  "pm.test('Still returns 403 after reactivation', function() {",
+                  "  pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.equal(403);",
+                  "});",
+                  "pm.test('Rejection is still the expired reason', function() {",
+                  "  pm.expect(pm.response.text()).to.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text().toLowerCase()).to.include('expired');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Extend expiry of expired VK",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var extended = new Date(Date.now() + 3600000).toISOString();",
+                  "pm.request.body.raw = JSON.stringify({expires_at: extended});"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Extend expired VK returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET reflects extension into the future",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('GET VK returns 200', function() { pm.expect(pm.response.code).to.equal(200); });",
+                  "var jsonData = pm.response.json();",
+                  "var vk = (jsonData && (jsonData.virtual_key || jsonData)) || null;",
+                  "pm.test('expires_at is about 1h from now', function() {",
+                  "  pm.expect(vk).to.be.an('object');",
+                  "  pm.expect(vk.expires_at).to.be.a('string').and.not.be.empty;",
+                  "  var exp = new Date(vk.expires_at).getTime();",
+                  "  pm.expect(exp).to.be.greaterThan(Date.now() + 50 * 60000);",
+                  "  pm.expect(exp).to.be.lessThan(Date.now() + 70 * 60000);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Inference works after extending expiry",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Extension restores access (no expiry rejection)', function() {",
+                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Clear expiry",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Clear expiry returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"expires_at\": \"\"}"
+            },
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Inference after clearing expiry is not blocked",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Response carries no governance rejection', function() {",
+                  "  pm.expect(pm.response.text()).to.not.include('virtual_key_blocked');",
+                  "  pm.expect(pm.response.text()).to.not.include('Virtual key has expired');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-vk",
+                "value": "{{vk_value}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+            },
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Teardown",
+      "item": [
+        {
+          "name": "Delete VK",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Delete VK returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk_id}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete future-expiry VK",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Nothing to delete when the future-expiry VK was never created; skip so the",
+                  "// request doesn't fire a DELETE against the collection route with no ID.",
+                  "if (!pm.collectionVariables.get('vk2_id') && pm.execution && typeof pm.execution.skipRequest === 'function') {",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.collectionVariables.get('vk2_id')) {",
+                  "  pm.test('Delete future-expiry VK returns 2xx', function() { pm.expect(pm.response.code).to.be.within(200, 299); });",
+                  "} else {",
+                  "  pm.test('Skipped: future-expiry VK was never created', function() { pm.expect(true).to.be.true; });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys/{{vk2_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys",
+                "{{vk2_id}}"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/api/runners/individual/run-newman-vk-expiry-tests.sh
+++ b/tests/e2e/api/runners/individual/run-newman-vk-expiry-tests.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+# Bifrost V1 Virtual Key Expiry Newman Test Runner
+# Runs VK expiry tests: create/update validation, runtime expiry enforcement, and cleanup.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$API_DIR"
+
+# Configuration
+COLLECTION="collections/bifrost-v1-vk-expiry.postman_collection.json"
+REPORT_DIR="newman-reports/vk-expiry"
+PROVIDER_CONFIG_DIR="provider_config"
+PROVIDER_CAPABILITIES_JSON="provider-capabilities.json"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+PROVIDER_ENV_FILE=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env)
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo -e "${RED}Error: --env requires a value${NC}"
+                exit 1
+            fi
+            PROVIDER_ENV_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --env <provider>    Postman env path or provider name (e.g. openai or provider_config/bifrost-v1-openai.postman_environment.json)"
+            echo "  --verbose           Show detailed output"
+            echo "  --html              Generate HTML report"
+            echo "  --json              Generate JSON report"
+            echo "  --bail              Stop on first failure"
+            echo "  --help              Show this help message"
+            echo ""
+            echo "Environment Variables:"
+            echo "  BIFROST_BASE_URL    Override base URL (default: http://localhost:8080)"
+            echo ""
+            echo "Examples:"
+            echo "  $0 --env openai     # Run with OpenAI provider"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${ARGS[@]}"
+
+# Print banner
+echo -e "${GREEN}==============================================${NC}"
+echo -e "${GREEN}Bifrost V1 Virtual Key Expiry Test Runner${NC}"
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+
+# Check if Newman is installed
+if ! command -v newman &> /dev/null; then
+    echo -e "${RED}Error: Newman is not installed${NC}"
+    echo "Install it with: npm install -g newman"
+    exit 1
+fi
+
+# Check if collection exists
+if [ ! -f "$COLLECTION" ]; then
+    echo -e "${RED}Error: Collection file not found: $COLLECTION${NC}"
+    exit 1
+fi
+
+# Create report directory
+mkdir -p "$REPORT_DIR"
+
+# Load provider capabilities into globals (for consistency with v1 runner)
+GLOBALS_TMP=""
+if [ -f "$PROVIDER_CAPABILITIES_JSON" ] && command -v jq &>/dev/null; then
+    GLOBALS_TMP=$(mktemp)
+    trap 'rm -f "$GLOBALS_TMP"' EXIT
+    jq -n --rawfile cap "$PROVIDER_CAPABILITIES_JSON" '{id: "bifrost-provider-capabilities", name: "Provider capabilities", values: [{key: "provider_capabilities", value: $cap, type: "default", enabled: true}]}' > "$GLOBALS_TMP"
+fi
+
+# Parse remaining options
+VERBOSE=""
+REPORTERS="cli"
+BAIL=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE="--verbose"
+            shift
+            ;;
+        --html)
+            REPORTERS="${REPORTERS},html"
+            shift
+            ;;
+        --json)
+            REPORTERS="${REPORTERS},json"
+            shift
+            ;;
+        --bail)
+            BAIL="--bail"
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve provider env file
+SINGLE_JSON_ENV=""
+if [ -n "$PROVIDER_ENV_FILE" ]; then
+    if [ -f "$PROVIDER_ENV_FILE" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_ENV_FILE"
+    elif [ -f "$PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE"
+    elif [ -f "$PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json"
+    else
+        echo -e "${RED}Error: Could not find environment file for: $PROVIDER_ENV_FILE${NC}"
+        echo "Searched:"
+        echo "  - $PROVIDER_ENV_FILE"
+        echo "  - $PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE"
+        echo "  - $PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json"
+        exit 1
+    fi
+fi
+
+# Default to openai if no env specified
+if [ -z "$SINGLE_JSON_ENV" ]; then
+    if [ -f "$PROVIDER_CONFIG_DIR/bifrost-v1-openai.postman_environment.json" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/bifrost-v1-openai.postman_environment.json"
+        echo -e "${YELLOW}No --env specified, using openai${NC}"
+    fi
+fi
+
+# Build Newman command
+cmd=(newman run "$COLLECTION")
+[ -n "$GLOBALS_TMP" ] && [ -f "$GLOBALS_TMP" ] && cmd+=(-g "$GLOBALS_TMP")
+[ -n "$SINGLE_JSON_ENV" ] && [ -f "$SINGLE_JSON_ENV" ] && cmd+=(-e "$SINGLE_JSON_ENV")
+
+# Base URL override
+base_url="${BIFROST_BASE_URL:-http://localhost:8080}"
+cmd+=(--env-var "base_url=$base_url")
+
+cmd+=(--timeout-script 120000 --timeout 900000)
+cmd+=(-r "$REPORTERS")
+
+if [[ "$REPORTERS" == *"html"* ]]; then
+    cmd+=(--reporter-html-export "$REPORT_DIR/report.html")
+fi
+if [[ "$REPORTERS" == *"json"* ]]; then
+    cmd+=(--reporter-json-export "$REPORT_DIR/report.json")
+fi
+[ -n "$VERBOSE" ] && cmd+=("$VERBOSE")
+[ -n "$BAIL" ] && cmd+=("$BAIL")
+
+echo -e "Configuration:"
+echo -e "  Collection: ${YELLOW}$COLLECTION${NC}"
+echo -e "  Base URL:   ${YELLOW}$base_url${NC}"
+if [ -n "$SINGLE_JSON_ENV" ]; then
+    echo -e "  Env:        ${YELLOW}$SINGLE_JSON_ENV${NC}"
+fi
+echo -e "  Reports:    ${YELLOW}$REPORT_DIR${NC}"
+echo ""
+echo -e "${GREEN}Running tests...${NC}"
+echo ""
+
+set +e
+"${cmd[@]}"
+EXIT_CODE=$?
+set -e
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}✓ All VK expiry tests passed!${NC}"
+else
+    echo -e "${RED}✗ Some tests failed${NC}"
+fi
+if [[ "$REPORTERS" == *"html"* ]] || [[ "$REPORTERS" == *"json"* ]]; then
+    echo ""
+    echo -e "Reports saved to: ${YELLOW}$REPORT_DIR${NC}"
+    ls -lh "$REPORT_DIR" 2>/dev/null | tail -n +2
+fi
+
+exit $EXIT_CODE

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -165,6 +165,7 @@ type CreateVirtualKeyRequest struct {
 	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 	IsActive        *bool                   `json:"is_active,omitempty"`
 	CalendarAligned bool                    `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
+	ExpiresAt       *time.Time              `json:"expires_at,omitempty"`       // Optional expiry; nil means never expires
 }
 
 // UpdateVirtualKeyRequest represents the request body for updating a virtual key
@@ -193,6 +194,7 @@ type UpdateVirtualKeyRequest struct {
 	IsActive         *bool                        `json:"is_active,omitempty"`
 	CalendarAligned  *bool                        `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
 	ResetBudgetUsage *bool                        `json:"reset_budget_usage,omitempty"`
+	ExpiresAt        *string                      `json:"expires_at,omitempty"` // RFC3339 timestamp sets a new expiry, "" clears it, omitted leaves it unchanged
 }
 
 var errVirtualKeyDualAssociation = errors.New("VirtualKey cannot be attached to both Team and Customer")
@@ -1271,6 +1273,14 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			seenDurations[b.ResetDuration] = true
 		}
 	}
+	// Validate expires_at: must be in the future if provided
+	if req.ExpiresAt != nil {
+		now := time.Now().UTC()
+		if !req.ExpiresAt.After(now) {
+			SendError(ctx, 400, "expires_at must be a future timestamp")
+			return
+		}
+	}
 	// Set defaults: nil means "use DB default (true)"
 	isActive := req.IsActive
 	if isActive == nil {
@@ -1297,6 +1307,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			CustomerID:      req.CustomerID,
 			IsActive:        isActive,
 			CalendarAligned: req.CalendarAligned,
+			ExpiresAt:       req.ExpiresAt,
 		}
 		if err := h.configStore.CreateVirtualKey(ctx, &vk, tx); err != nil {
 			return err
@@ -1495,6 +1506,20 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "VirtualKey cannot be attached to both Team and Customer")
 		return
 	}
+	// Parse expires_at when provided: a timestamp must be in the future, "" clears the expiry.
+	var newExpiresAt *time.Time
+	if req.ExpiresAt != nil && *req.ExpiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			SendError(ctx, 400, "expires_at must be an RFC3339 timestamp")
+			return
+		}
+		if !parsed.After(time.Now().UTC()) {
+			SendError(ctx, 400, "expires_at must be a future timestamp")
+			return
+		}
+		newExpiresAt = &parsed
+	}
 	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -1550,6 +1575,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		}
 		if req.IsActive != nil {
 			vk.IsActive = req.IsActive
+		}
+		if req.ExpiresAt != nil {
+			vk.ExpiresAt = newExpiresAt
 		}
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -7317,6 +7317,39 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		t.Error("Expected different hash for virtual keys with different IsActive")
 	}
 
+	// Setting ExpiresAt should produce a different hash; nil ExpiresAt keeps the original hash
+	expiry := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	vkExpiring := tables.TableVirtualKey{
+		ID:          "vk-1",
+		Name:        "test-vk",
+		Description: "Test virtual key",
+		Value:       *schemas.NewSecretVar("vk_abc123"),
+		IsActive:    schemas.Ptr(true),
+		TeamID:      &teamID,
+		ExpiresAt:   &expiry,
+	}
+
+	hashExpiring, err := configstore.GenerateVirtualKeyHash(vkExpiring)
+	if err != nil {
+		t.Fatalf("Failed to generate hash: %v", err)
+	}
+
+	if hash1 == hashExpiring {
+		t.Error("Expected different hash for virtual keys with ExpiresAt set")
+	}
+
+	// Different expiry timestamps should produce different hashes
+	laterExpiry := expiry.Add(time.Hour)
+	vkExpiring.ExpiresAt = &laterExpiry
+	hashLaterExpiry, err := configstore.GenerateVirtualKeyHash(vkExpiring)
+	if err != nil {
+		t.Fatalf("Failed to generate hash: %v", err)
+	}
+
+	if hashExpiring == hashLaterExpiry {
+		t.Error("Expected different hash for virtual keys with different ExpiresAt")
+	}
+
 	// Different TeamID should produce different hash
 	differentTeamID := "team-2"
 	vk6 := tables.TableVirtualKey{

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -768,6 +768,11 @@
                 "description": "Whether the virtual key is active",
                 "default": true
               },
+              "expires_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Optional expiry timestamp (RFC3339). Once passed, requests using this virtual key are rejected. Omit for a key that never expires."
+              },
               "calendar_aligned": {
                 "type": "boolean",
                 "description": "Snap all budget resets to calendar boundaries (day, week, month, year)",

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -136,11 +136,26 @@ export default function VirtualKeyDetailSheet({
 							<div className="grid grid-cols-3 items-center gap-4">
 								<span className="text-muted-foreground text-sm">Status</span>
 								<div className="col-span-2">
-									<Badge variant={virtualKey.is_active ? (isExhausted ? "destructive" : "default") : "secondary"}>
-										{virtualKey.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive"}
-									</Badge>
+									{(() => {
+										const isExpired = !!virtualKey.expires_at && Date.now() >= new Date(virtualKey.expires_at).getTime();
+										const variant = !virtualKey.is_active ? "secondary" : isExpired || isExhausted ? "destructive" : "default";
+										const label = !virtualKey.is_active ? "Inactive" : isExpired ? "Expired" : isExhausted ? "Exhausted" : "Active";
+										return <Badge variant={variant}>{label}</Badge>;
+									})()}
 								</div>
 							</div>
+
+							{virtualKey.expires_at && (
+								<div className="grid grid-cols-3 items-center gap-4">
+									<span className="text-muted-foreground text-sm">Expires</span>
+									<div className="col-span-2 text-sm">
+										{formatDistanceToNow(new Date(virtualKey.expires_at), {
+											addSuffix: true,
+										})}
+										<span className="text-muted-foreground ml-1 text-xs">({new Date(virtualKey.expires_at).toLocaleString()})</span>
+									</div>
+								</div>
+							)}
 
 							<div className="grid grid-cols-3 items-center gap-4">
 								<span className="text-muted-foreground text-sm">Created</span>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/alertDialog";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
+import { DateTimePicker } from "@/components/ui/datePickerWithRange";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -49,6 +50,7 @@ import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, Virtu
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
+import { formatDistanceToNow } from "date-fns";
 import { Info, Lock, RotateCcw, Trash2, Users, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -113,6 +115,7 @@ const formSchema = z
 		teamId: z.string().optional(),
 		customerId: z.string().optional(),
 		isActive: z.boolean(),
+		expiresAt: z.string().nullable().optional(), // ISO 8601 datetime-local string, or null to clear
 		// Budget
 		budgetCalendarAligned: z.boolean(),
 		budgets: z
@@ -163,6 +166,78 @@ type VirtualKeyType = {
 	description: string;
 	provider: string;
 };
+
+const pad2 = (n: number) => n.toString().padStart(2, "0");
+
+const toDatetimeLocal = (d: Date) =>
+	`${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+
+const presetFromNow = (offsetMs: number) => toDatetimeLocal(new Date(Date.now() + offsetMs));
+
+const EXPIRY_PRESETS = [
+	{ label: "30 min", ms: 30 * 60_000 },
+	{ label: "1 hour", ms: 60 * 60_000 },
+	{ label: "24 hours", ms: 24 * 60 * 60_000 },
+	{ label: "7 days", ms: 7 * 24 * 60 * 60_000 },
+] as const;
+
+interface ExpiryFieldProps {
+	value: string | null | undefined;
+	onChange: (v: string | null) => void;
+}
+
+function ExpiryPickerField({ value, onChange }: ExpiryFieldProps) {
+	// Preset timestamps are computed from Date.now() at click time, so the picked
+	// preset can't be derived back from the value; track it for highlighting.
+	const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+
+	return (
+		<FormItem>
+			<FormLabel>Expiry</FormLabel>
+			<p className="text-muted-foreground text-xs">
+				{value ? `This key expires ${formatDistanceToNow(new Date(value), { addSuffix: true })}.` : "This key never expires."}
+			</p>
+			<div className="flex flex-wrap gap-1.5">
+				<Button
+					type="button"
+					variant={!value ? "default" : "outline"}
+					size="sm"
+					onClick={() => {
+						setSelectedPreset(null);
+						onChange(null);
+					}}
+				>
+					Never
+				</Button>
+				{EXPIRY_PRESETS.map(({ label, ms }) => (
+					<Button
+						key={label}
+						type="button"
+						variant={value && selectedPreset === label ? "default" : "outline"}
+						size="sm"
+						onClick={() => {
+							setSelectedPreset(label);
+							onChange(presetFromNow(ms));
+						}}
+					>
+						{label}
+					</Button>
+				))}
+				<DateTimePicker
+					buttonClassName="h-8 text-sm px-3"
+					buttonVariant={value && !selectedPreset ? "default" : "outline"}
+					dateTime={value ? new Date(value) : undefined}
+					disabledBefore={new Date()}
+					onDateTimeUpdate={(dt) => {
+						setSelectedPreset(null);
+						onChange(toDatetimeLocal(dt));
+					}}
+				/>
+			</div>
+			<FormMessage />
+		</FormItem>
+	);
+}
 
 export default function VirtualKeySheet({ virtualKey, teams, customers, defaultTeamId, onSave, onCancel }: VirtualKeySheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
@@ -241,6 +316,12 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 			teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
 			customerId: virtualKey?.customer_id || "",
 			isActive: virtualKey?.is_active ?? true,
+			expiresAt: virtualKey?.expires_at
+				? (() => {
+						const d = new Date(virtualKey.expires_at);
+						return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+					})()
+				: null,
 			budgets:
 				virtualKey?.budgets && virtualKey.budgets.length > 0
 					? virtualKey.budgets.map((b) => ({
@@ -646,6 +727,19 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 				: [];
 			if (isEditing && virtualKey) {
 				// Update existing virtual key
+				// Only include expires_at when the user actually changed the expiry field
+				// (a timestamp sets it, "" clears it). Pre-filled defaultValues are not dirty,
+				// so an unchanged expired key won't resend its old expired timestamp and
+				// cause the backend to reject the edit.
+				const expiryChanged = !!form.formState.dirtyFields.expiresAt;
+				const expiryPayload = expiryChanged
+					? data.expiresAt
+						? { expires_at: new Date(data.expiresAt).toISOString() }
+						: virtualKey?.expires_at
+							? { expires_at: "" }
+							: {}
+					: {};
+
 				const updateData: UpdateVirtualKeyRequest = {
 					name: data.name,
 					description: data.description,
@@ -670,6 +764,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					is_active: data.isActive,
 					calendar_aligned: data.budgetCalendarAligned,
 					reset_budget_usage: resetBudgetUsage,
+					...expiryPayload,
 				};
 
 				// Add budgets if enabled
@@ -716,6 +811,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					is_active: data.isActive,
 					// VK-level setting that governs both budget and rate-limit calendar alignment.
 					calendar_aligned: data.budgetCalendarAligned,
+					// Optional expiry: send as UTC ISO string, or omit for no expiry
+					...(data.expiresAt ? { expires_at: new Date(data.expiresAt).toISOString() } : {}),
 				};
 
 				// Add budgets if enabled
@@ -869,6 +966,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 												<Toggle label="Is this key active?" val={field.value} setVal={field.onChange} data-testid="vk-is-active-toggle" />
 											</FormItem>
 										)}
+									/>
+									<FormField
+										control={form.control}
+										name="expiresAt"
+										render={({ field }) => <ExpiryPickerField value={field.value} onChange={field.onChange} />}
 									/>
 								</div>
 								{/* Provider Configurations */}

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -80,7 +80,8 @@ function virtualKeysToCSV(vks: VirtualKey[], accessProfileNames: Record<number, 
 			(vk.rate_limit?.request_current_usage &&
 				vk.rate_limit?.request_max_limit &&
 				vk.rate_limit.request_current_usage >= vk.rate_limit.request_max_limit);
-		const status = vk.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive";
+		const isExpired = !!vk.expires_at && Date.now() >= new Date(vk.expires_at).getTime();
+		const status = !vk.is_active ? "Inactive" : isExpired ? "Expired" : isExhausted ? "Exhausted" : "Active";
 		const assignedTo = vk.team ? `Team: ${vk.team.name}` : vk.customer ? `Customer: ${vk.customer.name}` : "";
 		const budgetLimit = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ") : "";
 		const budgetSpent = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ") : "";
@@ -845,6 +846,8 @@ export default function VirtualKeysTable({
 							) : (
 								virtualKeys.map((vk) => {
 									const isRevealed = revealedKeys.has(vk.id);
+									const isExpired = !!vk.expires_at && Date.now() >= new Date(vk.expires_at).getTime();
+									const showExpiredBadge = vk.is_active && isExpired;
 
 									return (
 										<TableRow
@@ -899,7 +902,13 @@ export default function VirtualKeysTable({
 												<VKRateLimitCell vk={vk} />
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
-												<VKActiveSwitch vk={vk} hasUpdateAccess={hasUpdateAccess} onToggle={handleToggleActive} />
+												{showExpiredBadge ? (
+													<Badge variant="destructive" className="text-xs">
+														Expired
+													</Badge>
+												) : (
+													<VKActiveSwitch vk={vk} hasUpdateAccess={hasUpdateAccess} onToggle={handleToggleActive} />
+												)}
 											</TableCell>
 											<TableCell
 												className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}

--- a/ui/components/ui/datePickerWithRange.tsx
+++ b/ui/components/ui/datePickerWithRange.tsx
@@ -374,6 +374,7 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 
 interface DateTimePickerProps extends React.HTMLAttributes<HTMLDivElement> {
 	buttonClassName?: string;
+	buttonVariant?: React.ComponentProps<typeof Button>["variant"];
 	triggerLabel?: string;
 	onTrigger?: (e: React.MouseEvent<HTMLButtonElement>, dateTime: { date?: Date; time: TimeValue }) => void;
 	popupAlignment?: "start" | "end" | "center";
@@ -384,7 +385,7 @@ interface DateTimePickerProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export function DateTimePicker(props: DateTimePickerProps) {
-	const { className, buttonClassName, triggerLabel, onTrigger, dateTime } = props;
+	const { className, buttonClassName, buttonVariant, triggerLabel, onTrigger, dateTime } = props;
 
 	const initialDate = dateTime ? new Date(dateTime) : new Date();
 	const [date, setDate] = React.useState<Date | undefined>(initialDate);
@@ -438,7 +439,7 @@ export function DateTimePicker(props: DateTimePickerProps) {
 				<PopoverTrigger asChild>
 					<Button
 						id="date"
-						variant="default"
+						variant={buttonVariant ?? "default"}
 						className={cn(
 							"w-max justify-start text-left font-normal",
 							!date && "text-content-disabled",

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -74,6 +74,7 @@ export interface VirtualKey {
 	customer_id?: string;
 	rate_limit_id?: string;
 	is_active: boolean;
+	expires_at?: string | null; // ISO 8601 UTC timestamp; null or absent means never expires
 	calendar_aligned?: boolean;
 	created_at: string;
 	updated_at: string;
@@ -164,6 +165,7 @@ export interface CreateVirtualKeyRequest {
 	rate_limit?: CreateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
+	expires_at?: string; // RFC3339 UTC timestamp; omit for a key that never expires
 }
 
 export interface UpdateVirtualKeyRequest {
@@ -178,6 +180,7 @@ export interface UpdateVirtualKeyRequest {
 	is_active?: boolean;
 	calendar_aligned?: boolean;
 	reset_budget_usage?: boolean;
+	expires_at?: string; // RFC3339 UTC timestamp sets a new expiry, "" clears it, omit to leave unchanged
 }
 
 export interface BulkRotateVirtualKeysRequest {


### PR DESCRIPTION
## Summary

Adds an end-to-end Postman collection and Newman runner script for virtual key expiry functionality. This covers the full lifecycle of `expires_at` on virtual keys: create/update validation, persistence and retrieval semantics, and runtime enforcement at the governance layer for both inference and MCP tool execution.

## Changes

- Added `bifrost-v1-vk-expiry.postman_collection.json` with four test groups:
  - **Setup**: Creates a VK without expiry, discovers connected MCP clients, grants MCP access, and probes candidates to select a working tool for enforcement tests.
  - **Create Validation**: Asserts that past expiry timestamps are rejected with 400 and a "future" error message, and that future timestamps are accepted and echoed back correctly.
  - **Update Semantics**: Verifies setting, extending, and clearing `expires_at` via PUT; confirms that omitting `expires_at` in an update leaves the existing value unchanged; validates RFC3339 parsing including timezone offsets; and asserts that invalid timestamps return 400 with an RFC3339 error.
  - **Enforcement**: Confirms unexpired VKs pass governance, expired VKs return 403 with `virtual_key_blocked` and an "expired" reason, inactive takes precedence over expired in the rejection reason, reactivation alone does not un-expire a key, and clearing or extending expiry restores access. All enforcement checks cover both `/v1/chat/completions` and `/v1/mcp/tool/execute`.
  - **Teardown**: Deletes both VKs created during the run.
- Added `run-newman-vk-expiry-tests.sh` to run the collection via Newman with support for `--env`, `--verbose`, `--html`, `--json`, and `--bail` flags, provider environment file resolution, and `BIFROST_BASE_URL` override.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Install Newman if not already installed
npm install -g newman

# Run with the default OpenAI environment
cd tests/e2e/api
bash runners/individual/run-newman-vk-expiry-tests.sh

# Run with a specific provider environment
bash runners/individual/run-newman-vk-expiry-tests.sh --env openai

# Run with HTML and JSON reports
bash runners/individual/run-newman-vk-expiry-tests.sh --env openai --html --json

# Override the base URL
BIFROST_BASE_URL=http://localhost:9090 bash runners/individual/run-newman-vk-expiry-tests.sh
```

Expected outcome: all tests pass. Enforcement tests that depend on a connected MCP client with a safe probe tool are automatically skipped when no suitable client is available.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The collection self-provisions and cleans up its own virtual keys. No credentials or secrets are embedded; provider API keys are supplied via the existing Postman environment files.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable