### PR TITLE
Filter out provider-level keys from selector in prompt manager

### DIFF
--- a/ui/components/prompts/components/apiKeySelectorView.tsx
+++ b/ui/components/prompts/components/apiKeySelectorView.tsx
@@ -19,6 +19,7 @@ export function ApiKeySelectorView({
 	onValueChange,
 	disabled,
 	placeholder,
+	requireVirtualKey,
 }: {
 	providerKeys: DBKey[];
 	virtualKeys: VirtualKey[];
@@ -26,14 +27,16 @@ export function ApiKeySelectorView({
 	onValueChange: (v: string | null) => void;
 	disabled?: boolean;
 	placeholder?: string;
+	requireVirtualKey?: boolean;
 }) {
 	const [query, setQuery] = useState("");
 
 	const allOptions = useMemo(() => {
 		const apiKeyOpts = providerKeys.map((k) => ({ label: k.name, value: k.key_id, group: "api" as const }));
 		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.value, group: "virtual" as const }));
+		if (requireVirtualKey) return vkOpts;
 		return [{ label: "Auto (default)", value: "__auto__", group: "api" as const }, ...apiKeyOpts, ...vkOpts];
-	}, [providerKeys, virtualKeys]);
+	}, [providerKeys, virtualKeys, requireVirtualKey]);
 
 	const filtered = useMemo(() => {
 		if (!query) return allOptions;
@@ -44,11 +47,19 @@ export function ApiKeySelectorView({
 	const filteredApiKeys = useMemo(() => filtered.filter((o) => o.group === "api"), [filtered]);
 	const filteredVirtualKeys = useMemo(() => filtered.filter((o) => o.group === "virtual"), [filtered]);
 
-	const getLabel = useCallback((val: string | null) => allOptions.find((o) => o.value === val)?.label ?? val ?? "", [allOptions]);
+	const getLabel = useCallback(
+		(val: string | null) => {
+			if (requireVirtualKey && val === "__auto__") return "";
+			return allOptions.find((o) => o.value === val)?.label ?? val ?? "";
+		},
+		[allOptions, requireVirtualKey],
+	);
 
 	return (
 		<div className="flex flex-col gap-2">
-			<Label className="text-muted-foreground text-xs font-medium uppercase">Virtual key/ API Key</Label>
+			<Label className="text-muted-foreground text-xs font-medium uppercase">
+				{requireVirtualKey ? "Virtual key" : "Virtual key / API Key"}
+			</Label>
 			<Combobox
 				value={value}
 				onValueChange={(v) => onValueChange(v)}
@@ -59,7 +70,12 @@ export function ApiKeySelectorView({
 				filter={null}
 				itemToStringLabel={getLabel}
 			>
-				<ComboboxInput placeholder={placeholder ?? "Select API key"} showClear={value !== "__auto__"} showTrigger disabled={disabled} />
+				<ComboboxInput
+					placeholder={placeholder ?? (requireVirtualKey ? "Select virtual key" : "Select API key")}
+					showClear={Boolean(value) && value !== "__auto__"}
+					showTrigger
+					disabled={disabled}
+				/>
 				<ComboboxContent>
 					<ComboboxList>
 						{filteredApiKeys.length > 0 && (

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -8,12 +8,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { Input } from "@/components/ui/input";
 import { useGetVirtualKeysQuery } from "@/lib/store";
+import { useGetCoreConfigQuery } from "@/lib/store/apis/configApi";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { ModelProviderName } from "@/lib/types/config";
 import { ModelParams } from "@/lib/types/prompts";
 import { cn } from "@/lib/utils";
 import { PromptDeploymentsAccordionItem } from "@enterprise/components/prompt-deployments/promptDeploymentsAccordionItem";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ApiKeySelectorView } from "../components/apiKeySelectorView";
 import { VariablesTableView } from "../components/variablesTableView";
 import { usePromptContext } from "../context";
@@ -55,6 +56,8 @@ export function SettingsPanel() {
 	// Dynamic providers
 	const { data: providers, isLoading: isLoadingProviders } = useGetProvidersQuery();
 	const { data: virtualKeysData } = useGetVirtualKeysQuery();
+	const { data: coreConfig } = useGetCoreConfigQuery({});
+	const enforceVirtualKeys = coreConfig?.client_config?.enforce_auth_on_inference ?? false;
 	// Keys for the API Key selector (from /api/keys endpoint, provider-filtered)
 	const { data: allKeys, isSuccess: hasLoadedAllKeys } = useGetAllKeysQuery();
 
@@ -98,15 +101,23 @@ export function SettingsPanel() {
 		});
 	}, [virtualKeysData, provider]);
 
+	useEffect(() => {
+		if (!enforceVirtualKeys) return;
+		if (providerKeys.some((k) => k.key_id === apiKeyId)) {
+			setApiKeyId("__auto__");
+		}
+	}, [apiKeyId, enforceVirtualKeys, providerKeys, setApiKeyId]);
+
 	// Separate keys/vks to pass to model fetch for filtering.
 	const filterKeys = useMemo(() => {
+		if (enforceVirtualKeys) return undefined;
 		const isProviderKey = providerKeys.some((k) => k.key_id === apiKeyId);
 		if (isProviderKey) return [apiKeyId];
-		const isVirtualKey = providerVirtualKeys.some((vk) => vk.id === apiKeyId);
+		const isVirtualKey = providerVirtualKeys.some((vk) => vk.value === apiKeyId);
 		if (isVirtualKey) return undefined;
 		// Auto: pass all provider key IDs
 		return providerKeys.map((k) => k.key_id);
-	}, [apiKeyId, providerKeys, providerVirtualKeys]);
+	}, [apiKeyId, enforceVirtualKeys, providerKeys, providerVirtualKeys]);
 
 	const filterVks = useMemo(() => {
 		const virtualKey = providerVirtualKeys.find((vk) => vk.value === apiKeyId);
@@ -115,7 +126,7 @@ export function SettingsPanel() {
 	}, [apiKeyId, providerVirtualKeys]);
 
 	const handleModelParamsChange = useCallback(
-		(params: Record<string, any>) => {
+		(params: Record<string, unknown>) => {
 			onModelParamsChange(params as ModelParams);
 		},
 		[onModelParamsChange],
@@ -200,13 +211,14 @@ export function SettingsPanel() {
 									/>
 								</div>
 
-								{(providerKeys.length > 0 || providerVirtualKeys.length > 0) && !!provider && (
+								{((!enforceVirtualKeys && providerKeys.length > 0) || providerVirtualKeys.length > 0) && !!provider && (
 									<ApiKeySelectorView
 										providerKeys={providerKeys}
 										virtualKeys={providerVirtualKeys}
 										value={apiKeyId}
 										onValueChange={(v) => onApiKeyIdChange(v ?? "__auto__")}
 										disabled={!provider}
+										requireVirtualKey={enforceVirtualKeys}
 									/>
 								)}
 


### PR DESCRIPTION
## Summary

In current bifrost code, when VK is enforced, prompt manager allows you to select provider key - but request will fail, since prompt manager is basically a web client, asking you to pass VK header instead. It's a bit confusing for user.

## Changes

Tiny change, really.
UI now filters out provider keys during load - if VK is enforced, only VK keys are displayed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Add one provider with key.
Add one VK key, attach provider key to it.

Without VK enabled, should show both VK and provider keys.
With VK enabled, should show only VK ones.

## Screenshots/Recordings

VK enabled:
<img width="340" height="382" alt="Screenshot 2026-07-08 at 02 31 51" src="https://github.com/user-attachments/assets/e0411300-2a32-4936-a248-05a0c78d2b8d" />
VK disabled:
<img width="336" height="486" alt="Screenshot 2026-07-08 at 02 33 19" src="https://github.com/user-attachments/assets/51cff05d-239b-41e1-8118-8f95135a48cd" />


## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


