### PR TITLE
fix: persist Responses stream usage when providers omit or reuse sequence numbers

### DIFF
--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -153,6 +153,7 @@ func (a *Accumulator) createStreamAccumulator(requestID string) *StreamAccumulat
 		MaxTranscriptionChunkIndex: -1,
 		MaxAudioChunkIndex:         -1,
 		TerminalErrorChunkIndex:    -1,
+		TerminalResponseChunkIndex: -1,
 		IsComplete:                 false,
 		mu:                         sync.Mutex{},
 		Timestamp:                  now,
@@ -192,6 +193,7 @@ func (a *Accumulator) getOrCreateStreamAccumulator(requestID string) *StreamAccu
 		MaxTranscriptionChunkIndex: -1,
 		MaxAudioChunkIndex:         -1,
 		TerminalErrorChunkIndex:    -1,
+		TerminalResponseChunkIndex: -1,
 		IsComplete:                 false,
 		mu:                         sync.Mutex{},
 		Timestamp:                  now,
@@ -321,6 +323,15 @@ func (a *Accumulator) addResponsesStreamChunk(requestID string, chunk *Responses
 	// Track first chunk timestamp for TTFT calculation
 	if accumulator.FirstChunkTimestamp.IsZero() {
 		accumulator.FirstChunkTimestamp = chunk.Timestamp
+	}
+	if isFinalChunk && chunk.StreamResponse != nil && chunk.ChunkIndex <= accumulator.MaxResponsesChunkIndex {
+		if accumulator.TerminalResponseChunkIndex >= 0 {
+			chunk.ChunkIndex = accumulator.TerminalResponseChunkIndex
+		} else {
+			accumulator.MaxResponsesChunkIndex++
+			chunk.ChunkIndex = accumulator.MaxResponsesChunkIndex
+			accumulator.TerminalResponseChunkIndex = chunk.ChunkIndex
+		}
 	}
 	if _, seen := accumulator.ResponsesChunksSeen[chunk.ChunkIndex]; !seen {
 		accumulator.ResponsesChunksSeen[chunk.ChunkIndex] = struct{}{}

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -311,6 +311,25 @@ func (a *Accumulator) addAudioStreamChunk(requestID string, chunk *AudioStreamCh
 	return nil
 }
 
+// reserveTerminalChunkIndex returns the stable chunk index reserved for a terminal
+// chunk, seeding the reservation on first call: an index that is already unique
+// (greater than the current max) is reserved as-is, while a reused/lower one gets a
+// fresh trailing index. Duplicate plugin deliveries of the same terminal chunk then
+// remap to the reservation and are dropped by the seen-index dedup. Keep separate
+// reservation fields per terminal kind (error vs response) — merging them would
+// change dedup behavior if a stream ever produced both. Caller must hold mu.
+func (sa *StreamAccumulator) reserveTerminalChunkIndex(field *int, chunkIndex int) int {
+	if *field >= 0 {
+		return *field
+	}
+	if chunkIndex <= sa.MaxResponsesChunkIndex {
+		sa.MaxResponsesChunkIndex++
+		chunkIndex = sa.MaxResponsesChunkIndex
+	}
+	*field = chunkIndex
+	return chunkIndex
+}
+
 // addResponsesStreamChunk adds a responses stream chunk to the stream accumulator
 func (a *Accumulator) addResponsesStreamChunk(requestID string, chunk *ResponsesStreamChunk, isFinalChunk bool) error {
 	accumulator := a.getOrCreateStreamAccumulator(requestID)
@@ -324,14 +343,8 @@ func (a *Accumulator) addResponsesStreamChunk(requestID string, chunk *Responses
 	if accumulator.FirstChunkTimestamp.IsZero() {
 		accumulator.FirstChunkTimestamp = chunk.Timestamp
 	}
-	if isFinalChunk && chunk.StreamResponse != nil && chunk.ChunkIndex <= accumulator.MaxResponsesChunkIndex {
-		if accumulator.TerminalResponseChunkIndex >= 0 {
-			chunk.ChunkIndex = accumulator.TerminalResponseChunkIndex
-		} else {
-			accumulator.MaxResponsesChunkIndex++
-			chunk.ChunkIndex = accumulator.MaxResponsesChunkIndex
-			accumulator.TerminalResponseChunkIndex = chunk.ChunkIndex
-		}
+	if isFinalChunk && chunk.StreamResponse != nil {
+		chunk.ChunkIndex = accumulator.reserveTerminalChunkIndex(&accumulator.TerminalResponseChunkIndex, chunk.ChunkIndex)
 	}
 	if _, seen := accumulator.ResponsesChunksSeen[chunk.ChunkIndex]; !seen {
 		accumulator.ResponsesChunksSeen[chunk.ChunkIndex] = struct{}{}

--- a/framework/streaming/accumulator_test.go
+++ b/framework/streaming/accumulator_test.go
@@ -769,6 +769,83 @@ func TestProcessStreamingResponsePreservesTerminalResponsesUsageWhenChunkIndexIs
 	}
 }
 
+// On a monotonic stream the terminal chunk arrives with a unique highest index, so
+// the first delivery is stored as-is — the reservation must still be seeded then,
+// or a second plugin delivering the same terminal chunk (logging + maxim both call
+// ProcessStreamingChunk with the final result) mints a fresh index and the chunk is
+// double-appended into the persisted raw log.
+func TestProcessStreamingResponseDedupesDuplicateTerminalChunkWithUniqueIndex(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-responses-terminal-monotonic-duplicate"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	for i := 0; i < 3; i++ {
+		chunk := &ResponsesStreamChunk{
+			ChunkIndex: i,
+			Timestamp:  time.Now(),
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:  schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta: bifrost.Ptr("chunk"),
+			},
+		}
+		if err := accumulator.addResponsesStreamChunk(requestID, chunk, false); err != nil {
+			t.Fatalf("addResponsesStreamChunk() error = %v", err)
+		}
+	}
+
+	response := &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeCompleted,
+			SequenceNumber: 3,
+			Response: &schemas.BifrostResponsesResponse{
+				ID: bifrost.Ptr("resp_monotonic_terminal"),
+				Usage: &schemas.ResponsesResponseUsage{
+					InputTokens:  11,
+					OutputTokens: 7,
+					TotalTokens:  18,
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ResponsesStreamRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o-mini",
+				ChunkIndex:             3,
+			},
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	for call := 1; call <= 2; call++ {
+		processed, err := accumulator.ProcessStreamingResponse(ctx, response, nil)
+		if err != nil {
+			t.Fatalf("ProcessStreamingResponse() call %d error = %v", call, err)
+		}
+		if processed == nil || processed.Data == nil || processed.Data.TokenUsage == nil || processed.Data.TokenUsage.TotalTokens != 18 {
+			t.Fatalf("call %d: expected terminal usage 18 total tokens, got %+v", call, processed)
+		}
+	}
+
+	streamAccumulator := accumulator.getOrCreateStreamAccumulator(requestID)
+	streamAccumulator.mu.Lock()
+	defer streamAccumulator.mu.Unlock()
+	completedChunks := 0
+	for _, chunk := range streamAccumulator.ResponsesStreamChunks {
+		if chunk.StreamResponse != nil && chunk.StreamResponse.Type == schemas.ResponsesStreamResponseTypeCompleted {
+			completedChunks++
+		}
+	}
+	if completedChunks != 1 {
+		t.Fatalf("expected exactly one terminal chunk after duplicate delivery of a unique-index final chunk, got %d", completedChunks)
+	}
+	if got := len(streamAccumulator.ResponsesStreamChunks); got != 4 {
+		t.Fatalf("expected 4 stored chunks (3 deltas + 1 terminal), got %d", got)
+	}
+}
+
 func TestProcessStreamingResponseSupportsWebSocketResponsesRequest(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	accumulator := NewAccumulator(nil, logger)

--- a/framework/streaming/accumulator_test.go
+++ b/framework/streaming/accumulator_test.go
@@ -660,6 +660,115 @@ func TestGetLastAudioAndTranscriptionChunksSafe(t *testing.T) {
 	}
 }
 
+func TestProcessStreamingResponsePreservesTerminalResponsesUsageWhenChunkIndexIsReused(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-responses-terminal-usage-reused-index"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	priorChunks := []*ResponsesStreamChunk{
+		{
+			ChunkIndex: 0,
+			Timestamp:  time.Now(),
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type: schemas.ResponsesStreamResponseTypeCreated,
+				Response: &schemas.BifrostResponsesResponse{
+					ID: bifrost.Ptr("resp_terminal_usage"),
+				},
+			},
+		},
+		{
+			ChunkIndex: 7,
+			Timestamp:  time.Now(),
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:  schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta: bifrost.Ptr("partial"),
+			},
+		},
+		{
+			ChunkIndex: 7,
+			Timestamp:  time.Now(),
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:  schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta: bifrost.Ptr("duplicate index ignored"),
+			},
+		},
+	}
+	for _, chunk := range priorChunks {
+		if err := accumulator.addResponsesStreamChunk(requestID, chunk, false); err != nil {
+			t.Fatalf("addResponsesStreamChunk() error = %v", err)
+		}
+	}
+
+	response := &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeCompleted,
+			SequenceNumber: 0,
+			Response: &schemas.BifrostResponsesResponse{
+				ID: bifrost.Ptr("resp_terminal_usage"),
+				Usage: &schemas.ResponsesResponseUsage{
+					InputTokens:  31,
+					OutputTokens: 17,
+					TotalTokens:  48,
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ResponsesStreamRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o-mini",
+				ChunkIndex:             0,
+			},
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	processed, err := accumulator.ProcessStreamingResponse(ctx, response, nil)
+	if err != nil {
+		t.Fatalf("ProcessStreamingResponse() error = %v", err)
+	}
+	assertTokenUsage := func(t *testing.T, processed *ProcessedStreamResponse) {
+		t.Helper()
+		if processed == nil {
+			t.Fatal("expected processed response, got nil")
+		}
+		if processed.Data == nil || processed.Data.TokenUsage == nil {
+			t.Fatal("expected terminal response.completed usage to be accumulated")
+		}
+		if processed.Data.TokenUsage.PromptTokens != 31 {
+			t.Fatalf("expected prompt tokens 31, got %d", processed.Data.TokenUsage.PromptTokens)
+		}
+		if processed.Data.TokenUsage.CompletionTokens != 17 {
+			t.Fatalf("expected completion tokens 17, got %d", processed.Data.TokenUsage.CompletionTokens)
+		}
+		if processed.Data.TokenUsage.TotalTokens != 48 {
+			t.Fatalf("expected total tokens 48, got %d", processed.Data.TokenUsage.TotalTokens)
+		}
+	}
+	assertTokenUsage(t, processed)
+
+	processedAgain, err := accumulator.ProcessStreamingResponse(ctx, response, nil)
+	if err != nil {
+		t.Fatalf("second ProcessStreamingResponse() error = %v", err)
+	}
+	assertTokenUsage(t, processedAgain)
+
+	streamAccumulator := accumulator.getOrCreateStreamAccumulator(requestID)
+	streamAccumulator.mu.Lock()
+	defer streamAccumulator.mu.Unlock()
+	completedChunks := 0
+	for _, chunk := range streamAccumulator.ResponsesStreamChunks {
+		if chunk.StreamResponse != nil && chunk.StreamResponse.Type == schemas.ResponsesStreamResponseTypeCompleted {
+			completedChunks++
+		}
+	}
+	if completedChunks != 1 {
+		t.Fatalf("expected exactly one terminal response.completed chunk after duplicate processing, got %d", completedChunks)
+	}
+}
+
 func TestProcessStreamingResponseSupportsWebSocketResponsesRequest(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	accumulator := NewAccumulator(nil, logger)

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -948,13 +948,7 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *schemas.BifrostCont
 		// Assign a stable trailing index; reuse on duplicate plugin calls so dedup fires correctly.
 		accumulator := a.getOrCreateStreamAccumulator(requestID)
 		accumulator.mu.Lock()
-		if accumulator.TerminalErrorChunkIndex >= 0 {
-			chunk.ChunkIndex = accumulator.TerminalErrorChunkIndex
-		} else {
-			accumulator.MaxResponsesChunkIndex++
-			chunk.ChunkIndex = accumulator.MaxResponsesChunkIndex
-			accumulator.TerminalErrorChunkIndex = chunk.ChunkIndex
-		}
+		chunk.ChunkIndex = accumulator.reserveTerminalChunkIndex(&accumulator.TerminalErrorChunkIndex, chunk.ChunkIndex)
 		accumulator.mu.Unlock()
 	} else if result != nil && result.ResponsesStreamResponse != nil {
 		if result.ResponsesStreamResponse.ExtraFields.RawResponse != nil {

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -140,6 +140,8 @@ type StreamAccumulator struct {
 
 	// TerminalErrorChunkIndex holds the reserved chunk index for the terminal error (-1 = unset); reused across plugin calls for correct dedup.
 	TerminalErrorChunkIndex int
+	// TerminalResponseChunkIndex holds the reserved index for a terminal response event when providers omit or reuse sequence numbers.
+	TerminalResponseChunkIndex int
 
 	// Passthrough streaming accumulation
 	PassthroughBody       []byte            // Accumulated body bytes from passthrough streaming chunks


### PR DESCRIPTION
## Problem

For Responses API streaming requests, the final `response.completed` SSE event contains `response.usage` (e.g. 9/12/21 tokens), but Observability → LLM Logs shows Tokens in/out 0/0, total 0, and "No raw JSON available". Reported with Codex CLI driving a Responses Stream through an OpenAI-compatible provider (Unsloth).

## Root cause

The responses stream accumulator (`framework/streaming`) dedupes chunks by `ChunkIndex` and extracts stream metadata (usage, raw response) from the chunk with the highest index. Some OpenAI-compatible providers omit or reuse `sequence_number`, so the terminal `response.completed` event arrives with `ChunkIndex == 0` (or another already-seen index) — it gets deduped away or never selected as the metadata chunk, and logging persists zero usage.

## Fix

When a terminal responses-stream event arrives with a chunk index that is not greater than the current max, remap it to a reserved stable trailing index (`TerminalResponseChunkIndex`, initialized to -1 like the existing `TerminalErrorChunkIndex` pattern). The terminal event carrying `response.usage` survives dedup and is selected for persistence; duplicate final processing stays idempotent (the reserved index is reused, so the terminal chunk is only stored once).

## Testing

Added `TestProcessStreamingResponsePreservesTerminalResponsesUsageWhenChunkIndexIsReused`:
- prior stream chunks with indexes 0 and 7 (including a duplicate index 7);
- terminal `response.completed` with usage and reused `ChunkIndex == 0`;
- asserts accumulated usage 31/17/48, and that reprocessing the same final event does not append a duplicate terminal chunk.

With the repo go.work workspace (`core` + `framework` + `transports`):
- `go build ./...` (framework) — pass
- `go vet ./streaming/` — pass
- `go test -count=1 ./streaming/` — pass

Note: `go vet ./...` on framework has one pre-existing unrelated finding in `framework/tracing/tracer_test.go` (copies a `schemas.Trace` containing a mutex), present on clean `dev`.

Fixes #4846
