### PR TITLE
fix: report stop_reason tool_use for tool calls on Anthropic-compatible egress

### DIFF
--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -521,6 +521,24 @@ func TestToAnthropicResponsesResponse_StopReasonFromBifrost(t *testing.T) {
 			expectedReason: AnthropicStopReasonEndTurn,
 		},
 		{
+			name:           "tool_use mapped from tool_calls without output items",
+			stopReason:     schemas.Ptr("tool_calls"),
+			expectedReason: AnthropicStopReasonToolUse,
+		},
+		{
+			name:       "reasoning-only function_call output does not infer tool_use",
+			stopReason: nil,
+			contentBlocks: []schemas.ResponsesMessage{
+				{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					ResponsesReasoning: &schemas.ResponsesReasoning{
+						EncryptedContent: schemas.Ptr("opaque-reasoning-payload"),
+					},
+				},
+			},
+			expectedReason: AnthropicStopReasonEndTurn,
+		},
+		{
 			name:       "tool_use mapped from tool_calls with function call output",
 			stopReason: schemas.Ptr("tool_calls"),
 			contentBlocks: []schemas.ResponsesMessage{

--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -521,8 +521,18 @@ func TestToAnthropicResponsesResponse_StopReasonFromBifrost(t *testing.T) {
 			expectedReason: AnthropicStopReasonEndTurn,
 		},
 		{
-			name:           "tool_use mapped from tool_calls",
-			stopReason:     schemas.Ptr("tool_calls"),
+			name:       "tool_use mapped from tool_calls with function call output",
+			stopReason: schemas.Ptr("tool_calls"),
+			contentBlocks: []schemas.ResponsesMessage{
+				{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID:    schemas.Ptr("call_123"),
+						Name:      schemas.Ptr("my_tool"),
+						Arguments: schemas.Ptr(`{"foo":"bar"}`),
+					},
+				},
+			},
 			expectedReason: AnthropicStopReasonToolUse,
 		},
 		{
@@ -699,6 +709,50 @@ func TestToAnthropicResponsesStreamResponse_CompletedWithCompactionStopReason(t 
 	messageStop := events[1]
 	if messageStop.Type != AnthropicStreamEventTypeMessageStop {
 		t.Errorf("event[1] type = %v, want message_stop", messageStop.Type)
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_CompletedWithFunctionCallInfersToolUseStopReason(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeCompleted,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:    schemas.Ptr("resp_test"),
+			Model: "gpt-4o",
+			Output: []schemas.ResponsesMessage{
+				{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID:    schemas.Ptr("call_123"),
+						Name:      schemas.Ptr("my_tool"),
+						Arguments: schemas.Ptr(`{"foo":"bar"}`),
+					},
+				},
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+	if len(events) != 2 {
+		t.Fatalf("expected message_delta + message_stop for response.completed, got %d", len(events))
+	}
+
+	messageDelta := events[0]
+	if messageDelta.Type != AnthropicStreamEventTypeMessageDelta {
+		t.Fatalf("event[0] type = %v, want message_delta", messageDelta.Type)
+	}
+	if messageDelta.Delta == nil || messageDelta.Delta.StopReason == nil {
+		t.Fatalf("expected message_delta stop_reason in events: %#v", events)
+	}
+	if *messageDelta.Delta.StopReason != AnthropicStopReasonToolUse {
+		t.Fatalf("message_delta stop_reason = %q, want %q", *messageDelta.Delta.StopReason, AnthropicStopReasonToolUse)
+	}
+	if events[1].Type != AnthropicStreamEventTypeMessageStop {
+		t.Fatalf("event[1] type = %v, want message_stop", events[1].Type)
 	}
 }
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2682,22 +2682,19 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		if alreadyEmitted, ok := ctx.Value(schemas.BifrostContextKeyHasEmittedMessageDelta).(bool); ok && alreadyEmitted {
 			return []*AnthropicStreamEvent{streamResp}
 		}
+		stopReason := AnthropicStopReasonEndTurn
+		if bifrostResp.Response != nil {
+			stopReason = inferAnthropicStopReasonFromBifrostResponse(bifrostResp.Response, nil)
+		}
 		anthropicContentDeltaEvent := &AnthropicStreamEvent{
 			Type: AnthropicStreamEventTypeMessageDelta,
 			Delta: &AnthropicStreamDelta{
-				StopReason:   schemas.Ptr(AnthropicStopReasonEndTurn),
-				StopSequence: schemas.Ptr(""),
+				StopReason: &stopReason,
 			},
 		}
 		// Convert usage from Bifrost to Anthropic
 		if bifrostResp.Response != nil {
 			anthropicContentDeltaEvent.Usage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Response.Usage)
-			if bifrostResp.Response.StopReason != nil {
-				anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{
-					StopReason:   schemas.Ptr(ConvertBifrostFinishReasonToAnthropic(*bifrostResp.Response.StopReason)),
-					StopSequence: nil,
-				}
-			}
 			// Re-emit the code-execution sandbox container on the message_delta.
 			if bifrostResp.Response.Container != nil {
 				if anthropicContentDeltaEvent.Delta == nil {
@@ -3541,6 +3538,39 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 	return bifrostResp
 }
 
+func bifrostResponsesOutputHasFunctionCall(output []schemas.ResponsesMessage) bool {
+	for _, msg := range output {
+		if msg.Type != nil && *msg.Type == schemas.ResponsesMessageTypeFunctionCall {
+			return true
+		}
+	}
+	return false
+}
+
+func anthropicContentBlocksHaveToolUse(contentBlocks []AnthropicContentBlock) bool {
+	for _, block := range contentBlocks {
+		if block.Type == AnthropicContentBlockTypeToolUse {
+			return true
+		}
+	}
+	return false
+}
+
+func inferAnthropicStopReasonFromBifrostResponse(bifrostResp *schemas.BifrostResponsesResponse, contentBlocks []AnthropicContentBlock) AnthropicStopReason {
+	if bifrostResp != nil {
+		if bifrostResp.StopReason != nil {
+			return ConvertBifrostFinishReasonToAnthropic(*bifrostResp.StopReason)
+		}
+		if bifrostResponsesOutputHasFunctionCall(bifrostResp.Output) {
+			return AnthropicStopReasonToolUse
+		}
+	}
+	if anthropicContentBlocksHaveToolUse(contentBlocks) {
+		return AnthropicStopReasonToolUse
+	}
+	return AnthropicStopReasonEndTurn
+}
+
 // ToAnthropicResponsesResponse converts a BifrostResponse with Responses structure back to AnthropicMessageResponse
 func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *schemas.BifrostResponsesResponse) *AnthropicMessageResponse {
 	anthropicResp := &AnthropicMessageResponse{
@@ -3596,18 +3626,7 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 		break
 	}
 
-	// Map stop reason from Bifrost response if available, otherwise infer from content
-	if bifrostResp.StopReason != nil {
-		anthropicResp.StopReason = ConvertBifrostFinishReasonToAnthropic(*bifrostResp.StopReason)
-	} else {
-		anthropicResp.StopReason = AnthropicStopReasonEndTurn
-		for _, block := range contentBlocks {
-			if block.Type == AnthropicContentBlockTypeToolUse {
-				anthropicResp.StopReason = AnthropicStopReasonToolUse
-				break
-			}
-		}
-	}
+	anthropicResp.StopReason = inferAnthropicStopReasonFromBifrostResponse(bifrostResp, contentBlocks)
 
 	anthropicResp.Model = bifrostResp.Model
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3540,7 +3540,10 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 
 func bifrostResponsesOutputHasFunctionCall(output []schemas.ResponsesMessage) bool {
 	for _, msg := range output {
-		if msg.Type != nil && *msg.Type == schemas.ResponsesMessageTypeFunctionCall {
+		// Reasoning-only items can carry the function_call type but convert to
+		// thinking blocks, not tool_use — they must not force a tool_use stop reason.
+		if msg.Type != nil && *msg.Type == schemas.ResponsesMessageTypeFunctionCall &&
+			msg.ResponsesReasoning == nil && msg.ResponsesToolMessage != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

When Bifrost's Anthropic-compatible ingress (`/anthropic/v1/messages`) routes to a non-Anthropic backend (e.g. Azure OpenAI), a tool-calling turn emits a correct `tool_use` content block but the terminal `message_delta.delta.stop_reason` is `"end_turn"` instead of `"tool_use"`. Anthropic SDK consumers that dispatch tools on `stop_reason == "tool_use"` (the documented signal) fail to detect the tool call.

## Root cause

The Anthropic Responses streaming egress converter defaulted `response.completed` to `stop_reason: "end_turn"` unless `BifrostResponsesResponse.StopReason` was explicitly set. OpenAI/Azure Responses-style completed payloads can carry `function_call` output items with no Bifrost stop reason — the converter had enough information to know the turn requested a tool, but didn't infer `"tool_use"`.

## Fix

Centralized Anthropic stop-reason inference for Responses egress (`inferAnthropicStopReasonFromBifrostResponse`), used by both the non-streaming conversion and the streaming `response.completed` → `message_delta` conversion:

- explicit stop reason mapping preserved (`"tool_calls"` → `"tool_use"`, etc. via the existing mapping table);
- nil stop reason + `function_call` output items ⇒ `"tool_use"`;
- nil stop reason + converted `tool_use` content blocks ⇒ `"tool_use"` (existing non-streaming inference, kept);
- otherwise `"end_turn"`.

## Testing

- Extended the non-streaming stop-reason table test (`tool_calls` + function-call output ⇒ `tool_use`).
- Added `TestToAnthropicResponsesStreamResponse_CompletedWithFunctionCallInfersToolUseStopReason` covering the reported streaming case: `response.completed`, nil `StopReason`, function-call output ⇒ `message_delta` with `stop_reason: "tool_use"`.
- `go build ./...`, `go vet ./providers/anthropic/`, `go test -count=1 ./providers/anthropic/` (core, cgo enabled) — all pass.

Fixes #4065
