### PR TITLE
fix: skip plaintext fallback lookup for secret-based virtual key values

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -39,13 +39,15 @@ func inferSecretType(ref string) SecretType {
 	return SecretTypePlainText
 }
 
-// NewSecretVar creates a new SecretVar from a string.
-func NewSecretVar(value string) *SecretVar {
+// parseSecretRef classifies value and returns a *SecretVar with SecretType and ref
+// populated but Val unresolved — no vault HTTP calls, no env lookups.
+// For JSON-encoded SecretVars the raw "value" field is preserved in Val unchanged.
+// Adding a new secret type only requires updating this function.
+func parseSecretRef(value string) *SecretVar {
 	val := value
 	if unquoted, err := strconv.Unquote(value); err == nil {
 		val = unquoted
 	}
-	// If it's a valid JSON object following the SecretVar schema, unmarshal it
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
 		if valueNode.Exists() {
@@ -76,55 +78,49 @@ func NewSecretVar(value string) *SecretVar {
 					}
 					e.ref = ref
 					e.SecretType = SecretTypeEnv
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(ref, "env.")); ok {
-						e.Val = envValue
-					} else {
-						e.Val = ""
-					}
-					return e
 				} else if strings.HasPrefix(raw.Val, "env.") && raw.Val == raw.EnvVar {
 					// Legacy format: value == env_var == "env.XXX"
 					e.ref = raw.EnvVar
 					e.SecretType = SecretTypeEnv
-					e.Val = ""
-					if envValue, ok := os.LookupEnv(strings.TrimPrefix(raw.EnvVar, "env.")); ok {
-						e.Val = envValue
-					}
-					return e
-				}
-				// Resolve references
-				if e.SecretType == SecretTypeVault {
-					e.Val = ""
-					if vaultValue, ok := LookupVault(e.ref); ok {
-						e.Val = vaultValue
-					}
-				}
-				if e.SecretType == SecretTypeEnv {
-					if envValue, ok := os.LookupEnv(e.EnvKey()); ok {
-						e.Val = envValue
-					} else {
-						e.Val = ""
-					}
 				}
 				return e
 			}
 		}
 	}
 	if strings.HasPrefix(val, "vault.") {
-		e := &SecretVar{ref: val, SecretType: SecretTypeVault}
-		if vaultValue, ok := LookupVault(val); ok {
-			e.Val = vaultValue
-		}
-		return e
+		return &SecretVar{ref: val, SecretType: SecretTypeVault}
 	}
-	if envKey, ok := strings.CutPrefix(val, "env."); ok {
-		e := &SecretVar{ref: val, SecretType: SecretTypeEnv}
-		if envValue, ok := os.LookupEnv(envKey); ok {
-			e.Val = envValue
-		}
-		return e
+	if strings.HasPrefix(val, "env.") {
+		return &SecretVar{ref: val, SecretType: SecretTypeEnv}
 	}
 	return &SecretVar{Val: val}
+}
+
+// IsSecretRef reports whether value is a secret reference (env.* or vault.* prefix,
+// or a JSON-encoded SecretVar with an env/vault type) without resolving it.
+// Use this instead of NewSecretVar(...).IsFromSecret() when resolution side-effects
+// (vault HTTP calls, env lookups) must be avoided.
+func IsSecretRef(value string) bool {
+	return parseSecretRef(value).IsFromSecret()
+}
+
+// NewSecretVar creates a new SecretVar from a string.
+func NewSecretVar(value string) *SecretVar {
+	e := parseSecretRef(value)
+	switch e.SecretType {
+	case SecretTypeVault:
+		e.Val = ""
+		if vaultValue, ok := LookupVault(e.ref); ok {
+			e.Val = vaultValue
+		}
+	case SecretTypeEnv:
+		if envValue, ok := os.LookupEnv(e.EnvKey()); ok {
+			e.Val = envValue
+		} else {
+			e.Val = ""
+		}
+	}
+	return e
 }
 
 // GetRawRef returns the full secret reference string including prefix

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3299,6 +3299,9 @@ func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string)
 	// Use hash-based lookup if hash column is populated, fall back to plaintext for backward compat
 	if err := query.Where("value_hash = ?", valueHash).First(&virtualKey).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if schemas.IsSecretRef(value) {
+				return nil, ErrNotFound
+			}
 			// Fallback: try plaintext lookup for rows not yet migrated
 			if err := query.Where("value = ?", value).First(&virtualKey).Error; err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -3326,6 +3329,9 @@ func (s *RDBConfigStore) GetVirtualKeyQuotaByValue(ctx context.Context, value st
 		Preload("ProviderConfigs.RateLimit")
 	if err := baseQuery.Session(&gorm.Session{}).Where("value_hash = ?", valueHash).First(&virtualKey).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if schemas.IsSecretRef(value) {
+				return nil, ErrNotFound
+			}
 			// Fallback: try plaintext lookup for rows not yet migrated
 			if err := baseQuery.Session(&gorm.Session{}).Where("value = ?", value).First(&virtualKey).Error; err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
## Summary

Prevents plaintext database fallback lookups when a virtual key value appears to be a secret reference (e.g., a vault or environment variable reference). Without this guard, a value like `vault.my-secret` or `env.MY_VAR` would be passed as a raw string into a `WHERE value = ?` query, which could never match a real row but still leaks information about the lookup path and wastes a database round-trip.

## Changes

- In `GetVirtualKeyByValue`, when a hash-based lookup returns no record, the value is parsed as a `SecretVar`. If it originates from a secret reference, the function returns `ErrNotFound` immediately instead of falling back to a plaintext query.
- In `GetVirtualKeyQuotaByValue`, the same early-exit behavior is applied by checking for `vault.` and `env.` prefixes directly, consistent with the rationale in `GetVirtualKeyByValue`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

- Submit a request using a virtual key value formatted as `vault.<secret-name>` or `env.<VAR_NAME>`.
- Confirm the response returns a not-found error without triggering a secondary plaintext database query.
- Confirm that normal virtual key values (non-secret-reference strings) still fall back to plaintext lookup as expected.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Secret references (vault/env-style values) should never be stored or queried as plaintext in the database. Allowing them to reach a `WHERE value = ?` clause could expose the reference string in query logs or slow query logs. This change ensures such values are short-circuited before any plaintext lookup occurs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable