### PR TITLE
fix: fan out Bedrock Titan batched embeddings instead of concatenating inputs

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -45,6 +45,8 @@ type BedrockProvider struct {
 	sendBackRawResponse   bool                          // Whether to include raw response in BifrostResponse
 }
 
+const maxTitanEmbeddingBatchConcurrency = 8
+
 // assumeRoleCredsCache caches *aws.CredentialsCache instances keyed by the
 // unique combination of role parameters so that STS AssumeRole is not called
 // on every request.
@@ -1984,6 +1986,106 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 	return responseChan, nil
 }
 
+type titanEmbeddingBatchResult struct {
+	response                *BedrockTitanEmbeddingResponse
+	jsonData                []byte
+	rawResponse             []byte
+	latency                 time.Duration
+	providerResponseHeaders map[string]string
+	err                     *schemas.BifrostError
+}
+
+func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest, path string) (*schemas.BifrostEmbeddingResponse, []byte, [][]byte, time.Duration, map[string]string, *schemas.BifrostError) {
+	texts := request.Input.Texts
+	results := make([]titanEmbeddingBatchResult, len(texts))
+	start := time.Now()
+
+	workerCount := maxTitanEmbeddingBatchConcurrency
+	if len(texts) < workerCount {
+		workerCount = len(texts)
+	}
+
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				text := texts[i]
+				singleRequest := *request
+				singleRequest.Input = &schemas.EmbeddingInput{Text: &text}
+				singleRequest.RawRequestBody = nil
+
+				jsonData, bifrostError := providerUtils.CheckContextAndGetRequestBody(
+					ctx,
+					&singleRequest,
+					func() (providerUtils.RequestBodyWithExtraParams, error) {
+						return ToBedrockTitanEmbeddingRequest(&singleRequest)
+					})
+				if bifrostError != nil {
+					results[i].jsonData = jsonData
+					results[i].err = bifrostError
+					continue
+				}
+
+				rawResponse, latency, headers, bifrostError := provider.completeRequest(ctx, jsonData, path, key, request.Model)
+				results[i] = titanEmbeddingBatchResult{
+					jsonData:                jsonData,
+					rawResponse:             rawResponse,
+					latency:                 latency,
+					providerResponseHeaders: headers,
+					err:                     bifrostError,
+				}
+				if bifrostError != nil {
+					continue
+				}
+
+				var titanResp BedrockTitanEmbeddingResponse
+				if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
+					results[i].err = providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err)
+					continue
+				}
+				results[i].response = &titanResp
+			}
+		}()
+	}
+
+	for i := range texts {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+
+	latency := time.Since(start)
+	var providerResponseHeaders map[string]string
+	for i := range results {
+		if results[i].providerResponseHeaders != nil {
+			providerResponseHeaders = results[i].providerResponseHeaders
+		}
+		if results[i].err != nil {
+			return nil, results[i].jsonData, nil, latency, providerResponseHeaders, results[i].err
+		}
+	}
+
+	data := make([]schemas.EmbeddingData, len(results))
+	rawResponses := make([][]byte, len(results))
+	usage := &schemas.BifrostLLMUsage{}
+	for i := range results {
+		data[i] = results[i].response.toBifrostEmbeddingData(i)
+		rawResponses[i] = results[i].rawResponse
+		usage.PromptTokens += results[i].response.InputTextTokenCount
+		usage.TotalTokens += results[i].response.InputTextTokenCount
+	}
+
+	return &schemas.BifrostEmbeddingResponse{
+		Object: "list",
+		Model:  request.Model,
+		Data:   data,
+		Usage:  usage,
+	}, nil, rawResponses, latency, providerResponseHeaders, nil
+}
+
 // Embedding generates embeddings for the given input text(s) using Amazon Bedrock.
 // Supports Titan and Cohere embedding models. Returns a BifrostResponse containing the embedding(s) and any error that occurred.
 func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
@@ -1999,25 +2101,30 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 
 	// Convert request and execute based on model type
 	var rawResponse []byte
+	var rawResponses [][]byte
+	var bifrostResponse *schemas.BifrostEmbeddingResponse
 	var bifrostError *schemas.BifrostError
 	var latency time.Duration
 	var providerResponseHeaders map[string]string
 	var path string
 	var jsonData []byte
-
 	switch modelType {
 	case "titan":
-		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return ToBedrockTitanEmbeddingRequest(request)
-			})
-		if bifrostError != nil {
-			return nil, bifrostError
-		}
 		path, _ = provider.getModelPathAndRegion(ctx, "invoke", request.Model, key)
-		rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key, request.Model)
+		if request.Input != nil && len(request.Input.Texts) > 0 {
+			bifrostResponse, jsonData, rawResponses, latency, providerResponseHeaders, bifrostError = provider.completeTitanEmbeddingBatch(ctx, key, request, path)
+		} else {
+			jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
+				ctx,
+				request,
+				func() (providerUtils.RequestBodyWithExtraParams, error) {
+					return ToBedrockTitanEmbeddingRequest(request)
+				})
+			if bifrostError != nil {
+				return nil, bifrostError
+			}
+			rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key, request.Model)
+		}
 
 	case "cohere":
 		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
@@ -2043,15 +2150,16 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		return nil, providerUtils.EnrichError(ctx, bifrostError, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
 	// Parse response based on model type
-	var bifrostResponse *schemas.BifrostEmbeddingResponse
 	switch modelType {
 	case "titan":
-		var titanResp BedrockTitanEmbeddingResponse
-		if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
-			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+		if bifrostResponse == nil {
+			var titanResp BedrockTitanEmbeddingResponse
+			if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
+				return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
+			}
+			bifrostResponse = titanResp.ToBifrostEmbeddingResponse()
+			bifrostResponse.Model = request.Model
 		}
-		bifrostResponse = titanResp.ToBifrostEmbeddingResponse()
-		bifrostResponse.Model = request.Model
 
 	case "cohere":
 		var cohereResp BedrockCohereEmbeddingResponse
@@ -2093,9 +2201,22 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 
 	// Set raw response if enabled
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-		var rawResponseData interface{}
-		if err := sonic.Unmarshal(rawResponse, &rawResponseData); err == nil {
-			bifrostResponse.ExtraFields.RawResponse = rawResponseData
+		if len(rawResponses) > 0 {
+			rawResponseData := make([]interface{}, 0, len(rawResponses))
+			for _, raw := range rawResponses {
+				var item interface{}
+				if err := sonic.Unmarshal(raw, &item); err == nil {
+					rawResponseData = append(rawResponseData, item)
+				}
+			}
+			if len(rawResponseData) > 0 {
+				bifrostResponse.ExtraFields.RawResponse = rawResponseData
+			}
+		} else {
+			var rawResponseData interface{}
+			if err := sonic.Unmarshal(rawResponse, &rawResponseData); err == nil {
+				bifrostResponse.ExtraFields.RawResponse = rawResponseData
+			}
 		}
 	}
 

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2005,6 +2005,27 @@ func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.Bifros
 		workerCount = len(texts)
 	}
 
+	// Derive a cancellable context from the caller's so the first sub-request
+	// failure aborts the rest of the fan-out: in-flight HTTP calls are cancelled
+	// via their request context and not-yet-started jobs are skipped before they
+	// issue a call. Sub-requests receive batchCtx (not ctx) so the cancellation
+	// actually reaches provider.completeRequest.
+	batchCtx, cancelBatch := schemas.NewBifrostContextWithCancel(ctx)
+	defer cancelBatch()
+	var firstErrOnce sync.Once
+	var firstErr *schemas.BifrostError
+	var firstErrJSON []byte
+	recordFirstErr := func(jsonData []byte, bifrostError *schemas.BifrostError) {
+		if bifrostError == nil {
+			return
+		}
+		firstErrOnce.Do(func() {
+			firstErr = bifrostError
+			firstErrJSON = jsonData
+			cancelBatch()
+		})
+	}
+
 	jobs := make(chan int)
 	var wg sync.WaitGroup
 	wg.Add(workerCount)
@@ -2012,13 +2033,18 @@ func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.Bifros
 		go func() {
 			defer wg.Done()
 			for i := range jobs {
+				// Skip remaining jobs fast once a sibling sub-request has failed.
+				if batchCtx.Err() != nil {
+					continue
+				}
+
 				text := texts[i]
 				singleRequest := *request
 				singleRequest.Input = &schemas.EmbeddingInput{Text: &text}
 				singleRequest.RawRequestBody = nil
 
 				jsonData, bifrostError := providerUtils.CheckContextAndGetRequestBody(
-					ctx,
+					batchCtx,
 					&singleRequest,
 					func() (providerUtils.RequestBodyWithExtraParams, error) {
 						return ToBedrockTitanEmbeddingRequest(&singleRequest)
@@ -2026,10 +2052,15 @@ func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.Bifros
 				if bifrostError != nil {
 					results[i].jsonData = jsonData
 					results[i].err = bifrostError
+					recordFirstErr(jsonData, bifrostError)
 					continue
 				}
 
-				rawResponse, latency, headers, bifrostError := provider.completeRequest(ctx, jsonData, path, key, request.Model)
+				if batchCtx.Err() != nil {
+					continue
+				}
+
+				rawResponse, latency, headers, bifrostError := provider.completeRequest(batchCtx, jsonData, path, key, request.Model)
 				results[i] = titanEmbeddingBatchResult{
 					jsonData:                jsonData,
 					rawResponse:             rawResponse,
@@ -2038,12 +2069,15 @@ func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.Bifros
 					err:                     bifrostError,
 				}
 				if bifrostError != nil {
+					recordFirstErr(jsonData, bifrostError)
 					continue
 				}
 
 				var titanResp BedrockTitanEmbeddingResponse
 				if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
-					results[i].err = providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err)
+					bifrostError := providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err)
+					results[i].err = bifrostError
+					recordFirstErr(jsonData, bifrostError)
 					continue
 				}
 				results[i].response = &titanResp
@@ -2051,20 +2085,46 @@ func (provider *BedrockProvider) completeTitanEmbeddingBatch(ctx *schemas.Bifros
 		}()
 	}
 
+dispatch:
 	for i := range texts {
-		jobs <- i
+		select {
+		case jobs <- i:
+		case <-batchCtx.Done():
+			// A sub-request already failed; stop dispatching new jobs.
+			break dispatch
+		}
 	}
 	close(jobs)
 	wg.Wait()
 
 	latency := time.Since(start)
+
+	// Accumulate provider response headers across all sub-requests before
+	// scanning for errors, so an error at an early index does not discard
+	// headers returned by later (successful) sub-requests — tracing middleware
+	// relies on provider headers being present even on error paths.
 	var providerResponseHeaders map[string]string
 	for i := range results {
 		if results[i].providerResponseHeaders != nil {
 			providerResponseHeaders = results[i].providerResponseHeaders
 		}
-		if results[i].err != nil {
-			return nil, results[i].jsonData, nil, latency, providerResponseHeaders, results[i].err
+	}
+	if firstErr != nil {
+		return nil, firstErrJSON, nil, latency, providerResponseHeaders, firstErr
+	}
+
+	// If the batch context was cancelled without any sub-request recording an
+	// error (e.g. the caller's context was cancelled before dispatch, so every
+	// job was skipped), surface the cancellation instead of dereferencing the
+	// skipped, response-less results below.
+	if ctxErr := batchCtx.Err(); ctxErr != nil {
+		return nil, nil, nil, latency, providerResponseHeaders, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Type:    schemas.Ptr(schemas.RequestCancelled),
+				Message: schemas.ErrRequestCancelled,
+				Error:   ctxErr,
+			},
 		}
 	}
 

--- a/core/providers/bedrock/embedding.go
+++ b/core/providers/bedrock/embedding.go
@@ -36,22 +36,18 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 		return nil, fmt.Errorf("bifrost embedding request is nil")
 	}
 
-	// Validate that only single text input is provided for Titan models
-	if bifrostReq.Input.Text == nil && len(bifrostReq.Input.Texts) == 0 {
+	if bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && len(bifrostReq.Input.Texts) == 0) {
 		return nil, fmt.Errorf("no input text provided for embedding")
 	}
 
 	titanReq := &BedrockTitanEmbeddingRequest{}
 
-	// Set input text
 	if bifrostReq.Input.Text != nil {
 		titanReq.InputText = *bifrostReq.Input.Text
-	} else if len(bifrostReq.Input.Texts) > 0 {
-		var embeddingText string
-		for _, text := range bifrostReq.Input.Texts {
-			embeddingText += text + " \n"
-		}
-		titanReq.InputText = embeddingText
+	} else if len(bifrostReq.Input.Texts) == 1 {
+		titanReq.InputText = bifrostReq.Input.Texts[0]
+	} else {
+		return nil, fmt.Errorf("Titan embedding batches must be fanned out before request conversion")
 	}
 
 	if bifrostReq.Params != nil {
@@ -84,17 +80,10 @@ func (response *BedrockTitanEmbeddingResponse) ToBifrostEmbeddingResponse() *sch
 		return nil
 	}
 
+	data := response.toBifrostEmbeddingData(0)
 	bifrostResponse := &schemas.BifrostEmbeddingResponse{
 		Object: "list",
-		Data: []schemas.EmbeddingData{
-			{
-				Index:  0,
-				Object: "embedding",
-				Embedding: schemas.EmbeddingStruct{
-					EmbeddingArray: response.Embedding,
-				},
-			},
-		},
+		Data:   []schemas.EmbeddingData{data},
 		Usage: &schemas.BifrostLLMUsage{
 			PromptTokens: response.InputTextTokenCount,
 			TotalTokens:  response.InputTextTokenCount,
@@ -102,6 +91,16 @@ func (response *BedrockTitanEmbeddingResponse) ToBifrostEmbeddingResponse() *sch
 	}
 
 	return bifrostResponse
+}
+
+func (response *BedrockTitanEmbeddingResponse) toBifrostEmbeddingData(index int) schemas.EmbeddingData {
+	return schemas.EmbeddingData{
+		Index:  index,
+		Object: "embedding",
+		Embedding: schemas.EmbeddingStruct{
+			EmbeddingArray: response.Embedding,
+		},
+	}
 }
 
 // ToBedrockCohereEmbeddingRequest converts a Bifrost embedding request to Bedrock Cohere format.

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -1,9 +1,14 @@
 package bedrock
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"sync"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -111,4 +116,117 @@ func TestToBedrockCohereEmbeddingRequestBodyOmitsModel(t *testing.T) {
 		"texts": ["hello"],
 		"embedding_types": ["float"]
 	}`, string(wireBody))
+}
+
+type titanEmbeddingCaptureTransport struct {
+	mu       sync.Mutex
+	requests []BedrockTitanEmbeddingRequest
+	paths    []string
+}
+
+func (t *titanEmbeddingCaptureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	var titanReq BedrockTitanEmbeddingRequest
+	if err := sonic.Unmarshal(body, &titanReq); err != nil {
+		return nil, err
+	}
+
+	t.mu.Lock()
+	t.requests = append(t.requests, titanReq)
+	t.paths = append(t.paths, req.URL.Path)
+	t.mu.Unlock()
+
+	embeddingValueByInput := map[string]float64{
+		"alpha":   3,
+		"bravo":   2,
+		"charlie": 1,
+	}
+	tokenCountByInput := map[string]int{
+		"alpha":   11,
+		"bravo":   13,
+		"charlie": 17,
+	}
+	respBody, err := sonic.Marshal(BedrockTitanEmbeddingResponse{
+		Embedding:           []float64{embeddingValueByInput[titanReq.InputText]},
+		InputTextTokenCount: tokenCountByInput[titanReq.InputText],
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"X-Test": []string{titanReq.InputText}},
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+	}, nil
+}
+
+func (t *titanEmbeddingCaptureTransport) captured() ([]BedrockTitanEmbeddingRequest, []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	requests := append([]BedrockTitanEmbeddingRequest(nil), t.requests...)
+	paths := append([]string(nil), t.paths...)
+	return requests, paths
+}
+
+func TestBedrockTitanEmbeddingBatchFansOutAndAggregates(t *testing.T) {
+	transport := &titanEmbeddingCaptureTransport{}
+	provider := &BedrockProvider{
+		client: &http.Client{Transport: transport},
+	}
+	normalize := true
+	dimensions := 256
+	request := &schemas.BifrostEmbeddingRequest{
+		Model: "amazon.titan-embed-text-v2:0",
+		Input: &schemas.EmbeddingInput{Texts: []string{"alpha", "bravo", "charlie"}},
+		Params: &schemas.EmbeddingParameters{
+			Dimensions: &dimensions,
+			ExtraParams: map[string]interface{}{
+				"normalize": normalize,
+			},
+		},
+	}
+	key := schemas.Key{
+		Value: *schemas.NewSecretVar("bedrock-api-key"),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			Region: schemas.NewSecretVar("us-west-2"),
+		},
+	}
+
+	response, bifrostErr := provider.Embedding(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), key, request)
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, response)
+
+	require.Len(t, response.Data, 3)
+	assert.Equal(t, "list", response.Object)
+	assert.Equal(t, request.Model, response.Model)
+	assert.Equal(t, 41, response.Usage.PromptTokens)
+	assert.Equal(t, 41, response.Usage.TotalTokens)
+	assert.Equal(t, 0, response.Data[0].Index)
+	assert.Equal(t, []float64{3}, response.Data[0].Embedding.EmbeddingArray)
+	assert.Equal(t, 1, response.Data[1].Index)
+	assert.Equal(t, []float64{2}, response.Data[1].Embedding.EmbeddingArray)
+	assert.Equal(t, 2, response.Data[2].Index)
+	assert.Equal(t, []float64{1}, response.Data[2].Embedding.EmbeddingArray)
+
+	capturedRequests, paths := transport.captured()
+	require.Len(t, capturedRequests, 3)
+	assert.Len(t, paths, 3)
+	inputs := make(map[string]bool, len(capturedRequests))
+	for _, capturedRequest := range capturedRequests {
+		inputs[capturedRequest.InputText] = true
+		require.NotNil(t, capturedRequest.Dimensions)
+		assert.Equal(t, dimensions, *capturedRequest.Dimensions)
+		require.NotNil(t, capturedRequest.Normalize)
+		assert.Equal(t, normalize, *capturedRequest.Normalize)
+		assert.NotContains(t, capturedRequest.InputText, "\n")
+	}
+	assert.Equal(t, map[string]bool{"alpha": true, "bravo": true, "charlie": true}, inputs)
+	for _, path := range paths {
+		assert.Equal(t, "/model/amazon.titan-embed-text-v2:0/invoke", path)
+	}
 }

--- a/core/providers/bedrock/embedding_test.go
+++ b/core/providers/bedrock/embedding_test.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -122,6 +123,11 @@ type titanEmbeddingCaptureTransport struct {
 	mu       sync.Mutex
 	requests []BedrockTitanEmbeddingRequest
 	paths    []string
+
+	failInput               string
+	failStatus              int
+	releaseFailureOnSuccess chan struct{}
+	releaseFailureOnce      sync.Once
 }
 
 func (t *titanEmbeddingCaptureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -138,6 +144,27 @@ func (t *titanEmbeddingCaptureTransport) RoundTrip(req *http.Request) (*http.Res
 	t.requests = append(t.requests, titanReq)
 	t.paths = append(t.paths, req.URL.Path)
 	t.mu.Unlock()
+
+	if titanReq.InputText == t.failInput {
+		if t.releaseFailureOnSuccess != nil {
+			<-t.releaseFailureOnSuccess
+		}
+		status := t.failStatus
+		if status == 0 {
+			status = http.StatusInternalServerError
+		}
+		respBody, err := sonic.Marshal(BedrockError{
+			Type:    "InternalServerException",
+			Message: "forced titan embedding failure",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(bytes.NewReader(respBody)),
+		}, nil
+	}
 
 	embeddingValueByInput := map[string]float64{
 		"alpha":   3,
@@ -157,6 +184,11 @@ func (t *titanEmbeddingCaptureTransport) RoundTrip(req *http.Request) (*http.Res
 		return nil, err
 	}
 
+	if t.releaseFailureOnSuccess != nil {
+		t.releaseFailureOnce.Do(func() {
+			close(t.releaseFailureOnSuccess)
+		})
+	}
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"X-Test": []string{titanReq.InputText}},
@@ -229,4 +261,73 @@ func TestBedrockTitanEmbeddingBatchFansOutAndAggregates(t *testing.T) {
 	for _, path := range paths {
 		assert.Equal(t, "/model/amazon.titan-embed-text-v2:0/invoke", path)
 	}
+}
+
+func TestBedrockTitanEmbeddingSingleTextUsesNonBatchPath(t *testing.T) {
+	transport := &titanEmbeddingCaptureTransport{}
+	provider := &BedrockProvider{
+		client: &http.Client{Transport: transport},
+	}
+	text := "alpha"
+	request := &schemas.BifrostEmbeddingRequest{
+		Model: "amazon.titan-embed-text-v2:0",
+		Input: &schemas.EmbeddingInput{Text: &text},
+	}
+	key := schemas.Key{
+		Value: *schemas.NewSecretVar("bedrock-api-key"),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			Region: schemas.NewSecretVar("us-west-2"),
+		},
+	}
+
+	response, bifrostErr := provider.Embedding(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), key, request)
+	require.Nil(t, bifrostErr)
+	require.NotNil(t, response)
+
+	require.Len(t, response.Data, 1)
+	assert.Equal(t, request.Model, response.Model)
+	assert.Equal(t, 0, response.Data[0].Index)
+	assert.Equal(t, []float64{3}, response.Data[0].Embedding.EmbeddingArray)
+	assert.Equal(t, 11, response.Usage.PromptTokens)
+	assert.Equal(t, 11, response.Usage.TotalTokens)
+
+	capturedRequests, paths := transport.captured()
+	require.Len(t, capturedRequests, 1)
+	assert.Equal(t, "alpha", capturedRequests[0].InputText)
+	assert.Equal(t, []string{"/model/amazon.titan-embed-text-v2:0/invoke"}, paths)
+}
+
+func TestBedrockTitanEmbeddingBatchReturnsFirstRealErrorAndHeaders(t *testing.T) {
+	transport := &titanEmbeddingCaptureTransport{
+		failInput:               "bravo",
+		releaseFailureOnSuccess: make(chan struct{}),
+	}
+	provider := &BedrockProvider{
+		client: &http.Client{Transport: transport},
+	}
+	request := &schemas.BifrostEmbeddingRequest{
+		Model: "amazon.titan-embed-text-v2:0",
+		Input: &schemas.EmbeddingInput{Texts: []string{"alpha", "bravo"}},
+	}
+	key := schemas.Key{
+		Value: *schemas.NewSecretVar("bedrock-api-key"),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			Region: schemas.NewSecretVar("us-west-2"),
+		},
+	}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	response, bifrostErr := provider.Embedding(ctx, key, request)
+	require.Nil(t, response)
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, http.StatusInternalServerError, *bifrostErr.StatusCode)
+	assert.Equal(t, "forced titan embedding failure", bifrostErr.Error.Message)
+	if bifrostErr.Error.Error != nil {
+		assert.False(t, errors.Is(bifrostErr.Error.Error, context.Canceled))
+	}
+
+	headers, ok := ctx.Value(schemas.BifrostContextKeyProviderResponseHeaders).(map[string]string)
+	require.True(t, ok)
+	assert.Equal(t, "alpha", headers["X-Test"])
 }


### PR DESCRIPTION
## Problem

Calling `/v1/embeddings` with a Bedrock Titan model (e.g. `amazon.titan-embed-text-v2:0`) and the standard OpenAI batched form (`input` as an array of N strings) misbehaves two ways:

1. **Silent corruption**: all N strings are concatenated into one Titan `inputText`, so the caller gets `data` of length 1 (at `index: 0`) for N inputs — violating the OpenAI contract (N inputs ⇒ N embeddings) and storing one vector against N chunks.
2. **400 on large batches**: when the concatenation exceeds Titan's 50,000-char per-input limit, Bedrock rejects the whole batch with `Malformed input request: expected maxLength: 50000`.

Cohere-on-Bedrock, Gemini, and Vertex pass lists through natively and are unaffected — Titan's API only accepts a single `inputText`, so the Titan path must fan out.

## Root cause

`ToBedrockTitanEmbeddingRequest` joined `Input.Texts` with `" \n"` separators into a single request, and `ToBifrostEmbeddingResponse` hard-coded a single-element `Data` slice with `Index: 0`.

## Fix

- Fan out Titan embedding batches at the Bedrock call site: one `InvokeModel` request per input string, with bounded concurrency (8 workers).
- Aggregate responses preserving caller input order, with `EmbeddingData.Index` set to the original input position.
- Sum Titan `inputTextTokenCount` into usage (`PromptTokens`/`TotalTokens`).
- Preserve raw-response echoing as a list of per-call raw responses when enabled.
- Keep the single-string path unchanged; the request converter now rejects multi-text input instead of silently concatenating if called directly.

## Testing

- Added an offline unit test with a fake HTTP transport: a 3-input batch produces 3 separate Titan request bodies; verifies response ordering, indices, vectors, and usage aggregation.
- `go build ./...`, `go vet ./providers/bedrock/`, `go test -count=1 ./providers/bedrock/` (core, cgo enabled) — all pass.

Fixes #3471
