### PR TITLE
fix: propagate max_tokens from openai integration

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -10,12 +10,16 @@ import (
 // ToBifrostChatRequest converts an OpenAI chat request to Bifrost format
 func (req *OpenAIChatRequest) ToBifrostChatRequest(ctx *schemas.BifrostContext) *schemas.BifrostChatRequest {
 	provider, model := schemas.ParseModelString(req.Model, "")
+	params := req.ChatParameters
+	if params.MaxCompletionTokens == nil && req.MaxTokens != nil {
+		params.MaxCompletionTokens = req.MaxTokens
+	}
 
 	return &schemas.BifrostChatRequest{
 		Provider:  provider,
 		Model:     model,
 		Input:     ConvertOpenAIMessagesToBifrostMessages(req.Messages),
-		Params:    &req.ChatParameters,
+		Params:    &params,
 		Fallbacks: schemas.ParseFallbacks(req.Fallbacks),
 	}
 }

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1221,7 +1221,7 @@ func TestToOpenAIChatRequest_CacheControl_OpenRouterOnly(t *testing.T) {
 // (sonic.Unmarshal of the raw body into *OpenAIChatRequest, then
 // ToBifrostChatRequest) and asserts the top-level server-tool name survives.
 func TestOpenAIInbound_ServerToolNameSurvives(t *testing.T) {
-	body := `{"model":"bedrock/global.anthropic.claude-sonnet-4-6","max_tokens":1024,"tools":[{"type":"bash_20250124","name":"bash"}],"messages":[{"role":"user","content":"Run ls"}]}`
+	body := `{"model":"bedrock/global.anthropic.claude-sonnet-4-6","max_tokens":8000,"tools":[{"type":"bash_20250124","name":"bash"}],"messages":[{"role":"user","content":"Run ls"}]}`
 
 	var req OpenAIChatRequest
 	if err := sonic.Unmarshal([]byte(body), &req); err != nil {
@@ -1236,6 +1236,27 @@ func TestOpenAIInbound_ServerToolNameSurvives(t *testing.T) {
 	bifReq := req.ToBifrostChatRequest(ctx)
 	if bifReq.Params == nil || len(bifReq.Params.Tools) != 1 || bifReq.Params.Tools[0].Name != "bash" {
 		t.Fatalf("ToBifrostChatRequest dropped name: %+v", bifReq.Params)
+	}
+	if bifReq.Params.MaxCompletionTokens == nil || *bifReq.Params.MaxCompletionTokens != 8000 {
+		t.Fatalf("ToBifrostChatRequest did not map max_tokens to max_completion_tokens: %+v", bifReq.Params.MaxCompletionTokens)
+	}
+}
+
+func TestOpenAIInbound_MaxCompletionTokensTakesPriorityOverMaxTokens(t *testing.T) {
+	body := `{"model":"bedrock/global.anthropic.claude-sonnet-4-6","max_tokens":100,"max_completion_tokens":200,"messages":[{"role":"user","content":"Run ls"}]}`
+
+	var req OpenAIChatRequest
+	if err := sonic.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifReq := req.ToBifrostChatRequest(ctx)
+	if bifReq.Params == nil || bifReq.Params.MaxCompletionTokens == nil {
+		t.Fatalf("ToBifrostChatRequest dropped max_completion_tokens: %+v", bifReq.Params)
+	}
+	if *bifReq.Params.MaxCompletionTokens != 200 {
+		t.Fatalf("max_completion_tokens should take priority over max_tokens, got %d", *bifReq.Params.MaxCompletionTokens)
 	}
 }
 

--- a/core/providers/utils/modelparamscache.go
+++ b/core/providers/utils/modelparamscache.go
@@ -13,7 +13,7 @@ const DefaultModelParamsCacheSize = 2048
 // ModelParams holds cached parameters for a model.
 // Add new fields here as more model-level parameters need caching.
 type ModelParams struct {
-	MaxOutputTokens    *int
+	MaxOutputTokens         *int
 	IsVertexMultiRegionOnly *bool // true when model is only available on Vertex multi-region pool endpoints (rep.googleapis.com)
 }
 
@@ -48,6 +48,7 @@ var (
 // knownAnthropicMaxOutputTokens provides static fallback defaults for Claude models
 // when both cache and DB miss handler return nothing. Only Anthropic requires max_tokens.
 var knownAnthropicMaxOutputTokens = map[string]int{
+	"claude-fable-5":    128000,
 	"claude-opus-4-6":   128000,
 	"claude-sonnet-5":   128000,
 	"claude-sonnet-4-6": 64000,


### PR DESCRIPTION
## Summary

When an OpenAI-compatible inbound request uses the legacy `max_tokens` field instead of `max_completion_tokens`, the value was previously ignored during conversion to Bifrost format. This PR ensures `max_tokens` is automatically promoted to `max_completion_tokens` when the latter is not explicitly set, preserving token limit intent across the conversion boundary.

## Changes

- In `ToBifrostChatRequest`, if `MaxCompletionTokens` is not set but `MaxTokens` is present, `MaxTokens` is copied into `MaxCompletionTokens` before constructing the Bifrost request.
- A local copy of `ChatParameters` is made before modification to avoid mutating the original request struct.
- A test assertion was added to verify that `max_tokens` is correctly mapped to `max_completion_tokens` after conversion.
- Added `claude-fable-5` with a 128k token limit to the static Anthropic max output token fallback map.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/...
```

Send an OpenAI-compatible chat request with `max_tokens` set but without `max_completion_tokens`. Verify the resulting Bifrost request has `MaxCompletionTokens` populated with the value from `max_tokens`.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable