### PR TITLE
fix: surface Gemini batch inline responses from response field, not dest

### DIFF
--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -346,34 +346,9 @@ func (provider *GeminiProvider) downloadBatchResultsFile(ctx context.Context, ke
 				Message: resultLine.Error.Message,
 			}
 		} else if resultLine.Response != nil {
-			// Convert the response to a map for the Body field
-			respBody := make(map[string]interface{})
-			if len(resultLine.Response.Candidates) > 0 {
-				candidate := resultLine.Response.Candidates[0]
-				if candidate.Content != nil && len(candidate.Content.Parts) > 0 {
-					var textParts []string
-					for _, part := range candidate.Content.Parts {
-						if part.Text != "" {
-							textParts = append(textParts, part.Text)
-						}
-					}
-					if len(textParts) > 0 {
-						respBody["text"] = strings.Join(textParts, "")
-					}
-				}
-				respBody["finish_reason"] = string(candidate.FinishReason)
-			}
-			if resultLine.Response.UsageMetadata != nil {
-				respBody["usage"] = map[string]interface{}{
-					"prompt_tokens":     resultLine.Response.UsageMetadata.PromptTokenCount,
-					"completion_tokens": resultLine.Response.UsageMetadata.CandidatesTokenCount,
-					"total_tokens":      resultLine.Response.UsageMetadata.TotalTokenCount,
-				}
-			}
-
 			resultItem.Response = &schemas.BatchResultResponse{
 				StatusCode: 200,
-				Body:       respBody,
+				Body:       geminiGenerateContentToBatchResultBody(resultLine.Response),
 			}
 		}
 
@@ -382,6 +357,83 @@ func (provider *GeminiProvider) downloadBatchResultsFile(ctx context.Context, ke
 	})
 
 	return results, parseResult.Errors, nil
+}
+
+// geminiBatchOutput extracts the batch output (a responses file name or inline responses)
+// from a Gemini batch job response. The generativelanguage REST API reports the output
+// under the Operation's top-level `response` field, mirrored in `metadata.output`; the
+// `dest` field is a client-SDK-only abstraction and is never present on the wire. The
+// top-level response is preferred, with metadata.output as a fallback.
+func geminiBatchOutput(resp *GeminiBatchJobResponse) (fileName string, inlined []GeminiInlinedResponse) {
+	if resp == nil {
+		return "", nil
+	}
+	if resp.Response != nil {
+		fileName = resp.Response.ResponsesFile
+		if resp.Response.InlinedResponses != nil {
+			inlined = resp.Response.InlinedResponses.InlinedResponses
+		}
+	}
+	if fileName == "" && len(inlined) == 0 && resp.Metadata != nil && resp.Metadata.Output != nil {
+		fileName = resp.Metadata.Output.ResponsesFile
+		if resp.Metadata.Output.InlinedResponses != nil {
+			inlined = resp.Metadata.Output.InlinedResponses.InlinedResponses
+		}
+	}
+	return fileName, inlined
+}
+
+// geminiGenerateContentToBatchResultBody flattens a Gemini GenerateContentResponse into
+// the compact result body shape shared by the inline and file-based batch result paths.
+func geminiGenerateContentToBatchResultBody(resp *GenerateContentResponse) map[string]interface{} {
+	body := make(map[string]interface{})
+	if len(resp.Candidates) > 0 {
+		candidate := resp.Candidates[0]
+		if candidate.Content != nil && len(candidate.Content.Parts) > 0 {
+			var textParts []string
+			for _, part := range candidate.Content.Parts {
+				if part.Text != "" {
+					textParts = append(textParts, part.Text)
+				}
+			}
+			if len(textParts) > 0 {
+				body["text"] = strings.Join(textParts, "")
+			}
+		}
+		body["finish_reason"] = string(candidate.FinishReason)
+	}
+	if resp.UsageMetadata != nil {
+		body["usage"] = map[string]interface{}{
+			"prompt_tokens":     resp.UsageMetadata.PromptTokenCount,
+			"completion_tokens": resp.UsageMetadata.CandidatesTokenCount,
+			"total_tokens":      resp.UsageMetadata.TotalTokenCount,
+		}
+	}
+	return body
+}
+
+// geminiInlineResponseToBatchResultItem converts a single Gemini inline batch response
+// into a Bifrost BatchResultItem. customIDFallback is used when the response carries no
+// metadata key.
+func geminiInlineResponseToBatchResultItem(inlineResp GeminiInlinedResponse, customIDFallback string) schemas.BatchResultItem {
+	customID := customIDFallback
+	if inlineResp.Metadata != nil && inlineResp.Metadata.Key != "" {
+		customID = inlineResp.Metadata.Key
+	}
+
+	resultItem := schemas.BatchResultItem{CustomID: customID}
+	if inlineResp.Error != nil {
+		resultItem.Error = &schemas.BatchResultError{
+			Code:    fmt.Sprintf("%d", inlineResp.Error.Code),
+			Message: inlineResp.Error.Message,
+		}
+	} else if inlineResp.Response != nil {
+		resultItem.Response = &schemas.BatchResultResponse{
+			StatusCode: 200,
+			Body:       geminiGenerateContentToBatchResultBody(inlineResp.Response),
+		}
+	}
+	return resultItem
 }
 
 // extractGeminiUsageMetadata extracts usage metadata (as ints) from Gemini response

--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -387,6 +387,9 @@ func geminiBatchOutput(resp *GeminiBatchJobResponse) (fileName string, inlined [
 // the compact result body shape shared by the inline and file-based batch result paths.
 func geminiGenerateContentToBatchResultBody(resp *GenerateContentResponse) map[string]interface{} {
 	body := make(map[string]interface{})
+	if resp == nil {
+		return body
+	}
 	if len(resp.Candidates) > 0 {
 		candidate := resp.Candidates[0]
 		if candidate.Content != nil && len(candidate.Content.Parts) > 0 {

--- a/core/providers/gemini/batchresults_test.go
+++ b/core/providers/gemini/batchresults_test.go
@@ -1,0 +1,195 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeminiBatchOutput locks in the fix for issue #3951: the generativelanguage batch
+// REST API reports output under the Operation's `response` field (mirrored in
+// `metadata.output`), never under `dest`. Inline responses are nested one level deep
+// (response.inlinedResponses.inlinedResponses). geminiBatchOutput must read the real
+// fields so completed results are no longer silently dropped.
+func TestGeminiBatchOutput(t *testing.T) {
+	t.Run("InlineUnderResponse", func(t *testing.T) {
+		raw := `{
+  "name": "batches/abc123",
+  "metadata": {
+    "@type": "type.googleapis.com/google.ai.generativelanguage.v1beta.GenerateContentBatch",
+    "name": "batches/abc123",
+    "state": "BATCH_STATE_SUCCEEDED",
+    "batchStats": {"requestCount": "2", "successfulRequestCount": "2", "pendingRequestCount": "0"}
+  },
+  "done": true,
+  "response": {
+    "@type": "type.googleapis.com/google.ai.generativelanguage.v1beta.GenerateContentBatchOutput",
+    "inlinedResponses": {
+      "inlinedResponses": [
+        {"metadata": {"key": "req-1"}, "response": {"candidates": [{"content": {"parts": [{"text": "4"}]}, "finishReason": "STOP"}], "usageMetadata": {"promptTokenCount": 5, "candidatesTokenCount": 1, "totalTokenCount": 6}}},
+        {"metadata": {"key": "req-2"}, "response": {"candidates": [{"content": {"parts": [{"text": "Paris"}]}, "finishReason": "STOP"}], "usageMetadata": {"promptTokenCount": 4, "candidatesTokenCount": 1, "totalTokenCount": 5}}}
+      ]
+    }
+  }
+}`
+		var resp GeminiBatchJobResponse
+		require.NoError(t, sonic.Unmarshal([]byte(raw), &resp))
+
+		fileName, inlined := geminiBatchOutput(&resp)
+		assert.Empty(t, fileName)
+		require.Len(t, inlined, 2)
+
+		require.NotNil(t, inlined[0].Metadata)
+		assert.Equal(t, "req-1", inlined[0].Metadata.Key)
+		require.NotNil(t, inlined[0].Response)
+		require.Len(t, inlined[0].Response.Candidates, 1)
+		require.NotNil(t, inlined[0].Response.Candidates[0].Content)
+		require.Len(t, inlined[0].Response.Candidates[0].Content.Parts, 1)
+		assert.Equal(t, "4", inlined[0].Response.Candidates[0].Content.Parts[0].Text)
+
+		require.NotNil(t, inlined[1].Metadata)
+		assert.Equal(t, "req-2", inlined[1].Metadata.Key)
+	})
+
+	t.Run("FileUnderResponse", func(t *testing.T) {
+		raw := `{
+  "name": "batches/file1",
+  "metadata": {"name": "batches/file1", "state": "BATCH_STATE_SUCCEEDED", "batchStats": {"requestCount": "10", "successfulRequestCount": "10", "pendingRequestCount": "0"}},
+  "done": true,
+  "response": {"@type": "type.googleapis.com/google.ai.generativelanguage.v1beta.GenerateContentBatchOutput", "responsesFile": "files/batch-out-1"}
+}`
+		var resp GeminiBatchJobResponse
+		require.NoError(t, sonic.Unmarshal([]byte(raw), &resp))
+
+		fileName, inlined := geminiBatchOutput(&resp)
+		assert.Equal(t, "files/batch-out-1", fileName)
+		assert.Empty(t, inlined)
+	})
+
+	t.Run("MetadataOutputFallback", func(t *testing.T) {
+		// No top-level response; output only present under metadata.output.
+		raw := `{
+  "name": "batches/meta1",
+  "metadata": {
+    "name": "batches/meta1",
+    "state": "BATCH_STATE_SUCCEEDED",
+    "batchStats": {"requestCount": "1", "successfulRequestCount": "1", "pendingRequestCount": "0"},
+    "output": {"inlinedResponses": {"inlinedResponses": [{"metadata": {"key": "only-1"}, "response": {"candidates": [{"content": {"parts": [{"text": "hey"}]}, "finishReason": "STOP"}]}}]}}
+  },
+  "done": true
+}`
+		var resp GeminiBatchJobResponse
+		require.NoError(t, sonic.Unmarshal([]byte(raw), &resp))
+
+		fileName, inlined := geminiBatchOutput(&resp)
+		assert.Empty(t, fileName)
+		require.Len(t, inlined, 1)
+		require.NotNil(t, inlined[0].Metadata)
+		assert.Equal(t, "only-1", inlined[0].Metadata.Key)
+	})
+
+	t.Run("IgnoresDestField", func(t *testing.T) {
+		// The legacy dest field must never be read: only response/metadata.output count.
+		resp := &GeminiBatchJobResponse{
+			Name: "batches/dest1",
+			Dest: &GeminiBatchDest{FileName: "files/should-be-ignored"},
+		}
+		fileName, inlined := geminiBatchOutput(resp)
+		assert.Empty(t, fileName)
+		assert.Empty(t, inlined)
+	})
+
+	t.Run("NilResponse", func(t *testing.T) {
+		fileName, inlined := geminiBatchOutput(nil)
+		assert.Empty(t, fileName)
+		assert.Empty(t, inlined)
+	})
+}
+
+// TestGeminiInlineResponseToBatchResultItem verifies the per-response conversion used by
+// the batch results path for inline batches.
+func TestGeminiInlineResponseToBatchResultItem(t *testing.T) {
+	t.Run("SuccessWithMetadataKey", func(t *testing.T) {
+		inline := GeminiInlinedResponse{
+			Metadata: &GeminiBatchMetadata{Key: "row-9"},
+			Response: &GenerateContentResponse{
+				Candidates: []*Candidate{{
+					Content:      &Content{Parts: []*Part{{Text: "hi"}}},
+					FinishReason: FinishReasonStop,
+				}},
+				UsageMetadata: &GenerateContentResponseUsageMetadata{
+					PromptTokenCount:     2,
+					CandidatesTokenCount: 3,
+					TotalTokenCount:      5,
+				},
+			},
+		}
+
+		item := geminiInlineResponseToBatchResultItem(inline, "request-0")
+		assert.Equal(t, "row-9", item.CustomID)
+		assert.Nil(t, item.Error)
+		require.NotNil(t, item.Response)
+		assert.Equal(t, 200, item.Response.StatusCode)
+		assert.Equal(t, "hi", item.Response.Body["text"])
+		assert.Equal(t, "STOP", item.Response.Body["finish_reason"])
+
+		usage, ok := item.Response.Body["usage"].(map[string]interface{})
+		require.True(t, ok)
+		assert.EqualValues(t, 2, usage["prompt_tokens"])
+		assert.EqualValues(t, 3, usage["completion_tokens"])
+		assert.EqualValues(t, 5, usage["total_tokens"])
+	})
+
+	t.Run("ErrorUsesFallbackID", func(t *testing.T) {
+		inline := GeminiInlinedResponse{
+			Error: &GeminiBatchErrorInfo{Code: 429, Message: "rate limited"},
+		}
+
+		item := geminiInlineResponseToBatchResultItem(inline, "request-3")
+		assert.Equal(t, "request-3", item.CustomID)
+		assert.Nil(t, item.Response)
+		require.NotNil(t, item.Error)
+		assert.Equal(t, "429", item.Error.Code)
+		assert.Equal(t, "rate limited", item.Error.Message)
+	})
+}
+
+// TestGeminiGenerateContentToBatchResultBody verifies the flattening of a Gemini
+// GenerateContentResponse into the compact batch result body shared by inline and
+// file-based result paths.
+func TestGeminiGenerateContentToBatchResultBody(t *testing.T) {
+	t.Run("TextAndUsage", func(t *testing.T) {
+		resp := &GenerateContentResponse{
+			Candidates: []*Candidate{{
+				Content:      &Content{Parts: []*Part{{Text: "foo"}, {Text: "bar"}}},
+				FinishReason: FinishReasonStop,
+			}},
+			UsageMetadata: &GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     1,
+				CandidatesTokenCount: 2,
+				TotalTokenCount:      3,
+			},
+		}
+
+		body := geminiGenerateContentToBatchResultBody(resp)
+		assert.Equal(t, "foobar", body["text"])
+		assert.Equal(t, "STOP", body["finish_reason"])
+		_, ok := body["usage"].(map[string]interface{})
+		assert.True(t, ok)
+	})
+
+	t.Run("NoUsageNoText", func(t *testing.T) {
+		resp := &GenerateContentResponse{
+			Candidates: []*Candidate{{FinishReason: FinishReasonMaxTokens}},
+		}
+
+		body := geminiGenerateContentToBatchResultBody(resp)
+		assert.Equal(t, "MAX_TOKENS", body["finish_reason"])
+		_, hasText := body["text"]
+		assert.False(t, hasText)
+		_, hasUsage := body["usage"]
+		assert.False(t, hasUsage)
+	})
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2629,8 +2629,9 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	failedCount := 0
 
 	// If results are already available (fast completion), count them
-	if geminiResp.Dest != nil && len(geminiResp.Dest.InlinedResponses) > 0 {
-		for _, inlineResp := range geminiResp.Dest.InlinedResponses {
+	outputFile, inlinedResponses := geminiBatchOutput(&geminiResp)
+	if len(inlinedResponses) > 0 {
+		for _, inlineResp := range inlinedResponses {
 			if inlineResp.Error != nil {
 				failedCount++
 			} else if inlineResp.Response != nil {
@@ -2645,9 +2646,9 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	status := ToBifrostBatchStatus(geminiResp.Metadata.State)
 
 	// If state is empty but we have results, it's completed
-	if geminiResp.Metadata.State == "" && geminiResp.Dest != nil && len(geminiResp.Dest.InlinedResponses) > 0 {
+	if geminiResp.Metadata.State == "" && len(inlinedResponses) > 0 {
 		status = schemas.BatchStatusCompleted
-		completedCount = len(geminiResp.Dest.InlinedResponses) - failedCount
+		completedCount = len(inlinedResponses) - failedCount
 	}
 
 	// Build response
@@ -2674,8 +2675,8 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	}
 
 	// Include output file ID if results are in a file
-	if geminiResp.Dest != nil && geminiResp.Dest.FileName != "" {
-		result.OutputFileID = &geminiResp.Dest.FileName
+	if outputFile != "" {
+		result.OutputFileID = &outputFile
 	}
 
 	return result, nil
@@ -2904,7 +2905,7 @@ func (provider *GeminiProvider) batchRetrieveByKey(ctx *schemas.BifrostContext, 
 		geminiResp.Metadata.State == GeminiBatchStateCancelled ||
 		geminiResp.Metadata.State == GeminiBatchStateExpired
 
-	return &schemas.BifrostBatchRetrieveResponse{
+	result := &schemas.BifrostBatchRetrieveResponse{
 		ID:            geminiResp.Metadata.Name,
 		Object:        "batch",
 		Status:        ToBifrostBatchStatus(geminiResp.Metadata.State),
@@ -2921,7 +2922,16 @@ func (provider *GeminiProvider) batchRetrieveByKey(ctx *schemas.BifrostContext, 
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency: latency.Milliseconds(),
 		},
-	}, nil
+	}
+
+	// Surface the output file id for file-based batches so callers can download the
+	// results via files.content. Inline batches carry no file; their responses are
+	// exposed through BatchResults instead.
+	if outputFile, _ := geminiBatchOutput(&geminiResp); outputFile != "" {
+		result.OutputFileID = &outputFile
+	}
+
+	return result, nil
 }
 
 // BatchRetrieve retrieves a specific batch job for Gemini, trying each key until successful.
@@ -3302,66 +3312,21 @@ func (provider *GeminiProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 	var results []schemas.BatchResultItem
 	var parseErrors []schemas.BatchError
 
-	if geminiResp.Dest != nil && geminiResp.Dest.FileName != "" {
+	outputFile, inlinedResponses := geminiBatchOutput(&geminiResp)
+	if outputFile != "" {
 		// File-based results: download and parse the results file
-		provider.logger.Debug("gemini batch results in file: " + geminiResp.Dest.FileName)
-		fileResults, fileParseErrors, bifrostErr := provider.downloadBatchResultsFile(ctx, key, geminiResp.Dest.FileName)
+		provider.logger.Debug("gemini batch results in file: " + outputFile)
+		fileResults, fileParseErrors, bifrostErr := provider.downloadBatchResultsFile(ctx, key, outputFile)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
 		results = fileResults
 		parseErrors = fileParseErrors
-	} else if geminiResp.Dest != nil && len(geminiResp.Dest.InlinedResponses) > 0 {
-		// Inline results: extract from inlinedResponses
-		results = make([]schemas.BatchResultItem, 0, len(geminiResp.Dest.InlinedResponses))
-		for i, inlineResp := range geminiResp.Dest.InlinedResponses {
-			customID := fmt.Sprintf("request-%d", i)
-			if inlineResp.Metadata != nil && inlineResp.Metadata.Key != "" {
-				customID = inlineResp.Metadata.Key
-			}
-
-			resultItem := schemas.BatchResultItem{
-				CustomID: customID,
-			}
-
-			if inlineResp.Error != nil {
-				resultItem.Error = &schemas.BatchResultError{
-					Code:    fmt.Sprintf("%d", inlineResp.Error.Code),
-					Message: inlineResp.Error.Message,
-				}
-			} else if inlineResp.Response != nil {
-				// Convert the response to a map for the Body field
-				respBody := make(map[string]interface{})
-				if len(inlineResp.Response.Candidates) > 0 {
-					candidate := inlineResp.Response.Candidates[0]
-					if candidate.Content != nil && len(candidate.Content.Parts) > 0 {
-						var textParts []string
-						for _, part := range candidate.Content.Parts {
-							if part.Text != "" {
-								textParts = append(textParts, part.Text)
-							}
-						}
-						if len(textParts) > 0 {
-							respBody["text"] = strings.Join(textParts, "")
-						}
-					}
-					respBody["finish_reason"] = string(candidate.FinishReason)
-				}
-				if inlineResp.Response.UsageMetadata != nil {
-					respBody["usage"] = map[string]interface{}{
-						"prompt_tokens":     inlineResp.Response.UsageMetadata.PromptTokenCount,
-						"completion_tokens": inlineResp.Response.UsageMetadata.CandidatesTokenCount,
-						"total_tokens":      inlineResp.Response.UsageMetadata.TotalTokenCount,
-					}
-				}
-
-				resultItem.Response = &schemas.BatchResultResponse{
-					StatusCode: 200,
-					Body:       respBody,
-				}
-			}
-
-			results = append(results, resultItem)
+	} else if len(inlinedResponses) > 0 {
+		// Inline results: extract from response.inlinedResponses
+		results = make([]schemas.BatchResultItem, 0, len(inlinedResponses))
+		for i, inlineResp := range inlinedResponses {
+			results = append(results, geminiInlineResponseToBatchResultItem(inlineResp, fmt.Sprintf("request-%d", i)))
 		}
 	}
 
@@ -3394,8 +3359,9 @@ func (provider *GeminiProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 }
 
 // BatchResults retrieves batch results for Gemini, trying each key until successful.
-// Results are extracted from dest.inlinedResponses for inline batches,
-// or downloaded from dest.fileName for file-based batches.
+// Results are extracted from the batch response's inline responses
+// (response.inlinedResponses) for inline batches, or downloaded from the responses
+// file (response.responsesFile) for file-based batches.
 func (provider *GeminiProvider) BatchResults(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.BatchResultsRequest); err != nil {
 		return nil, err

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -2261,7 +2261,8 @@ type GeminiBatchMetadataInputConfig struct {
 
 // GeminiBatchMetadataOutputConfig represents the output config in batch job metadata.
 type GeminiBatchMetadataOutputConfig struct {
-	ResponsesFile string `json:"responsesFile,omitempty"`
+	ResponsesFile    string                  `json:"responsesFile,omitempty"`
+	InlinedResponses *GeminiInlinedResponses `json:"inlinedResponses,omitempty"`
 }
 
 // GeminiBatchMetadata contains metadata for tracking batch requests.
@@ -2290,18 +2291,26 @@ type GeminiBatchJobResponse struct {
 	Response *GeminiBatchOutput    `json:"response,omitempty"`
 }
 
-// GeminiBatchOutput represents the output of a successful batch job.
+// GeminiBatchOutput represents the output of a successful batch job. It mirrors the
+// GenerateContentBatchOutput union returned under the Operation's response field
+// (and metadata.output): either a responses file or a set of inline responses.
 type GeminiBatchOutput struct {
-	Type          string `json:"@type,omitempty"`
-	ResponsesFile string `json:"responsesFile,omitempty"`
+	Type             string                  `json:"@type,omitempty"`
+	ResponsesFile    string                  `json:"responsesFile,omitempty"`
+	InlinedResponses *GeminiInlinedResponses `json:"inlinedResponses,omitempty"`
 }
 
-// GeminiBatchDest contains the destination/output of a batch job.
-// For inline requests, results are in InlinedResponses.
-// For file-based input, results are in a file referenced by FileName.
+// GeminiBatchDest is the client-SDK-facing output shape (dest.fileName) emitted when
+// converting a Bifrost batch response back to Gemini format. The raw REST API reports
+// output under the Operation's response / metadata.output fields, not dest.
 type GeminiBatchDest struct {
+	FileName string `json:"fileName,omitempty"`
+}
+
+// GeminiInlinedResponses wraps the array of inline batch responses. The REST API nests
+// the array one level deep: response.inlinedResponses.inlinedResponses[].
+type GeminiInlinedResponses struct {
 	InlinedResponses []GeminiInlinedResponse `json:"inlinedResponses,omitempty"`
-	FileName         string                  `json:"fileName,omitempty"`
 }
 
 // GeminiInlinedResponse represents a single response in the batch output.


### PR DESCRIPTION
## Problem

When a Gemini batch completes with **inline** results (small batches), Bifrost drops them: the OpenAI-compatible `GET /v1/batches/{id}` returns `output_file_id: null` and `GET /v1/batches/{id}/results` returns no payload — completed results are unreachable through the gateway.

## Root cause

Bifrost parsed batch output from `geminiResp.Dest.InlinedResponses` / `Dest.FileName` (JSON `dest.*`). But `dest` is the Google **client-SDK** abstraction — it is never present in the raw `generativelanguage` REST response. The real `GET /v1beta/batches/{id}` `Operation` reports output under `response.inlinedResponses.inlinedResponses[]` (inline, note the nested shape) or `response.responsesFile` (file), mirrored in `metadata.output.*`. Since `dest` was always nil on the wire, inline results were never extracted and `output_file_id` was never set on retrieve. `GeminiBatchOutput` also lacked an `inlinedResponses` field.

## Fix

- Add the correct output types: `GeminiInlinedResponses` (nested `inlinedResponses.inlinedResponses[]`), wired into `GeminiBatchOutput` and `GeminiBatchMetadataOutputConfig`.
- New `geminiBatchOutput()` reads the real `response.*` fields, falling back to `metadata.output.*`, and ignores `dest`.
- Route `BatchCreate`, `BatchRetrieve`, and `BatchResults` through it: `BatchResults` now returns inline responses; `BatchRetrieve` now populates `output_file_id` for file-based batches.
- Extracted the response-body flattening into a pure helper shared by the inline and file-based result paths (behavior-preserving for the file path).
- `GeminiBatchDest` keeps only `FileName`, used by the outbound Bifrost→Gemini conversion; its doc now states the REST reality.

Inline Gemini batches have no output file, so their results are retrieved via `GET /v1/batches/{id}/results` (the provider-agnostic Bifrost batch-results endpoint); file-based batches additionally expose `output_file_id`.

## Testing

- New offline unit tests (`batchresults_test.go`): inline extraction from real REST-shaped JSON (`response.inlinedResponses.inlinedResponses`), the `metadata.output` fallback, file extraction, a `dest`-is-ignored regression guard, and the shared converter helpers.
- `go build ./...`, `go vet ./providers/gemini/`, `go test -count=1 ./providers/gemini/` in `core/` — all pass.

Fixes #3951
