### PR TITLE
feat: add ClickHouse logs store, MCP OAuth2 server config, `bedrock_mantle` provider, virtual key `expires_at`, and per-client `toolExecutionTimeout` to Helm chart

### DIFF
--- a/docs/changelogs/helm-v2.1.26.mdx
+++ b/docs/changelogs/helm-v2.1.26.mdx
@@ -1,0 +1,17 @@
+---
+title: "v2.1.26"
+description: "Helm v2.1.26 changelog - 2026-07-06"
+---
+
+<Update label="Bifrost Helm" description="v2.1.26">
+
+## Changelog
+
+- `bifrost.client.mcpServerAuthMode` (`headers` | `both` | `oauth`) and `bifrost.client.oauth2ServerConfig` (`issuerUrl`, `authCodeTtl`, `accessTokenTtl`, `disableVkIdentity`) to control how `/mcp` authenticates inbound MCP clients. `authCodeTtl` is capped at 900 seconds. Render into `client.mcp_server_auth_mode` and `client.oauth2_server_config`.
+- ClickHouse logs store: set `storage.logsStore.type: clickhouse` with a `storage.logsStore.clickhouse` block (`host` required; optional `port`, `database`, `username`, `password`, `protocol`, `secure`, `dialTimeout`, `cluster`).
+- `bedrock_mantle` provider with `bedrock_mantle_key_config` (`region` required; optional `access_key`, `secret_key`, `session_token`, `role_arn`, `external_id`, `session_name`).
+- `deepseek` provider support via the generic provider passthrough.
+- `toolExecutionTimeout` on `bifrost.mcp.clientConfigs[]` — a per-server override of the global `toolManagerConfig.toolExecutionTimeout`. Accepts a Go duration string (e.g. `"30s"`) or a bare integer treated as seconds.
+- `expires_at` on `bifrost.governance.virtualKeys[]` — optional RFC3339 timestamp after which requests using the virtual key are rejected. Omit for a key that never expires.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -974,6 +974,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.26",
               "changelogs/helm-v2.1.25",
               "changelogs/helm-v2.1.24",
               "changelogs/helm-v2.1.23",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.25
+version: 2.1.26
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,17 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.25
+**Latest Version:** 2.1.26
 
 ## Changelog
+
+### 2.1.26
+
+- Added `bifrost.client.mcpServerAuthMode` (`headers` | `both` | `oauth`) and `bifrost.client.oauth2ServerConfig` (`issuerUrl`, `authCodeTtl`, `accessTokenTtl`, `disableVkIdentity`) to control how `/mcp` authenticates inbound MCP clients. Renders into `client.mcp_server_auth_mode` and `client.oauth2_server_config`. `authCodeTtl` is capped at 900 seconds.
+- Added ClickHouse as a `storage.logsStore.type` option. Set `type: clickhouse` and a `storage.logsStore.clickhouse` block (`host` required; optional `port`, `database`, `username`, `password`, `protocol`, `secure`, `dialTimeout`, `cluster`). Renders into `logs_store` with `type: clickhouse`.
+- Added the `bedrock_mantle` provider with `bedrock_mantle_key_config` (`region` required; optional `access_key`, `secret_key`, `session_token`, `role_arn`, `external_id`, `session_name`). Added the key-config schema and mutual-exclusion validation in `values.schema.json`.
+- Added `toolExecutionTimeout` to `bifrost.mcp.clientConfigs[]` as a per-server override of the global `toolManagerConfig.toolExecutionTimeout`. Accepts a Go duration string (e.g. `"30s"`) or a bare integer treated as seconds. Renders into `mcp.client_configs[].tool_execution_timeout`.
+- Added `expires_at` to `bifrost.governance.virtualKeys[]`. Optional RFC3339 timestamp; requests using the virtual key are rejected once it passes. Omit for a key that never expires.
 
 ### 2.1.25
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -328,6 +328,17 @@ false
 {{- if .Values.bifrost.client.mcpExternalClientUrl }}
 {{- $_ := set $client "mcp_external_client_url" .Values.bifrost.client.mcpExternalClientUrl }}
 {{- end }}
+{{- if .Values.bifrost.client.mcpServerAuthMode }}
+{{- $_ := set $client "mcp_server_auth_mode" .Values.bifrost.client.mcpServerAuthMode }}
+{{- end }}
+{{- if .Values.bifrost.client.oauth2ServerConfig }}
+{{- $oauth2 := dict }}
+{{- with .Values.bifrost.client.oauth2ServerConfig.issuerUrl }}{{- $_ := set $oauth2 "issuer_url" . }}{{- end }}
+{{- with .Values.bifrost.client.oauth2ServerConfig.authCodeTtl }}{{- $_ := set $oauth2 "auth_code_ttl" (. | int) }}{{- end }}
+{{- with .Values.bifrost.client.oauth2ServerConfig.accessTokenTtl }}{{- $_ := set $oauth2 "access_token_ttl" (. | int) }}{{- end }}
+{{- if hasKey .Values.bifrost.client.oauth2ServerConfig "disableVkIdentity" }}{{- $_ := set $oauth2 "disable_vk_identity" .Values.bifrost.client.oauth2ServerConfig.disableVkIdentity }}{{- end }}
+{{- if $oauth2 }}{{- $_ := set $client "oauth2_server_config" $oauth2 }}{{- end }}
+{{- end }}
 {{- $_ := set $config "client" $client }}
 {{- end }}
 {{- /* Server */ -}}
@@ -496,6 +507,7 @@ false
 {{- if .value }}{{- $_ := set $vk "value" .value }}{{- end }}
 {{- if .description }}{{- $_ := set $vk "description" .description }}{{- end }}
 {{- if hasKey . "is_active" }}{{- $_ := set $vk "is_active" .is_active }}{{- end }}
+{{- if .expires_at }}{{- $_ := set $vk "expires_at" .expires_at }}{{- end }}
 {{- if .team_id }}{{- $_ := set $vk "team_id" .team_id }}{{- end }}
 {{- if .customer_id }}{{- $_ := set $vk "customer_id" .customer_id }}{{- end }}
 {{- if hasKey . "access_profile_id" }}{{- $_ := set $vk "access_profile_id" .access_profile_id }}{{- end }}
@@ -826,6 +838,30 @@ false
 {{- if $writer }}{{- $_ := set $logsStore "writer" $writer }}{{- end }}
 {{- end }}
 {{- $_ := set $config "logs_store" $logsStore }}
+{{- else if eq $logsStoreType "clickhouse" }}
+{{- if not .Values.storage.logsStore.clickhouse }}{{- fail "ERROR: storage.logsStore.clickhouse is required when storage.logsStore.type is 'clickhouse'." }}{{- end }}
+{{- if not .Values.storage.logsStore.clickhouse.host }}{{- fail "ERROR: storage.logsStore.clickhouse.host is required when storage.logsStore.type is 'clickhouse'." }}{{- end }}
+{{- $ch := .Values.storage.logsStore.clickhouse }}
+{{- $chConfig := dict "host" $ch.host }}
+{{- with $ch.port }}{{- $_ := set $chConfig "port" (. | toString) }}{{- end }}
+{{- with $ch.database }}{{- $_ := set $chConfig "database" . }}{{- end }}
+{{- with $ch.username }}{{- $_ := set $chConfig "username" . }}{{- end }}
+{{- with $ch.password }}{{- $_ := set $chConfig "password" . }}{{- end }}
+{{- with $ch.protocol }}{{- $_ := set $chConfig "protocol" . }}{{- end }}
+{{- if hasKey $ch "secure" }}{{- $_ := set $chConfig "secure" $ch.secure }}{{- end }}
+{{- with $ch.dialTimeout }}{{- $_ := set $chConfig "dial_timeout" (. | int) }}{{- end }}
+{{- with $ch.cluster }}{{- $_ := set $chConfig "cluster" . }}{{- end }}
+{{- $clickhouseLogsStore := dict "enabled" true "type" "clickhouse" "config" $chConfig }}
+{{- if .Values.storage.logsStore.writer }}
+{{- $writer := dict }}
+{{- with .Values.storage.logsStore.writer.maxBatchSize }}{{- $_ := set $writer "max_batch_size" (. | int) }}{{- end }}
+{{- with .Values.storage.logsStore.writer.batchInterval }}{{- $_ := set $writer "batch_interval" . }}{{- end }}
+{{- with .Values.storage.logsStore.writer.maxBatchBytes }}{{- $_ := set $writer "max_batch_bytes" (. | int) }}{{- end }}
+{{- with .Values.storage.logsStore.writer.writeQueueCapacity }}{{- $_ := set $writer "write_queue_capacity" (. | int) }}{{- end }}
+{{- with .Values.storage.logsStore.writer.deferredUsageConcurrency }}{{- $_ := set $writer "deferred_usage_concurrency" (. | int) }}{{- end }}
+{{- if $writer }}{{- $_ := set $clickhouseLogsStore "writer" $writer }}{{- end }}
+{{- end }}
+{{- $_ := set $config "logs_store" $clickhouseLogsStore }}
 {{- else }}
 {{- $sqliteLogsStore := dict "enabled" true "type" "sqlite" "config" (dict "path" (printf "%s/logs.db" .Values.bifrost.appDir)) }}
 {{- if .Values.storage.logsStore.writer }}
@@ -1080,6 +1116,9 @@ false
 {{- end }}
 {{- if $client.toolSyncInterval }}
 {{- $_ := set $cc "tool_sync_interval" $client.toolSyncInterval }}
+{{- end }}
+{{- if hasKey $client "toolExecutionTimeout" }}
+{{- $_ := set $cc "tool_execution_timeout" $client.toolExecutionTimeout }}
 {{- end }}
 {{- if $client.toolPricing }}
 {{- $_ := set $cc "tool_pricing" $client.toolPricing }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -547,6 +547,37 @@
             "mcpExternalClientUrl": {
               "type": "string",
               "description": "Public base URL Bifrost uses as the redirect_uri when acting as an OAuth client to upstream MCP servers. Maps to client.mcp_external_client_url."
+            },
+            "mcpServerAuthMode": {
+              "type": "string",
+              "enum": ["headers", "both", "oauth"],
+              "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only. Maps to client.mcp_server_auth_mode."
+            },
+            "oauth2ServerConfig": {
+              "type": "object",
+              "description": "OAuth2 authorization server settings for /mcp. Only relevant when mcpServerAuthMode is 'both' or 'oauth'. Maps to client.oauth2_server_config.",
+              "properties": {
+                "issuerUrl": {
+                  "type": "string",
+                  "description": "Stable public URL advertised as the OAuth2 AS issuer in discovery documents and JWT iss claim. Required for multi-host deployments. Supports env var syntax: \"env.MY_VAR\"."
+                },
+                "authCodeTtl": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 900,
+                  "description": "Lifetime of the single-use authorization code in seconds (default: 300, max: 900)."
+                },
+                "accessTokenTtl": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Lifetime of the issued JWT Bearer token in seconds (default: 600)."
+                },
+                "disableVkIdentity": {
+                  "type": "boolean",
+                  "description": "When true, the OAuth consent flow no longer offers or accepts virtual-key identity. Honored only when an identity provider is configured. Only valid when mcpServerAuthMode is 'oauth'."
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1658,6 +1689,11 @@
                   },
                   "is_active": {
                     "type": "boolean"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Optional expiry timestamp (RFC3339). Once passed, requests using this virtual key are rejected. Omit for a key that never expires."
                   },
                   "team_id": {
                     "type": "string"
@@ -3500,7 +3536,7 @@
             },
             "type": {
               "type": "string",
-              "enum": ["", "sqlite", "postgres"]
+              "enum": ["", "sqlite", "postgres", "clickhouse"]
             },
             "maxIdleConns": {
               "type": "integer",
@@ -3514,6 +3550,52 @@
               "type": "string",
               "description": "How often to refresh materialized views. Go duration string (e.g. '30s', '5m', '1h'). Minimum 5s.",
               "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+            },
+            "clickhouse": {
+              "type": "object",
+              "description": "ClickHouse connection settings (only applies when type is clickhouse)",
+              "properties": {
+                "host": {
+                  "type": "string",
+                  "description": "ClickHouse host"
+                },
+                "port": {
+                  "type": ["string", "integer"],
+                  "description": "ClickHouse port. Defaults by protocol: native 9000 (9440 TLS), http 8123 (8443 TLS)"
+                },
+                "database": {
+                  "type": "string",
+                  "description": "ClickHouse database name (default: default)"
+                },
+                "username": {
+                  "type": "string",
+                  "description": "ClickHouse username"
+                },
+                "password": {
+                  "type": "string",
+                  "description": "ClickHouse password (can use env. prefix)"
+                },
+                "protocol": {
+                  "type": "string",
+                  "enum": ["native", "http"],
+                  "description": "ClickHouse wire protocol (default: native)"
+                },
+                "secure": {
+                  "type": "boolean",
+                  "description": "Enable TLS (native: secure=true; http: switches to https)"
+                },
+                "dialTimeout": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Connection dial timeout in milliseconds (default: 10000)"
+                },
+                "cluster": {
+                  "type": "string",
+                  "description": "Optional cluster name; when set, DDL runs ON CLUSTER with replicated table engines"
+                }
+              },
+              "required": ["host"],
+              "additionalProperties": false
             },
             "writer": {
               "type": "object",
@@ -4661,6 +4743,41 @@
           "required": ["region"],
           "additionalProperties": false
         },
+        "bedrock_mantle_key_config": {
+          "type": "object",
+          "properties": {
+            "access_key": {
+              "type": "string",
+              "description": "AWS access key for SigV4 (can use env. prefix)"
+            },
+            "secret_key": {
+              "type": "string",
+              "description": "AWS secret key for SigV4 (can use env. prefix)"
+            },
+            "session_token": {
+              "type": "string",
+              "description": "AWS session token for temporary credentials (can use env. prefix)"
+            },
+            "region": {
+              "type": "string",
+              "description": "AWS region used to build the bedrock-mantle endpoint host"
+            },
+            "role_arn": {
+              "type": "string",
+              "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+            },
+            "external_id": {
+              "type": "string",
+              "description": "External ID for AssumeRole (can use env. prefix)"
+            },
+            "session_name": {
+              "type": "string",
+              "description": "Role session name for AssumeRole (can use env. prefix)"
+            }
+          },
+          "required": ["region"],
+          "additionalProperties": false
+        },
         "vllm_key_config": {
           "type": "object",
           "properties": {
@@ -4764,6 +4881,9 @@
                 "required": ["bedrock_key_config"]
               },
               {
+                "required": ["bedrock_mantle_key_config"]
+              },
+              {
                 "required": ["vllm_key_config"]
               }
             ]
@@ -4778,6 +4898,9 @@
               },
               {
                 "required": ["bedrock_key_config"]
+              },
+              {
+                "required": ["bedrock_mantle_key_config"]
               },
               {
                 "required": ["vllm_key_config"]
@@ -4796,6 +4919,9 @@
                 "required": ["bedrock_key_config"]
               },
               {
+                "required": ["bedrock_mantle_key_config"]
+              },
+              {
                 "required": ["vllm_key_config"]
               }
             ]
@@ -4810,6 +4936,28 @@
               },
               {
                 "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["bedrock_mantle_key_config"]
+              },
+              {
+                "required": ["vllm_key_config"]
+              }
+            ]
+          }
+        },
+        {
+          "required": ["bedrock_mantle_key_config"],
+          "not": {
+            "anyOf": [
+              {
+                "required": ["azure_key_config"]
+              },
+              {
+                "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["bedrock_key_config"]
               },
               {
                 "required": ["vllm_key_config"]
@@ -4829,6 +4977,9 @@
               },
               {
                 "required": ["bedrock_key_config"]
+              },
+              {
+                "required": ["bedrock_mantle_key_config"]
               }
             ]
           }
@@ -5075,6 +5226,10 @@
         "toolSyncInterval": {
           "type": "string",
           "description": "Per-client override for tool sync interval"
+        },
+        "toolExecutionTimeout": {
+          "type": ["string", "integer"],
+          "description": "Per-client override for tool execution timeout. Go duration string (e.g. '30s', '2m') or a bare integer treated as seconds. Overrides the global mcp.toolManagerConfig.toolExecutionTimeout for this server only. Omit or set to 0 to use the global default."
         },
         "isPingAvailable": {
           "type": "boolean",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -297,6 +297,14 @@ bifrost:
     # routingChainMaxDepth: 10        # Maximum depth for routing rule chain evaluation
     # allowDirectKeys: false          # Allow callers to bypass the key pool via x-bf-direct-key + Authorization header
     # mcpExternalClientUrl: ""        # Public base URL used as redirect_uri when Bifrost is an OAuth client to MCP servers
+    # How /mcp authenticates inbound MCP clients: headers (default), both, or oauth
+    # mcpServerAuthMode: "headers"
+    # OAuth2 authorization server settings for /mcp (only used when mcpServerAuthMode is "both" or "oauth")
+    # oauth2ServerConfig:
+    #   issuerUrl: ""             # Stable public issuer URL; required for multi-host deployments. Supports env.VAR_NAME
+    #   authCodeTtl: 300          # Authorization code lifetime in seconds (default 300, max 900)
+    #   accessTokenTtl: 600       # Issued JWT lifetime in seconds (default 600)
+    #   disableVkIdentity: false  # Only valid when mcpServerAuthMode is "oauth"
 
   # Server configuration
   server:
@@ -402,6 +410,21 @@ bifrost:
   #         region: "us-east-1"
   #         access_key: "env.AWS_ACCESS_KEY_ID"
   #         secret_key: "env.AWS_SECRET_ACCESS_KEY"
+  #
+  # # AWS Bedrock Mantle example (requires bedrock_mantle_key_config)
+  # bedrock_mantle:
+  #   keys:
+  #     - name: "bedrock-mantle-key"
+  #       value: ""
+  #       weight: 1
+  #       bedrock_mantle_key_config:
+  #         region: "us-east-1"                     # Required
+  #         access_key: "env.AWS_ACCESS_KEY_ID"
+  #         secret_key: "env.AWS_SECRET_ACCESS_KEY"
+  #         # session_token: "env.AWS_SESSION_TOKEN"
+  #         # role_arn: ""                          # For AssumeRole
+  #         # external_id: ""
+  #         # session_name: ""
 
   # Provider secrets - use existing Kubernetes secrets for provider API keys
   # These will be injected as environment variables that can be referenced in providers config
@@ -436,6 +459,10 @@ bifrost:
       # - name: "example-https-mcp"
       #   connectionType: "http"
       #   connectionString: "https://my-internal-mcp.corp/mcp"
+      #   # Per-server tool execution timeout override. Go duration string ("30s", "2m")
+      #   # or a bare integer treated as seconds. Overrides toolManagerConfig.toolExecutionTimeout
+      #   # for this server only. Omit or set to 0 to use the global default.
+      #   toolExecutionTimeout: "30s"
       #   # TLS configuration for HTTP and SSE connection types.
       #   # Use when the MCP server presents a self-signed or private CA certificate.
       #   tlsConfig:
@@ -718,6 +745,7 @@ bifrost:
       #   description: "Virtual key description"
       #   value: "sk-bf-..."           # Optional - auto-generated if omitted
       #   is_active: true
+      #   expires_at: "2026-12-31T23:59:59Z"  # Optional RFC3339 expiry; requests rejected once passed. Omit for no expiry
       #   team_id: "team-1"        # Mutually exclusive with customer_id
       #   customer_id: ""          # Mutually exclusive with team_id
       #   rate_limit_id: "rate-limit-1"
@@ -1123,11 +1151,22 @@ storage:
   logsStore:
     enabled: true
     # Backend type for logs store. Empty string uses storage.mode as default
-    type: "" # Options: sqlite, postgres, or "" (uses storage.mode)
+    type: "" # Options: sqlite, postgres, clickhouse, or "" (uses storage.mode)
     # PostgreSQL connection pool tuning (only applies when type is postgres)
     # maxIdleConns: 5
     # maxOpenConns: 50
     # matviewRefreshInterval: "30s"  # How often to refresh materialized views. Go duration string (e.g. '30s', '5m', '1h'). Minimum 5s.
+    # ClickHouse connection settings (only applies when type is clickhouse)
+    # clickhouse:
+    #   host: "clickhouse.default.svc.cluster.local"  # Required
+    #   port: "9000"          # Defaults by protocol: native 9000 (9440 TLS), http 8123 (8443 TLS)
+    #   database: "default"
+    #   username: "default"
+    #   password: "env.CLICKHOUSE_PASSWORD"
+    #   protocol: "native"    # Options: native, http (default: native)
+    #   secure: false         # Enable TLS
+    #   dialTimeout: 10000    # Connection dial timeout in milliseconds
+    #   cluster: ""           # Optional cluster name; runs DDL ON CLUSTER with replicated engines
     # Async writer queue and batch tuning. Omitted fields use Bifrost defaults.
     # writer:
     #   maxBatchSize: 1000

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.12
+    created: "2026-07-06T19:36:21.933983+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 8484fdfeec2c0f9c7c90024f897ea946d113f4599a20a70d7891465bf1b389eb
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.26/bifrost-2.1.26.tgz
+    version: 2.1.26
+  - apiVersion: v2
+    appVersion: 1.5.12
     created: "2026-06-25T16:30:36.787778+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -1108,4 +1132,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-06-25T16:30:36.784122+05:30"
+generated: "2026-07-06T19:36:21.930494+05:30"


### PR DESCRIPTION
## Summary

Extends the Bifrost Helm chart with several new configuration capabilities: OAuth2/MCP server authentication modes, ClickHouse as a logs store backend, AWS Bedrock Mantle provider support, virtual key expiry, and per-client tool execution timeout overrides.

## Changes

- **MCP server auth modes**: Added `mcpServerAuthMode` (`headers`, `both`, `oauth`) to control how `/mcp` authenticates inbound clients. Added `oauth2ServerConfig` block supporting `issuerUrl`, `authCodeTtl`, `accessTokenTtl`, and `disableVkIdentity` for Bifrost-issued JWT flows.
- **ClickHouse logs store**: Added `clickhouse` as a valid `storage.logsStore.type`. Supports full connection configuration including host, port, database, credentials, protocol (`native`/`http`), TLS, dial timeout, and optional cluster name for replicated DDL.
- **Bedrock Mantle provider**: Added `bedrock_mantle_key_config` schema and example configuration supporting SigV4 credentials, AssumeRole via `role_arn`, `external_id`, and `session_name`. Added mutual-exclusivity constraints alongside existing provider key configs.
- **Virtual key expiry**: Added `expires_at` (RFC3339) field to virtual key definitions. Requests using a key past its expiry timestamp are rejected.
- **Per-client tool execution timeout**: Added `toolExecutionTimeout` to MCP client configuration, allowing per-server overrides of the global `toolManagerConfig.toolExecutionTimeout`. Accepts a Go duration string or bare integer (seconds); `0` falls back to the global default.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Render the chart and verify new fields appear in the generated config
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.client.mcpServerAuthMode=both \
  --set bifrost.client.oauth2ServerConfig.issuerUrl=https://example.com \
  --set bifrost.client.oauth2ServerConfig.authCodeTtl=300 \
  --set bifrost.client.oauth2ServerConfig.accessTokenTtl=600 \
  --set storage.logsStore.type=clickhouse \
  --set storage.logsStore.clickhouse.host=clickhouse.default.svc.cluster.local

# Validate schema
helm lint ./helm-charts/bifrost

# Verify ClickHouse logs store block is rendered correctly
helm template bifrost ./helm-charts/bifrost \
  --set storage.logsStore.type=clickhouse \
  --set storage.logsStore.clickhouse.host=ch-host \
  --set storage.logsStore.clickhouse.protocol=native \
  --set storage.logsStore.clickhouse.secure=true

# Verify virtual key expiry field is included
helm template bifrost ./helm-charts/bifrost \
  --set 'bifrost.virtualKeys[0].name=test' \
  --set 'bifrost.virtualKeys[0].expires_at=2026-12-31T23:59:59Z'
```

New configuration fields:

| Field | Description |
|---|---|
| `bifrost.client.mcpServerAuthMode` | `headers` (default), `both`, or `oauth` |
| `bifrost.client.oauth2ServerConfig.*` | OAuth2 AS settings for `/mcp` |
| `storage.logsStore.type=clickhouse` | ClickHouse backend for logs |
| `storage.logsStore.clickhouse.*` | ClickHouse connection parameters |
| `virtualKeys[].expires_at` | RFC3339 expiry for virtual keys |
| `mcpClients[].toolExecutionTimeout` | Per-server tool execution timeout override |
| `providers.bedrock_mantle.*` | AWS Bedrock Mantle provider key config |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `oauth2ServerConfig` introduces Bifrost as an OAuth2 authorization server issuing JWTs for MCP clients. The `issuerUrl` must be a stable, publicly reachable URL in multi-host deployments to ensure JWT `iss` claims and discovery documents are consistent.
- `disableVkIdentity` removes virtual-key identity from the OAuth consent flow; only valid in `oauth` mode.
- `bedrock_mantle_key_config` credentials support the `env.` prefix to avoid embedding secrets directly in values files.
- Virtual key `expires_at` enforcement happens server-side; expired keys are rejected at request time.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable