### PR TITLE
fix: set `SecretTypePlainText` for plain-text JSON and non-prefixed secret values

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -82,6 +82,9 @@ func parseSecretRef(value string) *SecretVar {
 					// Legacy format: value == env_var == "env.XXX"
 					e.ref = raw.EnvVar
 					e.SecretType = SecretTypeEnv
+				} else {
+					// Plain text JSON object ({value, ...} with no type/ref/from_env).
+					e.SecretType = SecretTypePlainText
 				}
 				return e
 			}
@@ -93,7 +96,7 @@ func parseSecretRef(value string) *SecretVar {
 	if strings.HasPrefix(val, "env.") {
 		return &SecretVar{ref: val, SecretType: SecretTypeEnv}
 	}
-	return &SecretVar{Val: val}
+	return &SecretVar{Val: val, SecretType: SecretTypePlainText}
 }
 
 // IsSecretRef reports whether value is a secret reference (env.* or vault.* prefix,
@@ -353,6 +356,9 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 					} else {
 						e.Val = ""
 					}
+				}
+				if e.SecretType == "" {
+					e.SecretType = SecretTypePlainText
 				}
 				return nil
 			}


### PR DESCRIPTION
## Summary

Ensures that `SecretVar` instances parsed from plain-text values (i.e., JSON objects with a `value` field but no `type`, `ref`, or `from_env`) are explicitly tagged with `SecretTypePlainText` rather than left with an empty `SecretType`. Previously, these cases fell through without a type assignment, making it ambiguous whether a secret was intentionally plain text or simply uninitialized.

## Changes

- When parsing a JSON secret object that has no `type`, `ref`, or `from_env` field, `SecretType` is now explicitly set to `SecretTypePlainText`.
- When `parseSecretRef` returns a plain string value (no `env.` or `vault.` prefix), the returned `SecretVar` now carries `SecretTypePlainText`.
- During `UnmarshalJSON`, if `SecretType` remains empty after processing a recognized JSON structure, it is defaulted to `SecretTypePlainText`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
```

Verify that a `SecretVar` parsed from a plain string or a JSON object like `{"value": "my-secret"}` has `SecretType == SecretTypePlainText` rather than an empty string.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change makes secret type classification more explicit. Code that previously relied on an empty `SecretType` to identify plain-text secrets should be reviewed to ensure it handles `SecretTypePlainText` correctly.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable