### PR TITLE
test case fixes for cancelling streams

### DIFF
--- a/tests/e2e/api/runners/run-stream-cancellation.mjs
+++ b/tests/e2e/api/runners/run-stream-cancellation.mjs
@@ -115,11 +115,12 @@ function expectedCost(entry, row) {
   return nonCached * input + cachedRead * cr + cachedWrite * cw + completion * output;
 }
 
-// A streaming cancel is always logged status=error; a non-streaming cancel may finish
-// server-side and log success — accept either for non-stream.
+// A streaming cancel is logged status=cancelled (dedicated status since #4930;
+// older builds logged error); a non-streaming cancel may finish server-side
+// and log success - accept any terminal cancel outcome per kind.
 function statusIsCancelOutcome(status, nonStream) {
-  if (nonStream) return status === "error" || status === "success";
-  return status === "error";
+  if (nonStream) return status === "cancelled" || status === "error" || status === "success";
+  return status === "cancelled" || status === "error";
 }
 
 // Compare the logged cost against the datasheet-recomputed cost. Returns
@@ -397,10 +398,10 @@ if (skipCostCheck) {
         if (!row) {
           r.costCheck = "FAIL"; r.costDetail = `no log row for ${r.requestId}`; costFailures++;
         } else if (!statusIsCancelOutcome(row.status, r.nonStream)) {
-          // A streaming cancel is always logged status=error. A non-streaming cancel may
-          // instead finish the upstream call server-side and log success — either way it
-          // must be billed, so we accept both for non-stream and key the cost rules off
-          // the provider, not the status.
+          // A streaming cancel is logged status=cancelled (error on pre-#4930 builds).
+          // A non-streaming cancel may instead finish the upstream call server-side and
+          // log success - either way it must be billed, so we accept all terminal cancel
+          // outcomes and key the cost rules off the provider, not the status.
           r.costCheck = "FAIL"; r.costDetail = `status=${row.status}, unexpected for ${kind} cancel`; costFailures++;
         } else {
           const cost = Number(row.cost || 0), tokens = Number(row.total_tokens || 0);


### PR DESCRIPTION
## Summary

Updates the stream cancellation E2E test to recognize `cancelled` as a valid terminal status for cancelled requests, introduced in #4930. Previously, only `error` (and `success` for non-streaming) were accepted as valid cancel outcomes. This aligns the test with the dedicated cancellation status while retaining backward compatibility with older builds that logged `error`.

## Changes

- `statusIsCancelOutcome` now accepts `cancelled` in addition to `error` for both streaming and non-streaming cancel paths
- Updated inline comments to reflect that `cancelled` is the expected status on current builds, with `error` retained as a fallback for pre-#4930 builds
- Removed a duplicate `go.sum` entry for `github.com/tidwall/pretty v1.2.0`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the stream cancellation E2E test against a current build and verify that cancelled requests with `status=cancelled` no longer produce unexpected cost-check failures.

```sh
node tests/e2e/api/runners/run-stream-cancellation.mjs
```

Expected: cost checks pass for both streaming and non-streaming cancel scenarios, with `cancelled`, `error`, or `success` (non-stream only) all accepted as valid outcomes.

## Breaking changes

- [x] No

## Related issues

Closes #4930

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable