### PR TITLE
refactor: extract shared `TablePagination` component and standardize table header/cell styles across all table views

### DIFF
--- a/ui/app/workspace/config/views/featureFlagsView.tsx
+++ b/ui/app/workspace/config/views/featureFlagsView.tsx
@@ -41,10 +41,10 @@ export default function FeatureFlagsView() {
 			{!isLoading && !isError && (
 				<div className="overflow-auto rounded-sm border">
 					<Table data-testid="feature-flags-table">
-						<TableHeader>
-							<TableRow className="bg-muted/50">
-								<TableHead className="font-semibold">Flag</TableHead>
-								<TableHead className="w-px text-right font-semibold">Enabled</TableHead>
+						<TableHeader className="bg-muted sticky top-0 z-20">
+							<TableRow>
+								<TableHead>Flag</TableHead>
+								<TableHead className="w-px text-right">Enabled</TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -14,6 +14,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
@@ -27,7 +28,7 @@ import {
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { PricingOverride, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { useLocation } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import PricingOverrideSheet from "./pricingOverrideSheet";
@@ -296,7 +297,7 @@ export default function ScopedPricingOverridesView() {
 	}
 
 	return (
-		<div className="flex flex-col overflow-y-auto">
+		<div className="flex min-h-0 grow flex-col overflow-y-auto">
 			<div className="mb-4 flex items-center justify-between gap-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Overrides</h2>
@@ -306,7 +307,7 @@ export default function ScopedPricingOverridesView() {
 				</div>
 				<Button data-testid="pricing-override-create-btn" onClick={openCreateDrawer} className="gap-2">
 					<Plus className="h-4 w-4" />
-					<span className="hidden sm:inline">New Override</span>
+					<span className="hidden sm:inline">Add Override</span>
 				</Button>
 			</div>
 
@@ -323,23 +324,21 @@ export default function ScopedPricingOverridesView() {
 				/>
 			</div>
 
-			<div className="mb-2 overflow-hidden rounded-sm border">
+			<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border">
 				{isLoading ? (
 					<div className="p-4 text-sm">Loading overrides...</div>
 				) : error ? (
 					<div className="p-4 text-sm text-red-500">Failed to load pricing overrides. Please try refreshing the page.</div>
 				) : (
 					<Table containerClassName="h-full overflow-auto">
-						<TableHeader className="bg-muted sticky top-0 z-10">
-							<TableRow className="bg-muted/50">
-								<TableHead className="font-semibold">Name</TableHead>
-								<TableHead className="font-semibold">Scope</TableHead>
-								<TableHead className="font-semibold">Provider</TableHead>
-								<TableHead className="font-semibold">Key</TableHead>
-								<TableHead className="font-semibold">Model</TableHead>
-								<TableHead className={`bg-muted sticky right-0 z-30 w-[50px] text-right font-semibold ${PIN_SHADOW_RIGHT}`}>
-									Actions
-								</TableHead>
+						<TableHeader className="bg-muted sticky top-0 z-20">
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Scope</TableHead>
+								<TableHead>Provider</TableHead>
+								<TableHead>Key</TableHead>
+								<TableHead>Model</TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-10 w-[50px] text-right ${PIN_SHADOW_RIGHT}`}><span className="sr-only">Actions</span></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -371,7 +370,7 @@ export default function ScopedPricingOverridesView() {
 										<TableCell>{keyLabel(row, providerKeyLabelMap)}</TableCell>
 										<TableCell>{row.pattern}</TableCell>
 										<TableCell
-											className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+											className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 											onClick={(e) => e.stopPropagation()}
 										>
 											<div className="flex items-center justify-center">
@@ -387,44 +386,14 @@ export default function ScopedPricingOverridesView() {
 			</div>
 
 			{/* Pagination */}
-			{totalCount > 0 && (
-				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-					<div className="text-muted-foreground flex items-center gap-2">
-						{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-						entries
-					</div>
-
-					<div className="flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-							disabled={offset === 0}
-							data-testid="pricing-overrides-pagination-prev-btn"
-							aria-label="Previous page"
-						>
-							<ChevronLeft className="size-3" />
-						</Button>
-
-						<div className="flex items-center gap-1">
-							<span>Page</span>
-							<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
-							<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
-						</div>
-
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => setOffset(offset + PAGE_SIZE)}
-							disabled={offset + PAGE_SIZE >= totalCount}
-							data-testid="pricing-overrides-pagination-next-btn"
-							aria-label="Next page"
-						>
-							<ChevronRight className="size-3" />
-						</Button>
-					</div>
-				</div>
-			)}
+			<TablePagination
+				offset={offset}
+				limit={PAGE_SIZE}
+				totalCount={totalCount}
+				onOffsetChange={setOffset}
+				prevTestId="pricing-overrides-pagination-prev-btn"
+				nextTestId="pricing-overrides-pagination-next-btn"
+			/>
 
 			<PricingOverrideSheet
 				open={isDrawerOpen}

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -1,4 +1,5 @@
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -24,7 +25,7 @@ import { formatCurrency } from "@/lib/utils/governance";
 import { CustomerDetailSheet } from "@enterprise/components/user-groups/sheets/customerDetailSheet";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, ScrollText, Search, Trash2 } from "lucide-react";
+import { Edit, MoreHorizontal, Plus, ScrollText, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { CustomersEmptyState } from "./customersEmptyState";
@@ -256,7 +257,7 @@ export default function CustomersTable({
 
 					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="customer-table-container">
 						<Table className="min-w-[1100px]">
-							<TableHeader>
+							<TableHeader className="bg-muted sticky top-0 z-20">
 								<TableRow>
 									<TableHead>Name</TableHead>
 									<TableHead>Teams</TableHead>
@@ -487,8 +488,7 @@ export default function CustomersTable({
 												</TableCell>
 												<TableCell
 													className={cn(
-														"dark:bg-card dark:group-hover:bg-muted",
-														isExhausted ? "bg-red-500/5 group-hover:bg-red-500/10" : "bg-white group-hover:bg-muted",
+														isExhausted ? "bg-red-500/5 group-hover:bg-red-500/10" : "bg-card group-hover:bg-muted",
 														ACTIONS_COLUMN_CLASS,
 													)}
 												>
@@ -509,44 +509,14 @@ export default function CustomersTable({
 					</div>
 
 					{/* Pagination */}
-					{totalCount > 0 && (
-						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-							<div className="text-muted-foreground flex items-center gap-2">
-								{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-								entries
-							</div>
-
-							<div className="flex items-center gap-2">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-									disabled={offset === 0}
-									data-testid="customers-pagination-prev-btn"
-									aria-label="Previous page"
-								>
-									<ChevronLeft className="size-3" />
-								</Button>
-
-								<div className="flex items-center gap-1">
-									<span>Page</span>
-									<span>{Math.floor(offset / limit) + 1}</span>
-									<span>of {Math.ceil(totalCount / limit)}</span>
-								</div>
-
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(offset + limit)}
-									disabled={offset + limit >= totalCount}
-									data-testid="customers-pagination-next-btn"
-									aria-label="Next page"
-								>
-									<ChevronRight className="size-3" />
-								</Button>
-							</div>
-						</div>
-					)}
+					<TablePagination
+						offset={offset}
+						limit={limit}
+						totalCount={totalCount}
+						onOffsetChange={onOffsetChange}
+						prevTestId="customers-pagination-prev-btn"
+						nextTestId="customers-pagination-next-btn"
+					/>
 				</div>
 
 				<AlertDialog open={!!confirmDeleteCustomer} onOpenChange={(open) => !open && setConfirmDeleteCustomer(null)}>
@@ -564,7 +534,7 @@ export default function CustomersTable({
 								data-testid="customer-button-delete-confirm"
 								onClick={() => confirmDeleteCustomer && handleDelete(confirmDeleteCustomer.id)}
 								disabled={isDeleting}
-								className="bg-red-600 hover:bg-red-700"
+								className="bg-destructive hover:bg-destructive/90"
 							>
 								{isDeleting ? "Deleting..." : "Delete"}
 							</AlertDialogAction>

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -1,4 +1,5 @@
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -23,7 +24,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, ScrollText, Search, Trash2 } from "lucide-react";
+import { Edit, MoreHorizontal, Plus, ScrollText, Search, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import TeamSheet from "./teamSheet";
@@ -113,7 +114,7 @@ function TeamActionsMenu({
 					</AlertDialogHeader>
 					<AlertDialogFooter>
 						<AlertDialogCancel>Cancel</AlertDialogCancel>
-						<AlertDialogAction onClick={() => onDelete(team.id)} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+						<AlertDialogAction onClick={() => onDelete(team.id)} disabled={isDeleting} className="bg-destructive hover:bg-destructive/90">
 							{isDeleting ? "Deleting..." : "Delete"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
@@ -253,7 +254,7 @@ export default function TeamsTable({
 
 					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="teams-table">
 						<Table className="min-w-[1100px]" containerClassName="h-full">
-							<TableHeader className="bg-background sticky top-0">
+							<TableHeader className="bg-muted sticky top-0 z-20">
 								<TableRow>
 									<TableHead>Name</TableHead>
 									<TableHead>Customer</TableHead>
@@ -455,7 +456,7 @@ export default function TeamsTable({
 													)}
 												</TableCell>
 												<TableCell
-													className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+													className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 												>
 													<TeamActionsMenu
 														team={team}
@@ -475,44 +476,14 @@ export default function TeamsTable({
 					</div>
 
 					{/* Pagination */}
-					{totalCount > 0 && (
-						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-							<div className="text-muted-foreground flex items-center gap-2">
-								{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-								entries
-							</div>
-
-							<div className="flex items-center gap-2">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-									disabled={offset === 0}
-									data-testid="teams-pagination-prev-btn"
-									aria-label="Previous page"
-								>
-									<ChevronLeft className="size-3" />
-								</Button>
-
-								<div className="flex items-center gap-1">
-									<span>Page</span>
-									<span>{Math.floor(offset / limit) + 1}</span>
-									<span>of {Math.ceil(totalCount / limit)}</span>
-								</div>
-
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(offset + limit)}
-									disabled={offset + limit >= totalCount}
-									data-testid="teams-pagination-next-btn"
-									aria-label="Next page"
-								>
-									<ChevronRight className="size-3" />
-								</Button>
-							</div>
-						</div>
-					)}
+					<TablePagination
+						offset={offset}
+						limit={limit}
+						totalCount={totalCount}
+						onOffsetChange={onOffsetChange}
+						prevTestId="teams-pagination-prev-btn"
+						nextTestId="teams-pagination-next-btn"
+					/>
 				</div>
 			</TooltipProvider>
 		</>

--- a/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
@@ -242,7 +242,7 @@ export function SessionDetailsSheet({
 
 				<div className="min-h-0 flex-1 overflow-hidden rounded-sm border">
 					<Table containerClassName="h-full overflow-auto">
-						<TableHeader className="sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]">
+						<TableHeader className="sticky top-0 z-10 bg-muted">
 							<TableRow>
 								<TableHead className="w-2"></TableHead>
 								<TableHead>Time</TableHead>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -147,7 +147,7 @@ export function LogsDataTable({
 		<div className="flex h-full flex-col gap-2">
 			<div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
 				<Table containerClassName="h-full overflow-auto">
-					<thead className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]")}>
+					<thead className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-muted")}>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<tr
 								key={headerGroup.id}
@@ -159,7 +159,7 @@ export function LogsDataTable({
 										header={header}
 										isConfigurable={!fixedColumnIds.has(header.column.id)}
 										pinStyle={buildPinStyle(header.column, pinOffsets)}
-										pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
+										pinnedHeaderClassName="bg-muted"
 										className={cn(
 											header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
 											header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
@@ -223,7 +223,7 @@ export function LogsDataTable({
 													pinned && "bg-card",
 													cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
 													cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-													"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+													"group-hover/table-row:bg-muted/50",
 												)}
 											>
 												{flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -132,7 +132,7 @@ export function MCPLogsDataTable({
 			<div className="flex h-full grow flex-col gap-2">
 				<div className="grow overflow-y-auto rounded-sm border">
 					<Table containerClassName="h-full">
-						<thead className={cn("sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a] px-2 [&_tr]:border-b")}>
+						<thead className={cn("sticky top-0 z-10 bg-muted px-2 [&_tr]:border-b")}>
 							{table.getHeaderGroups().map((headerGroup) => (
 								<tr
 									key={headerGroup.id}
@@ -144,7 +144,7 @@ export function MCPLogsDataTable({
 											header={header}
 											isConfigurable={!fixedColumnIds.has(header.column.id)}
 											pinStyle={buildPinStyle(header.column, pinOffsets)}
-											pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
+											pinnedHeaderClassName="bg-muted"
 											className={cn(
 												header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
 												header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
@@ -192,7 +192,7 @@ export function MCPLogsDataTable({
 														pinned && "bg-card",
 														cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
 														cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-														"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+														"group-hover/table-row:bg-muted/50",
 													)}
 												>
 													{flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -212,7 +212,7 @@ export function MCPLogsDataTable({
 					</Table>
 				</div>
 				{/* Pagination Footer */}
-				<div className="flex items-center justify-between text-xs" data-testid="pagination">
+				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
 					<div className="text-muted-foreground flex items-center gap-2">
 						{startItemDisplay.toLocaleString()}-{endItemDisplay.toLocaleString()} of {totalItems.toLocaleString()} entries
 					</div>

--- a/ui/app/workspace/mcp-registry/library/page.tsx
+++ b/ui/app/workspace/mcp-registry/library/page.tsx
@@ -1,3 +1,4 @@
+import { TablePagination } from "@/components/table/tablePagination";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scrollArea";
@@ -8,7 +9,7 @@ import { getErrorMessage, useGetMCPClientsQuery, useGetMCPLibraryQuery } from "@
 import type { MCPLibraryEntry } from "@/lib/types/mcp";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, LayoutGrid, Library, List, Plus, Search, Settings } from "lucide-react";
+import { LayoutGrid, Library, List, Plus, Search, Settings } from "lucide-react";
 import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { MCPLibraryAddServerSheet } from "./views/mcpLibraryAddServerSheet";
@@ -144,10 +145,6 @@ export default function MCPLibraryPage() {
 			// Keep the in-memory preference when browser storage is unavailable.
 		}
 	}, []);
-
-	// Pagination
-	const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
-	const currentPage = Math.floor(urlState.offset / PAGE_SIZE) + 1;
 
 	const hasActiveFilters =
 		filters.categories.length > 0 || filters.connection_types.length > 0 || filters.auth_types.length > 0 || filters.tags.length > 0;
@@ -306,44 +303,15 @@ export default function MCPLibraryPage() {
 									)}
 
 									{/* Pagination */}
-									{totalCount > 0 && (
-										<div className="mt-auto flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-											<div className="text-muted-foreground flex items-center gap-2">
-												{(urlState.offset + 1).toLocaleString()}-{Math.min(urlState.offset + PAGE_SIZE, totalCount).toLocaleString()} of{" "}
-												{totalCount.toLocaleString()} entries
-											</div>
-
-											<div className="flex items-center gap-2">
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => setUrlState({ offset: Math.max(0, urlState.offset - PAGE_SIZE) }, { history: "push" })}
-													disabled={urlState.offset === 0}
-													data-testid="mcp-library-pagination-prev-btn"
-													aria-label="Previous page"
-												>
-													<ChevronLeft className="size-3" />
-												</Button>
-
-												<div className="flex items-center gap-1">
-													<span>Page</span>
-													<span>{currentPage}</span>
-													<span>of {totalPages}</span>
-												</div>
-
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => setUrlState({ offset: urlState.offset + PAGE_SIZE }, { history: "push" })}
-													disabled={urlState.offset + PAGE_SIZE >= totalCount}
-													data-testid="mcp-library-pagination-next-btn"
-													aria-label="Next page"
-												>
-													<ChevronRight className="size-3" />
-												</Button>
-											</div>
-										</div>
-									)}
+									<TablePagination
+										offset={urlState.offset}
+										limit={PAGE_SIZE}
+										totalCount={totalCount}
+										onOffsetChange={(newOffset) => setUrlState({ offset: newOffset }, { history: "push" })}
+										className="mt-auto"
+										prevTestId="mcp-library-pagination-prev-btn"
+										nextTestId="mcp-library-pagination-next-btn"
+									/>
 								</>
 							)}
 						</div>

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryServersTable.tsx
@@ -42,14 +42,14 @@ export function MCPLibraryServersTable({
 	};
 
 	return (
-		<div className="mb-2 overflow-y-auto rounded-md border" data-testid="mcp-library-table-view">
+		<div className="mb-2 min-h-0 grow overflow-y-auto rounded-sm border" data-testid="mcp-library-table-view">
 			<Table containerClassName="overflow-x-clip">
-				<TableHeader className="bg-muted sticky top-0 z-10">
+				<TableHeader className="bg-muted sticky top-0 z-20">
 					<TableRow>
 						<TableHead className="w-16">Icon</TableHead>
 						<TableHead>Server</TableHead>
 						<TableHead className="hidden w-10 lg:table-cell">Details</TableHead>
-						<TableHead className="w-32 text-right">Actions</TableHead>
+						<TableHead className="w-32 text-right"><span className="sr-only">Actions</span></TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody>
@@ -189,14 +189,14 @@ export function MCPLibraryServersTable({
 /** Skeleton placeholder mirroring the table layout while the library catalog loads. */
 export function MCPLibraryServersTableSkeleton({ rows = 8 }: { rows?: number }) {
 	return (
-		<div className="mb-2 overflow-y-auto rounded-md border" data-testid="mcp-library-table-skeleton">
+		<div className="mb-2 min-h-0 grow overflow-y-auto rounded-sm border" data-testid="mcp-library-table-skeleton">
 			<Table containerClassName="overflow-x-clip">
-				<TableHeader className="bg-muted sticky top-0 z-10">
+				<TableHeader className="bg-muted sticky top-0 z-20">
 					<TableRow>
 						<TableHead className="w-16">Icon</TableHead>
 						<TableHead>Server</TableHead>
 						<TableHead className="hidden w-10 lg:table-cell">Details</TableHead>
-						<TableHead className="w-32 text-right">Actions</TableHead>
+						<TableHead className="w-32 text-right"><span className="sr-only">Actions</span></TableHead>
 					</TableRow>
 				</TableHeader>
 				<TableBody>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -1,5 +1,6 @@
 import ClientForm from "@/app/workspace/mcp-registry/views/mcpClientForm";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -22,7 +23,7 @@ import { getErrorMessage, useDeleteMCPClientMutation, useReconnectMCPClientMutat
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { Box, ChevronLeft, ChevronRight, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
+import { Box, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import MCPClientSheet from "./mcpClientSheet";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
@@ -357,11 +358,11 @@ export default function MCPClientsTable({
 						onClick={handleCreate}
 						disabled={!hasCreateMCPClientAccess}
 						data-testid="create-mcp-client-btn"
-						aria-label="New MCP Server"
+						aria-label="Add MCP Server"
 						className="h-8 gap-2"
 					>
 						<Plus />
-						<span className="hidden sm:inline">New MCP Server</span>
+						<span className="hidden sm:inline">Add MCP Server</span>
 					</Button>
 				</div>
 			</div>
@@ -396,19 +397,19 @@ export default function MCPClientsTable({
 			<div className="flex grow flex-col overflow-auto">
 				<div className="mb-2 grow overflow-auto rounded-sm border">
 					<Table data-testid="mcp-clients-table" className="w-full min-w-[1516px] table-fixed">
-						<TableHeader className="sticky top-0">
-							<TableRow className="bg-muted/50">
-								<TableHead className="w-[260px] font-semibold">Name</TableHead>
-								<TableHead className="w-[150px] font-semibold">Connection Type</TableHead>
-								<TableHead className="w-[150px] font-semibold">Auth Type</TableHead>
-								<TableHead className="w-[140px] font-semibold">Auth Scope</TableHead>
-								<TableHead className="w-[120px] font-semibold">Code Mode</TableHead>
-								<TableHead className="w-[120px] font-semibold">VK Access</TableHead>
-								<TableHead className="w-[130px] font-semibold">Enabled Tools</TableHead>
-								<TableHead className="w-[160px] font-semibold">Auto-execute Tools</TableHead>
-								<TableHead className="w-[140px] font-semibold">State</TableHead>
-								<TableHead className="w-[90px] font-semibold">Status</TableHead>
-								<TableHead className={`bg-muted/50 sticky right-0 z-10 w-14 text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
+						<TableHeader className="bg-muted sticky top-0 z-20">
+							<TableRow>
+								<TableHead className="w-[260px]">Name</TableHead>
+								<TableHead className="w-[150px]">Connection Type</TableHead>
+								<TableHead className="w-[150px]">Auth Type</TableHead>
+								<TableHead className="w-[140px]">Auth Scope</TableHead>
+								<TableHead className="w-[120px]">Code Mode</TableHead>
+								<TableHead className="w-[120px]">VK Access</TableHead>
+								<TableHead className="w-[130px]">Enabled Tools</TableHead>
+								<TableHead className="w-[160px]">Auto-execute Tools</TableHead>
+								<TableHead className="w-[140px]">State</TableHead>
+								<TableHead className="w-[90px]">Status</TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-10 w-14 text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -530,7 +531,7 @@ export default function MCPClientsTable({
 												/>
 											</TableCell>
 											<TableCell
-												className={`bg-card group-hover:bg-muted/50 sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
+												className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 												onClick={(e) => e.stopPropagation()}
 											>
 												<MCPClientActionsMenu
@@ -553,44 +554,14 @@ export default function MCPClientsTable({
 				</div>
 
 				{/* Pagination */}
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-						<div className="text-muted-foreground flex items-center gap-2">
-							{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							entries
-						</div>
-
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-								disabled={offset === 0}
-								data-testid="mcp-clients-pagination-prev-btn"
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / limit) + 1}</span>
-								<span>of {Math.ceil(totalCount / limit)}</span>
-							</div>
-
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(offset + limit)}
-								disabled={offset + limit >= totalCount}
-								data-testid="mcp-clients-pagination-next-btn"
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
+				<TablePagination
+					offset={offset}
+					limit={limit}
+					totalCount={totalCount}
+					onOffsetChange={onOffsetChange}
+					prevTestId="mcp-clients-pagination-prev-btn"
+					nextTestId="mcp-clients-pagination-next-btn"
+				/>
 			</div>
 
 			{formOpen && <ClientForm open={formOpen} onClose={() => setFormOpen(false)} onSaved={handleSaved} />}

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -31,9 +31,10 @@ import {
 } from "@/components/ui/alertDialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { ChevronLeft, ChevronRight, Info } from "lucide-react";
+import { Info } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useReauthMCPSessionMutation, useRevokeMCPSessionMutation } from "@/lib/store";
 import { MCPSessionRow } from "@/lib/types/mcpSessions";
@@ -241,7 +242,7 @@ export default function SessionsTable({
 										</TableCell>
 										<TableCell className="text-muted-foreground text-sm">{formatRelativePast(row.created_at)}</TableCell>
 										<TableCell
-											className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+											className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 										>
 											<RowActions
 												row={row}
@@ -259,44 +260,14 @@ export default function SessionsTable({
 					</Table>
 				</div>
 
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-						<div className="text-muted-foreground flex items-center gap-2">
-							{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							entries
-						</div>
-
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-								disabled={offset === 0}
-								data-testid="mcp-sessions-pagination-prev-btn"
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / limit) + 1}</span>
-								<span>of {Math.ceil(totalCount / limit)}</span>
-							</div>
-
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(offset + limit)}
-								disabled={offset + limit >= totalCount}
-								data-testid="mcp-sessions-pagination-next-btn"
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
+				<TablePagination
+					offset={offset}
+					limit={limit}
+					totalCount={totalCount}
+					onOffsetChange={onOffsetChange}
+					prevTestId="mcp-sessions-pagination-prev-btn"
+					nextTestId="mcp-sessions-pagination-next-btn"
+				/>
 			</div>
 		</div>
 	);

--- a/ui/app/workspace/model-catalog/views/attributesTab.tsx
+++ b/ui/app/workspace/model-catalog/views/attributesTab.tsx
@@ -1,4 +1,5 @@
 import FullPageLoader from "@/components/fullPageLoader";
+import { TablePagination } from "@/components/table/tablePagination";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,7 +12,7 @@ import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { ModelDetails, useGetModelDetailsQuery, useGetProvidersQuery } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, Edit, Search } from "lucide-react";
+import { Edit, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import AttributeSheet from "./attributeSheet";
 
@@ -209,41 +210,15 @@ export default function AttributesTab({ hasAccess }: AttributesTabProps) {
 					</Table>
 				</div>
 
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="model-catalog-pagination">
-						<div className="text-muted-foreground">
-							{(offset + 1).toLocaleString()}–{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							entries
-						</div>
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-								disabled={offset === 0}
-								data-testid="model-catalog-pagination-prev-btn"
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
-								<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
-							</div>
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => setOffset(offset + PAGE_SIZE)}
-								disabled={offset + PAGE_SIZE >= totalCount}
-								data-testid="model-catalog-pagination-next-btn"
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
+				<TablePagination
+					offset={offset}
+					limit={PAGE_SIZE}
+					totalCount={totalCount}
+					onOffsetChange={setOffset}
+					testId="model-catalog-pagination"
+					prevTestId="model-catalog-pagination-prev-btn"
+					nextTestId="model-catalog-pagination-next-btn"
+				/>
 			</div>
 		</>
 	);

--- a/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
@@ -99,7 +99,7 @@ export default function ModelCatalogTable({
 						<col className="w-[16%]" />
 						<col className="w-[14%]" />
 					</colgroup>
-					<TableHeader>
+					<TableHeader className="bg-muted sticky top-0 z-20">
 						<TableRow>
 							<TableHead>Provider</TableHead>
 							<TableHead>

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { getScopeLabel } from "@/lib/utils/labels";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ArrowUpRight, ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { ArrowUpRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
@@ -36,6 +36,7 @@ import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
 // "user" deep-link, etc.). No-op for OSS builds.
 import "@enterprise/lib/registrations/modelLimitScopes";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import { useNavigate } from "@tanstack/react-router";
 
 // Helper to format reset duration for display
@@ -227,7 +228,7 @@ export default function ModelLimitsTable({
 						<AlertDialogAction
 							onClick={() => deletingModelConfig && handleDelete(deletingModelConfig.id)}
 							disabled={isDeleting}
-							className="bg-red-600 hover:bg-red-700"
+							className="bg-destructive hover:bg-destructive/90"
 						>
 							{isDeleting ? "Deleting..." : "Delete"}
 						</AlertDialogAction>
@@ -235,7 +236,7 @@ export default function ModelLimitsTable({
 				</AlertDialogContent>
 			</AlertDialog>
 
-			<div className="flex flex-col overflow-y-auto">
+			<div className="flex min-h-0 grow flex-col overflow-y-auto">
 				<div className="mb-4 flex items-center justify-between">
 					<div>
 						<h1 className="text-lg font-semibold">Model Limits</h1>
@@ -310,9 +311,9 @@ export default function ModelLimitsTable({
 					)}
 				</div>
 
-				<div className="mb-2 overflow-hidden rounded-sm border" data-testid="model-limits-table">
+				<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border" data-testid="model-limits-table">
 					<Table containerClassName="h-full overflow-auto">
-						<TableHeader className="bg-muted sticky top-0 z-10">
+						<TableHeader className="bg-muted sticky top-0 z-20">
 							<TableRow className="hover:bg-transparent">
 								<TableHead className="font-medium">Model</TableHead>
 								<TableHead className="font-medium">Provider</TableHead>
@@ -516,7 +517,7 @@ export default function ModelLimitsTable({
 											</TableCell>
 											<TableCell
 												className={cn(
-													"group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right",
+													"bg-card group-hover:bg-muted sticky right-0 z-10 text-right",
 													PIN_SHADOW_RIGHT,
 												)}
 												onClick={(e) => e.stopPropagation()}
@@ -540,44 +541,14 @@ export default function ModelLimitsTable({
 				</div>
 
 				{/* Pagination */}
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-						<div className="text-muted-foreground flex items-center gap-2">
-							{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							entries
-						</div>
-
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-								disabled={offset === 0}
-								data-testid="model-limits-pagination-prev-btn"
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / limit) + 1}</span>
-								<span>of {Math.ceil(totalCount / limit)}</span>
-							</div>
-
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(offset + limit)}
-								disabled={offset + limit >= totalCount}
-								data-testid="model-limits-pagination-next-btn"
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
+				<TablePagination
+					offset={offset}
+					limit={limit}
+					totalCount={totalCount}
+					onOffsetChange={onOffsetChange}
+					prevTestId="model-limits-pagination-prev-btn"
+					nextTestId="model-limits-pagination-next-btn"
+				/>
 			</div>
 		</>
 	);

--- a/ui/app/workspace/oauth-grants/views/grantsTable.tsx
+++ b/ui/app/workspace/oauth-grants/views/grantsTable.tsx
@@ -3,7 +3,6 @@
 // times, and a per-row actions menu. Owns the empty state and pagination; the
 // page passes in the current page slice plus filter/revoke state.
 
-import { Button } from "@/components/ui/button";
 import {
 	Table,
 	TableBody,
@@ -14,10 +13,9 @@ import {
 } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import type { OAuth2GrantRow } from "@/lib/store/apis/oauth2SessionsApi";
 import {
-	ChevronLeft,
-	ChevronRight,
 	Fingerprint,
 	Info,
 	KeyRound,
@@ -111,7 +109,7 @@ export default function GrantsTable({
 										{formatRelativePast(row.last_used_at || row.created_at)}
 									</TableCell>
 									<TableCell
-										className={`relative group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+										className={`relative bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 									>
 										<GrantActions
 											row={row}
@@ -127,43 +125,14 @@ export default function GrantsTable({
 				</Table>
 			</div>
 
-			{totalCount > 0 && (
-				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-					<div className="text-muted-foreground flex items-center gap-2">
-						{(offset + 1).toLocaleString()}-{Math.min(offset + pageSize, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
-					</div>
-
-					<div className="flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onOffsetChange(Math.max(0, offset - pageSize))}
-							disabled={offset === 0}
-							data-testid="oauth-grants-prev-page-btn"
-							aria-label="Previous page"
-						>
-							<ChevronLeft className="size-3" />
-						</Button>
-
-						<div className="flex items-center gap-1">
-							<span>Page</span>
-							<span>{Math.floor(offset / pageSize) + 1}</span>
-							<span>of {Math.ceil(totalCount / pageSize)}</span>
-						</div>
-
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onOffsetChange(offset + pageSize)}
-							disabled={offset + pageSize >= totalCount}
-							data-testid="oauth-grants-next-page-btn"
-							aria-label="Next page"
-						>
-							<ChevronRight className="size-3" />
-						</Button>
-					</div>
-				</div>
-			)}
+			<TablePagination
+				offset={offset}
+				limit={pageSize}
+				totalCount={totalCount}
+				onOffsetChange={onOffsetChange}
+				prevTestId="oauth-grants-prev-page-btn"
+				nextTestId="oauth-grants-next-page-btn"
+			/>
 		</div>
 	);
 }

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -186,7 +186,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 							<col className="w-[12%]" />
 							<col className="w-[12%]" />
 						</colgroup>
-						<TableHeader className="w-full">
+						<TableHeader className="bg-muted sticky top-0 z-20 w-full">
 							<TableRow>
 								<TableHead>{isVLLM ? "Model" : isOllamaOrSGL ? "Server" : "API Key"}</TableHead>
 								<TableHead>Weight</TableHead>
@@ -208,7 +208,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 									<TableRow
 										key={key.id}
 										data-testid={`key-row-${key.name}`}
-										className="text-sm transition-colors hover:bg-white"
+										className="text-sm transition-colors hover:bg-card"
 										onClick={() => {}}
 									>
 										<TableCell className="overflow-hidden">

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage } from "@/lib/store";
@@ -27,7 +28,7 @@ import { useDeleteRoutingRuleMutation, useUpdateRoutingRuleMutation } from "@/li
 import { RoutingRule, RoutingTarget } from "@/lib/types/routingRules";
 import { getScopeLabel } from "@/lib/utils/labels";
 import { getPriorityBadgeClass, truncateCELExpression } from "@/lib/utils/routingRules";
-import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Search, Trash2 } from "lucide-react";
+import { Edit, MoreHorizontal, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -143,7 +144,7 @@ export function RoutingRulesTable({
 		return (
 			<div className="rounded-sm border">
 				<Table>
-					<TableHeader>
+					<TableHeader className="bg-muted sticky top-0 z-20">
 						<TableRow>
 							<TableHead>Name</TableHead>
 							<TableHead>Targets</TableHead>
@@ -151,7 +152,7 @@ export function RoutingRulesTable({
 							<TableHead className="text-right">Priority</TableHead>
 							<TableHead>Expression</TableHead>
 							<TableHead>Enabled</TableHead>
-							<TableHead className="text-right">Actions</TableHead>
+							<TableHead className="text-right"><span className="sr-only">Actions</span></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -188,19 +189,17 @@ export function RoutingRulesTable({
 				</div>
 			</div>
 
-			<div className="mb-2 overflow-hidden rounded-sm border">
+			<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border">
 				<Table containerClassName="h-full overflow-auto">
-					<TableHeader className="bg-muted sticky top-0 z-10">
-						<TableRow className="bg-muted/50">
-							<TableHead className="font-semibold">Name</TableHead>
-							<TableHead className="font-semibold">Targets</TableHead>
-							<TableHead className="font-semibold">Scope</TableHead>
-							<TableHead className="text-right font-semibold">Priority</TableHead>
-							<TableHead className="font-semibold">Expression</TableHead>
-							<TableHead className="font-semibold">Status</TableHead>
-							<TableHead className={`bg-muted sticky right-0 z-30 w-[50px] text-right font-semibold ${PIN_SHADOW_RIGHT}`}>
-								Actions
-							</TableHead>
+					<TableHeader className="bg-muted sticky top-0 z-20">
+						<TableRow>
+							<TableHead>Name</TableHead>
+							<TableHead>Targets</TableHead>
+							<TableHead>Scope</TableHead>
+							<TableHead className="text-right">Priority</TableHead>
+							<TableHead>Expression</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead className={`bg-muted sticky right-0 z-10 w-[50px] text-right ${PIN_SHADOW_RIGHT}`}><span className="sr-only">Actions</span></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
@@ -265,7 +264,7 @@ export function RoutingRulesTable({
 										/>
 									</TableCell>
 									<TableCell
-										className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+										className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 										onClick={(e) => e.stopPropagation()}
 									>
 										<div className="flex items-center justify-center">
@@ -286,43 +285,14 @@ export function RoutingRulesTable({
 			</div>
 
 			{/* Pagination */}
-			{totalCount > 0 && (
-				<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-					<div className="text-muted-foreground flex items-center gap-2">
-						{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
-					</div>
-
-					<div className="flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-							disabled={offset === 0}
-							data-testid="routing-rules-pagination-prev-btn"
-							aria-label="Previous page"
-						>
-							<ChevronLeft className="size-3" />
-						</Button>
-
-						<div className="flex items-center gap-1">
-							<span>Page</span>
-							<span>{Math.floor(offset / limit) + 1}</span>
-							<span>of {Math.ceil(totalCount / limit)}</span>
-						</div>
-
-						<Button
-							variant="ghost"
-							size="sm"
-							onClick={() => onOffsetChange(offset + limit)}
-							disabled={offset + limit >= totalCount}
-							data-testid="routing-rules-pagination-next-btn"
-							aria-label="Next page"
-						>
-							<ChevronRight className="size-3" />
-						</Button>
-					</div>
-				</div>
-			)}
+			<TablePagination
+				offset={offset}
+				limit={limit}
+				totalCount={totalCount}
+				onOffsetChange={onOffsetChange}
+				prevTestId="routing-rules-pagination-prev-btn"
+				nextTestId="routing-rules-pagination-next-btn"
+			/>
 
 			<AlertDialog open={!!deleteRuleId} onOpenChange={(open) => !open && setDeleteRuleId(null)}>
 				<AlertDialogContent>

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -113,7 +113,7 @@ export function RoutingRulesView() {
 	}
 
 	return (
-		<div className="flex flex-col overflow-y-auto">
+		<div className="flex min-h-0 grow flex-col overflow-y-auto">
 			{/* Header */}
 			<div className="mb-4 flex items-center justify-between">
 				<div>
@@ -130,7 +130,7 @@ export function RoutingRulesView() {
 					{canCreate && (
 						<Button data-testid="create-routing-rule-btn" onClick={handleCreateNew} disabled={isLoading} className="gap-2">
 							<Plus className="h-4 w-4" />
-							<span className="hidden sm:inline">New Rule</span>
+							<span className="hidden sm:inline">Add Routing Rule</span>
 						</Button>
 					)}
 				</div>

--- a/ui/app/workspace/skills-repo/components/skillListView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillListView.tsx
@@ -2,6 +2,7 @@
 
 import FullPageLoader from "@/components/fullPageLoader";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -31,16 +32,14 @@ import { AllSkillsVersionBump, SkillListItem } from "@/lib/types/skills";
 import { cn } from "@/lib/utils";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { EmptyStateView } from "@/components/emptyStateView";
 import {
 	ArrowDown,
 	ArrowUp,
 	ArrowUpDown,
-	ArrowUpRight,
 	BookOpenText,
 	Check,
 	ChevronDown,
-	ChevronLeft,
-	ChevronRight,
 	Clipboard,
 	Download,
 	FileText,
@@ -373,35 +372,22 @@ export function SkillsListView({
 	// True empty state: no skills at all (not just filtered to zero)
 	if (total === 0 && !search && !debouncedSearch && !isFetching) {
 		return (
-			<div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center" data-testid="skills-repo-empty-state">
-				<div className="text-muted-foreground">
-					<BookOpenText className="h-24 w-24" strokeWidth={1} />
-				</div>
-				<div className="flex flex-col gap-1">
-					<h1 className="text-muted-foreground text-xl font-medium">Create, version, and share Agent Skills from Bifrost</h1>
-					<div className="text-muted-foreground mx-auto mt-2 max-w-xl text-sm font-normal">
-						Manage SKILL.md instructions and supporting files in one place, publish immutable versions, and expose them as installable
-						plugins for Claude Code, Codex, and other skill-aware clients.
-					</div>
-					<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
-						<Button
-							variant="outline"
-							aria-label="Read more about skills (opens in new tab)"
-							data-testid="skills-button-read-more"
-							onClick={() => {
-								window.open(`${SKILLS_REPOSITORY_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
-							}}
-						>
-							Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+			<EmptyStateView
+				icon={BookOpenText}
+				testId="skills-repo-empty-state"
+				title="Create, version, and share Agent Skills from Bifrost"
+				description="Manage SKILL.md instructions and supporting files in one place, publish immutable versions, and expose them as installable plugins for Claude Code, Codex, and other skill-aware clients."
+				readmeLink={SKILLS_REPOSITORY_DOCS_URL}
+				readMoreAriaLabel="Read more about skills (opens in new tab)"
+				readMoreTestId="skills-button-read-more"
+				actions={
+					hasCreateAccess && (
+						<Button aria-label="Add your first skill" data-testid="skill-create-btn" onClick={onCreateNew}>
+							Add Skill
 						</Button>
-						{hasCreateAccess && (
-							<Button aria-label="Create your first skill" data-testid="skill-create-btn" onClick={onCreateNew}>
-								Create Skill
-							</Button>
-						)}
-					</div>
-				</div>
-			</div>
+					)
+				}
+			/>
 		);
 	}
 
@@ -572,7 +558,7 @@ export function SkillsListView({
 										{!search && hasCreateAccess && (
 											<Button variant="outline" size="sm" onClick={onCreateNew} className="mt-2">
 												<Plus className="h-3.5 w-3.5" />
-												Create your first skill
+												Add your first skill
 											</Button>
 										)}
 									</div>
@@ -618,7 +604,7 @@ export function SkillsListView({
 										</TableCell>
 										<TableCell className="text-muted-foreground text-sm">{formatDateShort(skill.updated_at)}</TableCell>
 										<TableCell
-											className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+											className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 											onClick={(e) => e.stopPropagation()}
 										>
 											<SkillActionsMenu
@@ -639,40 +625,14 @@ export function SkillsListView({
 			</div>
 
 			{/* Pagination */}
-			{total > 0 && (
-				<div className="flex shrink-0 items-center justify-between text-xs">
-					<div className="text-muted-foreground flex items-center gap-2">
-						{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, total).toLocaleString()} of {total.toLocaleString()} entries
-					</div>
-					<div className="flex items-center gap-2">
-						<Button
-							variant="ghost"
-							size="sm"
-							data-testid="skill-pagination-prev"
-							onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
-							disabled={offset === 0 || isFetching}
-							aria-label="Previous page"
-						>
-							<ChevronLeft className="size-3" />
-						</Button>
-						<div className="flex items-center gap-1">
-							<span>Page</span>
-							<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
-							<span>of {Math.ceil(total / PAGE_SIZE)}</span>
-						</div>
-						<Button
-							variant="ghost"
-							size="sm"
-							data-testid="skill-pagination-next"
-							onClick={() => setOffset(offset + PAGE_SIZE)}
-							disabled={offset + PAGE_SIZE >= total || isFetching}
-							aria-label="Next page"
-						>
-							<ChevronRight className="size-3" />
-						</Button>
-					</div>
-				</div>
-			)}
+			<TablePagination
+				offset={offset}
+				limit={PAGE_SIZE}
+				totalCount={total}
+				onOffsetChange={setOffset}
+				prevTestId="skill-pagination-prev"
+				nextTestId="skill-pagination-next"
+			/>
 		</div>
 	);
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -1,6 +1,7 @@
 import { BudgetDisplay } from "@/components/budgetDisplay";
 import { RateLimitDisplay } from "@/components/rateLimitDisplay";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import { TablePagination } from "@/components/table/tablePagination";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -41,8 +42,6 @@ import {
 	ArrowDown,
 	ArrowUp,
 	ArrowUpDown,
-	ChevronLeft,
-	ChevronRight,
 	Copy,
 	Download,
 	Edit,
@@ -833,7 +832,7 @@ export default function VirtualKeysTable({
 								<TableHead className="w-[120px]">
 									<SortableHeader column="status" label="Status" />
 								</TableHead>
-								<TableHead className={`bg-muted sticky right-0 z-30 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -911,7 +910,7 @@ export default function VirtualKeysTable({
 												)}
 											</TableCell>
 											<TableCell
-												className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-20 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+												className={`bg-card group-hover:bg-muted sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 												onClick={(e) => e.stopPropagation()}
 											>
 												<VKActionsMenu
@@ -932,44 +931,14 @@ export default function VirtualKeysTable({
 				</div>
 
 				{/* Pagination */}
-				{totalCount > 0 && (
-					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-						<div className="text-muted-foreground flex items-center gap-2">
-							{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-							entries
-						</div>
-
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-								disabled={offset === 0}
-								data-testid="vk-pagination-prev-btn"
-								aria-label="Previous page"
-							>
-								<ChevronLeft className="size-3" />
-							</Button>
-
-							<div className="flex items-center gap-1">
-								<span>Page</span>
-								<span>{Math.floor(offset / limit) + 1}</span>
-								<span>of {Math.ceil(totalCount / limit)}</span>
-							</div>
-
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() => onOffsetChange(offset + limit)}
-								disabled={offset + limit >= totalCount}
-								data-testid="vk-pagination-next-btn"
-								aria-label="Next page"
-							>
-								<ChevronRight className="size-3" />
-							</Button>
-						</div>
-					</div>
-				)}
+				<TablePagination
+					offset={offset}
+					limit={limit}
+					totalCount={totalCount}
+					onOffsetChange={onOffsetChange}
+					prevTestId="vk-pagination-prev-btn"
+					nextTestId="vk-pagination-next-btn"
+				/>
 			</div>
 		</>
 	);

--- a/ui/components/table/tablePagination.tsx
+++ b/ui/components/table/tablePagination.tsx
@@ -1,0 +1,67 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface TablePaginationProps {
+	offset: number;
+	limit: number;
+	totalCount: number;
+	onOffsetChange: (offset: number) => void;
+	className?: string;
+	testId?: string;
+	prevTestId?: string;
+	nextTestId?: string;
+}
+
+export function TablePagination({
+	offset,
+	limit,
+	totalCount,
+	onOffsetChange,
+	className,
+	testId = "pagination",
+	prevTestId,
+	nextTestId,
+}: TablePaginationProps) {
+	if (totalCount <= 0) {
+		return null;
+	}
+
+	return (
+		<div className={cn("flex shrink-0 items-center justify-between text-xs", className)} data-testid={testId}>
+			<div className="text-muted-foreground flex items-center gap-2">
+				{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()} entries
+			</div>
+
+			<div className="flex items-center gap-2">
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+					disabled={offset === 0}
+					data-testid={prevTestId}
+					aria-label="Previous page"
+				>
+					<ChevronLeft className="size-3" />
+				</Button>
+
+				<div className="flex items-center gap-1">
+					<span>Page</span>
+					<span>{Math.floor(offset / limit) + 1}</span>
+					<span>of {Math.ceil(totalCount / limit)}</span>
+				</div>
+
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={() => onOffsetChange(offset + limit)}
+					disabled={offset + limit >= totalCount}
+					data-testid={nextTestId}
+					aria-label="Next page"
+				>
+					<ChevronRight className="size-3" />
+				</Button>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Extracts the repeated inline pagination UI into a shared `TablePagination` component and standardizes table header styling across the workspace.

## Changes

- Introduced `ui/components/table/tablePagination.tsx`, a reusable `TablePagination` component that accepts `offset`, `limit`, `totalCount`, `onOffsetChange`, and optional test ID props. It renders nothing when `totalCount` is zero, replacing the `{totalCount > 0 && (...)}` pattern that was duplicated across every table.
- Replaced inline pagination blocks in all affected tables (virtual keys, routing rules, model limits, MCP clients, MCP sessions, MCP library, pricing overrides, customers, teams, skills, OAuth grants, and model catalog attributes) with the new `TablePagination` component.
- Standardized `TableHeader` styling to `bg-muted sticky top-0 z-20` across all tables for consistent sticky header behavior and theming.
- Replaced hardcoded light/dark background values (`bg-white`, `dark:bg-card`, `bg-[#f9f9f9] dark:bg-[#27272a]`, etc.) with semantic tokens (`bg-card`, `bg-muted`) throughout table headers, pinned action cells, and row hover states.
- Removed redundant `font-semibold` from `TableHead` cells and `bg-muted/50` from `TableRow` inside headers, deferring to the header-level background.
- Replaced visible "Actions" text in pinned action column headers with `<span className="sr-only">Actions</span>` for accessibility.
- Updated delete confirmation button styling from `bg-red-600 hover:bg-red-700` to `bg-destructive hover:bg-destructive/90` in customers, teams, and model limits tables.
- Renamed button labels from "New Override" / "New Rule" / "New MCP Server" to "Add Override" / "Add Routing Rule" / "Add MCP Server" for consistency.
- Replaced the inline empty state in `SkillsListView` with the shared `EmptyStateView` component.
- Reduced z-index on pinned action cells from `z-20`/`z-30` to `z-10` to avoid unnecessary stacking context conflicts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify pagination controls appear and function correctly on: Virtual Keys, Routing Rules, Model Limits, MCP Clients, MCP Sessions, MCP Library, Pricing Overrides, Customers, Teams, Skills Repo, OAuth Grants, and Model Catalog Attributes pages. Confirm table headers remain sticky on scroll and render with the correct muted background in both light and dark mode.

## Screenshots/Recordings

Verify before/after that table headers are visually consistent across all affected pages and that pagination controls look and behave identically.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable