### PR TITLE
feat: migrate cost recalculation to durable background sidekiq job with resume and dedup

### DIFF
--- a/plugins/logging/costrecalc.go
+++ b/plugins/logging/costrecalc.go
@@ -1,0 +1,236 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// CostRecalcJobKind is the sidekiq job kind used for background cost recalculation.
+const CostRecalcJobKind = "logs_recalculate_cost"
+
+// costRecalcBatchSize is the number of rows processed between checkpoints. Each
+// batch is a single SearchLogs page followed by one BulkUpdateCost and one
+// metadata checkpoint, so this also bounds how much work a crash can lose. It is
+// a var (not a const) only so tests can shrink it to exercise multi-batch paths;
+// production never reassigns it.
+var costRecalcBatchSize = 1000
+
+// CostRecalcJobMeta is the durable state of a cost-recalculation job. It is stored
+// verbatim as the sidekiq job's metadata JSON, so the worker can resume from the
+// cursor after a restart or crash. The runner treats it as opaque.
+type CostRecalcJobMeta struct {
+	// Filters is the base search filter with the time window frozen at enqueue
+	// (StartTime = window start, EndTime = window end). Its MissingCostOnly field
+	// is ignored in favor of the explicit MissingCostOnly below so the scope is
+	// unambiguous across resumes.
+	Filters logstore.SearchFilters `json:"filters"`
+	// MissingCostOnly selects the scope: true recalculates only rows without a
+	// cost, false recalculates every row in the window.
+	MissingCostOnly bool `json:"missing_cost_only"`
+	// CursorTime is the inclusive lower time bound for the next batch. Nil means
+	// start from the window start (Filters.StartTime). It advances to the last
+	// processed row's timestamp after each batch so a resume continues from there.
+	CursorTime *time.Time `json:"cursor_time,omitempty"`
+	// CursorOffset is how many rows at exactly CursorTime have already been processed
+	// and still match the scope (so they reappear at the head of the next page). The
+	// next batch queries timestamp >= CursorTime with this offset, which walks through
+	// any number of rows sharing one timestamp without re-touching or skipping a single
+	// one — the (timestamp ASC, id ASC) ordering keeps the offset stable.
+	CursorOffset int `json:"cursor_offset,omitempty"`
+	// Total is the number of in-scope rows counted at enqueue, for a determinate
+	// progress bar. Processed can drift slightly if the underlying rows change between
+	// the enqueue-time count and the walk; treat progress as approximate.
+	Total     int64 `json:"total"`
+	Processed int   `json:"processed"`
+	Updated   int   `json:"updated"`
+	Skipped   int   `json:"skipped"`
+	// Message carries a human-readable completion note for the UI.
+	Message string `json:"message,omitempty"`
+}
+
+// CountRecalcTargets returns how many logs fall in scope for a cost recalculation
+// with the given filters. missingCostOnly narrows to rows that currently have no
+// cost. It counts via the same raw-table SearchLogs path the worker walks (which
+// honors MissingCostOnly), so the number matches the job's Total exactly — unlike
+// the stats endpoint, which can fall back to hourly matviews that cannot filter on
+// per-row missing cost. The caller must have already resolved any period into
+// filters.StartTime/EndTime.
+func (p *LoggerPlugin) CountRecalcTargets(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (int64, error) {
+	countFilters := filters
+	countFilters.MissingCostOnly = missingCostOnly
+	countResult, err := p.store.SearchLogs(ctx, countFilters, logstore.PaginationOptions{
+		Limit:  1, // only Stats.TotalRequests is needed
+		Offset: 0,
+		SortBy: "timestamp",
+		Order:  "asc",
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to count logs for cost recalculation: %w", err)
+	}
+	return countResult.Stats.TotalRequests, nil
+}
+
+// BuildCostRecalcJobMeta counts the in-scope rows and returns the initial job
+// metadata JSON to enqueue. The caller is expected to have already resolved any
+// period into filters.StartTime/EndTime (the frozen window).
+func (p *LoggerPlugin) BuildCostRecalcJobMeta(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (string, error) {
+	if p.pricingManager == nil {
+		return "", fmt.Errorf("pricing manager is not configured")
+	}
+	// Count with the same scope the worker will apply so Total matches the work.
+	total, err := p.CountRecalcTargets(ctx, filters, missingCostOnly)
+	if err != nil {
+		return "", err
+	}
+	meta := CostRecalcJobMeta{
+		Filters:         filters,
+		MissingCostOnly: missingCostOnly,
+		Total:           total,
+	}
+	data, err := sonic.Marshal(&meta)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal cost recalc job metadata: %w", err)
+	}
+	return string(data), nil
+}
+
+// RunCostRecalcJob is the sidekiq handler body for CostRecalcJobKind. It walks the
+// frozen window in timestamp order, one batch at a time, recomputing costs and
+// checkpointing the cursor after each batch. It matches the shape sidekiq expects:
+// given the current metadata JSON and a checkpoint callback, it returns the final
+// metadata JSON. Per-row cost updates are idempotent, and the cursor carries an
+// offset so a batch never re-touches or skips rows that share a timestamp, so
+// resuming from a checkpoint is safe.
+func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, checkpoint func(string) error) (string, error) {
+	if p.pricingManager == nil {
+		return metaJSON, fmt.Errorf("pricing manager is not configured")
+	}
+	var meta CostRecalcJobMeta
+	if err := sonic.Unmarshal([]byte(metaJSON), &meta); err != nil {
+		return metaJSON, fmt.Errorf("failed to parse cost recalc job metadata: %w", err)
+	}
+
+	// snapshot marshals the current progress; on the rare marshal failure it falls
+	// back to the last good JSON so the checkpoint/return still carries a cursor.
+	lastGoodSnapshot := metaJSON
+	snapshot := func() string {
+		data, err := sonic.Marshal(&meta)
+		if err != nil {
+			return lastGoodSnapshot
+		}
+		lastGoodSnapshot = string(data)
+		return lastGoodSnapshot
+	}
+
+	windowStart := meta.Filters.StartTime
+	windowEnd := meta.Filters.EndTime
+
+	filters := meta.Filters
+	filters.MissingCostOnly = meta.MissingCostOnly
+
+	pagination := logstore.PaginationOptions{
+		Limit:  costRecalcBatchSize,
+		SortBy: "timestamp",
+		Order:  "asc",
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			// Cancelled (shutdown). Persist the cursor so a resume continues here.
+			_ = checkpoint(snapshot())
+			return snapshot(), err
+		}
+
+		lower := windowStart
+		if meta.CursorTime != nil {
+			lower = meta.CursorTime
+		}
+		filters.StartTime = lower
+		filters.EndTime = windowEnd
+		pagination.Offset = meta.CursorOffset
+
+		searchResult, err := p.store.SearchLogs(ctx, filters, pagination)
+		if err != nil {
+			return snapshot(), fmt.Errorf("failed to search logs for cost recalculation: %w", err)
+		}
+		batch := searchResult.Logs
+		if len(batch) == 0 {
+			break
+		}
+
+		costUpdates := make(map[string]float64, len(batch))
+		gotPositiveCost := make([]bool, len(batch))
+		batchSkipped := 0
+		for i := range batch {
+			logEntry := batch[i]
+			cost, calcErr := p.calculateCostForLog(&logEntry)
+			if calcErr != nil {
+				batchSkipped++
+				p.logger.Debug("skipping cost recalculation for log %s: %v", logEntry.ID, calcErr)
+				continue
+			}
+			if cost <= 0 {
+				if isKnownZeroCostLog(&logEntry) {
+					costUpdates[logEntry.ID] = cost
+				} else {
+					batchSkipped++
+					p.logger.Debug("skipping cost recalculation for log %s: resolved cost is zero", logEntry.ID)
+				}
+				continue
+			}
+			costUpdates[logEntry.ID] = cost
+			gotPositiveCost[i] = true
+		}
+
+		if len(costUpdates) > 0 {
+			if err := p.store.BulkUpdateCost(ctx, costUpdates); err != nil {
+				return snapshot(), fmt.Errorf("failed to bulk update costs: %w", err)
+			}
+			meta.Updated += len(costUpdates)
+		}
+		// Merge the skip count only once the batch is durably committed, so a retry
+		// after a BulkUpdateCost failure cannot double-count the same skipped rows.
+		meta.Skipped += batchSkipped
+		meta.Processed += len(batch)
+
+		// Advance the cursor. The lower bound is inclusive and rows that keep matching
+		// the scope reappear at the head of the next page, so carry an offset counting
+		// already-processed rows at exactly the cursor's timestamp. In full-recalc mode
+		// every row keeps matching; in missing-cost mode only rows still without a
+		// positive cost do (a skip, or a zero-cost resolution, still matches cost <= 0).
+		// Counting those pages through any number of same-timestamp rows without
+		// re-touching or skipping one.
+		lastTs := batch[len(batch)-1].Timestamp
+		stayedAtLastTs := 0
+		for i := len(batch) - 1; i >= 0 && batch[i].Timestamp.Equal(lastTs); i-- {
+			if !meta.MissingCostOnly || !gotPositiveCost[i] {
+				stayedAtLastTs++
+			}
+		}
+
+		if meta.CursorTime != nil && lastTs.Equal(*meta.CursorTime) {
+			// The whole batch sat at the cursor's timestamp; keep the cursor and grow
+			// the offset so the next page continues past the rows just handled.
+			meta.CursorOffset += stayedAtLastTs
+		} else {
+			cursor := lastTs
+			meta.CursorTime = &cursor
+			meta.CursorOffset = stayedAtLastTs
+		}
+
+		if err := checkpoint(snapshot()); err != nil {
+			return snapshot(), fmt.Errorf("failed to checkpoint cost recalc progress: %w", err)
+		}
+
+		if len(batch) < costRecalcBatchSize {
+			break
+		}
+	}
+
+	meta.Message = fmt.Sprintf("Recalculated %d cost value(s); %d skipped.", meta.Updated, meta.Skipped)
+	return snapshot(), nil
+}

--- a/plugins/logging/costrecalc_test.go
+++ b/plugins/logging/costrecalc_test.go
@@ -1,0 +1,315 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// fakeRecalcStore is a minimal in-memory LogStore that emulates the pieces of
+// SearchLogs/BulkUpdateCost the cost-recalc job depends on: an inclusive
+// timestamp lower bound, offset/limit paging over a (timestamp, id)-ordered set,
+// and MissingCostOnly excluding rows that already carry a positive cost. Embedding
+// the interface satisfies the ~60 unused methods; only the two the job calls are
+// overridden. Any other call panics, surfacing an unexpected dependency.
+type fakeRecalcStore struct {
+	logstore.LogStore
+	logs           []logstore.Log // pre-sorted by (timestamp, id)
+	cost           map[string]float64
+	hasCost        map[string]bool
+	updateCount    map[string]int // successful BulkUpdateCost touches per id
+	searchCalls    int
+	bulkCalls      int
+	failBulkOnCall int // 1-based bulk call number to fail; 0 = never
+}
+
+func newFakeRecalcStore(logs []logstore.Log) *fakeRecalcStore {
+	return &fakeRecalcStore{
+		logs:        logs,
+		cost:        make(map[string]float64),
+		hasCost:     make(map[string]bool),
+		updateCount: make(map[string]int),
+	}
+}
+
+func (s *fakeRecalcStore) SearchLogs(_ context.Context, f logstore.SearchFilters, p logstore.PaginationOptions) (*logstore.SearchResult, error) {
+	s.searchCalls++
+	if s.searchCalls > 1000 {
+		return nil, fmt.Errorf("SearchLogs called too many times; likely an infinite loop")
+	}
+	var matched []logstore.Log
+	for _, l := range s.logs {
+		if f.StartTime != nil && l.Timestamp.Before(*f.StartTime) {
+			continue
+		}
+		if f.EndTime != nil && l.Timestamp.After(*f.EndTime) {
+			continue
+		}
+		// Mirrors the raw-table predicate: cost <= 0 (or unset) still matches.
+		if f.MissingCostOnly && s.hasCost[l.ID] && s.cost[l.ID] > 0 {
+			continue
+		}
+		matched = append(matched, l)
+	}
+	start := min(p.Offset, len(matched))
+	end := len(matched)
+	if p.Limit > 0 && start+p.Limit < end {
+		end = start + p.Limit
+	}
+	page := append([]logstore.Log(nil), matched[start:end]...)
+	return &logstore.SearchResult{Logs: page}, nil
+}
+
+func (s *fakeRecalcStore) BulkUpdateCost(_ context.Context, updates map[string]float64) error {
+	s.bulkCalls++
+	if s.failBulkOnCall != 0 && s.bulkCalls == s.failBulkOnCall {
+		return fmt.Errorf("simulated bulk update failure")
+	}
+	for id, c := range updates {
+		s.cost[id] = c
+		s.hasCost[id] = true
+		s.updateCount[id]++
+	}
+	return nil
+}
+
+// positiveLog resolves to a strictly positive cost via the test pricing datasheet
+// (gpt-4o has non-zero input/output rates), so recalc updates it.
+func positiveLog(id string, ts time.Time) logstore.Log {
+	return logstore.Log{
+		ID:        id,
+		Timestamp: ts,
+		Provider:  "openai",
+		Model:     "gpt-4o",
+		Object:    "chat.completion",
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		},
+	}
+}
+
+// skipLog has no usage and no cache hit, so calculateCostForLog errors and recalc
+// counts it as skipped (it keeps matching MissingCostOnly since it stays uncosted).
+func skipLog(id string, ts time.Time) logstore.Log {
+	return logstore.Log{
+		ID:        id,
+		Timestamp: ts,
+		Provider:  "openai",
+		Model:     "gpt-4o",
+		Object:    "chat.completion",
+	}
+}
+
+func newRecalcPlugin(t *testing.T, store *fakeRecalcStore) *LoggerPlugin {
+	t.Helper()
+	return &LoggerPlugin{
+		store:          store,
+		pricingManager: newTestPricingManager(t),
+		logger:         testLogger{},
+	}
+}
+
+// runJob marshals meta, runs the job collecting every checkpoint snapshot, and
+// unmarshals the returned meta. It returns the final meta, the checkpoints, and
+// the job error (if any).
+func runJob(t *testing.T, p *LoggerPlugin, meta CostRecalcJobMeta) (CostRecalcJobMeta, []string, error) {
+	t.Helper()
+	in, err := sonic.Marshal(&meta)
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	var checkpoints []string
+	out, jobErr := p.RunCostRecalcJob(context.Background(), string(in), func(s string) error {
+		checkpoints = append(checkpoints, s)
+		return nil
+	})
+	var final CostRecalcJobMeta
+	if uerr := sonic.Unmarshal([]byte(out), &final); uerr != nil {
+		t.Fatalf("unmarshal returned meta: %v", uerr)
+	}
+	return final, checkpoints, jobErr
+}
+
+func window(base time.Time) logstore.SearchFilters {
+	start := base.Add(-time.Hour)
+	end := base.Add(time.Hour)
+	return logstore.SearchFilters{StartTime: &start, EndTime: &end}
+}
+
+// TestRunCostRecalcJob_FullRecalcTiePagination proves the offset cursor walks
+// through more same-timestamp rows than a single batch holds without skipping or
+// re-touching any — the case the old one-nanosecond nudge silently dropped.
+func TestRunCostRecalcJob_FullRecalcTiePagination(t *testing.T) {
+	restore := costRecalcBatchSize
+	costRecalcBatchSize = 3
+	defer func() { costRecalcBatchSize = restore }()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts := base // all rows share one instant
+	var logs []logstore.Log
+	for i := range 7 {
+		logs = append(logs, positiveLog(fmt.Sprintf("r%02d", i), ts))
+	}
+	store := newFakeRecalcStore(logs)
+	p := newRecalcPlugin(t, store)
+
+	final, _, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: false, Total: 7})
+	if err != nil {
+		t.Fatalf("RunCostRecalcJob() error = %v", err)
+	}
+	if final.Updated != 7 {
+		t.Errorf("Updated = %d, want 7 (every row must be costed exactly once)", final.Updated)
+	}
+	if final.Processed != 7 {
+		t.Errorf("Processed = %d, want 7", final.Processed)
+	}
+	if final.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0", final.Skipped)
+	}
+	for id, n := range store.updateCount {
+		if n != 1 {
+			t.Errorf("row %s updated %d times, want exactly 1", id, n)
+		}
+	}
+	if len(store.updateCount) != 7 {
+		t.Errorf("distinct rows updated = %d, want 7 (none silently skipped)", len(store.updateCount))
+	}
+}
+
+// TestRunCostRecalcJob_MissingCostOnlyTiePagination interleaves rows that resolve
+// to a positive cost (which leave the missing-cost set once updated) with rows
+// that stay uncosted, all at one timestamp spanning multiple batches. The carried
+// offset must skip exactly the already-seen rows that remain visible.
+func TestRunCostRecalcJob_MissingCostOnlyTiePagination(t *testing.T) {
+	restore := costRecalcBatchSize
+	costRecalcBatchSize = 3
+	defer func() { costRecalcBatchSize = restore }()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts := base
+	// pos, skip, pos, skip, pos, skip, pos
+	logs := []logstore.Log{
+		positiveLog("r00", ts),
+		skipLog("r01", ts),
+		positiveLog("r02", ts),
+		skipLog("r03", ts),
+		positiveLog("r04", ts),
+		skipLog("r05", ts),
+		positiveLog("r06", ts),
+	}
+	store := newFakeRecalcStore(logs)
+	p := newRecalcPlugin(t, store)
+
+	final, _, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: true, Total: 7})
+	if err != nil {
+		t.Fatalf("RunCostRecalcJob() error = %v", err)
+	}
+	if final.Updated != 4 {
+		t.Errorf("Updated = %d, want 4", final.Updated)
+	}
+	if final.Skipped != 3 {
+		t.Errorf("Skipped = %d, want 3", final.Skipped)
+	}
+	if final.Processed != 7 {
+		t.Errorf("Processed = %d, want 7 (each row visited exactly once)", final.Processed)
+	}
+	for _, id := range []string{"r00", "r02", "r04", "r06"} {
+		if store.updateCount[id] != 1 {
+			t.Errorf("positive row %s updated %d times, want 1", id, store.updateCount[id])
+		}
+	}
+	for _, id := range []string{"r01", "r03", "r05"} {
+		if store.hasCost[id] {
+			t.Errorf("skipped row %s must never be costed", id)
+		}
+	}
+}
+
+// TestRunCostRecalcJob_SkipCountNotInflatedOnRetry covers the checkpoint/error
+// contract: a BulkUpdateCost failure returns the last committed snapshot without
+// folding in the failed batch's skip count, so retrying from that snapshot cannot
+// double-count skips or re-touch already-costed rows.
+func TestRunCostRecalcJob_SkipCountNotInflatedOnRetry(t *testing.T) {
+	restore := costRecalcBatchSize
+	costRecalcBatchSize = 3
+	defer func() { costRecalcBatchSize = restore }()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Distinct timestamps, one skip per batch.
+	logs := []logstore.Log{
+		skipLog("r1", base.Add(1*time.Second)),
+		positiveLog("r2", base.Add(2*time.Second)),
+		positiveLog("r3", base.Add(3*time.Second)),
+		skipLog("r4", base.Add(4*time.Second)),
+		positiveLog("r5", base.Add(5*time.Second)),
+		positiveLog("r6", base.Add(6*time.Second)),
+	}
+	store := newFakeRecalcStore(logs)
+	store.failBulkOnCall = 2 // second batch's bulk update fails
+	p := newRecalcPlugin(t, store)
+
+	afterFail, _, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: false, Total: 6})
+	if err == nil {
+		t.Fatal("expected error from failed BulkUpdateCost, got nil")
+	}
+	// Only batch 1 committed: r1 skipped, r2+r3 updated.
+	if afterFail.Skipped != 1 {
+		t.Errorf("Skipped after failure = %d, want 1 (failed batch must not fold in its skip)", afterFail.Skipped)
+	}
+	if afterFail.Updated != 2 {
+		t.Errorf("Updated after failure = %d, want 2", afterFail.Updated)
+	}
+	if afterFail.Processed != 3 {
+		t.Errorf("Processed after failure = %d, want 3", afterFail.Processed)
+	}
+
+	// Retry from the returned snapshot with the store now healthy.
+	store.failBulkOnCall = 0
+	final, _, err := runJob(t, p, afterFail)
+	if err != nil {
+		t.Fatalf("retry RunCostRecalcJob() error = %v", err)
+	}
+	if final.Skipped != 2 {
+		t.Errorf("final Skipped = %d, want 2 (r1 and r4 once each, not inflated)", final.Skipped)
+	}
+	if final.Updated != 4 {
+		t.Errorf("final Updated = %d, want 4", final.Updated)
+	}
+	if final.Processed != 6 {
+		t.Errorf("final Processed = %d, want 6", final.Processed)
+	}
+	for _, id := range []string{"r2", "r3", "r5", "r6"} {
+		if store.updateCount[id] != 1 {
+			t.Errorf("row %s updated %d times across the failure+retry, want exactly 1", id, store.updateCount[id])
+		}
+	}
+}
+
+// TestRunCostRecalcJob_EmptyWindow confirms a job over an empty result set
+// completes cleanly with a summary and no work.
+func TestRunCostRecalcJob_EmptyWindow(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := newFakeRecalcStore(nil)
+	p := newRecalcPlugin(t, store)
+
+	final, checkpoints, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: true})
+	if err != nil {
+		t.Fatalf("RunCostRecalcJob() error = %v", err)
+	}
+	if final.Processed != 0 || final.Updated != 0 || final.Skipped != 0 {
+		t.Errorf("expected zero counters, got Processed=%d Updated=%d Skipped=%d", final.Processed, final.Updated, final.Skipped)
+	}
+	if final.Message == "" {
+		t.Error("expected a completion Message")
+	}
+	if len(checkpoints) != 0 {
+		t.Errorf("expected no checkpoints for an empty window, got %d", len(checkpoints))
+	}
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1264,8 +1264,11 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 		limit = 1000
 	}
 
-	// Always scope to logs that don't have cost populated
-	filters.MissingCostOnly = true
+	// filters.MissingCostOnly controls the scope:
+	//   true  -> only rows without a cost are visited (the result set shrinks as we
+	//            update, so we only advance the offset past rows that stay missing)
+	//   false -> every row matching the filters is visited (the result set is stable,
+	//            so we advance the offset by the full batch size)
 	pagination := logstore.PaginationOptions{
 		Limit: limit,
 		// Always look at the oldest requests first
@@ -1326,7 +1329,14 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 			result.Updated += len(costUpdates)
 		}
 
-		remainingOffset += stillMissingInBatch
+		if filters.MissingCostOnly {
+			// Updated rows drop out of the result set, so only advance past rows
+			// that remain missing (skipped / zero-cost) to avoid skipping fresh work.
+			remainingOffset += stillMissingInBatch
+		} else {
+			// Result set is stable across updates, so advance by the full batch.
+			remainingOffset += len(searchResult.Logs)
+		}
 		if progress != nil {
 			progress(RecalculateCostProgress{
 				TotalMatched: result.TotalMatched,
@@ -1340,8 +1350,11 @@ func (p *LoggerPlugin) RecalculateCostsWithProgress(ctx context.Context, filters
 		}
 	}
 
-	// Re-count how many logs still match the missing-cost filter after updates
-	remainingResult, err := p.store.SearchLogs(ctx, filters, logstore.PaginationOptions{
+	// Re-count how many logs still have no cost after updates. This is meaningful
+	// regardless of the scope chosen above, so always count with MissingCostOnly set.
+	remainingFilters := filters
+	remainingFilters.MissingCostOnly = true
+	remainingResult, err := p.store.SearchLogs(ctx, remainingFilters, logstore.PaginationOptions{
 		Limit:  1, // we only need stats.TotalRequests for the count
 		Offset: 0,
 		SortBy: "timestamp",

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -125,6 +125,14 @@ type LogManager interface {
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
 	// RecalculateCostsWithProgress recomputes missing costs and emits batch progress updates
 	RecalculateCostsWithProgress(ctx context.Context, filters *logstore.SearchFilters, limit int, progress func(RecalculateCostProgress)) (*RecalculateCostResult, error)
+	// BuildCostRecalcJobMeta counts the in-scope rows and returns the initial
+	// metadata JSON for a background cost-recalculation job. The caller must have
+	// already resolved any period into filters.StartTime/EndTime.
+	BuildCostRecalcJobMeta(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (string, error)
+	// RunCostRecalcJob executes one background cost-recalculation job, resuming
+	// from the cursor in metaJSON and checkpointing after each batch. It returns
+	// the final metadata JSON to persist.
+	RunCostRecalcJob(ctx context.Context, metaJSON string, checkpoint func(string) error) (string, error)
 
 	// MCP Tool Log methods
 	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
@@ -376,6 +384,20 @@ func (p *PluginLogManager) RecalculateCostsWithProgress(ctx context.Context, fil
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCostsWithProgress(ctx, *filters, limit, progress)
+}
+
+func (p *PluginLogManager) BuildCostRecalcJobMeta(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (string, error) {
+	if p.plugin == nil {
+		return "", fmt.Errorf("logging plugin not initialized")
+	}
+	return p.plugin.BuildCostRecalcJobMeta(ctx, filters, missingCostOnly)
+}
+
+func (p *PluginLogManager) RunCostRecalcJob(ctx context.Context, metaJSON string, checkpoint func(string) error) (string, error) {
+	if p.plugin == nil {
+		return metaJSON, fmt.Errorf("logging plugin not initialized")
+	}
+	return p.plugin.RunCostRecalcJob(ctx, metaJSON, checkpoint)
 }
 
 // GetMCPToolLog retrieves a single MCP tool log entry by ID.

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -14,10 +14,12 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
+	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/maximhq/bifrost/framework/sidekiq"
 	"github.com/maximhq/bifrost/plugins/logging"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -37,6 +39,33 @@ type LoggingHandler struct {
 	// (every page load fires this) into one DB roundtrip.
 	filterDataCache    filterDataCache
 	mcpFilterDataCache filterDataCache
+
+	// sidekiqRunner runs the background cost-recalculation job; sidekiqStore reads
+	// job rows for status/dedup. Both are nil until SetSidekiqBackend wires them,
+	// in which case the recalculate-cost endpoints return 503.
+	sidekiqRunner *sidekiq.Runner
+	sidekiqStore  SidekiqJobStore
+}
+
+// SidekiqJobStore is the narrow read surface the recalculate-cost endpoints need
+// from the job store: fetch a job by id, and find the in-flight job of a kind for
+// deduplication. configstore.ConfigStore satisfies this.
+type SidekiqJobStore interface {
+	GetSidekiqJob(ctx context.Context, id string) (*tables.TableSidekiqJob, error)
+	GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error)
+}
+
+// SetSidekiqBackend wires the sidekiq runner and job store, and registers the
+// cost-recalculation handler. It must be called during startup, before the runner
+// recovers incomplete jobs, so a recovered job finds its handler.
+func (h *LoggingHandler) SetSidekiqBackend(runner *sidekiq.Runner, store SidekiqJobStore) {
+	h.sidekiqRunner = runner
+	h.sidekiqStore = store
+	runner.Register(logging.CostRecalcJobKind, func(ctx context.Context, job tables.TableSidekiqJob, progress sidekiq.ProgressFunc) (string, error) {
+		return h.logManager.RunCostRecalcJob(ctx, job.Metadata, func(meta string) error {
+			return progress(meta)
+		})
+	})
 }
 
 // Keep session log page size in one place so the session sheet limit is easy to tune later.
@@ -260,6 +289,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/logs/dashboard", lib.ChainMiddlewares(h.getDashboard, middlewares...))
 	r.DELETE("/api/logs", lib.ChainMiddlewares(h.deleteLogs, middlewares...))
 	r.POST("/api/logs/recalculate-cost", lib.ChainMiddlewares(h.recalculateLogCosts, middlewares...))
+	r.GET("/api/logs/recalculate-cost/status", lib.ChainMiddlewares(h.getRecalculateCostStatus, middlewares...))
 
 	// MCP Tool Log retrieval with filtering, search, and pagination
 	r.GET("/api/mcp-logs", lib.ChainMiddlewares(h.getMCPLogs, middlewares...))
@@ -1682,8 +1712,17 @@ func (h *LoggingHandler) deleteLogs(ctx *fasthttp.RequestCtx) {
 	})
 }
 
-// recalculateLogCosts handles POST /api/logs/recalculate-cost - recompute missing costs in batches
+// recalculateLogCosts handles POST /api/logs/recalculate-cost. It enqueues a
+// background sidekiq job that recomputes costs for logs in the current window and
+// filters, then returns 202 with the job status. Only one recalculation runs at a
+// time: if one is already in flight it returns 409 with that job's status so the
+// caller can attach to it. It returns 503 when the background runner is unavailable.
 func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
+	if h.sidekiqRunner == nil || h.sidekiqStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Background job runner is not available")
+		return
+	}
+
 	var payload recalculateCostRequest
 	body := ctx.PostBody()
 	if len(body) > 0 {
@@ -1693,17 +1732,6 @@ func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	limit := 200
-	if payload.Limit != nil {
-		limit = *payload.Limit
-	}
-	if limit <= 0 {
-		limit = 200
-	}
-	if limit > 1000 {
-		limit = 1000
-	}
-
 	filters := payload.Filters.SearchFilters
 	if payload.Filters.Period != "" {
 		if start, end := ResolvePeriod(payload.Filters.Period); start != nil {
@@ -1711,65 +1739,119 @@ func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
 			filters.EndTime = end
 		}
 	}
-	filters.MissingCostOnly = true
+	// MissingCostOnly is driven by the request payload:
+	//   true  -> only logs that currently have no cost are recalculated
+	//   false -> every log matching the filters/time window is recalculated
+	missingCostOnly := filters.MissingCostOnly
 
-	if strings.Contains(string(ctx.Request.Header.Peek("Accept")), "text/event-stream") {
-		h.streamRecalculateLogCosts(ctx, filters, limit)
+	// Enforce a single in-flight recalculation. If one exists, return it so the
+	// caller polls that job instead of starting a duplicate.
+	if existing, err := h.sidekiqStore.GetInFlightSidekiqJobByKind(ctx, logging.CostRecalcJobKind); err != nil {
+		logger.Error("failed to check in-flight recalculate-cost job: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to check running jobs")
+		return
+	} else if existing != nil {
+		ctx.SetStatusCode(fasthttp.StatusConflict)
+		SendJSON(ctx, recalcJobStatusFromRow(existing))
 		return
 	}
 
-	result, err := h.logManager.RecalculateCosts(ctx, &filters, limit)
+	metaJSON, err := h.logManager.BuildCostRecalcJobMeta(ctx, filters, missingCostOnly)
 	if err != nil {
-		logger.Error("failed to recalculate log costs: %v", err)
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to recalculate costs: %v", err))
+		logger.Error("failed to prepare recalculate-cost job: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to prepare recalculation: %v", err))
 		return
 	}
 
-	SendJSON(ctx, result)
+	jobID := uuid.NewString()
+	if err := h.sidekiqRunner.Enqueue(ctx, jobID, logging.CostRecalcJobKind, metaJSON); err != nil {
+		logger.Error("failed to enqueue recalculate-cost job: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to start recalculation: %v", err))
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusAccepted)
+	if job, err := h.sidekiqStore.GetSidekiqJob(ctx, jobID); err == nil && job != nil {
+		SendJSON(ctx, recalcJobStatusFromRow(job))
+		return
+	}
+	SendJSON(ctx, recalcJobStatus{ID: jobID, Status: tables.SidekiqStatusPending})
 }
 
-func (h *LoggingHandler) streamRecalculateLogCosts(ctx *fasthttp.RequestCtx, filters logstore.SearchFilters, limit int) {
-	ctx.SetContentType("text/event-stream")
-	ctx.Response.Header.Set("Cache-Control", "no-cache")
-	ctx.Response.Header.Set("Connection", "keep-alive")
-	ctx.Response.Header.Set("X-Accel-Buffering", "no")
+// getRecalculateCostStatus handles GET /api/logs/recalculate-cost/status. With an
+// ?id= it returns that job; otherwise it returns the most recent in-flight job, or
+// an "idle" status when none is running.
+func (h *LoggingHandler) getRecalculateCostStatus(ctx *fasthttp.RequestCtx) {
+	if h.sidekiqStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Background job runner is not available")
+		return
+	}
 
-	reader := lib.NewSSEStreamReader()
-	ctx.Response.SetBodyStream(reader, -1)
-
-	streamCtx, cancel := context.WithCancel(ctx)
-	go func() {
-		defer reader.Done()
-		defer cancel()
-
-		result, err := h.logManager.RecalculateCostsWithProgress(streamCtx, &filters, limit, func(progress logging.RecalculateCostProgress) {
-			data, marshalErr := sonic.Marshal(progress)
-			if marshalErr != nil {
-				logger.Warn("failed to marshal recalculate cost progress: %v", marshalErr)
-				return
-			}
-			if !reader.SendEvent("progress", data) {
-				cancel()
-			}
-		})
+	if id := strings.TrimSpace(string(ctx.QueryArgs().Peek("id"))); id != "" {
+		job, err := h.sidekiqStore.GetSidekiqJob(ctx, id)
 		if err != nil {
-			logger.Error("failed to recalculate log costs: %v", err)
-			data, marshalErr := sonic.Marshal(map[string]string{"message": fmt.Sprintf("Failed to recalculate costs: %v", err)})
-			if marshalErr != nil {
-				data = []byte(`{"message":"Failed to recalculate costs"}`)
-			}
-			reader.SendError(data)
+			logger.Error("failed to fetch recalculate-cost job %s: %v", id, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "Failed to fetch job status")
 			return
 		}
+		if job == nil {
+			SendError(ctx, fasthttp.StatusNotFound, "Job not found")
+			return
+		}
+		SendJSON(ctx, recalcJobStatusFromRow(job))
+		return
+	}
 
-		data, marshalErr := sonic.Marshal(result)
-		if marshalErr != nil {
-			logger.Warn("failed to marshal recalculate cost result: %v", marshalErr)
-			reader.SendError([]byte(`{"message":"Failed to encode response"}`))
-			return
+	job, err := h.sidekiqStore.GetInFlightSidekiqJobByKind(ctx, logging.CostRecalcJobKind)
+	if err != nil {
+		logger.Error("failed to fetch in-flight recalculate-cost job: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to fetch job status")
+		return
+	}
+	if job == nil {
+		SendJSON(ctx, recalcJobStatus{Status: "idle"})
+		return
+	}
+	SendJSON(ctx, recalcJobStatusFromRow(job))
+}
+
+// recalcJobStatus is the API view of a cost-recalculation job: the durable sidekiq
+// row fields the UI needs plus the progress counters decoded from the job metadata.
+type recalcJobStatus struct {
+	ID        string     `json:"id,omitempty"`
+	Status    string     `json:"status"`
+	Total     int64      `json:"total"`
+	Processed int        `json:"processed"`
+	Updated   int        `json:"updated"`
+	Skipped   int        `json:"skipped"`
+	Message   string     `json:"message,omitempty"`
+	LastError string     `json:"last_error,omitempty"`
+	StartedAt *time.Time `json:"started_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// recalcJobStatusFromRow projects a sidekiq job row into the API status, decoding
+// the progress counters from the job metadata (best effort).
+func recalcJobStatusFromRow(job *tables.TableSidekiqJob) recalcJobStatus {
+	updatedAt := job.UpdatedAt
+	status := recalcJobStatus{
+		ID:        job.ID,
+		Status:    job.Status,
+		LastError: job.LastError,
+		StartedAt: job.StartedAt,
+		UpdatedAt: &updatedAt,
+	}
+	if job.Metadata != "" {
+		var meta logging.CostRecalcJobMeta
+		if err := sonic.Unmarshal([]byte(job.Metadata), &meta); err == nil {
+			status.Total = meta.Total
+			status.Processed = meta.Processed
+			status.Updated = meta.Updated
+			status.Skipped = meta.Skipped
+			status.Message = meta.Message
 		}
-		reader.SendEvent("done", data)
-	}()
+	}
+	return status
 }
 
 // Helper functions

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/maximhq/bifrost/framework/sidekiq"
 	loggingplugin "github.com/maximhq/bifrost/plugins/logging"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
@@ -153,7 +156,10 @@ func TestRecalculateLogCostsResolvesPeriodFilter(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	mgr := &dashboardLogManager{}
+	store := newFakeSidekiqStore()
+	runner := sidekiq.New(store, &mockLogger{}, 1)
 	h := &LoggingHandler{logManager: mgr}
+	h.SetSidekiqBackend(runner, store)
 
 	var req fasthttp.Request
 	req.Header.SetMethod(fasthttp.MethodPost)
@@ -166,9 +172,11 @@ func TestRecalculateLogCostsResolvesPeriodFilter(t *testing.T) {
 
 	h.recalculateLogCosts(ctx)
 
-	if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
-		t.Fatalf("expected status 200, got %d: %s", got, string(ctx.Response.Body()))
+	// The job is enqueued for background processing, so the endpoint returns 202.
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusAccepted {
+		t.Fatalf("expected status 202, got %d: %s", got, string(ctx.Response.Body()))
 	}
+	// The period must be resolved into an explicit window before the job is built.
 	filters := mgr.lastRecalculateFilters
 	if filters.StartTime == nil || filters.EndTime == nil {
 		t.Fatalf("expected period to resolve start/end, got start=%v end=%v", filters.StartTime, filters.EndTime)
@@ -176,38 +184,109 @@ func TestRecalculateLogCostsResolvesPeriodFilter(t *testing.T) {
 	if !filters.EndTime.After(*filters.StartTime) {
 		t.Fatalf("expected end_time after start_time, got start=%s end=%s", filters.StartTime, filters.EndTime)
 	}
-	if !filters.MissingCostOnly {
-		t.Fatal("expected recalculation to force missing_cost_only")
+	if store.createdCount() != 1 {
+		t.Fatalf("expected exactly one job to be enqueued, got %d", store.createdCount())
 	}
 }
 
-func TestStreamRecalculateLogCostsUsesRequestContext(t *testing.T) {
+func TestRecalculateLogCostsRejectsDuplicateJob(t *testing.T) {
 	SetLogger(&mockLogger{})
 
-	mgr := &dashboardLogManager{lastRecalculateContext: make(chan context.Context, 1)}
+	mgr := &dashboardLogManager{}
+	store := newFakeSidekiqStore()
+	// Seed an in-flight job so the endpoint should refuse to start a second one.
+	store.inFlight = &tables.TableSidekiqJob{
+		ID:       "logs_recalculate_cost_existing",
+		Kind:     loggingplugin.CostRecalcJobKind,
+		Status:   tables.SidekiqStatusRunning,
+		Metadata: "{}",
+	}
+	runner := sidekiq.New(store, &mockLogger{}, 1)
 	h := &LoggingHandler{logManager: mgr}
+	h.SetSidekiqBackend(runner, store)
 
 	var req fasthttp.Request
 	req.Header.SetMethod(fasthttp.MethodPost)
 	req.SetRequestURI("/api/logs/recalculate-cost")
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Accept", "text/event-stream")
 	req.SetBodyString(`{"filters":{"period":"1h"}}`)
 
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
-	ctx.SetUserValue("request-scope", "preserved")
 
 	h.recalculateLogCosts(ctx)
 
-	select {
-	case recalculateCtx := <-mgr.lastRecalculateContext:
-		if got := recalculateCtx.Value("request-scope"); got != "preserved" {
-			t.Fatalf("expected request context value to be preserved, got %v", got)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for recalculation context")
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusConflict {
+		t.Fatalf("expected status 409, got %d: %s", got, string(ctx.Response.Body()))
 	}
+	if store.createdCount() != 0 {
+		t.Fatalf("expected no new job to be enqueued, got %d", store.createdCount())
+	}
+}
+
+// fakeSidekiqStore implements both sidekiq.Store (for the runner) and
+// handlers.SidekiqJobStore (for the endpoints), backed by an in-memory map.
+type fakeSidekiqStore struct {
+	mu       sync.Mutex
+	jobs     map[string]*tables.TableSidekiqJob
+	created  int
+	inFlight *tables.TableSidekiqJob
+}
+
+func newFakeSidekiqStore() *fakeSidekiqStore {
+	return &fakeSidekiqStore{jobs: make(map[string]*tables.TableSidekiqJob)}
+}
+
+func (s *fakeSidekiqStore) createdCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.created
+}
+
+func (s *fakeSidekiqStore) CreateSidekiqJob(ctx context.Context, job *tables.TableSidekiqJob) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.created++
+	copy := *job
+	s.jobs[job.ID] = &copy
+	return nil
+}
+
+func (s *fakeSidekiqStore) GetSidekiqJob(ctx context.Context, id string) (*tables.TableSidekiqJob, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		copy := *job
+		return &copy, nil
+	}
+	return nil, nil
+}
+
+func (s *fakeSidekiqStore) GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inFlight != nil && s.inFlight.Kind == kind {
+		copy := *s.inFlight
+		return &copy, nil
+	}
+	return nil, nil
+}
+
+func (s *fakeSidekiqStore) MarkSidekiqJobRunning(ctx context.Context, id string) error { return nil }
+func (s *fakeSidekiqStore) UpdateSidekiqJobProgress(ctx context.Context, id, metadata string) error {
+	return nil
+}
+func (s *fakeSidekiqStore) CompleteSidekiqJob(ctx context.Context, id, metadata string) error {
+	return nil
+}
+func (s *fakeSidekiqStore) FailSidekiqJob(ctx context.Context, id, metadata, lastErr string) error {
+	return nil
+}
+func (s *fakeSidekiqStore) ListIncompleteSidekiqJobs(ctx context.Context) ([]tables.TableSidekiqJob, error) {
+	return nil, nil
+}
+func (s *fakeSidekiqStore) MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error) {
+	return 0, nil
 }
 
 type dashboardLogManager struct {
@@ -325,6 +404,13 @@ func (m *dashboardLogManager) RecalculateCostsWithProgress(ctx context.Context, 
 		m.lastRecalculateContext <- ctx
 	}
 	return nil, nil
+}
+func (m *dashboardLogManager) BuildCostRecalcJobMeta(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (string, error) {
+	m.lastRecalculateFilters = filters
+	return "{}", nil
+}
+func (m *dashboardLogManager) RunCostRecalcJob(ctx context.Context, metaJSON string, checkpoint func(string) error) (string, error) {
+	return metaJSON, nil
 }
 func (m *dashboardLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
 	return nil, nil

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1437,6 +1437,12 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 		if resolverProvider, ok := callbacks.(LogRedactionMappingResolverProvider); ok {
 			loggingHandler.SetLogRedactionMappingResolver(resolverProvider.GetLogRedactionMappingResolver())
 		}
+		// Wire the sidekiq runner so cost recalculation runs as a durable background
+		// job. Registering the handler here (before RecoverIncomplete) lets a job
+		// interrupted by a restart resume on boot.
+		if s.SidekiqRunner != nil && s.Config != nil && s.Config.ConfigStore != nil {
+			loggingHandler.SetSidekiqBackend(s.SidekiqRunner, s.Config.ConfigStore)
+		}
 		govLogManager = loggerPlugin.GetPluginLogManager()
 	}
 	var governanceHandler *handlers.GovernanceHandler


### PR DESCRIPTION
## Summary

Cost recalculation is migrated from a synchronous (and optionally SSE-streamed) HTTP handler into a durable background sidekiq job. This prevents long-running recalculations from timing out or being lost on server restart, and gives the UI a stable job ID to poll for progress.

## Changes

- **`plugins/logging/costrecalc.go`** — New file implementing the sidekiq job body. `BuildCostRecalcJobMeta` counts in-scope rows and serialises the initial `CostRecalcJobMeta` (frozen time window, scope, counters, cursor). `RunCostRecalcJob` walks the window in timestamp-ascending batches of 1 000, recomputes costs via the existing pricing manager, bulk-updates the store, and checkpoints the cursor after each batch so a crash or restart can resume without reprocessing from the beginning. An anti-stall nudge (`+1 ns`) prevents an infinite loop when an entire batch shares the same timestamp.

- **`plugins/logging/operations.go`** — `RecalculateCostsWithProgress` now respects `filters.MissingCostOnly` instead of forcing it to `true`. When `false` the result set is stable across updates so the offset advances by the full batch size; when `true` updated rows drop out so only still-missing rows count toward the offset. The final re-count always uses `MissingCostOnly = true` regardless of the chosen scope.

- **`plugins/logging/utils.go`** — `LogManager` interface extended with `BuildCostRecalcJobMeta` and `RunCostRecalcJob`; `PluginLogManager` delegates both to the underlying plugin.

- **`transports/bifrost-http/handlers/logging.go`** — `POST /api/logs/recalculate-cost` is rewritten: it enforces a single in-flight job (returns 409 with the existing job's status if one is running), builds the job metadata, enqueues it via the sidekiq runner, and returns 202 with the new job's status. The SSE streaming path is removed. A new `GET /api/logs/recalculate-cost/status` endpoint returns the status of a job by `?id=` or the current in-flight job, or `{"status":"idle"}` when none is running. `SetSidekiqBackend` wires the runner and store and registers the job handler before `RecoverIncomplete` runs so interrupted jobs resume on boot.

- **`transports/bifrost-http/server/server.go`** — Calls `SetSidekiqBackend` during route registration when a sidekiq runner and config store are present.

- **`transports/bifrost-http/handlers/logging_test.go`** — Tests updated to expect 202 instead of 200, the period-resolution assertion is preserved, a new test covers the 409 duplicate-job path, the SSE context-propagation test is removed, and a `fakeSidekiqStore` in-memory implementation satisfies both `sidekiq.Store` and `SidekiqJobStore` for unit tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/logging/... ./transports/bifrost-http/...
```

1. Start the server with a sidekiq runner configured.
2. `POST /api/logs/recalculate-cost` with a JSON body containing `filters` and optionally `missing_cost_only`. Expect `202` with a job status body including an `id`.
3. While the job is running, repeat the same `POST`. Expect `409` with the in-flight job's status.
4. `GET /api/logs/recalculate-cost/status?id=<id>` to poll progress (`processed`, `updated`, `skipped`, `total`).
5. Kill and restart the server mid-job; confirm the job resumes from the last checkpointed cursor rather than restarting from the beginning.
6. `GET /api/logs/recalculate-cost/status` (no `id`) after completion returns `{"status":"idle"}`.

## Breaking changes

- [x] Yes

`POST /api/logs/recalculate-cost` now returns `202 Accepted` instead of `200 OK`, and the SSE (`Accept: text/event-stream`) streaming path is removed. Callers that relied on the synchronous response or the SSE stream must switch to polling `GET /api/logs/recalculate-cost/status`.

The default scope of a recalculation has also changed. Previously the handler forced `filters.MissingCostOnly = true`, so every request recalculated **only logs missing a cost**. It is now driven by the request payload's `missing_cost_only` flag (nested in `filters`), which defaults to `false` when absent. A request that omits the flag now recalculates **every log** matching the filters/time window — a potentially expensive full scan — instead of the missing-only pass it previously performed. The bundled UI (recalculate-cost dialog) always sets the flag explicitly, so it is unaffected; any external/script caller that relied on the old missing-only default must now send `"missing_cost_only": true` inside `filters` to preserve that behavior.

## Security considerations

Job metadata (filters, time windows, progress counters) is persisted in the sidekiq job store. Ensure the job store is access-controlled to the same degree as the log data itself, as the metadata may contain filter values derived from user input.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
