### PR TITLE
fix: tier costs evaluated via input tokens instead of total tokens

### DIFF
--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -386,7 +386,6 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		return 0
 	}
 
-	totalTokens := usage.TotalTokens
 	promptTokens := usage.PromptTokens
 	completionTokens := usage.CompletionTokens
 
@@ -402,11 +401,15 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		}
 	}
 
-	inputRate := tieredInputRate(pricing, totalTokens, tier)
-	outputRate := tieredOutputRate(pricing, totalTokens, tier)
-	cacheReadInputRate := tieredCacheReadInputTokenRate(pricing, totalTokens, tier)
-	cacheCreationInputRate := tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
-	cacheCreationInputAbove1hrInputRate := tieredCacheCreationInputAbove1hrTokenRate(pricing, totalTokens, tier)
+	// Long-context pricing tiers are selected by input context size. Once
+	// selected, the tier's input/cache/output rates apply to their respective
+	// billed token categories for the request.
+	tierTokens := promptTokens
+	inputRate := tieredInputRate(pricing, tierTokens, tier)
+	outputRate := tieredOutputRate(pricing, tierTokens, tier)
+	cacheReadInputRate := tieredCacheReadInputTokenRate(pricing, tierTokens, tier)
+	cacheCreationInputRate := tieredCacheCreationInputTokenRate(pricing, tierTokens, tier)
+	cacheCreationInputAbove1hrInputRate := tieredCacheCreationInputAbove1hrTokenRate(pricing, tierTokens, tier)
 
 	// Clamp cached token counts to avoid negative billing on malformed provider payloads
 	if cachedReadTokens > promptTokens {
@@ -483,7 +486,7 @@ func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *s
 	if usage == nil {
 		return 0
 	}
-	return float64(usage.PromptTokens) * tieredInputRate(pricing, usage.TotalTokens, tier)
+	return float64(usage.PromptTokens) * tieredInputRate(pricing, usage.PromptTokens, tier)
 }
 
 // computeRerankCost handles rerank requests.
@@ -491,8 +494,9 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 	if usage == nil {
 		return 0
 	}
-	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, usage.TotalTokens, tier)
-	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, usage.TotalTokens, tier)
+	tierTokens := usage.PromptTokens
+	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
+	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 
 	searchCost := 0.0
 	if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
@@ -511,7 +515,7 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // since TTS providers report their billable unit in that field.
 // Output falls back to per-second duration when no audio token rate is configured.
 func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: per-character rate takes precedence for TTS/audio models
 	inputCost := 0.0
@@ -519,14 +523,14 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 		if pricing.InputCostPerCharacter != nil {
 			inputCost = float64(audioTextInputChars) * *pricing.InputCostPerCharacter
 		} else {
-			inputCost = float64(audioTextInputChars) * tieredInputRate(pricing, totalTokens, tier)
+			inputCost = float64(audioTextInputChars) * tieredInputRate(pricing, tierTokens, tier)
 		}
 	} else if usage != nil && usage.PromptTokens > 0 {
-		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, totalTokens, tier)
+		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
 	}
 
 	// Output: audio tokens first, then per-second fallback
-	outputCost := computeAudioOutputCost(pricing, usage, audioSeconds, totalTokens, tier)
+	outputCost := computeAudioOutputCost(pricing, usage, audioSeconds, tierTokens, tier)
 
 	return inputCost + outputCost
 }
@@ -535,15 +539,15 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // Input is audio, output is text (CompletionTokens).
 // Input and output are calculated independently — tokens first, then per-second fallback.
 func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: audio tokens/details first, then per-second fallback
-	inputCost := computeAudioInputCost(pricing, usage, audioSeconds, audioTokenDetails, totalTokens, tier)
+	inputCost := computeAudioInputCost(pricing, usage, audioSeconds, audioTokenDetails, tierTokens, tier)
 
 	// Output: text tokens
 	outputCost := 0.0
 	if usage != nil && usage.CompletionTokens > 0 {
-		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, totalTokens, tier)
+		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 	}
 
 	return inputCost + outputCost
@@ -600,10 +604,10 @@ func computeImageCost(pricing *configstoreTables.TableModelPricing, imageUsage *
 		return 0
 	}
 
-	totalTokens := imageUsage.TotalTokens
+	tierTokens := imageInputTierTokens(imageUsage)
 	pixels := parseImagePixels(imageSize)
-	inputCost := computeImageInputCost(pricing, imageUsage, totalTokens, pixels, tier)
-	outputCost := computeImageOutputCost(pricing, imageUsage, totalTokens, pixels, imageQuality, tier)
+	inputCost := computeImageInputCost(pricing, imageUsage, tierTokens, pixels, tier)
+	outputCost := computeImageOutputCost(pricing, imageUsage, tierTokens, pixels, imageQuality, tier)
 
 	return inputCost + outputCost
 }
@@ -720,14 +724,14 @@ func computeImageOutputCost(pricing *configstoreTables.TableModelPricing, imageU
 // computeVideoCost handles video generation requests.
 // Input and output are calculated independently — tokens first, then per-second fallback.
 func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, videoSeconds *int, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: text prompt tokens first, then per-second fallback
 	inputCost := 0.0
 	if usage != nil && usage.PromptTokens > 0 {
-		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, totalTokens, tier)
+		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
 	} else if videoSeconds != nil && *videoSeconds > 0 {
-		if rate := tieredVideoInputPerSecondRate(pricing, totalTokens); rate > 0 {
+		if rate := tieredVideoInputPerSecondRate(pricing, tierTokens); rate > 0 {
 			inputCost = float64(*videoSeconds) * rate
 		}
 	}
@@ -735,7 +739,7 @@ func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schem
 	// Output: completion tokens first, then per-second fallback
 	outputCost := 0.0
 	if usage != nil && usage.CompletionTokens > 0 {
-		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, totalTokens, tier)
+		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 	} else if videoSeconds != nil && *videoSeconds > 0 {
 		if pricing.OutputCostPerVideoPerSecond != nil {
 			outputCost = float64(*videoSeconds) * *pricing.OutputCostPerVideoPerSecond
@@ -984,11 +988,42 @@ func tieredCacheCreationInputAbove1hrTokenRate(pricing *configstoreTables.TableM
 	return tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
 }
 
-func safeTotalTokens(usage *schemas.BifrostLLMUsage) int {
+func inputTierTokens(usage *schemas.BifrostLLMUsage) int {
 	if usage == nil {
 		return 0
 	}
-	return usage.TotalTokens
+	return usage.PromptTokens
+}
+
+func imageInputTierTokens(usage *schemas.ImageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.InputTokensDetails != nil {
+		return usage.InputTokensDetails.TextTokens + usage.InputTokensDetails.ImageTokens
+	}
+	if usage.InputTokens > 0 {
+		return usage.InputTokens
+	}
+
+	// Some older/provider-specific image adapters only report TotalTokens.
+	// Derive input from total-output when output is known, but do not treat a
+	// bare total as input: total includes generated output tokens.
+	outputTokens := imageOutputTokens(usage)
+	if usage.TotalTokens > outputTokens {
+		return usage.TotalTokens - outputTokens
+	}
+	return 0
+}
+
+func imageOutputTokens(usage *schemas.ImageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.OutputTokensDetails != nil {
+		return usage.OutputTokensDetails.TextTokens + usage.OutputTokensDetails.ImageTokens
+	}
+	return usage.OutputTokens
 }
 
 // parseImagePixels parses a size string like "1024x1024" into total pixel count.

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -395,9 +395,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *
 	p.CacheCreationInputTokenCostAbove1hrAbove200kTokens = bifrost.Ptr(0.000015)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000, // above 200k threshold
+		TotalTokens:      235000, // input is above 200k threshold
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -409,11 +409,11 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Input rate (>200k): 0.000006; output rate (>200k): 0.00003
-	// Input (non-cached): (180000-10000)*0.000006 = 170000*0.000006 = 1.02
+	// Input (non-cached): (210000-10000)*0.000006 = 200000*0.000006 = 1.20
 	// Cache creation 1hr above 200k: 10000*0.000015 = 0.15
 	// Output: 25000*0.00003 = 0.75
-	// Total: 1.02 + 0.15 + 0.75 = 1.92
-	assert.InDelta(t, 1.92, cost, 1e-9)
+	// Total: 1.20 + 0.15 + 0.75 = 2.10
+	assert.InDelta(t, 2.10, cost, 1e-9)
 }
 
 func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove200kRateAbsent(t *testing.T) {
@@ -429,9 +429,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove2
 	// CacheCreationInputTokenCostAbove1hrAbove200kTokens intentionally left nil
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000,
+		TotalTokens:      235000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -443,10 +443,10 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove2
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Cache creation 1hr (no above_200k_1hr rate, uses above_1hr): 10000*0.000009 = 0.09
-	// Input (non-cached): 170000*0.000006 = 1.02
+	// Input (non-cached): 200000*0.000006 = 1.20
 	// Output: 25000*0.00003 = 0.75
-	// Total: 1.02 + 0.09 + 0.75 = 1.86
-	assert.InDelta(t, 1.86, cost, 1e-9)
+	// Total: 1.20 + 0.09 + 0.75 = 2.04
+	assert.InDelta(t, 2.04, cost, 1e-9)
 }
 
 func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kWhenNo1hrRates(t *testing.T) {
@@ -460,9 +460,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kW
 	// Neither CacheCreationInputTokenCostAbove1hr nor Above1hrAbove200k is set
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000,
+		TotalTokens:      235000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -474,10 +474,10 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kW
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Cache creation (1hr → no 1hr rates → standard above_200k): 10000*0.000002 = 0.02
-	// Input (non-cached): 170000*0.0000016 = 0.272
+	// Input (non-cached): 200000*0.0000016 = 0.32
 	// Output: 25000*0.000008 = 0.2
-	// Total: 0.272 + 0.02 + 0.2 = 0.492
-	assert.InDelta(t, 0.492, cost, 1e-9)
+	// Total: 0.32 + 0.02 + 0.2 = 0.54
+	assert.InDelta(t, 0.54, cost, 1e-9)
 }
 
 func TestComputeTextCost_Tiered200k(t *testing.T) {
@@ -487,16 +487,16 @@ func TestComputeTextCost_Tiered200k(t *testing.T) {
 	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 30000,
-		TotalTokens:      210000, // Above 200k threshold
+		TotalTokens:      240000, // input is above 200k threshold
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses tiered rate since total > 200k
-	// 180000 * 0.000006 + 30000 * 0.00003 = 1.08 + 0.90 = 1.98
-	assert.InDelta(t, 1.98, cost, 1e-9)
+	// Uses tiered rate since input > 200k
+	// 210000 * 0.000006 + 30000 * 0.00003 = 1.26 + 0.90 = 2.16
+	assert.InDelta(t, 2.16, cost, 1e-9)
 }
 
 func TestComputeTextCost_Below200kUsesBaseRate(t *testing.T) {
@@ -512,9 +512,27 @@ func TestComputeTextCost_Below200kUsesBaseRate(t *testing.T) {
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses base rate since total < 200k
+	// Uses base rate since input < 200k
 	// 1000 * 0.000003 + 500 * 0.000015 = 0.003 + 0.0075 = 0.0105
 	assert.InDelta(t, 0.0105, cost, 1e-12)
+}
+
+func TestComputeTextCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000, // total is above 200k, input is not
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Uses base rates because long-context tiers are selected by input tokens.
+	// 180000 * 0.000003 + 30000 * 0.000015 = 0.54 + 0.45 = 0.99
+	assert.InDelta(t, 0.99, cost, 1e-9)
 }
 
 func TestComputeTextCost_Tiered272k(t *testing.T) {
@@ -525,16 +543,16 @@ func TestComputeTextCost_Tiered272k(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k threshold
+		TotalTokens:      310000, // input is above 272k threshold
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses 272k tiered rate since total > 272k
-	// 250000 * 0.000009 + 30000 * 0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// Uses 272k tiered rate since input > 272k
+	// 280000 * 0.000009 + 30000 * 0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestComputeTextCost_Between200kAnd272kUses200kRate(t *testing.T) {
@@ -545,16 +563,16 @@ func TestComputeTextCost_Between200kAnd272kUses200kRate(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     200000,
+		PromptTokens:     230000,
 		CompletionTokens: 30000,
-		TotalTokens:      230000, // Between 200k and 272k
+		TotalTokens:      260000, // input is between 200k and 272k
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses 200k tiered rate since total > 200k but <= 272k
-	// 200000 * 0.000006 + 30000 * 0.00003 = 1.20 + 0.90 = 2.10
-	assert.InDelta(t, 2.10, cost, 1e-9)
+	// Uses 200k tiered rate since input > 200k but <= 272k
+	// 230000 * 0.000006 + 30000 * 0.00003 = 1.38 + 0.90 = 2.28
+	assert.InDelta(t, 2.28, cost, 1e-9)
 }
 
 func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
@@ -565,9 +583,9 @@ func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
 	p.CacheReadInputTokenCostAbove272kTokens = new(0.0000009)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k
+		TotalTokens:      310000, // input is above 272k
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedReadTokens: 50000,
 		},
@@ -575,11 +593,11 @@ func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Non-cached input: (250000-50000) * 0.000009 = 200000 * 0.000009 = 1.80
+	// Non-cached input: (280000-50000) * 0.000009 = 230000 * 0.000009 = 2.07
 	// Cached read: 50000 * 0.0000009 = 0.045
 	// Output: 30000 * 0.000045 = 1.35
-	// Total: 1.80 + 0.045 + 1.35 = 3.195
-	assert.InDelta(t, 3.195, cost, 1e-9)
+	// Total: 2.07 + 0.045 + 1.35 = 3.465
+	assert.InDelta(t, 3.465, cost, 1e-9)
 }
 
 func TestComputeTextCost_SearchQueryCost(t *testing.T) {
@@ -643,6 +661,21 @@ func TestComputeEmbeddingCost_Basic(t *testing.T) {
 	assert.InDelta(t, 0.0005, cost, 1e-12)
 }
 
+func TestComputeEmbeddingCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		InputCostPerToken:                bifrost.Ptr(0.000003),
+		InputCostPerTokenAbove200kTokens: bifrost.Ptr(0.000006),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 180000,
+		TotalTokens:  210000,
+	}
+
+	cost := computeEmbeddingCost(&p, usage, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003, cost, 1e-9)
+}
+
 func TestComputeEmbeddingCost_NilUsage(t *testing.T) {
 	p := configstoreTables.TableModelPricing{InputCostPerToken: new(0.0000001)}
 	assert.Equal(t, 0.0, computeEmbeddingCost(&p, nil, serviceTier{}))
@@ -665,6 +698,21 @@ func TestComputeRerankCost_Basic(t *testing.T) {
 	cost := computeRerankCost(&p, usage, serviceTier{})
 	// 2000*0.000001 + 100*0.000002 = 0.002 + 0.0002 = 0.0022
 	assert.InDelta(t, 0.0022, cost, 1e-12)
+}
+
+func TestComputeRerankCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeRerankCost(&p, usage, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeRerankCost_WithSearchCost(t *testing.T) {
@@ -760,6 +808,21 @@ func TestComputeSpeechCost_TokenFallback(t *testing.T) {
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
 
+func TestComputeSpeechCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
+}
+
 func TestComputeSpeechCost_NilUsageNilSeconds(t *testing.T) {
 	p := chatPricing(0.000005, 0.000015)
 	assert.Equal(t, 0.0, computeSpeechCost(&p, nil, nil, 0, serviceTier{}))
@@ -815,6 +878,21 @@ func TestComputeTranscriptionCost_TokenFallback(t *testing.T) {
 	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
 	// 1000*0.000005 + 200*0.000015 = 0.005 + 0.003 = 0.008
 	assert.InDelta(t, 0.008, cost, 1e-12)
+}
+
+func TestComputeTranscriptionCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeTranscriptionCost_TokenDetailsPreferredOverDuration(t *testing.T) {
@@ -901,6 +979,47 @@ func TestComputeImageCost_TokenBased(t *testing.T) {
 	cost := computeImageCost(&p, usage, "", "", serviceTier{})
 	// 1000*0.000005 + 500*0.000015 = 0.005 + 0.0075 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
+func TestComputeImageCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		InputTokens:  180000,
+		OutputTokens: 30000,
+		TotalTokens:  210000,
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
+}
+
+func TestComputeImageCost_DerivesTierTokensFromTotalMinusOutputWhenInputMissing(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		OutputTokens: 30000,
+		TotalTokens:  240000, // derived input = 210000, so output uses long-context rate
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 30000*0.00003, cost, 1e-9)
+}
+
+func TestComputeImageCost_DoesNotUseBareTotalTokensAsInputTierTokens(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.OutputCostPerImage = bifrost.Ptr(0.05)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		TotalTokens: 210000, // no input/output split; total includes output, so do not use it as input
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 0.05, cost, 1e-9)
 }
 
 func TestComputeImageCost_TokenBasedWithDetails(t *testing.T) {
@@ -1069,6 +1188,21 @@ func TestComputeVideoCost_DurationBased(t *testing.T) {
 	// Input:  500 * 0.000001 = 0.0005
 	// Total:  0.0305
 	assert.InDelta(t, 0.0305, cost, 1e-12)
+}
+
+func TestComputeVideoCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeVideoCost(&p, usage, nil, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeVideoCost_OutputCostPerSecondFallback(t *testing.T) {
@@ -1832,15 +1966,15 @@ func TestCalculateCost_200kTier_EndToEnd(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Bedrock, "anthropic.claude-3-5-sonnet-20240620-v1:0", &schemas.BifrostLLMUsage{
-		PromptTokens:     190000,
+		PromptTokens:     210000,
 		CompletionTokens: 20000,
-		TotalTokens:      210000, // Above 200k
+		TotalTokens:      230000, // input is above 200k
 	})
 
 	cost := s.CalculateCost(resp, nil)
 	// Tiered rate: input=0.000006, output=0.00003
-	// 190000*0.000006 + 20000*0.00003 = 1.14 + 0.6 = 1.74
-	assert.InDelta(t, 1.74, cost, 1e-9)
+	// 210000*0.000006 + 20000*0.00003 = 1.26 + 0.6 = 1.86
+	assert.InDelta(t, 1.86, cost, 1e-9)
 }
 
 func TestCalculateCost_272kTier_EndToEnd(t *testing.T) {
@@ -1862,15 +1996,15 @@ func TestCalculateCost_272kTier_EndToEnd(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Anthropic, "claude-3-7-sonnet", &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k
+		TotalTokens:      310000, // input is above 272k
 	})
 
 	cost := s.CalculateCost(resp, nil)
 	// Tiered rate: input=0.000009, output=0.000045
-	// 250000*0.000009 + 30000*0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// 280000*0.000009 + 30000*0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestCalculateCost_272kTier_CacheReadFallbackChain(t *testing.T) {
@@ -1891,20 +2025,20 @@ func TestCalculateCost_272kTier_CacheReadFallbackChain(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Anthropic, "claude-3-7-sonnet", &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedReadTokens: 50000,
 		},
 	})
 
 	cost := s.CalculateCost(resp, nil)
-	// Non-cached input: (250000-50000) * 0.000009 = 200000 * 0.000009 = 1.80
+	// Non-cached input: (280000-50000) * 0.000009 = 230000 * 0.000009 = 2.07
 	// Cached read (272k rate): 50000 * 0.0000009 = 0.045
 	// Output: 30000 * 0.000045 = 1.35
-	// Total: 1.80 + 0.045 + 1.35 = 3.195
-	assert.InDelta(t, 3.195, cost, 1e-9)
+	// Total: 2.07 + 0.045 + 1.35 = 3.465
+	assert.InDelta(t, 3.465, cost, 1e-9)
 }
 
 // =========================================================================
@@ -1955,15 +2089,15 @@ func TestComputeTextCost_Priority272kTier(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokensPriority = new(0.00006)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
 
-	// Uses 272k priority rates: 250000*0.000012 + 30000*0.00006 = 3.00 + 1.80 = 4.80
-	assert.InDelta(t, 4.80, cost, 1e-9)
+	// Uses 272k priority rates: 280000*0.000012 + 30000*0.00006 = 3.36 + 1.80 = 5.16
+	assert.InDelta(t, 5.16, cost, 1e-9)
 }
 
 func TestComputeTextCost_Priority272kTierFallsBackToNonPriority272k(t *testing.T) {
@@ -1973,15 +2107,15 @@ func TestComputeTextCost_Priority272kTierFallsBackToNonPriority272k(t *testing.T
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
 
-	// Falls back to non-priority 272k rate: 250000*0.000009 + 30000*0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// Falls back to non-priority 272k rate: 280000*0.000009 + 30000*0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestComputeTextCost_PriorityCacheReadRate(t *testing.T) {


### PR DESCRIPTION
## Summary

Long-context pricing tiers were being selected using `TotalTokens` (input + output combined) rather than `PromptTokens` (input only). This caused incorrect tier selection for requests where the input context alone did not cross a threshold but the combined token count did, and vice versa. Pricing tiers for long-context models are defined by input context size, so tier selection should be driven exclusively by prompt/input tokens.

## Changes

- Replaced all uses of `TotalTokens` for tier selection with `PromptTokens` (or the equivalent input token count for image/audio/video modalities)
- Renamed `safeTotalTokens` to `inputTierTokens` to make the intent explicit; the function now returns `PromptTokens` instead of `TotalTokens`
- Added `imageInputTierTokens` for image requests, which resolves input tokens from `InputTokens` or falls back to the sum of `InputTokensDetails.TextTokens + ImageTokens`
- Updated all affected compute functions: text, embedding, rerank, speech, transcription, image, and video cost calculations
- Added a new test `TestComputeTextCost_TotalAbove200kButInputBelow200kUsesBaseRate` that explicitly validates the corrected behavior: when total tokens exceed a threshold but input tokens do not, base rates are applied
- Updated existing tiered-pricing tests to use input token counts that correctly cross the relevant thresholds, with `TotalTokens` set higher to reflect realistic payloads

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
```

The new and updated tests cover:
- Tier selection driven by input tokens, not total tokens
- Cases where total tokens exceed a threshold but input tokens do not (should use base rate)
- All modalities: text, embedding, rerank, speech, transcription, image, video

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable