### PR TITLE
feat: add `shouldSweep` gate to OAuth2 sweep worker and expose `StartOAuth2SweepWorker`

### DIFF
--- a/transports/bifrost-http/server/oauth2.go
+++ b/transports/bifrost-http/server/oauth2.go
@@ -16,12 +16,18 @@ type oauth2SweepWorker struct {
 	sweepInterval     time.Duration
 	revokedRetention  time.Duration
 	orphanClientGrace time.Duration
-	stopCh            chan struct{}
-	stopOnce          sync.Once
-	cancel            context.CancelFunc
+	// shouldSweep is consulted before each pass; when it returns false the pass
+	// is skipped. The deletes touch shared state, so when several instances use
+	// one config store a single sweeper suffices — the gate is re-checked every
+	// interval because which instance should sweep can change at runtime. nil
+	// means always sweep.
+	shouldSweep func() bool
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	cancel      context.CancelFunc
 }
 
-func newOAuth2SweepWorker(store configstore.ConfigStore) *oauth2SweepWorker {
+func newOAuth2SweepWorker(store configstore.ConfigStore, shouldSweep func() bool) *oauth2SweepWorker {
 	if store == nil {
 		return nil
 	}
@@ -33,6 +39,7 @@ func newOAuth2SweepWorker(store configstore.ConfigStore) *oauth2SweepWorker {
 		// authorization code TTL so a client mid-handshake (code issued, not yet
 		// exchanged) is not swept before it can mint its first token.
 		orphanClientGrace: time.Hour,
+		shouldSweep:       shouldSweep,
 		stopCh:            make(chan struct{}),
 	}
 }
@@ -71,11 +78,14 @@ func (w *oauth2SweepWorker) run(ctx context.Context) {
 }
 
 func (w *oauth2SweepWorker) sweep(ctx context.Context) {
+	if w.shouldSweep != nil && !w.shouldSweep() {
+		return
+	}
 	if err := w.store.SweepExpiredOAuth2AuthorizeRequests(ctx); err != nil {
-		logger.Debug("oauth2 authorize request sweep failed: %v", err)
+		logger.Warn("oauth2 authorize request sweep failed: %v", err)
 	}
 	if n, err := w.store.SweepOAuth2RefreshTokens(ctx, w.revokedRetention); err != nil {
-		logger.Debug("oauth2 refresh token sweep failed: %v", err)
+		logger.Warn("oauth2 refresh token sweep failed: %v", err)
 	} else if n > 0 {
 		logger.Debug("oauth2 refresh token sweep removed %d revoked rows", n)
 	}
@@ -83,9 +93,8 @@ func (w *oauth2SweepWorker) sweep(ctx context.Context) {
 	// tokens have aged out of their retention window, never while they are still
 	// kept for reuse detection.
 	if n, err := w.store.SweepOrphanedOAuth2Clients(ctx, w.orphanClientGrace); err != nil {
-		logger.Debug("oauth2 orphaned client sweep failed: %v", err)
+		logger.Warn("oauth2 orphaned client sweep failed: %v", err)
 	} else if n > 0 {
 		logger.Debug("oauth2 orphaned client sweep removed %d rows", n)
 	}
 }
-

--- a/transports/bifrost-http/server/oauth2_test.go
+++ b/transports/bifrost-http/server/oauth2_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// sweepRecordingStore counts sweep invocations. It embeds the ConfigStore
+// interface so only the three methods sweep() touches need real bodies; any
+// other call would panic, proving the gate short-circuits before store access.
+type sweepRecordingStore struct {
+	configstore.ConfigStore
+	calls int
+}
+
+func (s *sweepRecordingStore) SweepExpiredOAuth2AuthorizeRequests(ctx context.Context) error {
+	s.calls++
+	return nil
+}
+
+func (s *sweepRecordingStore) SweepOAuth2RefreshTokens(ctx context.Context, revokedOlderThan time.Duration) (int64, error) {
+	s.calls++
+	return 0, nil
+}
+
+func (s *sweepRecordingStore) SweepOrphanedOAuth2Clients(ctx context.Context, registeredOlderThan time.Duration) (int64, error) {
+	s.calls++
+	return 0, nil
+}
+
+func TestOAuth2SweepWorkerShouldSweepGate(t *testing.T) {
+	tests := []struct {
+		name        string
+		shouldSweep func() bool
+		wantCalls   int
+	}{
+		{"nil gate always sweeps", nil, 3},
+		{"true gate sweeps", func() bool { return true }, 3},
+		{"false gate skips the pass entirely", func() bool { return false }, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &sweepRecordingStore{}
+			w := newOAuth2SweepWorker(store, tt.shouldSweep)
+			w.sweep(context.Background())
+			if store.calls != tt.wantCalls {
+				t.Errorf("sweep() made %d store calls, want %d", store.calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestOAuth2SweepWorkerGateReevaluatedPerPass(t *testing.T) {
+	store := &sweepRecordingStore{}
+	allowed := false
+	w := newOAuth2SweepWorker(store, func() bool { return allowed })
+
+	w.sweep(context.Background())
+	if store.calls != 0 {
+		t.Fatalf("gated-off pass made %d store calls, want 0", store.calls)
+	}
+
+	// Flipping the gate must take effect on the next pass — the decision is
+	// per-pass, not latched at construction.
+	allowed = true
+	w.sweep(context.Background())
+	if store.calls != 3 {
+		t.Fatalf("gated-on pass made %d store calls, want 3", store.calls)
+	}
+
+	allowed = false
+	w.sweep(context.Background())
+	if store.calls != 3 {
+		t.Fatalf("re-gated-off pass made %d store calls, want 3 total", store.calls)
+	}
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1365,6 +1365,26 @@ func (s *BifrostHTTPServer) RemovePlugin(ctx context.Context, displayName string
 	return nil
 }
 
+// StartOAuth2SweepWorker creates and starts the janitor for the OAuth2
+// issuance tables (expired authorize requests, aged-out revoked refresh
+// tokens, orphaned dynamically-registered clients). Call it once from
+// single-threaded bootstrap wiring, like the other worker fields on this
+// struct — the nil-check makes double-wiring a no-op, it is not a concurrency
+// guard. It is also a no-op when no config store is configured. The Start()
+// shutdown path stops the worker.
+//
+// shouldSweep, when non-nil, is consulted before each pass; returning false
+// skips that pass. Deployments running several instances against one config
+// store can use it to restrict sweeping to a single instance. nil means
+// always sweep.
+func (s *BifrostHTTPServer) StartOAuth2SweepWorker(ctx context.Context, shouldSweep func() bool) {
+	if s.OAuth2SweepWorker != nil || s.Config == nil || s.Config.ConfigStore == nil {
+		return
+	}
+	s.OAuth2SweepWorker = newOAuth2SweepWorker(s.Config.ConfigStore, shouldSweep)
+	s.OAuth2SweepWorker.start(ctx)
+}
+
 // RegisterInferenceRoutes initializes the routes for the inference handler
 func (s *BifrostHTTPServer) RegisterInferenceRoutes(ctx context.Context, middlewares ...schemas.BifrostHTTPMiddleware) error {
 	// Initialize WebSocket pool and handler before integrations so it can be wired through
@@ -1837,10 +1857,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		if s.TempTokenSweepWorker != nil {
 			s.TempTokenSweepWorker.Start(s.Ctx)
 		}
-		s.OAuth2SweepWorker = newOAuth2SweepWorker(s.Config.ConfigStore)
-		if s.OAuth2SweepWorker != nil {
-			s.OAuth2SweepWorker.start(s.Ctx)
-		}
+		s.StartOAuth2SweepWorker(s.Ctx, nil)
 		// Hand the service to the OAuth provider so InitiateUserOAuthFlow mints
 		// a mcp_auth token and embeds it as a URL fragment on the auth-page link.
 		if s.Config.OAuthProvider != nil {


### PR DESCRIPTION
## Summary

Exposes the OAuth2 sweep worker startup as a public method (`StartOAuth2SweepWorker`) and adds a `shouldSweep` gate so multi-node deployments can restrict database sweeping to a single node at a time.

## Changes

- Added a `shouldSweep func() bool` field to `oauth2SweepWorker`. When non-nil, it is consulted before each sweep pass; returning `false` skips the pass entirely. This allows multi-node deployments to elect a single sweeping node without disabling the worker on others, and the gate is re-evaluated every interval so leadership can change at runtime.
- Updated `newOAuth2SweepWorker` to accept and store the `shouldSweep` callback.
- Extracted sweep worker creation and startup into a new public method `StartOAuth2SweepWorker(ctx, shouldSweep)` on `BifrostHTTPServer`. The method is a no-op if a worker is already running or no config store is present, preventing double-starts.
- `Bootstrap` now delegates to `StartOAuth2SweepWorker(ctx, nil)` (always sweep), replacing the inline construction logic.
- Elevated sweep failure log messages from `Debug` to `Warn` so errors surface in production logs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/server/...
```

- Verify that a server bootstrapped normally still runs the sweep worker and cleans up expired OAuth2 records.
- In a multi-node setup, pass a `shouldSweep` function that returns `false` on non-leader nodes and confirm those nodes skip sweep passes while the leader node continues sweeping.
- Confirm that sweep errors now appear at `WARN` level rather than `DEBUG`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No changes to auth logic or token issuance. The sweep worker only removes already-expired or revoked records; restricting it to a single node in a cluster does not affect correctness of token validation on other nodes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable