### PR TITLE
migration test fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -746,6 +746,7 @@ append_dynamic_mcp_clients_insert() {
     generate_pricing_overrides_insert_postgres "$now" "$faker_sql"
     generate_mcp_library_insert_postgres "$now" "$faker_sql"
     generate_skills_repo_tables_insert_postgres "$now" "$faker_sql"
+    generate_oauth2_issuance_tables_insert_postgres "$now" "$faker_sql"
     append_dynamic_columns_postgres "$now" "$past" "$faker_sql"
   else
     now="datetime('now')"
@@ -763,6 +764,7 @@ append_dynamic_mcp_clients_insert() {
     generate_pricing_overrides_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_mcp_library_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_skills_repo_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_oauth2_issuance_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
     append_dynamic_columns_sqlite "$now" "$past" "$faker_sql" "$config_db"
   fi
 }
@@ -1902,6 +1904,40 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.6.3 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  # config_client.mcp_server_auth_mode (added in v1.6.3 - varchar(20), default 'headers')
+  if column_exists_postgres "config_client" "mcp_server_auth_mode"; then
+    echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+  fi
+
+  # config_client.oauth2_server_config_json (added in v1.6.3 - text, empty string when unset)
+  if column_exists_postgres "config_client" "oauth2_server_config_json"; then
+    echo "UPDATE config_client SET oauth2_server_config_json = '' WHERE id = 1;" >> "$output_file"
+  fi
+
+  # config_keys.bedrock_mantle_* (added in v1.6.3 - nullable text SecretVars for Bedrock Mantle auth)
+  for mantle_col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name; do
+    if column_exists_postgres "config_keys" "$mantle_col"; then
+      echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+  done
+
+  # governance_model_pricing.is_deprecated (added in v1.6.3 - bool, default false)
+  if column_exists_postgres "governance_model_pricing" "is_deprecated"; then
+    echo "UPDATE governance_model_pricing SET is_deprecated = false WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET is_deprecated = false WHERE id = 2;" >> "$output_file"
+  fi
+
+  # governance_virtual_keys.expires_at (added in v1.6.3 - nullable timestamp, NULL = never expires)
+  if column_exists_postgres "governance_virtual_keys" "expires_at"; then
+    echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -2965,6 +3001,40 @@ append_dynamic_columns_sqlite() {
       echo "UPDATE governance_model_pricing SET output_cost_per_token_fast = NULL WHERE id = 1;" >> "$output_file"
       echo "UPDATE governance_model_pricing SET output_cost_per_token_fast = NULL WHERE id = 2;" >> "$output_file"
     fi
+
+    # -----------------------------------------------------------------------
+    # v1.6.3 columns - config store tables
+    # -----------------------------------------------------------------------
+
+    # config_client.mcp_server_auth_mode (added in v1.6.3 - varchar(20), default 'headers')
+    if column_exists_sqlite "$config_db" "config_client" "mcp_server_auth_mode"; then
+      echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+    fi
+
+    # config_client.oauth2_server_config_json (added in v1.6.3 - text, empty string when unset)
+    if column_exists_sqlite "$config_db" "config_client" "oauth2_server_config_json"; then
+      echo "UPDATE config_client SET oauth2_server_config_json = '' WHERE id = 1;" >> "$output_file"
+    fi
+
+    # config_keys.bedrock_mantle_* (added in v1.6.3 - nullable text SecretVars for Bedrock Mantle auth)
+    for mantle_col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name; do
+      if column_exists_sqlite "$config_db" "config_keys" "$mantle_col"; then
+        echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+        echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+      fi
+    done
+
+    # governance_model_pricing.is_deprecated (added in v1.6.3 - bool, default false)
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "is_deprecated"; then
+      echo "UPDATE governance_model_pricing SET is_deprecated = 0 WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET is_deprecated = 0 WHERE id = 2;" >> "$output_file"
+    fi
+
+    # governance_virtual_keys.expires_at (added in v1.6.3 - nullable timestamp, NULL = never expires)
+    if column_exists_sqlite "$config_db" "governance_virtual_keys" "expires_at"; then
+      echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+    fi
   fi
 
   # logs multi-team/BU/customer JSON-array columns (added in v1.5.9 via
@@ -3005,15 +3075,15 @@ extract_faker_columns() {
 
   # Extract INSERT statements and parse table/columns
   # Handles both "INSERT INTO table (cols)" and "INSERT INTO table (cols) SELECT ..."
-  grep -E "^INSERT INTO [a-z_]+ \(" "$faker_sql" | \
-    sed -E 's/INSERT INTO ([a-z_]+) \(([^)]+)\).*/\1:\2/' | \
+  grep -E "^INSERT INTO [a-z0-9_]+ \(" "$faker_sql" | \
+    sed -E 's/INSERT INTO ([a-z0-9_]+) \(([^)]+)\).*/\1:\2/' | \
     tr -d ' ' | sort -u > "$output_file"
 
   # Also extract UPDATE SET columns (for dynamically added columns)
   # Pattern: UPDATE table SET col = value WHERE ...
-  # Note: Column names can contain digits (e.g., input_cost_per_token_above_128k_tokens)
-  grep -E "^UPDATE [a-z_]+ SET [a-z0-9_]+" "$faker_sql" | \
-    sed -E 's/UPDATE ([a-z_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
+  # Note: Table and column names can contain digits (e.g., oauth2_clients, input_cost_per_token_above_128k_tokens)
+  grep -E "^UPDATE [a-z0-9_]+ SET [a-z0-9_]+" "$faker_sql" | \
+    sed -E 's/UPDATE ([a-z0-9_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
     tr -d ' ' | sort -u >> "$output_file"
 }
 
@@ -3119,6 +3189,12 @@ generate_mcp_clients_insert_postgres() {
     cols="$cols, per_user_header_keys_json"
     # Non-default JSON so preservation of this field is verified by snapshot comparison.
     vals="$vals, '[\"X-Tenant-Id\",\"X-Request-Id\"]'"
+  fi
+
+  # config_mcp_clients.tool_execution_timeout (added in v1.6.3 - per-client timeout in seconds, 0 = use global)
+  if column_exists_postgres "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    vals="$vals, 0"
   fi
 
   # Append the dynamic INSERT to the output file
@@ -3385,6 +3461,12 @@ generate_mcp_clients_insert_sqlite() {
     cols="$cols, per_user_header_keys_json"
     # Non-default JSON so preservation of this field is verified by snapshot comparison.
     vals="$vals, '[\"X-Tenant-Id\",\"X-Request-Id\"]'"
+  fi
+
+  # config_mcp_clients.tool_execution_timeout (added in v1.6.3 - per-client timeout in seconds, 0 = use global)
+  if column_exists_sqlite "$config_db" "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    vals="$vals, 0"
   fi
 
   # Append the dynamic INSERT to the output file
@@ -3886,6 +3968,46 @@ generate_temp_tokens_insert_sqlite() {
   echo "" >> "$output_file"
   echo "-- temp_tokens (short-lived narrow-scope credentials - added in v1.5.3, dynamically generated)" >> "$output_file"
   echo "INSERT INTO temp_tokens (id, token, token_hash, scope, resource_id, expires_at, created_at, updated_at, encryption_status) VALUES ('temp-token-migration-test-001', 'migration-test-temp-token-value-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', 'mcp_auth', 'oauth-config-migration-test-001', datetime('now', '+15 minutes'), $now, $now, 'plain_text') ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate oauth2_clients / oauth2_authorize_requests / oauth2_refresh_tokens INSERTs for PostgreSQL
+# (added in v1.6.3 via migrationAddOAuth2IssuanceTables - MCP OAuth2 authorization server)
+# Every column is named explicitly so faker coverage validation passes; the authorize request
+# uses a future expires_at and 'consented' status so no TTL cleanup mutates it between snapshots.
+generate_oauth2_issuance_tables_insert_postgres() {
+  local now="$1"
+  local output_file="$2"
+
+  if ! column_exists_postgres "oauth2_clients" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- oauth2 issuance tables (MCP OAuth2 authorization server - added in v1.6.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'migration-test-oauth2-client-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\",\"refresh_token\"]', 'openid', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authreq-migration-test-001', 'migration-test-oauth2-client-001', 'http://localhost:3000/callback', 'migration-test-state-001', 'openid', 'https://bifrost.example.com/mcp', 'migration-test-challenge-001', 'S256', 'consented', 'vk', 'vk-migration-test-1', 'migration-test-code-hash-001', $now + INTERVAL '10 minutes', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-rt-migration-test-001', 'migration-test-rt-hash-001', 'oauth2-authreq-migration-test-001', 'migration-test-oauth2-client-001', 'vk', 'vk-migration-test-1', 'openid', 'https://bifrost.example.com/mcp', NULL, NULL, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate oauth2 issuance table INSERTs for SQLite (added in v1.6.3 via migrationAddOAuth2IssuanceTables)
+generate_oauth2_issuance_tables_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
+
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  if ! column_exists_sqlite "$config_db" "oauth2_clients" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- oauth2 issuance tables (MCP OAuth2 authorization server - added in v1.6.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'migration-test-oauth2-client-001', 'Migration Test Client', '[\"http://localhost:3000/callback\"]', '[\"authorization_code\",\"refresh_token\"]', 'openid', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authreq-migration-test-001', 'migration-test-oauth2-client-001', 'http://localhost:3000/callback', 'migration-test-state-001', 'openid', 'https://bifrost.example.com/mcp', 'migration-test-challenge-001', 'S256', 'consented', 'vk', 'vk-migration-test-1', 'migration-test-code-hash-001', datetime('now', '+10 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-rt-migration-test-001', 'migration-test-rt-hash-001', 'oauth2-authreq-migration-test-001', 'migration-test-oauth2-client-001', 'vk', 'vk-migration-test-1', 'openid', 'https://bifrost.example.com/mcp', NULL, NULL, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Generate governance_model_parameters INSERT for PostgreSQL


### PR DESCRIPTION
## Summary

Extends the migration test harness to cover v1.6.3 schema additions, including the new OAuth2 issuance tables (`oauth2_clients`, `oauth2_authorize_requests`, `oauth2_refresh_tokens`), new columns on `config_client`, `config_keys`, `config_mcp_clients`, `governance_model_pricing`, and `governance_virtual_keys`, and fixes a regex gap that prevented table names containing digits from being recognized during faker coverage validation.

## Changes

- Added `generate_oauth2_issuance_tables_insert_postgres` and `generate_oauth2_issuance_tables_insert_sqlite` functions that insert representative rows into the three new OAuth2 authorization-server tables introduced in v1.6.3. The authorize request is inserted with a future `expires_at` and `consented` status to prevent TTL-based cleanup from mutating it between snapshot comparisons.
- Wired both new functions into `append_dynamic_mcp_clients_insert` for both the PostgreSQL and SQLite paths.
- Added dynamic column guards for the following v1.6.3 additions:
  - `config_client.mcp_server_auth_mode` (default `'headers'`)
  - `config_client.oauth2_server_config_json` (empty string when unset)
  - `config_keys.bedrock_mantle_*` (seven nullable SecretVar columns for Bedrock Mantle auth)
  - `governance_model_pricing.is_deprecated` (boolean, default false)
  - `governance_virtual_keys.expires_at` (nullable timestamp, `NULL` = never expires)
  - `config_mcp_clients.tool_execution_timeout` (integer, `0` = use global timeout)
- Fixed `extract_faker_columns` regex patterns to allow digits in table names (e.g., `oauth2_clients`), matching the existing allowance for digits in column names.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run the migration test script locally against both SQLite and PostgreSQL targets
bash .github/workflows/scripts/run-migration-tests.sh

# Confirm the new oauth2_* table rows appear in the generated faker SQL
grep -E "oauth2_(clients|authorize_requests|refresh_tokens)" /tmp/faker*.sql

# Confirm the v1.6.3 dynamic column UPDATEs are emitted when the columns exist
grep -E "mcp_server_auth_mode|oauth2_server_config_json|bedrock_mantle|is_deprecated|expires_at|tool_execution_timeout" /tmp/faker*.sql
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The OAuth2 test rows use placeholder values (non-secret challenge strings, localhost redirect URIs) and are inserted with `ON CONFLICT DO NOTHING`, so they do not affect production data or expose real credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable