### PR TITLE
fix: re-seed config marshallers for disabled custom .so   plugins

### DIFF
--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -1156,6 +1156,32 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 }
 ```
 
+### Redacting Secrets in Stored Config <sup>v1.6.x+</sup>
+
+If your plugin's config contains secrets (API keys, service-account JSON, tokens), implement the `ConfigMarshallerPlugin` interface so Bifrost can normalize what it writes to the database and redact what it returns from the management API:
+
+```go
+// MarshalConfigForStorage normalizes config before it is persisted.
+func (p *MyPlugin) MarshalConfigForStorage(raw map[string]any) (map[string]any, error) { /* ... */ }
+
+// RedactConfig masks secrets before config is returned by the API.
+func (p *MyPlugin) RedactConfig(raw map[string]any) (map[string]any, error) { /* ... */ }
+```
+
+The `.so` loader does **not** look up these methods as symbols. Instead, register the marshaller from an `init()` so Bifrost picks it up when it opens your shared object:
+
+```go
+var _ schemas.ConfigMarshallerPlugin = (*MyPlugin)(nil)
+
+func init() {
+	schemas.RegisterConfigMarshaller(PluginName, &MyPlugin{})
+}
+```
+
+<Note>
+Both methods must be **stateless** — they operate only on the `raw` map passed in, so the zero-value `&MyPlugin{}` registered here is sufficient. This is what lets Bifrost redact/normalize a plugin's stored config **even when the plugin is disabled**: Bifrost opens the `.so` (running its `init()`) during startup verification regardless of whether the plugin is enabled.
+</Note>
+
 ### Error Handling with Fallbacks
 
 Control whether Bifrost should try fallback providers:

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -162,6 +162,21 @@ func (s *BifrostHTTPServer) LoadPlugins(ctx context.Context) error {
 	if err := s.loadCustomPlugins(ctx); err != nil {
 		return err
 	}
+	// Re-seed after custom plugins load. A custom .so plugin's init() only runs when
+	// its shared object is opened — which happens inside loadCustomPlugins (LoadPlugin
+	// for enabled plugins, VerifyBasePlugin for disabled ones), i.e. after the seed
+	// above. This pass picks up any marshallers those inits self-registered so a
+	// disabled custom plugin can still redact/normalize its stored config. Skip names
+	// already registered so we never clobber an enabled plugin's live instance.
+	existing := s.Config.ConfigMarshallers.Load()
+	for name, cm := range schemas.ConfigMarshallers() {
+		if existing != nil {
+			if _, ok := (*existing)[name]; ok {
+				continue
+			}
+		}
+		s.Config.RegisterConfigMarshaller(name, cm)
+	}
 	// Sort all plugins by placement group and order
 	s.Config.SortAndRebuildPlugins()
 	return nil


### PR DESCRIPTION
## Summary

Adds support for Go plugins to implement a `ConfigMarshallerPlugin` interface that controls how plugin configuration is normalized before being persisted and how secrets are redacted before being returned by the management API. This ensures sensitive values (API keys, tokens, service-account JSON) are never exposed through the API or stored in a raw form, even when the plugin is disabled.

## Changes

- Documents the `ConfigMarshallerPlugin` interface (`MarshalConfigForStorage` and `RedactConfig`) and the `init()`-based self-registration pattern via `schemas.RegisterConfigMarshaller` in the Go plugin authoring guide.
- After custom plugins are loaded, the HTTP server re-seeds config marshallers from the global registry. This picks up any marshallers registered by a plugin's `init()` — including those from disabled plugins whose `.so` is opened only for verification — without clobbering marshallers already registered by enabled plugins with live instances.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Build a `.so` plugin that implements `ConfigMarshallerPlugin` and registers itself in `init()`.
2. Add the plugin to the Bifrost config but set it as **disabled**.
3. Start Bifrost and call the management API endpoint that returns plugin config.
4. Verify that secret fields are redacted in the response even though the plugin is disabled.
5. Enable the plugin and repeat — confirm the live instance's marshaller is used and the disabled-path registration did not clobber it.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change is specifically motivated by secret hygiene. Plugin authors can now guarantee that API keys, tokens, and other credentials stored in plugin config are masked before being returned from the management API and normalized before being written to the database. The stateless constraint on both methods ensures the zero-value instance registered during `init()` is safe to use without any plugin runtime state.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable