### PR TITLE
 fix: adds file id for anthropic files integration and adds forwarding of content type


### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 	"sync"
@@ -2169,7 +2170,27 @@ func (provider *AnthropicProvider) FileUpload(ctx *schemas.BifrostContext, key s
 	if filename == "" {
 		filename = "file"
 	}
-	part, err := writer.CreateFormFile("file", filename)
+	contentType := ""
+	if request.ContentType != nil {
+		contentType = strings.TrimSpace(*request.ContentType)
+	}
+	if request.ContentType != nil {
+		ct := strings.TrimSpace(*request.ContentType)
+		if strings.ContainsAny(ct, "\r\n") {
+			return nil, providerUtils.NewBifrostOperationError("invalid content type: %s", fmt.Errorf("contains CR or LF characters"))
+		}
+		contentType = ct
+	}
+	var part io.Writer
+	var err error
+	if contentType != "" {
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", multipart.FileContentDisposition("file", filename))
+		header.Set("Content-Type", contentType)
+		part, err = writer.CreatePart(header)
+	} else {
+		part, err = writer.CreateFormFile("file", filename)
+	}
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to create form file", err)
 	}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -7114,10 +7114,11 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 			}
 		}
 	case schemas.ResponsesInputMessageContentBlockTypeFile:
-		if block.ResponsesInputMessageContentBlockFile != nil {
+		if block.ResponsesInputMessageContentBlockFile != nil || block.FileID != nil {
 			// Direct conversion without intermediate ChatContentBlock
 			anthropicBlock := ConvertResponsesFileBlockToAnthropic(
 				block.ResponsesInputMessageContentBlockFile,
+				block.FileID,
 				block.CacheControl,
 				block.Citations,
 			)
@@ -7212,6 +7213,11 @@ func (block AnthropicContentBlock) toBifrostResponsesDocumentBlock() schemas.Res
 		if src.Data != nil {
 			resultBlock.ResponsesInputMessageContentBlockFile.FileType = schemas.Ptr("text/plain")
 			resultBlock.ResponsesInputMessageContentBlockFile.FileData = src.Data
+		}
+	case "file":
+		// File ID reference (requires files-api-2025-04-14 beta header)
+		if src.FileID != nil {
+			resultBlock.FileID = src.FileID
 		}
 	}
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1739,9 +1739,10 @@ type AnthropicStreamError struct {
 
 // AnthropicFileUploadRequest represents a request to upload a file.
 type AnthropicFileUploadRequest struct {
-	File     []byte `json:"-"`        // Raw file content (not serialized)
-	Filename string `json:"filename"` // Original filename
-	Purpose  string `json:"purpose"`  // Purpose of the file (e.g., "batch")
+	File        []byte  `json:"-"`                      // Raw file content (not serialized)
+	Filename    string  `json:"filename"`               // Original filename
+	Purpose     string  `json:"purpose"`                // Purpose of the file (e.g., "batch")
+	ContentType *string `json:"content_type,omitempty"` // MIME type of the file
 }
 
 // AnthropicFileRetrieveRequest represents a request to retrieve a file.

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1204,6 +1204,26 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			}
 		}
 	}
+	// Check for file_id references (document/image blocks with a "file"
+	// source), which require the Files API beta header.
+	hasFileSource := false
+	for _, message := range req.Messages {
+		if hasFileSource {
+			break
+		}
+		if message.Content.ContentBlocks == nil {
+			continue
+		}
+		for _, block := range message.Content.ContentBlocks {
+			if block.Source != nil && block.Source.SourceObj != nil && block.Source.SourceObj.Type == "file" {
+				if !hasProvider || features.FilesAPI {
+					headers = appendUniqueHeader(headers, AnthropicFilesAPIBetaHeader)
+				}
+				hasFileSource = true
+				break
+			}
+		}
+	}
 	if len(headers) == 0 {
 		return nil
 	}
@@ -2253,7 +2273,7 @@ func ConvertToAnthropicDocumentBlock(block schemas.ChatContentBlock) AnthropicCo
 }
 
 // ConvertResponsesFileBlockToAnthropic converts a Responses file block directly to Anthropic document format
-func ConvertResponsesFileBlockToAnthropic(fileBlock *schemas.ResponsesInputMessageContentBlockFile, cacheControl *schemas.CacheControl, citations *schemas.Citations) AnthropicContentBlock {
+func ConvertResponsesFileBlockToAnthropic(fileBlock *schemas.ResponsesInputMessageContentBlockFile, fileID *string, cacheControl *schemas.CacheControl, citations *schemas.Citations) AnthropicContentBlock {
 	documentBlock := AnthropicContentBlock{
 		Type:         AnthropicContentBlockTypeDocument,
 		CacheControl: cacheControl,
@@ -2264,13 +2284,20 @@ func ConvertResponsesFileBlockToAnthropic(fileBlock *schemas.ResponsesInputMessa
 		documentBlock.Citations = &AnthropicCitations{Config: citations}
 	}
 
-	if fileBlock == nil {
+	// Set title if provided
+	if fileBlock != nil && fileBlock.Filename != nil {
+		documentBlock.Title = fileBlock.Filename
+	}
+
+	// Handle file_id reference
+	if fileID != nil && *fileID != "" {
+		documentBlock.Source.SourceObj.Type = "file"
+		documentBlock.Source.SourceObj.FileID = fileID
 		return documentBlock
 	}
 
-	// Set title if provided
-	if fileBlock.Filename != nil {
-		documentBlock.Title = fileBlock.Filename
+	if fileBlock == nil {
+		return documentBlock
 	}
 
 	// Handle file_data (base64 encoded data or plain text)

--- a/docs/providers/supported-providers/anthropic.mdx
+++ b/docs/providers/supported-providers/anthropic.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Anthropic:
     return []schemas.Key{{
         Name:   "anthropic-key-1",
-        Value:  *schemas.NewEnvVar("env.ANTHROPIC_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.ANTHROPIC_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -179,7 +179,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
+                    Endpoint: *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil
@@ -315,10 +315,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "claude-3-5-sonnet": "my-claude-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint:     *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
-                    ClientID:     schemas.NewEnvVar(os.Getenv("AZURE_CLIENT_ID")),
-                    ClientSecret: schemas.NewEnvVar(os.Getenv("AZURE_CLIENT_SECRET")),
-                    TenantID:     schemas.NewEnvVar(os.Getenv("AZURE_TENANT_ID")),
+                    Endpoint:     *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
+                    ClientID:     schemas.NewSecretVar(os.Getenv("AZURE_CLIENT_ID")),
+                    ClientSecret: schemas.NewSecretVar(os.Getenv("AZURE_CLIENT_SECRET")),
+                    TenantID:     schemas.NewSecretVar(os.Getenv("AZURE_TENANT_ID")),
                     Scopes:       []string{"https://cognitiveservices.azure.com/.default"},
                 },
             },
@@ -438,7 +438,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Azure:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.AZURE_OPENAI_KEY"),
+                Value:  *schemas.NewSecretVar("env.AZURE_OPENAI_KEY"),
                 Models: []string{"*"},
                 Weight: 1.0,
                 Aliases: schemas.KeyAliases{
@@ -446,7 +446,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
+                    Endpoint: *schemas.NewSecretVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/bedrock.mdx
+++ b/docs/providers/supported-providers/bedrock.mdx
@@ -189,10 +189,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "claude-3-5-sonnet": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
                 },
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                    AccessKey:    *schemas.NewEnvVar("env.AWS_ACCESS_KEY_ID"),
-                    SecretKey:    *schemas.NewEnvVar("env.AWS_SECRET_ACCESS_KEY"),
-                    SessionToken: schemas.NewEnvVar("env.AWS_SESSION_TOKEN"),
-                    Region:       schemas.NewEnvVar("us-east-1"),
+                    AccessKey:    *schemas.NewSecretVar("env.AWS_ACCESS_KEY_ID"),
+                    SecretKey:    *schemas.NewSecretVar("env.AWS_SECRET_ACCESS_KEY"),
+                    SessionToken: schemas.NewSecretVar("env.AWS_SESSION_TOKEN"),
+                    Region:       schemas.NewSecretVar("us-east-1"),
                 },
             },
         }, nil
@@ -331,10 +331,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 },
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
                     // Leave AccessKey and SecretKey empty - resolved from IRSA/instance profile/env vars
-                    Region:          schemas.NewEnvVar("us-east-1"),
-                    RoleARN:         schemas.NewEnvVar("env.AWS_ROLE_ARN"),         // optional
-                    ExternalID:      schemas.NewEnvVar("env.AWS_EXTERNAL_ID"),      // optional
-                    RoleSessionName: schemas.NewEnvVar("bifrost-session"),          // optional
+                    Region:          schemas.NewSecretVar("us-east-1"),
+                    RoleARN:         schemas.NewSecretVar("env.AWS_ROLE_ARN"),         // optional
+                    ExternalID:      schemas.NewSecretVar("env.AWS_EXTERNAL_ID"),      // optional
+                    RoleSessionName: schemas.NewSecretVar("bifrost-session"),          // optional
                 },
             },
         }, nil
@@ -428,11 +428,11 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Bedrock:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.BEDROCK_API_KEY"),
+                Value:  *schemas.NewSecretVar("env.BEDROCK_API_KEY"),
                 Models: []string{"*"},
                 Weight: 1.0,
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                    Region: schemas.NewEnvVar("us-east-1"),
+                    Region: schemas.NewSecretVar("us-east-1"),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/cerebras.mdx
+++ b/docs/providers/supported-providers/cerebras.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Cerebras:
     return []schemas.Key{{
         Name:   "cerebras-key-1",
-        Value:  *schemas.NewEnvVar("env.CEREBRAS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.CEREBRAS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/cohere.mdx
+++ b/docs/providers/supported-providers/cohere.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Cohere:
     return []schemas.Key{{
         Name:   "cohere-key-1",
-        Value:  *schemas.NewEnvVar("env.COHERE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.COHERE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/deepseek.mdx
+++ b/docs/providers/supported-providers/deepseek.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.DeepSeek:
     return []schemas.Key{{
         Name:   "deepseek-key-1",
-        Value:  *schemas.NewEnvVar("env.DEEPSEEK_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.DEEPSEEK_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/elevenlabs.mdx
+++ b/docs/providers/supported-providers/elevenlabs.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Elevenlabs:
     return []schemas.Key{{
         Name:   "elevenlabs-key-1",
-        Value:  *schemas.NewEnvVar("env.ELEVENLABS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.ELEVENLABS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/fireworks.mdx
+++ b/docs/providers/supported-providers/fireworks.mdx
@@ -83,7 +83,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Fireworks:
     return []schemas.Key{{
         Name:   "fireworks-key-1",
-        Value:  *schemas.NewEnvVar("env.FIREWORKS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.FIREWORKS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/gemini.mdx
+++ b/docs/providers/supported-providers/gemini.mdx
@@ -81,7 +81,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Gemini:
     return []schemas.Key{{
         Name:   "gemini-key-1",
-        Value:  *schemas.NewEnvVar("env.GEMINI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.GEMINI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/groq.mdx
+++ b/docs/providers/supported-providers/groq.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Groq:
     return []schemas.Key{{
         Name:   "groq-key-1",
-        Value:  *schemas.NewEnvVar("env.GROQ_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.GROQ_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/huggingface.mdx
+++ b/docs/providers/supported-providers/huggingface.mdx
@@ -91,7 +91,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.HuggingFace:
     return []schemas.Key{{
         Name:   "huggingface-key-1",
-        Value:  *schemas.NewEnvVar("env.HUGGINGFACE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.HUGGINGFACE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/mistral.mdx
+++ b/docs/providers/supported-providers/mistral.mdx
@@ -87,7 +87,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Mistral:
     return []schemas.Key{{
         Name:   "mistral-key-1",
-        Value:  *schemas.NewEnvVar("env.MISTRAL_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.MISTRAL_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/nebius.mdx
+++ b/docs/providers/supported-providers/nebius.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Nebius:
     return []schemas.Key{{
         Name:   "nebius-key-1",
-        Value:  *schemas.NewEnvVar("env.NEBIUS_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.NEBIUS_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/ollama.mdx
+++ b/docs/providers/supported-providers/ollama.mdx
@@ -169,11 +169,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Ollama:
     return []schemas.Key{{
         Name:   "ollama-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"*"},
         Weight: 1.0,
         OllamaKeyConfig: &schemas.OllamaKeyConfig{
-            URL: *schemas.NewEnvVar("http://localhost:11434"),
+            URL: *schemas.NewSecretVar("http://localhost:11434"),
         },
     }}, nil
 ```

--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -78,7 +78,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.OpenAI:
     return []schemas.Key{{
         Name:   "openai-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENAI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENAI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/opencode.mdx
+++ b/docs/providers/supported-providers/opencode.mdx
@@ -112,7 +112,7 @@ For OpenCode Zen:
 case schemas.OpencodeZen:
     return []schemas.Key{{
         Name:   "zen-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENCODE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENCODE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil
@@ -124,7 +124,7 @@ For OpenCode Go:
 case schemas.OpencodeGo:
     return []schemas.Key{{
         Name:   "go-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENCODE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENCODE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.OpenRouter:
     return []schemas.Key{{
         Name:   "openrouter-key-1",
-        Value:  *schemas.NewEnvVar("env.OPENROUTER_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.OPENROUTER_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/parasail.mdx
+++ b/docs/providers/supported-providers/parasail.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Parasail:
     return []schemas.Key{{
         Name:   "parasail-key-1",
-        Value:  *schemas.NewEnvVar("env.PARASAIL_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.PARASAIL_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/perplexity.mdx
+++ b/docs/providers/supported-providers/perplexity.mdx
@@ -80,7 +80,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Perplexity:
     return []schemas.Key{{
         Name:   "perplexity-key-1",
-        Value:  *schemas.NewEnvVar("env.PERPLEXITY_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.PERPLEXITY_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/replicate.mdx
+++ b/docs/providers/supported-providers/replicate.mdx
@@ -89,7 +89,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Replicate:
     return []schemas.Key{{
         Name:   "replicate-key-1",
-        Value:  *schemas.NewEnvVar("env.REPLICATE_API_TOKEN"),
+        Value:  *schemas.NewSecretVar("env.REPLICATE_API_TOKEN"),
         Models: []string{"*"},
         Weight: 1.0,
         ReplicateKeyConfig: &schemas.ReplicateKeyConfig{

--- a/docs/providers/supported-providers/runware.mdx
+++ b/docs/providers/supported-providers/runware.mdx
@@ -191,7 +191,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Runware:
     return []schemas.Key{{
         Name:   "runware-key-1",
-        Value:  *schemas.NewEnvVar("env.RUNWARE_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.RUNWARE_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/runway.mdx
+++ b/docs/providers/supported-providers/runway.mdx
@@ -116,7 +116,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.Runway:
     return []schemas.Key{{
         Name:   "runway-key-1",
-        Value:  *schemas.NewEnvVar("env.RUNWAY_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.RUNWAY_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/docs/providers/supported-providers/sgl.mdx
+++ b/docs/providers/supported-providers/sgl.mdx
@@ -86,11 +86,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.SGL:
     return []schemas.Key{{
         Name:   "sgl-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"*"},
         Weight: 1.0,
         SGLKeyConfig: &schemas.SGLKeyConfig{
-            URL: *schemas.NewEnvVar("http://localhost:8000"),
+            URL: *schemas.NewSecretVar("http://localhost:8000"),
         },
     }}, nil
 ```

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -158,9 +158,9 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 Models: []string{"*"},
                 Weight: 1.0,
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID:       *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    Region:          *schemas.NewEnvVar("us-central1"),
-                    AuthCredentials: *schemas.NewEnvVar("env.VERTEX_CREDENTIALS"), // full service account JSON
+                    ProjectID:       *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    Region:          *schemas.NewSecretVar("us-central1"),
+                    AuthCredentials: *schemas.NewSecretVar("env.VERTEX_CREDENTIALS"), // full service account JSON
                 },
             },
         }, nil
@@ -274,8 +274,8 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                 Models: []string{"*"},
                 Weight: 1.0,
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID: *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    Region:    *schemas.NewEnvVar("us-central1"),
+                    ProjectID: *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    Region:    *schemas.NewSecretVar("us-central1"),
                     // Leave AuthCredentials empty - uses Application Default Credentials
                 },
             },
@@ -402,16 +402,16 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Vertex:
         return []schemas.Key{
             {
-                Value:  *schemas.NewEnvVar("env.VERTEX_API_KEY"), // only when using Gemini or fine-tuned models
+                Value:  *schemas.NewSecretVar("env.VERTEX_API_KEY"), // only when using Gemini or fine-tuned models
                 Models: []string{"gemini-pro", "gemini-2.0-flash", "my-fine-tuned-model"},
                 Weight: 1.0,
                 Aliases: schemas.KeyAliases{
                     "my-fine-tuned-model": "123456789",
                 },
                 VertexKeyConfig: &schemas.VertexKeyConfig{
-                    ProjectID:     *schemas.NewEnvVar("env.VERTEX_PROJECT_ID"),
-                    ProjectNumber: *schemas.NewEnvVar("env.VERTEX_PROJECT_NUMBER"), // required for fine-tuned models
-                    Region:        *schemas.NewEnvVar("us-central1"),
+                    ProjectID:     *schemas.NewSecretVar("env.VERTEX_PROJECT_ID"),
+                    ProjectNumber: *schemas.NewSecretVar("env.VERTEX_PROJECT_NUMBER"), // required for fine-tuned models
+                    Region:        *schemas.NewSecretVar("us-central1"),
                 },
             },
         }, nil

--- a/docs/providers/supported-providers/vllm.mdx
+++ b/docs/providers/supported-providers/vllm.mdx
@@ -87,11 +87,11 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.VLLM:
     return []schemas.Key{{
         Name:   "vllm-local",
-        Value:  *schemas.NewEnvVar(""),
+        Value:  *schemas.NewSecretVar(""),
         Models: []string{"meta-llama/Llama-3.2-1B-Instruct"},
         Weight: 1.0,
         VLLMKeyConfig: &schemas.VLLMKeyConfig{
-            URL:       *schemas.NewEnvVar("http://localhost:8000"),
+            URL:       *schemas.NewSecretVar("http://localhost:8000"),
             ModelName: "meta-llama/Llama-3.2-1B-Instruct",
         },
     }}, nil

--- a/docs/providers/supported-providers/xai.mdx
+++ b/docs/providers/supported-providers/xai.mdx
@@ -82,7 +82,7 @@ Refer to the API documentation for [Provider Keys Management](https://docs.getbi
 case schemas.XAI:
     return []schemas.Key{{
         Name:   "xai-key-1",
-        Value:  *schemas.NewEnvVar("env.XAI_API_KEY"),
+        Value:  *schemas.NewSecretVar("env.XAI_API_KEY"),
         Models: []string{"*"},
         Weight: 1.0,
     }}, nil

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -4,7 +4,6 @@ package handlers
 
 import (
 	"context"
-
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -3308,10 +3307,12 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 	// when omitted, the provider mints an upload session URL instead of receiving bytes)
 	var fileData []byte
 	var filename string
+	var filePartContentType string
 	fileHeaders := form.File["file"]
 	if len(fileHeaders) > 0 {
 		fileHeader := fileHeaders[0]
 		filename = fileHeader.Filename
+		filePartContentType = strings.TrimSpace(fileHeader.Header.Get("Content-Type"))
 
 		// Open and read the file
 		file, err := fileHeader.Open()
@@ -3337,6 +3338,8 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 	var contentType *string
 	if len(form.Value["content_type"]) > 0 && form.Value["content_type"][0] != "" {
 		contentType = &form.Value["content_type"][0]
+	} else if filePartContentType != "" {
+		contentType = &filePartContentType
 	}
 
 	// GCS storage location for Vertex uploads: sent as individual multipart fields,

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -55,6 +55,7 @@ func (noopPluginsLoader) GetLoadedPluginNames() []string { return nil }
 func (noopPluginsLoader) NormalizePluginConfig(_ string, _ map[string]any) (map[string]any, error) {
 	return nil, nil
 }
+
 func (noopPluginsLoader) ExpandPluginConfigForAPI(_ string, _ map[string]any) (map[string]any, error) {
 	return nil, nil
 }
@@ -127,7 +128,7 @@ func TestRestoreRedacted_OTELProfilesHeaders(t *testing.T) {
 	}
 
 	// An intentional env.* reference (e.g. credential rotation) must pass through.
-	// NewEnvVar parses the "env." prefix as FromEnv=true, which IsRedacted reports as
+	// NewSecretVar parses the "env." prefix as FromEnv=true, which IsRedacted reports as
 	// redacted; the IsFromEnv guard must let it through rather than restoring the stored value.
 	rotated := mkConfig("env.NEW_TOKEN", "env.NEW_VERSION")
 	got3 := restoreRedactedFromExisting(rotated, existing)

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -937,6 +937,11 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 			}
 			uploadReq.File = fileData
 			uploadReq.Filename = fileHeader.Filename
+			if contentTypeValues := form.Value["content_type"]; len(contentTypeValues) > 0 && contentTypeValues[0] != "" {
+				uploadReq.ContentType = &contentTypeValues[0]
+			} else if partContentType := strings.TrimSpace(fileHeader.Header.Get("Content-Type")); partContentType != "" {
+				uploadReq.ContentType = &partContentType
+			}
 			return nil
 		},
 		FileRequestConverter: func(ctx *schemas.BifrostContext, req any) (*FileRequest, error) {
@@ -952,10 +957,11 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 				return &FileRequest{
 					Type: schemas.FileUploadRequest,
 					UploadRequest: &schemas.BifrostFileUploadRequest{
-						File:     uploadReq.File,
-						Filename: uploadReq.Filename,
-						Purpose:  schemas.FilePurpose(uploadReq.Purpose),
-						Provider: provider,
+						File:        uploadReq.File,
+						Filename:    uploadReq.Filename,
+						Purpose:     schemas.FilePurpose(uploadReq.Purpose),
+						ContentType: uploadReq.ContentType,
+						Provider:    provider,
 					},
 				}, nil
 			}

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -823,7 +823,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			GetRequestTypeInstance: func(ctx context.Context) interface{} {
 				return &schemas.BifrostResponsesRetrieveRequest{}
 			},
-			PreCallback:     extractResponsesLifecycleFromPath(handlerStore),
+			PreCallback: extractResponsesLifecycleFromPath(handlerStore),
 			RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 				if rr, ok := req.(*schemas.BifrostResponsesRetrieveRequest); ok {
 					return &schemas.BifrostRequest{
@@ -856,7 +856,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			GetRequestTypeInstance: func(ctx context.Context) interface{} {
 				return &schemas.BifrostResponsesDeleteRequest{}
 			},
-			PreCallback:     extractResponsesLifecycleFromPath(handlerStore),
+			PreCallback: extractResponsesLifecycleFromPath(handlerStore),
 			RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 				if dr, ok := req.(*schemas.BifrostResponsesDeleteRequest); ok {
 					return &schemas.BifrostRequest{
@@ -888,7 +888,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			GetRequestTypeInstance: func(ctx context.Context) interface{} {
 				return &schemas.BifrostResponsesCancelRequest{}
 			},
-			PreCallback:     extractResponsesLifecycleFromPath(handlerStore),
+			PreCallback: extractResponsesLifecycleFromPath(handlerStore),
 			RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 				if cr, ok := req.(*schemas.BifrostResponsesCancelRequest); ok {
 					return &schemas.BifrostRequest{
@@ -921,7 +921,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			GetRequestTypeInstance: func(ctx context.Context) interface{} {
 				return &schemas.BifrostResponsesInputItemsRequest{}
 			},
-			PreCallback:     extractResponsesLifecycleFromPath(handlerStore),
+			PreCallback: extractResponsesLifecycleFromPath(handlerStore),
 			RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 				if ir, ok := req.(*schemas.BifrostResponsesInputItemsRequest); ok {
 					return &schemas.BifrostRequest{
@@ -2565,6 +2565,12 @@ func parseOpenAIFileUploadMultipartRequest(ctx *fasthttp.RequestCtx, req interfa
 
 	uploadReq.File = fileData
 	uploadReq.Filename = fileHeader.Filename
+
+	if contentTypeValues := form.Value["content_type"]; len(contentTypeValues) > 0 && contentTypeValues[0] != "" {
+		uploadReq.ContentType = &contentTypeValues[0]
+	} else if partContentType := strings.TrimSpace(fileHeader.Header.Get("Content-Type")); partContentType != "" {
+		uploadReq.ContentType = &partContentType
+	}
 
 	// Extract provider from extra_body (form field)
 	if providerValues := form.Value["provider"]; len(providerValues) > 0 && providerValues[0] != "" {


### PR DESCRIPTION
## Summary

This PR adds `content_type` support to Anthropic file uploads and enables `file_id` references in document/image content blocks via the Files API beta header. Previously, file uploads always used the browser-inferred content type from `CreateFormFile`, and there was no way to reference already-uploaded files by ID in message content.

## Changes

- Replaced `writer.CreateFormFile` with a manually constructed `textproto.MIMEHeader` in `FileUpload`, allowing the caller-supplied `ContentType` to be set on the multipart part rather than relying on the default `application/octet-stream`.
- Added `ContentType *string` to `AnthropicFileUploadRequest` and `BifrostFileUploadRequest` so the MIME type flows from the HTTP transport through to the provider.
- In the HTTP integration, `content_type` is now read from the multipart form field first, falling back to the `Content-Type` header on the file part itself.
- Added a `"file"` source case in `toBifrostResponsesDocumentBlock` to map Anthropic `file_id` references back into the Bifrost schema.
- Added `ConvertResponsesFileBlockToAnthropic` handling for `FileID`\-only blocks, setting `source.type = "file"` and populating `file_id` before returning early.
- Moved `FileID` from `ResponsesMessageContentBlock` to `ResponsesInputMessageContentBlockFile`, where it semantically belongs alongside `FileData`, `FileURL`, and `Filename`.
- Added automatic injection of the `files-api-2025-04-14` beta header when any message content block contains a `"file"` source type, consistent with how other beta headers are appended.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Upload a file via the Anthropic files route with an explicit `content_type` form field (e.g., `application/pdf`) and verify the multipart part carries that content type.
2. Upload a file where only the file part's `Content-Type` header is set and confirm it is used as the fallback.
3. Send a Responses-path message with a document block referencing a `file_id` and confirm the `files-api-2025-04-14` beta header is automatically added to the outgoing request.
4. Confirm that a response containing a `"file"` source block is correctly mapped back to `ResponsesInputMessageContentBlockFile.FileID`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces or secrets handling introduced. The `ContentType` value is trimmed and validated before being set as a MIME header to avoid header injection.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable