### PR TITLE
feat: replace SSE streaming with background job polling for cost recalculation

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -628,6 +628,7 @@ export default function LogsPage() {
 								onPollToggle={handlePollToggle}
 								period={period}
 								onPeriodChange={handlePeriodChange}
+								totalLogs={totalItems}
 								columnEntries={columnEntries}
 								columnLabels={COLUMN_LABELS}
 								onToggleColumnVisibility={toggleColumnVisibility}

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -6,13 +6,15 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage } from "@/lib/store";
+import { useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
 import { getActiveTempToken } from "@/lib/store/apis/tempToken";
-import type { LogFilters as LogFiltersType, RecalculateCostProgress, RecalculateCostResponse } from "@/lib/types/logs";
+import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { RecalculateCostDialog, type RecalculateCostMode } from "./recalculateCostDialog";
 
 interface LogsHeaderViewProps {
 	filters: LogFiltersType;
@@ -25,6 +27,8 @@ interface LogsHeaderViewProps {
 	onPollToggle: (enabled: boolean) => void;
 	period: string;
 	onPeriodChange: (period?: string, from?: Date, to?: Date) => void;
+	/** Total logs matching the current filters/time window (stats.total_requests) */
+	totalLogs: number;
 	/** Column config for the ColumnConfigDropdown */
 	columnEntries: ColumnConfigEntry[];
 	columnLabels: Record<string, string>;
@@ -43,12 +47,29 @@ export function LogsHeaderView({
 	onPollToggle,
 	period,
 	onPeriodChange,
+	totalLogs,
 	columnEntries,
 	columnLabels,
 	onToggleColumnVisibility,
 	onResetColumns,
 }: LogsHeaderViewProps) {
 	const [openMoreActionsPopover, setOpenMoreActionsPopover] = useState(false);
+	const [recalcDialogOpen, setRecalcDialogOpen] = useState(false);
+	// Id of the recalculation job to track. Setting it starts polling via the query
+	// hook below; clearing it (on a terminal status) stops the polling.
+	const [activeRecalcJobId, setActiveRecalcJobId] = useState<string | null>(null);
+	const activeRecalcJobIdRef = useRef<string | null>(null);
+	useEffect(() => {
+		activeRecalcJobIdRef.current = activeRecalcJobId;
+	}, [activeRecalcJobId]);
+	const { data: recalcJobStatus, isError: recalcJobStatusError } = useGetRecalculateCostStatusQuery(
+		activeRecalcJobId ? { id: activeRecalcJobId } : undefined,
+		{
+			pollingInterval: 2000,
+			skip: !activeRecalcJobId,
+		},
+	);
+	const isRecalcRunning = !!activeRecalcJobId;
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 	const filtersRef = useRef<LogFiltersType>(filters);
@@ -77,38 +98,85 @@ export function LogsHeaderView({
 		};
 	}, []);
 
-	const handleRecalculateCosts = useCallback(async () => {
-		setOpenMoreActionsPopover(false);
+	const handleRecalculateCosts = useCallback(
+		async (mode: RecalculateCostMode) => {
+			setRecalcDialogOpen(false);
+			const missingCostOnly = mode === "missing";
+			const toastId = "logs-recalculate-costs";
+			toast.loading("Starting cost recalculation...", { id: toastId });
+
+			try {
+				// Recalculation runs as a background job. Enqueue it (or attach to the one
+				// already running); the status query below polls it to a terminal state.
+				const { status, alreadyRunning } = await startRecalculateCostJob(filters, missingCostOnly);
+				if (!status.id) {
+					throw new Error("Recalculation job did not start");
+				}
+				if (alreadyRunning) {
+					toast.loading("A cost recalculation is already running...", { id: toastId });
+				}
+				setActiveRecalcJobId(status.id);
+			} catch (err) {
+				toast.error("Cost recalculation failed", { id: toastId, description: getErrorMessage(err) });
+			}
+		},
+		[filters],
+	);
+
+	// If the status endpoint keeps failing, stop polling and surface the error so the
+	// user isn't left with a loading toast that never resolves.
+	useEffect(() => {
+		if (!activeRecalcJobId || !recalcJobStatusError) return;
+		toast.error("Cost recalculation failed", {
+			id: "logs-recalculate-costs",
+			description: "Lost track of the recalculation job status. Please refresh and try again.",
+		});
+		setActiveRecalcJobId(null);
+	}, [activeRecalcJobId, recalcJobStatusError]);
+
+	// If we unmount while a job is still being tracked, polling stops but the global
+	// loading toast would otherwise linger — dismiss it on the way out.
+	useEffect(() => {
+		return () => {
+			if (activeRecalcJobIdRef.current) toast.dismiss("logs-recalculate-costs");
+		};
+	}, []);
+
+	// React to each polled status snapshot: update the progress toast while running,
+	// and on a terminal status show the result, refresh the view, and stop polling.
+	useEffect(() => {
+		if (!activeRecalcJobId || !recalcJobStatus) return;
 		const toastId = "logs-recalculate-costs";
-		const recalculatePromise = recalculateCostsWithProgress(filters, (progress) => {
-			const total = progress.total_matched || 0;
-			const processed = Math.min(progress.processed, total || progress.processed);
-			toast.loading("Recalculating log costs...", {
-				id: toastId,
-				description:
-					total > 0
-						? `${processed}/${total} checked, ${progress.updated} updated, ${progress.skipped} skipped`
-						: "Finding logs with missing costs",
-			});
-		});
 
-		toast.promise(recalculatePromise, {
+		if (recalcJobStatus.status === "completed" || recalcJobStatus.status === "failed") {
+			if (recalcJobStatus.status === "failed") {
+				toast.error("Cost recalculation failed", {
+					id: toastId,
+					description: recalcJobStatus.last_error || recalcJobStatus.message || "The job did not complete",
+				});
+			} else {
+				toast.success("Cost recalculation complete", {
+					id: toastId,
+					description: recalcJobStatus.message || `${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
+					duration: 5000,
+				});
+			}
+			setActiveRecalcJobId(null);
+			void fetchLogs();
+			void fetchStats();
+			return;
+		}
+
+		const total = recalcJobStatus.total || 0;
+		const processed = total > 0 ? Math.min(recalcJobStatus.processed, total) : recalcJobStatus.processed;
+		toast.loading("Recalculating log costs...", {
 			id: toastId,
-			loading: "Recalculating log costs...",
-			success: (response) => ({
-				message: `Recalculated costs for ${response.updated} logs`,
-				description: `${response.updated} logs updated, ${response.skipped} logs skipped, ${response.remaining} logs remaining`,
-				duration: 5000,
-			}),
-			error: (err) => getErrorMessage(err),
+			description:
+				total > 0
+					? `${processed}/${total} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`
+					: `${recalcJobStatus.processed} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
 		});
-
-		try {
-			await recalculatePromise;
-			await fetchLogs();
-			await fetchStats();
-		} catch {}
-	}, [filters, fetchLogs, fetchStats]);
+	}, [activeRecalcJobId, recalcJobStatus, fetchLogs, fetchStats]);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
@@ -190,11 +258,25 @@ export function LogsHeaderView({
 				<PopoverContent className="bg-accent w-[250px] p-2" align="end">
 					<Command>
 						<CommandList>
-							<CommandItem className="hover:bg-accent/50 cursor-pointer" onSelect={handleRecalculateCosts}>
-								<Calculator className="text-muted-foreground size-4" />
+							<CommandItem
+								className="hover:bg-accent/50 cursor-pointer"
+								disabled={isRecalcRunning}
+								onSelect={() => {
+									if (isRecalcRunning) return;
+									setOpenMoreActionsPopover(false);
+									setRecalcDialogOpen(true);
+								}}
+							>
+								{isRecalcRunning ? (
+									<RefreshCw className="text-muted-foreground size-4 animate-spin" />
+								) : (
+									<Calculator className="text-muted-foreground size-4" />
+								)}
 								<div className="flex flex-col">
-									<span className="text-sm">Recalculate costs</span>
-									<span className="text-muted-foreground text-xs">For all logs that don't have a cost</span>
+									<span className="text-sm">{isRecalcRunning ? "Recalculating costs…" : "Recalculate costs"}</span>
+									<span className="text-muted-foreground text-xs">
+										{isRecalcRunning ? "A recalculation is already running" : "Recompute cost for logs in this view"}
+									</span>
 								</div>
 							</CommandItem>
 						</CommandList>
@@ -207,16 +289,26 @@ export function LogsHeaderView({
 				onToggleVisibility={onToggleColumnVisibility}
 				onReset={onResetColumns}
 			/>
+
+			<RecalculateCostDialog
+				open={recalcDialogOpen}
+				onOpenChange={setRecalcDialogOpen}
+				filters={filters}
+				totalLogs={totalLogs}
+				onConfirm={handleRecalculateCosts}
+			/>
 		</div>
 	);
 }
 
-async function recalculateCostsWithProgress(
+// startRecalculateCostJob enqueues a background recalculation (or attaches to the
+// one already running) and returns its status. A 202 means a new job started; a
+// 409 means one was already in flight and its status is returned instead.
+async function startRecalculateCostJob(
 	filters: LogFiltersType,
-	onProgress: (progress: RecalculateCostProgress) => void,
-): Promise<RecalculateCostResponse> {
+	missingCostOnly: boolean,
+): Promise<{ status: RecalcJobStatus; alreadyRunning: boolean }> {
 	const headers: Record<string, string> = {
-		Accept: "text/event-stream",
 		"Content-Type": "application/json",
 	};
 	const tempToken = getActiveTempToken();
@@ -228,73 +320,16 @@ async function recalculateCostsWithProgress(
 		method: "POST",
 		credentials: "include",
 		headers,
-		body: JSON.stringify({ filters }),
+		// Override the page's own missing_cost_only filter with the mode chosen in the dialog.
+		body: JSON.stringify({ filters: { ...filters, missing_cost_only: missingCostOnly } }),
 	});
 
-	if (!response.ok) {
-		throw await readRecalculateCostError(response);
+	// 202 Accepted (new job) and 409 Conflict (already running) both carry a status.
+	if (response.status === 202 || response.status === 409) {
+		const status = (await response.json()) as RecalcJobStatus;
+		return { status, alreadyRunning: response.status === 409 };
 	}
-	if (!response.body) {
-		throw new Error("Recalculate cost stream is unavailable");
-	}
-
-	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
-	let finalResult: RecalculateCostResponse | undefined;
-
-	while (true) {
-		const { value, done } = await reader.read();
-		if (done) break;
-		buffer += decoder.decode(value, { stream: true });
-		const events = buffer.split("\n\n");
-		buffer = events.pop() || "";
-		for (const eventBlock of events) {
-			const parsed = parseSSEEvent(eventBlock);
-			if (!parsed || parsed.data === "[DONE]") continue;
-			if (parsed.event === "error") {
-				throw parseRecalculateCostStreamError(parsed.data);
-			}
-			if (parsed.event === "progress") {
-				onProgress(JSON.parse(parsed.data) as RecalculateCostProgress);
-				continue;
-			}
-			if (parsed.event === "done") {
-				finalResult = JSON.parse(parsed.data) as RecalculateCostResponse;
-			}
-		}
-	}
-
-	buffer += decoder.decode();
-	if (buffer.trim()) {
-		const parsed = parseSSEEvent(buffer);
-		if (parsed?.event === "error") {
-			throw parseRecalculateCostStreamError(parsed.data);
-		}
-		if (parsed?.event === "done") {
-			finalResult = JSON.parse(parsed.data) as RecalculateCostResponse;
-		}
-	}
-
-	if (!finalResult) {
-		throw new Error("Recalculate cost stream ended before a final result was received");
-	}
-	return finalResult;
-}
-
-function parseSSEEvent(block: string): { event: string; data: string } | undefined {
-	let event = "message";
-	const data: string[] = [];
-	for (const rawLine of block.split("\n")) {
-		const line = rawLine.trimEnd();
-		if (line.startsWith("event: ")) {
-			event = line.slice(7);
-		} else if (line.startsWith("data: ")) {
-			data.push(line.slice(6));
-		}
-	}
-	if (data.length === 0) return undefined;
-	return { event, data: data.join("\n") };
+	throw await readRecalculateCostError(response);
 }
 
 async function readRecalculateCostError(response: Response): Promise<Error> {

--- a/ui/app/workspace/logs/views/recalculateCostDialog.tsx
+++ b/ui/app/workspace/logs/views/recalculateCostDialog.tsx
@@ -1,0 +1,143 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useLazyGetLogsStatsQuery } from "@/lib/store/apis/logsApi";
+import type { LogFilters as LogFiltersType } from "@/lib/types/logs";
+import { formatCompactNumber } from "@/lib/utils/numbers";
+import { Check, Info } from "lucide-react";
+import { useCallback, useState } from "react";
+
+export type RecalculateCostMode = "missing" | "all";
+
+interface RecalculateCostDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	filters: LogFiltersType;
+	/** Total logs matching the current filters/time window (stats.total_requests). */
+	totalLogs: number;
+	/** Invoked with the chosen mode when the user confirms. */
+	onConfirm: (mode: RecalculateCostMode) => void;
+}
+
+export function RecalculateCostDialog({ open, onOpenChange, filters, totalLogs, onConfirm }: RecalculateCostDialogProps) {
+	const [mode, setMode] = useState<RecalculateCostMode>("missing");
+	// Lazy query for the missing-cost count: triggered imperatively on open and on
+	// selecting "Missing cost only", so there is no data-fetching effect to manage.
+	const [triggerStats, { data, isFetching, isError }] = useLazyGetLogsStatsQuery();
+
+	const loadMissingCount = useCallback(() => {
+		// preferCacheValue=false: always refetch so the count reflects the current
+		// filters even if they changed since the last time the dialog was opened.
+		triggerStats({ filters: { ...filters, missing_cost_only: true } }, /* preferCacheValue */ false);
+	}, [triggerStats, filters]);
+
+	const selectMode = (next: RecalculateCostMode) => {
+		setMode(next);
+		if (next === "missing") loadMissingCount();
+	};
+
+	const missingCount = data?.total_requests ?? null;
+	const confirmDisabled = mode === "missing" ? isFetching || missingCount === 0 : totalLogs === 0;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="sm:max-w-[500px]"
+				// Fires whenever the dialog opens (including programmatic open): reset to
+				// the default mode and fetch its count without a useEffect.
+				onOpenAutoFocus={() => {
+					setMode("missing");
+					loadMissingCount();
+				}}
+			>
+				<DialogHeader className="pb-2">
+					<DialogTitle>Recalculate costs</DialogTitle>
+					<DialogDescription>
+						The current time window and filters will be applied. Choose which logs to recompute cost for.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="flex flex-col gap-2">
+					<RecalculateModeOption
+						selected={mode === "missing"}
+						onSelect={() => selectMode("missing")}
+						title="Missing cost only"
+						description="Only recompute logs that don't have a cost yet."
+					/>
+					<RecalculateModeOption
+						selected={mode === "all"}
+						onSelect={() => selectMode("all")}
+						title="All selected logs"
+						description="Recompute cost for every log matching the current filters."
+					/>
+				</div>
+
+				<p className="text-muted-foreground text-xs">
+					{mode === "all" ? (
+						<>
+							<span className="text-foreground font-medium">{formatCompactNumber(totalLogs)}</span> logs match the current filters and will be
+							recalculated.
+						</>
+					) : isFetching ? (
+						"Checking how many logs are missing a cost…"
+					) : isError || missingCount === null ? (
+						"Logs in the current window that don't have a cost yet will be recalculated."
+					) : missingCount === 0 ? (
+						"All logs in the current window already have a cost."
+					) : (
+						<>
+							<span className="text-foreground font-medium">{formatCompactNumber(missingCount)}</span> {missingCount === 1 ? "log" : "logs"} in the
+							current window {missingCount === 1 ? "doesn't have" : "don't have"} a cost yet and will be recalculated.
+						</>
+					)}
+				</p>
+
+				<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-muted-foreground">
+					<Info className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+					<span>Affects the logs dashboard only. Governance budgets and usage tracking remain unchanged.</span>
+				</div>
+
+				<DialogFooter className="pt-0">
+					<Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button size="sm" onClick={() => onConfirm(mode)} disabled={confirmDisabled}>
+						Recalculate
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function RecalculateModeOption({
+	selected,
+	onSelect,
+	title,
+	description,
+}: {
+	selected: boolean;
+	onSelect: () => void;
+	title: string;
+	description: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			aria-pressed={selected}
+			className={`flex items-start cursor-pointer gap-3 rounded-md border p-3 text-left transition-colors ${selected ? "border-primary bg-primary/5" : "border-input hover:bg-accent/50"
+				}`}
+		>
+			<span
+				className={`mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border ${selected ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/40"
+					}`}
+			>
+				{selected && <Check className="size-3" />}
+			</span>
+			<span className="flex flex-col gap-0.5">
+				<span className="text-sm font-medium">{title}</span>
+				<span className="text-muted-foreground text-xs">{description}</span>
+			</span>
+		</button>
+	);
+}

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -16,6 +16,7 @@ import {
 	ProviderLatencyHistogramResponse,
 	ProviderTokenHistogramResponse,
 	RankingDimension,
+	RecalcJobStatus,
 	RecalculateCostResponse,
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
@@ -364,6 +365,15 @@ export const logsApi = baseApi.injectEndpoints({
 			invalidatesTags: ["Logs"],
 		}),
 
+		// Status of a background cost-recalculation job. Intended to be polled with a
+		// pollingInterval while a job is active; omit id to get the latest in-flight job.
+		getRecalculateCostStatus: builder.query<RecalcJobStatus, { id?: string } | void>({
+			query: (arg) => ({
+				url: "/logs/recalculate-cost/status",
+				params: arg?.id ? { id: arg.id } : {},
+			}),
+		}),
+
 		// Get a single log entry by ID (includes raw_request and raw_response)
 		getLogById: builder.query<LogEntry, string>({
 			query: (id) => `/logs/${encodeURIComponent(id)}`,
@@ -405,6 +415,7 @@ export const {
 	useLazyGetAvailableFilterDataQuery,
 	useDeleteLogsMutation,
 	useRecalculateLogCostsMutation,
+	useGetRecalculateCostStatusQuery,
 	useLazyGetLogByIdQuery,
 	useGetLogByIdQuery,
 } = logsApi;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -801,6 +801,21 @@ export interface RecalculateCostProgress {
 	done: boolean;
 }
 
+// RecalcJobStatus is the status of a background cost-recalculation job, returned by
+// POST /api/logs/recalculate-cost (202/409) and GET /api/logs/recalculate-cost/status.
+export interface RecalcJobStatus {
+	id?: string;
+	status: "idle" | "pending" | "running" | "completed" | "failed";
+	total: number;
+	processed: number;
+	updated: number;
+	skipped: number;
+	message?: string;
+	last_error?: string;
+	started_at?: string;
+	updated_at?: string;
+}
+
 // Responses API types (for responses_output field)
 
 // Message roles for responses


### PR DESCRIPTION
## Summary

Replaces the SSE-based streaming approach for cost recalculation with a background job model. Instead of holding an open HTTP stream until recalculation finishes, the UI now enqueues a job, receives a job ID, and polls a status endpoint until the job reaches a terminal state. A new confirmation dialog lets users choose between recalculating only logs missing a cost or all logs matching the current filters.

## Changes

- **Background job polling**: `startRecalculateCostJob` replaces `recalculateCostsWithProgress`. It POSTs to the recalculate endpoint and handles `202 Accepted` (new job started) and `409 Conflict` (job already running), returning the job ID in both cases. A `useGetRecalculateCostStatusQuery` hook polls `/logs/recalculate-cost/status` every 2 seconds while a job ID is active, stopping automatically on a terminal status (`completed` or `failed`).
- **RecalculateCostDialog**: A new confirmation dialog (`recalculateCostDialog.tsx`) presents two modes — "Missing cost only" and "All selected logs". On open it lazily fetches the count of logs missing a cost for the current filters and displays it inline. The confirm button is disabled when the missing-cost count is zero or still loading.
- **`RecalcJobStatus` type**: Replaces `RecalculateCostProgress` and `RecalculateCostResponse` for the new job-based API shape, covering `idle | pending | running | completed | failed` statuses with progress counters and error fields.
- **`totalLogs` prop**: Passed down from the logs page to the header view and into the dialog so the "All selected logs" mode can display the count without an extra fetch.
- **`buildFilterParams` exported**: Made public so it can be reused by the lazy stats query inside the dialog.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the Logs page and apply any filters or time window.
2. Click the **⋮** (more actions) menu and select **Recalculate costs**.
3. Verify the confirmation dialog opens showing the count of logs missing a cost.
4. Switch to "All selected logs" and confirm the total log count is displayed.
5. Confirm with either mode and verify:
   - A loading toast appears immediately.
   - The toast updates with progress (`processed/total checked, N updated, N skipped`).
   - On completion, a success toast appears with the final counts.
   - If a recalculation is already running, a "already running" toast appears and polling attaches to the existing job.
6. Trigger a failure scenario and confirm an error toast is shown.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the recalculate costs dialog and toast progression._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces. The recalculate endpoint already requires credentials; the polling status endpoint follows the same auth model.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable