### PR TITLE
refactor: introduce `WorkspacePageShell` and consolidate page layout/padding across workspace routes

### DIFF
--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -310,7 +310,7 @@ export default function ComplexityRouterPage() {
 
 	if (error && !data) {
 		return (
-			<div className="mx-auto w-full max-w-7xl space-y-4 px-14 pt-8">
+			<div className="mx-auto w-full space-y-4">
 				<p className="text-destructive font-mono text-sm">{getErrorMessage(error)}</p>
 				<Button data-testid="complexity-router-fetch-retry-button" type="button" variant="outline" size="sm" onClick={() => refetch()}>
 					Retry
@@ -321,7 +321,7 @@ export default function ComplexityRouterPage() {
 
 	if (!data) {
 		return (
-			<div className="mx-auto w-full max-w-7xl space-y-4 px-14 pt-8">
+			<div className="mx-auto w-full space-y-4">
 				<p className="text-muted-foreground font-mono text-sm">No complexity router configuration is available.</p>
 				<Button data-testid="complexity-router-fetch-retry-button" type="button" variant="outline" size="sm" onClick={() => refetch()}>
 					Retry
@@ -335,13 +335,13 @@ export default function ComplexityRouterPage() {
 	const hasErrors = Boolean(boundaryErrors || keywordErrors);
 
 	return (
-		<ScrollArea className="no-padding-parent h-[calc(100vh_-_16px)] w-full px-14 pt-4">
-			<form className="mx-auto w-full max-w-7xl space-y-8" onSubmit={handleSubmit(onValid)} noValidate>
+		<ScrollArea className="no-padding-parent h-[calc(100dvh-1rem)] w-full p-4">
+			<form className="mx-auto w-full space-y-8" onSubmit={handleSubmit(onValid)} noValidate>
 				{/* ── Page header ── */}
-				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-					<div className="space-y-1.5">
-						<h1 className="text-2xl font-semibold tracking-tight">Complexity Router</h1>
-						<p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
+				<div className="flex items-center justify-between gap-4">
+					<div>
+						<h1 className="text-foreground text-lg font-semibold">Complexity Router</h1>
+						<p className="text-muted-foreground text-sm">
 							Tune how incoming requests are classified into four tiers. Thresholds and keyword lists feed the{" "}
 							<code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
 							target.
@@ -521,7 +521,7 @@ export default function ComplexityRouterPage() {
 				)}
 
 				{/* ── Action footer ── */}
-				<div className="bg-card sticky bottom-0 flex flex-wrap items-center justify-end gap-2.5 border-t py-4 z-10">
+				<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 					<Button
 						data-testid="complexity-router-restore-defaults-button"
 						type="button"

--- a/ui/app/workspace/config/api-keys/page.tsx
+++ b/ui/app/workspace/config/api-keys/page.tsx
@@ -1,9 +1,5 @@
 import APIKeysView from "@enterprise/components/api-keys/apiKeysIndexView";
 
 export default function APIKeysPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<APIKeysView />
-		</div>
-	);
+	return <APIKeysView />;
 }

--- a/ui/app/workspace/config/caching/page.tsx
+++ b/ui/app/workspace/config/caching/page.tsx
@@ -1,9 +1,5 @@
 import CachingView from "../views/cachingView";
 
 export default function CachingPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<CachingView />
-		</div>
-	);
+	return <CachingView />;
 }

--- a/ui/app/workspace/config/client-settings/page.tsx
+++ b/ui/app/workspace/config/client-settings/page.tsx
@@ -1,9 +1,5 @@
 import ClientSettingsView from "../views/clientSettingsView";
 
 export default function ClientSettingsPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<ClientSettingsView />
-		</div>
-	);
+	return <ClientSettingsView />;
 }

--- a/ui/app/workspace/config/compatibility/page.tsx
+++ b/ui/app/workspace/config/compatibility/page.tsx
@@ -1,9 +1,5 @@
 import CompatibilityView from "../views/compatibilityView";
 
 export default function CompatibilityPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<CompatibilityView />
-		</div>
-	);
+	return <CompatibilityView />;
 }

--- a/ui/app/workspace/config/feature-flags/page.tsx
+++ b/ui/app/workspace/config/feature-flags/page.tsx
@@ -1,9 +1,5 @@
 import FeatureFlagsView from "../views/featureFlagsView";
 
 export default function FeatureFlagsPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<FeatureFlagsView />
-		</div>
-	);
+	return <FeatureFlagsView />;
 }

--- a/ui/app/workspace/config/layout.tsx
+++ b/ui/app/workspace/config/layout.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet, useChildMatches, useLocation } from "@tanstack/react-router";
 import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import { useGetCoreConfigQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import ConfigPage from "./page";
@@ -24,7 +25,7 @@ function RouteComponent() {
 		return <FullPageLoader />;
 	}
 
-	return childMatches.length === 0 ? <ConfigPage /> : <Outlet />;
+	return <WorkspacePageShell>{childMatches.length === 0 ? <ConfigPage /> : <Outlet />}</WorkspacePageShell>;
 }
 
 export const Route = createFileRoute("/workspace/config")({

--- a/ui/app/workspace/config/logging/page.tsx
+++ b/ui/app/workspace/config/logging/page.tsx
@@ -1,9 +1,5 @@
 import LoggingView from "../views/loggingView";
 
 export default function LoggingPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<LoggingView />
-		</div>
-	);
+	return <LoggingView />;
 }

--- a/ui/app/workspace/config/mcp-gateway/page.tsx
+++ b/ui/app/workspace/config/mcp-gateway/page.tsx
@@ -1,9 +1,5 @@
 import MCPGatewayView from "../views/mcpView";
 
 export default function MCPGatewayPage() {
-	return (
-		<div className="mx-auto w-full max-w-7xl">
-			<MCPGatewayView />
-		</div>
-	);
+	return <MCPGatewayView />;
 }

--- a/ui/app/workspace/config/observability/page.tsx
+++ b/ui/app/workspace/config/observability/page.tsx
@@ -1,9 +1,5 @@
 import ObservabilityView from "../views/observabilityView";
 
 export default function ObservabilityPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<ObservabilityView />
-		</div>
-	);
+	return <ObservabilityView />;
 }

--- a/ui/app/workspace/config/performance-tuning/page.tsx
+++ b/ui/app/workspace/config/performance-tuning/page.tsx
@@ -1,9 +1,5 @@
 import PerformanceTuningView from "../views/performanceTuningView";
 
 export default function PerformanceTuningPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<PerformanceTuningView />
-		</div>
-	);
+	return <PerformanceTuningView />;
 }

--- a/ui/app/workspace/config/pricing-config/page.tsx
+++ b/ui/app/workspace/config/pricing-config/page.tsx
@@ -1,9 +1,5 @@
 import ModelSettingsView from "../views/modelSettingsView";
 
 export default function PricingConfigPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<ModelSettingsView />
-		</div>
-	);
+	return <ModelSettingsView />;
 }

--- a/ui/app/workspace/config/proxy/page.tsx
+++ b/ui/app/workspace/config/proxy/page.tsx
@@ -16,9 +16,5 @@ export default function ProxyPage() {
 		return null;
 	}
 
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<ProxyView />
-		</div>
-	);
+	return <ProxyView />;
 }

--- a/ui/app/workspace/config/security/page.tsx
+++ b/ui/app/workspace/config/security/page.tsx
@@ -1,9 +1,5 @@
 import SecurityView from "../views/securityView";
 
 export default function SecurityPage() {
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			<SecurityView />
-		</div>
-	);
+	return <SecurityView />;
 }

--- a/ui/app/workspace/config/views/cachingView.tsx
+++ b/ui/app/workspace/config/views/cachingView.tsx
@@ -263,7 +263,7 @@ export default function CachingView() {
 	const isLoading = configLoading || pluginsLoading;
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-6">
+		<div className="mx-auto w-full space-y-6">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Local Cache</h2>
 				<p className="text-muted-foreground text-sm">
@@ -664,7 +664,7 @@ export default function CachingView() {
 								</div>
 							</div>
 
-							<div className="flex justify-end pt-2">
+							<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 								<Button
 									data-testid="caching-save-button"
 									onClick={handleSave}

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -285,7 +285,7 @@ export default function ClientSettingsView() {
 	}, []);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-6">
+		<div className="mx-auto w-full space-y-6">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Client Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure client behavior and request handling.</p>
@@ -568,7 +568,7 @@ export default function ClientSettingsView() {
 				controlsDisabled={isLoading || !hasSettingsUpdateAccess}
 			/>
 
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				{hasSecurityHeaderError ? (
 					<Tooltip>
 						<TooltipTrigger asChild>

--- a/ui/app/workspace/config/views/compatibilityView.tsx
+++ b/ui/app/workspace/config/views/compatibilityView.tsx
@@ -56,7 +56,7 @@ export default function CompatibilityView() {
 	}, [bifrostConfig, localCompatConfig, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-6">
+		<div className="mx-auto w-full space-y-6">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Compatibility</h2>
 				<p className="text-muted-foreground text-sm">
@@ -145,7 +145,7 @@ export default function CompatibilityView() {
 				</div>
 			</div>
 
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess} data-testid="compat-save-button">
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -74,7 +74,7 @@ export default function LoggingView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full space-y-4">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Logs Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure logging settings for requests and responses.</p>
@@ -252,7 +252,7 @@ export default function LoggingView() {
 				)}
 			</div>
 
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -278,7 +278,7 @@ export default function MCPView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="mcp-settings-view">
+		<div className="mx-auto w-full space-y-4" data-testid="mcp-settings-view">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">MCP Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure MCP (Model Context Protocol) agent and tool settings.</p>
@@ -691,7 +691,7 @@ export default function MCPView() {
 					</AccordionItem>
 				</Accordion>
 			</div>
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess} data-testid="mcp-settings-save-btn">
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/config/views/modelSettingsView.tsx
+++ b/ui/app/workspace/config/views/modelSettingsView.tsx
@@ -104,7 +104,7 @@ export default function ModelSettingsView() {
 	};
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="model-settings-view">
+		<div className="mx-auto w-full space-y-4" data-testid="model-settings-view">
 			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Model Settings</h2>
@@ -215,7 +215,7 @@ export default function ModelSettingsView() {
 					{errors.routing_chain_max_depth && <p className="text-destructive text-sm">{errors.routing_chain_max_depth.message}</p>}
 				</div>
 
-				<div className="flex justify-end gap-2 pt-2">
+				<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 					<Button
 						variant="outline"
 						type="button"

--- a/ui/app/workspace/config/views/observabilityView.tsx
+++ b/ui/app/workspace/config/views/observabilityView.tsx
@@ -59,7 +59,7 @@ export default function ObservabilityView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full space-y-4">
 			<div className="flex items-center justify-between"></div>
 
 			<Alert variant="destructive">
@@ -91,7 +91,7 @@ export default function ObservabilityView() {
 					{needsRestart && <RestartWarning />}
 				</div>
 			</div>
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/config/views/performanceTuningView.tsx
+++ b/ui/app/workspace/config/views/performanceTuningView.tsx
@@ -86,7 +86,7 @@ export default function PerformanceTuningView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full space-y-4">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Performance Tuning</h2>
 				<p className="text-muted-foreground text-sm">Configure performance-related settings.</p>
@@ -143,7 +143,7 @@ export default function PerformanceTuningView() {
 					{needsRestart && <RestartWarning />}
 				</div>
 			</div>
-			<div className="flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -87,7 +87,7 @@ export default function PricingConfigView() {
 	};
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="pricing-config-view">
+		<div className="mx-auto w-full space-y-4" data-testid="pricing-config-view">
 			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Configuration</h2>
@@ -181,7 +181,7 @@ export default function PricingConfigView() {
 						</div>
 					</div>
 				</div>
-				<div className="flex justify-end gap-2 pt-2">
+				<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 					<Button
 						variant="outline"
 						type="button"

--- a/ui/app/workspace/config/views/proxyView.tsx
+++ b/ui/app/workspace/config/views/proxyView.tsx
@@ -56,7 +56,7 @@ export default function ProxyView() {
 	const isTypeUnsupported = watchedType === "socks5" || watchedType === "tcp";
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full space-y-4">
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
 					<div>
@@ -350,7 +350,7 @@ export default function ProxyView() {
 							)}
 						</div>
 					</fieldset>
-					<div className="flex justify-end pt-2">
+					<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<span tabIndex={!hasSettingsUpdateAccess ? 0 : undefined}>

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -211,7 +211,7 @@ export default function SecurityView() {
 	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto h-[calc(100vh-50px)] w-full max-w-4xl space-y-4 overflow-y-auto">
+		<div className="mx-auto w-full space-y-4">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Security Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
@@ -423,7 +423,7 @@ export default function SecurityView() {
 					</div>
 				</div>
 			</div>
-			<div className="bg-card sticky bottom-0 flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2 border-t py-4">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/custom-pricing/overrides/page.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/page.tsx
@@ -1,9 +1,10 @@
 import ScopedPricingOverridesView from "@/app/workspace/custom-pricing/overrides/scopedPricingOverridesView";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 
 export default function ScopedPricingOverridesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<WorkspacePageShell className="overflow-hidden">
 			<ScopedPricingOverridesView />
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/app/workspace/custom-pricing/page.tsx
+++ b/ui/app/workspace/custom-pricing/page.tsx
@@ -1,9 +1,10 @@
 import ModelSettingsView from "@/app/workspace/config/views/modelSettingsView";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 
 export default function CustomPricingPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<WorkspacePageShell>
 			<ModelSettingsView />
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/app/workspace/governance/access-profiles/page.tsx
+++ b/ui/app/workspace/governance/access-profiles/page.tsx
@@ -9,9 +9,5 @@ export default function AccessProfilesPage() {
 		return <NoPermissionView entity="access-profiles" />;
 	}
 
-	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
-			<AccessProfilesIndexView />
-		</div>
-	);
+	return <AccessProfilesIndexView />;
 }

--- a/ui/app/workspace/governance/business-units/page.tsx
+++ b/ui/app/workspace/governance/business-units/page.tsx
@@ -1,9 +1,5 @@
 import { BusinessUnitsView } from "@enterprise/components/user-groups/businessUnitsView";
 
 export default function GovernanceBusinessUnitsPage() {
-	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
-			<BusinessUnitsView />
-		</div>
-	);
+	return <BusinessUnitsView />;
 }

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -89,20 +89,18 @@ export default function GovernanceCustomersPage() {
 	}
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
-			<CustomersTable
-				customers={customersData?.customers || []}
-				totalCount={customersData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				virtualKeys={virtualKeysData?.virtual_keys || []}
-				search={urlState.search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 })}
-				offset={urlState.offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={(newOffset) => setUrlState({ offset: newOffset })}
-				isFetching={isFetching}
-			/>
-		</div>
+		<CustomersTable
+			customers={customersData?.customers || []}
+			totalCount={customersData?.total_count || 0}
+			teams={teamsData?.teams || []}
+			virtualKeys={virtualKeysData?.virtual_keys || []}
+			search={urlState.search}
+			debouncedSearch={debouncedSearch}
+			onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 })}
+			offset={urlState.offset}
+			limit={PAGE_SIZE}
+			onOffsetChange={(newOffset) => setUrlState({ offset: newOffset })}
+			isFetching={isFetching}
+		/>
 	);
 }

--- a/ui/app/workspace/governance/layout.tsx
+++ b/ui/app/workspace/governance/layout.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
 import { NoPermissionView } from "@/components/noPermissionView";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import GovernancePage from "./page";
 
@@ -25,7 +26,7 @@ function RouteComponent() {
 	if (!hasAnyGovernanceAccess) {
 		return <NoPermissionView entity="governance" />;
 	}
-	return childMatches.length === 0 ? <GovernancePage /> : <Outlet />;
+	return <WorkspacePageShell>{childMatches.length === 0 ? <GovernancePage /> : <Outlet />}</WorkspacePageShell>;
 }
 
 export const Route = createFileRoute("/workspace/governance")({

--- a/ui/app/workspace/governance/rbac/page.tsx
+++ b/ui/app/workspace/governance/rbac/page.tsx
@@ -1,9 +1,5 @@
 import RBACView from "@enterprise/components/rbac/rbacView";
 
 export default function GovernanceRbacPage() {
-	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4">
-			<RBACView />
-		</div>
-	);
+	return <RBACView />;
 }

--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -2,7 +2,7 @@ import { TeamsView } from "@enterprise/components/user-groups/teamsView";
 
 export default function GovernanceTeamsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] w-full flex-col p-4" data-testid="teams-view">
+		<div className="flex min-h-0 w-full grow flex-col" data-testid="teams-view">
 			<TeamsView />
 		</div>
 	);

--- a/ui/app/workspace/governance/users/page.tsx
+++ b/ui/app/workspace/governance/users/page.tsx
@@ -1,9 +1,5 @@
 import UsersView from "@enterprise/components/user-groups/usersView";
 
 export default function GovernanceUsersPage() {
-	return (
-		<div className="no-padding-parent mx-auto h-[calc(100dvh-1rem)] w-full p-4">
-			<UsersView />
-		</div>
-	);
+	return <UsersView />;
 }

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -139,29 +139,27 @@ export default function GovernanceVirtualKeysPage() {
 	};
 
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
-			<VirtualKeysTable
-				virtualKeys={virtualKeysData?.virtual_keys || []}
-				totalCount={virtualKeysData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				customers={customersData?.customers || []}
-				search={urlState.search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={handleSearchChange}
-				customerFilter={urlState.customer_id}
-				onCustomerFilterChange={handleCustomerFilterChange}
-				teamFilter={urlState.team_id}
-				onTeamFilterChange={handleTeamFilterChange}
-				offset={urlState.offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={handleOffsetChange}
-				sortBy={urlState.sort_by}
-				order={urlState.order}
-				onSortChange={handleSortChange}
-				selectedVkId={urlState.selected_vk}
-				onSelectedVkChange={handleSelectedVkChange}
-				isFetching={isFetching}
-			/>
-		</div>
+		<VirtualKeysTable
+			virtualKeys={virtualKeysData?.virtual_keys || []}
+			totalCount={virtualKeysData?.total_count || 0}
+			teams={teamsData?.teams || []}
+			customers={customersData?.customers || []}
+			search={urlState.search}
+			debouncedSearch={debouncedSearch}
+			onSearchChange={handleSearchChange}
+			customerFilter={urlState.customer_id}
+			onCustomerFilterChange={handleCustomerFilterChange}
+			teamFilter={urlState.team_id}
+			onTeamFilterChange={handleTeamFilterChange}
+			offset={urlState.offset}
+			limit={PAGE_SIZE}
+			onOffsetChange={handleOffsetChange}
+			sortBy={urlState.sort_by}
+			order={urlState.order}
+			onSortChange={handleSortChange}
+			selectedVkId={urlState.selected_vk}
+			onSelectedVkChange={handleSelectedVkChange}
+			isFetching={isFetching}
+		/>
 	);
 }

--- a/ui/app/workspace/mcp-sessions/page.tsx
+++ b/ui/app/workspace/mcp-sessions/page.tsx
@@ -1,4 +1,5 @@
 import FullPageLoader from "@/components/fullPageLoader";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetMCPSessionsQuery } from "@/lib/store";
 import { AuthMode, MCPSessionKind, MCPSessionStatus } from "@/lib/types/mcpSessions";
@@ -53,7 +54,7 @@ export default function MCPSessionsPage() {
 
 	if (isError) {
 		return (
-			<div className="mx-auto w-full max-w-7xl">
+			<div className="mx-auto w-full">
 				<div className="border-destructive bg-destructive/10 text-destructive rounded-lg border p-6 text-sm">
 					Failed to load MCP sessions: {getErrorMessage(error)}
 				</div>
@@ -77,7 +78,7 @@ export default function MCPSessionsPage() {
 	const handleClearFilters = () => setUrlState({ q: null, kind: null, status: null, auth_mode: null, mcp_client_id: null, identity: null, offset: 0 });
 
 	return (
-		<div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">
+		<WorkspacePageShell>
 			<SessionsTable
 				sessions={data?.sessions ?? []}
 				totalCount={totalCount}
@@ -96,6 +97,6 @@ export default function MCPSessionsPage() {
 				limit={PAGE_SIZE}
 				onOffsetChange={handleOffsetChange}
 			/>
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/app/workspace/mcp-settings/page.tsx
+++ b/ui/app/workspace/mcp-settings/page.tsx
@@ -1,5 +1,10 @@
 import MCPView from "../config/views/mcpView";
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 
 export default function MCPSettingsPage() {
-	return <MCPView />;
+	return (
+		<WorkspacePageShell>
+			<MCPView />
+		</WorkspacePageShell>
+	);
 }

--- a/ui/app/workspace/model-limits/page.tsx
+++ b/ui/app/workspace/model-limits/page.tsx
@@ -1,9 +1,10 @@
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import ModelLimitsView from "./views/modelLimitsView";
 
 export default function ModelLimitsPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<WorkspacePageShell className="overflow-hidden">
 			<ModelLimitsView />
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/app/workspace/oauth-grants/page.tsx
+++ b/ui/app/workspace/oauth-grants/page.tsx
@@ -1,3 +1,4 @@
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetOAuth2GrantsQuery, useRevokeOAuth2GrantMutation } from "@/lib/store";
 import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
@@ -70,7 +71,7 @@ export default function OAuthGrantsPage() {
 	};
 
 	return (
-		<div className="mx-auto flex h-[calc(100dvh-50px)] w-full max-w-7xl flex-col">
+		<WorkspacePageShell>
 			<RevokeGrantDialog
 				open={pendingDelete !== null}
 				onOpenChange={(open) => !open && setPendingDelete(null)}
@@ -120,6 +121,6 @@ export default function OAuthGrantsPage() {
 					onRevoke={setPendingDelete}
 				/>
 			)}
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/app/workspace/routing-rules/page.tsx
+++ b/ui/app/workspace/routing-rules/page.tsx
@@ -3,12 +3,13 @@
  * Main container for routing rules management
  */
 
+import { WorkspacePageShell } from "@/components/workspacePageShell";
 import { RoutingRulesView } from "./views/routingRulesView";
 
 export default function RoutingRulesPage() {
 	return (
-		<div className="no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col overflow-hidden p-4">
+		<WorkspacePageShell className="overflow-hidden">
 			<RoutingRulesView />
-		</div>
+		</WorkspacePageShell>
 	);
 }

--- a/ui/components/prompts/promptsView.tsx
+++ b/ui/components/prompts/promptsView.tsx
@@ -21,7 +21,7 @@ export default function PromptsView() {
 
 	if (foldersError || promptsError) {
 		return (
-			<div className="no-padding-parent no-border-parent p-4">
+			<div className="w-full">
 				<Alert variant="destructive">
 					<AlertCircle className="h-4 w-4" />
 					<AlertDescription>Failed to load prompt repository</AlertDescription>
@@ -32,7 +32,7 @@ export default function PromptsView() {
 
 	if (folders.length === 0 && prompts.length === 0) {
 		return (
-			<div className="no-padding-parent no-border-parent flex h-[calc(100dvh_-_18px)] w-full items-center">
+			<div className="w-full">
 				<PromptSheets />
 				<PromptsEmptyState />
 			</div>
@@ -40,7 +40,7 @@ export default function PromptsView() {
 	}
 
 	return (
-		<div className="no-padding-parent no-border-parent bg-background h-[calc(100dvh_-_16px)] w-full">
+		<div className="no-padding-parent bg-background h-[calc(100dvh_-_16px)] w-full">
 			<DeleteFolderDialog />
 			<DeletePromptDialog />
 			<PromptSheets />

--- a/ui/components/workspacePageShell.tsx
+++ b/ui/components/workspacePageShell.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface WorkspacePageShellProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export function WorkspacePageShell({ children, className }: WorkspacePageShellProps) {
+	return (
+		<div className={cn("no-padding-parent mx-auto flex h-[calc(100dvh-1rem)] min-h-0 w-full flex-col p-4", className)}>
+			<div className="flex min-h-0 w-full grow flex-col overflow-y-auto">{children}</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Introduces a shared `WorkspacePageShell` component to standardize page-level layout across workspace routes, replacing the inconsistent mix of inline wrapper divs that each page was managing independently.

## Changes

- Added a new `WorkspacePageShell` component that encapsulates the common `no-padding-parent`, full-height, padded flex container pattern used across workspace pages. It accepts an optional `className` for overrides (e.g., `overflow-hidden` for table-heavy pages).
- Replaced inline layout wrapper divs in governance, config, routing rules, model limits, MCP sessions/settings, OAuth grants, custom pricing, and scoped pricing overrides pages with `WorkspacePageShell`.
- Moved layout responsibility for config and governance routes into their respective layout components rather than individual page files.
- Removed hardcoded `max-w-7xl` and `max-w-4xl` constraints from config view components so width is controlled by the shell.
- Updated save/action footers across all config views (caching, client settings, compatibility, logging, MCP, model settings, observability, performance tuning, pricing config, proxy, security) to use a consistent sticky bottom bar style with a top border.
- Cleaned up the complexity router page layout to use `100dvh` units and align header styling with the rest of the workspace.
- Removed redundant `no-border-parent` classes and fixed height calculations in `PromptsView` error and empty states.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Navigate through the workspace pages (governance, config, routing rules, model limits, MCP sessions, OAuth grants, custom pricing) and verify:
- Pages render with consistent padding and full-height layout
- Sticky save footers appear at the bottom of each config view with a top border
- No layout regressions on smaller viewports or when content overflows

## Screenshots/Recordings

Before/after screenshots recommended for the config views and governance table pages to confirm layout consistency.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable