### PR TITLE
fix: enable rerank for custom OpenAI-compatible providers

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -3541,9 +3541,27 @@ func HandleOpenAIImageGenerationStreaming(
 	return responseChan, nil
 }
 
-// Rerank is not supported by the OpenAI provider.
+// Rerank performs a rerank request for custom OpenAI-compatible providers.
 func (provider *OpenAIProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+	if provider.customProviderConfig == nil {
+		return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, schemas.OpenAI)
+	}
+	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.RerankRequest); err != nil {
+		return nil, err
+	}
+
+	return HandleOpenAIRerankRequest(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/rerank", schemas.RerankRequest),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.logger,
+	)
 }
 
 // OCR is not supported by the Openai provider.

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -3564,6 +3564,98 @@ func (provider *OpenAIProvider) Rerank(ctx *schemas.BifrostContext, key schemas.
 	)
 }
 
+// HandleOpenAIRerankRequest handles rerank requests for custom OpenAI-compatible APIs.
+func HandleOpenAIRerankRequest(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	url string,
+	request *schemas.BifrostRerankRequest,
+	key schemas.Key,
+	extraHeaders map[string]string,
+	providerName schemas.ModelProvider,
+	sendBackRawRequest bool,
+	sendBackRawResponse bool,
+	logger schemas.Logger,
+) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	respOwned := true
+	defer func() {
+		if respOwned {
+			fasthttp.ReleaseResponse(resp)
+		}
+	}()
+	// Rerank JSON is always parsed in-process (no transport streaming). Skip
+	// PrepareResponseStreaming so large-response threshold mode never leaves the body
+	// on a stream-only path that finalizeOpenAIResponse would treat as unsupported here.
+	activeClient := client
+
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
+	req.SetRequestURI(url)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	for k, v := range BearerAuthHeader(key) {
+		req.Header.Set(k, v)
+	}
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIRerankRequest(request), nil
+		},
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	// CheckContextAndGetRequestBody returns nil jsonData when large-payload passthrough
+	// staged the request body as a stream. Mirror the other OpenAI-compatible handlers and
+	// apply that stream instead of sending an empty body; the normal JSON path is unchanged.
+	if !providerUtils.ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, providerName) {
+		req.SetBody(jsonData)
+	}
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		providerUtils.MaterializeStreamErrorBody(ctx, resp)
+		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
+		return nil, providerUtils.EnrichError(ctx, ParseOpenAIError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+
+	body, _, finalErr := finalizeOpenAIResponse(ctx, resp, latency, providerName, logger)
+	respOwned = false
+	if finalErr != nil {
+		return nil, providerUtils.EnrichError(ctx, finalErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+
+	response := &OpenAIRerankResponse{}
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, body, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+
+	returnDocuments := request.Params != nil && request.Params.ReturnDocuments != nil && *request.Params.ReturnDocuments
+	bifrostResponse := response.ToBifrostRerankResponse(request.Documents, returnDocuments)
+	bifrostResponse.Model = request.Model
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	if sendBackRawRequest {
+		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	}
+	if sendBackRawResponse {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+	return bifrostResponse, nil
+}
+
 // OCR is not supported by the Openai provider.
 func (provider *OpenAIProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.OCRRequest, provider.GetProviderKey())

--- a/core/providers/openai/rerank.go
+++ b/core/providers/openai/rerank.go
@@ -1,0 +1,276 @@
+package openai
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+type openAIRerankRequest struct {
+	Model           string                   `json:"model"`
+	Query           string                   `json:"query"`
+	Documents       []schemas.RerankDocument `json:"documents"`
+	TopN            *int                     `json:"top_n,omitempty"`
+	MaxTokensPerDoc *int                     `json:"max_tokens_per_doc,omitempty"`
+	Priority        *int                     `json:"priority,omitempty"`
+	ExtraParams     map[string]interface{}   `json:"-"`
+}
+
+func (r *openAIRerankRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
+func toOpenAIRerankRequest(request *schemas.BifrostRerankRequest) *openAIRerankRequest {
+	if request == nil {
+		return nil
+	}
+
+	converted := &openAIRerankRequest{
+		Model:     request.Model,
+		Query:     request.Query,
+		Documents: request.Documents,
+	}
+	if request.Params != nil {
+		converted.TopN = request.Params.TopN
+		converted.MaxTokensPerDoc = request.Params.MaxTokensPerDoc
+		converted.Priority = request.Params.Priority
+		converted.ExtraParams = request.Params.ExtraParams
+	}
+	return converted
+}
+
+type openAIRerankResponse struct {
+	ID      string                       `json:"id"`
+	Results []openAIRerankResponseResult `json:"results"`
+	Meta    *openAIRerankMeta            `json:"meta,omitempty"`
+	Usage   *schemas.BifrostLLMUsage     `json:"usage,omitempty"`
+}
+
+type openAIRerankResponseResult struct {
+	Index          int             `json:"index"`
+	RelevanceScore float64         `json:"relevance_score"`
+	Document       json.RawMessage `json:"document,omitempty"`
+}
+
+type openAIRerankMeta struct {
+	BilledUnits *openAIRerankTokenUsage `json:"billed_units,omitempty"`
+	Tokens      *openAIRerankTokenUsage `json:"tokens,omitempty"`
+}
+
+type openAIRerankTokenUsage struct {
+	InputTokens  *int64 `json:"input_tokens,omitempty"`
+	OutputTokens *int64 `json:"output_tokens,omitempty"`
+}
+
+func (response *openAIRerankResponse) toBifrostRerankResponse(documents []schemas.RerankDocument, returnDocuments bool) *schemas.BifrostRerankResponse {
+	if response == nil {
+		return nil
+	}
+
+	bifrostResponse := &schemas.BifrostRerankResponse{
+		ID: response.ID,
+	}
+	for _, result := range response.Results {
+		rerankResult := schemas.RerankResult{
+			Index:          result.Index,
+			RelevanceScore: result.RelevanceScore,
+		}
+		if doc := parseOpenAIRerankDocument(result.Document); doc != nil {
+			rerankResult.Document = doc
+		}
+		bifrostResponse.Results = append(bifrostResponse.Results, rerankResult)
+	}
+	sort.SliceStable(bifrostResponse.Results, func(i, j int) bool {
+		if bifrostResponse.Results[i].RelevanceScore == bifrostResponse.Results[j].RelevanceScore {
+			return bifrostResponse.Results[i].Index < bifrostResponse.Results[j].Index
+		}
+		return bifrostResponse.Results[i].RelevanceScore > bifrostResponse.Results[j].RelevanceScore
+	})
+	if returnDocuments {
+		for i := range bifrostResponse.Results {
+			resultIndex := bifrostResponse.Results[i].Index
+			if resultIndex >= 0 && resultIndex < len(documents) {
+				bifrostResponse.Results[i].Document = schemas.Ptr(documents[resultIndex])
+			}
+		}
+	}
+	if response.Usage != nil {
+		bifrostResponse.Usage = response.Usage
+	} else if response.Meta != nil {
+		bifrostResponse.Usage = openAIRerankUsage(response.Meta.Tokens)
+		if bifrostResponse.Usage == nil {
+			bifrostResponse.Usage = openAIRerankUsage(response.Meta.BilledUnits)
+		}
+	}
+	return bifrostResponse
+}
+
+func parseOpenAIRerankDocument(raw json.RawMessage) *schemas.RerankDocument {
+	if len(raw) == 0 {
+		return nil
+	}
+	var text string
+	if err := sonic.Unmarshal(raw, &text); err == nil {
+		return &schemas.RerankDocument{Text: text}
+	}
+
+	var docMap map[string]interface{}
+	if err := sonic.Unmarshal(raw, &docMap); err != nil {
+		return nil
+	}
+	doc := &schemas.RerankDocument{}
+	populated := false
+	if text, ok := docMap["text"].(string); ok {
+		doc.Text = text
+		populated = true
+	}
+	if id, ok := docMap["id"].(string); ok {
+		doc.ID = &id
+		populated = true
+	}
+	meta := make(map[string]interface{})
+	if rawMeta, ok := docMap["metadata"].(map[string]interface{}); ok {
+		for k, v := range rawMeta {
+			meta[k] = v
+		}
+	} else if rawMeta, ok := docMap["meta"].(map[string]interface{}); ok {
+		for k, v := range rawMeta {
+			meta[k] = v
+		}
+	}
+	for k, v := range docMap {
+		if k != "text" && k != "id" && k != "metadata" && k != "meta" {
+			meta[k] = v
+		}
+	}
+	if len(meta) > 0 {
+		doc.Meta = meta
+		populated = true
+	}
+	if !populated {
+		return nil
+	}
+	return doc
+}
+
+func openAIRerankUsage(tokens *openAIRerankTokenUsage) *schemas.BifrostLLMUsage {
+	if tokens == nil {
+		return nil
+	}
+	promptTokens := 0
+	completionTokens := 0
+	hasUsage := false
+	if tokens.InputTokens != nil {
+		promptTokens = int(*tokens.InputTokens)
+		hasUsage = true
+	}
+	if tokens.OutputTokens != nil {
+		completionTokens = int(*tokens.OutputTokens)
+		hasUsage = true
+	}
+	if !hasUsage {
+		return nil
+	}
+	return &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      promptTokens + completionTokens,
+	}
+}
+
+// HandleOpenAIRerankRequest handles rerank requests for custom OpenAI-compatible APIs.
+func HandleOpenAIRerankRequest(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	url string,
+	request *schemas.BifrostRerankRequest,
+	key schemas.Key,
+	extraHeaders map[string]string,
+	providerName schemas.ModelProvider,
+	sendBackRawRequest bool,
+	sendBackRawResponse bool,
+	logger schemas.Logger,
+) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	respOwned := true
+	defer func() {
+		if respOwned {
+			fasthttp.ReleaseResponse(resp)
+		}
+	}()
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
+	req.SetRequestURI(url)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	for k, v := range BearerAuthHeader(key) {
+		req.Header.Set(k, v)
+	}
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return toOpenAIRerankRequest(request), nil
+		},
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	req.SetBody(jsonData)
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		providerUtils.MaterializeStreamErrorBody(ctx, resp)
+		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
+		return nil, providerUtils.EnrichError(ctx, ParseOpenAIError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+
+	body, lpResult, finalErr := finalizeOpenAIResponse(ctx, resp, latency, providerName, logger)
+	respOwned = false
+	if finalErr != nil {
+		return nil, providerUtils.EnrichError(ctx, finalErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+	if lpResult != nil {
+		return &schemas.BifrostRerankResponse{
+			Model:       request.Model,
+			Usage:       lpResult.Usage,
+			ExtraFields: schemas.BifrostResponseExtraFields{Latency: lpResult.Latency},
+		}, nil
+	}
+
+	response := &openAIRerankResponse{}
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, body, sendBackRawRequest, sendBackRawResponse, latency)
+	}
+
+	returnDocuments := request.Params != nil && request.Params.ReturnDocuments != nil && *request.Params.ReturnDocuments
+	bifrostResponse := response.toBifrostRerankResponse(request.Documents, returnDocuments)
+	bifrostResponse.Model = request.Model
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	if sendBackRawRequest {
+		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	}
+	if sendBackRawResponse {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+	return bifrostResponse, nil
+}

--- a/core/providers/openai/rerank.go
+++ b/core/providers/openai/rerank.go
@@ -2,36 +2,19 @@ package openai
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"sort"
 
 	"github.com/bytedance/sonic"
-	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/valyala/fasthttp"
 )
 
-type openAIRerankRequest struct {
-	Model           string                   `json:"model"`
-	Query           string                   `json:"query"`
-	Documents       []schemas.RerankDocument `json:"documents"`
-	TopN            *int                     `json:"top_n,omitempty"`
-	MaxTokensPerDoc *int                     `json:"max_tokens_per_doc,omitempty"`
-	Priority        *int                     `json:"priority,omitempty"`
-	ExtraParams     map[string]interface{}   `json:"-"`
-}
-
-func (r *openAIRerankRequest) GetExtraParams() map[string]interface{} {
-	return r.ExtraParams
-}
-
-func toOpenAIRerankRequest(request *schemas.BifrostRerankRequest) *openAIRerankRequest {
+// ToOpenAIRerankRequest converts a Bifrost rerank request to OpenAI-compatible format
+func ToOpenAIRerankRequest(request *schemas.BifrostRerankRequest) *OpenAIRerankRequest {
 	if request == nil {
 		return nil
 	}
 
-	converted := &openAIRerankRequest{
+	converted := &OpenAIRerankRequest{
 		Model:     request.Model,
 		Query:     request.Query,
 		Documents: request.Documents,
@@ -45,31 +28,8 @@ func toOpenAIRerankRequest(request *schemas.BifrostRerankRequest) *openAIRerankR
 	return converted
 }
 
-type openAIRerankResponse struct {
-	ID      string                       `json:"id"`
-	Results []openAIRerankResponseResult `json:"results"`
-	Meta    *openAIRerankMeta            `json:"meta,omitempty"`
-	Usage   *schemas.BifrostLLMUsage     `json:"usage,omitempty"`
-}
-
-type openAIRerankResponseResult struct {
-	Index          int             `json:"index"`
-	RelevanceScore float64         `json:"relevance_score"`
-	Document       json.RawMessage `json:"document,omitempty"`
-}
-
-type openAIRerankMeta struct {
-	BilledUnits *openAIRerankTokenUsage `json:"billed_units,omitempty"`
-	Tokens      *openAIRerankTokenUsage `json:"tokens,omitempty"`
-}
-
-type openAIRerankTokenUsage struct {
-	InputTokens  *int64 `json:"input_tokens,omitempty"`
-	OutputTokens *int64 `json:"output_tokens,omitempty"`
-	SearchUnits  *int64 `json:"search_units,omitempty"`
-}
-
-func (response *openAIRerankResponse) toBifrostRerankResponse(documents []schemas.RerankDocument, returnDocuments bool) *schemas.BifrostRerankResponse {
+// ToBifrostRerankResponse converts an OpenAI-compatible rerank response to Bifrost format
+func (response *OpenAIRerankResponse) ToBifrostRerankResponse(documents []schemas.RerankDocument, returnDocuments bool) *schemas.BifrostRerankResponse {
 	if response == nil {
 		return nil
 	}
@@ -116,6 +76,8 @@ func (response *openAIRerankResponse) toBifrostRerankResponse(documents []schema
 	return bifrostResponse
 }
 
+// parseOpenAIRerankDocument parses a rerank document returned by the upstream,
+// accepting either a bare string or an object with text/id/metadata fields.
 func parseOpenAIRerankDocument(raw json.RawMessage) *schemas.RerankDocument {
 	if len(raw) == 0 {
 		return nil
@@ -164,7 +126,8 @@ func parseOpenAIRerankDocument(raw json.RawMessage) *schemas.RerankDocument {
 	return doc
 }
 
-func openAIRerankUsage(tokens *openAIRerankTokenUsage) *schemas.BifrostLLMUsage {
+// openAIRerankUsage maps rerank token/billing counts onto Bifrost usage.
+func openAIRerankUsage(tokens *OpenAIRerankTokenUsage) *schemas.BifrostLLMUsage {
 	if tokens == nil {
 		return nil
 	}
@@ -195,96 +158,4 @@ func openAIRerankUsage(tokens *openAIRerankTokenUsage) *schemas.BifrostLLMUsage 
 		CompletionTokens: completionTokens,
 		TotalTokens:      totalTokens,
 	}
-}
-
-// HandleOpenAIRerankRequest handles rerank requests for custom OpenAI-compatible APIs.
-func HandleOpenAIRerankRequest(
-	ctx *schemas.BifrostContext,
-	client *fasthttp.Client,
-	url string,
-	request *schemas.BifrostRerankRequest,
-	key schemas.Key,
-	extraHeaders map[string]string,
-	providerName schemas.ModelProvider,
-	sendBackRawRequest bool,
-	sendBackRawResponse bool,
-	logger schemas.Logger,
-) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	req := fasthttp.AcquireRequest()
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseRequest(req)
-	respOwned := true
-	defer func() {
-		if respOwned {
-			fasthttp.ReleaseResponse(resp)
-		}
-	}()
-	// Rerank JSON is always parsed in-process (no transport streaming). Skip
-	// PrepareResponseStreaming so large-response threshold mode never leaves the body
-	// on a stream-only path that finalizeOpenAIResponse would treat as unsupported here.
-	activeClient := client
-
-	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
-	req.SetRequestURI(url)
-	req.Header.SetMethod(http.MethodPost)
-	req.Header.SetContentType("application/json")
-	for k, v := range BearerAuthHeader(key) {
-		req.Header.Set(k, v)
-	}
-
-	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
-		ctx,
-		request,
-		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return toOpenAIRerankRequest(request), nil
-		},
-	)
-	if bifrostErr != nil {
-		return nil, bifrostErr
-	}
-	// CheckContextAndGetRequestBody returns nil jsonData when large-payload passthrough
-	// staged the request body as a stream. Mirror the other OpenAI-compatible handlers and
-	// apply that stream instead of sending an empty body; the normal JSON path is unchanged.
-	if !providerUtils.ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, providerName) {
-		req.SetBody(jsonData)
-	}
-
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
-	defer wait()
-	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
-	}
-	providerResponseHeaders := providerUtils.ExtractProviderResponseHeaders(resp)
-	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
-
-	if resp.StatusCode() != fasthttp.StatusOK {
-		providerUtils.MaterializeStreamErrorBody(ctx, resp)
-		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, providerUtils.EnrichError(ctx, ParseOpenAIError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
-	}
-
-	body, _, finalErr := finalizeOpenAIResponse(ctx, resp, latency, providerName, logger)
-	respOwned = false
-	if finalErr != nil {
-		return nil, providerUtils.EnrichError(ctx, finalErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
-	}
-
-	response := &openAIRerankResponse{}
-	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
-	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, body, sendBackRawRequest, sendBackRawResponse, latency)
-	}
-
-	returnDocuments := request.Params != nil && request.Params.ReturnDocuments != nil && *request.Params.ReturnDocuments
-	bifrostResponse := response.toBifrostRerankResponse(request.Documents, returnDocuments)
-	bifrostResponse.Model = request.Model
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
-	if sendBackRawRequest {
-		bifrostResponse.ExtraFields.RawRequest = rawRequest
-	}
-	if sendBackRawResponse {
-		bifrostResponse.ExtraFields.RawResponse = rawResponse
-	}
-	return bifrostResponse, nil
 }

--- a/core/providers/openai/rerank.go
+++ b/core/providers/openai/rerank.go
@@ -66,6 +66,7 @@ type openAIRerankMeta struct {
 type openAIRerankTokenUsage struct {
 	InputTokens  *int64 `json:"input_tokens,omitempty"`
 	OutputTokens *int64 `json:"output_tokens,omitempty"`
+	SearchUnits  *int64 `json:"search_units,omitempty"`
 }
 
 func (response *openAIRerankResponse) toBifrostRerankResponse(documents []schemas.RerankDocument, returnDocuments bool) *schemas.BifrostRerankResponse {
@@ -178,13 +179,21 @@ func openAIRerankUsage(tokens *openAIRerankTokenUsage) *schemas.BifrostLLMUsage 
 		completionTokens = int(*tokens.OutputTokens)
 		hasUsage = true
 	}
+	totalTokens := promptTokens + completionTokens
+	if tokens.SearchUnits != nil {
+		// Cohere-shaped rerank upstreams bill via billed_units.search_units instead of
+		// token counts (input/output tokens are typically null for rerank). Surface the
+		// search-unit count in the usage total so search-unit-billed providers aren't dropped.
+		totalTokens += int(*tokens.SearchUnits)
+		hasUsage = true
+	}
 	if !hasUsage {
 		return nil
 	}
 	return &schemas.BifrostLLMUsage{
 		PromptTokens:     promptTokens,
 		CompletionTokens: completionTokens,
-		TotalTokens:      promptTokens + completionTokens,
+		TotalTokens:      totalTokens,
 	}
 }
 
@@ -233,7 +242,12 @@ func HandleOpenAIRerankRequest(
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
-	req.SetBody(jsonData)
+	// CheckContextAndGetRequestBody returns nil jsonData when large-payload passthrough
+	// staged the request body as a stream. Mirror the other OpenAI-compatible handlers and
+	// apply that stream instead of sending an empty body; the normal JSON path is unchanged.
+	if !providerUtils.ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, providerName) {
+		req.SetBody(jsonData)
+	}
 
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, activeClient, req, resp)
 	defer wait()

--- a/core/providers/openai/rerank.go
+++ b/core/providers/openai/rerank.go
@@ -94,6 +94,10 @@ func (response *openAIRerankResponse) toBifrostRerankResponse(documents []schema
 	})
 	if returnDocuments {
 		for i := range bifrostResponse.Results {
+			// Preserve any document the upstream already returned; only backfill from the request otherwise.
+			if bifrostResponse.Results[i].Document != nil {
+				continue
+			}
 			resultIndex := bifrostResponse.Results[i].Index
 			if resultIndex >= 0 && resultIndex < len(documents) {
 				bifrostResponse.Results[i].Document = schemas.Ptr(documents[resultIndex])
@@ -206,7 +210,10 @@ func HandleOpenAIRerankRequest(
 			fasthttp.ReleaseResponse(resp)
 		}
 	}()
-	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
+	// Rerank JSON is always parsed in-process (no transport streaming). Skip
+	// PrepareResponseStreaming so large-response threshold mode never leaves the body
+	// on a stream-only path that finalizeOpenAIResponse would treat as unsupported here.
+	activeClient := client
 
 	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
 	req.SetRequestURI(url)
@@ -242,17 +249,10 @@ func HandleOpenAIRerankRequest(
 		return nil, providerUtils.EnrichError(ctx, ParseOpenAIError(resp), jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
 	}
 
-	body, lpResult, finalErr := finalizeOpenAIResponse(ctx, resp, latency, providerName, logger)
+	body, _, finalErr := finalizeOpenAIResponse(ctx, resp, latency, providerName, logger)
 	respOwned = false
 	if finalErr != nil {
 		return nil, providerUtils.EnrichError(ctx, finalErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse, latency)
-	}
-	if lpResult != nil {
-		return &schemas.BifrostRerankResponse{
-			Model:       request.Model,
-			Usage:       lpResult.Usage,
-			ExtraFields: schemas.BifrostResponseExtraFields{Latency: lpResult.Latency},
-		}, nil
 	}
 
 	response := &openAIRerankResponse{}

--- a/core/providers/openai/rerank_test.go
+++ b/core/providers/openai/rerank_test.go
@@ -1,0 +1,189 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+type testNoopLogger struct{}
+
+func (testNoopLogger) Debug(string, ...any)                   {}
+func (testNoopLogger) Info(string, ...any)                    {}
+func (testNoopLogger) Warn(string, ...any)                    {}
+func (testNoopLogger) Error(string, ...any)                   {}
+func (testNoopLogger) Fatal(string, ...any)                   {}
+func (testNoopLogger) SetLevel(schemas.LogLevel)              {}
+func (testNoopLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testNoopLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func TestCustomOpenAIProviderRerankUsesGenericEndpoint(t *testing.T) {
+	var upstreamCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/rerank" {
+			t.Fatalf("expected /v1/rerank, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("expected bearer auth header, got %q", got)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		var payload struct {
+			Model           string                   `json:"model"`
+			Query           string                   `json:"query"`
+			Documents       []schemas.RerankDocument `json:"documents"`
+			TopN            *int                     `json:"top_n"`
+			MaxTokensPerDoc *int                     `json:"max_tokens_per_doc"`
+			ReturnDocuments *bool                    `json:"return_documents"`
+			Truncate        string                   `json:"truncate"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("failed to parse request body %s: %v", string(body), err)
+		}
+		if payload.Model != "zerank-2" {
+			t.Fatalf("expected model zerank-2, got %q", payload.Model)
+		}
+		if payload.Query != "What is Bifrost?" {
+			t.Fatalf("expected query to be forwarded, got %q", payload.Query)
+		}
+		if len(payload.Documents) != 2 || payload.Documents[0].Text != "Bifrost is an AI gateway." || payload.Documents[1].Text != "Paris is in France." {
+			t.Fatalf("expected documents to be forwarded as document objects, got %#v", payload.Documents)
+		}
+		if payload.TopN == nil || *payload.TopN != 2 {
+			t.Fatalf("expected top_n=2, got %#v", payload.TopN)
+		}
+		if payload.MaxTokensPerDoc == nil || *payload.MaxTokensPerDoc != 512 {
+			t.Fatalf("expected max_tokens_per_doc=512, got %#v", payload.MaxTokensPerDoc)
+		}
+		if payload.ReturnDocuments != nil {
+			t.Fatalf("return_documents is handled by Bifrost and should not be sent upstream")
+		}
+		if payload.Truncate != "END" {
+			t.Fatalf("expected passthrough extra param truncate=END, got %q", payload.Truncate)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Test-Header", "present")
+		_, _ = w.Write([]byte(`{
+			"id":"rr-1",
+			"results":[
+				{"index":0,"relevance_score":0.2},
+				{"index":1,"relevance_score":0.9}
+			],
+			"meta":{"tokens":{"input_tokens":11,"output_tokens":0}}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{Rerank: true},
+		},
+	}, testNoopLogger{})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+	topN := 2
+	maxTokensPerDoc := 512
+	returnDocuments := true
+	response, bifrostErr := provider.Rerank(ctx, schemas.Key{Value: *schemas.NewSecretVar("test-key")}, &schemas.BifrostRerankRequest{
+		Model: "zerank-2",
+		Query: "What is Bifrost?",
+		Documents: []schemas.RerankDocument{
+			{Text: "Bifrost is an AI gateway."},
+			{Text: "Paris is in France."},
+		},
+		Params: &schemas.RerankParameters{
+			TopN:            &topN,
+			MaxTokensPerDoc: &maxTokensPerDoc,
+			ReturnDocuments: &returnDocuments,
+			ExtraParams: map[string]interface{}{
+				"truncate": "END",
+			},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("expected rerank to succeed, got %v", bifrostErr)
+	}
+	if !upstreamCalled {
+		t.Fatal("expected upstream rerank endpoint to be called")
+	}
+	if response == nil {
+		t.Fatal("expected rerank response")
+	}
+	if response.ID != "rr-1" {
+		t.Fatalf("expected response id rr-1, got %q", response.ID)
+	}
+	if response.Model != "zerank-2" {
+		t.Fatalf("expected response model zerank-2, got %q", response.Model)
+	}
+	if len(response.Results) != 2 {
+		t.Fatalf("expected two rerank results, got %#v", response.Results)
+	}
+	if response.Results[0].Index != 1 || response.Results[0].RelevanceScore != 0.9 {
+		t.Fatalf("expected results sorted by relevance, got %#v", response.Results)
+	}
+	if response.Results[0].Document == nil || response.Results[0].Document.Text != "Paris is in France." {
+		t.Fatalf("expected return_documents to backfill request document, got %#v", response.Results[0].Document)
+	}
+	if response.Usage == nil || response.Usage.PromptTokens != 11 || response.Usage.TotalTokens != 11 {
+		t.Fatalf("expected usage from rerank meta tokens, got %#v", response.Usage)
+	}
+	if response.ExtraFields.ProviderResponseHeaders["X-Test-Header"] != "present" {
+		t.Fatalf("expected provider response headers, got %#v", response.ExtraFields.ProviderResponseHeaders)
+	}
+}
+
+func TestOpenAIRerankUnsupportedForNativeProvider(t *testing.T) {
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: "http://127.0.0.1:1"},
+	}, testNoopLogger{})
+	_, bifrostErr := provider.Rerank(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), schemas.Key{}, &schemas.BifrostRerankRequest{Model: "rerank"})
+	assertUnsupportedRerank(t, bifrostErr, schemas.OpenAI)
+}
+
+func TestCustomOpenAIRerankHonorsAllowedRequests(t *testing.T) {
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: "http://127.0.0.1:1"},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{},
+		},
+	}, testNoopLogger{})
+	_, bifrostErr := provider.Rerank(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), schemas.Key{}, &schemas.BifrostRerankRequest{Model: "rerank"})
+	assertUnsupportedRerank(t, bifrostErr, schemas.ModelProvider("hawk"))
+}
+
+func assertUnsupportedRerank(t *testing.T, bifrostErr *schemas.BifrostError, provider schemas.ModelProvider) {
+	t.Helper()
+	if bifrostErr == nil {
+		t.Fatal("expected unsupported operation error")
+	}
+	if bifrostErr.Error == nil || bifrostErr.Error.Code == nil || *bifrostErr.Error.Code != "unsupported_operation" {
+		t.Fatalf("expected unsupported_operation code, got %#v", bifrostErr)
+	}
+	if bifrostErr.ExtraFields.Provider != provider {
+		t.Fatalf("expected provider %q, got %q", provider, bifrostErr.ExtraFields.Provider)
+	}
+	if bifrostErr.ExtraFields.RequestType != schemas.RerankRequest {
+		t.Fatalf("expected rerank request type, got %q", bifrostErr.ExtraFields.RequestType)
+	}
+}

--- a/core/providers/openai/rerank_test.go
+++ b/core/providers/openai/rerank_test.go
@@ -151,6 +151,112 @@ func TestCustomOpenAIProviderRerankUsesGenericEndpoint(t *testing.T) {
 	}
 }
 
+func TestCustomOpenAIRerankPreservesUpstreamDocument(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"rr-doc",
+			"results":[
+				{"index":0,"relevance_score":0.1},
+				{"index":1,"relevance_score":0.8,"document":{"text":"upstream returned B"}}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{Rerank: true},
+		},
+	}, testNoopLogger{})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	returnDocuments := true
+	response, bifrostErr := provider.Rerank(ctx, schemas.Key{Value: *schemas.NewSecretVar("test-key")}, &schemas.BifrostRerankRequest{
+		Model: "zerank-2",
+		Query: "What is Bifrost?",
+		Documents: []schemas.RerankDocument{
+			{Text: "request doc A"},
+			{Text: "request doc B"},
+		},
+		Params: &schemas.RerankParameters{
+			ReturnDocuments: &returnDocuments,
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("expected rerank to succeed, got %v", bifrostErr)
+	}
+	if response == nil || len(response.Results) != 2 {
+		t.Fatalf("expected two rerank results, got %#v", response)
+	}
+	// Highest score first — index 1, whose document the upstream returned itself.
+	if response.Results[0].Index != 1 {
+		t.Fatalf("expected index 1 first, got %#v", response.Results)
+	}
+	if response.Results[0].Document == nil || response.Results[0].Document.Text != "upstream returned B" {
+		t.Fatalf("expected upstream-returned document to be preserved, got %#v", response.Results[0].Document)
+	}
+	// Index 0 had no upstream document — backfilled from the request.
+	if response.Results[1].Document == nil || response.Results[1].Document.Text != "request doc A" {
+		t.Fatalf("expected request document backfill for index 0, got %#v", response.Results[1].Document)
+	}
+}
+
+func TestCustomOpenAIRerankLargeResponseThresholdReturnsResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"rr-large",
+			"results":[
+				{"index":0,"relevance_score":0.3},
+				{"index":1,"relevance_score":0.7}
+			],
+			"meta":{"tokens":{"input_tokens":5,"output_tokens":0}}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{Rerank: true},
+		},
+	}, testNoopLogger{})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	// A tiny threshold would route the structured JSON body onto the large-response
+	// streaming path; rerank must parse it in-process regardless and still return results.
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseThreshold, int64(1))
+
+	response, bifrostErr := provider.Rerank(ctx, schemas.Key{Value: *schemas.NewSecretVar("test-key")}, &schemas.BifrostRerankRequest{
+		Model: "zerank-2",
+		Query: "What is Bifrost?",
+		Documents: []schemas.RerankDocument{
+			{Text: "Bifrost is an AI gateway."},
+			{Text: "Paris is in France."},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("expected rerank to succeed, got %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("expected rerank response")
+	}
+	if len(response.Results) != 2 {
+		t.Fatalf("expected two rerank results despite large-response threshold, got %#v", response.Results)
+	}
+	if response.Results[0].Index != 1 || response.Results[0].RelevanceScore != 0.7 {
+		t.Fatalf("expected results sorted by relevance, got %#v", response.Results)
+	}
+	if response.Usage == nil || response.Usage.PromptTokens != 5 {
+		t.Fatalf("expected usage parsed from body, got %#v", response.Usage)
+	}
+}
+
 func TestOpenAIRerankUnsupportedForNativeProvider(t *testing.T) {
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{BaseURL: "http://127.0.0.1:1"},

--- a/core/providers/openai/rerank_test.go
+++ b/core/providers/openai/rerank_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -291,5 +292,114 @@ func assertUnsupportedRerank(t *testing.T, bifrostErr *schemas.BifrostError, pro
 	}
 	if bifrostErr.ExtraFields.RequestType != schemas.RerankRequest {
 		t.Fatalf("expected rerank request type, got %q", bifrostErr.ExtraFields.RequestType)
+	}
+}
+
+func TestCustomOpenAIRerankMapsSearchUnits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Cohere-shaped rerank billing: token counts are null; usage lives in
+		// meta.billed_units.search_units.
+		_, _ = w.Write([]byte(`{
+			"id":"rr-su",
+			"results":[
+				{"index":0,"relevance_score":0.5},
+				{"index":1,"relevance_score":0.9}
+			],
+			"meta":{
+				"tokens":{"input_tokens":null,"output_tokens":null},
+				"billed_units":{"search_units":3}
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{Rerank: true},
+		},
+	}, testNoopLogger{})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	response, bifrostErr := provider.Rerank(ctx, schemas.Key{Value: *schemas.NewSecretVar("test-key")}, &schemas.BifrostRerankRequest{
+		Model: "zerank-2",
+		Query: "What is Bifrost?",
+		Documents: []schemas.RerankDocument{
+			{Text: "Bifrost is an AI gateway."},
+			{Text: "Paris is in France."},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("expected rerank to succeed, got %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("expected rerank response")
+	}
+	if response.Usage == nil {
+		t.Fatal("expected usage from billed_units.search_units, got nil")
+	}
+	if response.Usage.TotalTokens != 3 {
+		t.Fatalf("expected search_units surfaced as total tokens 3, got %#v", response.Usage)
+	}
+	if response.Usage.PromptTokens != 0 || response.Usage.CompletionTokens != 0 {
+		t.Fatalf("expected zero token counts for search-unit billing, got %#v", response.Usage)
+	}
+}
+
+func TestCustomOpenAIRerankLargePayloadStreamsBody(t *testing.T) {
+	streamedBody := `{"model":"zerank-2","query":"stream me","documents":[{"text":"a"},{"text":"b"}]}`
+	var receivedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+		receivedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"rr-lp",
+			"results":[
+				{"index":0,"relevance_score":0.4},
+				{"index":1,"relevance_score":0.6}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey: "hawk",
+			BaseProviderType:  schemas.OpenAI,
+			AllowedRequests:   &schemas.AllowedRequests{Rerank: true},
+		},
+	}, testNoopLogger{})
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	// Simulate the transport staging the request body as a stream (large-payload passthrough):
+	// CheckContextAndGetRequestBody then returns nil jsonData and the handler must stream the
+	// staged reader instead of sending an empty body.
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadReader, strings.NewReader(streamedBody))
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadContentLength, len(streamedBody))
+
+	response, bifrostErr := provider.Rerank(ctx, schemas.Key{Value: *schemas.NewSecretVar("test-key")}, &schemas.BifrostRerankRequest{
+		Model: "zerank-2",
+		Query: "stream me",
+		Documents: []schemas.RerankDocument{
+			{Text: "a"},
+			{Text: "b"},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("expected rerank to succeed, got %v", bifrostErr)
+	}
+	if receivedBody != streamedBody {
+		t.Fatalf("expected upstream to receive streamed passthrough body %q, got %q", streamedBody, receivedBody)
+	}
+	if response == nil || len(response.Results) != 2 {
+		t.Fatalf("expected two rerank results from passthrough response, got %#v", response)
 	}
 }

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -73,6 +73,49 @@ func (r *OpenAIEmbeddingRequest) SetExtraParams(params map[string]interface{}) {
 	r.EmbeddingParameters.ExtraParams = params
 }
 
+// OpenAIRerankRequest represents an OpenAI-compatible rerank request
+type OpenAIRerankRequest struct {
+	Model           string                   `json:"model"`
+	Query           string                   `json:"query"`
+	Documents       []schemas.RerankDocument `json:"documents"`
+	TopN            *int                     `json:"top_n,omitempty"`
+	MaxTokensPerDoc *int                     `json:"max_tokens_per_doc,omitempty"`
+	Priority        *int                     `json:"priority,omitempty"`
+	ExtraParams     map[string]interface{}   `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIRerankRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
+// OpenAIRerankResponse represents an OpenAI-compatible rerank response
+type OpenAIRerankResponse struct {
+	ID      string                       `json:"id"`
+	Results []OpenAIRerankResponseResult `json:"results"`
+	Meta    *OpenAIRerankMeta            `json:"meta,omitempty"`
+	Usage   *schemas.BifrostLLMUsage     `json:"usage,omitempty"`
+}
+
+// OpenAIRerankResponseResult represents a single ranked document in a rerank response
+type OpenAIRerankResponseResult struct {
+	Index          int             `json:"index"`
+	RelevanceScore float64         `json:"relevance_score"`
+	Document       json.RawMessage `json:"document,omitempty"`
+}
+
+// OpenAIRerankMeta captures Cohere-style rerank billing/token metadata
+type OpenAIRerankMeta struct {
+	BilledUnits *OpenAIRerankTokenUsage `json:"billed_units,omitempty"`
+	Tokens      *OpenAIRerankTokenUsage `json:"tokens,omitempty"`
+}
+
+// OpenAIRerankTokenUsage represents token/billing counts reported by rerank upstreams
+type OpenAIRerankTokenUsage struct {
+	InputTokens  *int64 `json:"input_tokens,omitempty"`
+	OutputTokens *int64 `json:"output_tokens,omitempty"`
+	SearchUnits  *int64 `json:"search_units,omitempty"`
+}
+
 // OpenAIChatRequest represents an OpenAI chat completion request
 type OpenAIChatRequest struct {
 	Model    string          `json:"model"`

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -244,6 +244,7 @@ Available operations:
 - **`speech_stream`**: Streaming text-to-speech
 - **`transcription`**: Speech-to-text conversion
 - **`transcription_stream`**: Streaming speech-to-text
+- **`rerank`**: Document reranking via `/v1/rerank` (OpenAI-compatible base only)
 
 ### Base Provider Types
 

--- a/docs/quickstart/gateway/reranking.mdx
+++ b/docs/quickstart/gateway/reranking.mdx
@@ -62,6 +62,10 @@ curl --location 'http://localhost:8080/v1/rerank' \
 
 When using a `vllm/...` model, Bifrost sends rerank requests to `/v1/rerank` first and automatically retries `/rerank` when the upstream endpoint responds with `404`, `405`, or `501`.
 
+## Custom OpenAI-Compatible Providers
+
+Custom providers built on the `openai` base type can serve reranking against any OpenAI-compatible endpoint that exposes a Cohere-style rerank contract. It follows the standard `allowed_requests` behavior: allowed when `allowed_requests` is omitted, otherwise it must be explicitly enabled with `rerank: true`. Requests are sent to `/v1/rerank` by default; override the path with a `rerank` entry in `request_path_overrides`. See [Custom Providers](../../providers/custom-providers) for configuration details.
+
 ## Response Shape
 
 ```json


### PR DESCRIPTION
## Problem

Custom providers using `base_provider_type: openai` cannot serve `/v1/rerank`. Requests fail before reaching the upstream provider with:

```json
{"code":"unsupported_operation","message":"rerank is not supported by hawk provider"}
```

This blocks OpenAI-compatible local/upstream runtimes (omlx, llama.cpp, vLLM, ...) that implement `/v1/rerank` even though OpenAI itself does not.

## Root cause

Custom OpenAI-compatible providers are instantiated as `OpenAIProvider`, but `OpenAIProvider.Rerank` unconditionally returned `unsupported_operation`. As a result `custom_provider_config.allowed_requests.rerank` had no effect and the request never reached upstream.

## Fix

- Native OpenAI rerank stays unsupported (no `custom_provider_config` ⇒ unchanged behavior).
- For custom OpenAI-compatible providers:
  - honor `custom_provider_config.allowed_requests` via the existing `CheckOperationAllowed` helper (no gating configured ⇒ allowed, matching other operations);
  - route rerank to `/v1/rerank` by default, honoring `request_path_overrides` through the existing OpenAI request URL builder;
  - parse Cohere-style rerank responses (`results[].index`, `relevance_score`, optional `document`, `meta.tokens`/`billed_units`, top-level `usage`) into Bifrost rerank responses;
  - preserve extra params passthrough, raw request/response options, latency, usage, and provider response headers.

## Testing

Added offline unit tests (fake upstream via local HTTP): custom-provider rerank routing to `/v1/rerank`, auth header forwarding, document-object forwarding, extra-params passthrough, local `return_documents` handling, result ordering, usage extraction, response headers, native OpenAI still unsupported, and `allowed_requests` gating.

- `go build ./...` (core) — pass
- `go vet ./providers/openai/` — pass
- `go test ./providers/openai/` — pass

Fixes #4834
