### PR TITLE
cost accuracy flakyness fixes

### DIFF
--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -357,11 +357,22 @@ params = {
     "order": "asc",
 }
 
+def logs_complete(logs):
+    # Log writes are fully async (single batched insert in PostLLMHook), so a
+    # row can be visible before its usage/cost are readable. Poll on the
+    # predicate we assert (every row has usage and cost), not just row count.
+    return all(
+        (item.get("token_usage") or {}).get("prompt_tokens") is not None
+        and (item.get("token_usage") or {}).get("completion_tokens") is not None
+        and item.get("cost") is not None
+        for item in logs
+    )
+
 logs = []
 for _ in range(60):
     payload = get_json("/api/logs", params)
     logs = payload.get("logs", [])
-    if len(logs) >= expected_count:
+    if len(logs) >= expected_count and logs_complete(logs):
         break
     time.sleep(1)
 


### PR DESCRIPTION
## Summary

The cost-accuracy CI test was occasionally failing because log rows can become visible in the database before their `token_usage` and `cost` fields are fully populated. This is due to the async, batched nature of the `PostLLMHook` write path. The polling loop was only checking row count, so it could proceed with incomplete data and produce false negatives.

## Changes

- Introduced a `logs_complete` helper that checks every polled log row for the presence of `prompt_tokens`, `completion_tokens`, and `cost` before considering the poll successful.
- Updated the polling condition to require both the expected row count **and** fully populated fields before breaking out of the retry loop.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the cost-accuracy CI workflow and confirm it no longer flakes on assertions about `token_usage` and `cost` fields being present in log rows.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable