### PR TITLE
fix: minor claude code fixes

### DIFF
--- a/core/providers/anthropic/passthroughstream_test.go
+++ b/core/providers/anthropic/passthroughstream_test.go
@@ -176,6 +176,13 @@ type ptFrame struct {
 func runAnthropicPassthrough(t *testing.T, raws []string, applyFix bool) ([]ptFrame, *schemas.BifrostContext) {
 	t.Helper()
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	// This harness always models the passthrough path (raw frames interleaved), so
+	// mark the reverse converter accordingly — mirroring the transport, which calls
+	// SetResponsesStreamPassthrough when shouldUsePassthrough is true. This drives the
+	// server-tool result-block index bumps that keep converted frames in lockstep with
+	// the raw ones; the all-normalized path (TestAnthropicConverterOnly_*) leaves it
+	// unset so indices stay contiguous.
+	SetResponsesStreamPassthrough(ctx)
 	state := newAdvisorStreamState()
 	var out []ptFrame
 	seq := 0
@@ -365,5 +372,56 @@ func TestAnthropicConverterOnlyStream_WellFormed(t *testing.T) {
 	rs := getOrCreateAnthropicToResponsesStreamState(ctx)
 	if len(rs.blockIndexMisses) > 0 {
 		t.Errorf("reverse converter recorded block-index misses (stop/delta for unregistered blocks): %v", rs.blockIndexMisses)
+	}
+}
+
+// TestAnthropicConverterOnly_IndicesContiguous guards the all-normalized path
+// (OpenAI-via-Anthropic, curl — never Claude Code): with no interleaved raw frames,
+// SetResponsesStreamPassthrough is NOT called, so the converter must emit contiguous
+// content_block indices 0,1,2,… A gap (an index consumed for a dropped server-tool
+// result block but no block emitted) is what a strict Anthropic SDK client sees as a
+// missing block; native Anthropic never produces one. web_fetch and zero-result
+// web_search are the two cases that drop a result block — anti-vacuous: before the
+// passthrough gating they emit [0,1,3].
+func TestAnthropicConverterOnly_IndicesContiguous(t *testing.T) {
+	scenarios := map[string][]string{
+		"web_fetch":              ptConcat([]string{ptMsgStart()}, ptThinking(0), ptWebFetch(1, "srv_F"), ptText(3), ptMsgEnd()),
+		"websearch_no_results":   ptConcat([]string{ptMsgStart()}, ptThinking(0), ptWebSearchNoResults(1, "srv_W"), ptText(3), ptMsgEnd()),
+		"websearch_with_results": ptConcat([]string{ptMsgStart()}, ptThinking(0), ptWebSearch(1, "srv_W"), ptText(3), ptMsgEnd()),
+		"two_web_fetch":          ptConcat([]string{ptMsgStart()}, ptWebFetch(0, "srv_F"), ptWebFetch(2, "srv_F2"), ptText(4), ptMsgEnd()),
+		"web_fetch_then_search":  ptConcat([]string{ptMsgStart()}, ptWebFetch(0, "srv_F"), ptWebSearchNoResults(2, "srv_W"), ptText(4), ptMsgEnd()),
+	}
+	for name, raws := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			// No SetResponsesStreamPassthrough: this is the all-normalized path.
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			state := newAdvisorStreamState()
+			seq := 0
+			var starts []int
+			for _, raw := range raws {
+				var chunk AnthropicStreamEvent
+				if err := sonic.Unmarshal([]byte(raw), &chunk); err != nil {
+					t.Fatalf("unmarshal event: %v", err)
+				}
+				responses, bErr, _ := chunk.ToBifrostResponsesStream(ctx, seq, state)
+				if bErr != nil {
+					t.Fatalf("ToBifrostResponsesStream error: %v", bErr)
+				}
+				for _, r := range responses {
+					seq++
+					for _, e := range ToAnthropicResponsesStreamResponse(ctx, r) {
+						if e.Type == AnthropicStreamEventTypeContentBlockStart && e.Index != nil {
+							starts = append(starts, *e.Index)
+						}
+					}
+				}
+			}
+			for i, idx := range starts {
+				if idx != i {
+					t.Errorf("non-contiguous content_block_start indices %v (position %d is index %d, not %d); native Anthropic never skips an index", starts, i, idx, i)
+					break
+				}
+			}
+		})
 	}
 }

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -178,6 +178,16 @@ type anthropicToResponsesStreamState struct {
 	// loudly instead of the stream silently mis-numbering blocks.
 	blockIndexMisses []string
 
+	// passthrough is true when this reverse conversion runs on the Claude Code
+	// passthrough path, where verbatim raw upstream frames are interleaved with the
+	// converter's own. Only then must the converter consume a content-block index for
+	// server-tool result blocks it drops (web_fetch, zero-result web_search) — to stay
+	// in lockstep with the upstream indices carried by the interleaved raw frames. On
+	// the all-normalized path (OpenAI-via-Anthropic, curl) every frame is converter-
+	// built, so consuming the index would skip a number — which native Anthropic never
+	// does. Set by the transport via SetResponsesStreamPassthrough.
+	passthrough bool
+
 	// codeExecToolNameByItem remembers each code_interpreter_call's Anthropic
 	// sub-tool name (captured at output_item.added) so the code block's input can be
 	// reconstructed and closed on code.done — emitted before the nested web_search
@@ -257,6 +267,15 @@ func getOrCreateAnthropicToResponsesStreamState(ctx *schemas.BifrostContext) *an
 	state := &anthropicToResponsesStreamState{}
 	ctx.SetValue(anthropicToResponsesStreamStateKey, state)
 	return state
+}
+
+// SetResponsesStreamPassthrough marks this request's Anthropic reverse stream
+// conversion as running on the Claude Code passthrough path (raw upstream frames
+// interleaved with converted ones). The transport calls it; the converter reads
+// state.passthrough to decide whether to consume server-tool result-block indices
+// it does not emit. See the passthrough field.
+func SetResponsesStreamPassthrough(ctx *schemas.BifrostContext) {
+	getOrCreateAnthropicToResponsesStreamState(ctx).passthrough = true
 }
 
 // AcquireAnthropicResponsesStreamState gets an Anthropic responses stream state from the pool.
@@ -2646,13 +2665,15 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 					&AnthropicStreamEvent{Type: AnthropicStreamEventTypeContentBlockStart, Index: resultIndex, ContentBlock: resultBlock},
 					&AnthropicStreamEvent{Type: AnthropicStreamEventTypeContentBlockStop, Index: resultIndex},
 				)
-			} else {
+			} else if state.passthrough {
 				// A resultless or error web_search (no sources, max_uses_exceeded,
 				// web_search_tool_result_error, …) still consumed a content-block index
 				// upstream (the web_search_tool_result block), so allocate (and discard)
 				// one here to keep the counter in lockstep with upstream indices — else
 				// the following block collides with the verbatim raw frames on the
-				// passthrough path. Mirrors the web_fetch handling below.
+				// passthrough path. Mirrors the web_fetch handling below. Passthrough
+				// only: on the all-normalized path there are no raw frames to align with,
+				// so skipping this keeps indices contiguous (matching native Anthropic).
 				_ = state.allocBlockIndex("")
 			}
 
@@ -2663,14 +2684,18 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Web fetch call complete - close the server_tool_use block. No paired
 			// web_fetch_tool_result block is emitted (its content has no Responses
-			// representation), mirroring the non-streaming reverse path. The upstream
-			// result block still consumed a content-block index, so allocate (and
-			// discard) one here to keep the block-index counter in lockstep with
-			// upstream indices — otherwise later blocks (e.g. the assistant text) would
-			// be numbered one short and collide with the verbatim raw frames.
+			// representation), mirroring the non-streaming reverse path.
 			state := getOrCreateAnthropicToResponsesStreamState(ctx)
 			serverIdx := state.blockIndexFor(reverseStreamItemKey(bifrostResp))
-			_ = state.allocBlockIndex("")
+			// Passthrough only: the upstream result block still consumed a content-block
+			// index, so allocate (and discard) one here to keep the counter in lockstep
+			// with the interleaved raw frames — otherwise later blocks (e.g. the
+			// assistant text) collide with them. On the all-normalized path there are no
+			// raw frames to align with, so skipping this keeps indices contiguous
+			// (matching native Anthropic).
+			if state.passthrough {
+				_ = state.allocBlockIndex("")
+			}
 			return []*AnthropicStreamEvent{{
 				Type:  AnthropicStreamEventTypeContentBlockStop,
 				Index: serverIdx,
@@ -6289,28 +6314,14 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 
 	// Handle special tool types first
 	if tool.Type != nil {
-		switch *tool.Type {
-		case AnthropicToolTypeComputer20250124, AnthropicToolTypeComputer20251124:
-			bifrostTool := &schemas.ResponsesTool{
-				Type: schemas.ResponsesToolTypeComputerUsePreview,
-			}
-			if tool.AnthropicToolComputerUse != nil {
-				bifrostTool.ResponsesToolComputerUsePreview = &schemas.ResponsesToolComputerUsePreview{
-					Environment: "browser", // Default environment
-				}
-				if tool.AnthropicToolComputerUse.DisplayWidthPx != nil {
-					bifrostTool.ResponsesToolComputerUsePreview.DisplayWidth = *tool.AnthropicToolComputerUse.DisplayWidthPx
-				}
-				if tool.AnthropicToolComputerUse.DisplayHeightPx != nil {
-					bifrostTool.ResponsesToolComputerUsePreview.DisplayHeight = *tool.AnthropicToolComputerUse.DisplayHeightPx
-				}
-				if tool.AnthropicToolComputerUse.EnableZoom != nil {
-					bifrostTool.ResponsesToolComputerUsePreview.EnableZoom = tool.AnthropicToolComputerUse.EnableZoom
-				}
-			}
-			return bifrostTool
-
-		case AnthropicToolTypeWebSearch20250305, AnthropicToolTypeWebSearch20260209:
+		// Version-dated server search tools ship new versions regularly; match them by
+		// prefix so a newer version (e.g. web_fetch_20260318) is recognized as a server
+		// tool instead of falling through to the client-function default at the end of
+		// this function. Mirrors applySharedServerToolFields and the chat path. Tools
+		// that must round-trip their exact version (code_execution, text_editor) stay in
+		// the exact switch below.
+		switch typeStr := string(*tool.Type); {
+		case strings.HasPrefix(typeStr, "web_search_"):
 			bifrostTool := &schemas.ResponsesTool{
 				Type: schemas.ResponsesToolTypeWebSearch,
 			}
@@ -6336,7 +6347,7 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 
 			return bifrostTool
 
-		case AnthropicToolTypeWebFetch20250910, AnthropicToolTypeWebFetch20260209, AnthropicToolTypeWebFetch20260309:
+		case strings.HasPrefix(typeStr, "web_fetch_"):
 			bifrostTool := &schemas.ResponsesTool{
 				Type: schemas.ResponsesToolTypeWebFetch,
 			}
@@ -6350,6 +6361,28 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 						AllowedDomains: tool.AnthropicToolWebFetch.AllowedDomains,
 						BlockedDomains: tool.AnthropicToolWebFetch.BlockedDomains,
 					}
+				}
+			}
+			return bifrostTool
+		}
+
+		switch *tool.Type {
+		case AnthropicToolTypeComputer20250124, AnthropicToolTypeComputer20251124:
+			bifrostTool := &schemas.ResponsesTool{
+				Type: schemas.ResponsesToolTypeComputerUsePreview,
+			}
+			if tool.AnthropicToolComputerUse != nil {
+				bifrostTool.ResponsesToolComputerUsePreview = &schemas.ResponsesToolComputerUsePreview{
+					Environment: "browser", // Default environment
+				}
+				if tool.AnthropicToolComputerUse.DisplayWidthPx != nil {
+					bifrostTool.ResponsesToolComputerUsePreview.DisplayWidth = *tool.AnthropicToolComputerUse.DisplayWidthPx
+				}
+				if tool.AnthropicToolComputerUse.DisplayHeightPx != nil {
+					bifrostTool.ResponsesToolComputerUsePreview.DisplayHeight = *tool.AnthropicToolComputerUse.DisplayHeightPx
+				}
+				if tool.AnthropicToolComputerUse.EnableZoom != nil {
+					bifrostTool.ResponsesToolComputerUsePreview.EnableZoom = tool.AnthropicToolComputerUse.EnableZoom
 				}
 			}
 			return bifrostTool

--- a/core/providers/anthropic/websearch_test.go
+++ b/core/providers/anthropic/websearch_test.go
@@ -269,3 +269,39 @@ func TestWebSearch_FullFlow_AnyUserAgent(t *testing.T) {
 		t.Errorf("reconstructed query = %v, want %q", got["query"], "latest AI news")
 	}
 }
+
+// TestServerSearchTools_VersionRecognition guards the request converter against a
+// newer version-dated web_search / web_fetch tool type being silently downgraded to
+// a client function tool. convertAnthropicToolToBifrost matches these by prefix
+// (mirroring the unmarshaler and the chat path), so any current or future dated
+// version must map to the neutral server-tool type. Anti-vacuous: the future-dated
+// entries (…20260318) fall through to ResponsesToolTypeFunction before the fix.
+func TestServerSearchTools_VersionRecognition(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		toolType string
+		want     schemas.ResponsesToolType
+	}{
+		// web_search: known versions + a future-dated one.
+		{"web_search_20250305", schemas.ResponsesToolTypeWebSearch},
+		{"web_search_20260209", schemas.ResponsesToolTypeWebSearch},
+		{"web_search_20260318", schemas.ResponsesToolTypeWebSearch},
+		// web_fetch: known versions + the reported 20260318.
+		{"web_fetch_20250910", schemas.ResponsesToolTypeWebFetch},
+		{"web_fetch_20260209", schemas.ResponsesToolTypeWebFetch},
+		{"web_fetch_20260309", schemas.ResponsesToolTypeWebFetch},
+		{"web_fetch_20260318", schemas.ResponsesToolTypeWebFetch},
+	}
+	for _, c := range cases {
+		t.Run(c.toolType, func(t *testing.T) {
+			in := &AnthropicTool{Type: schemas.Ptr(AnthropicToolType(c.toolType)), Name: "web_fetch"}
+			neutral := convertAnthropicToolToBifrost(in)
+			if neutral == nil {
+				t.Fatalf("%s: convertAnthropicToolToBifrost returned nil", c.toolType)
+			}
+			if neutral.Type != c.want {
+				t.Errorf("%s: neutral tool type = %q, want %q (must not fall through to a client function tool)", c.toolType, neutral.Type, c.want)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -117,6 +117,7 @@ func createAnthropicMessagesRouteConfig(pathPrefix string, logger schemas.Logger
 				ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
 					soToolName, _ := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string)
 					if soToolName == "" && shouldUsePassthrough(ctx, resp.ExtraFields.Provider, resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed) {
+						anthropic.SetResponsesStreamPassthrough(ctx)
 						// Skip passthrough for ContentPartAdded: it's a synthetic bifrost event whose
 						// RawResponse carries the parent content_block_start already emitted by OutputItemAdded.
 						// Passing through here would produce a duplicate content_block_start that causes


### PR DESCRIPTION
## Summary

Fixes two bugs in the Anthropic reverse-stream converter that caused incorrect `content_block` index numbering depending on the request path:

1. **Passthrough path (Claude Code):** The converter was unconditionally consuming (and discarding) a content-block index for dropped server-tool result blocks (`web_fetch`, zero-result `web_search`). This is correct only on the passthrough path, where verbatim raw upstream frames are interleaved and indices must stay in lockstep. On the all-normalized path, this caused a gap in indices (e.g. `[0, 1, 3]` instead of `[0, 1, 2]`), which strict Anthropic SDK clients reject as a missing block.

2. **Tool version recognition:** `convertAnthropicToolToBifrost` matched `web_search` and `web_fetch` tool types by exact version string. Any future-dated version (e.g. `web_fetch_20260318`) silently fell through to the client-function default instead of being recognized as a server tool.

## Changes

- Introduced a `passthrough bool` field on `anthropicToResponsesStreamState` and a `SetResponsesStreamPassthrough(ctx)` function. The transport calls this when `shouldUsePassthrough` is true; the converter reads it to decide whether to consume the discarded result-block index.
- The index-consuming `allocBlockIndex("")` calls for `web_fetch` and resultless `web_search` are now gated on `state.passthrough`, keeping indices contiguous on the all-normalized path.
- `convertAnthropicToolToBifrost` now matches `web_search_*` and `web_fetch_*` tool types by prefix (via `strings.HasPrefix`) in a separate `switch typeStr := string(*tool.Type); { case ... }` block before the exact-match switch, so any current or future dated version is correctly recognized.
- The passthrough test harness (`runAnthropicPassthrough`) now calls `SetResponsesStreamPassthrough` to mirror what the transport does, keeping existing passthrough tests accurate.
- Added `TestAnthropicConverterOnly_IndicesContiguous` to assert that the all-normalized path emits contiguous `content_block_start` indices `0, 1, 2, …` across `web_fetch`, zero-result `web_search`, and combinations thereof.
- Added `TestServerSearchTools_VersionRecognition` to assert that known and future-dated `web_search_*` / `web_fetch_*` tool types all map to the correct neutral server-tool type and never fall through to `ResponsesToolTypeFunction`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... -run "TestAnthropicConverterOnly_IndicesContiguous|TestServerSearchTools_VersionRecognition|TestAnthropicPassthrough|TestAnthropicConverterOnlyStream"
go test ./transports/bifrost-http/...
go test ./...
```

`TestAnthropicConverterOnly_IndicesContiguous` will fail before the fix with output like:
```
non-contiguous content_block_start indices [0 1 3] (position 2 is index 3, not 2); native Anthropic never skips an index
```

`TestServerSearchTools_VersionRecognition` will fail before the fix for `web_search_20260318` and `web_fetch_20260318` with:
```
neutral tool type = "function", want "web_search" (must not fall through to a client function tool)
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable