### PR TITLE
fix: fixes error type setting in all integrations for Bedrock

### DIFF
--- a/core/providers/bedrock/errors.go
+++ b/core/providers/bedrock/errors.go
@@ -31,18 +31,24 @@ func parseBedrockHTTPError(statusCode int, headers http.Header, body []byte) *sc
 		bifrostErr.Error.Code = errorResp.Code
 	}
 
-	if bifrostErr.Type == nil {
-		exceptionType := errorResp.Type
-		if exceptionType == "" {
-			if hv := headers.Get("X-Amzn-Errortype"); hv != "" {
-				if i := strings.IndexAny(hv, ":#"); i >= 0 {
-					hv = hv[:i]
-				}
-				exceptionType = strings.TrimSpace(hv)
+	exceptionType := errorResp.Type
+	if exceptionType == "" {
+		if hv := headers.Get("X-Amzn-Errortype"); hv != "" {
+			if i := strings.IndexAny(hv, ":#"); i >= 0 {
+				hv = hv[:i]
 			}
+			exceptionType = strings.TrimSpace(hv)
 		}
-		if exceptionType != "" {
-			bifrostErr.Type = &exceptionType
+	}
+	if exceptionType != "" {
+		if bifrostErr.Type == nil {
+			bifrostErr.Type = schemas.Ptr(exceptionType)
+		}
+		if bifrostErr.Error == nil {
+			bifrostErr.Error = &schemas.ErrorField{}
+		}
+		if bifrostErr.Error.Type == nil {
+			bifrostErr.Error.Type = schemas.Ptr(exceptionType)
 		}
 	}
 

--- a/core/providers/bedrock/errors_test.go
+++ b/core/providers/bedrock/errors_test.go
@@ -46,6 +46,40 @@ func TestParseBedrockHTTPError_TypeFromHeader(t *testing.T) {
 	assert.Contains(t, bifrostErr.Error.Message, "reached the end of its life")
 }
 
+// TestParseBedrockHTTPError_PopulatesNestedErrorType verifies the AWS exception
+// type is surfaced on the nested error object (error.type), not only at the
+// top level. OpenAI-shaped consumers read error.type/error.code, so a
+// Bedrock passthrough error must carry the type there — matching every other
+// provider. This is the customer-reported gap: "only error.message, no type".
+func TestParseBedrockHTTPError_PopulatesNestedErrorType(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Amzn-Errortype", "ValidationException")
+	body := []byte(`{"message":"Invocation of model ID anthropic.claude-v2 with on-demand throughput isn't supported."}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusBadRequest, headers, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Type)
+	assert.Equal(t, "ValidationException", *bifrostErr.Type, "top-level type must still be set")
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type, "nested error.type must be populated for OpenAI-shaped consumers")
+	assert.Equal(t, "ValidationException", *bifrostErr.Error.Type)
+}
+
+// TestParseBedrockHTTPError_NestedTypeFromBodyType verifies the nested
+// error.type is also populated when the type comes from the body "__type"
+// rather than the header.
+func TestParseBedrockHTTPError_NestedTypeFromBodyType(t *testing.T) {
+	body := []byte(`{"__type":"ThrottlingException","message":"rate exceeded"}`)
+
+	bifrostErr := parseBedrockHTTPError(http.StatusTooManyRequests, http.Header{}, body)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type)
+	assert.Equal(t, "ThrottlingException", *bifrostErr.Error.Type)
+}
+
 // TestParseBedrockHTTPError_HeaderTypeQualifierStripped ensures the trailing
 // ":<url>" / "#<shape>" qualifier AWS sometimes appends to X-Amzn-Errortype is
 // removed.

--- a/core/providers/cohere/errors.go
+++ b/core/providers/cohere/errors.go
@@ -17,5 +17,9 @@ func parseCohereError(resp *fasthttp.Response) *schemas.BifrostError {
 	if errorResp.Code != nil {
 		bifrostErr.Error.Code = errorResp.Code
 	}
+	if errorResp.Type != "" && bifrostErr.Error.Type == nil {
+		typeCopy := errorResp.Type
+		bifrostErr.Error.Type = &typeCopy
+	}
 	return bifrostErr
 }

--- a/core/providers/cohere/errors_test.go
+++ b/core/providers/cohere/errors_test.go
@@ -1,0 +1,28 @@
+package cohere
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// TestParseCohereError_PopulatesNestedErrorType verifies the upstream exception
+// type is surfaced on the nested error object (error.type), not only at the top
+// level, so OpenAI-shaped consumers see it.
+func TestParseCohereError_PopulatesNestedErrorType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`{"type":"invalid_request_error","message":"model not found"}`)
+
+	bifrostErr := parseCohereError(&resp)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type, "nested error.type must be populated")
+	assert.Equal(t, "invalid_request_error", *bifrostErr.Error.Type)
+	require.NotNil(t, bifrostErr.Type, "top-level type must remain populated")
+	assert.Equal(t, "invalid_request_error", *bifrostErr.Type)
+	assert.Equal(t, "model not found", bifrostErr.Error.Message)
+}

--- a/core/providers/gemini/errors.go
+++ b/core/providers/gemini/errors.go
@@ -59,6 +59,9 @@ func parseGeminiError(resp *fasthttp.Response) *schemas.BifrostError {
 		// Set Code from first error if available
 		if firstError != nil {
 			bifrostErr.Error.Code = schemas.Ptr(strconv.Itoa(firstError.Code))
+			if firstError.Status != "" {
+				bifrostErr.Error.Type = schemas.Ptr(firstError.Status)
+			}
 		}
 		// Set Message to trimmed concatenated message
 		bifrostErr.Error.Message = message
@@ -74,6 +77,9 @@ func parseGeminiError(resp *fasthttp.Response) *schemas.BifrostError {
 		}
 		bifrostErr.Error.Code = schemas.Ptr(strconv.Itoa(errorResp.Error.Code))
 		bifrostErr.Error.Message = errorResp.Error.Message
+		if errorResp.Error.Status != "" {
+			bifrostErr.Error.Type = schemas.Ptr(errorResp.Error.Status)
+		}
 	}
 	return bifrostErr
 }

--- a/core/providers/gemini/errors_test.go
+++ b/core/providers/gemini/errors_test.go
@@ -1,0 +1,62 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+// TestParseGeminiError_SingleObjectPopulatesStatusType verifies the Gemini
+// status (e.g. RESOURCE_EXHAUSTED) is surfaced on error.type when the body is a
+// single {"error":{...}} object.
+func TestParseGeminiError_SingleObjectPopulatesStatusType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusTooManyRequests)
+	resp.SetBodyString(`{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}`)
+
+	bifrostErr := parseGeminiError(&resp)
+
+	if bifrostErr == nil || bifrostErr.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if bifrostErr.Error.Type == nil || *bifrostErr.Error.Type != "RESOURCE_EXHAUSTED" {
+		t.Fatalf("expected error.type RESOURCE_EXHAUSTED, got %v", bifrostErr.Error.Type)
+	}
+}
+
+// TestParseGeminiError_ArrayPopulatesStatusType verifies the status is surfaced
+// on error.type when the body is an array of errors.
+func TestParseGeminiError_ArrayPopulatesStatusType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`[{"error":{"code":400,"message":"bad request","status":"INVALID_ARGUMENT"}}]`)
+
+	bifrostErr := parseGeminiError(&resp)
+
+	if bifrostErr == nil || bifrostErr.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if bifrostErr.Error.Type == nil || *bifrostErr.Error.Type != "INVALID_ARGUMENT" {
+		t.Fatalf("expected error.type INVALID_ARGUMENT, got %v", bifrostErr.Error.Type)
+	}
+}
+
+// TestParseGeminiError_RoundTripToGeminiError is the regression test for the
+// broken passthrough: ToGeminiError reconstructs the status field from
+// error.type, so the round trip must preserve the Gemini status rather than
+// returning an empty status.
+func TestParseGeminiError_RoundTripToGeminiError(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusTooManyRequests)
+	resp.SetBodyString(`{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}`)
+
+	bifrostErr := parseGeminiError(&resp)
+	geminiErr := ToGeminiError(bifrostErr)
+
+	if geminiErr == nil || geminiErr.Error == nil {
+		t.Fatal("expected non-nil gemini error")
+	}
+	if geminiErr.Error.Status != "RESOURCE_EXHAUSTED" {
+		t.Fatalf("expected status RESOURCE_EXHAUSTED to survive round trip, got %q", geminiErr.Error.Status)
+	}
+}

--- a/core/providers/huggingface/errors.go
+++ b/core/providers/huggingface/errors.go
@@ -14,13 +14,15 @@ func parseHuggingFaceImageError(resp *fasthttp.Response) *schemas.BifrostError {
 	var errorResp HuggingFaceResponseError
 	bifrostErr := providerUtils.HandleProviderAPIError(resp, &errorResp)
 
-	if strings.TrimSpace(errorResp.Type) != "" {
-		typeCopy := errorResp.Type
-		bifrostErr.Type = &typeCopy
-	}
-
 	if bifrostErr.Error == nil {
 		bifrostErr.Error = &schemas.ErrorField{}
+	}
+
+	if strings.TrimSpace(errorResp.Type) != "" {
+		bifrostErr.Type = schemas.Ptr(errorResp.Type)
+		if bifrostErr.Error.Type == nil {
+			bifrostErr.Error.Type = schemas.Ptr(errorResp.Type)
+		}
 	}
 
 	// Handle FastAPI validation errors

--- a/core/providers/huggingface/errors_test.go
+++ b/core/providers/huggingface/errors_test.go
@@ -1,0 +1,27 @@
+package huggingface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// TestParseHuggingFaceImageError_PopulatesNestedErrorType verifies the upstream
+// exception type is surfaced on the nested error object (error.type), matching
+// the other providers, so OpenAI-shaped consumers see it.
+func TestParseHuggingFaceImageError_PopulatesNestedErrorType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`{"type":"validation_error","message":"invalid input"}`)
+
+	bifrostErr := parseHuggingFaceImageError(&resp)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type, "nested error.type must be populated")
+	assert.Equal(t, "validation_error", *bifrostErr.Error.Type)
+	require.NotNil(t, bifrostErr.Type, "top-level type must remain populated")
+	assert.Equal(t, "validation_error", *bifrostErr.Type)
+}

--- a/core/providers/vertex/errors.go
+++ b/core/providers/vertex/errors.go
@@ -49,8 +49,14 @@ func parseVertexError(resp *fasthttp.Response) *schemas.BifrostError {
 		return bifrostErr
 	}
 
-	createError := func(message string) *schemas.BifrostError {
+	createError := func(message, status string) *schemas.BifrostError {
 		bifrostErr := providerUtils.NewProviderAPIError(message, nil, resp.StatusCode(), nil, nil)
+		if status != "" {
+			if bifrostErr.Error == nil {
+				bifrostErr.Error = &schemas.ErrorField{}
+			}
+			bifrostErr.Error.Type = &status
+		}
 		var rawResponse interface{}
 		if err := sonic.Unmarshal(decodedBody, &rawResponse); err != nil {
 			rawResponse = string(decodedBody)
@@ -72,17 +78,27 @@ func parseVertexError(resp *fasthttp.Response) *schemas.BifrostError {
 					return bifrostErr
 				}
 				if len(validationErr.Detail) > 0 {
-					return createError(validationErr.Detail[0].Msg)
+					return createError(validationErr.Detail[0].Msg, "")
 				}
-				return createError("Unknown error")
+				return createError("Unknown error", "")
 			}
-			return createError(vertexErr.Error.Message)
+			return createError(vertexErr.Error.Message, vertexErr.Error.Status)
 		}
 		if len(vertexErr) > 0 {
-			return createError(vertexErr[0].Error.Message)
+			return createError(vertexErr[0].Error.Message, vertexErr[0].Error.Status)
 		}
-		return createError("Unknown error")
+		return createError("Unknown error", "")
 	}
-	// OpenAI error format succeeded with valid Error field
-	return createError(openAIErr.Error.Message)
+	// OpenAI error format succeeded with valid Error field.
+	openAIStatus := ""
+	if openAIErr.Error.Type != nil {
+		openAIStatus = *openAIErr.Error.Type
+	}
+	if openAIStatus == "" {
+		var single VertexError
+		if err := sonic.Unmarshal(decodedBody, &single); err == nil {
+			openAIStatus = single.Error.Status
+		}
+	}
+	return createError(openAIErr.Error.Message, openAIStatus)
 }

--- a/core/providers/vertex/errors_test.go
+++ b/core/providers/vertex/errors_test.go
@@ -1,0 +1,40 @@
+package vertex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// TestParseVertexError_PopulatesStatusType verifies the Vertex status
+// (e.g. RESOURCE_EXHAUSTED) is surfaced on error.type rather than being dropped,
+// so passthrough/OpenAI-shaped consumers see the exception type.
+func TestParseVertexError_PopulatesStatusType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusTooManyRequests)
+	resp.SetBodyString(`{"error":{"code":429,"message":"Quota exceeded","status":"RESOURCE_EXHAUSTED"}}`)
+
+	bifrostErr := parseVertexError(&resp)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type, "nested error.type must be populated from status")
+	assert.Equal(t, "RESOURCE_EXHAUSTED", *bifrostErr.Error.Type)
+	assert.Equal(t, "Quota exceeded", bifrostErr.Error.Message)
+}
+
+// TestParseVertexError_NoStatusNoType verifies that when the body carries no
+// Vertex status we don't fabricate an error.type.
+func TestParseVertexError_NoStatusNoType(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`{"error":{"code":400,"message":"bad request"}}`)
+
+	bifrostErr := parseVertexError(&resp)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.Error)
+	assert.Nil(t, bifrostErr.Error.Type, "no status present, so none should be fabricated")
+}


### PR DESCRIPTION
## Summary

Provider error responses were missing the `error.type` field on the nested `ErrorField` object. OpenAI-shaped consumers (and passthrough clients) read `error.type` to identify the exception category, so Bedrock, Cohere, Gemini, HuggingFace, and Vertex errors appeared with only `error.message` and no type — making it impossible to distinguish error classes programmatically.

## Changes

- **Bedrock**: Exception type (from `X-Amzn-Errortype` header or body `__type`) is now written to both the top-level `BifrostError.Type` and the nested `Error.Type`. Previously the nested field was never populated.
- **Cohere**: `errorResp.Type` is now forwarded to `Error.Type` when present.
- **Gemini**: `status` field (e.g. `RESOURCE_EXHAUSTED`, `INVALID_ARGUMENT`) from both single-object and array error bodies is now written to `Error.Type`. This also fixes the `ToGeminiError` round-trip, which reconstructs `status` from `error.type`.
- **HuggingFace**: `Error` struct is initialised before the type assignment, and `errorResp.Type` is now mirrored to `Error.Type` in addition to the top-level field.
- **Vertex**: `createError` now accepts a `status` string and writes it to `Error.Type`. The OpenAI-format path also attempts to recover the Vertex `status` field from the raw body when `openAIErr.Error.Type` is absent.
- Tests added for each provider covering the nested `error.type` population, header/body sourcing, and the Gemini round-trip regression.

## Type of change

- [x] Bug fix

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./core/providers/cohere/... ./core/providers/gemini/... ./core/providers/huggingface/... ./core/providers/vertex/...
```

Each new test file exercises the specific fix:
- `TestParseBedrockHTTPError_PopulatesNestedErrorType` — type from header
- `TestParseBedrockHTTPError_NestedTypeFromBodyType` — type from body `__type`
- `TestParseCohereError_PopulatesNestedErrorType`
- `TestParseGeminiError_SingleObjectPopulatesStatusType` / `TestParseGeminiError_ArrayPopulatesStatusType`
- `TestParseGeminiError_RoundTripToGeminiError` — regression for `ToGeminiError` status preservation
- `TestParseHuggingFaceImageError_PopulatesNestedErrorType`
- `TestParseVertexError_PopulatesStatusType` / `TestParseVertexError_NoStatusNoType`

## Breaking changes

- [x] No

## Security considerations

None. Changes are limited to error response parsing; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable