### PR TITLE
fix: always surface configured model aliases in ListModels regardless of key allowlist

### DIFF
--- a/core/providers/utils/models.go
+++ b/core/providers/utils/models.go
@@ -246,8 +246,10 @@ func (p *ListModelsPipeline) resolveModelID(modelID string) []aliasMatch {
 //  1. Resolve name — check alias VALUES for a match (uses MatchFns).
 //     If matched: resolvedName = alias KEY, aliasValue = provider ID.
 //     If not matched: resolvedName = original modelID, aliasValue = "".
-//  2. Allowlist check (only when allowlist is restricted, i.e. not wildcard):
-//     Skip if resolvedName is not in AllowedModels.
+//  2. Allowlist check (only for raw provider IDs under a restricted allowlist):
+//     Skip a raw candidate (aliasValue == "") if resolvedName is not in AllowedModels.
+//     Alias candidates (aliasValue != "") are always allowed — the allowlist filters
+//     the provider's own models, never the user's explicitly-configured aliases.
 //  3. Blacklist check (always):
 //     Skip if resolvedName is blacklisted. Blacklist takes precedence over everything.
 //  4. Return one FilterResult per passing candidate.
@@ -278,10 +280,13 @@ func (p *ListModelsPipeline) FilterModel(modelID string) []FilterResult {
 	for _, candidate := range candidates {
 		resolvedName := candidate.key
 
-		// Step 2: allowlist check.
-		// IsRestricted() is true for both an explicit list AND an empty list (deny-all).
-		// Only a wildcard allowlist marker bypasses this check (pass-through).
-		if !p.Unfiltered && p.AllowedModels.IsRestricted() {
+		// Step 2: allowlist check — applies only to raw provider model IDs.
+		// A configured alias (candidate.value != "") is always available and bypasses
+		// the allowlist: a restricted key allowlist filters the provider's own models,
+		// it must never hide the user's explicitly-configured aliases from the listing.
+		// IsRestricted() is true for both an explicit list AND an empty list (deny-all);
+		// only a wildcard allowlist marker bypasses this check (pass-through).
+		if !p.Unfiltered && candidate.value == "" && p.AllowedModels.IsRestricted() {
 			allowed := false
 			for _, entry := range p.AllowedModels {
 				if matches(resolvedName, entry, p.MatchFns) {
@@ -320,11 +325,11 @@ func (p *ListModelsPipeline) FilterModel(modelID string) []FilterResult {
 // returned by the provider's API response (or not matched during filtering).
 //
 // The `included` map tracks model IDs (lowercased) already added during the
-// filter pass, used to avoid duplicates.
+// filter pass; it is updated here so backfill never emits a duplicate entry.
 //
-// Two cases depending on whether the allowlist is restricted:
+// Two additive passes run:
 //
-// Case A — allowlist restricted (caller specified explicit model names):
+// Pass 1 — restricted allowlist (caller specified explicit model names):
 //
 //	Add each allowlist entry that is not yet in `included`, skip if blacklisted.
 //	If the entry has an alias mapping (aliases[entry] exists), set Alias to the
@@ -334,34 +339,30 @@ func (p *ListModelsPipeline) FilterModel(modelID string) []FilterResult {
 //	  "my-gpt4" not in included → add {ID:"openai/my-gpt4", Alias:"gpt-4-turbo"}
 //	  "gpt-3.5" not in included → add {ID:"openai/gpt-3.5"}
 //
-// Case B — allowlist wildcard (*) only:
+// Pass 2 — configured aliases (always):
 //
-//	We don't know all model names (no explicit list), so we only backfill entries
-//	that were explicitly configured via aliases and not yet matched from the API.
-//	Note: an empty allowlist is deny-all (IsRestricted()==true), not wildcard.
+//	Every configured alias not yet surfaced is added, regardless of the allowlist.
+//	Aliases are explicitly configured by the user, so a restricted allowlist (which
+//	only filters the provider's own models) must never drop them — this is what keeps
+//	aliases *added to* the listing rather than overwriting it.
 //
 //	Example: aliases={"my-gpt4":"gpt-4-turbo"}, "my-gpt4" not in included
 //	  → add {ID:"openai/my-gpt4", Alias:"gpt-4-turbo"}
 //
-// Blacklist always wins — nothing blacklisted is added in either case.
+// Blacklist always wins — nothing blacklisted is added in either pass.
+// Unfiltered listings skip backfill entirely (the raw API response is returned as-is).
 func (p *ListModelsPipeline) BackfillModels(included map[string]bool) []schemas.Model {
+	if p.Unfiltered {
+		return nil
+	}
+
 	var result []schemas.Model
 
-	if !p.Unfiltered && p.AllowedModels.IsRestricted() {
-		// Case A: backfill explicit allowlist entries not yet matched.
+	// Pass 1: backfill explicit allowlist entries not yet matched (restricted allowlist only).
+	if p.AllowedModels.IsRestricted() {
 		for _, entry := range p.AllowedModels {
-			if included[strings.ToLower(entry)] {
-				continue
-			}
-			// Blacklist check.
-			blacklisted := false
-			for _, bl := range p.BlacklistedModels {
-				if matches(entry, bl, p.MatchFns) {
-					blacklisted = true
-					break
-				}
-			}
-			if blacklisted {
+			key := strings.ToLower(entry)
+			if included[key] || p.isBlacklisted(entry) {
 				continue
 			}
 			m := schemas.Model{
@@ -376,34 +377,46 @@ func (p *ListModelsPipeline) BackfillModels(included map[string]bool) []schemas.
 				}
 			}
 			result = append(result, m)
+			included[key] = true
 		}
-		return result
 	}
 
-	// Case B: wildcard allowlist — backfill only explicitly configured aliases.
-	if !p.Unfiltered && len(p.Aliases) > 0 {
-		for aliasKey, alias := range p.Aliases {
-			if included[strings.ToLower(aliasKey)] {
-				continue
-			}
-			// Blacklist check.
-			blacklisted := false
-			for _, bl := range p.BlacklistedModels {
-				if matches(aliasKey, bl, p.MatchFns) {
-					blacklisted = true
-					break
-				}
-			}
-			if blacklisted {
-				continue
-			}
-			result = append(result, schemas.Model{
-				ID:    string(p.ProviderKey) + "/" + aliasKey,
-				Name:  schemas.Ptr(ToDisplayName(aliasKey)),
-				Alias: schemas.Ptr(alias.ModelID),
-			})
+	// Pass 2: always backfill configured aliases not yet surfaced. Sorted for
+	// deterministic ordering; blacklist still wins.
+	for _, aliasKey := range p.sortedAliasKeys() {
+		key := strings.ToLower(aliasKey)
+		if included[key] || p.isBlacklisted(aliasKey) {
+			continue
 		}
+		result = append(result, schemas.Model{
+			ID:    string(p.ProviderKey) + "/" + aliasKey,
+			Name:  schemas.Ptr(ToDisplayName(aliasKey)),
+			Alias: schemas.Ptr(p.Aliases[aliasKey].ModelID),
+		})
+		included[key] = true
 	}
 
 	return result
+}
+
+// isBlacklisted reports whether name matches any blacklist entry under the pipeline's MatchFns.
+func (p *ListModelsPipeline) isBlacklisted(name string) bool {
+	for _, bl := range p.BlacklistedModels {
+		if matches(name, bl, p.MatchFns) {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedAliasKeys returns the alias keys sorted case-insensitively for deterministic output.
+func (p *ListModelsPipeline) sortedAliasKeys() []string {
+	keys := make([]string, 0, len(p.Aliases))
+	for k := range p.Aliases {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
+	return keys
 }

--- a/core/providers/utils/models_test.go
+++ b/core/providers/utils/models_test.go
@@ -1,0 +1,156 @@
+package utils
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+// runListModelsPipeline mirrors the per-provider ToBifrostListModelsResponse driver
+// (see providers/openai/models.go): filter every API model, then backfill configured
+// entries not surfaced during filtering. It returns "id" / "id(alias=value)" strings.
+func runListModelsPipeline(p *ListModelsPipeline, apiIDs []string) []string {
+	if p.ShouldEarlyExit() {
+		return []string{}
+	}
+	included := make(map[string]bool)
+	out := make([]string, 0, len(apiIDs))
+	emit := func(resolvedID, aliasValue string) {
+		s := string(p.ProviderKey) + "/" + resolvedID
+		if aliasValue != "" {
+			s += "(alias=" + aliasValue + ")"
+		}
+		out = append(out, s)
+		included[strings.ToLower(resolvedID)] = true
+	}
+	for _, id := range apiIDs {
+		for _, r := range p.FilterModel(id) {
+			emit(r.ResolvedID, r.AliasValue)
+		}
+	}
+	for _, m := range p.BackfillModels(included) {
+		id := strings.TrimPrefix(m.ID, string(p.ProviderKey)+"/")
+		alias := ""
+		if m.Alias != nil {
+			alias = *m.Alias
+		}
+		if alias != "" {
+			out = append(out, string(p.ProviderKey)+"/"+id+"(alias="+alias+")")
+		} else {
+			out = append(out, string(p.ProviderKey)+"/"+id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func newTestPipeline(models schemas.WhiteList, blacklist schemas.BlackList, aliases schemas.KeyAliases) *ListModelsPipeline {
+	return &ListModelsPipeline{
+		AllowedModels:     models,
+		BlacklistedModels: blacklist,
+		Aliases:           aliases,
+		ProviderKey:       schemas.OpenAI,
+		MatchFns:          DefaultMatchFns(),
+	}
+}
+
+// TestListModels_WildcardWithAlias_AddsAliasKeepsModels is the baseline: an unrestricted
+// key lists every provider model AND the configured alias (alias is additive).
+func TestListModels_WildcardWithAlias_AddsAliasKeepsModels(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{"*"}, nil, schemas.KeyAliases{"best-model": {ModelID: "gpt-4o"}})
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4", "gpt-3.5-turbo"})
+	assert.Equal(t, []string{
+		"openai/best-model(alias=gpt-4o)",
+		"openai/gpt-3.5-turbo",
+		"openai/gpt-4",
+		"openai/gpt-4o",
+	}, got)
+}
+
+// TestListModels_RestrictedAllowlistKeepsConfiguredAlias is the #4170 regression: a key
+// whose allowlist restricts the provider's own models must still surface configured
+// aliases (previously the alias was dropped because its key was not in the allowlist).
+func TestListModels_RestrictedAllowlistKeepsConfiguredAlias(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{"gpt-4o"}, nil, schemas.KeyAliases{"my-alias": {ModelID: "gpt-4o"}})
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4", "gpt-3.5-turbo"})
+	// gpt-4o is allowlisted (kept); gpt-4/gpt-3.5 are filtered out; the alias is always surfaced.
+	assert.Equal(t, []string{
+		"openai/gpt-4o",
+		"openai/my-alias(alias=gpt-4o)",
+	}, got)
+}
+
+// TestListModels_EmptyAllowlistWithAliasSurfacesAlias: a deny-all allowlist filters every
+// provider model, but explicitly-configured aliases must still appear (previously empty).
+func TestListModels_EmptyAllowlistWithAliasSurfacesAlias(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{}, nil, schemas.KeyAliases{"best-model": {ModelID: "gpt-4o"}})
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4"})
+	assert.Equal(t, []string{"openai/best-model(alias=gpt-4o)"}, got)
+}
+
+// TestListModels_EmptyAllowlistNoAliasIsEmpty: deny-all with no aliases still returns nothing
+// (guards the early-exit path is unchanged).
+func TestListModels_EmptyAllowlistNoAliasIsEmpty(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{}, nil, nil)
+	assert.True(t, p.ShouldEarlyExit())
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4"})
+	assert.Empty(t, got)
+}
+
+// TestListModels_AliasBackfilledWhenTargetNotReturned: an alias whose target model is not in
+// the API response is still listed via backfill.
+func TestListModels_AliasBackfilledWhenTargetNotReturned(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{"*"}, nil, schemas.KeyAliases{"ft-alias": {ModelID: "ft:custom-model"}})
+	got := runListModelsPipeline(p, []string{"gpt-4o"})
+	assert.Equal(t, []string{
+		"openai/ft-alias(alias=ft:custom-model)",
+		"openai/gpt-4o",
+	}, got)
+}
+
+// TestListModels_BlacklistBlocksAlias: the blacklist still wins over an alias, whether the
+// alias is matched during filtering or backfilled.
+func TestListModels_BlacklistBlocksAlias(t *testing.T) {
+	p := newTestPipeline(
+		schemas.WhiteList{"*"},
+		schemas.BlackList{"blocked-alias"},
+		schemas.KeyAliases{"blocked-alias": {ModelID: "gpt-4o"}, "ok-alias": {ModelID: "gpt-4o"}},
+	)
+	got := runListModelsPipeline(p, []string{"gpt-4o"})
+	assert.Equal(t, []string{
+		"openai/gpt-4o",
+		"openai/ok-alias(alias=gpt-4o)",
+	}, got)
+}
+
+// TestListModels_NoDuplicateWhenAliasKeyAlsoAllowlisted: when a restricted allowlist contains
+// both a real model and an alias key that maps to it, no entry is duplicated.
+func TestListModels_NoDuplicateWhenAliasKeyAlsoAllowlisted(t *testing.T) {
+	p := newTestPipeline(
+		schemas.WhiteList{"best-model", "gpt-4o"},
+		nil,
+		schemas.KeyAliases{"best-model": {ModelID: "gpt-4o"}},
+	)
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4"})
+	assert.Equal(t, []string{
+		"openai/best-model(alias=gpt-4o)",
+		"openai/gpt-4o",
+	}, got)
+}
+
+// TestListModels_UnfilteredSkipsAllowlistAndBackfill: unfiltered listings skip allowlist
+// filtering and alias backfill, but still resolve aliases for models the API returned.
+func TestListModels_UnfilteredSkipsAllowlistAndBackfill(t *testing.T) {
+	p := newTestPipeline(schemas.WhiteList{"gpt-4o"}, nil, schemas.KeyAliases{"best-model": {ModelID: "gpt-4o"}})
+	p.Unfiltered = true
+	got := runListModelsPipeline(p, []string{"gpt-4o", "gpt-4"})
+	// gpt-4 is not filtered out (allowlist ignored); best-model resolves from gpt-4o; no backfill.
+	assert.Equal(t, []string{
+		"openai/best-model(alias=gpt-4o)",
+		"openai/gpt-4",
+		"openai/gpt-4o",
+	}, got)
+}


### PR DESCRIPTION
## Problem

Configuring provider model aliases breaks `GET /v1/models`: once aliases are configured, the listing stops being the provider's model list with aliases *added* and instead drops models and/or aliases depending on the key's `models` allowlist. Related: #3278 (aliases had to be double-specified in `models` to surface).

## Root cause

The shared ListModels pipeline (`core/providers/utils/models.go`) gated explicitly-configured aliases behind the key's `models` allowlist:

- `FilterModel` filtered *every* candidate — including alias-derived ones — against `AllowedModels`, so an alias whose name wasn't in the allowlist was dropped.
- `BackfillModels` only backfilled aliases in the wildcard (`["*"]`) case, so restricted or empty allowlists never surfaced them.

The allowlist is meant to restrict the provider's own models; it was also hiding the user's explicitly-configured aliases.

## Fix

- `FilterModel`: the allowlist check now applies only to raw provider model IDs. Alias-derived candidates bypass the allowlist (blacklist still wins), so a restricted allowlist never hides configured aliases; alias entries keep the provider's metadata when the target is in the API response.
- `BackfillModels`: two additive passes — restricted-allowlist entries as before (now marking `included` to prevent duplicates), then an unconditional pass backfilling every configured alias not yet surfaced (blacklist still wins, deterministic ordering). Unfiltered listings still skip backfill.

Aliases are now additive to the listing; allowlist filtering of the provider's own models, blacklist precedence, and default `["*"]` behavior are unchanged. Exported signatures unchanged.

## Testing

New offline unit tests (`models_test.go`) cover: wildcard+alias, restricted-allowlist keeps alias (the reported regression), empty-allowlist surfaces alias, empty-allowlist+no-alias stays empty, alias backfill when the target isn't in the API response, blacklist blocks alias, no duplicate when the alias name is also allowlisted, and unfiltered listings.

`go build ./...`, `go vet ./providers/utils/`, `go test -count=1 ./providers/utils/ ./providers/openai/ ./providers/gemini/` — all pass.

Fixes #4170
