### PR TITLE
fix: clear the stream close claim between attempts so streaming retries and fallbacks work

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6065,6 +6065,12 @@ func executeRequestWithRetries[T any](
 				checkedStream, drainDone, firstChunkErr := providerUtils.CheckFirstStreamChunkForError(ctx, streamChan)
 				if firstChunkErr != nil {
 					<-drainDone
+					// The dead stream's teardown (ReleaseStreamingResponse) claimed the
+					// connection_closed flag on the shared context. That claim is scoped
+					// to the response it released; clear it so the retry or fallback
+					// attempt that follows doesn't see its own fresh stream as already
+					// closed and fail every read with ErrStreamClosed.
+					ctx.ClearValue(schemas.BifrostContextKeyConnectionClosed)
 					bifrostError = firstChunkErr
 				} else {
 					result = any(checkedStream).(T)

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: clear the per-attempt stream close claim so streaming retries and fallbacks are not dead on arrival after an SSE-embedded provider error (closes #4788) [@fus3r](https://github.com/fus3r)
 - fix: emit reads-only `cached_tokens` in usage per the OpenAI spec so cache writes are not priced as cache reads (closes #4816) [@fus3r](https://github.com/fus3r)
 - fix: preserve Gemini file upload MIME types for GenAI file URI completions
 - fix: Gemini video reference fields map to instances [@vojthor](https://github.com/vojthor)

--- a/core/streamfallback_test.go
+++ b/core/streamfallback_test.go
@@ -1,0 +1,194 @@
+package bifrost
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// Regression tests for https://github.com/maximhq/bifrost/issues/4788.
+//
+// When a streaming attempt fails through an error embedded in an HTTP 200 SSE
+// stream (e.g. rate limits sent as SSE events), the provider goroutine exits
+// and its teardown claims the connection_closed flag on the request's shared
+// BifrostContext (ReleaseStreamingResponse). That claim is scoped to the
+// response it released, but the flag stayed set on the context, so the
+// idle-timeout reader of the next attempt's stream saw the context as already
+// closed and failed every read with "stream closed". Any streaming retry or
+// fallback that followed a first-chunk error was dead on arrival.
+
+// sseHandler serves the given payloads as one SSE data event each.
+func sseHandler(payloads ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		for _, p := range payloads {
+			fmt.Fprintf(w, "data: %s\n\n", p)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		if fl != nil {
+			fl.Flush()
+		}
+	}
+}
+
+// anthropicMessagesHandler serves a minimal valid Anthropic Messages API
+// stream that produces the text "hello".
+func anthropicMessagesHandler() http.HandlerFunc {
+	events := []struct{ typ, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude-3-5-haiku-20241022","usage":{"input_tokens":10,"output_tokens":1}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, _ := w.(http.Flusher)
+		for _, e := range events {
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", e.typ, e.data)
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+	}
+}
+
+// drainChatStream collects streamed content and any error chunks.
+func drainChatStream(ch chan *schemas.BifrostStreamChunk) (string, []string) {
+	var content strings.Builder
+	var errs []string
+	for chunk := range ch {
+		if chunk.BifrostError != nil && chunk.BifrostError.Error != nil {
+			errs = append(errs, chunk.BifrostError.Error.Message)
+			continue
+		}
+		if chunk.BifrostChatResponse == nil {
+			continue
+		}
+		for _, choice := range chunk.BifrostChatResponse.Choices {
+			if choice.ChatStreamResponseChoice != nil && choice.ChatStreamResponseChoice.Delta != nil && choice.ChatStreamResponseChoice.Delta.Content != nil {
+				content.WriteString(*choice.ChatStreamResponseChoice.Delta.Content)
+			}
+		}
+	}
+	return content.String(), errs
+}
+
+func newStreamTestClient(t *testing.T, account *MockAccount) *Bifrost {
+	t.Helper()
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("failed to initialize bifrost: %v", err)
+	}
+	t.Cleanup(client.Shutdown)
+	return client
+}
+
+func TestStreamFallbackAfterFirstChunkError(t *testing.T) {
+	primary := httptest.NewServer(sseHandler(`{"error":{"message":"rate limited","type":"rate_limit_error"}}`))
+	defer primary.Close()
+	var fallbackHits atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits.Add(1)
+		anthropicMessagesHandler()(w, r)
+	}))
+	defer fallback.Close()
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 1, primary.URL)
+	account.AddProviderWithBaseURL(schemas.Anthropic, 1, 1, fallback.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 0
+	account.configs[schemas.Anthropic].NetworkConfig.MaxRetries = 0
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
+		{ID: "primary-key", Value: *schemas.NewSecretVar("sk-primary"), Models: schemas.WhiteList{"*"}, Weight: 100},
+	})
+	account.SetKeysForProvider(schemas.Anthropic, []schemas.Key{
+		{ID: "fallback-key", Value: *schemas.NewSecretVar("sk-fallback"), Models: schemas.WhiteList{"*"}, Weight: 100},
+	})
+	client := newStreamTestClient(t, account)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(30*time.Second))
+	stream, bifrostErr := client.ChatCompletionStreamRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+		},
+		Fallbacks: []schemas.Fallback{{Provider: schemas.Anthropic, Model: "claude-3-5-haiku-20241022"}},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("fallback stream failed (fallback server hit %d time(s)): %s", fallbackHits.Load(), bifrostErr.Error.Message)
+	}
+	content, errs := drainChatStream(stream)
+	if got := fallbackHits.Load(); got != 1 {
+		t.Fatalf("fallback server hits = %d, want 1", got)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("fallback stream emitted error chunks: %v", errs)
+	}
+	if content != "hello" {
+		t.Fatalf("fallback stream content = %q, want %q", content, "hello")
+	}
+}
+
+func TestStreamRetryAfterFirstChunkError(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			sseHandler(`{"error":{"message":"rate limit exceeded, please retry","type":"rate_limit_error"}}`)(w, r)
+			return
+		}
+		sseHandler(
+			`{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"he"}}]}`,
+			`{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"llo"}}]}`,
+			`{"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}`,
+		)(w, r)
+	}))
+	defer server.Close()
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 1, server.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 1
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffInitial = time.Millisecond
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
+		{ID: "retry-key", Value: *schemas.NewSecretVar("sk-retry"), Models: schemas.WhiteList{"*"}, Weight: 100},
+	})
+	client := newStreamTestClient(t, account)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(30*time.Second))
+	stream, bifrostErr := client.ChatCompletionStreamRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("retried stream failed (server hit %d time(s)): %s", hits.Load(), bifrostErr.Error.Message)
+	}
+	content, errs := drainChatStream(stream)
+	if hits.Load() != 2 {
+		t.Fatalf("server hits = %d, want 2 (initial attempt plus one retry)", hits.Load())
+	}
+	if len(errs) > 0 {
+		t.Fatalf("retried stream emitted error chunks: %v", errs)
+	}
+	if content != "hello" {
+		t.Fatalf("retried stream content = %q, want %q", content, "hello")
+	}
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -331,6 +331,7 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyChangeRequestType)
 	ctx.ClearValue(schemas.BifrostContextKeyAttemptTrail)
 	ctx.ClearValue(schemas.BifrostContextKeyStreamEndIndicator)
+	ctx.ClearValue(schemas.BifrostContextKeyConnectionClosed)
 	ctx.ClearValue(schemas.BifrostContextKeySupportsAssistantPrefill)
 }
 


### PR DESCRIPTION
## Summary

Fixes #4788. Since v1.6.0, any streaming retry or fallback that follows a provider error embedded in an HTTP 200 SSE stream was dead on arrival: the new attempt's stream failed every read with `stream closed` before delivering a single chunk, and the request ultimately failed with the primary error. The reporter hit this with an OpenAI-compatible primary falling back to DeepSeek's Anthropic-compatible endpoint, but the bug is not specific to either provider.

When a stream dies through an SSE-embedded error, `CheckFirstStreamChunkForError` requalifies it as an attempt failure so retries and fallbacks can run. By then the dead stream's teardown has already run `ReleaseStreamingResponse`, which since #4678 claims the `connection_closed` flag on the request's shared context (an atomic guard against double-releasing the fasthttp body stream). That claim is scoped to the response it released, but the flag stayed set on the context. Nothing cleared it between attempts, so the idle-timeout reader of the next attempt's stream treated its own fresh stream as already closed and every read returned `stream closed`. On v1.5.16 the guard was read-only, which is why the same setup worked there.

## Changes

- `executeRequestWithRetries` clears `BifrostContextKeyConnectionClosed` when it requalifies a first-chunk error, right after the dead stream's teardown is known to be complete (`<-drainDone`). This covers both the in-loop retry and the fallback path, which re-enters `executeRequestWithRetries` per attempt. Clearing is race-free at that point: the drain only completes after the provider goroutine's deferred `ReleaseStreamingResponse`/`CloseStream` have run, and the cancellation watcher and idle timer are stopped before that.
- Regression tests in `core/streamfallback_test.go` cover both paths against local `httptest` servers: an OpenAI-compatible primary that returns HTTP 200 with an SSE error event, with an Anthropic fallback that streams normally, and a single-provider retry where the first attempt fails the same way. Both fail before the fix (the fallback test fails with the primary error after the fallback stream dies, the retry test fails with `Error reading stream: stream closed`) and pass with it.
- Changelog entry.

Cancellation semantics are unchanged: a genuinely cancelled request surfaces `RequestCancelled`, which neither retries nor falls back, and non-streaming requests never take this branch.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test . -run 'TestStreamFallbackAfterFirstChunkError|TestStreamRetryAfterFirstChunkError' -v
```

Both tests fail on `dev` without this change and pass with it. `go build ./...` passes and the package tests (`go test .`) are green, including under the race detector. The pre-existing `TestResponsesMessageToolCallArguments/real_tool_search_call_frames_from_openai` failure in `core/schemas` fails on `dev` without this change as well.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4788

## Security considerations

None. The flag only coordinates stream teardown ownership within a single request.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
