### PR TITLE
fix: stay on login page when SSO is configured but auth restart is pending

### DIFF
--- a/ui/app/login/layout.tsx
+++ b/ui/app/login/layout.tsx
@@ -54,6 +54,23 @@ export const Route = createFileRoute("/login")({
 			// Fetch failed — fall through to login page
 		}
 		if (data && (!data.is_auth_enabled || data.has_valid_token)) {
+			// If auth is disabled but SSO is configured (restart pending), stay on
+			// the login page so the user sees the restart notice instead of looping.
+			if (!data.is_auth_enabled) {
+				try {
+					const authTypeRes = await fetch(`${getApiBaseUrl()}/auth/type`, {
+						credentials: "include",
+					});
+					if (authTypeRes.ok) {
+						const authType: { type: string } = await authTypeRes.json();
+						if (authType.type === "sso") {
+							return; // SSO configured — show login form with restart notice
+						}
+					}
+				} catch {
+					// Ignore — fall through to the workspace redirect
+				}
+			}
 			throw redirect({ href: postLoginPath });
 		}
 	},


### PR DESCRIPTION
## Summary

When auth is disabled but SSO is configured (awaiting a server restart), the login page was incorrectly redirecting users away instead of showing the restart notice. This fix detects that SSO has been configured and keeps the user on the login page so they see the pending restart message.

## Changes

- Before redirecting to the post-login path when auth is disabled, the login layout now checks `/auth/type` to determine if SSO has been configured
- If the auth type is `sso`, the redirect is skipped so the login page renders with the restart notice visible
- If the fetch fails or returns a non-SSO type, behavior is unchanged and the redirect proceeds normally

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure SSO on an instance where auth is currently disabled (restart pending)
2. Navigate to the login page
3. Verify the restart notice is displayed instead of being redirected to the workspace
4. After restarting, verify the normal SSO login flow works as expected

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The additional `/auth/type` fetch uses the same credentials and base URL as other auth-related requests. No new auth surface is introduced; this is a read-only check to determine the configured auth type.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable