### PR TITLE
chore: adds harness test cases for file apis in anthropic

### DIFF
--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -126,6 +126,12 @@
           "    } else if (j.object === 'file' && typeof j.id === 'string') {",
           "        shape = 'file-object';",
           "        hasContent = !!j.id;",
+          "    } else if (j.type === 'file' && typeof j.id === 'string') {",
+          "        shape = 'anthropic-file-object';",
+          "        hasContent = !!j.id;",
+          "    } else if (j.type === 'file_deleted' && typeof j.id === 'string') {",
+          "        shape = 'anthropic-file-deleted';",
+          "        hasContent = !!j.id;",
           "    }",
           "    pm.expect(hasContent, 'expected non-empty content (shape=' + shape + ', body=' + JSON.stringify(j).slice(0, 200) + ')').to.be.true;",
           "  });",
@@ -14890,6 +14896,284 @@
                   ]
                 }
               }
+            },
+            {
+              "name": "Anthropic: file upload with content_type override",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "files-api-2025-04-14"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "file",
+                      "src": "tests/e2e/api/fixtures/sample.txt",
+                      "type": "file"
+                    },
+                    {
+                      "key": "purpose",
+                      "value": "user_data",
+                      "type": "text"
+                    },
+                    {
+                      "key": "content_type",
+                      "value": "text/markdown",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/files",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "files"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                      "var j = pm.response.json();",
+                      "pm.test('has file id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                      "pm.collectionVariables.set('anthropicUploadFileIdA', j.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Anthropic: file upload content_type inferred from file part",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "files-api-2025-04-14"
+                  }
+                ],
+                "body": {
+                  "mode": "formdata",
+                  "formdata": [
+                    {
+                      "key": "file",
+                      "src": "tests/e2e/api/fixtures/sample.txt",
+                      "type": "file"
+                    },
+                    {
+                      "key": "purpose",
+                      "value": "user_data",
+                      "type": "text"
+                    }
+                  ]
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/files",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "files"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                      "var j = pm.response.json();",
+                      "pm.test('has file id', function () { pm.expect(j.id).to.be.a('string').and.not.empty; });",
+                      "pm.collectionVariables.set('anthropicUploadFileIdB', j.id);"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[PREVIEW] Anthropic: document file_id source (auto files-api beta header)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"claude-haiku-4-5\",\n  \"max_tokens\": 512,\n  \"messages\": [{\"role\":\"user\",\"content\":[{\"type\":\"document\",\"source\":{\"type\":\"file\",\"file_id\":\"{{anthropicUploadFileIdB}}\"}},{\"type\":\"text\",\"text\":\"Summarize\"}]}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "[PREVIEW] Anthropic Responses: input_file by file_id (native /v1/responses)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"input\": [{\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"Summarize\"},{\"type\":\"input_file\",\"file_id\":\"{{anthropicUploadFileIdB}}\"}]}]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "Anthropic: delete content_type test file A (cleanup)",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "files-api-2025-04-14"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/files/{{anthropicUploadFileIdA}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "files",
+                    "{{anthropicUploadFileIdA}}"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                      "var j = pm.response.json();",
+                      "pm.test('Anthropic delete: file_deleted', function () { pm.expect(j.type).to.eql('file_deleted'); });",
+                      "pm.test('Anthropic delete: id matches', function () { pm.expect(j.id).to.eql(pm.collectionVariables.get('anthropicUploadFileIdA')); });"
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Anthropic: delete content_type test file B (cleanup)",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "x-api-key",
+                    "value": "{{anthropicKey}}"
+                  },
+                  {
+                    "key": "anthropic-version",
+                    "value": "2023-06-01"
+                  },
+                  {
+                    "key": "anthropic-beta",
+                    "value": "files-api-2025-04-14"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/files/{{anthropicUploadFileIdB}}",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "files",
+                    "{{anthropicUploadFileIdB}}"
+                  ]
+                }
+              },
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                      "var j = pm.response.json();",
+                      "pm.test('Anthropic delete: file_deleted', function () { pm.expect(j.type).to.eql('file_deleted'); });",
+                      "pm.test('Anthropic delete: id matches', function () { pm.expect(j.id).to.eql(pm.collectionVariables.get('anthropicUploadFileIdB')); });"
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
## Summary

Adds end-to-end test coverage for the Anthropic Files API, including file upload with an explicit `content_type` override, file upload with `content_type` inferred from the file part, using an uploaded file as a document source in `/v1/messages`, and using an uploaded file via `input_file` in `/v1/responses`. Cleanup requests delete both test files after the scenarios run.

## Changes

- Added response shape detection for Anthropic file objects (`type: "file"`) and deleted file objects (`type: "file_deleted"`) in the provider harness test script so the content-validation assertion correctly recognises Anthropic Files API responses.
- Added two upload scenarios: one that passes an explicit `content_type` field (`text/markdown`) alongside the file, and one that relies on the content type being inferred from the uploaded file part.
- Added a preview test for referencing an uploaded file as a `document` source with `file_id` in an Anthropic `/v1/messages` request (the proxy is expected to inject the `files-api-2025-04-14` beta header automatically).
- Added a preview test for referencing the same file via `input_file` / `file_id` through the native `/v1/responses` endpoint with an Anthropic model.
- Added DELETE cleanup requests for both uploaded files (`anthropicUploadFileIdA` and `anthropicUploadFileIdB`) to avoid leaving orphaned files after the test run.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Postman/Newman collection against a running instance with a valid `anthropicKey` and `baseUrl` set:

```sh
newman run tests/e2e/api/collections/provider-harness.json \
  --env-var "baseUrl=http://localhost:8080" \
  --env-var "anthropicKey=<your-key>"
```

Expected outcomes:

- Both upload requests return HTTP 200 with a non-empty `id` field.
- The document and `input_file` preview requests return a valid model response.
- Both DELETE cleanup requests succeed, removing the uploaded files.

## Breaking changes

- [x] No

## Related issues

## Security considerations

The `anthropicKey` is supplied via an environment variable and is not hardcoded in the collection. No PII or secrets are stored in the test fixtures.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable