### PR TITLE
feat: add budget reset endpoint and functionality

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -42121,6 +42121,82 @@
         }
       }
     },
+    "/api/governance/budgets/{budget_id}/reset": {
+      "post": {
+        "operationId": "resetBudget",
+        "summary": "Reset budget usage",
+        "description": "Manually resets a budget's current usage to zero without waiting for its reset window to elapse. The reset applies to the in-memory governance store immediately and is persisted to the database. Rolling budgets restart their window from the reset time; calendar-aligned budgets still reset at the next calendar boundary.",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "budget_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the budget to reset",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget reset successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "budget"
+                  ],
+                  "properties": {
+                    "budget": {
+                      "$ref": "#/components/schemas/Budget"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid budget ID",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Budget not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/governance/rate-limits": {
       "get": {
         "operationId": "listRateLimits",

--- a/plugins/governance/budgetreset_test.go
+++ b/plugins/governance/budgetreset_test.go
@@ -1,0 +1,127 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGovernanceStore_ResetBudget_ManualReset verifies a manual reset zeroes a not-yet-expired budget with all side effects.
+func TestGovernanceStore_ResetBudget_ManualReset(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 100.0, 75.0, "1M")
+	budget.LastReset = time.Now().Add(-1 * time.Hour) // well within the reset window
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", budget)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	store.LastDBUsagesBudgetsMu.Lock()
+	store.LastDBUsagesBudgets["budget1"] = 75.0
+	store.LastDBUsagesBudgetsMu.Unlock()
+
+	var hookBudgets []*configstoreTables.TableBudget
+	store.SetResetHooks(func(budgets []*configstoreTables.TableBudget) {
+		hookBudgets = append(hookBudgets, budgets...)
+	}, nil)
+
+	before := time.Now()
+	resetBudget, err := store.ResetBudget(context.Background(), "budget1")
+	require.NoError(t, err)
+	require.NotNil(t, resetBudget)
+
+	assert.Equal(t, 0.0, resetBudget.CurrentUsage, "usage should be zeroed")
+	assert.False(t, resetBudget.LastReset.Before(before), "LastReset should advance to now")
+
+	// The stored snapshot reflects the reset.
+	stored := store.LoadBudget(context.Background(), "budget1")
+	require.NotNil(t, stored)
+	assert.Equal(t, 0.0, stored.CurrentUsage)
+
+	// Embedded VK reference is refreshed.
+	updatedVK, found := store.GetVirtualKey(context.Background(), "sk-bf-test")
+	require.True(t, found)
+	require.NotEmpty(t, updatedVK.Budgets)
+	assert.Equal(t, 0.0, updatedVK.Budgets[0].CurrentUsage, "VK's embedded budget should be reset")
+
+	// LastDB baseline is zeroed so the next dump doesn't re-add stale usage.
+	store.LastDBUsagesBudgetsMu.RLock()
+	baseline := store.LastDBUsagesBudgets["budget1"]
+	store.LastDBUsagesBudgetsMu.RUnlock()
+	assert.Equal(t, 0.0, baseline)
+
+	// Reset hook fired with the reset budget.
+	require.Len(t, hookBudgets, 1)
+	assert.Equal(t, "budget1", hookBudgets[0].ID)
+}
+
+// TestGovernanceStore_ResetBudget_NotFound verifies unknown budget IDs surface ErrBudgetNotFound.
+func TestGovernanceStore_ResetBudget_NotFound(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	resetBudget, err := store.ResetBudget(context.Background(), "missing")
+	assert.Nil(t, resetBudget)
+	assert.ErrorIs(t, err, ErrBudgetNotFound)
+}
+
+// TestGovernanceStore_ResetBudget_CalendarAligned verifies a manual reset doesn't break the next calendar-boundary reset.
+func TestGovernanceStore_ResetBudget_CalendarAligned(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("cal-budget", 500.0, 120.0, "1M")
+	// Already reset at the start of the current calendar period, i.e. not expired.
+	budget.LastReset = configstoreTables.GetCalendarPeriodStart("1M", time.Now())
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", budget)
+	vk.CalendarAligned = true
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// Sanity: the expiry-driven path considers this budget up to date.
+	assert.Empty(t, store.ResetExpiredBudgetsInMemory(context.Background(), true, "cal-budget"),
+		"calendar-aligned budget should not be expired before the manual reset")
+
+	resetBudget, err := store.ResetBudget(context.Background(), "cal-budget")
+	require.NoError(t, err)
+	require.NotNil(t, resetBudget)
+	assert.Equal(t, 0.0, resetBudget.CurrentUsage)
+
+	// Next calendar boundary must still be ahead of the manual LastReset.
+	nextPeriodStart := configstoreTables.GetCalendarPeriodStart("1M", time.Now().AddDate(0, 1, 0))
+	assert.True(t, nextPeriodStart.After(resetBudget.LastReset),
+		"next calendar boundary must remain ahead of the manual reset timestamp")
+}
+
+// TestGovernanceStore_ResetBudget_Idempotent verifies a concurrent/duplicate reset returns the snapshot instead of erroring.
+func TestGovernanceStore_ResetBudget_Idempotent(t *testing.T) {
+	logger := NewMockLogger()
+
+	budget := buildBudgetWithUsage("budget1", 100.0, 40.0, "1d")
+	// Simulate a snapshot whose LastReset is (marginally) in the future — e.g.
+	// another node just reset it — so ResetBudgetAt's CAS declines.
+	budget.LastReset = time.Now().Add(1 * time.Minute)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Budgets: []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	resetBudget, err := store.ResetBudget(context.Background(), "budget1")
+	require.NoError(t, err)
+	require.NotNil(t, resetBudget)
+	assert.Equal(t, "budget1", resetBudget.ID)
+}

--- a/plugins/governance/budgetreset_test.go
+++ b/plugins/governance/budgetreset_test.go
@@ -106,13 +106,12 @@ func TestGovernanceStore_ResetBudget_CalendarAligned(t *testing.T) {
 		"next calendar boundary must remain ahead of the manual reset timestamp")
 }
 
-// TestGovernanceStore_ResetBudget_Idempotent verifies a concurrent/duplicate reset returns the snapshot instead of erroring.
+// TestGovernanceStore_ResetBudget_Idempotent verifies a manual reset still zeroes
+// usage when the stored LastReset is in the future (e.g. clock skew).
 func TestGovernanceStore_ResetBudget_Idempotent(t *testing.T) {
 	logger := NewMockLogger()
 
 	budget := buildBudgetWithUsage("budget1", 100.0, 40.0, "1d")
-	// Simulate a snapshot whose LastReset is (marginally) in the future — e.g.
-	// another node just reset it — so ResetBudgetAt's CAS declines.
 	budget.LastReset = time.Now().Add(1 * time.Minute)
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
@@ -124,4 +123,5 @@ func TestGovernanceStore_ResetBudget_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resetBudget)
 	assert.Equal(t, "budget1", resetBudget.ID)
+	assert.Equal(t, 0.0, resetBudget.CurrentUsage, "usage must be zeroed even when LastReset is in the future")
 }

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1872,15 +1872,27 @@ func (gs *LocalGovernanceStore) ResetBudget(ctx context.Context, budgetID string
 	if gs.LoadBudget(ctx, budgetID) == nil {
 		return nil, ErrBudgetNotFound
 	}
-	// LastReset=now restarts a rolling window; a calendar-aligned budget still
-	// resets at its next period boundary.
-	resetBudget, ok := gs.ResetBudgetAt(ctx, budgetID, time.Now())
-	if !ok {
-		// A concurrent reset already advanced LastReset; return the latest snapshot.
-		if budget := gs.LoadBudget(ctx, budgetID); budget != nil {
-			return budget, nil
+	// A manual reset must always zero usage. ResetBudgetAt only applies when the
+	// target is strictly after the stored LastReset, so advance past a future
+	// LastReset to force the reset rather than reporting a no-op as success.
+	var resetBudget *configstoreTables.TableBudget
+	for {
+		current := gs.LoadBudget(ctx, budgetID)
+		if current == nil {
+			return nil, ErrBudgetNotFound
 		}
-		return nil, ErrBudgetNotFound
+		if current.CurrentUsage == 0 {
+			return current, nil
+		}
+		target := time.Now()
+		if !current.LastReset.Before(target) {
+			target = current.LastReset.Add(time.Nanosecond)
+		}
+		rb, ok := gs.ResetBudgetAt(ctx, budgetID, target)
+		if ok {
+			resetBudget = rb
+			break
+		}
 	}
 	gs.LastDBUsagesBudgetsMu.Lock()
 	gs.LastDBUsagesBudgets[resetBudget.ID] = 0

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3,6 +3,7 @@ package governance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -150,6 +151,8 @@ type GovernanceStore interface {
 	// DB sync for expired items
 	ResetExpiredRateLimits(ctx context.Context, resetRateLimits []*configstoreTables.TableRateLimit) error
 	ResetExpiredBudgets(ctx context.Context, resetBudgets []*configstoreTables.TableBudget) error
+	// Manual/admin reset of a single budget; returns ErrBudgetNotFound for unknown IDs.
+	ResetBudget(ctx context.Context, budgetID string) (*configstoreTables.TableBudget, error)
 	// Provider and model-level usage updates (combined)
 	UpdateProviderAndModelBudgetUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error
 	UpdateProviderAndModelRateLimitUsageInMemory(ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
@@ -1859,6 +1862,38 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 		}
 	}
 	return resetBudgets
+}
+
+var ErrBudgetNotFound = errors.New("budget not found")
+
+// ResetBudget forcibly zeroes a budget's usage (manual/admin reset), applying
+// the same side effects as an expiry-driven reset.
+func (gs *LocalGovernanceStore) ResetBudget(ctx context.Context, budgetID string) (*configstoreTables.TableBudget, error) {
+	if gs.LoadBudget(ctx, budgetID) == nil {
+		return nil, ErrBudgetNotFound
+	}
+	// LastReset=now restarts a rolling window; a calendar-aligned budget still
+	// resets at its next period boundary.
+	resetBudget, ok := gs.ResetBudgetAt(ctx, budgetID, time.Now())
+	if !ok {
+		// A concurrent reset already advanced LastReset; return the latest snapshot.
+		if budget := gs.LoadBudget(ctx, budgetID); budget != nil {
+			return budget, nil
+		}
+		return nil, ErrBudgetNotFound
+	}
+	gs.LastDBUsagesBudgetsMu.Lock()
+	gs.LastDBUsagesBudgets[resetBudget.ID] = 0
+	gs.LastDBUsagesBudgetsMu.Unlock()
+	gs.updateBudgetReferences(ctx, resetBudget)
+	if onBudgetsReset := gs.getBudgetsResetHook(); onBudgetsReset != nil {
+		onBudgetsReset([]*configstoreTables.TableBudget{resetBudget})
+	}
+	if err := gs.ResetExpiredBudgets(ctx, []*configstoreTables.TableBudget{resetBudget}); err != nil {
+		return nil, err
+	}
+	gs.logger.Info("manually reset budget %s (usage zeroed, last_reset advanced to %s)", resetBudget.ID, resetBudget.LastReset.Format(time.RFC3339))
+	return resetBudget, nil
 }
 
 // rateLimitResetTarget returns the LastReset value to write when a rate-limit counter is expired.

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -60,6 +60,7 @@ type GovernanceManager interface {
 	RemoveRoutingRule(ctx context.Context, id string) error
 	UpsertPricingOverride(ctx context.Context, override *configstoreTables.TablePricingOverride) error
 	DeletePricingOverride(ctx context.Context, id string) error
+	ResetBudget(ctx context.Context, id string) (*configstoreTables.TableBudget, error)
 }
 
 type complexityAnalyzerConfigReloader interface {
@@ -993,6 +994,7 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 
 	// Budget and Rate Limit GET operations
 	r.GET("/api/governance/budgets", lib.ChainMiddlewares(h.getBudgets, middlewares...))
+	r.POST("/api/governance/budgets/{budget_id}/reset", lib.ChainMiddlewares(h.resetBudget, middlewares...))
 	r.GET("/api/governance/rate-limits", lib.ChainMiddlewares(h.getRateLimits, middlewares...))
 
 	// Routing Rules CRUD operations
@@ -2900,6 +2902,28 @@ func (h *GovernanceHandler) getBudgets(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"budgets": budgets,
 		"count":   len(budgets),
+	})
+}
+
+// resetBudget handles POST /api/governance/budgets/{budget_id}/reset - Manually reset a budget's usage
+func (h *GovernanceHandler) resetBudget(ctx *fasthttp.RequestCtx) {
+	budgetID, err := url.PathUnescape(ctx.UserValue("budget_id").(string))
+	if err != nil || budgetID == "" {
+		SendError(ctx, 400, "invalid budget ID")
+		return
+	}
+	budget, err := h.governanceManager.ResetBudget(ctx, budgetID)
+	if err != nil {
+		if errors.Is(err, governance.ErrBudgetNotFound) {
+			SendError(ctx, 404, "budget not found")
+			return
+		}
+		logger.Error("failed to reset budget %s: %v", budgetID, err)
+		SendError(ctx, 500, "failed to reset budget")
+		return
+	}
+	SendJSON(ctx, map[string]interface{}{
+		"budget": budget,
 	})
 }
 

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -3118,3 +3118,108 @@ func TestTeam_MalformedEncodingReturns400(t *testing.T) {
 		t.Fatalf("DELETE malformed encoding status got %d, want 400; body=%s", delCtx.Response.StatusCode(), delCtx.Response.Body())
 	}
 }
+
+// mockResetBudgetGovernanceManager embeds the interface so unimplemented
+// methods panic. Only ResetBudget is needed for the resetBudget handler path.
+type mockResetBudgetGovernanceManager struct {
+	GovernanceManager
+	resetIDs []string
+	budget   *configstoreTables.TableBudget
+	err      error
+}
+
+func (m *mockResetBudgetGovernanceManager) ResetBudget(_ context.Context, id string) (*configstoreTables.TableBudget, error) {
+	m.resetIDs = append(m.resetIDs, id)
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.budget, nil
+}
+
+func TestResetBudget_Success(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	manager := &mockResetBudgetGovernanceManager{
+		budget: &configstoreTables.TableBudget{
+			ID:            "budget-1",
+			MaxLimit:      100,
+			CurrentUsage:  0,
+			ResetDuration: "1M",
+			LastReset:     time.Now(),
+		},
+	}
+	h := &GovernanceHandler{governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("budget_id", "budget-1")
+
+	h.resetBudget(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(manager.resetIDs) != 1 || manager.resetIDs[0] != "budget-1" {
+		t.Fatalf("expected reset for budget-1, got %#v", manager.resetIDs)
+	}
+
+	var resp struct {
+		Budget configstoreTables.TableBudget `json:"budget"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Budget.ID != "budget-1" || resp.Budget.CurrentUsage != 0 {
+		t.Fatalf("unexpected budget in response: %#v", resp.Budget)
+	}
+}
+
+func TestResetBudget_NotFound(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	manager := &mockResetBudgetGovernanceManager{err: governance.ErrBudgetNotFound}
+	h := &GovernanceHandler{governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("budget_id", "missing")
+
+	h.resetBudget(ctx)
+
+	if ctx.Response.StatusCode() != 404 {
+		t.Fatalf("expected status 404, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+}
+
+func TestResetBudget_StoreErrorReturns500(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	manager := &mockResetBudgetGovernanceManager{err: errors.New("db unavailable")}
+	h := &GovernanceHandler{governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("budget_id", "budget-1")
+
+	h.resetBudget(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+}
+
+func TestResetBudget_MalformedEncodingReturns400(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	manager := &mockResetBudgetGovernanceManager{}
+	h := &GovernanceHandler{governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("budget_id", "budget%2")
+
+	h.resetBudget(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(manager.resetIDs) != 0 {
+		t.Fatalf("expected no reset calls for malformed ID, got %#v", manager.resetIDs)
+	}
+}

--- a/transports/bifrost-http/handlers/pricing_override_test.go
+++ b/transports/bifrost-http/handlers/pricing_override_test.go
@@ -65,6 +65,9 @@ func (pricingOverrideTestGovernanceManager) UpsertPricingOverride(context.Contex
 func (pricingOverrideTestGovernanceManager) DeletePricingOverride(context.Context, string) error {
 	return nil
 }
+func (pricingOverrideTestGovernanceManager) ResetBudget(context.Context, string) (*configstoreTables.TableBudget, error) {
+	return nil, nil
+}
 
 func setupPricingOverrideHandlerStore(t *testing.T) configstore.ConfigStore {
 	t.Helper()

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -90,6 +90,7 @@ type ServerCallbacks interface {
 	UpdateDropExcessRequests(ctx context.Context, value bool)
 	// Governance related callbacks
 	GetGovernanceData(ctx context.Context) *governance.GovernanceData
+	ResetBudget(ctx context.Context, id string) (*tables.TableBudget, error)
 	ReloadTeam(ctx context.Context, id string) (*tables.TableTeam, error)
 	RemoveTeam(ctx context.Context, id string) error
 	ReloadCustomer(ctx context.Context, id string) (*tables.TableCustomer, error)
@@ -432,6 +433,15 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	}
 	s.MCPServerHandler.SyncVKMCPServer(virtualKey)
 	return virtualKey, nil
+}
+
+// ResetBudget manually resets a budget's usage via the governance plugin's store
+func (s *BifrostHTTPServer) ResetBudget(ctx context.Context, id string) (*tables.TableBudget, error) {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil, err
+	}
+	return governancePlugin.GetGovernanceStore().ResetBudget(ctx, id)
 }
 
 // RemoveVirtualKey removes a virtual key from the in-memory store


### PR DESCRIPTION
## Summary

Adds a governance endpoint to manually reset a budget's usage on demand, without waiting for its reset window to elapse. Operators can now zero out a budget's `current_usage` immediately (e.g. after a billing correction or a mistaken spend) via `POST /api/governance/budgets/{budget_id}/reset`. The reset is applied to the in-memory governance store and persisted to the database, reusing the same side effects as an expiry-driven reset.

Ref #4892

## Changes

- **`plugins/governance/store.go`**: added `ResetBudget(ctx, budgetID)` to the `GovernanceStore` interface and its `LocalGovernanceStore` implementation. It advances `LastReset` to now (restarting rolling windows; calendar-aligned budgets still reset at their next boundary), zeroes usage, zeroes the `LastDBUsagesBudgets` baseline so the next dump doesn't re-add stale usage, refreshes embedded VK budget references, fires the reset hook, and persists via `ResetExpiredBudgets`. Added the `ErrBudgetNotFound` sentinel error, returned for unknown IDs. A concurrent reset that loses the CAS returns the latest snapshot instead of erroring (idempotent).
- **`transports/bifrost-http/handlers/governance.go`**: added `ResetBudget` to the `GovernanceManager` interface, registered the `POST /api/governance/budgets/{budget_id}/reset` route, and added the `resetBudget` handler — 400 on invalid ID, 404 on `ErrBudgetNotFound`, 500 on other errors, 200 with `{ "budget": ... }` on success.
- **`transports/bifrost-http/server/server.go`**: added `ResetBudget` to `ServerCallbacks` and implemented it on `BifrostHTTPServer`, delegating to the governance plugin's store.
- **`docs/openapi/openapi.json`**: documented the new endpoint (`resetBudget` operation, `ManagementBearerAuth`, 200/400/404/500 responses).
- Tests: added `plugins/governance/budgetreset_test.go` (manual reset side effects, not-found, calendar-aligned, idempotent) and handler tests in `governance_test.go` (success, not-found). Updated `pricing_override_test.go` to satisfy the extended interface.

### Design notes / trade-offs

- Manual reset uses the same `ResetBudgetAt` + `ResetExpiredBudgets` path as expiry-driven resets, so persistence and hook behavior stay consistent.
- For calendar-aligned budgets the manual reset only zeroes current usage; the next scheduled reset still fires at the calendar boundary (covered by a dedicated test).
- The CAS-loses case is treated as success (returns the current snapshot) rather than an error, making the endpoint safe to retry / call concurrently.


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [ ] Providers/Integrations
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Unit tests
go test ./plugins/governance/... -run ResetBudget
go test ./transports/bifrost-http/handlers/... -run ResetBudget

# Full suite
go test ./...
```

Manual check against a running server:

```sh
curl -X POST \
  -H "Authorization: Bearer $MANAGEMENT_TOKEN" \
  http://localhost:8080/api/governance/budgets/<budget_id>/reset
```

Expected: `200` with `{ "budget": { ... "current_usage": 0, "last_reset": "<now>" ... } }`. An unknown `budget_id` returns `404`; an empty/invalid ID returns `400`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

<!-- Link related issues, e.g. Closes #123 -->

## Security considerations

The endpoint is protected by `ManagementBearerAuth`, consistent with other governance management routes. Resetting a budget clears spend tracking, so access should remain restricted to management tokens.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed (OpenAPI spec)
- [x] I verified builds succeed (Go and UI)
