### PR TITLE
fix: assert `SecretTypePlainText` value in redaction test instead of empty

### DIFF
--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -86,7 +86,7 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 
 	assert.Equal(t, "https://foo.openai.azure.com", out.Value,
 		"plain Endpoint was incorrectly redacted")
-	assert.Empty(t, out.SecretType)
+	assert.Equal(t, out.SecretType, string(schemas.SecretTypePlainText))
 }
 
 // TestProviderConfig_Redacted_PreservesSecretVarReferenceForVertex verifies that


### PR DESCRIPTION
## Summary

Fixes an incorrect test assertion that was checking for an empty `SecretType` field when a non-secret plain text field is redacted. The field should explicitly be set to `SecretTypePlainText` rather than being empty.

## Changes

- Updated the assertion in `TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields` to verify that `SecretType` equals `schemas.SecretTypePlainText` instead of asserting it is empty, ensuring the test accurately reflects the expected behavior for plain, non-secret fields.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

The updated test should pass, confirming that plain non-secret fields carry a `SecretTypePlainText` designation after redaction rather than an empty `SecretType`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only corrects a test assertion around how plain text (non-secret) fields are labeled during config redaction.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable