### PR TITLE
allow v2.0.0 to publish prerelease cuts

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -3,7 +3,7 @@ name: Release Pipeline
 # Triggers automatically on push to main when any version file changes
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "v2.0.0"]
   workflow_dispatch:
     inputs:
       skip_tests:


### PR DESCRIPTION
## Summary

Adds the `v2.0.0` branch as a trigger for the release pipeline so that releases can be cut directly from that branch in addition to `main`.

## Changes

- Added `v2.0.0` to the list of branches that trigger the release pipeline on push, enabling the pipeline to run when changes are pushed to the `v2.0.0` branch.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Push a commit to the `v2.0.0` branch and verify the release pipeline is triggered automatically.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This only affects which branches trigger the CI release pipeline.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable