### PR TITLE
feat: add `GetInFlightSidekiqJobByKind` to config store interface

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -438,6 +438,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_virtual_key_expires_at_column"}, run: migrationAddVirtualKeyExpiresAtColumn},
 	{IDs: []string{"add_vertex_force_single_region_column"}, run: migrationAddVertexForceSingleRegionColumn},
 	{IDs: []string{"add_sidekiq_table"}, run: migrationAddSidekiqTable},
+	{IDs: []string{"add_sidekiq_kind_status_created_index"}, run: migrationAddSidekiqKindStatusCreatedIndex},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10413,3 +10414,41 @@ func migrationAddSidekiqTable(ctx context.Context, db *gorm.DB, logger schemas.L
 	return nil
 }
 
+// migrationAddSidekiqKindStatusCreatedIndex adds a composite index on
+// (kind, status, created_at) so GetInFlightSidekiqJobByKind — which filters by
+// kind + status and orders by created_at DESC — can seek instead of doing a
+// filtered full scan plus sort as the table accumulates historical jobs.
+// Idempotent via CREATE INDEX IF NOT EXISTS; works for postgres and sqlite.
+//
+// The index is built non-transactionally (UseTransaction=false) with CREATE
+// INDEX CONCURRENTLY on postgres so it does not take a ShareLock that blocks
+// concurrent writes to the sidekiq table for the duration of the build. SQLite
+// does not support CONCURRENTLY, so it uses the plain form there.
+func migrationAddSidekiqKindStatusCreatedIndex(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_sidekiq_kind_status_created_index"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	noTxOpts := *migrator.DefaultOptions
+	noTxOpts.UseTransaction = false
+	if err := RunSingleMigration(ctx, &noTxOpts, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			// SQLite does not support CONCURRENTLY; use the plain form there.
+			var stmt string
+			if tx.Dialector.Name() == "sqlite" {
+				stmt = "CREATE INDEX IF NOT EXISTS idx_sidekiq_kind_status_created ON sidekiq (kind, status, created_at)"
+			} else {
+				stmt = "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_sidekiq_kind_status_created ON sidekiq (kind, status, created_at)"
+			}
+			return tx.Exec(stmt).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Exec(`DROP INDEX IF EXISTS idx_sidekiq_kind_status_created`).Error
+		},
+	}); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}

--- a/framework/configstore/sidekiq.go
+++ b/framework/configstore/sidekiq.go
@@ -199,6 +199,24 @@ func (s *RDBConfigStore) ListClaimableSidekiqJobs(ctx context.Context, staleBefo
 	return jobs, nil
 }
 
+// GetInFlightSidekiqJobByKind returns the most recently created job of the given
+// kind that is still pending or running, or nil when none is in flight. Callers
+// use it to avoid enqueuing a duplicate while one of the same kind is active.
+func (s *RDBConfigStore) GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error) {
+	var job tables.TableSidekiqJob
+	err := s.DB().WithContext(ctx).
+		Where("kind = ? AND status IN ?", kind, []string{tables.SidekiqStatusPending, tables.SidekiqStatusRunning}).
+		Order("created_at DESC").
+		First(&job).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
 // MarkStaleSidekiqJobsFailed flips any running job whose heartbeat (updated_at) is
 // older than staleBefore to failed. This is the safety net for a goroutine or node
 // that died without marking its job: the job stops looking "running" and becomes

--- a/framework/configstore/sidekiq_test.go
+++ b/framework/configstore/sidekiq_test.go
@@ -335,6 +335,85 @@ func TestListClaimableSidekiqJobsOrderedOldestFirst(t *testing.T) {
 	assert.Equal(t, []string{"c", "a", "b"}, []string{jobs[0].ID, jobs[1].ID, jobs[2].ID})
 }
 
+func TestGetInFlightSidekiqJobByKindNoMatch(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	// No jobs at all.
+	job, err := store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	assert.Nil(t, job, "no jobs of any kind → nil")
+
+	// A job of a different kind must not match.
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "other", Kind: "reindex"}))
+	job, err = store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	assert.Nil(t, job, "only a different-kind job exists → nil")
+}
+
+func TestGetInFlightSidekiqJobByKindReturnsPendingOrRunning(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	// Pending job of the kind is in flight.
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "pending", Kind: "sync"}))
+	job, err := store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	require.NotNil(t, job, "pending job is in flight")
+	assert.Equal(t, "pending", job.ID)
+
+	// Claiming it flips it to running — still in flight.
+	_, err = store.ClaimSidekiqJob(ctx, "pending", "owner-A", time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	job, err = store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	require.NotNil(t, job, "running job is in flight")
+	assert.Equal(t, "pending", job.ID)
+	assert.Equal(t, tables.SidekiqStatusRunning, job.Status)
+}
+
+func TestGetInFlightSidekiqJobByKindExcludesTerminal(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	// completed → not in flight
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "done", Kind: "sync"}))
+	_, err := store.ClaimSidekiqJob(ctx, "done", "owner-A", time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	require.NoError(t, store.CompleteSidekiqJob(ctx, "done", "owner-A", "{}"))
+
+	// failed → not in flight
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "failed", Kind: "sync"}))
+	_, err = store.ClaimSidekiqJob(ctx, "failed", "owner-A", time.Now().Add(-time.Minute))
+	require.NoError(t, err)
+	require.NoError(t, store.FailSidekiqJob(ctx, "failed", "owner-A", "{}", "boom"))
+
+	job, err := store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	assert.Nil(t, job, "completed and failed jobs are not in flight")
+}
+
+func TestGetInFlightSidekiqJobByKindReturnsMostRecent(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "old", Kind: "sync"}))
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "mid", Kind: "sync"}))
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "new", Kind: "sync"}))
+	// Force a deterministic created_at ordering: old < mid < new.
+	require.NoError(t, store.DB().Model(&tables.TableSidekiqJob{}).Where("id = ?", "old").Update("created_at", time.Now().Add(-3*time.Hour)).Error)
+	require.NoError(t, store.DB().Model(&tables.TableSidekiqJob{}).Where("id = ?", "mid").Update("created_at", time.Now().Add(-2*time.Hour)).Error)
+	require.NoError(t, store.DB().Model(&tables.TableSidekiqJob{}).Where("id = ?", "new").Update("created_at", time.Now().Add(-1*time.Hour)).Error)
+
+	// A newer job of a different kind must not win.
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "newest-other", Kind: "reindex"}))
+
+	job, err := store.GetInFlightSidekiqJobByKind(ctx, "sync")
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	assert.Equal(t, "new", job.ID, "most-recently-created in-flight job of the kind wins")
+}
+
 func TestMarkStaleSidekiqJobsFailed(t *testing.T) {
 	store := setupSidekiqTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -672,6 +672,7 @@ type ConfigStore interface {
 	CompleteSidekiqJob(ctx context.Context, id, runnerID, metadata string) error
 	FailSidekiqJob(ctx context.Context, id, runnerID, metadata, lastErr string) error
 	ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error)
+	GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error)
 	MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error)
 
 	// DB returns the underlying database connection.

--- a/framework/configstore/tables/sidekiq.go
+++ b/framework/configstore/tables/sidekiq.go
@@ -20,8 +20,8 @@ const (
 // reads Status and UpdatedAt; everything else is opaque to it.
 type TableSidekiqJob struct {
 	ID          string     `gorm:"column:id;primaryKey;type:text" json:"id"`
-	Kind        string     `gorm:"column:kind;not null;type:text;index:idx_sidekiq_status_updated,priority:3" json:"kind"`
-	Status      string     `gorm:"column:status;not null;default:pending;type:text;index:idx_sidekiq_status_updated,priority:1" json:"status"`
+	Kind        string     `gorm:"column:kind;not null;type:text;index:idx_sidekiq_status_updated,priority:3;index:idx_sidekiq_kind_status_created,priority:1" json:"kind"`
+	Status      string     `gorm:"column:status;not null;default:pending;type:text;index:idx_sidekiq_status_updated,priority:1;index:idx_sidekiq_kind_status_created,priority:2" json:"status"`
 	// RunnerID identifies the runner process that currently owns (claimed) this job.
 	// Empty in OSS (single-node) mode; set to the node ID in enterprise cluster mode.
 	// Progress/complete/fail/heartbeat writes are fenced on this value so a revived
@@ -30,7 +30,7 @@ type TableSidekiqJob struct {
 	Metadata    string     `gorm:"column:metadata;type:text;default:'{}'" json:"metadata"`
 	Attempts    int        `gorm:"column:attempts;not null;default:0" json:"attempts"`
 	LastError   string     `gorm:"column:last_error;type:text" json:"last_error,omitempty"`
-	CreatedAt   time.Time  `gorm:"column:created_at;not null" json:"created_at"`
+	CreatedAt   time.Time  `gorm:"column:created_at;not null;index:idx_sidekiq_kind_status_created,priority:3" json:"created_at"`
 	UpdatedAt   time.Time  `gorm:"column:updated_at;not null;index:idx_sidekiq_status_updated,priority:2" json:"updated_at"`
 	StartedAt   *time.Time `gorm:"column:started_at" json:"started_at,omitempty"`
 	CompletedAt *time.Time `gorm:"column:completed_at" json:"completed_at,omitempty"`

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1586,6 +1586,10 @@ func (m *MockConfigStore) ListClaimableSidekiqJobs(ctx context.Context, staleBef
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
## Summary

Adds a `GetInFlightSidekiqJobByKind` method to the config store that looks up the most recently created pending or running Sidekiq job of a given kind. This allows callers to check whether a job of the same kind is already active before enqueuing a new one, preventing duplicate in-flight jobs.

## Changes

- Added `GetInFlightSidekiqJobByKind` to `RDBConfigStore` in `framework/configstore/sidekiq.go`, querying for the latest job matching the given kind with a `pending` or `running` status, returning `nil` when none exists.
- Added `GetInFlightSidekiqJobByKind` to the `ConfigStore` interface in `framework/configstore/store.go` so all implementations must satisfy the contract.
- Added a no-op stub implementation to `MockConfigStore` in `transports/bifrost-http/lib/config_test.go` to keep the mock in sync with the updated interface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

Verify that:
1. A job of a given kind that is `pending` or `running` is returned by `GetInFlightSidekiqJobByKind`.
2. `nil, nil` is returned when no matching in-flight job exists.
3. The most recently created job is returned when multiple in-flight jobs of the same kind exist.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a read-only query scoped to job kind and status with no exposure of sensitive data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable