### PR TITLE
fix: emit contentBlockStop events on the Bedrock ConverseStream egress

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: emit `contentBlockStop` events on the Bedrock ConverseStream egress so consumers that assemble messages on block boundaries get complete content (closes #4262) [@fus3r](https://github.com/fus3r)
 - fix: set the raw-storage log flag on standalone MCP tool executions so logging hooks see an explicit value
 - fix: clear the per-attempt stream close claim so streaming retries and fallbacks are not dead on arrival after an SSE-embedded provider error (closes #4788) [@fus3r](https://github.com/fus3r)
 - fix: emit reads-only `cached_tokens` in usage per the OpenAI spec so cache writes are not priced as cache reads (closes #4816) [@fus3r](https://github.com/fus3r)

--- a/core/providers/bedrock/conversestreamstop_test.go
+++ b/core/providers/bedrock/conversestreamstop_test.go
@@ -1,0 +1,201 @@
+package bedrock
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// encodeConverseStream runs each Bifrost stream event through the Converse stream
+// converter and flattens the results into wire-ready encoded events, in order,
+// the same way the HTTP transport does before AWS Event Stream encoding.
+func encodeConverseStream(t *testing.T, chunks []*schemas.BifrostResponsesStreamResponse) []BedrockEncodedEvent {
+	t.Helper()
+	var events []BedrockEncodedEvent
+	for i, chunk := range chunks {
+		bedrockEvent, err := ToBedrockConverseStreamResponse(chunk)
+		if err != nil {
+			t.Fatalf("chunk %d (%s): unexpected error: %v", i, chunk.Type, err)
+		}
+		if bedrockEvent == nil {
+			continue
+		}
+		events = append(events, bedrockEvent.ToEncodedEvents()...)
+	}
+	return events
+}
+
+func encodedEventTypes(events []BedrockEncodedEvent) []string {
+	types := make([]string, 0, len(events))
+	for _, event := range events {
+		types = append(types, event.EventType)
+	}
+	return types
+}
+
+func contentBlockStopPayloads(t *testing.T, events []BedrockEncodedEvent) []string {
+	t.Helper()
+	var payloads []string
+	for _, event := range events {
+		if event.EventType != "contentBlockStop" {
+			continue
+		}
+		data, err := sonic.Marshal(event.Payload)
+		if err != nil {
+			t.Fatalf("marshal contentBlockStop payload: %v", err)
+		}
+		payloads = append(payloads, string(data))
+	}
+	return payloads
+}
+
+// TestConverseStreamTextBlockEmitsContentBlockStop replays the stream lifecycle of a
+// plain text response and asserts the Converse egress closes the text block with a
+// contentBlockStop event before messageStop, as the Bedrock ConverseStream contract
+// requires (issue #4262). Text blocks have no contentBlockStart (the ContentBlockStart
+// union has no text member), so the block is opened implicitly by its first delta.
+func TestConverseStreamTextBlockEmitsContentBlockStop(t *testing.T) {
+	messageType := schemas.ResponsesMessageTypeMessage
+	chunks := []*schemas.BifrostResponsesStreamResponse{
+		{Type: schemas.ResponsesStreamResponseTypeCreated},
+		{Type: schemas.ResponsesStreamResponseTypeInProgress},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex: schemas.Ptr(0),
+			Item:        &schemas.ResponsesMessage{Type: &messageType},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+			ContentIndex: schemas.Ptr(0),
+			Delta:        schemas.Ptr("Hello"),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+			ContentIndex: schemas.Ptr(0),
+			Delta:        schemas.Ptr(" world"),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDone,
+			ContentIndex: schemas.Ptr(0),
+			Text:         schemas.Ptr("Hello world"),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeContentPartDone,
+			ContentIndex: schemas.Ptr(0),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex:  schemas.Ptr(0),
+			ContentIndex: schemas.Ptr(0),
+			Item:         &schemas.ResponsesMessage{Type: &messageType},
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{InputTokens: 10, OutputTokens: 2, TotalTokens: 12},
+			},
+		},
+	}
+
+	events := encodeConverseStream(t, chunks)
+
+	want := []string{"messageStart", "contentBlockDelta", "contentBlockDelta", "contentBlockStop", "messageStop", "metadata"}
+	if got := encodedEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event sequence mismatch:\n  want %v\n  got  %v", want, got)
+	}
+
+	stops := contentBlockStopPayloads(t, events)
+	if len(stops) != 1 || stops[0] != `{"contentBlockIndex":0}` {
+		t.Errorf(`contentBlockStop payloads: want [{"contentBlockIndex":0}], got %v`, stops)
+	}
+}
+
+// TestConverseStreamToolUseBlockEmitsContentBlockStop covers a tool use block: the
+// contentBlockStart(toolUse) opened at OutputItemAdded must be closed by a
+// contentBlockStop carrying the same block index, before messageStop.
+func TestConverseStreamToolUseBlockEmitsContentBlockStop(t *testing.T) {
+	functionCallType := schemas.ResponsesMessageTypeFunctionCall
+	toolItem := &schemas.ResponsesMessage{
+		Type: &functionCallType,
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: schemas.Ptr("call_1"),
+			Name:   schemas.Ptr("get_weather"),
+		},
+	}
+	chunks := []*schemas.BifrostResponsesStreamResponse{
+		{Type: schemas.ResponsesStreamResponseTypeCreated},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex:  schemas.Ptr(1),
+			ContentIndex: schemas.Ptr(1),
+			Item:         toolItem,
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			ContentIndex: schemas.Ptr(1),
+			Delta:        schemas.Ptr(`{"location":"Paris"}`),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex:  schemas.Ptr(1),
+			ContentIndex: schemas.Ptr(1),
+			Item:         toolItem,
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{InputTokens: 15, OutputTokens: 8, TotalTokens: 23},
+			},
+		},
+	}
+
+	events := encodeConverseStream(t, chunks)
+
+	want := []string{"messageStart", "contentBlockStart", "contentBlockDelta", "contentBlockStop", "messageStop", "metadata"}
+	if got := encodedEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event sequence mismatch:\n  want %v\n  got  %v", want, got)
+	}
+
+	stops := contentBlockStopPayloads(t, events)
+	if len(stops) != 1 || stops[0] != `{"contentBlockIndex":1}` {
+		t.Errorf(`contentBlockStop payloads: want [{"contentBlockIndex":1}], got %v`, stops)
+	}
+}
+
+// TestConverseStreamReasoningBlockEmitsContentBlockStop covers a reasoning block:
+// reasoning deltas stream as contentBlockDelta(reasoningContent) and the block is
+// closed by the contentBlockStop emitted on the reasoning item's OutputItemDone.
+func TestConverseStreamReasoningBlockEmitsContentBlockStop(t *testing.T) {
+	reasoningType := schemas.ResponsesMessageTypeReasoning
+	chunks := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type:         schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			ContentIndex: schemas.Ptr(0),
+			Delta:        schemas.Ptr("thinking"),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone,
+			ContentIndex: schemas.Ptr(0),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex:  schemas.Ptr(0),
+			ContentIndex: schemas.Ptr(0),
+			Item:         &schemas.ResponsesMessage{Type: &reasoningType},
+		},
+	}
+
+	events := encodeConverseStream(t, chunks)
+
+	want := []string{"contentBlockDelta", "contentBlockStop"}
+	if got := encodedEventTypes(events); !reflect.DeepEqual(got, want) {
+		t.Fatalf("event sequence mismatch:\n  want %v\n  got  %v", want, got)
+	}
+
+	stops := contentBlockStopPayloads(t, events)
+	if len(stops) != 1 || stops[0] != `{"contentBlockIndex":0}` {
+		t.Errorf(`contentBlockStop payloads: want [{"contentBlockIndex":0}], got %v`, stops)
+	}
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1773,12 +1773,20 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 	case schemas.ResponsesStreamResponseTypeOutputTextDone,
 		schemas.ResponsesStreamResponseTypeContentPartDone,
 		schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone:
-		// Content block done - Bedrock doesn't have explicit done events, so we skip them
+		// Content block done - the contentBlockStop is emitted on OutputItemDone,
+		// matching the invoke path
 		return nil, nil
 
 	case schemas.ResponsesStreamResponseTypeOutputItemDone:
-		// Item done - Bedrock doesn't have explicit done events, so we skip them
-		return nil, nil
+		// Item done - emit contentBlockStop. Bedrock terminates every content block
+		// with a contentBlockStop event carrying the block's index; consumers that
+		// assemble the message on block boundaries never finalize a block without it.
+		contentBlockIndex := 0
+		if bifrostResp.ContentIndex != nil {
+			contentBlockIndex = *bifrostResp.ContentIndex
+		}
+		event.ContentBlockIndex = &contentBlockIndex
+		event.ContentBlockStop = true
 
 	case schemas.ResponsesStreamResponseTypeCompleted:
 		// Message stop - always set stopReason
@@ -1865,6 +1873,17 @@ func (event *BedrockStreamEvent) ToEncodedEvents() []BedrockEncodedEvent {
 				ContentBlockIndex *int                      `json:"contentBlockIndex"`
 			}{
 				Delta:             event.Delta,
+				ContentBlockIndex: event.ContentBlockIndex,
+			},
+		})
+	}
+
+	if event.ContentBlockStop {
+		events = append(events, BedrockEncodedEvent{
+			EventType: "contentBlockStop",
+			Payload: struct {
+				ContentBlockIndex *int `json:"contentBlockIndex"`
+			}{
 				ContentBlockIndex: event.ContentBlockIndex,
 			},
 		})

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -761,6 +761,11 @@ type BedrockStreamEvent struct {
 	// Start field for tool use events
 	Start *BedrockContentBlockStart `json:"start,omitempty"` // For contentBlockStart events
 
+	// Marker for contentBlockStop events. The wire payload of contentBlockStop carries
+	// only contentBlockIndex, so the flat union needs an explicit flag to represent it.
+	// Never serialized directly: ToEncodedEvents builds the payload from ContentBlockIndex.
+	ContentBlockStop bool `json:"-"`
+
 	// Metadata and usage (can appear at top level)
 	Usage   *BedrockTokenUsage      `json:"usage,omitempty"`   // Usage information
 	Metrics *BedrockConverseMetrics `json:"metrics,omitempty"` // Performance metrics


### PR DESCRIPTION
## Summary

Fixes #4262. The Bedrock ConverseStream egress (`/bedrock/model/{modelId}/converse-stream`) never emitted `contentBlockStop` events: content blocks were opened and filled with deltas, but never closed before `messageStop`. The AWS contract terminates every content block with a `contentBlockStop` event carrying the block's `contentBlockIndex` (a required field), and consumers that assemble the final message on block boundaries (the AWS SDK stream unions, frameworks like strands) only finalize a block when they receive it. Through Bifrost they received all the deltas and still ended up with an empty assembled message, so the break is silent: live delta readers see output, assembling consumers get nothing.

The invoke egress (`invoke-with-response-stream`, Anthropic Messages shape) already maps `OutputItemDone` to `content_block_stop`. The Converse path dropped the same event with a comment saying Bedrock has no done events, which holds for the part-level done events but not at the block level.

## Changes

- `ToBedrockConverseStreamResponse` now maps `OutputItemDone` to a `contentBlockStop` event carrying the same content block index the block's start and delta events use, mirroring the invoke path. `OutputTextDone`, `ContentPartDone` and `ReasoningSummaryTextDone` stay skipped, so each block is closed exactly once, on its item's done event.
- `BedrockStreamEvent` gets an explicit `ContentBlockStop` marker: the wire payload of `contentBlockStop` is just `{"contentBlockIndex": n}`, so the flat event union had no way to represent it. The marker is never serialized; `ToEncodedEvents` builds the payload from `ContentBlockIndex`.
- `ToEncodedEvents` encodes the new event after deltas and before `messageStop`, so a text stream now encodes as `messageStart`, `contentBlockDelta` (xN), `contentBlockStop`, `messageStop`, `metadata`.
- Regression tests replay the Bifrost stream lifecycle for a text block, a tool use block and a reasoning block through the converter and the encoder, asserting the exact wire event sequences and the stop payloads.

Two notes on scope:

- The issue also suggests emitting `contentBlockStart` for text blocks. Real ConverseStream responses do not do that: the `ContentBlockStart` union only has `image`, `toolResult` and `toolUse` members, so text blocks start implicitly with their first delta. The current behavior already matches the contract there, so this PR leaves the start events unchanged.
- Nova models on `invoke-with-response-stream` delegate to the same Converse converter, so that path picks up the block terminator as well, which also matches Nova's native stream shape.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/bedrock/ -run 'ConverseStream.*ContentBlockStop' -v
```

All three tests fail on `dev` without this change, with the exact event sequence from the issue report (`messageStart, contentBlockDelta, contentBlockDelta, messageStop, metadata` and no `contentBlockStop`), and pass with it. `go build ./...` and the full `./providers/bedrock/` package suite are green.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

Consumers that only read `contentBlockDelta` are unaffected. The new event is part of the documented `ConverseStreamOutput` union, so Bedrock clients already handle it.

## Related issues

Closes #4262

## Security considerations

None. This only adds a lifecycle event to the outgoing stream encoding.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
