### PR TITLE
fix: bedrock responses type error forwrding

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -369,36 +369,7 @@ func (provider *BedrockProvider) executeBedrockRequest(req *http.Request) ([]byt
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		var errorResp BedrockError
-
-		var rawErrorResponse interface{}
-		if err := sonic.Unmarshal(body, &rawErrorResponse); err != nil {
-			rawErrorResponse = string(body)
-		}
-
-		if err := sonic.Unmarshal(body, &errorResp); err != nil {
-			return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(&schemas.BifrostError{
-				IsBifrostError: true,
-				StatusCode:     &resp.StatusCode,
-				Error: &schemas.ErrorField{
-					Message: schemas.ErrProviderResponseUnmarshal,
-					Error:   err,
-				},
-				ExtraFields: schemas.BifrostErrorExtraFields{
-					RawResponse: rawErrorResponse,
-				},
-			}, latency)
-		}
-
-		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(&schemas.BifrostError{
-			StatusCode: &resp.StatusCode,
-			Error: &schemas.ErrorField{
-				Message: errorResp.Message,
-			},
-			ExtraFields: schemas.BifrostErrorExtraFields{
-				RawResponse: rawErrorResponse,
-			},
-		}, latency)
+		return nil, latency, providerResponseHeaders, providerUtils.SetErrorLatency(parseBedrockHTTPError(resp.StatusCode, resp.Header, body), latency)
 	}
 
 	return body, latency, providerResponseHeaders, nil

--- a/core/providers/bedrock/errors_test.go
+++ b/core/providers/bedrock/errors_test.go
@@ -2,11 +2,44 @@ package bedrock
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestExecuteBedrockRequest_SurfacesExceptionType is an end-to-end guard for the
+// non-streaming executor path (Converse / chat_completion). It must route upstream
+// HTTP errors through parseBedrockHTTPError so the AWS exception type — delivered
+// here only via the X-Amzn-Errortype header with a ":<url>" qualifier, as real EOL
+// models return — is surfaced on both the top-level type and the nested error.type.
+// Regression for a bespoke inline error path that dropped the type entirely.
+func TestExecuteBedrockRequest_SurfacesExceptionType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Amzn-Errortype", "ResourceNotFoundException:http://internal.amazon.com/coral/com.amazon.bedrock/")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"This model version has reached the end of its life. Please refer to the AWS documentation for more details."}`))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, nil)
+	require.NoError(t, err)
+
+	provider := &BedrockProvider{client: server.Client()}
+	_, _, _, bifrostErr := provider.executeBedrockRequest(req)
+
+	require.NotNil(t, bifrostErr)
+	require.NotNil(t, bifrostErr.StatusCode)
+	assert.Equal(t, http.StatusNotFound, *bifrostErr.StatusCode)
+	assert.False(t, bifrostErr.IsBifrostError, "non-streaming path delegates retryability to the retry gate via status code")
+	require.NotNil(t, bifrostErr.Type, "top-level type must be recovered from the header")
+	assert.Equal(t, "ResourceNotFoundException", *bifrostErr.Type)
+	require.NotNil(t, bifrostErr.Error)
+	require.NotNil(t, bifrostErr.Error.Type, "nested error.type must be populated for OpenAI-shaped consumers")
+	assert.Equal(t, "ResourceNotFoundException", *bifrostErr.Error.Type)
+	assert.Contains(t, bifrostErr.Error.Message, "reached the end of its life")
+}
 
 // TestParseBedrockHTTPError_PreservesExceptionType verifies that the upstream
 // AWS exception type (the JSON "__type" field) is preserved on the resulting


### PR DESCRIPTION
## Summary

The Bedrock provider's non-streaming executor path (`executeBedrockRequest`) had a bespoke inline error-handling block that bypassed `parseBedrockHTTPError`, causing the AWS exception type (e.g., `ResourceNotFoundException`) to be silently dropped from error responses. This was particularly visible with end-of-life models that return the exception type only via the `X-Amzn-Errortype` header. The fix routes all upstream HTTP errors through the shared `parseBedrockHTTPError` function and adds a regression test to guard this path.

## Changes

- Replaced the inline error-parsing block in `executeBedrockRequest` with a call to `parseBedrockHTTPError`, ensuring the AWS exception type is consistently surfaced on both the top-level `BifrostError.Type` and the nested `Error.Type` field.
- Added `TestExecuteBedrockRequest_SurfacesExceptionType`, an end-to-end test that spins up a local HTTP server mimicking a real AWS EOL model response (with a `:<url>` qualifier on the `X-Amzn-Errortype` header) and asserts the exception type is correctly propagated.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

The new test `TestExecuteBedrockRequest_SurfacesExceptionType` will fail on the previous code and pass with this fix. Verify that `ResourceNotFoundException` appears on both `bifrostErr.Type` and `bifrostErr.Error.Type` when a 404 response carries the `X-Amzn-Errortype` header.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Regression for the bespoke inline error path in `executeBedrockRequest` that dropped the AWS exception type for retired/unsupported model responses.

## Security considerations

No security implications. This change only affects error message propagation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable