### PR TITLE
refactor: simplify audit-logs and SCIM page wrapper styles

### DIFF
--- a/ui/app/workspace/audit-logs/page.tsx
+++ b/ui/app/workspace/audit-logs/page.tsx
@@ -2,7 +2,7 @@ import AuditLogsView from "@enterprise/components/audit-logs/auditLogsView";
 
 export default function AuditLogsPage() {
 	return (
-		<div className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh-16px)] w-full">
+		<div className="mx-auto w-full">
 			<AuditLogsView />
 		</div>
 	);

--- a/ui/app/workspace/scim/page.tsx
+++ b/ui/app/workspace/scim/page.tsx
@@ -2,10 +2,8 @@ import SCIMView from "@enterprise/components/scim/scimView";
 
 export default function SCIMPage() {
 	return (
-		<div className="no-padding-parent bg-background no-border-parent flex h-[calc(100dvh-1rem)] w-full flex-col">
-			<div className="mx-auto w-full grow overflow-y-auto">
-				<SCIMView />
-			</div>
+		<div className="mx-auto w-full">
+			<SCIMView />
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Simplifies the layout wrappers for the Audit Logs and SCIM pages by removing custom height, overflow, and background utility classes that were previously handling page-level layout concerns.

## Changes

- Replaced the complex layout classes (`no-padding-parent`, `no-border-parent`, `bg-background`, `h-[calc(...)]`, `overflow-y-auto`, etc.) on the Audit Logs and SCIM page wrappers with a simple `mx-auto w-full` container, aligning them with how other pages handle their layout.
- Removed the extra nested `div` in the SCIM page that was managing scroll and growth behavior, as this is now handled at a higher layout level.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Audit Logs (`/workspace/audit-logs`) and SCIM (`/workspace/scim`) pages and verify that content renders correctly, scrolling behaves as expected, and no layout regressions are visible.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Verify the Audit Logs and SCIM pages render without layout issues (no clipped content, no missing backgrounds, correct scroll behavior).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable