### PR TITLE
fix: make tracing span lookup nil-safe to prevent panic on streaming errors

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -36,6 +36,9 @@ const (
 
 // AddSpan adds a span to the trace in a thread-safe manner
 func (t *Trace) AddSpan(span *Span) {
+	if t == nil || span == nil {
+		return
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.Spans = append(t.Spans, span)
@@ -43,9 +46,15 @@ func (t *Trace) AddSpan(span *Span) {
 
 // GetSpan retrieves a span by ID
 func (t *Trace) GetSpan(spanID string) *Span {
+	if t == nil || spanID == "" {
+		return nil
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for _, span := range t.Spans {
+		if span == nil {
+			continue
+		}
 		if span.SpanID == spanID {
 			return span
 		}
@@ -146,7 +155,7 @@ type Span struct {
 
 // SetAttribute sets an attribute on the span in a thread-safe manner
 func (s *Span) SetAttribute(key string, value any) {
-	if value == nil {
+	if s == nil || value == nil {
 		return
 	}
 	s.mu.Lock()
@@ -159,6 +168,9 @@ func (s *Span) SetAttribute(key string, value any) {
 
 // AddEvent adds an event to the span in a thread-safe manner
 func (s *Span) AddEvent(event SpanEvent) {
+	if s == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Events = append(s.Events, event)
@@ -166,6 +178,9 @@ func (s *Span) AddEvent(event SpanEvent) {
 
 // End marks the span as complete with the given status
 func (s *Span) End(status SpanStatus, statusMsg string) {
+	if s == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.EndTime = time.Now()

--- a/core/schemas/trace_test.go
+++ b/core/schemas/trace_test.go
@@ -1,0 +1,34 @@
+package schemas
+
+import "testing"
+
+func TestTraceGetSpanNilSafe(t *testing.T) {
+	var nilTrace *Trace
+	if span := nilTrace.GetSpan("span"); span != nil {
+		t.Fatalf("nil trace GetSpan returned %v, want nil", span)
+	}
+
+	trace := &Trace{Spans: []*Span{nil, &Span{SpanID: "target"}}}
+	if span := trace.GetSpan("missing"); span != nil {
+		t.Fatalf("missing span = %v, want nil", span)
+	}
+	if span := trace.GetSpan("target"); span == nil || span.SpanID != "target" {
+		t.Fatalf("target span = %v, want target", span)
+	}
+}
+
+func TestTraceAndSpanNilMutatorsNoop(t *testing.T) {
+	trace := &Trace{}
+	trace.AddSpan(nil)
+	if len(trace.Spans) != 0 {
+		t.Fatalf("nil span was appended: %v", trace.Spans)
+	}
+
+	var nilTrace *Trace
+	nilTrace.AddSpan(&Span{SpanID: "ignored"})
+
+	var nilSpan *Span
+	nilSpan.SetAttribute("key", "value")
+	nilSpan.AddEvent(SpanEvent{Name: "event"})
+	nilSpan.End(SpanStatusOk, "")
+}

--- a/core/schemas/trace_test.go
+++ b/core/schemas/trace_test.go
@@ -9,6 +9,9 @@ func TestTraceGetSpanNilSafe(t *testing.T) {
 	}
 
 	trace := &Trace{Spans: []*Span{nil, &Span{SpanID: "target"}}}
+	if span := trace.GetSpan(""); span != nil {
+		t.Fatalf("empty span ID = %v, want nil", span)
+	}
 	if span := trace.GetSpan("missing"); span != nil {
 		t.Fatalf("missing span = %v, want nil", span)
 	}


### PR DESCRIPTION
## Problem

A Bedrock streaming error can panic the whole Bifrost process while finalizing tracing spans, instead of forwarding the stream error to the caller (SIGSEGV in `schemas.(*Trace).GetSpan`, reported in production while streaming Anthropic models via Bedrock).

## Root cause

The streaming error path finalizes deferred tracing spans and sets span attributes through `Trace.GetSpan`. The trace/span helpers assumed the trace receiver and every entry in `Trace.Spans` are non-nil. When trace cleanup/reuse leaves a nil span entry (or a nil span/trace reaches the finalizer, as visible in the reported stack where `completeDeferredSpan` receives a nil argument), the tracing code dereferences nil and crashes before the stream error is delivered.

## Fix

Make the trace/span helpers defensive no-ops for nil data, keeping tracing best-effort:

- `Trace.GetSpan` returns nil for nil traces, empty span IDs, and skips nil span entries.
- `Trace.AddSpan` ignores nil traces/spans.
- `Span.SetAttribute`, `Span.AddEvent`, and `Span.End` ignore nil receivers.

Tracing edge cases can no longer crash provider streaming error handling; the stream error is forwarded gracefully.

## Testing

- Added offline unit tests: nil-safe `GetSpan` (nil trace, nil span entry, hit/miss) and nil-receiver mutators no-op instead of panicking — pass.
- `CGO_ENABLED=0 go build ./...` and `go vet` in `core/` — pass.
- Note: `go test ./schemas` has one pre-existing failure (`TestResponsesMessageToolCallArguments/real_tool_search_call_frames_from_openai`) that reproduces identically on a clean `dev` checkout (64843177e); unrelated to this change.

Fixes #3455
