### PR TITLE
review skill updates

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: review
-description: Reviews a PR or diff with multi-angle finders and adversarial verification, then reports a findings table, a merge/no-merge recommendation, required followups, and offers to create a follow-up PR. Use when the user types /review [PR# | branch | path].
+name: review-pr
+description: Reviews a PR or diff with multi-angle finders and adversarial verification, then reports a findings table, a merge/no-merge recommendation, required followups, and offers to create a follow-up PR. Use when the user types /review-pr [PR# | branch | path].
 ---
 
 # PR Review (bifrost custom)


### PR DESCRIPTION
## Summary

Renames the Claude skill from `review` to `review-pr` to make the command name more explicit and descriptive about its purpose.

## Changes

- Renamed `.claude/skills/review/SKILL.md` to `.claude/skills/review-pr/SKILL.md`
- Updated the skill `name` field from `review` to `review-pr`
- Updated the skill `description` to reflect the new command invocation `/review-pr` instead of `/review`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Invoke the skill using the updated command name:

```sh
/review-pr [PR# | branch | path]
```

Verify the skill executes the PR review workflow as expected.

## Breaking changes

- [x] Yes
- [ ] No

The `/review` command will no longer work. Users must update their usage to `/review-pr`.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable