### PR TITLE
fix: marshal `tool_sync_interval` as duration string, support negative sync intervals, and fix `tool_execution_timeout` round-trip for MCP clients

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -208,6 +208,22 @@ func (c *MCPConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON emits tool_sync_interval as a duration string so it round-trips
+// correctly and matches the per-client field's wire format — default
+// time.Duration marshaling emits nanoseconds.
+func (c MCPConfig) MarshalJSON() ([]byte, error) {
+	type alias MCPConfig
+	type shadow struct {
+		ToolSyncInterval string `json:"tool_sync_interval,omitempty"`
+		*alias
+	}
+	s := shadow{alias: (*alias)(&c)}
+	if c.ToolSyncInterval != 0 {
+		s.ToolSyncInterval = c.ToolSyncInterval.String()
+	}
+	return json.Marshal(s)
+}
+
 type MCPToolManagerConfig struct {
 	// ToolExecutionTimeout accepts a Go duration string (e.g. "30s", "2m") or a
 	// bare integer treated as seconds (e.g. 30 → 30s). This intentionally differs
@@ -278,19 +294,19 @@ const (
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
-	ID                  string            `json:"client_id"`                       // Client ID
-	Name                string            `json:"name"`                            // Client name
-	IsCodeModeClient    bool              `json:"is_code_mode_client"`             // Whether the client is a code mode client
-	ConnectionType      MCPConnectionType `json:"connection_type"`                 // How to connect (HTTP, STDIO, SSE, or InProcess)
-	ConnectionString    *SecretVar           `json:"connection_string,omitempty"`     // HTTP or SSE URL (required for HTTP or SSE connections)
-	StdioConfig         *MCPStdioConfig   `json:"stdio_config,omitempty"`          // STDIO configuration (required for STDIO connections)
-	TLSConfig           *MCPTLSConfig     `json:"tls_config,omitempty"`            // TLS configuration for HTTP/SSE connections
-	AuthType            MCPAuthType       `json:"auth_type"`                       // Authentication type (none, headers, or oauth)
-	OauthConfigID       *string           `json:"oauth_config_id,omitempty"`       // OAuth config ID (references oauth_configs table)
-	OauthClientID       *SecretVar           `json:"oauth_client_id,omitempty"`       // Redacted OAuth client ID (populated on GET, not stored here)
-	OauthClientSecret   *SecretVar           `json:"oauth_client_secret,omitempty"`   // Redacted OAuth client secret (populated on GET, not stored here)
-	State               string            `json:"state,omitempty"`                 // Connection state (connected, disconnected, error)
-	Headers             map[string]SecretVar `json:"headers,omitempty"`               // Headers to send with the request (for headers auth type)
+	ID                string               `json:"client_id"`                     // Client ID
+	Name              string               `json:"name"`                          // Client name
+	IsCodeModeClient  bool                 `json:"is_code_mode_client"`           // Whether the client is a code mode client
+	ConnectionType    MCPConnectionType    `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
+	ConnectionString  *SecretVar           `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)
+	StdioConfig       *MCPStdioConfig      `json:"stdio_config,omitempty"`        // STDIO configuration (required for STDIO connections)
+	TLSConfig         *MCPTLSConfig        `json:"tls_config,omitempty"`          // TLS configuration for HTTP/SSE connections
+	AuthType          MCPAuthType          `json:"auth_type"`                     // Authentication type (none, headers, or oauth)
+	OauthConfigID     *string              `json:"oauth_config_id,omitempty"`     // OAuth config ID (references oauth_configs table)
+	OauthClientID     *SecretVar           `json:"oauth_client_id,omitempty"`     // Redacted OAuth client ID (populated on GET, not stored here)
+	OauthClientSecret *SecretVar           `json:"oauth_client_secret,omitempty"` // Redacted OAuth client secret (populated on GET, not stored here)
+	State             string               `json:"state,omitempty"`               // Connection state (connected, disconnected, error)
+	Headers           map[string]SecretVar `json:"headers,omitempty"`             // Headers to send with the request (for headers auth type)
 	// PerUserHeaderKeys lists the header *names* each caller must supply for
 	// MCPAuthTypePerUserHeaders clients. Admin-declared schema only — the
 	// values live per-user in the mcp_per_user_header_credentials table and
@@ -314,13 +330,13 @@ type MCPClientConfig struct {
 	// - nil/omitted => treated as [] (no tools)
 	// - ["tool1", "tool2"] => auto-execute only the specified tools
 	// Note: If a tool is in ToolsToAutoExecute but not in ToolsToExecute, it will be skipped.
-	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`       // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
-	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`      // Per-client override for tool sync interval (0 = use global, negative = disabled)
-	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"`  // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
-	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`            // Tool pricing for each tool (cost per execution)
-	Disabled              bool               `json:"disabled"`                     // Whether the client is intentionally disabled (stops connection and workers)
-	ConfigHash            string             `json:"-"`                            // Config hash for reconciliation (not serialized)
-	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`    // Whether to allow the MCP client to run on all virtual keys
+	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`      // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
+	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`     // Per-client override for tool sync interval (0 = use global, negative = disabled)
+	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"` // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
+	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`           // Tool pricing for each tool (cost per execution)
+	Disabled              bool               `json:"disabled"`                         // Whether the client is intentionally disabled (stops connection and workers)
+	ConfigHash            string             `json:"-"`                                // Config hash for reconciliation (not serialized)
+	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`        // Whether to allow the MCP client to run on all virtual keys
 
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name
@@ -421,16 +437,23 @@ func parseToolExecutionTimeoutField(raw json.RawMessage) (time.Duration, error) 
 	return time.Duration(n) * time.Second, nil
 }
 
-// MarshalJSON emits tool_execution_timeout as a duration string so it round-trips
-// correctly — default time.Duration marshaling emits nanoseconds, but UnmarshalJSON
-// treats bare integers as seconds.
+// MarshalJSON emits tool_sync_interval and tool_execution_timeout as duration
+// strings so both round-trip correctly and share one wire format — default
+// time.Duration marshaling emits nanoseconds, but UnmarshalJSON treats bare
+// integers as nanoseconds for tool_sync_interval and as seconds for
+// tool_execution_timeout. A negative tool_sync_interval (sync disabled) is
+// emitted as a negative duration string.
 func (c MCPClientConfig) MarshalJSON() ([]byte, error) {
 	type alias MCPClientConfig
 	type shadow struct {
+		ToolSyncInterval     string `json:"tool_sync_interval,omitempty"`
 		ToolExecutionTimeout string `json:"tool_execution_timeout,omitempty"`
 		*alias
 	}
 	s := shadow{alias: (*alias)(&c)}
+	if c.ToolSyncInterval != 0 {
+		s.ToolSyncInterval = c.ToolSyncInterval.String()
+	}
 	if c.ToolExecutionTimeout > 0 {
 		s.ToolExecutionTimeout = c.ToolExecutionTimeout.String()
 	}
@@ -521,7 +544,7 @@ type MCPStdioConfig struct {
 // MCPTLSConfig holds TLS options for HTTP and SSE MCP connections.
 // InsecureSkipVerify takes priority over CACertPEM when both are set.
 type MCPTLSConfig struct {
-	InsecureSkipVerify bool    `json:"insecure_skip_verify,omitempty"` // Disable TLS certificate verification (development only)
+	InsecureSkipVerify bool       `json:"insecure_skip_verify,omitempty"` // Disable TLS certificate verification (development only)
 	CACertPEM          *SecretVar `json:"ca_cert_pem,omitempty"`          // PEM-encoded CA certificate to trust (supports env.*)
 }
 

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -129,3 +129,80 @@ func TestMCPClientConfigUnmarshalToolExecutionTimeoutNegativeString(t *testing.T
 	}
 }
 
+func TestMCPClientConfigMarshalEmitsDurationStrings(t *testing.T) {
+	cfg := MCPClientConfig{
+		Name:                 "demo",
+		ConnectionType:       "http",
+		ToolSyncInterval:     10 * time.Minute,
+		ToolExecutionTimeout: 45 * time.Second,
+	}
+	data, err := sonic.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"tool_sync_interval":"10m0s"`) {
+		t.Fatalf("expected tool_sync_interval as duration string, got: %s", s)
+	}
+	if !strings.Contains(s, `"tool_execution_timeout":"45s"`) {
+		t.Fatalf("expected tool_execution_timeout as duration string, got: %s", s)
+	}
+}
+
+func TestMCPClientConfigMarshalOmitsZeroDurations(t *testing.T) {
+	cfg := MCPClientConfig{Name: "demo", ConnectionType: "http"}
+	data, err := sonic.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "tool_sync_interval") {
+		t.Fatalf("expected tool_sync_interval omitted when zero, got: %s", s)
+	}
+	if strings.Contains(s, "tool_execution_timeout") {
+		t.Fatalf("expected tool_execution_timeout omitted when zero, got: %s", s)
+	}
+}
+
+func TestMCPClientConfigDurationFieldsRoundTrip(t *testing.T) {
+	for _, syncInterval := range []time.Duration{10 * time.Minute, 30 * time.Second, -time.Minute} {
+		cfg := MCPClientConfig{
+			Name:                 "demo",
+			ConnectionType:       "http",
+			ToolSyncInterval:     syncInterval,
+			ToolExecutionTimeout: 90 * time.Second,
+		}
+		data, err := sonic.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+		var decoded MCPClientConfig
+		if err := sonic.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+		if decoded.ToolSyncInterval != syncInterval {
+			t.Fatalf("tool_sync_interval did not round-trip: sent %v, got %v", syncInterval, decoded.ToolSyncInterval)
+		}
+		if decoded.ToolExecutionTimeout != 90*time.Second {
+			t.Fatalf("tool_execution_timeout did not round-trip: got %v", decoded.ToolExecutionTimeout)
+		}
+	}
+}
+
+func TestMCPConfigMarshalToolSyncIntervalRoundTrip(t *testing.T) {
+	cfg := MCPConfig{ToolSyncInterval: 10 * time.Minute}
+	data, err := sonic.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"tool_sync_interval":"10m0s"`) {
+		t.Fatalf("expected tool_sync_interval as duration string, got: %s", string(data))
+	}
+	var decoded MCPConfig
+	if err := sonic.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if decoded.ToolSyncInterval != 10*time.Minute {
+		t.Fatalf("tool_sync_interval did not round-trip: got %v", decoded.ToolSyncInterval)
+	}
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -131,9 +131,8 @@ func toolExecutionTimeoutDurationToStoredSeconds(timeout time.Duration) int {
 }
 
 func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error) {
-	if interval < 0 {
-		return 0, fmt.Errorf("tool_sync_interval must be non-negative, got %q", interval.String())
-	}
+	// Negative intervals are preserved: a negative value disables tool sync
+	// for the client (see mcp.ResolveToolSyncInterval).
 	if interval%time.Second != 0 {
 		return 0, fmt.Errorf("tool_sync_interval must be a whole number of seconds, got %q", interval.String())
 	}
@@ -1590,6 +1589,8 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	return &schemas.MCPConfig{
 		ClientConfigs:     clientConfigs,
 		ToolManagerConfig: &toolManagerConfig,
+		// MCPToolSyncInterval is stored in whole minutes (see TableClientConfig).
+		ToolSyncInterval: time.Duration(clientConfig.MCPToolSyncInterval) * time.Minute,
 	}, nil
 }
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -452,7 +452,8 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		if h.store.MCPConfig.ToolManagerConfig == nil {
 			h.store.MCPConfig.ToolManagerConfig = &schemas.MCPToolManagerConfig{}
 		}
-		h.store.MCPConfig.ToolSyncInterval = time.Duration(updatedConfig.MCPToolSyncInterval) * time.Second
+		// MCPToolSyncInterval is stored in whole minutes (see TableClientConfig).
+		h.store.MCPConfig.ToolSyncInterval = time.Duration(updatedConfig.MCPToolSyncInterval) * time.Minute
 		h.store.MCPConfig.ToolManagerConfig.MaxAgentDepth = updatedConfig.MCPAgentDepth
 		h.store.MCPConfig.ToolManagerConfig.ToolExecutionTimeout = schemas.Duration(time.Duration(updatedConfig.MCPToolExecutionTimeout) * time.Second)
 		h.store.MCPConfig.ToolManagerConfig.CodeModeBindingLevel = schemas.CodeModeBindingLevel(updatedConfig.MCPCodeModeBindingLevel)

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -566,6 +567,36 @@ type MCPVKConfigRequest struct {
 	ToolsToExecute schemas.WhiteList `json:"tools_to_execute"`
 }
 
+// Request values are minutes (tool_sync_interval) and seconds
+// (tool_execution_timeout); these bounds keep the conversion to time.Duration
+// from overflowing int64 nanoseconds.
+const (
+	maxToolSyncIntervalMinutes     = int64(math.MaxInt64 / int64(time.Minute))
+	maxToolExecutionTimeoutSeconds = int64(math.MaxInt64 / int64(time.Second))
+)
+
+// validateToolSyncIntervalMinutes rejects request values whose
+// minutes→duration conversion would overflow. Negative values are valid
+// (negative = sync disabled).
+func validateToolSyncIntervalMinutes(minutes int) error {
+	if int64(minutes) > maxToolSyncIntervalMinutes || int64(minutes) < -maxToolSyncIntervalMinutes {
+		return fmt.Errorf("tool_sync_interval must be between %d and %d minutes", -maxToolSyncIntervalMinutes, maxToolSyncIntervalMinutes)
+	}
+	return nil
+}
+
+// validateToolExecutionTimeoutSeconds rejects negative request values and
+// values whose seconds→duration conversion would overflow.
+func validateToolExecutionTimeoutSeconds(seconds int) error {
+	if seconds < 0 {
+		return errors.New("tool_execution_timeout must be >= 0")
+	}
+	if int64(seconds) > maxToolExecutionTimeoutSeconds {
+		return fmt.Errorf("tool_execution_timeout must be <= %d seconds", maxToolExecutionTimeoutSeconds)
+	}
+	return nil
+}
+
 // MCPClientUpdateRequest is the body for PUT /api/mcp/client/{id}.
 // All fields are optional — omitting a field retains its existing value (PATCH semantics).
 // Immutable fields (connection_type, auth_type, connection_string, stdio_config) are not
@@ -630,6 +661,16 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
 		return
 	}
+	if err := validateToolSyncIntervalMinutes(req.ToolSyncInterval); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateToolExecutionTimeoutSeconds(req.ToolExecutionTimeout); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	// 0 = use the global timeout from tool_manager_config, resolved at execution time.
+	toolExecutionTimeout := time.Duration(req.ToolExecutionTimeout) * time.Second
 
 	// Handle per-user headers: admin declares the required key names (schema)
 	// AND supplies a sample set of values inline so the server can verify
@@ -695,6 +736,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			IsCodeModeClient:      req.IsCodeModeClient,
 			IsPingAvailable:       &isPingAvailable,
 			ToolSyncInterval:      toolSyncInterval,
+			ToolExecutionTimeout:  toolExecutionTimeout,
 			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:      req.ConnectionString,
 			StdioConfig:           req.StdioConfig,
@@ -796,6 +838,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			IsCodeModeClient:      req.IsCodeModeClient,
 			IsPingAvailable:       &isPingAvailable,
 			ToolSyncInterval:      toolSyncInterval,
+			ToolExecutionTimeout:  toolExecutionTimeout,
 			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:      req.ConnectionString,
 			StdioConfig:           req.StdioConfig,
@@ -889,6 +932,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			IsCodeModeClient:      req.IsCodeModeClient,
 			IsPingAvailable:       req.IsPingAvailable,
 			ToolSyncInterval:      toolSyncInterval,
+			ToolExecutionTimeout:  toolExecutionTimeout,
 			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:      req.ConnectionString,
 			StdioConfig:           req.StdioConfig,
@@ -963,6 +1007,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		OauthConfigID:         req.OauthConfigID,
 		IsPingAvailable:       req.IsPingAvailable,
 		ToolSyncInterval:      toolSyncInterval,
+		ToolExecutionTimeout:  toolExecutionTimeout,
 		ToolPricing:           req.ToolPricing,
 		AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
 	}
@@ -1095,12 +1140,16 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// boundary below; the in-memory duration is the source of truth here.
 	resolvedToolSyncInterval := existingConfig.ToolSyncInterval
 	if req.ToolSyncInterval != nil {
+		if err := validateToolSyncIntervalMinutes(*req.ToolSyncInterval); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+			return
+		}
 		resolvedToolSyncInterval = time.Duration(*req.ToolSyncInterval) * time.Minute
 	}
 	resolvedToolExecutionTimeout := existingConfig.ToolExecutionTimeout
 	if req.ToolExecutionTimeout != nil {
-		if *req.ToolExecutionTimeout < 0 {
-			SendError(ctx, fasthttp.StatusBadRequest, "tool_execution_timeout must be >= 0")
+		if err := validateToolExecutionTimeoutSeconds(*req.ToolExecutionTimeout); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 			return
 		}
 		resolvedToolExecutionTimeout = time.Duration(*req.ToolExecutionTimeout) * time.Second
@@ -1795,6 +1844,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				ConnectionType:            string(mcpClientConfig.ConnectionType),
 				ConnectionString:          mcpClientConfig.ConnectionString,
 				StdioConfig:               mcpClientConfig.StdioConfig,
+				TLSConfig:                 mcpClientConfig.TLSConfig,
 				AuthType:                  string(mcpClientConfig.AuthType),
 				OauthConfigID:             mcpClientConfig.OauthConfigID,
 				ToolsToExecute:            mcpClientConfig.ToolsToExecute,
@@ -1804,6 +1854,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 				IsPingAvailable:           mcpClientConfig.IsPingAvailable,
 				ToolPricing:               mcpClientConfig.ToolPricing,
 				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+				ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
 				AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
 				DiscoveredTools:           mcpClientConfig.DiscoveredTools,
 				DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
@@ -1870,6 +1921,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			ConnectionType:            string(mcpClientConfig.ConnectionType),
 			ConnectionString:          mcpClientConfig.ConnectionString,
 			StdioConfig:               mcpClientConfig.StdioConfig,
+			TLSConfig:                 mcpClientConfig.TLSConfig,
 			AuthType:                  string(mcpClientConfig.AuthType),
 			OauthConfigID:             mcpClientConfig.OauthConfigID,
 			ToolsToExecute:            mcpClientConfig.ToolsToExecute,
@@ -1879,6 +1931,7 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			IsPingAvailable:           mcpClientConfig.IsPingAvailable,
 			ToolPricing:               mcpClientConfig.ToolPricing,
 			ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+			ToolExecutionTimeout:      int(mcpClientConfig.ToolExecutionTimeout / time.Second),
 			AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
 			DiscoveredTools:           mcpClientConfig.DiscoveredTools,
 			DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1785,6 +1785,7 @@ func applyMCPGlobalSettingsToClientConfig(ctx context.Context, config *Config, m
 	mcpCfg.ToolManagerConfig.DisableAutoToolInject = config.ClientConfig.MCPDisableAutoToolInject
 
 	// ToolSyncInterval lives only in MCPConfig (not a ClientConfig field), so reconcile separately.
+	// ClientConfig.MCPToolSyncInterval holds whole minutes (see TableClientConfig).
 	changed := false
 	if mcpCfg.ToolSyncInterval == 0 {
 		if config.ClientConfig.MCPToolSyncInterval != 0 {
@@ -1792,15 +1793,15 @@ func applyMCPGlobalSettingsToClientConfig(ctx context.Context, config *Config, m
 			changed = true
 		}
 	} else if mcpCfg.ToolSyncInterval > 0 {
-		if mcpCfg.ToolSyncInterval%time.Second != 0 {
+		if mcpCfg.ToolSyncInterval%time.Minute != 0 {
 			logger.Warn(
-				"ignoring mcp.tool_sync_interval %q: must be a whole number of seconds",
+				"not mirroring mcp.tool_sync_interval %q to client config: must be a whole number of minutes",
 				mcpCfg.ToolSyncInterval.String(),
 			)
 		} else {
-			syncSeconds := int(mcpCfg.ToolSyncInterval / time.Second)
-			if config.ClientConfig.MCPToolSyncInterval != syncSeconds {
-				config.ClientConfig.MCPToolSyncInterval = syncSeconds
+			syncMinutes := int(mcpCfg.ToolSyncInterval / time.Minute)
+			if config.ClientConfig.MCPToolSyncInterval != syncMinutes {
+				config.ClientConfig.MCPToolSyncInterval = syncMinutes
 				changed = true
 			}
 		}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -51,20 +51,9 @@ interface MCPClientSheetProps {
 	hasNext?: boolean;
 }
 
-/** API sends tool_sync_interval as nanoseconds (Go time.Duration). Normalize to minutes for form/store. */
-function toolSyncIntervalToMinutes(v: number | undefined | null): number {
-	if (v === undefined || v === null) return 0;
-	const n = Number(v);
-	if (Number.isNaN(n)) return 0;
-	if (Math.abs(n) >= 1e9) return Math.round(n / 6e10);
-	return n;
-}
-
-/** API sends tool_execution_timeout as a Go duration string e.g. "30s". Normalize to whole seconds for form. */
-function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): number {
-	if (v === undefined || v === null || v === "") return 0;
-	if (typeof v === "number") return v;
-	// Parse Go duration string: "30s", "1m30s", "2h", etc.
+/** Parse a Go duration string ("30s", "1m30s", "2h", "-1m0s") to seconds. */
+function goDurationToSeconds(v: string): number {
+	const sign = v.trim().startsWith("-") ? -1 : 1;
 	let total = 0;
 	const re = /(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)/g;
 	let match;
@@ -79,7 +68,28 @@ function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): n
 			case "h": total += n * 3600; break;
 		}
 	}
-	return Math.ceil(total);
+	return sign * total;
+}
+
+/**
+ * API sends tool_sync_interval as a Go duration string e.g. "10m0s" (legacy
+ * responses: nanoseconds number; optimistic cache patches: minutes number).
+ * Normalize to whole minutes for the form. Negative = sync disabled.
+ */
+function toolSyncIntervalToMinutes(v: string | number | undefined | null): number {
+	if (v === undefined || v === null || v === "") return 0;
+	if (typeof v === "string") return Math.round(goDurationToSeconds(v) / 60);
+	const n = Number(v);
+	if (Number.isNaN(n)) return 0;
+	if (Math.abs(n) >= 1e9) return Math.round(n / 6e10);
+	return n;
+}
+
+/** API sends tool_execution_timeout as a Go duration string e.g. "30s". Normalize to whole seconds for form. */
+function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): number {
+	if (v === undefined || v === null || v === "") return 0;
+	if (typeof v === "number") return v;
+	return Math.ceil(goDurationToSeconds(v));
 }
 
 export default function MCPClientSheet({
@@ -97,6 +107,7 @@ export default function MCPClientSheet({
 
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const globalToolSyncInterval = bifrostConfig?.client_config?.mcp_tool_sync_interval ?? 10;
+	const globalToolExecutionTimeout = bifrostConfig?.client_config?.mcp_tool_execution_timeout ?? 30;
 	const { toast } = useToast();
 	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
@@ -213,7 +224,7 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
-				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
+			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
@@ -242,7 +253,7 @@ export default function MCPClientSheet({
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
-				tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
+			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
@@ -824,7 +835,7 @@ export default function MCPClientSheet({
 														<Input
 															type="number"
 															className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
-															placeholder="0"
+															placeholder={String(globalToolExecutionTimeout)}
 															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
 															onChange={(e) => {
 																if (e.target.value === "") {

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -496,20 +496,13 @@ export default function MCPClientsTable({
 													disabled={!hasUpdateMCPClientAccess || togglingClientIds.has(c.config.client_id)}
 													onAsyncCheckedChange={async (checked) => {
 														setTogglingClientIds((prev) => new Set(prev).add(c.config.client_id));
+														// PATCH semantics: omitted fields keep their stored values, so only
+														// send the flag being flipped. Echoing GET values back is unsafe —
+														// they use response formats (e.g. duration strings), not request units.
 														await updateMCPClient({
 															id: c.config.client_id,
 															data: {
-																name: c.config.name,
-																is_code_mode_client: c.config.is_code_mode_client,
-																is_ping_available: c.config.is_ping_available,
-																allow_on_all_virtual_keys: c.config.allow_on_all_virtual_keys,
 																disabled: !checked,
-																headers: c.config.headers ?? {},
-																tools_to_execute: c.config.tools_to_execute,
-																tools_to_auto_execute: c.config.tools_to_auto_execute,
-																tool_pricing: c.config.tool_pricing,
-																tool_sync_interval: c.config.tool_sync_interval ?? 0,
-																allowed_extra_headers: c.config.allowed_extra_headers,
 															},
 														})
 															.unwrap()

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -173,7 +173,11 @@ export const mcpApi = baseApi.injectEndpoints({
 										draft.clients[index].config.tools_to_auto_execute = data.tools_to_auto_execute;
 									if (data.is_ping_available !== undefined) draft.clients[index].config.is_ping_available = data.is_ping_available;
 									if (data.tool_pricing !== undefined) draft.clients[index].config.tool_pricing = data.tool_pricing;
+									// Request units (minutes / seconds) diverge from response formats
+									// (duration strings); the sheet's normalizers accept both.
 									if (data.tool_sync_interval !== undefined) draft.clients[index].config.tool_sync_interval = data.tool_sync_interval;
+									if (data.tool_execution_timeout !== undefined)
+										draft.clients[index].config.tool_execution_timeout = data.tool_execution_timeout;
 									if (data.disabled !== undefined) {
 										draft.clients[index].config.disabled = data.disabled;
 										if (data.disabled) {

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -67,7 +67,7 @@ export interface MCPClientConfig {
 	per_user_header_keys?: string[];
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
-	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
+	tool_sync_interval?: string | number; // Per-client override; API returns a Go duration string e.g. "10m0s" (legacy responses: nanoseconds number), negative = sync disabled, omitted = use global
 	tool_execution_timeout?: string | number; // Per-client tool execution timeout; API returns string e.g. "30s", UI sends integer seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this


### PR DESCRIPTION
## Summary

`tool_sync_interval` was being serialized as raw nanoseconds (Go's default `time.Duration` JSON encoding) while `tool_execution_timeout` already emitted a human-readable duration string. This mismatch caused `tool_sync_interval` to round-trip incorrectly between the API and the UI, and the storage layer was treating the interval as seconds instead of minutes. This PR aligns both fields to use Go duration strings on the wire, fixes the minutes/seconds unit confusion in storage and config application, and hardens the API handlers with overflow-safe validation.

## Changes

- Added `MarshalJSON` to `MCPConfig` so `tool_sync_interval` is emitted as a duration string (e.g. `"10m0s"`) instead of nanoseconds, matching the existing `MCPClientConfig.MarshalJSON` behavior.
- Extended `MCPClientConfig.MarshalJSON` to also emit `tool_sync_interval` as a duration string; negative values (sync disabled) are preserved correctly.
- Fixed `GetMCPConfig` in the RDB store to multiply `MCPToolSyncInterval` by `time.Minute` instead of `time.Second`, matching the stored unit (whole minutes).
- Fixed `updateConfig` in the HTTP config handler to apply the same `time.Minute` multiplier when reading `MCPToolSyncInterval` from the client config.
- Fixed `applyMCPGlobalSettingsToClientConfig` to mirror `ToolSyncInterval` in whole minutes rather than whole seconds, and updated the granularity warning accordingly.
- Removed the negative-interval rejection from `toolSyncIntervalDurationToStoredSeconds`; negative values are now valid and mean "sync disabled."
- Added `validateToolSyncIntervalMinutes` and `validateToolExecutionTimeoutSeconds` helpers in the MCP HTTP handler to guard against `int64` overflow when converting request integers to `time.Duration`.
- Applied the new validators in both `addMCPClient` and `updateMCPClient`, and ensured `ToolExecutionTimeout` is populated from the request in `addMCPClient` (it was previously missing).
- Propagated `TLSConfig` and `ToolExecutionTimeout` into the OAuth completion response structs where they were previously omitted.
- Simplified the disable-toggle call in `mcpClientsTable.tsx` to send only `{ disabled }`, avoiding the unsafe practice of echoing GET response values (duration strings) back as request units.
- Updated `toolSyncIntervalToMinutes` in the UI to accept Go duration strings in addition to legacy nanosecond numbers and optimistic-cache minute integers.
- Extracted a shared `goDurationToSeconds` helper in the UI that correctly handles negative duration strings.
- Updated the `MCPClientConfig` TypeScript type to reflect that `tool_sync_interval` may be a duration string or a number.
- Added optimistic cache update for `tool_execution_timeout` in `mcpApi.ts`.
- Added the global tool execution timeout as a placeholder in the execution timeout input field.
- Added round-trip tests for `tool_sync_interval` and `tool_execution_timeout` on both `MCPConfig` and `MCPClientConfig`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Create an MCP client with a `tool_sync_interval` of 10 minutes and a `tool_execution_timeout` of 45 seconds via `POST /api/mcp/client`.
2. Fetch the client via `GET /api/mcp/client/{id}` and confirm `tool_sync_interval` is `"10m0s"` and `tool_execution_timeout` is `"45s"`.
3. Update only the `disabled` flag via `PUT /api/mcp/client/{id}` with `{ "disabled": true }` and confirm no other fields are altered.
4. Set a negative `tool_sync_interval` (e.g. `-1`) and confirm the client is accepted and sync is disabled for that client.
5. In the UI, open the MCP client sheet for a client with a non-zero `tool_sync_interval` and confirm the minutes value is displayed correctly.

## Breaking changes

- [x] Yes
- [ ] No

The wire format for `tool_sync_interval` changes from a raw nanosecond integer to a Go duration string (e.g. `"10m0s"`). Any client that was reading `tool_sync_interval` as a plain integer from the GET response will need to be updated to parse the duration string. The UI has been updated accordingly. The storage unit for `MCPToolSyncInterval` is whole minutes; deployments that previously stored this field as seconds will see values interpreted as minutes after this change.

## Related issues

N/A

## Security considerations

No new secrets or auth surfaces introduced. The overflow guards on `tool_sync_interval` and `tool_execution_timeout` prevent a malicious request from causing integer overflow when converting to `time.Duration`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable