### PR TITLE
feat: mark deprecated models instead of filtering them from API responses

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -82,20 +82,6 @@ type BifrostListModelsResponse struct {
 	HasMore *bool   `json:"-"`
 }
 
-func (response *BifrostListModelsResponse) FilterDeprecatedModels() {
-	if response == nil || len(response.Data) == 0 {
-		return
-	}
-	models := response.Data[:0]
-	for _, model := range response.Data {
-		if model.IsDeprecated {
-			continue
-		}
-		models = append(models, model)
-	}
-	response.Data = models
-}
-
 // ApplyPagination applies offset-based pagination to a BifrostListModelsResponse.
 // Uses opaque tokens with LastID validation to ensure cursor integrity.
 // Returns the paginated response with properly set NextPageToken.

--- a/framework/modelcatalog/datasheet/store.go
+++ b/framework/modelcatalog/datasheet/store.go
@@ -269,30 +269,6 @@ func (s *Store) DistinctBaseModelNames() []string {
 	return out
 }
 
-// DistinctActiveBaseModelNames returns unique base names from non-deprecated
-// pricing rows only. Use this for API responses that should hide deprecated
-// catalog entries while preserving the full datasheet internally.
-func (s *Store) DistinctActiveBaseModelNames() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	seen := make(map[string]struct{})
-	for _, pricing := range s.pricingData {
-		if pricing.IsDeprecated {
-			continue
-		}
-		baseName := pricing.BaseModel
-		if baseName == "" {
-			baseName = s.baseModelNameUnsafe(pricing.Model)
-		}
-		seen[baseName] = struct{}{}
-	}
-	out := make([]string, 0, len(seen))
-	for name := range seen {
-		out = append(out, name)
-	}
-	return out
-}
-
 // DatasheetModelsForProvider returns the per-provider model slice derived
 // from pricing data on the last load/sync. Composer unions this with
 // live.ModelsForProvider on read.

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -150,13 +150,6 @@ func (mc *ModelCatalog) GetDistinctBaseModelNames() []string {
 	return mc.datasheet.DistinctBaseModelNames()
 }
 
-// GetDistinctActiveBaseModelNames returns unique base model names backed by
-// non-deprecated pricing rows only. API handlers use this to avoid exposing
-// deprecated catalog entries.
-func (mc *ModelCatalog) GetDistinctActiveBaseModelNames() []string {
-	return mc.datasheet.DistinctActiveBaseModelNames()
-}
-
 // GetProvidersForModel returns every provider that can serve the model.
 // Composes across stores and applies the cross-provider special cases
 // (openrouter / vertex / groq-gpt / bedrock-claude) preserved verbatim from

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -872,7 +872,7 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	enrichAndFilterListModelsResponse(resp, h.config.ModelCatalog)
+	enrichListModelsResponse(resp, h.config.ModelCatalog)
 	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
 		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
 	}
@@ -880,28 +880,24 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, resp)
 }
 
-func enrichAndFilterListModelsResponse(resp *schemas.BifrostListModelsResponse, catalog *modelcatalog.ModelCatalog) {
+func enrichListModelsResponse(resp *schemas.BifrostListModelsResponse, catalog *modelcatalog.ModelCatalog) {
 	if resp == nil || len(resp.Data) == 0 {
 		return
 	}
 
 	if catalog == nil {
-		resp.FilterDeprecatedModels()
 		return
 	}
 
-	models := resp.Data[:0]
-	for _, modelEntry := range resp.Data {
+	for i := range resp.Data {
+		modelEntry := resp.Data[i]
 		provider, modelName := schemas.ParseModelString(modelEntry.ID, "")
 		pricingEntry := catalog.GetPricingEntryForModel(modelName, provider)
 		if pricingEntry == nil && modelEntry.Alias != nil {
 			pricingEntry = catalog.GetPricingEntryForModel(*modelEntry.Alias, provider)
 		}
-		if modelEntry.IsDeprecated || (pricingEntry != nil && pricingEntry.IsDeprecated) {
-			continue
-		}
 		if pricingEntry != nil {
-			modelEntry.IsDeprecated = false
+			modelEntry.IsDeprecated = modelEntry.IsDeprecated || pricingEntry.IsDeprecated
 			if pricingEntry.BaseModel != "" && modelEntry.NormalizedName == nil {
 				modelEntry.NormalizedName = bifrost.Ptr(providerUtils.NormalizeBaseModelSlug(pricingEntry.BaseModel))
 			}
@@ -945,9 +941,8 @@ func enrichAndFilterListModelsResponse(resp *schemas.BifrostListModelsResponse, 
 				modelEntry.Pricing = pricing
 			}
 		}
-		models = append(models, modelEntry)
+		resp.Data[i] = modelEntry
 	}
-	resp.Data = models
 }
 
 // prepareTextCompletionRequest prepares a BifrostTextCompletionRequest from the HTTP request body

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -869,9 +869,6 @@ func (h *ProviderHandler) listManagementModels(query modelListQuery) ([]listedMo
 	for _, provider := range providers {
 		models = append(models, h.listManagementModelsForProvider(provider, query)...)
 	}
-	models = slices.DeleteFunc(models, func(model listedModel) bool {
-		return h.isModelDeprecated(model.Name, model.Provider)
-	})
 
 	total := len(models)
 	if query.Offset > 0 {
@@ -1144,7 +1141,7 @@ func (h *ProviderHandler) listBaseModels(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	baseModels := modelCatalog.GetDistinctActiveBaseModelNames()
+	baseModels := modelCatalog.GetDistinctBaseModelNames()
 	sort.Strings(baseModels)
 
 	// Apply query filter if provided

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -347,11 +348,6 @@ func TestUpdateProvider_PassesThroughForEmptyOrAbsentKeys(t *testing.T) {
 	}
 }
 
-// boolPtr keeps pointer-valued key fixtures inline without pulling in pointer helpers.
-func boolPtr(v bool) *bool {
-	return &v
-}
-
 func modelCatalogForPricingJSON(t *testing.T, pricingJSON []byte) *modelcatalog.ModelCatalog {
 	t.Helper()
 	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
@@ -485,7 +481,7 @@ func TestListModels_AppliesQueryAndLimitAfterFiltering(t *testing.T) {
 	}
 }
 
-func TestListModels_FiltersDeprecatedModelsBeforePagination(t *testing.T) {
+func TestListModels_MarksDeprecatedModelsWithoutFiltering(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
@@ -504,7 +500,7 @@ func TestListModels_FiltersDeprecatedModelsBeforePagination(t *testing.T) {
 
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod("GET")
-	ctx.Request.SetRequestURI("/api/models?provider=openai&limit=1")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&limit=10")
 
 	h.listModels(ctx)
 
@@ -517,18 +513,24 @@ func TestListModels_FiltersDeprecatedModelsBeforePagination(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 
-	if resp.Total != 2 {
-		t.Fatalf("expected total=2 after filtering deprecated models, got %d", resp.Total)
+	if resp.Total != 3 {
+		t.Fatalf("expected total=3 (deprecated models are not filtered), got %d", resp.Total)
 	}
-	if len(resp.Models) != 1 {
-		t.Fatalf("expected limit to apply after deprecated filtering, got %#v", resp.Models)
+	var deprecated *ModelResponse
+	for i := range resp.Models {
+		if resp.Models[i].Name == "deprecated-model" {
+			deprecated = &resp.Models[i]
+		}
 	}
-	if resp.Models[0].Name == "deprecated-model" || resp.Models[0].IsDeprecated {
-		t.Fatalf("deprecated model should not be returned, got %#v", resp.Models[0])
+	if deprecated == nil {
+		t.Fatalf("deprecated model should still be returned, got %#v", resp.Models)
+	}
+	if !deprecated.IsDeprecated {
+		t.Fatalf("deprecated model should carry is_deprecated=true, got %#v", *deprecated)
 	}
 }
 
-func TestListBaseModels_FiltersDeprecatedPricingRows(t *testing.T) {
+func TestListBaseModels_IncludesDeprecatedPricingRows(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
@@ -556,12 +558,12 @@ func TestListBaseModels_FiltersDeprecatedPricingRows(t *testing.T) {
 	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
-	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0] != "current-base" {
-		t.Fatalf("expected only current-base, got %#v", resp)
+	if resp.Total != 2 || !slices.Contains(resp.Models, "current-base") || !slices.Contains(resp.Models, "deprecated-base") {
+		t.Fatalf("expected both base models, got %#v", resp)
 	}
 }
 
-func TestEnrichAndFilterListModelsResponse_FiltersDeprecatedPricingRows(t *testing.T) {
+func TestEnrichListModelsResponse_MarksDeprecatedPricingRows(t *testing.T) {
 	catalog := modelCatalogForPricingJSON(t, []byte(`{
 		"deprecated-model": {"provider":"openai","mode":"chat","base_model":"deprecated-model","is_deprecated":true},
 		"current-model": {"provider":"openai","mode":"chat","base_model":"current-model"}
@@ -572,13 +574,23 @@ func TestEnrichAndFilterListModelsResponse_FiltersDeprecatedPricingRows(t *testi
 		{ID: "openai/provider-deprecated", IsDeprecated: true},
 	}}
 
-	enrichAndFilterListModelsResponse(resp, catalog)
+	enrichListModelsResponse(resp, catalog)
 
-	if len(resp.Data) != 1 || resp.Data[0].ID != "openai/current-model" {
-		t.Fatalf("expected only current model, got %#v", resp.Data)
+	if len(resp.Data) != 3 {
+		t.Fatalf("expected all models retained, got %#v", resp.Data)
 	}
-	if resp.Data[0].IsDeprecated {
-		t.Fatalf("current model should not be marked deprecated: %#v", resp.Data[0])
+	byID := map[string]schemas.Model{}
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+	if !byID["openai/deprecated-model"].IsDeprecated {
+		t.Fatalf("catalog-deprecated model should be marked deprecated: %#v", byID["openai/deprecated-model"])
+	}
+	if byID["openai/current-model"].IsDeprecated {
+		t.Fatalf("current model should not be marked deprecated: %#v", byID["openai/current-model"])
+	}
+	if !byID["openai/provider-deprecated"].IsDeprecated {
+		t.Fatalf("provider-deprecated flag should be preserved: %#v", byID["openai/provider-deprecated"])
 	}
 }
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -82,7 +82,7 @@ func (m *mockHandlerStore) GetModelCatalog() *modelcatalog.ModelCatalog {
 // Ensure mockHandlerStore implements lib.HandlerStore
 var _ lib.HandlerStore = (*mockHandlerStore)(nil)
 
-func TestGenericRouter_FilterDeprecatedListModelsResponseUsesCatalog(t *testing.T) {
+func TestGenericRouter_MarkDeprecatedListModelsResponseUsesCatalog(t *testing.T) {
 	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
 	pricingJSON := []byte(`{
 		"deprecated-model": {"provider":"openai","mode":"chat","base_model":"deprecated-model","is_deprecated":true},
@@ -98,11 +98,17 @@ func TestGenericRouter_FilterDeprecatedListModelsResponseUsesCatalog(t *testing.
 		{ID: "openai/provider-deprecated", IsDeprecated: true},
 	}}
 
-	router.filterDeprecatedListModelsResponse(resp)
+	router.markDeprecatedListModelsResponse(resp)
 
-	require.Len(t, resp.Data, 1)
-	assert.Equal(t, "openai/current-model", resp.Data[0].ID)
-	assert.False(t, resp.Data[0].IsDeprecated)
+	// No models are removed; deprecated ones are flagged instead.
+	require.Len(t, resp.Data, 3)
+	byID := map[string]schemas.Model{}
+	for _, m := range resp.Data {
+		byID[m.ID] = m
+	}
+	assert.True(t, byID["openai/deprecated-model"].IsDeprecated)
+	assert.False(t, byID["openai/current-model"].IsDeprecated)
+	assert.True(t, byID["openai/provider-deprecated"].IsDeprecated)
 }
 
 func Test_parseS3URI(t *testing.T) {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -953,7 +953,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Bifrost response is nil after post-request callback"))
 			return
 		}
-		g.filterDeprecatedListModelsResponse(listModelsResponse)
+		g.markDeprecatedListModelsResponse(listModelsResponse)
 
 		response, err = config.ListModelsResponseConverter(bifrostCtx, listModelsResponse)
 		bifrostExtraFields = listModelsResponse.ExtraFields
@@ -1782,30 +1782,30 @@ func (g *GenericRouter) handleAsyncJobResponse(ctx *fasthttp.RequestCtx, bifrost
 	}
 }
 
-func (g *GenericRouter) filterDeprecatedListModelsResponse(resp *schemas.BifrostListModelsResponse) {
+// markDeprecatedListModelsResponse annotates deprecated models with the
+// IsDeprecated flag using catalog pricing data, without removing them from the
+// response. Clients decide how to surface deprecated entries (e.g. the UI keeps
+// them visible but non-selectable).
+func (g *GenericRouter) markDeprecatedListModelsResponse(resp *schemas.BifrostListModelsResponse) {
 	if resp == nil || len(resp.Data) == 0 {
 		return
 	}
 	catalogProvider, ok := g.handlerStore.(modelCatalogProvider)
 	if !ok || catalogProvider.GetModelCatalog() == nil {
-		resp.FilterDeprecatedModels()
 		return
 	}
 	catalog := catalogProvider.GetModelCatalog()
-	models := resp.Data[:0]
-	for _, model := range resp.Data {
+	for i := range resp.Data {
+		model := resp.Data[i]
 		provider, modelName := schemas.ParseModelString(model.ID, "")
 		pricingEntry := catalog.GetPricingEntryForModel(modelName, provider)
 		if pricingEntry == nil && model.Alias != nil {
 			pricingEntry = catalog.GetPricingEntryForModel(*model.Alias, provider)
 		}
-		if model.IsDeprecated || (pricingEntry != nil && pricingEntry.IsDeprecated) {
-			continue
+		if pricingEntry != nil && pricingEntry.IsDeprecated {
+			resp.Data[i].IsDeprecated = true
 		}
-		model.IsDeprecated = false
-		models = append(models, model)
 	}
-	resp.Data = models
 }
 
 // handleBatchRequest handles batch API requests (create, list, retrieve, cancel, results)

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -56,6 +56,9 @@ interface ModelOption {
 	label: string;
 	value: string;
 	provider?: string;
+	isDeprecated?: boolean;
+	/** react-select reads this to make an option non-selectable */
+	isDisabled?: boolean;
 }
 
 const ALL_MODELS_OPTION: ModelOption = { label: "All Models", value: "*" };
@@ -159,6 +162,8 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 							label: model.name,
 							value: model.name,
 							provider: model.provider,
+							isDeprecated: model.is_deprecated,
+							isDisabled: model.is_deprecated,
 						}));
 						callback([...prefix, ...options]);
 					})
@@ -242,6 +247,8 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 				label: model.name,
 				value: model.name,
 				provider: model.provider,
+				isDeprecated: model.is_deprecated,
+				isDisabled: model.is_deprecated,
 			})) || []),
 		];
 	}, [modelsData, baseModelsData, shouldUseBaseModels, allowAllOption]);
@@ -307,17 +314,23 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 						},
 				option: (optionProps: OptionProps<ModelOption>) => {
 					const { Option } = components;
+					const isDeprecated = optionProps.data.isDeprecated;
 					return (
 						<Option
 							{...optionProps}
 							className={cn(
-								"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
-								optionProps.isFocused && "bg-accent dark:!bg-card",
-								"hover:bg-accent",
-								optionProps.isSelected && "bg-accent dark:!bg-card",
+								"flex w-full items-center gap-2 rounded-sm px-2 py-2 text-sm",
+								isDeprecated ? "cursor-not-allowed opacity-60" : "cursor-pointer hover:bg-accent",
+								!isDeprecated && optionProps.isFocused && "bg-accent dark:!bg-card",
+								!isDeprecated && optionProps.isSelected && "bg-accent dark:!bg-card",
 							)}
 						>
-							<span className="grow truncate text-sm">{optionProps.data.label}</span>
+							<span className={cn("grow truncate text-sm", isDeprecated && "text-muted-foreground")}>{optionProps.data.label}</span>
+							{isDeprecated && (
+								<span className="text-muted-foreground border-border shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide">
+									Deprecated
+								</span>
+							)}
 						</Option>
 					);
 				},

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -23,6 +23,7 @@ function sortProviders(a: ModelProvider, b: ModelProvider) {
 export interface ModelResponse {
 	name: string;
 	provider: string;
+	is_deprecated?: boolean;
 	accessible_by_keys?: string[];
 	additional_attributes?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary

Deprecated models are no longer silently removed from list-models API responses. Instead, they are retained in the response and annotated with `is_deprecated: true`. The UI consumes this flag to render deprecated models as non-selectable (dimmed, with a "Deprecated" badge) rather than hiding them entirely.

## Changes

- Removed `FilterDeprecatedModels` from `BifrostListModelsResponse` and all call sites that dropped deprecated entries from responses.
- Removed `DistinctActiveBaseModelNames` and `GetDistinctActiveBaseModelNames`; `GetDistinctBaseModelNames` is now used everywhere, including the base models endpoint.
- Renamed `enrichAndFilterListModelsResponse` → `enrichListModelsResponse` and `filterDeprecatedListModelsResponse` → `markDeprecatedListModelsResponse` to reflect the new behavior: models are annotated, not removed.
- The enrichment logic now sets `IsDeprecated = true` when either the provider or the catalog pricing entry marks the model as deprecated, instead of excluding it from the result set.
- The management models list endpoint no longer calls `isModelDeprecated` to delete entries before pagination.
- `ModelResponse` in the providers API type definition gains an `is_deprecated` field.
- `ModelMultiselect` maps `is_deprecated` to `isDisabled` on each option, preventing selection of deprecated models. Deprecated options render with reduced opacity, a `cursor-not-allowed` style, and a small "Deprecated" badge.
- Updated all affected tests to assert that deprecated models are present in responses with the correct flag value rather than asserting they are absent.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./framework/modelcatalog/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Call the list-models endpoint for a provider that has deprecated models in the pricing catalog. Verify all models are returned and deprecated ones carry `"is_deprecated": true`.
2. Call the base models endpoint and confirm deprecated base model names appear in the response.
3. Open the model multiselect in the UI, confirm deprecated models appear with the "Deprecated" badge and cannot be selected.

## Screenshots/Recordings

![image.png](https://app.graphite.com/user-attachments/assets/cd496e4e-7c6b-4559-9f33-224dc17f0815.png)



## Breaking changes

- [x] Yes
- [ ] No

Clients that relied on deprecated models being absent from list-models or list-base-models responses will now receive them. Clients should filter on `is_deprecated: true` if they wish to exclude deprecated entries.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable