### PR TITLE
fix: stats for cancelled requests

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -41,6 +41,7 @@ SELECT
     COUNT(*) AS count,
     SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS success_count,
     SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_count,
+    SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) AS cancelled_count,
     COALESCE(AVG(latency), 0) AS avg_latency,
     COALESCE(percentile_cont(0.90) WITHIN GROUP (ORDER BY latency), 0) AS p90_latency,
     COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency), 0) AS p95_latency,
@@ -51,7 +52,7 @@ SELECT
     COALESCE(SUM(cached_read_tokens), 0) AS total_cached_read_tokens,
     COALESCE(SUM(cost), 0) AS total_cost
 FROM logs
-WHERE status IN ('success', 'error')
+WHERE status IN ('success', 'error', 'cancelled')
 GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 `
 
@@ -80,6 +81,7 @@ var mvLogsHourlyRequiredColumns = []string{
 	"customer_id",
 	"business_unit_id",
 	"alias",
+	"cancelled_count",
 }
 
 // legacyMatViewNames are matviews from previous schema versions that no longer
@@ -764,6 +766,7 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Durat
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
 		len(f.MetadataFilters) == 0 &&
+		canUseMatViewStatusFilter(f.Status) &&
 		len(f.RoutingEngineUsed) == 0 &&
 		len(f.StopReasons) == 0 &&
 		f.MinLatency == nil && f.MaxLatency == nil &&
@@ -774,6 +777,24 @@ func canUseMatViewFilters(f SearchFilters) bool {
 		len(f.TeamIDs) == 0 &&
 		len(f.BusinessUnitIDs) == 0 &&
 		len(f.CustomerIDs) == 0
+}
+
+func canUseMatViewStatusFilter(statuses []string) bool {
+	for _, status := range statuses {
+		if !isTerminalLogStatus(status) {
+			return false
+		}
+	}
+	return true
+}
+
+func isTerminalLogStatus(status string) bool {
+	for _, terminalStatus := range terminalLogStatuses {
+		if status == terminalStatus {
+			return true
+		}
+	}
+	return false
 }
 
 // canUseMatView checks both that materialized views are ready (created and
@@ -950,7 +971,7 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 		alignedEnd := filters.EndTime.Truncate(time.Hour).Add(time.Hour - time.Nanosecond)
 		alignedFilters.EndTime = &alignedEnd
 	}
-	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
+	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", terminalLogStatuses)
 	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, alignedFilters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
@@ -963,13 +984,14 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 }
 
 // getHistogramFromMatView returns time-bucketed request counts (total,
-// success, error) by re-aggregating hourly buckets from mv_logs_hourly.
+// success, error, cancelled) by re-aggregating hourly buckets from mv_logs_hourly.
 func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*HistogramResult, error) {
 	var results []struct {
 		BucketTimestamp int64 `gorm:"column:bucket_timestamp"`
 		Total           int64 `gorm:"column:total"`
 		Success         int64 `gorm:"column:success"`
 		ErrorCount      int64 `gorm:"column:error_count"`
+		CancelledCount  int64 `gorm:"column:cancelled_count"`
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
@@ -977,7 +999,8 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		SUM(count) AS total,
 		SUM(success_count) AS success,
-		SUM(error_count) AS error_count
+		SUM(error_count) AS error_count,
+		SUM(cancelled_count) AS cancelled_count
 	`, bucketSizeSeconds, bucketSizeSeconds)).
 		Group("bucket_timestamp").
 		Order("bucket_timestamp ASC").
@@ -985,9 +1008,9 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 		return nil, err
 	}
 
-	resultMap := make(map[int64]*struct{ total, success, errCount int64 }, len(results))
+	resultMap := make(map[int64]*struct{ total, success, errCount, cancelledCount int64 }, len(results))
 	for _, r := range results {
-		resultMap[r.BucketTimestamp] = &struct{ total, success, errCount int64 }{r.Total, r.Success, r.ErrorCount}
+		resultMap[r.BucketTimestamp] = &struct{ total, success, errCount, cancelledCount int64 }{r.Total, r.Success, r.ErrorCount, r.CancelledCount}
 	}
 
 	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
@@ -998,6 +1021,7 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 			b.Count = a.total
 			b.Success = a.success
 			b.Error = a.errCount
+			b.Cancelled = a.cancelledCount
 		}
 		buckets = append(buckets, b)
 	}
@@ -1104,7 +1128,7 @@ func (s *RDBLogStore) getCostHistogramFromMatView(ctx context.Context, filters S
 }
 
 // getModelHistogramFromMatView returns time-bucketed model usage with
-// success/error breakdown per model from mv_logs_hourly.
+// success/error/cancelled breakdown per model from mv_logs_hourly.
 func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ModelHistogramResult, error) {
 	var results []struct {
 		BucketTimestamp int64  `gorm:"column:bucket_timestamp"`
@@ -1112,6 +1136,7 @@ func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters 
 		Total           int64  `gorm:"column:total"`
 		Success         int64  `gorm:"column:success"`
 		ErrorCount      int64  `gorm:"column:error_count"`
+		CancelledCount  int64  `gorm:"column:cancelled_count"`
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
@@ -1120,7 +1145,8 @@ func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters 
 		model,
 		SUM(count) AS total,
 		SUM(success_count) AS success,
-		SUM(error_count) AS error_count
+		SUM(error_count) AS error_count,
+		SUM(cancelled_count) AS cancelled_count
 	`, bucketSizeSeconds, bucketSizeSeconds)).
 		Group("bucket_timestamp, model").
 		Order("bucket_timestamp ASC").
@@ -1143,6 +1169,7 @@ func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters 
 		existing.Total += r.Total
 		existing.Success += r.Success
 		existing.Error += r.ErrorCount
+		existing.Cancelled += r.CancelledCount
 		a.byModel[r.Model] = existing
 		modelsSet[r.Model] = struct{}{}
 	}

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -82,7 +82,9 @@ func TestTeamOrBUFanoutFrom(t *testing.T) {
 func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
 	assert.True(t, canUseMatViewFilters(SearchFilters{}), "empty filters → matview eligible")
 	assert.True(t, canUseMatViewFilters(SearchFilters{Providers: []string{"openai"}}), "provider filter stays matview-eligible")
+	assert.True(t, canUseMatViewFilters(SearchFilters{Status: []string{"cancelled"}}), "cancelled is materialized as a terminal status")
 
+	assert.False(t, canUseMatViewFilters(SearchFilters{Status: []string{"processing"}}), "processing is not present in mv_logs_hourly")
 	assert.False(t, canUseMatViewFilters(SearchFilters{TeamIDs: []string{"t1"}}), "team filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{BusinessUnitIDs: []string{"bu1"}}), "BU filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{CustomerIDs: []string{"c1"}}), "customer filter must force the raw path")

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -44,6 +44,8 @@ const (
 	defaultFilterDataCutoffDays = 30
 )
 
+var terminalLogStatuses = []string{"success", "error", "cancelled"}
+
 // RDBLogStore represents a log store that uses a SQLite database.
 type RDBLogStore struct {
 	db            *gorm.DB
@@ -938,7 +940,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	}
 
 	if totalCount > 0 {
-		// Single query for all completed-request stats: counts, latency, tokens, cost
+		// Single query for all terminal-request stats: counts, latency, tokens, cost
 		var result struct {
 			CompletedCount sql.NullInt64   `gorm:"column:completed_count"`
 			SuccessCount   sql.NullInt64   `gorm:"column:success_count"`
@@ -949,7 +951,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 
 		statsQuery := s.ScopedDB(ctx).Model(&Log{})
 		statsQuery = s.applyFilters(statsQuery, filters)
-		statsQuery = statsQuery.Where("status IN ?", []string{"success", "error"})
+		statsQuery = statsQuery.Where("status IN ?", terminalLogStatuses)
 
 		if err := statsQuery.Select(`
 			COUNT(*) as completed_count,
@@ -992,7 +994,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			userFacingQuery = s.applyFilters(userFacingQuery, filters)
 			// Scope to root rows only so denominator and numerator are drawn from the same population.
 			// A chain is successful if the root itself succeeded or any of its fallbacks succeeded.
-			userFacingQuery = userFacingQuery.Where("fallback_index = ?", 0).Where("status IN ?", []string{"success", "error"})
+			userFacingQuery = userFacingQuery.Where("fallback_index = ?", 0).Where("status IN ?", terminalLogStatuses)
 			// Use a LEFT JOIN instead of a correlated EXISTS subquery: the inner set is computed
 			// once and hash-joined, reducing complexity from O(N×M) to O(N+M).
 			// The inner subquery is bounded by the same time window as the outer query for
@@ -1031,7 +1033,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	}
 
 	// Count cache hits by hit_type from cache_debug JSON
-	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
+	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", terminalLogStatuses)
 	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, filters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
@@ -1091,7 +1093,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 	// Build query with filters
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
 	// Query for histogram buckets - use int64 for bucket timestamp to avoid parsing issues
 	var results []struct {
@@ -1099,6 +1101,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 		Total           int64 `gorm:"column:total"`
 		Success         int64 `gorm:"column:success"`
 		Error           int64 `gorm:"column:error_count"`
+		Cancelled       int64 `gorm:"column:cancelled_count"`
 	}
 
 	// Build select clause with database-specific unix timestamp calculation
@@ -1110,7 +1113,8 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 			(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	case "mysql":
 		// MySQL: use UNIX_TIMESTAMP
@@ -1118,7 +1122,8 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 			(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	default:
 		// PostgreSQL (and others): use EXTRACT(EPOCH FROM timestamp)
@@ -1126,7 +1131,8 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 			CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT) as bucket_timestamp,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	}
 
@@ -1140,19 +1146,22 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 
 	// Create a map of bucket timestamp -> result for quick lookup
 	resultMap := make(map[int64]struct {
-		Total   int64
-		Success int64
-		Error   int64
+		Total     int64
+		Success   int64
+		Error     int64
+		Cancelled int64
 	})
 	for _, r := range results {
 		resultMap[r.BucketTimestamp] = struct {
-			Total   int64
-			Success int64
-			Error   int64
+			Total     int64
+			Success   int64
+			Error     int64
+			Cancelled int64
 		}{
-			Total:   r.Total,
-			Success: r.Success,
-			Error:   r.Error,
+			Total:     r.Total,
+			Success:   r.Success,
+			Error:     r.Error,
+			Cancelled: r.Cancelled,
 		}
 	}
 
@@ -1168,6 +1177,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 				Count:     r.Total,
 				Success:   r.Success,
 				Error:     r.Error,
+				Cancelled: r.Cancelled,
 			}
 		}
 		return &HistogramResult{
@@ -1185,6 +1195,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 				Count:     data.Total,
 				Success:   data.Success,
 				Error:     data.Error,
+				Cancelled: data.Cancelled,
 			}
 		} else {
 			buckets[i] = HistogramBucket{
@@ -1215,8 +1226,8 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	// Only count completed requests for token stats
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	// Only count terminal requests for token stats
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
 	var results []struct {
 		BucketTimestamp  int64 `gorm:"column:bucket_timestamp"`
@@ -1341,8 +1352,8 @@ func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilter
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	// Only count completed requests with cost
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	// Only count terminal requests with cost
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
 
 	// Query grouped by bucket and model
@@ -1463,7 +1474,7 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
 	// Query grouped by bucket and model with status counts
 	var results []struct {
@@ -1472,6 +1483,7 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 		Total           int64  `gorm:"column:total"`
 		Success         int64  `gorm:"column:success"`
 		Error           int64  `gorm:"column:error_count"`
+		Cancelled       int64  `gorm:"column:cancelled_count"`
 	}
 
 	var selectClause string
@@ -1482,7 +1494,8 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 			model,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	case "mysql":
 		selectClause = fmt.Sprintf(`
@@ -1490,7 +1503,8 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 			model,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	default:
 		selectClause = fmt.Sprintf(`
@@ -1498,7 +1512,8 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 			model,
 			COUNT(*) as total,
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
-			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled_count
 		`, bucketSizeSeconds, bucketSizeSeconds)
 	}
 
@@ -1518,18 +1533,20 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 		modelsSet[r.Model] = true
 		if bucket, exists := bucketMap[r.BucketTimestamp]; exists {
 			bucket.ByModel[r.Model] = ModelUsageStats{
-				Total:   r.Total,
-				Success: r.Success,
-				Error:   r.Error,
+				Total:     r.Total,
+				Success:   r.Success,
+				Error:     r.Error,
+				Cancelled: r.Cancelled,
 			}
 		} else {
 			bucketMap[r.BucketTimestamp] = &ModelHistogramBucket{
 				Timestamp: time.Unix(r.BucketTimestamp, 0).UTC(),
 				ByModel: map[string]ModelUsageStats{
 					r.Model: {
-						Total:   r.Total,
-						Success: r.Success,
-						Error:   r.Error,
+						Total:     r.Total,
+						Success:   r.Success,
+						Error:     r.Error,
+						Cancelled: r.Cancelled,
 					},
 				},
 			}
@@ -1618,7 +1635,7 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
 
 	switch dialect {
@@ -1841,7 +1858,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 	// Query current period
 	currentQuery := s.ScopedDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
-	currentQuery = currentQuery.Where("status IN ?", []string{"success", "error"})
+	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where("model IS NOT NULL AND model != ''")
 
 	var currentResults []struct {
@@ -1880,7 +1897,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 
 		prevQuery := s.ScopedDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
-		prevQuery = prevQuery.Where("status IN ?", []string{"success", "error"})
+		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		prevQuery = prevQuery.Where("model IS NOT NULL AND model != ''")
 
 		// Only fetch previous-period data for (model, provider) pairs that
@@ -1982,7 +1999,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 	// Query current period
 	currentQuery := s.ScopedDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
-	currentQuery = currentQuery.Where("status IN ?", []string{"success", "error"})
+	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where("user_id IS NOT NULL AND user_id != ''")
 
 	var currentResults []struct {
@@ -2014,7 +2031,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 
 		prevQuery := s.ScopedDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
-		prevQuery = prevQuery.Where("status IN ?", []string{"success", "error"})
+		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		prevQuery = prevQuery.Where("user_id IS NOT NULL AND user_id != ''")
 
 		if len(currentResults) > 0 {
@@ -2126,7 +2143,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 
 	currentQuery := baseTable(s.ScopedDB(ctx))
 	currentQuery = s.applyFilters(currentQuery, filters)
-	currentQuery = currentQuery.Where("status IN ?", []string{"success", "error"})
+	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 
 	var currentResults []struct {
@@ -2165,7 +2182,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 	if fanoutFrom != "" {
 		requestsCountsQuery := baseTable(s.ScopedDB(ctx))
 		requestsCountsQuery = s.applyFilters(requestsCountsQuery, filters)
-		requestsCountsQuery = requestsCountsQuery.Where("status IN ?", []string{"success", "error"})
+		requestsCountsQuery = requestsCountsQuery.Where("status IN ?", terminalLogStatuses)
 		requestsCountsQuery = requestsCountsQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 		if err := requestsCountsQuery.
 			Select("COUNT(DISTINCT id) as actual_requests, COUNT(*) as attributed_requests").
@@ -2186,7 +2203,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 
 		prevQuery := baseTable(s.ScopedDB(ctx))
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
-		prevQuery = prevQuery.Where("status IN ?", []string{"success", "error"})
+		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		prevQuery = prevQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
 
 		if len(currentResults) > 0 {
@@ -2281,7 +2298,7 @@ func (s *RDBLogStore) GetProviderCostHistogram(ctx context.Context, filters Sear
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
 
 	var results []struct {
@@ -2392,7 +2409,7 @@ func (s *RDBLogStore) GetProviderTokenHistogram(ctx context.Context, filters Sea
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
 	var results []struct {
 		BucketTimestamp  int64  `gorm:"column:bucket_timestamp"`
@@ -2519,7 +2536,7 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
 
 	switch dialect {
@@ -2815,7 +2832,7 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 		baseQuery = baseQuery.Model(&Log{})
 	}
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
 
 	var bucketExpr string
@@ -2924,7 +2941,7 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 		baseQuery = baseQuery.Model(&Log{})
 	}
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
 	var bucketExpr string
 	switch dialect {
@@ -3040,7 +3057,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	dialect := s.db.Dialector.Name()
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
-	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
 
 	var bucketExpr string

--- a/framework/logstore/rdb_perf_test.go
+++ b/framework/logstore/rdb_perf_test.go
@@ -35,6 +35,125 @@ func newTestSQLiteStore(t *testing.T) *RDBLogStore {
 	return store
 }
 
+func TestCancelledStatusIncludedInLogAggregates(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC)
+	cost := 0.01
+	successLatency := 100.0
+	errorLatency := 200.0
+	cancelledLatency := 300.0
+	processingLatency := 400.0
+
+	entries := []*Log{
+		{
+			ID:          "aggregate-success",
+			Timestamp:   base,
+			Object:      "chat.completion",
+			Provider:    "openai",
+			Model:       "gpt-4o-mini",
+			Status:      "success",
+			Latency:     &successLatency,
+			TotalTokens: 10,
+			Cost:        &cost,
+		},
+		{
+			ID:          "aggregate-error",
+			Timestamp:   base.Add(time.Minute),
+			Object:      "chat.completion",
+			Provider:    "openai",
+			Model:       "gpt-4o-mini",
+			Status:      "error",
+			Latency:     &errorLatency,
+			TotalTokens: 20,
+			Cost:        &cost,
+		},
+		{
+			ID:          "aggregate-cancelled",
+			Timestamp:   base.Add(2 * time.Minute),
+			Object:      "chat.completion",
+			Provider:    "openai",
+			Model:       "gpt-4o-mini",
+			Status:      "cancelled",
+			Latency:     &cancelledLatency,
+			TotalTokens: 30,
+			Cost:        &cost,
+		},
+		{
+			ID:        "aggregate-processing",
+			Timestamp: base.Add(3 * time.Minute),
+			Object:    "chat.completion",
+			Provider:  "openai",
+			Model:     "gpt-4o-mini",
+			Status:    "processing",
+			Latency:   &processingLatency,
+		},
+	}
+
+	for _, entry := range entries {
+		if err := store.Create(ctx, entry); err != nil {
+			t.Fatalf("Create(%s) error = %v", entry.ID, err)
+		}
+	}
+
+	search, err := store.SearchLogs(ctx, SearchFilters{Status: []string{"cancelled"}}, PaginationOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchLogs(cancelled) error = %v", err)
+	}
+	if search.Stats.TotalRequests != 1 {
+		t.Fatalf("expected cancelled search total to be 1, got %d", search.Stats.TotalRequests)
+	}
+
+	allStats, err := store.GetStats(ctx, SearchFilters{})
+	if err != nil {
+		t.Fatalf("GetStats(all) error = %v", err)
+	}
+	if allStats.TotalRequests != 4 {
+		t.Fatalf("expected total requests to include processing rows, got %d", allStats.TotalRequests)
+	}
+	if allStats.CacheHitRateTotalRequests == nil || *allStats.CacheHitRateTotalRequests != 3 {
+		t.Fatalf("expected terminal request denominator to include cancelled rows, got %v", allStats.CacheHitRateTotalRequests)
+	}
+
+	cancelledStats, err := store.GetStats(ctx, SearchFilters{Status: []string{"cancelled"}})
+	if err != nil {
+		t.Fatalf("GetStats(cancelled) error = %v", err)
+	}
+	if cancelledStats.TotalRequests != 1 {
+		t.Fatalf("expected cancelled stats total to be 1, got %d", cancelledStats.TotalRequests)
+	}
+	if cancelledStats.SuccessRate != 0 {
+		t.Fatalf("expected cancelled success rate to be 0, got %f", cancelledStats.SuccessRate)
+	}
+	if cancelledStats.AverageLatency != 300 {
+		t.Fatalf("expected cancelled average latency 300, got %f", cancelledStats.AverageLatency)
+	}
+
+	start := base.Add(-time.Minute)
+	end := base.Add(5 * time.Minute)
+	hist, err := store.GetHistogram(ctx, SearchFilters{
+		Status:    []string{"cancelled"},
+		StartTime: &start,
+		EndTime:   &end,
+	}, 3600)
+	if err != nil {
+		t.Fatalf("GetHistogram(cancelled) error = %v", err)
+	}
+	var cancelledBucket *HistogramBucket
+	for i := range hist.Buckets {
+		if hist.Buckets[i].Count > 0 {
+			cancelledBucket = &hist.Buckets[i]
+			break
+		}
+	}
+	if cancelledBucket == nil {
+		t.Fatal("expected a non-empty cancelled histogram bucket")
+	}
+	if cancelledBucket.Count != 1 || cancelledBucket.Success != 0 || cancelledBucket.Error != 0 || cancelledBucket.Cancelled != 1 {
+		t.Fatalf("unexpected cancelled histogram bucket: %+v", *cancelledBucket)
+	}
+}
+
 func TestLogCreateSerializesFields(t *testing.T) {
 	store := newTestSQLiteStore(t)
 	prompt := "hello"

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1349,6 +1349,7 @@ type HistogramBucket struct {
 	Count     int64     `json:"count"`
 	Success   int64     `json:"success"`
 	Error     int64     `json:"error"`
+	Cancelled int64     `json:"cancelled"`
 }
 
 // HistogramResult represents the histogram query result
@@ -1388,9 +1389,10 @@ type CostHistogramResult struct {
 
 // ModelUsageStats represents usage statistics for a single model
 type ModelUsageStats struct {
-	Total   int64 `json:"total"`
-	Success int64 `json:"success"`
-	Error   int64 `json:"error"`
+	Total     int64 `json:"total"`
+	Success   int64 `json:"success"`
+	Error     int64 `json:"error"`
+	Cancelled int64 `json:"cancelled"`
 }
 
 // ModelHistogramBucket represents a single time bucket for model usage

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -386,7 +386,6 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		return 0
 	}
 
-	totalTokens := usage.TotalTokens
 	promptTokens := usage.PromptTokens
 	completionTokens := usage.CompletionTokens
 
@@ -402,11 +401,15 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		}
 	}
 
-	inputRate := tieredInputRate(pricing, totalTokens, tier)
-	outputRate := tieredOutputRate(pricing, totalTokens, tier)
-	cacheReadInputRate := tieredCacheReadInputTokenRate(pricing, totalTokens, tier)
-	cacheCreationInputRate := tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
-	cacheCreationInputAbove1hrInputRate := tieredCacheCreationInputAbove1hrTokenRate(pricing, totalTokens, tier)
+	// Long-context pricing tiers are selected by input context size. Once
+	// selected, the tier's input/cache/output rates apply to their respective
+	// billed token categories for the request.
+	tierTokens := promptTokens
+	inputRate := tieredInputRate(pricing, tierTokens, tier)
+	outputRate := tieredOutputRate(pricing, tierTokens, tier)
+	cacheReadInputRate := tieredCacheReadInputTokenRate(pricing, tierTokens, tier)
+	cacheCreationInputRate := tieredCacheCreationInputTokenRate(pricing, tierTokens, tier)
+	cacheCreationInputAbove1hrInputRate := tieredCacheCreationInputAbove1hrTokenRate(pricing, tierTokens, tier)
 
 	// Clamp cached token counts to avoid negative billing on malformed provider payloads
 	if cachedReadTokens > promptTokens {
@@ -483,7 +486,7 @@ func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *s
 	if usage == nil {
 		return 0
 	}
-	return float64(usage.PromptTokens) * tieredInputRate(pricing, usage.TotalTokens, tier)
+	return float64(usage.PromptTokens) * tieredInputRate(pricing, usage.PromptTokens, tier)
 }
 
 // computeRerankCost handles rerank requests.
@@ -491,8 +494,9 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 	if usage == nil {
 		return 0
 	}
-	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, usage.TotalTokens, tier)
-	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, usage.TotalTokens, tier)
+	tierTokens := usage.PromptTokens
+	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
+	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 
 	searchCost := 0.0
 	if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
@@ -511,7 +515,7 @@ func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // since TTS providers report their billable unit in that field.
 // Output falls back to per-second duration when no audio token rate is configured.
 func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: per-character rate takes precedence for TTS/audio models
 	inputCost := 0.0
@@ -519,14 +523,14 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 		if pricing.InputCostPerCharacter != nil {
 			inputCost = float64(audioTextInputChars) * *pricing.InputCostPerCharacter
 		} else {
-			inputCost = float64(audioTextInputChars) * tieredInputRate(pricing, totalTokens, tier)
+			inputCost = float64(audioTextInputChars) * tieredInputRate(pricing, tierTokens, tier)
 		}
 	} else if usage != nil && usage.PromptTokens > 0 {
-		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, totalTokens, tier)
+		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
 	}
 
 	// Output: audio tokens first, then per-second fallback
-	outputCost := computeAudioOutputCost(pricing, usage, audioSeconds, totalTokens, tier)
+	outputCost := computeAudioOutputCost(pricing, usage, audioSeconds, tierTokens, tier)
 
 	return inputCost + outputCost
 }
@@ -535,15 +539,15 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // Input is audio, output is text (CompletionTokens).
 // Input and output are calculated independently — tokens first, then per-second fallback.
 func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: audio tokens/details first, then per-second fallback
-	inputCost := computeAudioInputCost(pricing, usage, audioSeconds, audioTokenDetails, totalTokens, tier)
+	inputCost := computeAudioInputCost(pricing, usage, audioSeconds, audioTokenDetails, tierTokens, tier)
 
 	// Output: text tokens
 	outputCost := 0.0
 	if usage != nil && usage.CompletionTokens > 0 {
-		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, totalTokens, tier)
+		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 	}
 
 	return inputCost + outputCost
@@ -600,10 +604,10 @@ func computeImageCost(pricing *configstoreTables.TableModelPricing, imageUsage *
 		return 0
 	}
 
-	totalTokens := imageUsage.TotalTokens
+	tierTokens := imageInputTierTokens(imageUsage)
 	pixels := parseImagePixels(imageSize)
-	inputCost := computeImageInputCost(pricing, imageUsage, totalTokens, pixels, tier)
-	outputCost := computeImageOutputCost(pricing, imageUsage, totalTokens, pixels, imageQuality, tier)
+	inputCost := computeImageInputCost(pricing, imageUsage, tierTokens, pixels, tier)
+	outputCost := computeImageOutputCost(pricing, imageUsage, tierTokens, pixels, imageQuality, tier)
 
 	return inputCost + outputCost
 }
@@ -720,14 +724,14 @@ func computeImageOutputCost(pricing *configstoreTables.TableModelPricing, imageU
 // computeVideoCost handles video generation requests.
 // Input and output are calculated independently — tokens first, then per-second fallback.
 func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, videoSeconds *int, tier serviceTier) float64 {
-	totalTokens := safeTotalTokens(usage)
+	tierTokens := inputTierTokens(usage)
 
 	// Input: text prompt tokens first, then per-second fallback
 	inputCost := 0.0
 	if usage != nil && usage.PromptTokens > 0 {
-		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, totalTokens, tier)
+		inputCost = float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
 	} else if videoSeconds != nil && *videoSeconds > 0 {
-		if rate := tieredVideoInputPerSecondRate(pricing, totalTokens); rate > 0 {
+		if rate := tieredVideoInputPerSecondRate(pricing, tierTokens); rate > 0 {
 			inputCost = float64(*videoSeconds) * rate
 		}
 	}
@@ -735,7 +739,7 @@ func computeVideoCost(pricing *configstoreTables.TableModelPricing, usage *schem
 	// Output: completion tokens first, then per-second fallback
 	outputCost := 0.0
 	if usage != nil && usage.CompletionTokens > 0 {
-		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, totalTokens, tier)
+		outputCost = float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
 	} else if videoSeconds != nil && *videoSeconds > 0 {
 		if pricing.OutputCostPerVideoPerSecond != nil {
 			outputCost = float64(*videoSeconds) * *pricing.OutputCostPerVideoPerSecond
@@ -984,11 +988,42 @@ func tieredCacheCreationInputAbove1hrTokenRate(pricing *configstoreTables.TableM
 	return tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
 }
 
-func safeTotalTokens(usage *schemas.BifrostLLMUsage) int {
+func inputTierTokens(usage *schemas.BifrostLLMUsage) int {
 	if usage == nil {
 		return 0
 	}
-	return usage.TotalTokens
+	return usage.PromptTokens
+}
+
+func imageInputTierTokens(usage *schemas.ImageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.InputTokensDetails != nil {
+		return usage.InputTokensDetails.TextTokens + usage.InputTokensDetails.ImageTokens
+	}
+	if usage.InputTokens > 0 {
+		return usage.InputTokens
+	}
+
+	// Some older/provider-specific image adapters only report TotalTokens.
+	// Derive input from total-output when output is known, but do not treat a
+	// bare total as input: total includes generated output tokens.
+	outputTokens := imageOutputTokens(usage)
+	if usage.TotalTokens > outputTokens {
+		return usage.TotalTokens - outputTokens
+	}
+	return 0
+}
+
+func imageOutputTokens(usage *schemas.ImageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.OutputTokensDetails != nil {
+		return usage.OutputTokensDetails.TextTokens + usage.OutputTokensDetails.ImageTokens
+	}
+	return usage.OutputTokens
 }
 
 // parseImagePixels parses a size string like "1024x1024" into total pixel count.

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -395,9 +395,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *
 	p.CacheCreationInputTokenCostAbove1hrAbove200kTokens = bifrost.Ptr(0.000015)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000, // above 200k threshold
+		TotalTokens:      235000, // input is above 200k threshold
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -409,11 +409,11 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Input rate (>200k): 0.000006; output rate (>200k): 0.00003
-	// Input (non-cached): (180000-10000)*0.000006 = 170000*0.000006 = 1.02
+	// Input (non-cached): (210000-10000)*0.000006 = 200000*0.000006 = 1.20
 	// Cache creation 1hr above 200k: 10000*0.000015 = 0.15
 	// Output: 25000*0.00003 = 0.75
-	// Total: 1.02 + 0.15 + 0.75 = 1.92
-	assert.InDelta(t, 1.92, cost, 1e-9)
+	// Total: 1.20 + 0.15 + 0.75 = 2.10
+	assert.InDelta(t, 2.10, cost, 1e-9)
 }
 
 func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove200kRateAbsent(t *testing.T) {
@@ -429,9 +429,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove2
 	// CacheCreationInputTokenCostAbove1hrAbove200kTokens intentionally left nil
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000,
+		TotalTokens:      235000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -443,10 +443,10 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove2
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Cache creation 1hr (no above_200k_1hr rate, uses above_1hr): 10000*0.000009 = 0.09
-	// Input (non-cached): 170000*0.000006 = 1.02
+	// Input (non-cached): 200000*0.000006 = 1.20
 	// Output: 25000*0.00003 = 0.75
-	// Total: 1.02 + 0.09 + 0.75 = 1.86
-	assert.InDelta(t, 1.86, cost, 1e-9)
+	// Total: 1.20 + 0.09 + 0.75 = 2.04
+	assert.InDelta(t, 2.04, cost, 1e-9)
 }
 
 func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kWhenNo1hrRates(t *testing.T) {
@@ -460,9 +460,9 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kW
 	// Neither CacheCreationInputTokenCostAbove1hr nor Above1hrAbove200k is set
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 25000,
-		TotalTokens:      205000,
+		TotalTokens:      235000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedWriteTokens: 10000,
 			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
@@ -474,10 +474,10 @@ func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kW
 	cost := computeTextCost(&p, usage, serviceTier{})
 
 	// Cache creation (1hr → no 1hr rates → standard above_200k): 10000*0.000002 = 0.02
-	// Input (non-cached): 170000*0.0000016 = 0.272
+	// Input (non-cached): 200000*0.0000016 = 0.32
 	// Output: 25000*0.000008 = 0.2
-	// Total: 0.272 + 0.02 + 0.2 = 0.492
-	assert.InDelta(t, 0.492, cost, 1e-9)
+	// Total: 0.32 + 0.02 + 0.2 = 0.54
+	assert.InDelta(t, 0.54, cost, 1e-9)
 }
 
 func TestComputeTextCost_Tiered200k(t *testing.T) {
@@ -487,16 +487,16 @@ func TestComputeTextCost_Tiered200k(t *testing.T) {
 	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     180000,
+		PromptTokens:     210000,
 		CompletionTokens: 30000,
-		TotalTokens:      210000, // Above 200k threshold
+		TotalTokens:      240000, // input is above 200k threshold
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses tiered rate since total > 200k
-	// 180000 * 0.000006 + 30000 * 0.00003 = 1.08 + 0.90 = 1.98
-	assert.InDelta(t, 1.98, cost, 1e-9)
+	// Uses tiered rate since input > 200k
+	// 210000 * 0.000006 + 30000 * 0.00003 = 1.26 + 0.90 = 2.16
+	assert.InDelta(t, 2.16, cost, 1e-9)
 }
 
 func TestComputeTextCost_Below200kUsesBaseRate(t *testing.T) {
@@ -512,9 +512,27 @@ func TestComputeTextCost_Below200kUsesBaseRate(t *testing.T) {
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses base rate since total < 200k
+	// Uses base rate since input < 200k
 	// 1000 * 0.000003 + 500 * 0.000015 = 0.003 + 0.0075 = 0.0105
 	assert.InDelta(t, 0.0105, cost, 1e-12)
+}
+
+func TestComputeTextCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000, // total is above 200k, input is not
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Uses base rates because long-context tiers are selected by input tokens.
+	// 180000 * 0.000003 + 30000 * 0.000015 = 0.54 + 0.45 = 0.99
+	assert.InDelta(t, 0.99, cost, 1e-9)
 }
 
 func TestComputeTextCost_Tiered272k(t *testing.T) {
@@ -525,16 +543,16 @@ func TestComputeTextCost_Tiered272k(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k threshold
+		TotalTokens:      310000, // input is above 272k threshold
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses 272k tiered rate since total > 272k
-	// 250000 * 0.000009 + 30000 * 0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// Uses 272k tiered rate since input > 272k
+	// 280000 * 0.000009 + 30000 * 0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestComputeTextCost_Between200kAnd272kUses200kRate(t *testing.T) {
@@ -545,16 +563,16 @@ func TestComputeTextCost_Between200kAnd272kUses200kRate(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     200000,
+		PromptTokens:     230000,
 		CompletionTokens: 30000,
-		TotalTokens:      230000, // Between 200k and 272k
+		TotalTokens:      260000, // input is between 200k and 272k
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Uses 200k tiered rate since total > 200k but <= 272k
-	// 200000 * 0.000006 + 30000 * 0.00003 = 1.20 + 0.90 = 2.10
-	assert.InDelta(t, 2.10, cost, 1e-9)
+	// Uses 200k tiered rate since input > 200k but <= 272k
+	// 230000 * 0.000006 + 30000 * 0.00003 = 1.38 + 0.90 = 2.28
+	assert.InDelta(t, 2.28, cost, 1e-9)
 }
 
 func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
@@ -565,9 +583,9 @@ func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
 	p.CacheReadInputTokenCostAbove272kTokens = new(0.0000009)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k
+		TotalTokens:      310000, // input is above 272k
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedReadTokens: 50000,
 		},
@@ -575,11 +593,11 @@ func TestComputeTextCost_272kTierWithCacheRead(t *testing.T) {
 
 	cost := computeTextCost(&p, usage, serviceTier{})
 
-	// Non-cached input: (250000-50000) * 0.000009 = 200000 * 0.000009 = 1.80
+	// Non-cached input: (280000-50000) * 0.000009 = 230000 * 0.000009 = 2.07
 	// Cached read: 50000 * 0.0000009 = 0.045
 	// Output: 30000 * 0.000045 = 1.35
-	// Total: 1.80 + 0.045 + 1.35 = 3.195
-	assert.InDelta(t, 3.195, cost, 1e-9)
+	// Total: 2.07 + 0.045 + 1.35 = 3.465
+	assert.InDelta(t, 3.465, cost, 1e-9)
 }
 
 func TestComputeTextCost_SearchQueryCost(t *testing.T) {
@@ -643,6 +661,21 @@ func TestComputeEmbeddingCost_Basic(t *testing.T) {
 	assert.InDelta(t, 0.0005, cost, 1e-12)
 }
 
+func TestComputeEmbeddingCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		InputCostPerToken:                bifrost.Ptr(0.000003),
+		InputCostPerTokenAbove200kTokens: bifrost.Ptr(0.000006),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 180000,
+		TotalTokens:  210000,
+	}
+
+	cost := computeEmbeddingCost(&p, usage, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003, cost, 1e-9)
+}
+
 func TestComputeEmbeddingCost_NilUsage(t *testing.T) {
 	p := configstoreTables.TableModelPricing{InputCostPerToken: new(0.0000001)}
 	assert.Equal(t, 0.0, computeEmbeddingCost(&p, nil, serviceTier{}))
@@ -665,6 +698,21 @@ func TestComputeRerankCost_Basic(t *testing.T) {
 	cost := computeRerankCost(&p, usage, serviceTier{})
 	// 2000*0.000001 + 100*0.000002 = 0.002 + 0.0002 = 0.0022
 	assert.InDelta(t, 0.0022, cost, 1e-12)
+}
+
+func TestComputeRerankCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeRerankCost(&p, usage, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeRerankCost_WithSearchCost(t *testing.T) {
@@ -760,6 +808,21 @@ func TestComputeSpeechCost_TokenFallback(t *testing.T) {
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
 
+func TestComputeSpeechCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeSpeechCost(&p, usage, nil, 0, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
+}
+
 func TestComputeSpeechCost_NilUsageNilSeconds(t *testing.T) {
 	p := chatPricing(0.000005, 0.000015)
 	assert.Equal(t, 0.0, computeSpeechCost(&p, nil, nil, 0, serviceTier{}))
@@ -815,6 +878,21 @@ func TestComputeTranscriptionCost_TokenFallback(t *testing.T) {
 	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
 	// 1000*0.000005 + 200*0.000015 = 0.005 + 0.003 = 0.008
 	assert.InDelta(t, 0.008, cost, 1e-12)
+}
+
+func TestComputeTranscriptionCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeTranscriptionCost(&p, usage, nil, nil, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeTranscriptionCost_TokenDetailsPreferredOverDuration(t *testing.T) {
@@ -901,6 +979,47 @@ func TestComputeImageCost_TokenBased(t *testing.T) {
 	cost := computeImageCost(&p, usage, "", "", serviceTier{})
 	// 1000*0.000005 + 500*0.000015 = 0.005 + 0.0075 = 0.0125
 	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
+func TestComputeImageCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		InputTokens:  180000,
+		OutputTokens: 30000,
+		TotalTokens:  210000,
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
+}
+
+func TestComputeImageCost_DerivesTierTokensFromTotalMinusOutputWhenInputMissing(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		OutputTokens: 30000,
+		TotalTokens:  240000, // derived input = 210000, so output uses long-context rate
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 30000*0.00003, cost, 1e-9)
+}
+
+func TestComputeImageCost_DoesNotUseBareTotalTokensAsInputTierTokens(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.OutputCostPerImage = bifrost.Ptr(0.05)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.ImageUsage{
+		TotalTokens: 210000, // no input/output split; total includes output, so do not use it as input
+	}
+
+	cost := computeImageCost(&p, usage, "", "", serviceTier{})
+
+	assert.InDelta(t, 0.05, cost, 1e-9)
 }
 
 func TestComputeImageCost_TokenBasedWithDetails(t *testing.T) {
@@ -1069,6 +1188,21 @@ func TestComputeVideoCost_DurationBased(t *testing.T) {
 	// Input:  500 * 0.000001 = 0.0005
 	// Total:  0.0305
 	assert.InDelta(t, 0.0305, cost, 1e-12)
+}
+
+func TestComputeVideoCost_TotalAbove200kButInputBelow200kUsesBaseRate(t *testing.T) {
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 30000,
+		TotalTokens:      210000,
+	}
+
+	cost := computeVideoCost(&p, usage, nil, serviceTier{})
+
+	assert.InDelta(t, 180000*0.000003+30000*0.000015, cost, 1e-9)
 }
 
 func TestComputeVideoCost_OutputCostPerSecondFallback(t *testing.T) {
@@ -1832,15 +1966,15 @@ func TestCalculateCost_200kTier_EndToEnd(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Bedrock, "anthropic.claude-3-5-sonnet-20240620-v1:0", &schemas.BifrostLLMUsage{
-		PromptTokens:     190000,
+		PromptTokens:     210000,
 		CompletionTokens: 20000,
-		TotalTokens:      210000, // Above 200k
+		TotalTokens:      230000, // input is above 200k
 	})
 
 	cost := s.CalculateCost(resp, nil)
 	// Tiered rate: input=0.000006, output=0.00003
-	// 190000*0.000006 + 20000*0.00003 = 1.14 + 0.6 = 1.74
-	assert.InDelta(t, 1.74, cost, 1e-9)
+	// 210000*0.000006 + 20000*0.00003 = 1.26 + 0.6 = 1.86
+	assert.InDelta(t, 1.86, cost, 1e-9)
 }
 
 func TestCalculateCost_272kTier_EndToEnd(t *testing.T) {
@@ -1862,15 +1996,15 @@ func TestCalculateCost_272kTier_EndToEnd(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Anthropic, "claude-3-7-sonnet", &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000, // Above 272k
+		TotalTokens:      310000, // input is above 272k
 	})
 
 	cost := s.CalculateCost(resp, nil)
 	// Tiered rate: input=0.000009, output=0.000045
-	// 250000*0.000009 + 30000*0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// 280000*0.000009 + 30000*0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestCalculateCost_272kTier_CacheReadFallbackChain(t *testing.T) {
@@ -1891,20 +2025,20 @@ func TestCalculateCost_272kTier_CacheReadFallbackChain(t *testing.T) {
 	})
 
 	resp := makeChatResponse(schemas.Anthropic, "claude-3-7-sonnet", &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
 			CachedReadTokens: 50000,
 		},
 	})
 
 	cost := s.CalculateCost(resp, nil)
-	// Non-cached input: (250000-50000) * 0.000009 = 200000 * 0.000009 = 1.80
+	// Non-cached input: (280000-50000) * 0.000009 = 230000 * 0.000009 = 2.07
 	// Cached read (272k rate): 50000 * 0.0000009 = 0.045
 	// Output: 30000 * 0.000045 = 1.35
-	// Total: 1.80 + 0.045 + 1.35 = 3.195
-	assert.InDelta(t, 3.195, cost, 1e-9)
+	// Total: 2.07 + 0.045 + 1.35 = 3.465
+	assert.InDelta(t, 3.465, cost, 1e-9)
 }
 
 // =========================================================================
@@ -1955,15 +2089,15 @@ func TestComputeTextCost_Priority272kTier(t *testing.T) {
 	p.OutputCostPerTokenAbove272kTokensPriority = new(0.00006)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
 
-	// Uses 272k priority rates: 250000*0.000012 + 30000*0.00006 = 3.00 + 1.80 = 4.80
-	assert.InDelta(t, 4.80, cost, 1e-9)
+	// Uses 272k priority rates: 280000*0.000012 + 30000*0.00006 = 3.36 + 1.80 = 5.16
+	assert.InDelta(t, 5.16, cost, 1e-9)
 }
 
 func TestComputeTextCost_Priority272kTierFallsBackToNonPriority272k(t *testing.T) {
@@ -1973,15 +2107,15 @@ func TestComputeTextCost_Priority272kTierFallsBackToNonPriority272k(t *testing.T
 	p.OutputCostPerTokenAbove272kTokens = new(0.000045)
 
 	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     250000,
+		PromptTokens:     280000,
 		CompletionTokens: 30000,
-		TotalTokens:      280000,
+		TotalTokens:      310000,
 	}
 
 	cost := computeTextCost(&p, usage, serviceTier{isPriority: true})
 
-	// Falls back to non-priority 272k rate: 250000*0.000009 + 30000*0.000045 = 2.25 + 1.35 = 3.60
-	assert.InDelta(t, 3.60, cost, 1e-9)
+	// Falls back to non-priority 272k rate: 280000*0.000009 + 30000*0.000045 = 2.52 + 1.35 = 3.87
+	assert.InDelta(t, 3.87, cost, 1e-9)
 }
 
 func TestComputeTextCost_PriorityCacheReadRate(t *testing.T) {

--- a/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
@@ -18,6 +18,7 @@ type LogVolumeDataPoint = {
 	count: number;
 	success: number;
 	error: number;
+	cancelled: number;
 	index: number;
 	formattedTime: string;
 };
@@ -51,6 +52,13 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
 					</span>
 					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
 				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
+						<span className="text-zinc-600 dark:text-zinc-400">Cancelled</span>
+					</span>
+					<span className="font-medium text-zinc-600 dark:text-zinc-400">{(data.cancelled ?? 0).toLocaleString()}</span>
+				</div>
 			</div>
 		</div>
 	);
@@ -64,6 +72,7 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 
 		return data.buckets.map((bucket, index) => ({
 			...bucket,
+			cancelled: bucket.cancelled ?? 0,
 			index,
 			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
 		}));
@@ -119,6 +128,15 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							stackId="requests"
 							fill={CHART_COLORS.error}
 							fillOpacity={0.9}
+							radius={[0, 0, 0, 0]}
+							barSize={30}
+						/>
+						<Bar
+							isAnimationActive={false}
+							dataKey="cancelled"
+							stackId="requests"
+							fill={CHART_COLORS.cancelled}
+							fillOpacity={0.9}
 							radius={[2, 2, 0, 0]}
 							barSize={30}
 						/>
@@ -161,6 +179,15 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							stackId="1"
 							stroke={CHART_COLORS.error}
 							fill={CHART_COLORS.error}
+							fillOpacity={0.7}
+						/>
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="cancelled"
+							stackId="1"
+							stroke={CHART_COLORS.cancelled}
+							fill={CHART_COLORS.cancelled}
 							fillOpacity={0.7}
 						/>
 					</AreaChart>

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -77,6 +77,15 @@ function CustomTooltip({ active, payload, selectedModel, displayModels }: any) {
 								{(data.by_model?.[selectedModel]?.error || 0).toLocaleString()}
 							</span>
 						</div>
+						<div className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
+								<span className="text-zinc-600 dark:text-zinc-400">Cancelled</span>
+							</span>
+							<span className="font-medium text-zinc-600 dark:text-zinc-400">
+								{(data.by_model?.[selectedModel]?.cancelled || 0).toLocaleString()}
+							</span>
+						</div>
 					</>
 				)}
 			</div>
@@ -124,10 +133,11 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 					}
 				});
 			} else {
-				// For specific model, show success/error breakdown
+				// For specific model, show success/error/cancelled breakdown
 				const stats = bucket.by_model?.[selectedModel];
 				item.success = stats?.success || 0;
 				item.error = stats?.error || 0;
+				item.cancelled = stats?.cancelled || 0;
 			}
 			return item;
 		});
@@ -203,6 +213,15 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 									stackId="status"
 									fill={CHART_COLORS.error}
 									fillOpacity={0.9}
+									radius={[0, 0, 0, 0]}
+									barSize={30}
+								/>
+								<Bar
+									isAnimationActive={false}
+									dataKey="cancelled"
+									stackId="status"
+									fill={CHART_COLORS.cancelled}
+									fillOpacity={0.9}
 									radius={[2, 2, 0, 0]}
 									barSize={30}
 								/>
@@ -269,6 +288,15 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 									stackId="1"
 									stroke={CHART_COLORS.error}
 									fill={CHART_COLORS.error}
+									fillOpacity={0.7}
+								/>
+								<Area
+									isAnimationActive={false}
+									type="monotone"
+									dataKey="cancelled"
+									stackId="1"
+									stroke={CHART_COLORS.cancelled}
+									fill={CHART_COLORS.cancelled}
 									fillOpacity={0.7}
 								/>
 							</>

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -170,6 +170,10 @@ function OverviewTabImpl({
 								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
 								<span className="text-muted-foreground">Error</span>
 							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
+								<span className="text-muted-foreground">Cancelled</span>
+							</span>
 						</div>
 					}
 					controls={
@@ -359,6 +363,10 @@ function OverviewTabImpl({
 									<span className="flex items-center gap-1">
 										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
 										<span className="text-muted-foreground">Error</span>
+									</span>
+									<span className="flex items-center gap-1">
+										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
+										<span className="text-muted-foreground">Cancelled</span>
 									</span>
 								</>
 							)}

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -108,6 +108,7 @@ export const CHART_HEADER_CONTROLS_CLASS = "flex items-center justify-end gap-2"
 export const CHART_COLORS = {
 	success: "#10b981", // emerald-500
 	error: "#ef4444", // red-500
+	cancelled: "#a1a1aa", // zinc-400
 	promptTokens: "#3b82f6", // blue-500
 	completionTokens: "#10b981", // emerald-500
 	totalTokens: "#8b5cf6", // violet-500

--- a/ui/app/workspace/dashboard/utils/exportUtils.ts
+++ b/ui/app/workspace/dashboard/utils/exportUtils.ts
@@ -24,8 +24,8 @@ import type {
 type CSVData = { headers: string[]; rows: unknown[][] };
 
 export function overviewVolumeToCSV(data: LogsHistogramResponse | null): CSVData {
-	const headers = ["Timestamp", "Total Requests", "Success", "Error"];
-	const rows = (data?.buckets ?? []).map((b) => [b.timestamp, b.count, b.success, b.error]);
+	const headers = ["Timestamp", "Total Requests", "Success", "Error", "Cancelled"];
+	const rows = (data?.buckets ?? []).map((b) => [b.timestamp, b.count, b.success, b.error, b.cancelled ?? 0]);
 	return { headers, rows };
 }
 
@@ -44,13 +44,13 @@ export function overviewCostToCSV(data: CostHistogramResponse | null): CSVData {
 
 export function overviewModelUsageToCSV(data: ModelHistogramResponse | null): CSVData {
 	const models = data?.models ?? [];
-	const modelHeaders = models.flatMap((m) => [`${m} Total`, `${m} Success`, `${m} Error`]);
+	const modelHeaders = models.flatMap((m) => [`${m} Total`, `${m} Success`, `${m} Error`, `${m} Cancelled`]);
 	const headers = ["Timestamp", ...modelHeaders];
 	const rows = (data?.buckets ?? []).map((b) => [
 		b.timestamp,
 		...models.flatMap((m) => {
 			const stats = b.by_model?.[m];
-			return [stats?.total ?? 0, stats?.success ?? 0, stats?.error ?? 0];
+			return [stats?.total ?? 0, stats?.success ?? 0, stats?.error ?? 0, stats?.cancelled ?? 0];
 		}),
 	]);
 	return { headers, rows };

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -158,6 +158,13 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
 					</span>
 					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
 				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-zinc-400" />
+						<span className="text-zinc-600 dark:text-zinc-400">Cancelled</span>
+					</span>
+					<span className="font-medium text-zinc-600 dark:text-zinc-400">{(data.cancelled ?? 0).toLocaleString()}</span>
+				</div>
 			</div>
 		</div>
 	);
@@ -218,6 +225,7 @@ export function LogsVolumeChart({
 			// If too many buckets, just return the original data without filling
 			const result = (data.buckets || []).map((bucket, index) => ({
 				...bucket,
+				cancelled: bucket.cancelled ?? 0,
 				index,
 				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
 			}));
@@ -229,6 +237,7 @@ export function LogsVolumeChart({
 					count: 0,
 					success: 0,
 					error: 0,
+					cancelled: 0,
 					index: 1,
 					formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
 				});
@@ -245,6 +254,7 @@ export function LogsVolumeChart({
 				count: 0,
 				success: 0,
 				error: 0,
+				cancelled: 0,
 				index: idx,
 				formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
 			});
@@ -260,6 +270,7 @@ export function LogsVolumeChart({
 			if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
 				filledBuckets[bucketIndex] = {
 					...bucket,
+					cancelled: bucket.cancelled ?? 0,
 					index: bucketIndex,
 					formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
 				};
@@ -274,6 +285,7 @@ export function LogsVolumeChart({
 				count: 0,
 				success: 0,
 				error: 0,
+				cancelled: 0,
 				index: 1,
 				formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
 			});
@@ -374,6 +386,10 @@ export function LogsVolumeChart({
 									<span className="h-2 w-2 rounded-full bg-red-500" />
 									<span className="text-muted-foreground">Error</span>
 								</span>
+								<span className="flex items-center gap-1.5">
+									<span className="h-2 w-2 rounded-full bg-zinc-400" />
+									<span className="text-muted-foreground">Cancelled</span>
+								</span>
 							</div>
 						)}
 						{isZoomed && onResetZoom && (
@@ -441,6 +457,16 @@ export function LogsVolumeChart({
 											fill="#ef4444"
 											barSize={30}
 											fillOpacity={0.7}
+											radius={[0, 0, 0, 0]}
+											cursor="pointer"
+											onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
+										/>
+										<Bar
+											dataKey="cancelled"
+											stackId="requests"
+											fill="#a1a1aa"
+											barSize={30}
+											fillOpacity={0.75}
 											radius={[2, 2, 0, 0]}
 											cursor="pointer"
 											onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -569,7 +569,7 @@ export interface LogEntry {
 	token_usage?: LLMUsage;
 	cache_debug?: CacheDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost)
-	status: string; // "success" or "error"
+	status: string; // "success", "error", "processing", or "cancelled"
 	stop_reason?: string; // Why the model stopped: "stop", "length", "content_filter", "tool_calls", etc.
 	error_details?: BifrostError;
 	stream: boolean; // true if this was a streaming response
@@ -656,6 +656,7 @@ export interface HistogramBucket {
 	count: number;
 	success: number;
 	error: number;
+	cancelled: number;
 }
 
 export interface LogsHistogramResponse {
@@ -695,6 +696,7 @@ export interface ModelUsageStats {
 	total: number;
 	success: number;
 	error: number;
+	cancelled: number;
 }
 
 export interface ModelHistogramBucket {


### PR DESCRIPTION
## Summary

Adds `cancelled` as a first-class terminal log status alongside `success` and `error`. Previously, cancelled requests were excluded from all aggregate queries, histograms, and materialized views. This change ensures cancelled requests are tracked, counted, and surfaced in charts and exports.

## Changes

- Introduced a `terminalLogStatuses` constant (`["success", "error", "cancelled"]`) to replace all scattered inline `[]string{"success", "error"}` slices across query filters in `rdb.go` and `matviews.go`.
- Added `cancelled_count` to the `mv_logs_hourly` materialized view definition and included `cancelled` in the `WHERE status IN (...)` clause so the view captures cancelled requests.
- Added `cancelled_count` to `mvLogsHourlyRequiredColumns` to enforce schema compatibility checks on startup.
- Added `canUseMatViewStatusFilter` to gate matview usage: non-terminal statuses (e.g. `processing`) force the raw query path, while terminal statuses (including `cancelled`) remain matview-eligible.
- Extended `HistogramBucket` and `ModelUsageStats` structs with a `Cancelled` field, and propagated it through all histogram query paths (raw DB and matview) for `GetHistogram`, `GetModelHistogram`, and their matview equivalents.
- Updated CSV export helpers (`overviewVolumeToCSV`, `overviewModelUsageToCSV`) to include cancelled counts.
- Updated UI chart components (`logVolumeChart.tsx`, `modelUsageChart.tsx`, `logsVolumeChart.tsx`, `overviewTab.tsx`) to render a stacked `cancelled` segment using `zinc-400` (`#a1a1aa`), display it in tooltips and legends, and handle missing values with a `?? 0` fallback.
- Added `cancelled` to the `CHART_COLORS` palette and updated the `HistogramBucket`, `ModelUsageStats`, and `MCPHistogramBucket` TypeScript interfaces.
- Added `TestCancelledStatusIncludedInLogAggregates` to verify that cancelled rows appear in `SearchLogs`, `GetStats`, and `GetHistogram` results while `processing` rows are excluded from terminal aggregates.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/logstore/...

# UI
cd ui
pnpm i
pnpm build
```

The new test `TestCancelledStatusIncludedInLogAggregates` covers the following scenarios:
- A `cancelled` log appears in `SearchLogs` when filtering by `status=cancelled`.
- `GetStats` with no filter counts all 4 rows as total requests but only 3 (terminal) as the cache-hit denominator.
- `GetStats` filtered to `cancelled` returns correct latency and a zero success rate.
- `GetHistogram` filtered to `cancelled` returns a bucket with `Count=1`, `Success=0`, `Error=0`, `Cancelled=1`.

Because `mv_logs_hourly` gains a new `cancelled_count` column, the materialized view must be recreated on first startup. The existing schema version/migration logic handles this via `mvLogsHourlyRequiredColumns`.

## Breaking changes

- [x] Yes
- [ ] No

The `mv_logs_hourly` materialized view schema changes (new `cancelled_count` column). On startup the store will detect the missing column and recreate the view. No manual migration is required, but there will be a brief period during view recreation where matview-backed queries fall back to raw table scans.

API consumers reading `HistogramBucket` or `ModelUsageStats` JSON will now receive an additional `cancelled` field. This is additive and backwards-compatible for consumers that ignore unknown fields.

## Related issues

## Security considerations

None. No new auth surfaces, secrets, or PII handling introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable