### PR TITLE
chore: renames NewEnvVar to NewSecretVar in docs

### DIFF
--- a/docs/providers/supported-providers/anthropic.mdx
+++ b/docs/providers/supported-providers/anthropic.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Anthropic:
     return []schemas.Key{{
         Name:   "anthropic-key-1",
-        Value:  *schemas.NewEnvVar("env.ANTHROPIC_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.ANTHROPIC_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -179,7 +179,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
+                    Endpoint: *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil
@@ -315,10 +315,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "claude-3-5-sonnet": "my-claude-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint:     *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
-                    ClientID:     schemas.NewEnvVar(os.Getenv("AZURE_CLIENT_ID")),
-                    ClientSecret: schemas.NewEnvVar(os.Getenv("AZURE_CLIENT_SECRET")),
-                    TenantID:     schemas.NewEnvVar(os.Getenv("AZURE_TENANT_ID")),
+                    Endpoint:     *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
+                    ClientID:     schemas.NewSecretVar(os.Getenv("AZURE_CLIENT_ID")),
+                    ClientSecret: schemas.NewSecretVar(os.Getenv("AZURE_CLIENT_SECRET")),
+                    TenantID:     schemas.NewSecretVar(os.Getenv("AZURE_TENANT_ID")),
                     Scopes:       []string{"https://cognitiveservices.azure.com/.default"},
                 },
             },
@@ -438,7 +438,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Azure:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.AZURE_OPENAI_KEY"),
+                Value:  *schemas.NewSecretVar("env.AZURE_OPENAI_KEY"),
                 Models: []string{"*"},
                 Weight: 1.0,
                 Aliases: schemas.KeyAliases{
@@ -446,7 +446,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
+                    Endpoint: *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/bedrock.mdx
+++ b/docs/providers/supported-providers/bedrock.mdx
@@ -189,10 +189,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "claude-3-5-sonnet": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
                 },
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                    AccessKey:    *schemas.NewEnvVar("env.AWS_ACCESS_KEY_ID"),
-                    SecretKey:    *schemas.NewEnvVar("env.AWS_SECRET_ACCESS_KEY"),
-                    SessionToken: schemas.NewEnvVar("env.AWS_SESSION_TOKEN"),
-                    Region:       schemas.NewEnvVar("us-east-1"),
+                    AccessKey:    *schemas.NewSecretVar("env.AWS_ACCESS_KEY_ID"),
+                    SecretKey:    *schemas.NewSecretVar("env.AWS_SECRET_ACCESS_KEY"),
+                    SessionToken: schemas.NewSecretVar("env.AWS_SESSION_TOKEN"),
+                    Region:       schemas.NewSecretVar("us-east-1"),
                 },
             },
         }, nil
@@ -331,10 +331,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 },
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
                     // Leave AccessKey and SecretKey empty - resolved from IRSA/instance profile/env vars
-                    Region:          schemas.NewEnvVar("us-east-1"),
-                    RoleARN:         schemas.NewEnvVar("env.AWS_ROLE_ARN"),         // optional
-                    ExternalID:      schemas.NewEnvVar("env.AWS_EXTERNAL_ID"),      // optional
-                    RoleSessionName: schemas.NewEnvVar("bifrost-session"),          // optional
+                    Region:          schemas.NewSecretVar("us-east-1"),
+                    RoleARN:         schemas.NewSecretVar("env.AWS_ROLE_ARN"),         // optional
+                    ExternalID:      schemas.NewSecretVar("env.AWS_EXTERNAL_ID"),      // optional
+                    RoleSessionName: schemas.NewSecretVar("bifrost-session"),          // optional
                 },
             },
         }, nil
@@ -428,11 +428,11 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Bedrock:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.BEDROCK_API_KEY"),
+                Value:  *schemas.NewSecretVar("env.BEDROCK_API_KEY"),
                 Models: []string{"*"},
                 Weight: 1.0,
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                    Region: schemas.NewEnvVar("us-east-1"),
+                    Region: schemas.NewSecretVar("us-east-1"),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/cerebras.mdx
+++ b/docs/providers/supported-providers/cerebras.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Cerebras:
     return []schemas.Key{{
         Name:   "cerebras-key-1",
-        Value:  *schemas.NewEnvVar("env.CEREBRAS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.CEREBRAS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/cohere.mdx
+++ b/docs/providers/supported-providers/cohere.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Cohere:
     return []schemas.Key{{
         Name:   "cohere-key-1",
-        Value:  *schemas.NewEnvVar("env.COHERE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.COHERE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/deepseek.mdx
+++ b/docs/providers/supported-providers/deepseek.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.DeepSeek:
     return []schemas.Key{{
         Name:   "deepseek-key-1",
-        Value:  *schemas.NewEnvVar("env.DEEPSEEK_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.DEEPSEEK_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/elevenlabs.mdx
+++ b/docs/providers/supported-providers/elevenlabs.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Elevenlabs:
     return []schemas.Key{{
         Name:   "elevenlabs-key-1",
-        Value:  *schemas.NewEnvVar("env.ELEVENLABS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.ELEVENLABS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/fireworks.mdx
+++ b/docs/providers/supported-providers/fireworks.mdx
@@ -83,7 +83,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Fireworks:
     return []schemas.Key{{
         Name:   "fireworks-key-1",
-        Value:  *schemas.NewEnvVar("env.FIREWORKS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.FIREWORKS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/gemini.mdx
+++ b/docs/providers/supported-providers/gemini.mdx
@@ -81,7 +81,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Gemini:
     return []schemas.Key{{
         Name:   "gemini-key-1",
-        Value:  *schemas.NewEnvVar("env.GEMINI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.GEMINI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/groq.mdx
+++ b/docs/providers/supported-providers/groq.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Groq:
     return []schemas.Key{{
         Name:   "groq-key-1",
-        Value:  *schemas.NewEnvVar("env.GROQ_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.GROQ_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/huggingface.mdx
+++ b/docs/providers/supported-providers/huggingface.mdx
@@ -91,7 +91,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.HuggingFace:
     return []schemas.Key{{
         Name:   "huggingface-key-1",
-        Value:  *schemas.NewEnvVar("env.HUGGINGFACE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.HUGGINGFACE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/mistral.mdx
+++ b/docs/providers/supported-providers/mistral.mdx
@@ -87,7 +87,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Mistral:
     return []schemas.Key{{
         Name:   "mistral-key-1",
-        Value:  *schemas.NewEnvVar("env.MISTRAL_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.MISTRAL_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/nebius.mdx
+++ b/docs/providers/supported-providers/nebius.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Nebius:
     return []schemas.Key{{
         Name:   "nebius-key-1",
-        Value:  *schemas.NewEnvVar("env.NEBIUS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.NEBIUS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/ollama.mdx
+++ b/docs/providers/supported-providers/ollama.mdx
@@ -169,11 +169,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Ollama:
     return []schemas.Key{{
         Name:   "ollama-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"*"},
         Weight: 1.0,
         OllamaKeyConfig: &schemas.OllamaKeyConfig{
-            URL: *schemas.NewEnvVar("http://localhost:11434"),
+            URL: *schemas.NewSecretVar("http://localhost:11434"),
         },
     }}, nil
 ```

--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -78,7 +78,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.OpenAI:
     return []schemas.Key{{
         Name:   "openai-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENAI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENAI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/opencode.mdx
+++ b/docs/providers/supported-providers/opencode.mdx
@@ -112,7 +112,7 @@ For OpenCode Zen:
 case schemas.OpencodeZen:
     return []schemas.Key{{
         Name:   "zen-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENCODE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENCODE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil
@@ -124,7 +124,7 @@ For OpenCode Go:
 case schemas.OpencodeGo:
     return []schemas.Key{{
         Name:   "go-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENCODE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENCODE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.OpenRouter:
     return []schemas.Key{{
         Name:   "openrouter-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENROUTER_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENROUTER_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/parasail.mdx
+++ b/docs/providers/supported-providers/parasail.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Parasail:
     return []schemas.Key{{
         Name:   "parasail-key-1",
-        Value:  *schemas.NewEnvVar("env.PARASAIL_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.PARASAIL_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/perplexity.mdx
+++ b/docs/providers/supported-providers/perplexity.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Perplexity:
     return []schemas.Key{{
         Name:   "perplexity-key-1",
-        Value:  *schemas.NewEnvVar("env.PERPLEXITY_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.PERPLEXITY_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/replicate.mdx
+++ b/docs/providers/supported-providers/replicate.mdx
@@ -89,7 +89,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Replicate:
     return []schemas.Key{{
         Name:   "replicate-key-1",
-        Value:  *schemas.NewEnvVar("env.REPLICATE_API_TOKEN"),
+        Value:  *schemas.NewSecretVar("env.REPLICATE_API_TOKEN"),
         Models: []string{"*"},
         Weight: 1.0,
         ReplicateKeyConfig: &schemas.ReplicateKeyConfig{

--- a/docs/providers/supported-providers/runware.mdx
+++ b/docs/providers/supported-providers/runware.mdx
@@ -191,7 +191,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Runware:
     return []schemas.Key{{
         Name:   "runware-key-1",
-        Value:  *schemas.NewEnvVar("env.RUNWARE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.RUNWARE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/runway.mdx
+++ b/docs/providers/supported-providers/runway.mdx
@@ -116,7 +116,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Runway:
     return []schemas.Key{{
         Name:   "runway-key-1",
-        Value:  *schemas.NewEnvVar("env.RUNWAY_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.RUNWAY_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/sgl.mdx
+++ b/docs/providers/supported-providers/sgl.mdx
@@ -86,11 +86,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.SGL:
     return []schemas.Key{{
         Name:   "sgl-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"*"},
         Weight: 1.0,
         SGLKeyConfig: &schemas.SGLKeyConfig{
-            URL: *schemas.NewEnvVar("http://localhost:8000"),
+            URL: *schemas.NewSecretVar("http://localhost:8000"),
         },
     }}, nil
 ```

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -158,9 +158,9 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 Models: []string{"*"},
                 Weight: 1.0,
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID:       *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    Region:          *schemas.NewEnvVar("us-central1"),
-                    AuthCredentials: *schemas.NewEnvVar("env.VERTEX_CREDENTIALS"), // full service account JSON
+                    ProjectID:       *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    Region:          *schemas.NewSecretVar("us-central1"),
+                    AuthCredentials: *schemas.NewSecretVar("env.VERTEX_CREDENTIALS"), // full service account JSON
                 },
             },
         }, nil
@@ -274,8 +274,8 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 Models: []string{"*"},
                 Weight: 1.0,
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID: *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    Region:    *schemas.NewEnvVar("us-central1"),
+                    ProjectID: *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    Region:    *schemas.NewSecretVar("us-central1"),
                     // Leave AuthCredentials empty - uses Application Default Credentials
                 },
             },
@@ -402,16 +402,16 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Vertex:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.VERTEX_API_KEY"), // only when using Gemini or fine-tuned models
+                Value:  *schemas.NewSecretVar("env.VERTEX_API_KEY"), // only when using Gemini or fine-tuned models
                 Models: []string{"gemini-pro", "gemini-2.0-flash", "my-fine-tuned-model"},
                 Weight: 1.0,
                 Aliases: schemas.KeyAliases{
                     "my-fine-tuned-model": "123456789",
                 },
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID:     *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    ProjectNumber: *schemas.NewEnvVar("env.VERTEX_PROJECT_NUMBER"), // required for fine-tuned models
-                    Region:        *schemas.NewEnvVar("us-central1"),
+                    ProjectID:     *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    ProjectNumber: *schemas.NewSecretVar("env.VERTEX_PROJECT_NUMBER"), // required for fine-tuned models
+                    Region:        *schemas.NewSecretVar("us-central1"),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/vllm.mdx
+++ b/docs/providers/supported-providers/vllm.mdx
@@ -87,11 +87,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.VLLM:
     return []schemas.Key{{
         Name:   "vllm-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"meta-llama/Llama-3.2-1B-Instruct"},
         Weight: 1.0,
         VLLMKeyConfig: &schemas.VLLMKeyConfig{
-            URL:       *schemas.NewEnvVar("http://localhost:8000"),
+            URL:       *schemas.NewSecretVar("http://localhost:8000"),
             ModelName: "meta-llama/Llama-3.2-1B-Instruct",
         },
     }}, nil

--- a/docs/providers/supported-providers/xai.mdx
+++ b/docs/providers/supported-providers/xai.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.XAI:
     return []schemas.Key{{
         Name:   "xai-key-1",
-        Value:  *schemas.NewEnvVar("env.XAI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.XAI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -55,6 +55,7 @@ func (noopPluginsLoader) GetLoadedPluginNames() []string { return nil }
 func (noopPluginsLoader) NormalizePluginConfig(_ string, _ map[string]any) (map[string]any, error) {
 	return nil, nil
 }
+
 func (noopPluginsLoader) ExpandPluginConfigForAPI(_ string, _ map[string]any) (map[string]any, error) {
 	return nil, nil
 }
@@ -127,7 +128,7 @@ func TestRestoreRedacted_OTELProfilesHeaders(t *testing.T) {
 	}
 
 	// An intentional env.* reference (e.g. credential rotation) must pass through.
-	// NewEnvVar parses the "env." prefix as FromEnv=true, which IsRedacted reports as
+	// NewSecretVar parses the "env." prefix as FromEnv=true, which IsRedacted reports as
 	// redacted; the IsFromEnv guard must let it through rather than restoring the stored value.
 	rotated := mkConfig("env.NEW_TOKEN", "env.NEW_VERSION")
 	got3 := restoreRedactedFromExisting(rotated, existing)


### PR DESCRIPTION
## Summary

All documentation code examples and a test comment have been updated to replace `schemas.NewEnvVar` with `schemas.NewSecretVar` across every supported provider. This aligns the docs with the renamed API and ensures users following the examples use the correct constructor.

## Changes

- Replaced all occurrences of `schemas.NewEnvVar(...)` with `schemas.NewSecretVar(...)` in provider documentation examples for Anthropic, Azure, Bedrock, Cerebras, Cohere, DeepSeek, ElevenLabs, Fireworks, Gemini, Groq, HuggingFace, Mistral, Nebius, Ollama, OpenAI, OpenCode, OpenRouter, Parasail, Perplexity, Replicate, Runware, Runway, SGL, Vertex, VLLM, and xAI.
- Updated a comment in `plugins_test.go` that referenced `NewEnvVar` to reference `NewSecretVar` instead.
- Added a blank line in `plugins_test.go` for formatting consistency.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify that all documentation examples reference `schemas.NewSecretVar` and that no remaining references to `schemas.NewEnvVar` exist in the provider docs.

```sh
grep -r "NewEnvVar" docs/providers/
```

Expected outcome: no matches returned.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security impact. This is a documentation-only rename that reflects the updated constructor name for handling secret/environment variable references.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable