### PR TITLE
fix: set content type header consistently for responses api requests

### DIFF
--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -87,14 +87,12 @@ func (provider *OpenAIProvider) executeResponsesLifecycleUnary(
 
 	req.SetRequestURI(fullURL)
 	req.Header.SetMethod(method)
-	if method == http.MethodPost || len(body) > 0 {
-		req.Header.SetContentType("application/json")
-		if len(body) > 0 {
-			req.SetBody(body)
-		} else if method == http.MethodPost {
-			effectiveBody = []byte("{}")
-			req.SetBody(effectiveBody)
-		}
+	req.Header.SetContentType("application/json")
+	if len(body) > 0 {
+		req.SetBody(body)
+	} else if method == http.MethodPost {
+		effectiveBody = []byte("{}")
+		req.SetBody(effectiveBody)
 	}
 
 	if key.Value.GetValue() != "" {


### PR DESCRIPTION
## Summary

The `Content-Type: application/json` header was previously only set when the request method was `POST` or when a body was present. This meant non-POST requests with no body (e.g., `GET` or `DELETE`) would not include the header, which could cause inconsistent behavior. The header is now always set regardless of method or body presence.

## Changes

- Removed the outer conditional that gated `Content-Type: application/json` on the method being `POST` or the body being non-empty
- The header is now unconditionally set on all requests in `executeResponsesLifecycleUnary`
- Body assignment logic remains unchanged: a provided body is used as-is, and an empty `POST` body defaults to `{}`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/...
```

Verify that requests made via the OpenAI Responses lifecycle (including non-POST methods) include the `Content-Type: application/json` header, and that POST requests with no body still default to `{}`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects request header construction.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable