### PR TITLE
feat: add allowlist for private-use redirect URI schemes (RFC 8252 §7.1) with `cursor://` as initial entry

### DIFF
--- a/transports/bifrost-http/handlers/localhostcheck_test.go
+++ b/transports/bifrost-http/handlers/localhostcheck_test.go
@@ -76,3 +76,58 @@ func TestLoopbackRedirectURIsIPv6(t *testing.T) {
 		t.Error("non-loopback IPv6 must require an exact match")
 	}
 }
+
+func TestPrivateUseRedirectSchemes(t *testing.T) {
+	tests := []struct {
+		uri  string
+		want bool
+	}{
+		// Allowlisted private-use scheme used by native apps (RFC 8252 §7.1).
+		{"cursor://anysphere.cursor-mcp/oauth/callback", true},
+		// https / loopback still allowed.
+		{"https://example.com/cb", true},
+		{"http://127.0.0.1:49152/cb", true},
+		// Default-deny: custom schemes not on the allowlist are rejected.
+		{"com.example.app://oauth/callback", false},
+		{"myapp://callback", false},
+		{"vscode://callback", false},
+		// Dangerous / opaque schemes must stay rejected.
+		{"javascript:alert(1)", false},
+		{"javascript://alert(1)", false},
+		{"data:text/html,<script>alert(1)</script>", false},
+		{"file:///etc/passwd", false},
+		{"http://example.com/cb", false},  // http on non-loopback
+		{"cursor:oauth/callback", false},  // allowlisted scheme but no authority
+		{"cursor:", false},                // scheme only
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isAllowedRedirectScheme(tt.uri); got != tt.want {
+			t.Errorf("isAllowedRedirectScheme(%q) = %v, want %v", tt.uri, got, tt.want)
+		}
+	}
+}
+
+func TestMatchRedirectURIPrivateUseSchemes(t *testing.T) {
+	registered := []string{"cursor://anysphere.cursor-mcp/oauth/callback"}
+	tests := []struct {
+		candidate string
+		want      bool
+	}{
+		// Exact match on a registered private-use URI.
+		{"cursor://anysphere.cursor-mcp/oauth/callback", true},
+		// Different path or host must not match.
+		{"cursor://anysphere.cursor-mcp/oauth/other", false},
+		{"cursor://evil.example/oauth/callback", false},
+		// Private-use hosts are not loopback, so the RFC 8252 §7.3 any-port
+		// leniency must not apply — a port makes it a different exact string.
+		{"cursor://anysphere.cursor-mcp:49152/oauth/callback", false},
+		// Scheme mismatch against the registration.
+		{"https://anysphere.cursor-mcp/oauth/callback", false},
+	}
+	for _, tt := range tests {
+		if got := matchRedirectURI(tt.candidate, registered); got != tt.want {
+			t.Errorf("matchRedirectURI(%q) = %v, want %v", tt.candidate, got, tt.want)
+		}
+	}
+}

--- a/transports/bifrost-http/handlers/mcpoauth2issuance.go
+++ b/transports/bifrost-http/handlers/mcpoauth2issuance.go
@@ -651,12 +651,24 @@ func isLoopbackRedirectHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-// matchRedirectURI validates redirect_uri against registered URIs.
-// For loopback addresses (localhost / 127.0.0.1 / [::1]), port is ignored per RFC 8252 §7.3.
+// allowedPrivateUseRedirectSchemes is the default-deny allowlist of private-use
+// ("custom") URI schemes accepted as redirect targets, in addition to https and
+// http-loopback. Native apps register such schemes per RFC 8252 §7.1 (e.g.
+// Cursor uses cursor://anysphere.cursor-mcp/oauth/callback). Everything not on
+// this list is rejected so a dangerous scheme (javascript:, data:, file:, …) can
+// never be written into the Location header built from a redirect URI. url.Parse
+// lowercases the scheme, so keys here must be lowercase.
+var allowedPrivateUseRedirectSchemes = map[string]struct{}{
+	"cursor": {},
+}
+
 // isAllowedRedirectScheme reports whether a redirect URI uses a safe scheme:
-// https for any host, or http only for loopback addresses (localhost/127.0.0.1/[::1]).
-// This rejects javascript:, data:, and other schemes that could be abused when a
-// Location header is built from the URI.
+//   - https for any host,
+//   - http only for loopback addresses (localhost/127.0.0.1/[::1]), and
+//   - a private-use ("custom") URI scheme on the allowedPrivateUseRedirectSchemes
+//     allowlist that also carries an authority component (scheme://host/...).
+//
+// It is default-deny: any scheme not matching one of the above is rejected.
 func isAllowedRedirectScheme(candidate string) bool {
 	parsed, err := url.Parse(candidate)
 	if err != nil {
@@ -668,10 +680,17 @@ func isAllowedRedirectScheme(candidate string) bool {
 	case "http":
 		return isLoopbackRedirectHost(parsed.Hostname())
 	default:
-		return false
+		if _, ok := allowedPrivateUseRedirectSchemes[parsed.Scheme]; !ok {
+			return false
+		}
+		// Require an authority (scheme://host/...) so an opaque form of an
+		// allowlisted scheme (e.g. "cursor:whatever") is still rejected.
+		return parsed.Host != ""
 	}
 }
 
+// matchRedirectURI validates redirect_uri against registered URIs.
+// For loopback addresses (localhost / 127.0.0.1 / [::1]), port is ignored per RFC 8252 §7.3.
 func matchRedirectURI(candidate string, registered []string) bool {
 	parsed, err := url.Parse(candidate)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a default-deny allowlist for private-use ("custom") URI schemes in OAuth2 redirect URI validation, enabling native app clients like Cursor to use schemes such as `cursor://anysphere.cursor-mcp/oauth/callback` (per RFC 8252 §7.1) without opening the door to dangerous schemes like `javascript:`, `data:`, or `file:`.

## Changes

- Introduced `allowedPrivateUseRedirectSchemes`, a map-based allowlist of permitted private-use URI schemes. Currently contains `cursor` as the only entry.
- Updated `isAllowedRedirectScheme` to accept URIs whose scheme appears in the allowlist, provided the URI also includes an authority component (`scheme://host/...`). Opaque forms such as `cursor:whatever` are still rejected.
- Added `TestPrivateUseRedirectSchemes` covering allowlisted schemes, loopback/https cases, non-allowlisted custom schemes, and dangerous schemes to ensure the default-deny behavior holds.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

Expected: all tests pass, including the new `TestPrivateUseRedirectSchemes` test which validates that:
- `cursor://anysphere.cursor-mcp/oauth/callback` is accepted
- `https://example.com/cb` and `http://127.0.0.1:49152/cb` are accepted
- `com.example.app://oauth/callback`, `myapp://callback`, `vscode://callback` are rejected
- `javascript:`, `data:`, `file:`, and opaque forms of allowlisted schemes are rejected

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The allowlist is intentionally default-deny. Only schemes explicitly added to `allowedPrivateUseRedirectSchemes` are permitted beyond `https` and `http`-loopback. An authority component is required even for allowlisted schemes, preventing opaque URI forms from being written into a `Location` header. Dangerous schemes (`javascript:`, `data:`, `file:`) remain rejected regardless of any allowlist entry. New native app clients requiring a custom scheme must be explicitly added to the allowlist.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable