### PR TITLE
bug notice for v1.6.2

### DIFF
--- a/docs/changelogs/ent-v1.5.2.mdx
+++ b/docs/changelogs/ent-v1.5.2.mdx
@@ -5,6 +5,10 @@ description: "Enterprise v1.5.2 changelog - 2026-07-01"
 
 <Update label="Bifrost Enterprise" description="v1.5.2">
 
+<Warning>
+v1.5.2 has a [know CPU spike issue](https://github.com/maximhq/bifrost/issues/4851) for large number of budgets/teams/customers. The fix is part of v1.5.3
+</Warning>
+
 ## Changelog
 
 Release on `transports/v1.6.2`. Fixes a governance reset-consistency gap where request-time budget/rate-limit bumps could skip ghost-node cleanup, corrects OIDC cookie token selection for Generic OIDC providers like AD FS, and picks up OSS support for the Claude Sonnet 5 model family.

--- a/docs/changelogs/v1.6.2.mdx
+++ b/docs/changelogs/v1.6.2.mdx
@@ -16,6 +16,10 @@ description: "v1.6.2 changelog - 2026-07-01"
   </Tab>
 </Tabs>
 
+<Warning>
+v1.6.2 has a [know CPU spike issue](https://github.com/maximhq/bifrost/issues/4851) for large number of budgets/teams/customers. The fix is part of v1.6.3
+</Warning>
+
 <Update label="Bifrost(HTTP)" description="1.6.2">
 ## ✨ Features
 


### PR DESCRIPTION
## Summary

Adds a warning notice to the v1.5.2 (Enterprise) and v1.6.2 changelogs alerting users to a known CPU spike issue that affects deployments with a large number of budgets, teams, or customers.

## Changes

- Added a `<Warning>` block to the Enterprise v1.5.2 changelog pointing to the known CPU spike issue ([#4851](https://github.com/maximhq/bifrost/issues/4851)) and noting the fix is included in v1.5.3
- Added the same `<Warning>` block to the v1.6.2 changelog, noting the fix is included in v1.6.3

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the warning banners render correctly on the v1.5.2 and v1.6.2 changelog pages and that the link to issue #4851 resolves properly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

https://github.com/maximhq/bifrost/issues/4851

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable