### PR TITLE
refactor: replace "Create" with "Add" across all creation sheet titles and buttons

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -741,7 +741,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		<Sheet open={open} onOpenChange={(o) => (o ? onOpenChange(true) : handleCloseDrawer())}>
 			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-0 pt-4 sm:max-w-2xl">
 				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
-					<SheetTitle className="">{editingOverride ? "Edit Pricing Override" : "Create Pricing Override"}</SheetTitle>
+					<SheetTitle className="">{editingOverride ? "Edit Pricing Override" : "Add Pricing Override"}</SheetTitle>
 				</SheetHeader>
 
 				<Form {...methods}>

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -274,7 +274,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="max-w-[900px] p-0 pt-4 sm:max-w-2xl" data-testid="customer-dialog-content">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Customer" : "Create Customer"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Customer" : "Add Customer"}</SheetTitle>
 					<SheetDescription>
 						{isEditing
 							? "Update the customer information and settings."
@@ -386,7 +386,7 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 								<TooltipTrigger asChild>
 									<span>
 										<Button type="submit" disabled={isSubmitDisabled}>
-											{loading ? "Saving..." : isEditing ? "Update Customer" : "Create Customer"}
+											{loading ? "Saving..." : isEditing ? "Update Customer" : "Add Customer"}
 										</Button>
 									</span>
 								</TooltipTrigger>

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -321,7 +321,7 @@ export default function TeamSheet({ team, customers, onSave, onCancel }: TeamShe
 				onEscapeKeyDown={() => onCancel()}
 			>
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Create Team"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Add Team"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the team information and settings." : "Create a new team to organize users and manage shared resources."}
 					</SheetDescription>
@@ -590,7 +590,7 @@ export default function TeamSheet({ team, customers, onSave, onCancel }: TeamShe
 									<TooltipTrigger asChild>
 										<span className="inline-block">
 											<Button type="submit" disabled={loading || !validator.isValid() || !hasPermission} data-testid="team-save-btn">
-												{loading ? "Saving..." : isEditing ? "Update Team" : "Create Team"}
+												{loading ? "Saving..." : isEditing ? "Update Team" : "Add Team"}
 											</Button>
 										</span>
 									</TooltipTrigger>

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -305,7 +305,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		<Sheet open={open} onOpenChange={(open) => !open && !oauthFlow && onClose()}>
 			<SheetContent className="flex w-full flex-col overflow-x-hidden px-0">
 				<SheetHeader className="flex flex-col items-start px-7 pt-8">
-					<SheetTitle>New MCP Server</SheetTitle>
+					<SheetTitle>Add MCP Server</SheetTitle>
 					<SheetDescription>Configure and connect to a new Model Context Protocol server.</SheetDescription>
 				</SheetHeader>
 

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -263,7 +263,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				data-testid="model-limit-sheet"
 			>
 				<SheetHeader className="flex flex-col items-start p-0 px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
-					<SheetTitle>{isEditing ? "Edit Model Limit" : "Create Model Limit"}</SheetTitle>
+					<SheetTitle>{isEditing ? "Edit Model Limit" : "Add Model Limit"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update budget and rate limit configuration." : "Set up budget and rate limits for a model."}
 					</SheetDescription>
@@ -531,7 +531,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 									Cancel
 								</Button>
 								<Button type="submit" data-testid="model-limit-button-submit" disabled={isLoading || !form.formState.isDirty || !canSubmit}>
-									{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Create Limit"}
+									{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Add Limit"}
 								</Button>
 							</div>
 						</div>

--- a/ui/app/workspace/plugins/page.tsx
+++ b/ui/app/workspace/plugins/page.tsx
@@ -110,7 +110,7 @@ export default function PluginsPage() {
 									}}
 								>
 									<PlusIcon className="h-4 w-4" />
-									<div className="text-xs">Install New Plugin</div>
+									<div className="text-xs">Add Plugin</div>
 								</Button>
 								{customPlugins && customPlugins.length > 0 && (
 									<Button

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -151,7 +151,7 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 		<Sheet open={open} onOpenChange={handleClose}>
 			<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4">
 				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky top-0 bg-card z-10">
-					<SheetTitle>{isEditMode ? "Update Plugin" : "Install New Plugin"}</SheetTitle>
+					<SheetTitle>{isEditMode ? "Update Plugin" : "Add Plugin"}</SheetTitle>
 					<SheetDescription>
 						{isEditMode
 							? "Update the plugin configuration. Note: Plugin name and path cannot be changed."
@@ -170,7 +170,7 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 								Cancel
 							</Button>
 							<Button type="submit" disabled={isLoading || !form.formState.isValid || disableAction} isLoading={isLoading}>
-								{isEditMode ? "Update Plugin" : "Install Plugin"}
+								{isEditMode ? "Update Plugin" : "Add Plugin"}
 							</Button>
 						</div>
 					</form>

--- a/ui/app/workspace/providers/views/addProviderDropdown.tsx
+++ b/ui/app/workspace/providers/views/addProviderDropdown.tsx
@@ -47,7 +47,7 @@ export function AddProviderDropdown({
 					disabled={disabled}
 				>
 					<PlusIcon className="h-4 w-4" />
-					{variant === "empty" ? <span>Add provider</span> : <div className="text-xs">Add New Provider</div>}
+					{variant === "empty" ? <span>Add Provider</span> : <div className="text-xs">Add Provider</div>}
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
@@ -62,7 +62,7 @@ export function AddProviderDropdown({
 					</DropdownMenuItem>
 				))}
 				{hasKnown && <DropdownMenuSeparator />}
-				{/* Add New Provider > Custom provider... — used by E2E (add-provider-option-custom) */}
+				{/* Add Provider > Custom provider... — used by E2E (add-provider-option-custom) */}
 				<DropdownMenuItem data-testid="add-provider-option-custom" onSelect={onAddCustomProvider}>
 					<Settings2Icon className="h-4 w-4" />
 					<span>Custom provider...</span>

--- a/ui/app/workspace/routing-rules/tree/views/routingTreeView.tsx
+++ b/ui/app/workspace/routing-rules/tree/views/routingTreeView.tsx
@@ -489,7 +489,7 @@ export function RoutingTreeView() {
 									/>
 								</TooltipTrigger>
 								<TooltipContent side="top" className="max-w-[200px] text-center">
-									Re-entry point is fully proven by static analysis — every condition on the path evaluated to a known value.
+									Re-entry point is fully proven by static analysis - every condition on the path evaluated to a known value.
 								</TooltipContent>
 							</Tooltip>
 						</div>
@@ -524,7 +524,7 @@ export function RoutingTreeView() {
 									/>
 								</TooltipTrigger>
 								<TooltipContent side="top" className="max-w-[200px] text-center">
-									Re-entry point is a conditional — one or more conditions on the path are not fully evaluated at build time.
+									Re-entry point is a conditional - one or more conditions on the path are not fully evaluated at build time.
 								</TooltipContent>
 							</Tooltip>
 						</div>

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -272,7 +272,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full min-w-1/2 flex-col gap-4 overflow-x-hidden p-0 pt-4">
 				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
-					<SheetTitle>{isEditing ? "Edit Routing Rule" : "Create New Routing Rule"}</SheetTitle>
+					<SheetTitle>{isEditing ? "Edit Routing Rule" : "Add Routing Rule"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the routing rule configuration" : "Create a new CEL-based routing rule for intelligent request routing"}
 					</SheetDescription>

--- a/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
+++ b/ui/app/workspace/skills-repo/forms/skillEditForm.tsx
@@ -467,7 +467,7 @@ export function SkillEditView({
 						<PopoverAnchor asChild>
 							<Button size="sm" data-testid="skill-create-save-btn" onClick={() => openVersionPopover(true)} disabled={isSaving}>
 								{isSaving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
-								{isSaving ? "Creating..." : "Create Skill"}
+								{isSaving ? "Adding..." : "Add Skill"}
 							</Button>
 						</PopoverAnchor>
 						<PopoverContent align="end" className="w-max">
@@ -769,7 +769,7 @@ function VersionPopoverBody({
 	return (
 		<>
 			<div className="mb-3 flex flex-col gap-0.5">
-				<p className="text-sm font-medium">{isCreate ? "Create skill" : "Save new version"}</p>
+				<p className="text-sm font-medium">{isCreate ? "Add skill" : "Save new version"}</p>
 				<p className="text-muted-foreground text-xs">
 					{isCreate ? "Set the initial version for this skill." : "Choose a new version number for these changes."}
 				</p>
@@ -814,7 +814,7 @@ function VersionPopoverBody({
 					Cancel
 				</Button>
 				<Button size="sm" data-testid="skill-version-confirm-btn" disabled={!canSave} onClick={submit}>
-					{isCreate ? "Create" : serve ? "Save & Serve" : "Save"}
+					{isCreate ? "Add" : serve ? "Save & Serve" : "Save"}
 				</Button>
 			</div>
 		</>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -879,7 +879,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 				onEscapeKeyDown={() => handleClose()}
 			>
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Add Virtual Key"}</SheetTitle>
 					<SheetDescription>
 						{isEditing
 							? "Update the virtual key configuration and permissions."
@@ -2043,7 +2043,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 											<TooltipTrigger asChild>
 												<span className="inline-block">
 													<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
-														{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+														{isLoading ? "Saving..." : isEditing ? "Update" : "Add"}
 													</Button>
 												</span>
 											</TooltipTrigger>

--- a/ui/components/prompts/fragments/sidebar.tsx
+++ b/ui/components/prompts/fragments/sidebar.tsx
@@ -196,7 +196,7 @@ export function PromptSidebar() {
 									variant="outline"
 									className="h-8 w-8 shrink-0 bg-transparent"
 									data-testid="sidebar-create-menu"
-									aria-label="Create prompt or folder"
+									aria-label="Add prompt or folder"
 								>
 									<PlusIcon className="h-3.5 w-3.5" />
 								</Button>

--- a/ui/components/prompts/sheets/folderSheet.tsx
+++ b/ui/components/prompts/sheets/folderSheet.tsx
@@ -82,7 +82,7 @@ export function FolderSheet({ open, onOpenChange, folder, onSaved }: FolderSheet
 			>
 				<form onSubmit={handleSubmit(onSubmit)}>
 					<SheetHeader className="flex flex-col items-start">
-						<SheetTitle>{isEditing ? "Edit Folder" : "Create Folder"}</SheetTitle>
+						<SheetTitle>{isEditing ? "Edit Folder" : "Add Folder"}</SheetTitle>
 						<SheetDescription>
 							{isEditing ? "Update the folder name and description." : "Create a new folder to organize your prompts."}
 						</SheetDescription>
@@ -121,7 +121,7 @@ export function FolderSheet({ open, onOpenChange, folder, onSaved }: FolderSheet
 							Cancel
 						</Button>
 						<Button type="submit" data-testid="folder-submit" disabled={isLoading}>
-							{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+							{isLoading ? "Saving..." : isEditing ? "Update" : "Add"}
 						</Button>
 					</SheetFooter>
 				</form>

--- a/ui/components/prompts/sheets/promptSheet.tsx
+++ b/ui/components/prompts/sheets/promptSheet.tsx
@@ -79,7 +79,7 @@ export function PromptSheet({ open, onOpenChange, prompt, folderId, onSaved }: P
 			>
 				<form onSubmit={handleSubmit(onSubmit)} className="flex grow flex-col">
 					<SheetHeader className="flex flex-col items-start px-8 pt-8">
-						<SheetTitle>{isEditing ? "Rename Prompt" : "Create Prompt"}</SheetTitle>
+						<SheetTitle>{isEditing ? "Rename Prompt" : "Add Prompt"}</SheetTitle>
 						<SheetDescription>
 							{isEditing ? "Update the prompt name." : folderId ? "Create a new prompt in this folder." : "Create a new prompt."}
 						</SheetDescription>
@@ -108,7 +108,7 @@ export function PromptSheet({ open, onOpenChange, prompt, folderId, onSaved }: P
 								Cancel
 							</Button>
 							<Button type="submit" data-testid="prompt-submit" disabled={isLoading}>
-								{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+								{isLoading ? "Saving..." : isEditing ? "Update" : "Add"}
 							</Button>
 						</SheetFooter>
 					</div>


### PR DESCRIPTION
## Summary

Standardizes the language used across creation-related UI actions by replacing "Create" with "Add" in sheet titles, button labels, and aria attributes throughout the workspace. This improves consistency in how new resource creation is presented to users.

## Changes

- Replaced "Create [Resource]" with "Add [Resource]" in sheet titles and submit button labels for: Pricing Overrides, Customers, Teams, MCP Servers, Model Limits, Plugins, Providers, Routing Rules, Skills, Virtual Keys, Prompt Folders, and Prompts
- Updated the "Install New Plugin" / "Install Plugin" button labels to "Add Plugin" to align with the same pattern
- Updated "Create New Routing Rule" to "Add Routing Rule"
- Changed em-dashes to hyphens in two routing tree tooltip strings
- Updated an aria-label from "Create prompt or folder" to "Add prompt or folder"

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Verify that all sheet headers and submit buttons for new resource creation display "Add [Resource]" instead of "Create [Resource]" across the affected workspace sections.

## Screenshots/Recordings

Before/after screenshots recommended for each affected sheet to confirm label changes are reflected correctly in the UI.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable