### PR TITLE
fix: support OpenShift arbitrary UIDs — build-time group-0 ownership, no runtime chown

### DIFF
--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -426,13 +426,34 @@ echo ""
 echo -e "${CYAN}🔒 7/7 - Validating OpenShift-compatible Security Contexts...${NC}"
 echo "----------------------------------------------------------------"
 
-test_name="default Bifrost pod does not pin runAsUser 1000 (fsGroup allowed)"
+test_name="default Bifrost pod does not set runAsUser (SCC assigns UID)"
 if helm template bifrost ./helm-charts/bifrost \
   --set image.tag=v1.0.0 \
   > /tmp/helm-template-output.yaml 2>&1; then
-  if grep -Eq '^[[:space:]]+runAsUser:[[:space:]]*1000[[:space:]]*$' /tmp/helm-template-output.yaml; then
+  if grep -Eq '^[[:space:]]*runAsUser:' /tmp/helm-template-output.yaml; then
     report_result "$test_name" 1
-    echo -e "${YELLOW}  hard-coded runAsUser 1000 found in rendered output${NC}"
+    echo -e "${YELLOW}  runAsUser found in default render (must stay unset so OpenShift can assign a UID)${NC}"
+  else
+    report_result "$test_name" 0
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
+
+# Postgres mode renders a Deployment (not the sqlite StatefulSet); assert the
+# pinned-UID regression can't sneak in on that code path either.
+test_name="postgres-mode Bifrost pod does not set runAsUser (SCC assigns UID)"
+if helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v1.0.0 \
+  --set storage.mode=postgres \
+  --set postgresql.enabled=true \
+  --set postgresql.auth.password=testpass \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq '^[[:space:]]*runAsUser:' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 1
+    echo -e "${YELLOW}  runAsUser found in postgres render (must stay unset so OpenShift can assign a UID)${NC}"
   else
     report_result "$test_name" 0
   fi

--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -54,7 +54,7 @@ test_template() {
 
 # 1. Storage Combinations (9 tests)
 echo ""
-echo -e "${CYAN}📦 1/6 - Testing Storage Combinations (9 tests)...${NC}"
+echo -e "${CYAN}📦 1/7 - Testing Storage Combinations (9 tests)...${NC}"
 echo "---------------------------------------------------"
 
 # config=no, logs=no
@@ -126,7 +126,7 @@ test_template "config=postgres, logs=postgres" \
 
 # 2. Vector Store Combinations (6 tests)
 echo ""
-echo -e "${CYAN}🗄️  2/6 - Testing Vector Store Combinations (6 tests)...${NC}"
+echo -e "${CYAN}🗄️  2/7 - Testing Vector Store Combinations (6 tests)...${NC}"
 echo "--------------------------------------------------------"
 
 # Weaviate
@@ -175,7 +175,7 @@ test_template "sqlite + qdrant" \
 
 # 3. Special Configurations (7 tests)
 echo ""
-echo -e "${CYAN}⚙️  3/6 - Testing Special Configurations (7 tests)...${NC}"
+echo -e "${CYAN}⚙️  3/7 - Testing Special Configurations (7 tests)...${NC}"
 echo "-----------------------------------------------------"
 
 # semantic cache: direct mode (dimension: 1, no provider/keys)
@@ -251,7 +251,7 @@ test_template "production-like config" \
 
 # 4. New Property Rendering (Gap 1-8 tests)
 echo ""
-echo -e "${CYAN}🆕 4/6 - Testing New Property Rendering (Gap 1-8)...${NC}"
+echo -e "${CYAN}🆕 4/7 - Testing New Property Rendering (Gap 1-8)...${NC}"
 echo "-----------------------------------------------------"
 
 # Gap 1+2: Client new properties
@@ -337,7 +337,7 @@ test_template "combined: all new Gap 1-9 fields" \
 
 # 5. Plugin Name Validation
 echo ""
-echo -e "${CYAN}🔌 5/6 - Validating Plugin Names Match Go Registry...${NC}"
+echo -e "${CYAN}🔌 5/7 - Validating Plugin Names Match Go Registry...${NC}"
 echo "------------------------------------------------------"
 
 # Verify semantic cache plugin renders with correct name ("semantic_cache", not "semantic_cache")
@@ -366,7 +366,7 @@ fi
 
 # 6. Custom Plugin Placement and Order Rendering
 echo ""
-echo -e "${CYAN}🔧 6/6 - Validating Custom Plugin placement and order Rendering...${NC}"
+echo -e "${CYAN}🔧 6/7 - Validating Custom Plugin placement and order Rendering...${NC}"
 echo "-------------------------------------------------------------------"
 
 # Test custom plugin renders successfully with placement and order
@@ -414,6 +414,27 @@ if helm template bifrost ./helm-charts/bifrost \
   else
     report_result "$test_name" 1
     echo -e "${YELLOW}  order field not found in rendered output${NC}"
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
+
+# 7. Security Context Rendering
+echo ""
+echo -e "${CYAN}🔒 7/7 - Validating OpenShift-compatible Security Contexts...${NC}"
+echo "----------------------------------------------------------------"
+
+test_name="default Bifrost pod does not pin UID/GID 1000"
+if helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v1.0.0 \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq '^[[:space:]]+(runAsUser|fsGroup):[[:space:]]*1000[[:space:]]*$' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 1
+    echo -e "${YELLOW}  hard-coded UID/GID 1000 found in rendered output${NC}"
+  else
+    report_result "$test_name" 0
   fi
 else
   report_result "$test_name" 1

--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -426,13 +426,13 @@ echo ""
 echo -e "${CYAN}🔒 7/7 - Validating OpenShift-compatible Security Contexts...${NC}"
 echo "----------------------------------------------------------------"
 
-test_name="default Bifrost pod does not pin UID/GID 1000"
+test_name="default Bifrost pod does not pin runAsUser 1000 (fsGroup allowed)"
 if helm template bifrost ./helm-charts/bifrost \
   --set image.tag=v1.0.0 \
   > /tmp/helm-template-output.yaml 2>&1; then
-  if grep -Eq '^[[:space:]]+(runAsUser|fsGroup):[[:space:]]*1000[[:space:]]*$' /tmp/helm-template-output.yaml; then
+  if grep -Eq '^[[:space:]]+runAsUser:[[:space:]]*1000[[:space:]]*$' /tmp/helm-template-output.yaml; then
     report_result "$test_name" 1
-    echo -e "${YELLOW}  hard-coded UID/GID 1000 found in rendered output${NC}"
+    echo -e "${YELLOW}  hard-coded runAsUser 1000 found in rendered output${NC}"
   else
     report_result "$test_name" 0
   fi

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -107,8 +107,9 @@ COPY --from=builder /app/docker-entrypoint.sh .
 # UID without needing CAP_CHOWN at runtime.
 RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:0 /app "$APP_DIR" && \
-    chmod -R g=rwX "$APP_DIR" && \
+    chown -R appuser:appuser /app && \
+    chown -R appuser:0 "$APP_DIR" && \
+    { [ "$APP_DIR" = "/app" ] || chmod -R g=rwX "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
 # Numeric UID:GID (group 0) so kubelet can verify runAsNonRoot and the container
 # stays writable under arbitrary OpenShift UIDs.

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -102,8 +102,17 @@ WORKDIR /app
 COPY --from=builder /app/main .
 COPY --from=builder /app/docker-entrypoint.sh .
 
-RUN mkdir -p $APP_DIR/logs
-USER appuser
+# Give the data dir group-0 ownership and group-write so the fail-fast
+# entrypoint can write config.db/logs.db under an arbitrary (OpenShift-assigned)
+# UID without needing CAP_CHOWN at runtime.
+RUN mkdir -p "$APP_DIR/logs" && \
+    adduser -D -s /bin/sh appuser && \
+    chown -R appuser:0 /app "$APP_DIR" && \
+    chmod -R g=rwX "$APP_DIR" && \
+    chmod +x /app/docker-entrypoint.sh
+# Numeric UID:GID (group 0) so kubelet can verify runAsNonRoot and the container
+# stays writable under arbitrary OpenShift UIDs.
+USER 1000:0
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["/app/main"]

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -441,7 +441,7 @@ The default install sets `podSecurityContext.fsGroup: 1000`. OpenShift's
 `restricted-v2` SCC enforces `MustRunAs` against the namespace's allocated
 group range and rejects that value at admission:
 
-```
+```text
 fsGroup: Invalid value: []int64{1000}: 1000 is not an allowed group
 ```
 

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -435,6 +435,38 @@ cd bifrost/helm-charts/bifrost
 ./scripts/install.sh
 ```
 
+### OpenShift (restricted-v2 SCC)
+
+The default install sets `podSecurityContext.fsGroup: 1000`. OpenShift's
+`restricted-v2` SCC enforces `MustRunAs` against the namespace's allocated
+group range and rejects that value at admission:
+
+```
+fsGroup: Invalid value: []int64{1000}: 1000 is not an allowed group
+```
+
+To deploy on OpenShift, clear the default `fsGroup` so the SCC can assign an
+in-range UID/GID:
+
+```yaml
+podSecurityContext:
+  # Helm merges maps, so `{}` does NOT clear this — you must use null.
+  fsGroup: null
+  runAsNonRoot: true
+```
+
+The Bifrost image supports arbitrary UIDs with group 0: the data directory is
+owned by group 0 and group-writable at build time, so the restricted-v2 UID
+(with GID 0) can write `config.db` and `logs.db` — no custom SCC or `anyuid` is
+needed.
+
+> **Behavior change:** the entrypoint's ownership repair now runs only as root
+> (uid 0). A non-root container that re-groups the data directory (for example
+> Docker Compose `user: "1000:2000"`) will no longer have its ownership silently
+> rewritten. Mount a volume already writable by the container's GID, or set
+> `BIFROST_SKIP_WRITE_CHECK=1` to boot read-only against external stores (e.g.
+> Postgres) even when `APP_DIR` is not writable.
+
 ## Configuration
 
 ### Image Configuration

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -57,10 +57,7 @@ deploymentLabels: {}
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-  runAsNonRoot: true
+podSecurityContext: {}
 
 securityContext:
   capabilities:
@@ -68,7 +65,6 @@ securityContext:
       - ALL
   readOnlyRootFilesystem: false
   runAsNonRoot: true
-  runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -57,7 +57,13 @@ deploymentLabels: {}
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
+# Pod-level security context. Defaults chown freshly provisioned PVCs (fsGroup)
+# and forbid running as root, which vanilla Kubernetes needs for restrictive
+# storage classes. On OpenShift (restricted-v2), set `podSecurityContext: {}` —
+# the image supports arbitrary UIDs with group 0, so no custom SCC is needed.
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
 
 securityContext:
   capabilities:

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -59,8 +59,9 @@ podLabels: {}
 
 # Pod-level security context. Defaults chown freshly provisioned PVCs (fsGroup)
 # and forbid running as root, which vanilla Kubernetes needs for restrictive
-# storage classes. On OpenShift (restricted-v2), set `podSecurityContext: {}` —
-# the image supports arbitrary UIDs with group 0, so no custom SCC is needed.
+# storage classes. On OpenShift (restricted-v2), set `podSecurityContext.fsGroup: null`
+# (Helm merges maps, so `{}` would keep this default) — the image supports
+# arbitrary UIDs with group 0, so no custom SCC is needed.
 podSecurityContext:
   fsGroup: 1000
   runAsNonRoot: true

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -93,7 +93,8 @@
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
-    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
+    chown -R appuser:0 "$APP_DIR" && \
+    chmod -R g=rwX "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
 

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -90,13 +90,20 @@
     GOMEMLIMIT=""
 
 
+  # adduser -D (no -u) on this alpine base assigns the first free UID, which is
+  # 1000 on a fresh image — so the numeric USER 1000:0 below resolves to appuser.
+  # Guard the group-writable chmod so it never applies when APP_DIR resolves to
+  # /app itself (e.g. --build-arg ARG_APP_DIR=/app), which would make the binary
+  # group-0-writable.
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
     chown -R appuser:0 "$APP_DIR" && \
-    chmod -R g=rwX "$APP_DIR" && \
+    { [ "$APP_DIR" = "/app" ] || chmod -R g=rwX "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
-  USER appuser
+  # Numeric USER (uid:gid) so kubelet can verify runAsNonRoot; group 0 grants
+  # write access to the group-0-owned data dir under arbitrary OpenShift UIDs.
+  USER 1000:0
 
 
   # Declare volume for data persistence

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -93,13 +93,20 @@
     APP_DIR=$ARG_APP_DIR
 
 
+  # adduser -D (no -u) on this alpine base assigns the first free UID, which is
+  # 1000 on a fresh image — so the numeric USER 1000:0 below resolves to appuser.
+  # Guard the group-writable chmod so it never applies when APP_DIR resolves to
+  # /app itself (e.g. --build-arg ARG_APP_DIR=/app), which would make the binary
+  # group-0-writable.
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
     chown -R appuser:0 "$APP_DIR" && \
-    chmod -R g=rwX "$APP_DIR" && \
+    { [ "$APP_DIR" = "/app" ] || chmod -R g=rwX "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
-  USER appuser
+  # Numeric USER (uid:gid) so kubelet can verify runAsNonRoot; group 0 grants
+  # write access to the group-0-owned data dir under arbitrary OpenShift UIDs.
+  USER 1000:0
 
 
   # Declare volume for data persistence

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -96,7 +96,8 @@
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
-    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
+    chown -R appuser:0 "$APP_DIR" && \
+    chmod -R g=rwX "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
 

--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -102,9 +102,10 @@ ENV GOGC="" \
 # UID 1001 is the Red Hat recommended non-root numeric UID for certified containers.
 # We avoid creating a named user (adduser) since UBI minimal may not have useradd,
 # and Red Hat Preflight expects a numeric USER instruction.
-RUN mkdir -p $APP_DIR/logs && \
-  chown -R 1001:0 /app /licenses && \
+RUN mkdir -p "$APP_DIR/logs" && \
+  chown -R 1001:0 /app /licenses "$APP_DIR" && \
   chmod -R g=u /app /licenses && \
+  chmod -R g=rwX "$APP_DIR" && \
   chmod +x /app/docker-entrypoint.sh
 
 USER 1001

--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -102,10 +102,13 @@ ENV GOGC="" \
 # UID 1001 is the Red Hat recommended non-root numeric UID for certified containers.
 # We avoid creating a named user (adduser) since UBI minimal may not have useradd,
 # and Red Hat Preflight expects a numeric USER instruction.
+# Guard the group-writable chmod so it never applies when APP_DIR resolves to
+# /app itself (e.g. --build-arg ARG_APP_DIR=/app), which would make the binary
+# group-0-writable. /app and /licenses already get g=u above.
 RUN mkdir -p "$APP_DIR/logs" && \
   chown -R 1001:0 /app /licenses "$APP_DIR" && \
   chmod -R g=u /app /licenses && \
-  chmod -R g=rwX "$APP_DIR" && \
+  { [ "$APP_DIR" = "/app" ] || chmod -R g=rwX "$APP_DIR"; } && \
   chmod +x /app/docker-entrypoint.sh
 
 USER 1001

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -11,23 +11,30 @@ ensure_app_dir() {
         return
     fi
 
-    if [ ! -w "$APP_DIR" ]; then
-        CURRENT_UID=$(id -u)
-        CURRENT_GID=$(id -g)
-        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
-        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
+    CURRENT_UID=$(id -u)
+    CURRENT_GID=$(id -g)
+    DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
+    DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
 
-        if [ "$CURRENT_UID" = "0" ]; then
+    if [ "$CURRENT_UID" = "0" ]; then
+        # Running as root, `test -w` always succeeds (the kernel bypasses DAC),
+        # so gate the repair on ownership instead: chown whenever the directory
+        # is not already owned by our UID.
+        if [ "$DATA_UID" != "$CURRENT_UID" ]; then
             echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
             if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
                 echo "Successfully updated permissions on $APP_DIR"
             else
                 echo "Warning: Could not update permissions on $APP_DIR"
             fi
-        else
-            echo "Warning: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID"
-            echo "  Ensure the directory is owned by this UID or group-writable for a supplemental group such as 0"
         fi
+    elif [ ! -w "$APP_DIR" ]; then
+        # Non-root without CAP_CHOWN cannot repair ownership. Fail fast with
+        # actionable guidance rather than crashing later while writing config.db.
+        echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
+        echo "  Ensure the directory is owned by this UID or group-writable for a supplemental group such as 0."
+        echo "  On Kubernetes, set podSecurityContext.fsGroup (e.g. 1000) so the volume is group-writable."
+        exit 1
     fi
 
     mkdir -p "$APP_DIR/logs" 2>/dev/null || true

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -29,26 +29,38 @@ ensure_app_dir() {
 
     CURRENT_UID=$(id -u)
     CURRENT_GID=$(id -g)
-    DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
-    DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
 
-    if [ "$CURRENT_UID" = "0" ] && [ "$DATA_UID:$DATA_GID" != "$CURRENT_UID:$CURRENT_GID" ]; then
-        echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
-        if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
-            echo "Successfully updated permissions on $APP_DIR"
-        else
-            echo "Warning: Could not update permissions on $APP_DIR"
+    # Ownership repair only works as root (needs CAP_CHOWN). Stat the data dir
+    # here, inside the branch that actually uses the values.
+    if [ "$CURRENT_UID" = "0" ]; then
+        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null)
+        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null)
+        if [ "$DATA_UID:$DATA_GID" != "$CURRENT_UID:$CURRENT_GID" ]; then
+            echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
+            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
+                echo "Successfully updated permissions on $APP_DIR"
+            else
+                echo "Warning: Could not update permissions on $APP_DIR"
+            fi
         fi
     fi
 
     if ! app_dir_writable; then
-        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
-        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
-        echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
-        echo "  Bifrost needs a writable APP_DIR for config.db and logs.db before startup."
-        echo "  On OpenShift/Kubernetes with a PVC, set podSecurityContext.fsGroup (for example, 0)"
-        echo "  or mount a volume writable by GID 0, matching the image's group-0 ownership."
-        exit 1
+        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null)
+        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null)
+        if [ "$BIFROST_SKIP_WRITE_CHECK" = "1" ]; then
+            echo "Warning: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
+            echo "  BIFROST_SKIP_WRITE_CHECK=1 set; continuing without a writable APP_DIR."
+            echo "  Only safe for read-only deployments backed by external stores (e.g. Postgres)."
+        else
+            echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
+            echo "  Bifrost needs a writable APP_DIR for config.db and logs.db before startup."
+            echo "  On vanilla Kubernetes, set podSecurityContext.fsGroup (for example, 1000)."
+            echo "  On OpenShift (restricted-v2), leave fsGroup unset/null so the SCC assigns an in-range GID."
+            echo "  Or mount a volume writable by GID 0, matching the image's group-0 ownership."
+            echo "  Set BIFROST_SKIP_WRITE_CHECK=1 to bypass for read-only deployments with external stores."
+            exit 1
+        fi
     fi
 
     mkdir -p "$APP_DIR/logs" 2>/dev/null || true

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -3,43 +3,39 @@ set -e
 
 APP_DIR=${APP_DIR:-/app/data}
 
-# Function to fix permissions on mounted volumes
-fix_permissions() {
-    # Ensure runtime APP_DIR overrides exist before ownership checks
+# Ensure APP_DIR exists when possible, but do not require CAP_CHOWN at startup.
+ensure_app_dir() {
     mkdir -p "$APP_DIR" 2>/dev/null || true
 
-    # Check if APP_DIR exists and fix ownership if needed
-    if [ -d "$APP_DIR" ]; then
-        # Get current user info
+    if [ ! -d "$APP_DIR" ]; then
+        return
+    fi
+
+    if [ ! -w "$APP_DIR" ]; then
         CURRENT_UID=$(id -u)
         CURRENT_GID=$(id -g)
-        
-        # Get directory ownership
         DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
         DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
-        
-        # If ownership doesn't match current user, try to fix it
-        if [ "$DATA_UID" != "$CURRENT_UID" ] || [ "$DATA_GID" != "$CURRENT_GID" ]; then
+
+        if [ "$CURRENT_UID" = "0" ]; then
             echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
-            
-            # Try to change ownership (will work if running as root or if user has permission)
-            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null; then
+            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
                 echo "Successfully updated permissions on $APP_DIR"
             else
-                echo "Warning: Could not change ownership of $APP_DIR. You may need to run:"
-                echo "  docker run --user \$(id -u):\$(id -g) ..."
-                echo "  or ensure the host directory is owned by UID:GID $CURRENT_UID:$CURRENT_GID"
+                echo "Warning: Could not update permissions on $APP_DIR"
             fi
+        else
+            echo "Warning: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID"
+            echo "  Ensure the directory is owned by this UID or group-writable for a supplemental group such as 0"
         fi
-        
-        # Ensure logs subdirectory exists with correct permissions
-        mkdir -p "$APP_DIR/logs"
-        chmod 755 "$APP_DIR/logs" 2>/dev/null || true
     fi
+
+    mkdir -p "$APP_DIR/logs" 2>/dev/null || true
+    chmod g+rwX "$APP_DIR/logs" 2>/dev/null || true
 }
 
-# Fix permissions before starting the application
-fix_permissions
+# Prepare the app directory before starting the application
+ensure_app_dir
 
 # Parse command line arguments and set environment variables
 parse_args() {

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -46,7 +46,7 @@ ensure_app_dir() {
         DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
         echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
         echo "  Bifrost needs a writable APP_DIR for config.db and logs.db before startup."
-        echo "  On OpenShift/Kubernetes with a PVC, set securityContext.fsGroup (for example, 0)"
+        echo "  On OpenShift/Kubernetes with a PVC, set podSecurityContext.fsGroup (for example, 0)"
         echo "  or mount a volume writable by GID 0, matching the image's group-0 ownership."
         exit 1
     fi

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -3,12 +3,28 @@ set -e
 
 APP_DIR=${APP_DIR:-/app/data}
 
+app_dir_writable() {
+    PROBE_DIR="$APP_DIR/.bifrost-write-test.$$"
+    if [ -e "$PROBE_DIR" ]; then
+        PROBE_DIR="$PROBE_DIR.$(date +%s)"
+    fi
+
+    if mkdir "$PROBE_DIR" 2>/dev/null; then
+        rmdir "$PROBE_DIR" 2>/dev/null || true
+        return 0
+    fi
+
+    return 1
+}
+
 # Ensure APP_DIR exists when possible, but do not require CAP_CHOWN at startup.
 ensure_app_dir() {
     mkdir -p "$APP_DIR" 2>/dev/null || true
 
     if [ ! -d "$APP_DIR" ]; then
-        return
+        echo "Error: Could not create APP_DIR at $APP_DIR"
+        echo "  Ensure the path exists or the parent directory is writable by the container user."
+        exit 1
     fi
 
     CURRENT_UID=$(id -u)
@@ -16,24 +32,22 @@ ensure_app_dir() {
     DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
     DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
 
-    if [ "$CURRENT_UID" = "0" ]; then
-        # Running as root, `test -w` always succeeds (the kernel bypasses DAC),
-        # so gate the repair on ownership instead: chown whenever the directory
-        # is not already owned by our UID.
-        if [ "$DATA_UID" != "$CURRENT_UID" ]; then
-            echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
-            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
-                echo "Successfully updated permissions on $APP_DIR"
-            else
-                echo "Warning: Could not update permissions on $APP_DIR"
-            fi
+    if [ "$CURRENT_UID" = "0" ] && [ "$DATA_UID:$DATA_GID" != "$CURRENT_UID:$CURRENT_GID" ]; then
+        echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
+        if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null && chmod -R g=rwX "$APP_DIR" 2>/dev/null; then
+            echo "Successfully updated permissions on $APP_DIR"
+        else
+            echo "Warning: Could not update permissions on $APP_DIR"
         fi
-    elif [ ! -w "$APP_DIR" ]; then
-        # Non-root without CAP_CHOWN cannot repair ownership. Fail fast with
-        # actionable guidance rather than crashing later while writing config.db.
+    fi
+
+    if ! app_dir_writable; then
+        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
+        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
         echo "Error: $APP_DIR is not writable by UID:GID $CURRENT_UID:$CURRENT_GID (owned by $DATA_UID:$DATA_GID)"
-        echo "  Ensure the directory is owned by this UID or group-writable for a supplemental group such as 0."
-        echo "  On Kubernetes, set podSecurityContext.fsGroup (e.g. 1000) so the volume is group-writable."
+        echo "  Bifrost needs a writable APP_DIR for config.db and logs.db before startup."
+        echo "  On OpenShift/Kubernetes with a PVC, set securityContext.fsGroup (for example, 0)"
+        echo "  or mount a volume writable by GID 0, matching the image's group-0 ownership."
         exit 1
     fi
 


### PR DESCRIPTION
## Problem

The Bifrost container image cannot start on OpenShift (or any platform using the `restricted-v2` SCC, which assigns a random high UID with supplemental group `0`). The entrypoint tries to `chown /app/data` at startup; without `CAP_CHOWN` that fails, and the server dies writing `config.db` into a directory still owned by `1000:1000`. The Helm chart additionally hardcodes `runAsUser: 1000` / `fsGroup: 1000`, forcing OpenShift users to create a custom SCC.

## Root cause

The image relies on runtime ownership mutation instead of the standard arbitrary-UID pattern (writable dirs owned by GID `0` and group-writable at build time).

## Fix

**Image** (`Dockerfile`, `Dockerfile.local`, `Dockerfile.redhat`):
- own `$APP_DIR` as `<appuser>:0` and `chmod -R g=rwX` at build time, so any assigned UID with group `0` can write;
- Red Hat image keeps `g=u` on `/app`/`/licenses` (binaries stay non-group-writable) and applies `g=rwX` only to `$APP_DIR`.

**Entrypoint** (`docker-entrypoint.sh`):
- skip permission repair entirely when `$APP_DIR` is already writable;
- attempt `chown`/`chmod` only when running as root (no `CAP_CHOWN` required otherwise);
- non-root, non-writable case logs an actionable warning instead of the misleading docker-specific one;
- keep `$APP_DIR/logs` group-writable instead of forcing `755`.

**Helm chart** (`values.yaml`):
- default `podSecurityContext` relaxed to `{}` and container `runAsUser: 1000` removed (keeps `runAsNonRoot: true` + dropped capabilities), matching what chart 2.1.19 already did for the bundled PostgreSQL. Users can still pin a UID explicitly.

**CI guard**: extended `validate-helm-templates.sh` to fail if default manifests reintroduce pinned `runAsUser`/`fsGroup` 1000.

## Testing

- `docker build --check` on all three Dockerfiles — clean.
- Docker smoke test simulating OpenShift: entrypoint run as UID `12345` GID `0` against a `1000:0` group-writable `/app/data` — `config.db` created successfully, no chown needed.
- `sh -n` on the entrypoint; `helm lint` clean; all 35 helm-template validations pass (including the new security-context check).

Fixes #4367
