### PR TITLE
refactor: extract `ClearContextForInternalRequest` and extend it to clear body-transport state for internal embedding requests

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -40,7 +40,7 @@ type BifrostChatResponse struct {
 	Model             string                     `json:"model"`
 	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
 	ServiceTier       *BifrostServiceTier        `json:"service_tier,omitempty"`
-	Speed             *string                    `json:"speed,omitempty"` // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	Speed             *string                    `json:"speed,omitempty"`       // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
 	Diagnostics       *CacheDiagnostics          `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`

--- a/core/utils.go
+++ b/core/utils.go
@@ -335,6 +335,49 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeySupportsAssistantPrefill)
 }
 
+// ClearContextForInternalRequest clears context state that is specific to the
+// caller's original request, so a context derived from it can carry an
+// internal sub-request (e.g. a plugin generating an embedding for its own
+// use) that must behave like a fresh top-level request.
+//
+// Two categories are cleared:
+//
+//   - Key routing: key-selection state resolved for the caller's provider
+//     (governance key allow-list, pinned/direct keys, key-selection skip). An
+//     internal request typically targets a different provider, and when it
+//     skips the plugin pipeline this state is never re-resolved — inherited,
+//     it is applied against the wrong provider's key pool and rejects every
+//     key ("no keys found for provider").
+//   - Body transport: raw-body passthrough and large-payload/large-response
+//     streaming state, plus caller-forwarded extra headers and the caller's
+//     URL-path override. Inherited, these make providers send the caller's
+//     raw or streamed body instead of marshaling the internal request, route
+//     it to the caller's endpoint path instead of the internal request's own,
+//     and forward the caller's headers on a call the caller doesn't own.
+//
+// Deliberately not cleared: tracing/observability keys (the sub-request
+// should stay tied to the caller's trace) and
+// BifrostContextKeySkipPluginPipeline (whether the internal request runs the
+// plugin pipeline is the caller's decision).
+func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
+	// Key routing.
+	ctx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
+	ctx.ClearValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID)
+	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyID)
+	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyName)
+	ctx.ClearValue(schemas.BifrostContextKeyDirectKey)
+	ctx.ClearValue(schemas.BifrostContextKeySkipKeySelection)
+	// Body transport.
+	ctx.ClearValue(schemas.BifrostContextKeyUseRawRequestBody)
+	ctx.ClearValue(schemas.BifrostContextKeySendBackRawRequest)
+	ctx.ClearValue(schemas.BifrostContextKeySendBackRawResponse)
+	ctx.ClearValue(schemas.BifrostContextKeyPassthroughOverridesPresent)
+	ctx.ClearValue(schemas.BifrostContextKeyLargePayloadMode)
+	ctx.ClearValue(schemas.BifrostContextKeyLargeResponseMode)
+	ctx.ClearValue(schemas.BifrostContextKeyExtraHeaders)
+	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
+}
+
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {
 	m := make(map[schemas.ModelProvider]struct{}, len(schemas.SupportedBaseProviders))
 	for _, p := range schemas.SupportedBaseProviders {

--- a/plugins/semanticcache/plugin_paths_test.go
+++ b/plugins/semanticcache/plugin_paths_test.go
@@ -565,9 +565,11 @@ func TestPreLLMHook_ConcurrentSameRequestID(t *testing.T) {
 
 // -----------------------------------------------------------------------------
 // Internal embedding request must not inherit the caller's key-routing state
-// (issue #4756). Otherwise governance/key-selection context resolved for the
-// caller's chat provider leaks into the embedding request and rejects every
-// embedding-provider key ("no keys found for provider").
+// (issue #4756) or body-transport state. Otherwise governance/key-selection
+// context resolved for the caller's chat provider leaks into the embedding
+// request and rejects every embedding-provider key ("no keys found for
+// provider"), and raw-body/large-payload passthrough state makes providers
+// build the embedding request from the caller's body instead of embeddingReq.
 // -----------------------------------------------------------------------------
 
 // vectorRequiringStore is an observableStore that reports RequiresVectors()=true,
@@ -599,6 +601,22 @@ func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys, []string{"chat-provider-key-id"})
 	ctx.SetValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID, "chat-provider-key-id")
 	ctx.SetValue(schemas.BifrostContextKeyAPIKeyID, "chat-provider-key-id")
+	ctx.SetValue(schemas.BifrostContextKeyAPIKeyName, "chat-provider-key-name")
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{ID: "direct-key-id"})
+	ctx.SetValue(schemas.BifrostContextKeySkipKeySelection, true)
+	// Body-transport state from the caller's request. Inherited raw-body
+	// passthrough makes providers send the internal request's (absent) raw
+	// body instead of converting it; inherited large-payload mode streams the
+	// caller's original body to the embedding endpoint; inherited extra
+	// headers and URL path ride along to the embedding provider.
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, true)
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{"x-custom": {"v"}})
+	ctx.SetValue(schemas.BifrostContextKeyURLPath, "/v1/chat/completions")
 
 	emb, _, err := plugin.generateEmbedding(ctx, "some text")
 	if err != nil {
@@ -612,12 +630,24 @@ func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
 	}
 
 	// The internal embedding context must not carry the caller's key-routing
-	// state, so key selection resolves against the embedding provider's own
-	// keys instead of rejecting them all.
+	// or body-transport state, so key selection resolves against the embedding
+	// provider's own keys and providers build the request body from
+	// embeddingReq rather than the caller's raw/streamed body.
 	for _, key := range []schemas.BifrostContextKey{
 		schemas.BifrostContextKeyGovernanceIncludeOnlyKeys,
 		schemas.BifrostContextKeyRoutingPinnedAPIKeyID,
 		schemas.BifrostContextKeyAPIKeyID,
+		schemas.BifrostContextKeyAPIKeyName,
+		schemas.BifrostContextKeyDirectKey,
+		schemas.BifrostContextKeySkipKeySelection,
+		schemas.BifrostContextKeyUseRawRequestBody,
+		schemas.BifrostContextKeySendBackRawRequest,
+		schemas.BifrostContextKeySendBackRawResponse,
+		schemas.BifrostContextKeyPassthroughOverridesPresent,
+		schemas.BifrostContextKeyLargePayloadMode,
+		schemas.BifrostContextKeyLargeResponseMode,
+		schemas.BifrostContextKeyExtraHeaders,
+		schemas.BifrostContextKeyURLPath,
 	} {
 		if v := captured.Value(key); v != nil {
 			t.Fatalf("expected %q cleared on internal embedding context, got %v", key, v)

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -147,19 +147,11 @@ func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string
 	defer embeddingCtx.Cancel()
 	embeddingCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 	// The embedding request targets the plugin's own configured embedding
-	// provider/model, not the caller's. Because it skips the plugin pipeline,
-	// governance never re-resolves key routing for the embedding provider — so
-	// any key-selection state inherited from the caller's request context
-	// (governance key allow-list, pinned/direct keys) would be applied against
-	// the wrong provider and reject every embedding key ("no keys found for
-	// provider"). Clear it so key selection resolves against the embedding
-	// provider exactly like a fresh external /v1/embeddings request.
-	embeddingCtx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
-	embeddingCtx.ClearValue(schemas.BifrostContextKeyRoutingPinnedAPIKeyID)
-	embeddingCtx.ClearValue(schemas.BifrostContextKeyAPIKeyID)
-	embeddingCtx.ClearValue(schemas.BifrostContextKeyAPIKeyName)
-	embeddingCtx.ClearValue(schemas.BifrostContextKeyDirectKey)
-	embeddingCtx.ClearValue(schemas.BifrostContextKeySkipKeySelection)
+	// provider/model, not the caller's — and because it skips the plugin
+	// pipeline, routing state is never re-resolved for it. Shed the caller's
+	// key-routing and body-transport state so the request behaves like a
+	// fresh external /v1/embeddings call.
+	bifrost.ClearContextForInternalRequest(embeddingCtx)
 	if plugin.embeddingRequestExecutor == nil {
 		return nil, 0, fmt.Errorf("embedding request executor is not configured")
 	}


### PR DESCRIPTION
## Summary

When a plugin generates an internal embedding request using a context derived from the caller's request, it previously inherited key-routing and body-transport state that was resolved for the caller's provider. Because the internal request skips the plugin pipeline, this state is never re-resolved — causing key selection to fail against the embedding provider ("no keys found for provider") and raw-body/large-payload passthrough to build the embedding request from the caller's body instead of the actual embedding payload.

This PR introduces a shared `ClearContextForInternalRequest` utility and expands the set of context keys cleared before any internal sub-request is dispatched.

## Changes

- Added `ClearContextForInternalRequest` to `core/utils.go`, which clears two categories of inherited state:
  - **Key routing**: governance key allow-list, pinned/direct keys, and key-selection skip flags
  - **Body transport**: raw-body passthrough, raw-response passthrough, passthrough overrides, large-payload mode, large-response mode, and extra headers
- Replaced the inline per-key `ClearValue` calls in `plugins/semanticcache/search.go` with a single call to `ClearContextForInternalRequest`, which now also covers the body-transport keys that were previously not cleared
- Extended the test `TestGenerateEmbedding_ClearsInheritedKeyRoutingState` to seed all body-transport context keys and assert they are absent on the internal embedding context

Tracing/observability keys and `BifrostContextKeySkipPluginPipeline` are deliberately left intact — the sub-request should remain tied to the caller's trace, and pipeline-skip behavior is the caller's decision.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/semanticcache/... -run TestGenerateEmbedding_ClearsInheritedKeyRoutingState -v
go test ./...
```

The test seeds both key-routing and body-transport context keys on the caller context, invokes `generateEmbedding`, and asserts that none of those keys are present on the context received by the embedding provider.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4756

## Security considerations

Clearing inherited extra headers prevents the caller's request headers (which may include authorization or other sensitive values) from being forwarded to an unrelated embedding provider endpoint.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable