### PR TITLE
feat: extend Bedrock vendor-prefix pricing fallback to OpenAI, Google, and xAI models, and fold `bedrock_mantle` onto `bedrock` lookups

### DIFF
--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1683,6 +1683,11 @@ func IsTitanModel(model string) bool {
 	return strings.Contains(model, "titan")
 }
 
+// IsGrokModel checks if the model is an xAI Grok model.
+func IsGrokModel(model string) bool {
+	return strings.Contains(model, "grok")
+}
+
 // List of grok reasoning models
 var grokReasoningModels = []string{
 	"grok-3",

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -1096,7 +1096,8 @@ func (s *Store) resolvePricing(routingInfo schemas.RoutingInfo, requestType sche
 //
 //   - Gemini: retries under the "vertex" provider, then falls back to chat mode for Responses requests.
 //   - Vertex: strips the "provider/model" prefix and retries, then falls back to chat mode for Responses requests.
-//   - Bedrock: prepends the "anthropic." namespace for Claude models, then falls back to chat mode for Responses requests.
+//   - Bedrock: prepends the vendor namespace ("anthropic.", "openai.", "google.", "xai.") inferred from the model family, then falls back to chat mode for Responses requests.
+//   - Bedrock Mantle: folded onto the "bedrock" provider up front (datasheet rows for all Bedrock variants are stored there), so it shares every Bedrock fallback.
 //   - All providers: for Responses/ResponsesStream requests, retries the lookup in chat mode.
 //   - All providers: for ImageEdit/ImageVariation requests, retries the lookup in image-generation mode.
 //
@@ -1115,6 +1116,13 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 	defer s.mu.RUnlock()
 
 	mode := normalizeRequestType(requestType)
+
+	// Datasheet rows for all Bedrock variants are stored under the "bedrock"
+	// provider (normalizeProvider folds bedrock_* onto "bedrock"), so
+	// bedrock_mantle lookups run entirely against "bedrock".
+	if provider == string(schemas.BedrockMantle) {
+		provider = string(schemas.Bedrock)
+	}
 
 	pricing, ok := s.pricingData[makeKey(model, provider, mode)]
 	if ok {
@@ -1161,10 +1169,24 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 	}
 
 	if provider == string(schemas.Bedrock) {
-		// If model is claude without "anthropic." prefix, try with "anthropic." prefix
-		if !strings.Contains(model, "anthropic.") && schemas.IsAnthropicModel(model) {
-			s.logger.Debug("primary lookup failed, trying with anthropic. prefix for the same model")
-			pricing, ok = s.pricingData[makeKey("anthropic."+model, provider, mode)]
+		// Bedrock model IDs carry a vendor namespace ("anthropic.claude-*",
+		// "openai.gpt-oss-*", "google.gemma-*", "xai.grok-*"). When the caller
+		// sends the bare model name, retry with the namespace inferred from
+		// the model family.
+		var vendorPrefix string
+		switch {
+		case !strings.Contains(model, "anthropic.") && schemas.IsAnthropicModel(model):
+			vendorPrefix = "anthropic."
+		case !strings.Contains(model, "openai.") && schemas.IsOpenAIModel(model):
+			vendorPrefix = "openai."
+		case !strings.Contains(model, "google.") && (schemas.IsGemmaModel(model) || schemas.IsGeminiModel(model)):
+			vendorPrefix = "google."
+		case !strings.Contains(model, "xai.") && schemas.IsGrokModel(model):
+			vendorPrefix = "xai."
+		}
+		if vendorPrefix != "" {
+			s.logger.Debug("primary lookup failed, trying with %s prefix for the same model", vendorPrefix)
+			pricing, ok = s.pricingData[makeKey(vendorPrefix+model, provider, mode)]
 			if ok {
 				return &pricing, true
 			}
@@ -1172,7 +1194,7 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 			// Lookup in chat if responses not found
 			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest || requestType == schemas.CompactionRequest {
 				s.logger.Debug("secondary lookup failed, trying chat provider for the same model in chat completion")
-				pricing, ok = s.pricingData[makeKey("anthropic."+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+				pricing, ok = s.pricingData[makeKey(vendorPrefix+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
 				if ok {
 					return &pricing, true
 				}

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -1587,6 +1587,80 @@ func TestGetPricing_BedrockAddsAnthropicPrefix(t *testing.T) {
 	assert.Equal(t, 0.000003, derefF(p.InputCostPerToken))
 }
 
+func TestGetPricing_BedrockAddsOpenAIPrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-oss-120b", "bedrock", "chat"): chatPricing(0.00000015, 0.0000006),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock", Model: "gpt-oss-120b"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000015, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockAddsGooglePrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("google.gemma-4-31b", "bedrock", "chat"): chatPricing(0.00000014, 0.0000004),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock", Model: "gemma-4-31b"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000014, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockAddsXAIPrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("xai.grok-4.3", "bedrock", "chat"): chatPricing(0.00000125, 0.0000025),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock", Model: "grok-4.3"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000125, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleFallsBackToBedrock(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-oss-120b", "bedrock", "chat"): chatPricing(0.00000015, 0.0000006),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "openai.gpt-oss-120b"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000015, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleResponsesFallsBackToBedrockChat(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-oss-120b", "bedrock", "chat"): chatPricing(0.00000015, 0.0000006),
+	})
+	// bedrock_mantle provider + responses request → try bedrock + responses → try bedrock + chat
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "openai.gpt-oss-120b"}, schemas.ResponsesRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000015, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleAddsAnthropicPrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("anthropic.claude-3-5-sonnet-20241022-v2:0", "bedrock", "chat"): chatPricing(0.000003, 0.000015),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "claude-3-5-sonnet-20241022-v2:0"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.000003, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleAddsOpenAIPrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-oss-120b", "bedrock", "chat"): chatPricing(0.00000015, 0.0000006),
+	})
+	// bedrock_mantle folds onto bedrock, then the openai. prefix retry fires
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "gpt-oss-120b"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.00000015, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleResponsesAddsOpenAIPrefix(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-5.5", "bedrock", "responses"): chatPricing(0.0000055, 0.000033),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "gpt-5.5"}, schemas.ResponsesRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.0000055, derefF(p.InputCostPerToken))
+}
+
 func TestGetPricing_ResponsesFallsBackToChat(t *testing.T) {
 	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),


### PR DESCRIPTION
## Summary

Bedrock pricing lookups previously only handled the `anthropic.` vendor namespace prefix when a bare model name was provided. This PR extends that fallback logic to cover all vendor namespaces used by Bedrock (`openai.`, `google.`, `xai.`), and ensures that `bedrock_mantle` provider lookups are folded onto the `bedrock` provider so they share all of the same fallback paths.

## Changes

- Added `IsGrokModel` helper to `core/schemas/utils.go` to detect xAI Grok models by name.
- Replaced the single `anthropic.`-prefix retry in `getBasePricing` with a `switch` that infers the correct vendor namespace (`anthropic.`, `openai.`, `google.`, `xai.`) from the model family, then retries the pricing lookup with that prefix.
- Added an early normalization step in `getBasePricing` that folds `bedrock_mantle` onto `bedrock` before any lookup, so all Bedrock datasheet rows (stored under `bedrock`) are reachable from `bedrock_mantle` requests without duplicating fallback logic.
- Updated the `resolvePricing` comment to document the expanded vendor namespace behavior and the `bedrock_mantle` folding.
- Added tests covering bare-name lookups for OpenAI, Google, and xAI prefixes on Bedrock, as well as `bedrock_mantle` folding for direct lookups, responses-to-chat fallback, and vendor prefix retries.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
```

The new test cases exercise each vendor prefix path and the `bedrock_mantle` folding behavior directly. Confirm all tests pass, including the pre-existing `TestGetPricing_BedrockAddsAnthropicPrefix` test to ensure no regression.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects internal pricing lookup logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable