### PR TITLE
fix(openai): serialize compaction request `input` correctly

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/providers/utils"
@@ -443,6 +444,28 @@ type OpenAICompactionRequest struct {
 
 // GetExtraParams implements RequestBodyWithExtraParams.
 func (r *OpenAICompactionRequest) GetExtraParams() map[string]interface{} { return r.ExtraParams }
+
+// MarshalJSON serializes the compaction request. The embedded Input is shadowed
+// by a json.RawMessage so the OpenAIResponsesRequestInput union is written via
+// its own MarshalJSON (a pointer-receiver method that default struct encoding of
+// the value field would skip, emitting `input` as an object the endpoint
+// rejects). Empty input is omitted, since a previous_response_id-only compaction
+// is valid. Mirrors OpenAIResponsesRequest.MarshalJSON.
+func (r *OpenAICompactionRequest) MarshalJSON() ([]byte, error) {
+	type Alias OpenAICompactionRequest
+	var input json.RawMessage
+	if r.Input.OpenAIResponsesRequestInputStr != nil || r.Input.OpenAIResponsesRequestInputArray != nil {
+		b, err := r.Input.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		input = json.RawMessage(b)
+	}
+	return utils.MarshalSorted(struct {
+		*Alias
+		Input json.RawMessage `json:"input,omitempty"`
+	}{Alias: (*Alias)(r), Input: input})
+}
 
 // ToOpenAICompactionRequest converts a BifrostCompactionRequest to the OpenAI wire format.
 func ToOpenAICompactionRequest(ctx *schemas.BifrostContext, req *schemas.BifrostCompactionRequest) *OpenAICompactionRequest {

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -967,3 +967,72 @@ func TestOpenAIResponsesRequest_MarshalJSON_CompactionSummaryStripped(t *testing
 		t.Errorf("reasoning item summary should be [], got: %s", string(rawSummary))
 	}
 }
+
+// TestOpenAICompactionRequest_MarshalJSON_Input guards against the `input` union
+// serializing as a JSON object (which /v1/responses/compact rejects with
+// "Invalid type for 'input': expected a string, but got an object instead").
+func TestOpenAICompactionRequest_MarshalJSON_Input(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *OpenAICompactionRequest
+		assert  func(t *testing.T, m map[string]interface{})
+	}{
+		{
+			name: "empty input is omitted (previous_response_id-only compaction)",
+			request: &OpenAICompactionRequest{
+				Model:              "gpt-5",
+				PreviousResponseID: schemas.Ptr("resp_123"),
+			},
+			assert: func(t *testing.T, m map[string]interface{}) {
+				if v, ok := m["input"]; ok {
+					t.Errorf("input should be omitted when empty, got: %#v", v)
+				}
+			},
+		},
+		{
+			name: "string input serializes as a bare string",
+			request: &OpenAICompactionRequest{
+				Model: "gpt-5",
+				Input: OpenAIResponsesRequestInput{OpenAIResponsesRequestInputStr: schemas.Ptr("hello")},
+			},
+			assert: func(t *testing.T, m map[string]interface{}) {
+				if s, ok := m["input"].(string); !ok || s != "hello" {
+					t.Errorf("input should be the string %q, got: %#v", "hello", m["input"])
+				}
+			},
+		},
+		{
+			name: "array input serializes as an array",
+			request: &OpenAICompactionRequest{
+				Model: "gpt-5",
+				Input: OpenAIResponsesRequestInput{OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+				}}},
+			},
+			assert: func(t *testing.T, m map[string]interface{}) {
+				if _, ok := m["input"].([]interface{}); !ok {
+					t.Errorf("input should be an array, got: %#v", m["input"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonBytes, err := tt.request.MarshalJSON()
+			if err != nil {
+				t.Fatalf("MarshalJSON failed: %v", err)
+			}
+			var m map[string]interface{}
+			if err := sonic.Unmarshal(jsonBytes, &m); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			// The regression: input must never be a JSON object.
+			if obj, ok := m["input"].(map[string]interface{}); ok {
+				t.Fatalf("input serialized as an object (the bug): %v", obj)
+			}
+			tt.assert(t, m)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

OpenAICompactionRequest had no MarshalJSON, so its value-typed OpenAIResponsesRequestInput field — whose only marshaler is a pointer receiver — was emitted by default struct encoding as a JSON object ({"OpenAIResponsesRequestInputArray":null,"OpenAIResponsesRequestInputStr":null}), which /v1/responses/compact rejects with "Invalid type for 'input': expected a string, but got an object instead." omitempty on the value field also never omitted an empty input.

## Changes

Add a MarshalJSON mirroring OpenAIResponsesRequest: route `input` through the union's marshaler (string/array) and omit it when empty, since a previous_response_id-only compaction is valid.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

`go test ./core/ -run -v TestOpenAICompactionRequest_MarshalJSON_Input`

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes #5013 

## Security considerations

None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (n/a)
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


