### PR TITLE
refactor: extract shared `EmptyStateView` component and migrate all empty/placeholder states to use it

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/access-profiles/accessProfilesIndexView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/access-profiles/accessProfilesIndexView.tsx
@@ -1,17 +1,14 @@
 import { ShieldCheck } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function AccessProfilesIndexView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<ShieldCheck className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock access profiles for better performance"
-				description="This feature is a part of the Bifrost enterprise license. Create access profiles to control access to your resources."
-				readmeLink="https://docs.getbifrost.ai/enterprise/access-profiles"
-				testIdPrefix="access-profiles"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={ShieldCheck}
+			title="Unlock access profiles for better performance"
+			description="This feature is a part of the Bifrost enterprise license. Create access profiles to control access to your resources."
+			readmeLink="https://docs.getbifrost.ai/enterprise/access-profiles"
+			testIdPrefix="access-profiles"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/adaptive-routing/adaptiveRoutingView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/adaptive-routing/adaptiveRoutingView.tsx
@@ -1,16 +1,13 @@
 import { Shuffle } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function AdaptiveRoutingView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Shuffle className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock adaptive routing for better performance"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/adaptive-load-balancing"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Shuffle}
+			title="Unlock adaptive routing for better performance"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/adaptive-load-balancing"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/alert-channels/alertChannelsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/alert-channels/alertChannelsView.tsx
@@ -1,16 +1,13 @@
 import { Siren } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function AlertChannelsView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Siren className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock alert channels for better observability"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/alert-channels"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Siren}
+			title="Unlock alert channels for better observability"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/alert-channels"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/api-keys/apiKeysIndexView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/apiKeysIndexView.tsx
@@ -56,7 +56,7 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 	const isInferenceAuthDisabled = !(bifrostConfig?.client_config?.enforce_auth_on_inference ?? false);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full space-y-4">
 			<Alert variant="default">
 				<InfoIcon className="text-muted h-4 w-4" />
 				<AlertDescription>

--- a/ui/app/_fallbacks/enterprise/components/audit-logs/auditLogsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/audit-logs/auditLogsView.tsx
@@ -1,16 +1,13 @@
 import { ScrollText } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function AuditLogsView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<ScrollText className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock audit logs for better compliance"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/audit-logs"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={ScrollText}
+			title="Unlock audit logs for better compliance"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/audit-logs"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/circuit-breaker/circuitBreakerView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/circuit-breaker/circuitBreakerView.tsx
@@ -1,16 +1,13 @@
 import { CircuitBoard } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function CircuitBreakerView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<CircuitBoard className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock circuit breaker for reliable fallbacks"
-				description="This feature is a part of the Bifrost enterprise license. Automatically redirect traffic to a fallback provider when your primary endpoint shows signs of failure."
-				readmeLink="https://docs.getbifrost.ai/enterprise/circuit-breaker"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={CircuitBoard}
+			title="Unlock circuit breaker for reliable fallbacks"
+			description="This feature is a part of the Bifrost enterprise license. Automatically redirect traffic to a fallback provider when your primary endpoint shows signs of failure."
+			readmeLink="https://docs.getbifrost.ai/enterprise/circuit-breaker"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/cluster/clusterView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/cluster/clusterView.tsx
@@ -1,16 +1,13 @@
-import { Layers } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import { Network } from "lucide-react";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function ClusterPage() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Layers className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock cluster mode to scale reliably"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/clustering"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Network}
+			title="Unlock cluster mode to scale reliably"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/clustering"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsConfigurationView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsConfigurationView.tsx
@@ -1,16 +1,13 @@
 import { Construction } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function GuardrailsConfigurationView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Construction className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock guardrails for better security"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/guardrails"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Construction}
+			title="Unlock guardrails for better security"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/guardrails"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsProviderView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsProviderView.tsx
@@ -1,16 +1,13 @@
 import { Construction } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
-export default function guardrailsProviderView() {
+export default function GuardrailsProviderView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Construction className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock guardrails for better security"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/guardrails"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Construction}
+			title="Unlock guardrails for better security"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/guardrails"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/mcp-auth-config/mcpAuthConfigView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/mcp-auth-config/mcpAuthConfigView.tsx
@@ -1,16 +1,13 @@
 import { ShieldUser } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function MCPAuthConfigView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<ShieldUser className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock MCP Auth Config"
-				description="This feature is a part of the Bifrost enterprise license. Configure authentication for MCP servers to secure your MCP connections."
-				readmeLink="https://docs.getbifrost.ai/mcp/overview"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={ShieldUser}
+			title="Unlock MCP Auth Config"
+			description="This feature is a part of the Bifrost enterprise license. Configure authentication for MCP servers to secure your MCP connections."
+			readmeLink="https://docs.getbifrost.ai/mcp/overview"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
+++ b/ui/app/_fallbacks/enterprise/components/mcp-tool-groups/mcpToolGroups.tsx
@@ -1,26 +1,13 @@
 import { ToolCase } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function MCPToolGroups() {
 	return (
-		<>
-			<div className="mb-4 flex items-center justify-between gap-4">
-				<div>
-					<h2 className="text-lg font-semibold tracking-tight">MCP Tool Groups</h2>
-					<p className="text-muted-foreground text-sm">Configure tool groups for MCP servers to organize and govern tools.</p>
-				</div>
-			</div>
-			<div className="rounded-sm border">
-				<div className="flex w-full flex-col items-center justify-center py-16">
-					<ContactUsView
-						className="mx-auto w-full max-w-lg"
-						icon={<ToolCase className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-						title="Unlock MCP Tool Groups"
-						description="This feature is a part of the Bifrost enterprise license. Configure tool groups for MCP servers to organize your MCP tools and govern them across your organization."
-						readmeLink="https://docs.getbifrost.ai/mcp/overview"
-					/>
-				</div>
-			</div>
-		</>
+		<FeaturePlaceholderView
+			icon={ToolCase}
+			title="Unlock MCP Tool Groups"
+			description="This feature is a part of the Bifrost enterprise license. Configure tool groups for MCP servers to organize your MCP tools and govern them across your organization."
+			readmeLink="https://docs.getbifrost.ai/mcp/overview"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentView.tsx
@@ -1,4 +1,4 @@
-import { Router } from "lucide-react";
+import { FolderGit } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
 export default function PromptDeploymentView(_props?: { omitTitle?: boolean }) {
@@ -7,7 +7,7 @@ export default function PromptDeploymentView(_props?: { omitTitle?: boolean }) {
 			<ContactUsView
 				align="top"
 				className="justify-start gap-3 rounded-md border p-4"
-				icon={<Router className="h-8 w-8" strokeWidth={1.5} />}
+				icon={<FolderGit className="h-8 w-8" strokeWidth={1.5} />}
 				title="Unlock prompt deployments for better prompt versioning and A/B testing."
 				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
 				readmeLink="https://docs.getbifrost.ai/enterprise/prompt-deployments"

--- a/ui/app/_fallbacks/enterprise/components/rbac/rbacView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/rbac/rbacView.tsx
@@ -1,16 +1,13 @@
 import { UserRoundCheck } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function RBACView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<UserRoundCheck className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock roles and permissions for better security"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={UserRoundCheck}
+			title="Unlock roles and permissions for better security"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/scim/scimView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/scim/scimView.tsx
@@ -1,16 +1,13 @@
 import { BookUser } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function SCIMView() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<BookUser className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock SCIM based access management for user provisioning"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={BookUser}
+			title="Unlock SCIM based access management for user provisioning"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/user-groups/businessUnitsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/businessUnitsView.tsx
@@ -1,17 +1,14 @@
 import { Building2 } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export function BusinessUnitsView() {
 	return (
-		<div className="w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				testIdPrefix="business-units-governance"
-				icon={<Building2 className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock business units & advanced governance"
-				description="Manage users, business units with our enterprise-grade governance. This feature is part of the Bifrost enterprise license."
-				readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Building2}
+			testIdPrefix="business-units-governance"
+			title="Unlock business units & advanced governance"
+			description="Manage users, business units with our enterprise-grade governance. This feature is part of the Bifrost enterprise license."
+			readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/user-groups/usersView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/usersView.tsx
@@ -1,16 +1,13 @@
 import { Users } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function UsersView() {
 	return (
-		<div className="w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Users className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock users & user governance"
-				description="Manage users, set per-user budgets and rate limits, and control access with enterprise-grade governance. This feature is part of the Bifrost enterprise license."
-				readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Users}
+			title="Unlock users & user governance"
+			description="Manage users, set per-user budgets and rate limits, and control access with enterprise-grade governance. This feature is part of the Bifrost enterprise license."
+			readmeLink="https://docs.getbifrost.ai/enterprise/advanced-governance"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/user-rankings/userRankingsTab.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-rankings/userRankingsTab.tsx
@@ -1,17 +1,14 @@
 import { Users } from "lucide-react";
-import ContactUsView from "../views/contactUsView";
+import FeaturePlaceholderView from "../views/featurePlaceholderView";
 
 export default function UserRankingsTab() {
 	return (
-		<div className="h-full w-full">
-			<ContactUsView
-				className="mx-auto min-h-[80vh]"
-				icon={<Users className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
-				title="Unlock user rankings for better visibility"
-				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
-				readmeLink="https://docs.getbifrost.ai/enterprise/user-rankings"
-				testIdPrefix="user-rankings"
-			/>
-		</div>
+		<FeaturePlaceholderView
+			icon={Users}
+			title="Unlock user rankings for better visibility"
+			description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+			readmeLink="https://docs.getbifrost.ai/enterprise/user-rankings"
+			testIdPrefix="user-rankings"
+		/>
 	);
 }

--- a/ui/app/_fallbacks/enterprise/components/views/featurePlaceholderView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/views/featurePlaceholderView.tsx
@@ -1,0 +1,35 @@
+import { EmptyStateView } from "@/components/emptyStateView";
+import { Button } from "@/components/ui/button";
+import type { LucideIcon } from "lucide-react";
+
+interface Props {
+	icon: LucideIcon;
+	title: string;
+	description: string;
+	readmeLink: string;
+	testIdPrefix?: string;
+}
+
+export default function FeaturePlaceholderView({ icon, title, description, readmeLink, testIdPrefix }: Props) {
+	return (
+		<EmptyStateView
+			icon={icon}
+			title={title}
+			description={description}
+			readmeLink={readmeLink}
+			readMoreAriaLabel="Read more about this feature (opens in new tab)"
+			readMoreTestId={testIdPrefix ? `${testIdPrefix}-read-more` : undefined}
+			actions={
+				<Button
+					aria-label="Book a demo (opens Calendly in new tab)"
+					data-testid={testIdPrefix ? `${testIdPrefix}-book-demo` : undefined}
+					onClick={() => {
+						window.open("https://calendly.com/maximai/bifrost-demo?utm_source=bfd_ent", "_blank", "noopener,noreferrer");
+					}}
+				>
+					Book a demo
+				</Button>
+			}
+		/>
+	);
+}

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverridesEmptyState.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverridesEmptyState.tsx
@@ -1,5 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
-import { ArrowUpRight, SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal } from "lucide-react";
 
 const PRICING_OVERRIDES_DOCS_URL = "https://docs.getbifrost.ai/features/governance/custom-pricing";
 
@@ -9,34 +10,19 @@ interface PricingOverridesEmptyStateProps {
 
 export function PricingOverridesEmptyState({ onCreateClick }: PricingOverridesEmptyStateProps) {
 	return (
-		<div
-			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
-			data-testid="pricing-overrides-empty-state"
-		>
-			<div className="text-muted-foreground">
-				<SlidersHorizontal className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Pricing overrides customize cost tracking per scope</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Define custom per-token prices for specific providers, keys, or virtual keys to accurately reflect your negotiated rates.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about pricing overrides (opens in new tab)"
-						data-testid="pricing-overrides-button-read-more"
-						onClick={() => {
-							window.open(`${PRICING_OVERRIDES_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button aria-label="Create your first pricing override" data-testid="pricing-override-create-btn" onClick={onCreateClick}>
-						Create Override
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={SlidersHorizontal}
+			testId="pricing-overrides-empty-state"
+			title="Pricing overrides customize cost tracking per scope"
+			description="Define custom per-token prices for specific providers, keys, or virtual keys to accurately reflect your negotiated rates."
+			readmeLink={PRICING_OVERRIDES_DOCS_URL}
+			readMoreAriaLabel="Read more about pricing overrides (opens in new tab)"
+			readMoreTestId="pricing-overrides-button-read-more"
+			actions={
+				<Button aria-label="Add your first pricing override" data-testid="pricing-override-create-btn" onClick={onCreateClick}>
+					Add Override
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/governance/views/customersEmptyState.tsx
+++ b/ui/app/workspace/governance/views/customersEmptyState.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { WalletCards } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
 
 const CUSTOMERS_DOCS_URL = "https://docs.getbifrost.ai/features/governance/virtual-keys#customers";
 
@@ -11,31 +11,18 @@ interface CustomersEmptyStateProps {
 
 export function CustomersEmptyState({ onAddClick, canCreate = true }: CustomersEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<WalletCards className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Customers have their own teams, budgets, and access controls</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Create customer accounts to manage multi-tenant usage, assign teams, and set spending and rate limits per customer.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about customers (opens in new tab)"
-						data-testid="customer-button-read-more"
-						onClick={() => {
-							window.open(`${CUSTOMERS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button aria-label="Add your first customer" onClick={onAddClick} disabled={!canCreate} data-testid="customer-button-create">
-						Add Customer
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={WalletCards}
+			title="Customers have their own teams, budgets, and access controls"
+			description="Create customer accounts to manage multi-tenant usage, assign teams, and set spending and rate limits per customer."
+			readmeLink={CUSTOMERS_DOCS_URL}
+			readMoreAriaLabel="Read more about customers (opens in new tab)"
+			readMoreTestId="customer-button-read-more"
+			actions={
+				<Button aria-label="Add your first customer" onClick={onAddClick} disabled={!canCreate} data-testid="customer-button-create">
+					Add Customer
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/governance/views/teamsEmptyState.tsx
+++ b/ui/app/workspace/governance/views/teamsEmptyState.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { Building } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
 
 const TEAMS_DOCS_URL = "https://docs.getbifrost.ai/features/governance/virtual-keys#teams";
 
@@ -11,31 +11,18 @@ interface TeamsEmptyStateProps {
 
 export function TeamsEmptyState({ onAddClick, canCreate = true }: TeamsEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<Building className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Teams organize users with shared budgets and access</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Create teams to group users, assign customer accounts, and set budgets and rate limits at the team level.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about teams (opens in new tab)"
-						data-testid="team-button-read-more"
-						onClick={() => {
-							window.open(`${TEAMS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button aria-label="Add your first team" onClick={onAddClick} disabled={!canCreate} data-testid="team-button-add">
-						Add Team
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={Building}
+			title="Teams organize users with shared budgets and access"
+			description="Create teams to group users, assign customer accounts, and set budgets and rate limits at the team level."
+			readmeLink={TEAMS_DOCS_URL}
+			readMoreAriaLabel="Read more about teams (opens in new tab)"
+			readMoreTestId="team-button-read-more"
+			actions={
+				<Button aria-label="Add your first team" onClick={onAddClick} disabled={!canCreate} data-testid="team-button-add">
+					Add Team
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/mcp-registry/views/mcpServersEmptyState.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpServersEmptyState.tsx
@@ -1,6 +1,7 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { Link } from "@tanstack/react-router";
-import { ArrowUpRight, Boxes, Server } from "lucide-react";
+import { Boxes, Server } from "lucide-react";
 
 const MCP_SERVERS_DOCS_URL = "https://docs.getbifrost.ai/features/mcp/overview";
 
@@ -11,27 +12,15 @@ interface MCPServersEmptyStateProps {
 
 export function MCPServersEmptyState({ onAddClick, canCreate = true }: MCPServersEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<Server className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">MCP servers connect tools and context to the gateway</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Add MCP servers to expose tools and resources to the MCP Tools endpoint. Configure connection type, auth, and which tools to
-					enable.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about MCP servers (opens in new tab)"
-						data-testid="mcp-registry-button-read-more"
-						onClick={() => {
-							window.open(`${MCP_SERVERS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
+		<EmptyStateView
+			icon={Server}
+			title="MCP servers connect tools and context to the gateway"
+			description="Add MCP servers to expose tools and resources to the MCP Tools endpoint. Configure connection type, auth, and which tools to enable."
+			readmeLink={MCP_SERVERS_DOCS_URL}
+			readMoreAriaLabel="Read more about MCP servers (opens in new tab)"
+			readMoreTestId="mcp-registry-button-read-more"
+			actions={
+				<>
 					<Button aria-label="Add your first MCP server" onClick={onAddClick} disabled={!canCreate} data-testid="create-mcp-client-btn">
 						Add MCP Server
 					</Button>
@@ -41,8 +30,8 @@ export function MCPServersEmptyState({ onAddClick, canCreate = true }: MCPServer
 							Browse Library
 						</Link>
 					</Button>
-				</div>
-			</div>
-		</div>
+				</>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/model-catalog/views/modelCatalogEmptyState.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogEmptyState.tsx
@@ -1,24 +1,19 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { Link } from "@tanstack/react-router";
 import { LayoutGrid } from "lucide-react";
 
 export function ModelCatalogEmptyState() {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<LayoutGrid className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">No providers configured yet</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Configure your first model provider to see an overview of all providers, API keys, models, and usage metrics.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button asChild data-testid="modelcatalog-configure-providers-cta">
-						<Link to="/workspace/providers">Configure Providers</Link>
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={LayoutGrid}
+			title="No providers configured yet"
+			description="Configure your first model provider to see an overview of all providers, API keys, models, and usage metrics."
+			actions={
+				<Button asChild data-testid="modelcatalog-configure-providers-cta">
+					<Link to="/workspace/providers">Configure Providers</Link>
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/model-limits/views/modelLimitsEmptyState.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsEmptyState.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { Wallet } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
 
 const MODEL_LIMITS_DOCS_URL = "https://docs.getbifrost.ai/features/governance";
 
@@ -11,36 +11,18 @@ interface ModelLimitsEmptyStateProps {
 
 export function ModelLimitsEmptyState({ onAddClick, canCreate = true }: ModelLimitsEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<Wallet className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Budgets and rate limits at the model level</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Set spending caps and rate limits per model. For provider-specific limits, configure each provider in Model providers.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about budgets and limits (opens in new tab)"
-						data-testid="model-limits-button-read-more"
-						onClick={() => {
-							window.open(`${MODEL_LIMITS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button
-						aria-label="Add your first model limit"
-						onClick={onAddClick}
-						disabled={!canCreate}
-						data-testid="model-limits-button-create"
-					>
-						Add Model Limit
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={Wallet}
+			title="Budgets and rate limits at the model level"
+			description="Set spending caps and rate limits per model. For provider-specific limits, configure each provider in Model providers."
+			readmeLink={MODEL_LIMITS_DOCS_URL}
+			readMoreAriaLabel="Read more about budgets and limits (opens in new tab)"
+			readMoreTestId="model-limits-button-read-more"
+			actions={
+				<Button aria-label="Add your first model limit" onClick={onAddClick} disabled={!canCreate} data-testid="model-limits-button-create">
+					Add Model Limit
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
+++ b/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
@@ -1,5 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
-import { ArrowUpRight, Puzzle } from "lucide-react";
+import { Puzzle } from "lucide-react";
 
 const CUSTOM_PLUGINS_DOCS_URL = "https://docs.getbifrost.ai/plugins";
 
@@ -10,39 +11,19 @@ interface PluginsEmptyStateProps {
 
 export function PluginsEmptyState({ onCreateClick, canCreate = true }: PluginsEmptyStateProps) {
 	return (
-		<div
-			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
-			data-testid="plugins-empty-state"
-		>
-			<div className="text-muted-foreground">
-				<Puzzle className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Custom plugins extend Bifrost with your own business logic</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Build and deploy plugins for custom integrations, workflow automation, and AI governance.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about custom plugins (opens in new tab)"
-						data-testid="plugins-button-read-more"
-						onClick={() => {
-							window.open(`${CUSTOM_PLUGINS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button
-						aria-label="Create your first plugin"
-						data-testid="plugins-button-install-new"
-						onClick={onCreateClick}
-						disabled={!canCreate}
-					>
-						Install New Plugin
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={Puzzle}
+			testId="plugins-empty-state"
+			title="Custom plugins extend Bifrost with your own business logic"
+			description="Build and deploy plugins for custom integrations, workflow automation, and AI governance."
+			readmeLink={CUSTOM_PLUGINS_DOCS_URL}
+			readMoreAriaLabel="Read more about custom plugins (opens in new tab)"
+			readMoreTestId="plugins-button-read-more"
+			actions={
+				<Button aria-label="Add your first plugin" data-testid="plugins-button-install-new" onClick={onCreateClick} disabled={!canCreate}>
+					Add Plugin
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/providers/views/providersEmptyState.tsx
+++ b/ui/app/workspace/providers/views/providersEmptyState.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@/components/ui/button";
-import { ArrowUpRight, Server } from "lucide-react";
+import { EmptyStateView } from "@/components/emptyStateView";
+import { Server } from "lucide-react";
 
 const PROVIDERS_DOCS_URL = "https://docs.getbifrost.ai/providers/supported-providers/overview";
 
@@ -10,29 +10,14 @@ interface ProvidersEmptyStateProps {
 
 export function ProvidersEmptyState({ addProviderDropdown }: ProvidersEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<Server className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Add a provider to start routing requests</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Configure API keys for OpenAI, Anthropic, Bedrock, and other supported providers. Bifrost unifies them behind a single API.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about providers (opens in new tab)"
-						data-testid="providers-button-read-more"
-						onClick={() => {
-							window.open(`${PROVIDERS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					{addProviderDropdown}
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={Server}
+			title="Add a provider to start routing requests"
+			description="Configure API keys for OpenAI, Anthropic, Bedrock, and other supported providers. Bifrost unifies them behind a single API."
+			readmeLink={PROVIDERS_DOCS_URL}
+			readMoreAriaLabel="Read more about providers (opens in new tab)"
+			readMoreTestId="providers-button-read-more"
+			actions={addProviderDropdown}
+		/>
 	);
 }

--- a/ui/app/workspace/routing-rules/views/routingRulesEmptyState.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesEmptyState.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { Route } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
 
 const ROUTING_RULES_DOCS_URL = "https://docs.getbifrost.ai/providers/routing-rules";
 
@@ -11,40 +11,19 @@ interface RoutingRulesEmptyStateProps {
 
 export function RoutingRulesEmptyState({ onAddClick, canCreate = true }: RoutingRulesEmptyStateProps) {
 	return (
-		<div
-			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
-			data-testid="routing-rules-empty-state"
-		>
-			<div className="text-muted-foreground">
-				<Route className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Routing rules direct requests using CEL conditions</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Create CEL-based rules to route requests by model, provider, budget, or custom attributes. Control which provider or model handles
-					each request.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about routing rules (opens in new tab)"
-						data-testid="routing-rules-empty-read-more"
-						onClick={() => {
-							window.open(`${ROUTING_RULES_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button
-						aria-label="Create your first routing rule"
-						data-testid="create-routing-rule-btn"
-						onClick={onAddClick}
-						disabled={!canCreate}
-					>
-						New Rule
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={Route}
+			testId="routing-rules-empty-state"
+			title="Routing rules direct requests using CEL conditions"
+			description="Create CEL-based rules to route requests by model, provider, budget, or custom attributes. Control which provider or model handles each request."
+			readmeLink={ROUTING_RULES_DOCS_URL}
+			readMoreAriaLabel="Read more about routing rules (opens in new tab)"
+			readMoreTestId="routing-rules-empty-read-more"
+			actions={
+				<Button aria-label="Add your first routing rule" data-testid="create-routing-rule-btn" onClick={onAddClick} disabled={!canCreate}>
+					Add Routing Rule
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeysEmptyState.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysEmptyState.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { KeyRound } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
 
 const VIRTUAL_KEYS_DOCS_URL = "https://docs.getbifrost.ai/features/governance/virtual-keys";
 
@@ -11,34 +11,19 @@ interface VirtualKeysEmptyStateProps {
 
 export function VirtualKeysEmptyState({ onAddClick, canCreate = true }: VirtualKeysEmptyStateProps) {
 	return (
-		<div
-			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
-			data-testid="virtual-keys-empty-state"
-		>
-			<div className="text-muted-foreground">
-				<KeyRound className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Virtual keys control access, budgets, and rate limits</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					Create virtual keys to assign permissions, spending limits, and usage quotas to teams, customers, or API clients.
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about virtual keys (opens in new tab)"
-						data-testid="virtual-keys-button-read-more"
-						onClick={() => {
-							window.open(`${VIRTUAL_KEYS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
-					</Button>
-					<Button aria-label="Add your first virtual key" onClick={onAddClick} disabled={!canCreate} data-testid="create-vk-btn">
-						Add Virtual Key
-					</Button>
-				</div>
-			</div>
-		</div>
+		<EmptyStateView
+			icon={KeyRound}
+			testId="virtual-keys-empty-state"
+			title="Virtual keys control access, budgets, and rate limits"
+			description="Create virtual keys to assign permissions, spending limits, and usage quotas to teams, customers, or API clients."
+			readmeLink={VIRTUAL_KEYS_DOCS_URL}
+			readMoreAriaLabel="Read more about virtual keys (opens in new tab)"
+			readMoreTestId="virtual-keys-button-read-more"
+			actions={
+				<Button aria-label="Add your first virtual key" onClick={onAddClick} disabled={!canCreate} data-testid="create-vk-btn">
+					Add Virtual Key
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/components/emptyStateView.tsx
+++ b/ui/components/emptyStateView.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ArrowUpRight, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface EmptyStateViewProps {
+	icon: LucideIcon;
+	title: string;
+	description: ReactNode;
+	readmeLink?: string;
+	readMoreAriaLabel?: string;
+	readMoreTestId?: string;
+	actions?: ReactNode;
+	className?: string;
+	testId?: string;
+}
+
+export function EmptyStateView({
+	icon: Icon,
+	title,
+	description,
+	readmeLink,
+	readMoreAriaLabel,
+	readMoreTestId,
+	actions,
+	className,
+	testId,
+}: EmptyStateViewProps) {
+	return (
+		<div
+			className={cn("flex min-h-[calc(100dvh-3rem)] w-full flex-col items-center justify-center gap-4 text-center", className)}
+			data-testid={testId}
+		>
+			<div className="text-muted-foreground">
+				<Icon className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
+			</div>
+			<div className="flex flex-col gap-1">
+				<h1 className="text-muted-foreground text-xl font-medium">{title}</h1>
+				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">{description}</div>
+				{(readmeLink || actions) && (
+					<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
+						{readmeLink && (
+							<Button
+								variant="outline"
+								aria-label={readMoreAriaLabel ?? "Read more (opens in new tab)"}
+								data-testid={readMoreTestId}
+								onClick={() => {
+									window.open(`${readmeLink}?utm_source=bfd`, "_blank", "noopener,noreferrer");
+								}}
+							>
+								Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+							</Button>
+						)}
+						{actions}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/ui/components/loggingDisabledView.tsx
+++ b/ui/components/loggingDisabledView.tsx
@@ -1,6 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
 import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } from "@/lib/store";
-import { cn } from "@/lib/utils";
 import { ScrollText } from "lucide-react";
 import { useCallback } from "react";
 import { toast } from "sonner";
@@ -26,19 +26,15 @@ export function LoggingDisabledView() {
 	}, [bifrostConfig, updateCoreConfig]);
 
 	return (
-		<div className={cn("flex flex-col items-center justify-center gap-4 text-center mx-auto w-full max-w-7xl min-h-[80vh]")}>
-			<div className="text-muted-foreground">
-				<ScrollText className="h-10 w-10" />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Logging is disabled</h1>
-				<div className="text-muted-foreground mt-2 max-w-[600px] text-sm font-normal">
-					Enable logging to view LLM and MCP request logs, traces, and observability data.
-				</div>
-			</div>
-			<Button onClick={handleEnable} disabled={isLoading}>
-				{isLoading ? "Enabling…" : "Enable logging"}
-			</Button>
-		</div>
+		<EmptyStateView
+			icon={ScrollText}
+			title="Logging is disabled"
+			description="Enable logging to view LLM and MCP request logs, traces, and observability data."
+			actions={
+				<Button onClick={handleEnable} disabled={isLoading}>
+					{isLoading ? "Enabling…" : "Enable logging"}
+				</Button>
+			}
+		/>
 	);
 }

--- a/ui/components/prompts/components/emptyState.tsx
+++ b/ui/components/prompts/components/emptyState.tsx
@@ -1,5 +1,6 @@
+import { EmptyStateView } from "@/components/emptyStateView";
 import { Button } from "@/components/ui/button";
-import { ArrowUpRight, SquareTerminal } from "lucide-react";
+import { FolderGit } from "lucide-react";
 import { usePromptContext } from "../context";
 
 export function EmptyState() {
@@ -35,39 +36,24 @@ export function PromptsEmptyState() {
 	const { setPromptSheet, canCreate } = usePromptContext();
 
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
-			<div className="text-muted-foreground">
-				<SquareTerminal className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
-			</div>
-			<div className="flex flex-col gap-1">
-				<h1 className="text-muted-foreground text-xl font-medium">Build, test, and version your prompts</h1>
-				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
-					{canCreate
-						? "Create prompts, test them with different models and parameters in the playground, and version your changes for deployment."
-						: "View prompts and test them with different models and parameters in the playground."}
-				</div>
-				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-					<Button
-						variant="outline"
-						aria-label="Read more about prompt repository (opens in new tab)"
-						data-testid="empty-state-read-more"
-						onClick={() => {
-							window.open(`https://docs.getbifrost.ai/features/prompt-repository?utm_source=bfd`, "_blank", "noopener,noreferrer");
-						}}
-					>
-						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+		<EmptyStateView
+			icon={FolderGit}
+			title="Build, test, and version your prompts"
+			description={
+				canCreate
+					? "Create prompts, test them with different models and parameters in the playground, and version your changes for deployment."
+					: "View prompts and test them with different models and parameters in the playground."
+			}
+			readmeLink="https://docs.getbifrost.ai/features/prompt-repository"
+			readMoreAriaLabel="Read more about prompt repository (opens in new tab)"
+			readMoreTestId="empty-state-read-more"
+			actions={
+				canCreate && (
+					<Button aria-label="Add your first prompt" data-testid="empty-state-create-prompt" onClick={() => setPromptSheet({ open: true })}>
+						Add Prompt
 					</Button>
-					{canCreate && (
-						<Button
-							aria-label="Create your first prompt"
-							data-testid="empty-state-create-prompt"
-							onClick={() => setPromptSheet({ open: true })}
-						>
-							Create Prompt
-						</Button>
-					)}
-				</div>
-			</div>
-		</div>
+				)
+			}
+		/>
 	);
 }


### PR DESCRIPTION
## Summary

Introduces a shared `EmptyStateView` component to consolidate the duplicated empty state UI pattern used across the application. Previously, each feature page and enterprise fallback view independently implemented the same layout (icon, title, description, "Read more" button, and action buttons). This PR extracts that pattern into a single reusable component and migrates all call sites to use it.

A companion `FeaturePlaceholderView` component is also introduced for enterprise feature gating screens, wrapping `EmptyStateView` with a consistent "Book a demo" CTA that links to the Bifrost Calendly page.

## Changes

- Added `ui/components/emptyStateView.tsx` — a new shared component that accepts an icon, title, description, optional docs link, and optional action slot. The "Read more" button with `ArrowUpRight` is rendered automatically when a `readmeLink` is provided, eliminating the need for each consumer to implement it manually.
- Added `ui/app/_fallbacks/enterprise/components/views/featurePlaceholderView.tsx` — wraps `EmptyStateView` with a "Book a demo" button for enterprise-gated features.
- Replaced all usages of the inline empty state pattern across virtual keys, routing rules, providers, plugins, model limits, model catalog, MCP servers, teams, customers, pricing overrides, and the logging disabled view with `EmptyStateView`.
- Replaced all enterprise fallback views (access profiles, adaptive routing, alert channels, audit logs, circuit breaker, cluster, guardrails, MCP auth config, MCP tool groups, RBAC, SCIM, business units, users, user rankings) with `FeaturePlaceholderView`, removing the wrapping `div` and `ContactUsView` pattern.
- Updated the cluster fallback icon from `Layers` to `Network` and the prompt deployment fallback icon from `Router` to `FolderGit` for better semantic accuracy.
- Fixed a casing bug in `guardrailsProviderView` — the component is now exported as `GuardrailsProviderView`.
- Removed the `max-w-4xl` constraint from the API keys index view.
- The `EmptyStateView` height uses `min-h-[calc(100dvh-3rem)]` instead of the previous `min-h-[80vh]` for more accurate full-viewport sizing.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Visually verify that empty state screens across providers, virtual keys, routing rules, plugins, model limits, MCP servers, teams, customers, pricing overrides, and all enterprise fallback pages render correctly with the icon, title, description, "Read more" button, and their respective action buttons.

## Screenshots/Recordings

Before/after screenshots recommended for any enterprise fallback page and at least one standard empty state page to confirm layout consistency.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a purely presentational refactor with no changes to auth, data access, or secrets handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable