### PR TITLE
fix: sanitize error details on log update path, set MCP raw-storage flag, remove redundant error serialization

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2776,6 +2776,34 @@ func (bifrost *Bifrost) PassthroughStream(
 	return bifrost.handleStreamRequest(ctx, bifrostReq)
 }
 
+// ensureMCPRawStorageContext sets BifrostContextKeyShouldStoreRawInLogs for standalone MCP
+// tool executions so PostMCPHook consumers (e.g. the logging plugin) see an explicit value.
+// In-pipeline tool calls already carry the key from the LLM request path (see the effective
+// raw-storage computation in requestWorker), so an existing value is never overwritten. There is
+// no provider config on the standalone path, so the default is false and only the per-request
+// override is honored, mirroring the per-request half of the LLM pipeline's logic.
+//
+// Callers must only pass request-scoped contexts, never the shared instance context
+// (bifrost.ctx): SetValue mutates the receiver's value map, so writing here would stamp the
+// flag onto state shared by unrelated calls. Nil-ctx standalone executions therefore skip this
+// entirely — consumers treat a missing key as false, and the per-request override keys can
+// never be present on the instance context, so the outcome is identical.
+func ensureMCPRawStorageContext(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	if _, ok := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool); ok {
+		return
+	}
+	effectiveStore := false
+	if allowStorageOverride, _ := ctx.Value(schemas.BifrostContextKeyAllowPerRequestStorageOverride).(bool); allowStorageOverride {
+		if override, ok := ctx.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
+			effectiveStore = override
+		}
+	}
+	ctx.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
+}
+
 // ExecuteChatMCPTool executes an MCP tool call and returns the result as a chat message.
 // This is the main public API for manual MCP tool execution in Chat format. All the
 // real work — request pooling, plugin gate (PreMCPHook / PostMCPHook), short-circuit
@@ -2783,6 +2811,8 @@ func (bifrost *Bifrost) PassthroughStream(
 func (bifrost *Bifrost) ExecuteChatMCPTool(ctx *schemas.BifrostContext, toolCall *schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, *schemas.BifrostError) {
 	if ctx == nil {
 		ctx = bifrost.ctx
+	} else {
+		ensureMCPRawStorageContext(ctx)
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{
@@ -2799,6 +2829,8 @@ func (bifrost *Bifrost) ExecuteChatMCPTool(ctx *schemas.BifrostContext, toolCall
 func (bifrost *Bifrost) ExecuteResponsesMCPTool(ctx *schemas.BifrostContext, toolCall *schemas.ResponsesToolMessage) (*schemas.ResponsesMessage, *schemas.BifrostError) {
 	if ctx == nil {
 		ctx = bifrost.ctx
+	} else {
+		ensureMCPRawStorageContext(ctx)
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: set the raw-storage log flag on standalone MCP tool executions so logging hooks see an explicit value
 - fix: clear the per-attempt stream close claim so streaming retries and fallbacks are not dead on arrival after an SSE-embedded provider error (closes #4788) [@fus3r](https://github.com/fus3r)
 - fix: emit reads-only `cached_tokens` in usage per the OpenAI spec so cache writes are not priced as cache reads (closes #4816) [@fus3r](https://github.com/fus3r)
 - fix: preserve Gemini file upload MIME types for GenAI file URI completions

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,1 +1,2 @@
-[fix]: sanitize ErrorDetailsParsed so raw payloads honor disable_content_logging [@citrocat](https://github.com/citrocat)
+- fix: sanitize ErrorDetailsParsed so raw payloads honor disable_content_logging [@citrocat](https://github.com/citrocat)
+- fix: sanitize error details on the log update path and remove redundant immediate error serialization

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -108,41 +108,15 @@ func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logsto
 	}
 }
 
-// applyErrorDetailsToEntry stores the sanitized error on the entry. Both the
-// serialized string and the parsed struct must hold the sanitized copy:
-// logstore's SerializeFields re-serializes ErrorDetailsParsed on write (it
-// takes precedence over ErrorDetails), so an unsanitized parsed struct would
-// leak raw request/response payloads to the store even when content logging
-// is disabled. Serialization happens immediately since bifrostErr may be
-// released back to the pool before the async batch writer processes the entry.
-func applyErrorDetailsToEntry(entry *logstore.Log, bifrostErr *schemas.BifrostError, contentLoggingEnabled, shouldStoreRaw bool) {
-	if bifrostErr == nil {
-		return
-	}
-	sanitizedErr := sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
-	if data, err := sonic.Marshal(sanitizedErr); err == nil {
-		entry.ErrorDetails = string(data)
-	}
-	entry.ErrorDetailsParsed = sanitizedErr
-}
-
-// applyErrorDetailsToMCPEntry is the MCPToolLog counterpart of
-// applyErrorDetailsToEntry: same sanitize-once, serialize-immediately,
-// store-sanitized-copy-in-both-fields semantics.
-func applyErrorDetailsToMCPEntry(entry *logstore.MCPToolLog, bifrostErr *schemas.BifrostError, contentLoggingEnabled, shouldStoreRaw bool) {
-	if bifrostErr == nil {
-		return
-	}
-	sanitizedErr := sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
-	if data, err := sonic.Marshal(sanitizedErr); err == nil {
-		entry.ErrorDetails = string(data)
-	}
-	entry.ErrorDetailsParsed = sanitizedErr
-}
-
 // sanitizeErrorForLogging returns a shallow copy of err with ExtraFields.RawRequest and
 // RawResponse cleared when raw-byte persistence is disabled, preventing raw bytes from
-// leaking into entry.ErrorDetails via JSON serialization.
+// leaking into the store via JSON serialization.
+//
+// Every assignment to ErrorDetailsParsed (Log and MCPToolLog alike) must go through this
+// function: logstore's SerializeFields, which runs on every write path (BeforeCreate hook,
+// hybrid store, rdb batch writes), serializes ErrorDetailsParsed into the error_details
+// column and overwrites anything a caller put in ErrorDetails. Callers set only the
+// sanitized ErrorDetailsParsed and leave the string serialization to SerializeFields.
 func sanitizeErrorForLogging(err *schemas.BifrostError, contentLoggingEnabled, shouldStoreRaw bool) *schemas.BifrostError {
 	if err == nil {
 		return nil
@@ -953,7 +927,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 			applyResolvedAliasInfo(entry, resolvedKeyAlias)
-			applyErrorDetailsToEntry(entry, bifrostErr, contentLoggingEnabled, shouldStoreRaw)
+			entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
 			if nodeID, _ := p.clusterNodeID.Load().(string); nodeID != "" {
 				entry.ClusterNodeID = &nodeID
 			}
@@ -1087,7 +1061,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			tracer.CleanupStreamAccumulator(traceID)
 		}
 
-		applyErrorDetailsToEntry(entry, bifrostErr, contentLoggingEnabled, shouldStoreRaw)
+		entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
 		if shouldStoreRaw && contentLoggingEnabled {
 			if bifrostErr.ExtraFields.RawRequest != nil {
 				rawReqBytes, err := sonic.Marshal(bifrostErr.ExtraFields.RawRequest)
@@ -1128,7 +1102,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.Status = logStatusForError(bifrostErr)
 			entry.Stream = true
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
-			applyErrorDetailsToEntry(entry, bifrostErr, contentLoggingEnabled, shouldStoreRaw)
+			entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
 			// Backfill raw request/response on streaming-error path so cancellation/timeout
 			// log entries still carry raw payloads when content logging + raw storage are
 			// enabled. Mirrors the non-streaming Path A pattern at line 872. Prefer the
@@ -1171,7 +1145,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.Stream = true
 			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
 		}
-		if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
+		if entry.ErrorDetailsParsed != nil {
 			entry.Status = logStatusForError(entry.ErrorDetailsParsed)
 		}
 		// Backfill passthrough status_code from response (streaming path)
@@ -1207,7 +1181,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if bifrostErr != nil {
 		entry.Status = logStatusForError(bifrostErr)
 		applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
-		applyErrorDetailsToEntry(entry, bifrostErr, contentLoggingEnabled, shouldStoreRaw)
+		entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)
 		// Realtime turns that fail mid-stream still need their input transcript
 		// surfaced — backfill from bifrostErr.ExtraFields.RawRequest if present.
 		if requestType == schemas.RealtimeRequest {
@@ -1612,7 +1586,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 	if bifrostErr != nil {
 		entry.Status = "error"
 		shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
-		applyErrorDetailsToMCPEntry(entry, bifrostErr, p.contentLoggingEnabled(ctx), shouldStoreRaw)
+		entry.ErrorDetailsParsed = sanitizeErrorForLogging(bifrostErr, p.contentLoggingEnabled(ctx), shouldStoreRaw)
 	} else if resp != nil {
 		entry.Status = "success"
 		if p.contentLoggingEnabled(ctx) {

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -319,7 +319,8 @@ func (p *LoggerPlugin) updateLogEntry(
 	}
 
 	if data.ErrorDetails != nil {
-		tempEntry.ErrorDetailsParsed = data.ErrorDetails
+		shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
+		tempEntry.ErrorDetailsParsed = sanitizeErrorForLogging(data.ErrorDetails, contentLoggingEnabled, shouldStoreRaw)
 		needsSerialization = true
 	}
 
@@ -386,10 +387,7 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 	// Handle error case first
 	if streamResponse.Data.ErrorDetails != nil {
 		entry.Status = logStatusForError(streamResponse.Data.ErrorDetails)
-		// Serializes immediately to avoid use-after-free with pooled errors, and
-		// stores the sanitized copy in both fields (SerializeFields re-serializes
-		// ErrorDetailsParsed on write, so it must not hold raw payloads).
-		applyErrorDetailsToEntry(entry, streamResponse.Data.ErrorDetails, contentLoggingEnabled, shouldStoreRaw)
+		entry.ErrorDetailsParsed = sanitizeErrorForLogging(streamResponse.Data.ErrorDetails, contentLoggingEnabled, shouldStoreRaw)
 		latF := float64(streamResponse.Data.Latency)
 		entry.Latency = &latF
 	} else {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -419,17 +419,20 @@ func TestApplyStreamingOutputToEntryPreservesAccumulatorCancelledStatus(t *testi
 	if entry.Status != "cancelled" {
 		t.Fatalf("expected initial cancelled status, got %q", entry.Status)
 	}
-	if entry.ErrorDetails == "" {
-		t.Fatalf("expected serialized error details to be set")
-	}
 	if entry.ErrorDetailsParsed == nil {
 		t.Fatalf("expected parsed error details to be set")
+	}
+	if err := entry.SerializeFields(); err != nil {
+		t.Fatalf("SerializeFields() error: %v", err)
+	}
+	if entry.ErrorDetails == "" {
+		t.Fatalf("expected serialized error details after SerializeFields")
 	}
 
 	// Match the downstream Path B re-derivation in PostLLMHook. If
 	// ErrorDetailsParsed is missing, this collapses accumulator-originated
 	// cancellations back to "error".
-	if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
+	if entry.ErrorDetailsParsed != nil {
 		entry.Status = logStatusForError(entry.ErrorDetailsParsed)
 	}
 	if entry.Status != "cancelled" {

--- a/plugins/logging/sanitize_test.go
+++ b/plugins/logging/sanitize_test.go
@@ -1,8 +1,10 @@
 package logging
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
@@ -19,13 +21,13 @@ func errorWithRawPayloads() *schemas.BifrostError {
 	}
 }
 
-// Regression test: logstore's SerializeFields re-serializes ErrorDetailsParsed
-// on write, overwriting ErrorDetails. If the parsed field holds the
-// unsanitized error, raw request/response payloads reach the store even when
-// content logging is disabled.
-func TestApplyErrorDetailsToEntry_SanitizedSurvivesSerializeFields(t *testing.T) {
+// Regression test: logstore's SerializeFields serializes ErrorDetailsParsed
+// into ErrorDetails on write. If the parsed field holds the unsanitized error,
+// raw request/response payloads reach the store even when content logging is
+// disabled.
+func TestSanitizedErrorDetailsSurviveSerializeFields(t *testing.T) {
 	entry := &logstore.Log{ID: "req-1"}
-	applyErrorDetailsToEntry(entry, errorWithRawPayloads(), false, false)
+	entry.ErrorDetailsParsed = sanitizeErrorForLogging(errorWithRawPayloads(), false, false)
 
 	if entry.ErrorDetailsParsed == nil {
 		t.Fatal("ErrorDetailsParsed should be set")
@@ -50,9 +52,9 @@ func TestApplyErrorDetailsToEntry_SanitizedSurvivesSerializeFields(t *testing.T)
 
 // When content logging and raw storage are both enabled, raw payloads are
 // intentionally preserved.
-func TestApplyErrorDetailsToEntry_RawPreservedWhenEnabled(t *testing.T) {
+func TestRawErrorDetailsPreservedWhenEnabled(t *testing.T) {
 	entry := &logstore.Log{ID: "req-2"}
-	applyErrorDetailsToEntry(entry, errorWithRawPayloads(), true, true)
+	entry.ErrorDetailsParsed = sanitizeErrorForLogging(errorWithRawPayloads(), true, true)
 
 	if entry.ErrorDetailsParsed == nil {
 		t.Fatal("ErrorDetailsParsed should be set")
@@ -68,22 +70,25 @@ func TestApplyErrorDetailsToEntry_RawPreservedWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestApplyErrorDetailsToEntry_NilError(t *testing.T) {
+func TestSanitizeErrorForLoggingNilError(t *testing.T) {
 	entry := &logstore.Log{ID: "req-3"}
-	applyErrorDetailsToEntry(entry, nil, false, false)
+	entry.ErrorDetailsParsed = sanitizeErrorForLogging(nil, false, false)
 	if entry.ErrorDetailsParsed != nil {
 		t.Error("nil error should leave ErrorDetailsParsed nil")
+	}
+	if err := entry.SerializeFields(); err != nil {
+		t.Fatalf("SerializeFields() error: %v", err)
 	}
 	if entry.ErrorDetails != "" {
 		t.Error("nil error should leave ErrorDetails empty")
 	}
 }
 
-// MCPToolLog counterpart: same sanitization semantics, and ErrorDetails is
-// serialized immediately rather than deferred to the BeforeCreate hook.
-func TestApplyErrorDetailsToMCPEntry_SanitizedAndSerializedImmediately(t *testing.T) {
+// MCPToolLog counterpart: same sanitization semantics through its own
+// SerializeFields.
+func TestSanitizedMCPErrorDetailsSurviveSerializeFields(t *testing.T) {
 	entry := &logstore.MCPToolLog{ID: "mcp-1"}
-	applyErrorDetailsToMCPEntry(entry, errorWithRawPayloads(), false, false)
+	entry.ErrorDetailsParsed = sanitizeErrorForLogging(errorWithRawPayloads(), false, false)
 
 	if entry.ErrorDetailsParsed == nil {
 		t.Fatal("ErrorDetailsParsed should be set")
@@ -92,17 +97,53 @@ func TestApplyErrorDetailsToMCPEntry_SanitizedAndSerializedImmediately(t *testin
 		entry.ErrorDetailsParsed.ExtraFields.RawResponse != nil {
 		t.Error("ErrorDetailsParsed should not retain raw payloads when content logging is disabled")
 	}
-	if entry.ErrorDetails == "" {
-		t.Error("ErrorDetails should be serialized immediately, not deferred to BeforeCreate")
-	}
-	if strings.Contains(entry.ErrorDetails, "RAW_REQUEST_MARKER") {
-		t.Error("serialized ErrorDetails must not contain raw payloads when content logging is disabled")
-	}
-
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error: %v", err)
 	}
 	if strings.Contains(entry.ErrorDetails, "RAW_REQUEST_MARKER") {
-		t.Error("serialized ErrorDetails must not contain raw payloads after SerializeFields")
+		t.Error("serialized ErrorDetails must not contain raw payloads when content logging is disabled")
+	}
+	if !strings.Contains(entry.ErrorDetails, "provider rejected request") {
+		t.Error("serialized ErrorDetails should still contain the error message")
+	}
+}
+
+// Update-path regression: updateLogEntry must sanitize UpdateLogData.ErrorDetails
+// before SerializeFields copies it into the error_details column update.
+func TestUpdateLogEntrySanitizesErrorDetails(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:  store,
+		logger: testLogger{},
+	}
+
+	requestID := "req-err-update"
+	initial := &InitialLogData{
+		Object:   "chat_completion",
+		Provider: "openai",
+		Model:    "gpt-4o-mini",
+	}
+	if err := plugin.insertInitialLogEntry(context.Background(), requestID, "", time.Now().UTC(), 0, nil, initial); err != nil {
+		t.Fatalf("insertInitialLogEntry() error = %v", err)
+	}
+
+	update := &UpdateLogData{
+		Status:       "error",
+		ErrorDetails: errorWithRawPayloads(),
+	}
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, false); err != nil {
+		t.Fatalf("updateLogEntry() error = %v", err)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), requestID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if strings.Contains(logEntry.ErrorDetails, "RAW_REQUEST_MARKER") ||
+		strings.Contains(logEntry.ErrorDetails, "RAW_RESPONSE_MARKER") {
+		t.Errorf("stored error_details must not contain raw payloads when content logging is disabled, got %q", logEntry.ErrorDetails)
+	}
+	if !strings.Contains(logEntry.ErrorDetails, "provider rejected request") {
+		t.Errorf("stored error_details should still contain the error message, got %q", logEntry.ErrorDetails)
 	}
 }


### PR DESCRIPTION
## Summary

Two related logging correctness bugs are fixed: standalone MCP tool executions did not set the raw-storage context flag before calling `PostMCPHook`, so logging consumers received an uninitialized value; and the `updateLogEntry` path assigned `ErrorDetails` directly to `ErrorDetailsParsed` without sanitizing it first, allowing raw request/response payloads to reach the store even when content logging was disabled.

## Changes

- Added `ensureMCPRawStorageContext` which computes and sets `BifrostContextKeyShouldStoreRawInLogs` on the context before standalone MCP tool executions (`ExecuteChatMCPTool` / `ExecuteResponsesMCPTool`). In-pipeline tool calls already carry this key from the LLM request path, so an existing value is never overwritten. Because there is no provider config on the standalone path, only the per-request override is honored.
- Removed `applyErrorDetailsToEntry` and `applyErrorDetailsToMCPEntry`. Their immediate-serialization behavior was based on a now-incorrect assumption that `ErrorDetails` (the string field) takes precedence; `logstore.SerializeFields` actually serializes `ErrorDetailsParsed` and overwrites `ErrorDetails` on every write path. Callers now assign `sanitizeErrorForLogging(...)` directly to `ErrorDetailsParsed` and let `SerializeFields` handle serialization.
- `updateLogEntry` now passes `ErrorDetails` through `sanitizeErrorForLogging` before assigning it to `ErrorDetailsParsed`, closing the update-path leak.
- `applyStreamingOutputToEntry` follows the same pattern for streaming error entries.
- Status re-derivation in the streaming Path B now checks only `ErrorDetailsParsed != nil` instead of also checking the string field, which was redundant after the above change.
- Tests updated to reflect that `ErrorDetails` is populated by `SerializeFields` rather than immediately, and a new end-to-end test (`TestUpdateLogEntrySanitizesErrorDetails`) verifies the update-path sanitization against a real store.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/... ./plugins/logging/...
```

The new `TestUpdateLogEntrySanitizesErrorDetails` test inserts an initial log entry, applies an update carrying raw payloads with content logging disabled, and asserts that the stored `error_details` column contains neither `RAW_REQUEST_MARKER` nor `RAW_RESPONSE_MARKER` while still containing the error message.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Raw request and response payloads were leaking into the log store on two paths (standalone MCP executions and the `updateLogEntry` path) when `disable_content_logging` was set. Both leaks are now closed. No new secrets, auth surfaces, or PII handling is introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable