### PR TITLE
fix: resolve semantic cache internal embedding keys like external requests

### DIFF
--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -609,7 +609,10 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	// rather than emit a broken point. cache_debug was already stamped above,
 	// so the miss stays observable.
 	if plugin.store.RequiresVectors() && len(embeddingToStore) == 0 {
-		plugin.logger.Warn("Skipping semantic cache write (namespace=%s, id=%s): store requires vectors but no embedding is available (embedding generation likely failed)", plugin.config.VectorStoreNamespace, storageID)
+		// PostLLMHook runs once per streaming chunk; warn only once per request.
+		if !isStream || isFinalChunk {
+			plugin.logger.Warn("Skipping semantic cache write (namespace=%s, id=%s): store requires vectors but no embedding is available (embedding generation likely failed)", plugin.config.VectorStoreNamespace, storageID)
+		}
 		return res, nil, nil
 	}
 

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -603,6 +603,16 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 		embeddingToStore = nil
 	}
 
+	// A store that requires vectors (Qdrant, Pinecone) rejects an empty-vector
+	// upsert ("Expected some vectors"). If embedding generation failed upstream
+	// (e.g. transient provider error, key resolution failure), skip the write
+	// rather than emit a broken point. cache_debug was already stamped above,
+	// so the miss stays observable.
+	if plugin.store.RequiresVectors() && len(embeddingToStore) == 0 {
+		plugin.logger.Warn("Skipping semantic cache write (namespace=%s, id=%s): store requires vectors but no embedding is available (embedding generation likely failed)", plugin.config.VectorStoreNamespace, storageID)
+		return res, nil, nil
+	}
+
 	plugin.writersWg.Add(1)
 	go func() {
 		defer plugin.writersWg.Done()

--- a/plugins/semanticcache/plugin_paths_test.go
+++ b/plugins/semanticcache/plugin_paths_test.go
@@ -562,3 +562,165 @@ func TestPreLLMHook_ConcurrentSameRequestID(t *testing.T) {
 		t.Fatal("expected cache state to exist after concurrent PreLLMHook")
 	}
 }
+
+// -----------------------------------------------------------------------------
+// Internal embedding request must not inherit the caller's key-routing state
+// (issue #4756). Otherwise governance/key-selection context resolved for the
+// caller's chat provider leaks into the embedding request and rejects every
+// embedding-provider key ("no keys found for provider").
+// -----------------------------------------------------------------------------
+
+// vectorRequiringStore is an observableStore that reports RequiresVectors()=true,
+// mirroring dedicated vector DBs (Qdrant, Pinecone) that reject empty-vector
+// upserts. All other behavior is inherited from observableStore.
+type vectorRequiringStore struct {
+	*observableStore
+}
+
+func (s *vectorRequiringStore) RequiresVectors() bool { return true }
+
+func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore())
+
+	var captured *schemas.BifrostContext
+	plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		captured = ctx
+		return &schemas.BifrostEmbeddingResponse{
+			Data: []schemas.EmbeddingData{{
+				Embedding: schemas.EmbeddingStruct{EmbeddingArray: []float64{0.1, 0.2, 0.3}},
+			}},
+		}, nil
+	})
+
+	// Simulate the caller's request context after governance resolved key
+	// routing for the CALLER's (chat) provider — none of these keys belong to
+	// the embedding provider.
+	ctx := scopedTestContext(t, "")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys, []string{"chat-provider-key-id"})
+	ctx.SetValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID, "chat-provider-key-id")
+	ctx.SetValue(schemas.BifrostContextKeyAPIKeyID, "chat-provider-key-id")
+
+	emb, _, err := plugin.generateEmbedding(ctx, "some text")
+	if err != nil {
+		t.Fatalf("generateEmbedding failed: %v", err)
+	}
+	if len(emb) == 0 {
+		t.Fatal("expected non-empty embedding")
+	}
+	if captured == nil {
+		t.Fatal("embedding executor was not invoked")
+	}
+
+	// The internal embedding context must not carry the caller's key-routing
+	// state, so key selection resolves against the embedding provider's own
+	// keys instead of rejecting them all.
+	for _, key := range []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyGovernanceIncludeOnlyKeys,
+		schemas.BifrostContextKeyRoutingPinnedAPIKeyID,
+		schemas.BifrostContextKeyAPIKeyID,
+	} {
+		if v := captured.Value(key); v != nil {
+			t.Fatalf("expected %q cleared on internal embedding context, got %v", key, v)
+		}
+	}
+
+	// SkipPluginPipeline must remain set — the internal embedding still bypasses
+	// the plugin pipeline; only the leaked key-routing state is cleared.
+	if skip, _ := captured.Value(schemas.BifrostContextKeySkipPluginPipeline).(bool); !skip {
+		t.Fatal("expected SkipPluginPipeline to remain set on internal embedding context")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// A failed embedding must not produce an empty-vector upsert on a store that
+// requires vectors (issue #4756: Qdrant "Expected some vectors").
+// -----------------------------------------------------------------------------
+
+func TestPostLLMHook_SkipsWriteWhenVectorRequiredButEmbeddingMissing(t *testing.T) {
+	base := newObservableStore()
+	plugin := newTestPlugin(t, &vectorRequiringStore{observableStore: base})
+	// Embedding executor fails, mirroring the "no keys found" resolution error
+	// that leaves state.Embeddings unset.
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return nil, &schemas.BifrostError{Error: &schemas.ErrorField{Message: "no keys found for provider"}}
+	})
+
+	ctx := CreateContextWithCacheKey(t, "")
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hello", 0.7, 50),
+	}
+	if _, sc, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	} else if sc != nil {
+		t.Fatalf("expected miss, got short-circuit %+v", sc)
+	}
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil {
+		t.Fatal("expected cache state to exist")
+	}
+	if len(state.Embeddings) != 0 {
+		t.Fatalf("expected no embedding after failed generation, got %v", state.Embeddings)
+	}
+
+	res := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{RequestType: schemas.ChatCompletionRequest},
+		},
+	}
+	if _, _, err := plugin.PostLLMHook(ctx, res, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+	plugin.WaitForPendingOperations()
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	if len(base.addIDs) != 0 {
+		t.Fatalf("expected zero cache writes when embedding is missing on a vector-requiring store, got %d", len(base.addIDs))
+	}
+}
+
+func TestPostLLMHook_WritesWhenVectorRequiredAndEmbeddingPresent(t *testing.T) {
+	base := newObservableStore()
+	plugin := newTestPlugin(t, &vectorRequiringStore{observableStore: base})
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data: []schemas.EmbeddingData{{
+				Embedding: schemas.EmbeddingStruct{EmbeddingArray: []float64{0.1, 0.2, 0.3}},
+			}},
+		}, nil
+	})
+
+	ctx := CreateContextWithCacheKey(t, "")
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hello", 0.7, 50),
+	}
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil || len(state.Embeddings) == 0 {
+		t.Fatalf("expected embedding populated after successful generation, got %+v", state)
+	}
+
+	res := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{RequestType: schemas.ChatCompletionRequest},
+		},
+	}
+	if _, _, err := plugin.PostLLMHook(ctx, res, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+	plugin.WaitForPendingOperations()
+
+	base.mu.Lock()
+	defer base.mu.Unlock()
+	if len(base.addIDs) != 1 {
+		t.Fatalf("expected one cache write when embedding is present, got %d", len(base.addIDs))
+	}
+}

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -146,6 +146,20 @@ func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string
 	// released back to its sync.Pool — see core/schemas.ReleasePluginScope.
 	defer embeddingCtx.Cancel()
 	embeddingCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+	// The embedding request targets the plugin's own configured embedding
+	// provider/model, not the caller's. Because it skips the plugin pipeline,
+	// governance never re-resolves key routing for the embedding provider — so
+	// any key-selection state inherited from the caller's request context
+	// (governance key allow-list, pinned/direct keys) would be applied against
+	// the wrong provider and reject every embedding key ("no keys found for
+	// provider"). Clear it so key selection resolves against the embedding
+	// provider exactly like a fresh external /v1/embeddings request.
+	embeddingCtx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
+	embeddingCtx.ClearValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID)
+	embeddingCtx.ClearValue(schemas.BifrostContextKeyAPIKeyID)
+	embeddingCtx.ClearValue(schemas.BifrostContextKeyAPIKeyName)
+	embeddingCtx.ClearValue(schemas.BifrostContextKeyDirectKey)
+	embeddingCtx.ClearValue(schemas.BifrostContextKeySkipKeySelection)
 	if plugin.embeddingRequestExecutor == nil {
 		return nil, 0, fmt.Errorf("embedding request executor is not configured")
 	}


### PR DESCRIPTION
## Problem

With `semantic_cache` enabled, cache-key embedding generation fails with `no keys found for provider: <emb-provider>` even though a direct `POST /v1/embeddings` against the same instance with the same provider/model succeeds. After the failure, the plugin can still attempt a vector-store write, which vector-requiring stores reject (`rpc error: ... Expected some vectors`).

## Root cause

The plugin's internal embedding request derives its context from the caller's (chat) request context, inheriting `BifrostContextKeyGovernanceIncludeOnlyKeys` — the key-ID allow-list governance resolved for the **caller's** provider/virtual key. Because the internal request sets `SkipPluginPipeline`, governance never re-resolves key routing for the embedding provider, so key selection applies the caller's allow-list against the embedding provider and filters out every key. A direct `/v1/embeddings` call works because it runs the pipeline fresh.

Secondary effect: when embedding generation fails, `PostLLMHook` still issues an upsert with no vector, which Qdrant/Pinecone reject.

## Fix

- `generateEmbedding` clears the caller's inherited key-routing state (`GovernanceIncludeOnlyKeys`, `RoutingPinnedAPIKeyID`, `APIKeyID`, `APIKeyName`, `DirectKey`, `SkipKeySelection`) on the internal embedding context, so key selection resolves against the plugin's configured embedding provider exactly like a fresh external `/v1/embeddings` request. `SkipPluginPipeline` remains set.
- `PostLLMHook` skips the cache write (with a warning) when the store requires vectors but no embedding is available. `cache_debug` telemetry is still stamped, so the miss stays observable.

## Testing

Added offline unit tests:
- `TestGenerateEmbedding_ClearsInheritedKeyRoutingState` — internal embedding context no longer carries caller key-routing state; `SkipPluginPipeline` stays set.
- `TestPostLLMHook_SkipsWriteWhenVectorRequiredButEmbeddingMissing` — no upsert when embedding generation failed on a vector-requiring store.
- `TestPostLLMHook_WritesWhenVectorRequiredAndEmbeddingPresent` — the guard doesn't over-skip.

`go build ./...`, `go vet ./...`, `go test -count=1 ./...` on `plugins/semanticcache` — all pass.

Fixes #4756
