### PR TITLE
feat: add S3/GCS object storage config schema for audit log archival

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1495,7 +1495,7 @@
             "bucket": {
               "anyOf": [
                 { "type": "string", "minLength": 1 },
-                { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
               ],
               "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET) or a structured secret reference."
             },
@@ -1526,42 +1526,42 @@
               "region": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS region. Supports env var reference"
               },
               "endpoint": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
               },
               "access_key_id": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
               },
               "secret_access_key": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS secret access key. Supports env var reference"
               },
               "session_token": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS session token for STS temporary credentials. Supports env var reference"
               },
               "role_arn": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
               },
@@ -1587,21 +1587,21 @@
               "credentials_json": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
               },
               "credentials": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
               },
               "project_id": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "GCP project ID override. Supports env var reference"
               },
@@ -5496,7 +5496,7 @@
             "bucket": {
               "anyOf": [
                 { "type": "string", "minLength": 1 },
-                { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
               ],
               "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET) or a structured secret reference."
             },
@@ -5527,42 +5527,42 @@
               "region": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS region. Supports env var reference"
               },
               "endpoint": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
               },
               "access_key_id": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
               },
               "secret_access_key": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS secret access key. Supports env var reference"
               },
               "session_token": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS session token for STS temporary credentials. Supports env var reference"
               },
               "role_arn": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
               },
@@ -5588,21 +5588,21 @@
               "credentials_json": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
               },
               "credentials": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
               },
               "project_id": {
                 "anyOf": [
                   { "type": "string" },
-                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                  { "type": "object", "properties": { "value": { "type": "string" }, "ref": { "type": "string" }, "type": { "type": "string", "enum": ["plain_text", "env", "vault"] }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "required": ["value"], "additionalProperties": false }
                 ],
                 "description": "GCP project ID override. Supports env var reference"
               },

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1493,9 +1493,11 @@
               "description": "Object storage backend type"
             },
             "bucket": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET)"
+              "anyOf": [
+                { "type": "string", "minLength": 1 },
+                { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+              ],
+              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET) or a structured secret reference."
             },
             "prefix": {
               "type": "string",
@@ -1522,27 +1524,45 @@
               "bucket": true,
               "prefix": true,
               "region": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS region. Supports env var reference"
               },
               "endpoint": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
               },
               "access_key_id": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
               },
               "secret_access_key": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS secret access key. Supports env var reference"
               },
               "session_token": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS session token for STS temporary credentials. Supports env var reference"
               },
               "role_arn": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
               },
               "force_path_style": {
@@ -1565,15 +1585,24 @@
               "bucket": true,
               "prefix": true,
               "credentials_json": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
               },
               "credentials": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
               },
               "project_id": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "GCP project ID override. Supports env var reference"
               },
               "compress": true
@@ -5465,9 +5494,11 @@
               "description": "Object storage backend type"
             },
             "bucket": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET)"
+              "anyOf": [
+                { "type": "string", "minLength": 1 },
+                { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+              ],
+              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET) or a structured secret reference."
             },
             "prefix": {
               "type": "string",
@@ -5494,27 +5525,45 @@
               "bucket": true,
               "prefix": true,
               "region": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS region. Supports env var reference"
               },
               "endpoint": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
               },
               "access_key_id": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
               },
               "secret_access_key": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS secret access key. Supports env var reference"
               },
               "session_token": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS session token for STS temporary credentials. Supports env var reference"
               },
               "role_arn": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
               },
               "force_path_style": {
@@ -5537,15 +5586,24 @@
               "bucket": true,
               "prefix": true,
               "credentials_json": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
               },
               "credentials": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
               },
               "project_id": {
-                "type": "string",
+                "anyOf": [
+                  { "type": "string" },
+                  { "type": "object", "properties": { "value": { "type": "string" }, "env_var": { "type": "string" }, "from_env": { "type": "boolean" } }, "additionalProperties": false }
+                ],
                 "description": "GCP project ID override. Supports env var reference"
               },
               "compress": true

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5454,6 +5454,104 @@
           "type": "integer",
           "minimum": 0,
           "description": "Number of days to retain audit logs (0 means no retention limit)"
+        },
+        "object_storage": {
+          "type": "object",
+          "description": "Optional object storage for archiving audit events to S3/GCS. When configured, each flushed batch of audit events is written as a gzipped JSONL object at {prefix}/audit-logs/YYYY/MM/DD/HH/{id}.jsonl[.gz], in addition to the database (which remains the source of truth). Archival is going-forward only; existing rows are not backfilled.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["s3", "gcs"],
+              "description": "Object storage backend type"
+            },
+            "bucket": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET)"
+            },
+            "prefix": {
+              "type": "string",
+              "description": "Configurable base key path for stored audit objects; the 'audit-logs/' segment is appended under it (default: bifrost)",
+              "default": "bifrost"
+            },
+            "compress": {
+              "type": "boolean",
+              "description": "Enable gzip compression for stored objects. Default: false",
+              "default": false
+            }
+          },
+          "required": ["type", "bucket"],
+          "if": {
+            "properties": {
+              "type": {
+                "const": "s3"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "type": true,
+              "bucket": true,
+              "prefix": true,
+              "region": {
+                "type": "string",
+                "description": "AWS region. Supports env var reference"
+              },
+              "endpoint": {
+                "type": "string",
+                "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
+              },
+              "access_key_id": {
+                "type": "string",
+                "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
+              },
+              "secret_access_key": {
+                "type": "string",
+                "description": "AWS secret access key. Supports env var reference"
+              },
+              "session_token": {
+                "type": "string",
+                "description": "AWS session token for STS temporary credentials. Supports env var reference"
+              },
+              "role_arn": {
+                "type": "string",
+                "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
+              },
+              "force_path_style": {
+                "type": "boolean",
+                "description": "Use path-style URLs for S3 (required for MinIO). Default: false",
+                "default": false
+              },
+              "compress": true
+            },
+            "dependentRequired": {
+              "access_key_id": ["secret_access_key"],
+              "secret_access_key": ["access_key_id"],
+              "session_token": ["access_key_id", "secret_access_key"]
+            },
+            "additionalProperties": false
+          },
+          "else": {
+            "properties": {
+              "type": true,
+              "bucket": true,
+              "prefix": true,
+              "credentials_json": {
+                "type": "string",
+                "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
+              },
+              "credentials": {
+                "type": "string",
+                "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
+              },
+              "project_id": {
+                "type": "string",
+                "description": "GCP project ID override. Supports env var reference"
+              },
+              "compress": true
+            },
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Adds optional object storage configuration to the audit log schema, enabling audit events to be archived to S3 or GCS in addition to the database. The database remains the source of truth; archival is going-forward only and does not backfill existing rows.

## Changes

- Added an `object_storage` block under the audit log config schema supporting `s3` and `gcs` backends
- S3-specific fields include `region`, `endpoint`, `access_key_id`, `secret_access_key`, `session_token`, `role_arn`, and `force_path_style` (for MinIO/R2 compatibility)
- GCS-specific fields include `credentials_json`, `credentials` (deprecated alias for backwards compatibility), and `project_id`
- Shared fields across both backends: `bucket`, `prefix` (default: `bifrost`), and `compress` (gzip, default: `false`)
- Archived objects are written at `{prefix}/audit-logs/YYYY/MM/DD/HH/{id}.jsonl[.gz]`
- S3 credential pairing is enforced via `dependentRequired` (`access_key_id` requires `secret_access_key` and vice versa; `session_token` requires both)
- `additionalProperties: false` is enforced per backend to prevent misconfiguration

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the schema accepts and rejects configurations as expected.

**Valid S3 config example:**
```json
{
  "object_storage": {
    "type": "s3",
    "bucket": "my-audit-bucket",
    "region": "us-east-1",
    "prefix": "bifrost",
    "compress": true
  }
}
```

**Valid GCS config example:**
```json
{
  "object_storage": {
    "type": "gcs",
    "bucket": "my-audit-bucket",
    "credentials_json": "env.GCP_CREDENTIALS_JSON"
  }
}
```

Verify that:
- Omitting `bucket` or `type` fails validation
- Providing `session_token` without `access_key_id`/`secret_access_key` fails validation
- Providing unknown properties for either backend fails validation

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- `access_key_id`, `secret_access_key`, `session_token`, and `credentials_json` are sensitive fields. All credential fields support env var references to avoid hardcoding secrets in config files.
- `role_arn` enables IAM role assumption via STS, supporting least-privilege access patterns.
- GCS Application Default Credentials are supported when `credentials_json` is omitted, avoiding the need to store credentials in config at all.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable