### PR TITLE
fix: fixes race conditions in tracer related to span locks

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -417,9 +417,8 @@ type ObservabilityPlugin interface {
 	// The context passed is a fresh background context, not the request context.
 	//
 	// Retention: implementations MUST NOT retain the *Trace pointer after Inject
-	// returns. The caller releases the trace back to a sync.Pool immediately after
-	// Inject completes, so any background goroutine that still references it will
-	// race with pool reuse. If a plugin needs to forward the trace asynchronously,
-	// it must copy the data it needs before returning.
+	// returns. The caller releases the underlying trace back to a sync.Pool
+	// immediately after Inject completes. If a plugin needs to forward the trace
+	// asynchronously, it must copy the data it needs before returning.
 	Inject(ctx context.Context, trace *Trace) error
 }

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -2,6 +2,7 @@
 package schemas
 
 import (
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -138,6 +139,60 @@ func (t *Trace) GetAttribute(key string) (any, bool) {
 	return value, ok
 }
 
+// SnapshotForExport returns a copy of the trace that is safe for concurrent
+// read-only use by observability exporters (Datadog, OTEL, ...) while the
+// original trace's spans may still be mutated.
+//
+// Trace- and span-level attribute maps are cloned under their respective locks,
+// so an exporter iterating the returned maps can never race a late writer — e.g.
+// streaming span finalization (completeDeferredSpan) or redaction replacement —
+// that legitimately holds the span lock. Without this, an exporter iterating the
+// live span.Attributes map (which cannot take the unexported span lock) triggers
+// a fatal "concurrent map iteration and map write" that recover() cannot catch.
+//
+// Span pointer identity is preserved *within* the returned trace: RootSpan and
+// the entries of Spans refer to the same copied *Span values, so pointer-equality
+// checks (e.g. span == finalAttempt) still work against the snapshot's own spans.
+// Attribute values are copied by reference and must be treated as read-only.
+func (t *Trace) SnapshotForExport() *Trace {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	clone := &Trace{
+		RequestID:      t.RequestID,
+		TraceID:        t.TraceID,
+		ParentID:       t.ParentID,
+		StartTime:      t.StartTime,
+		EndTime:        t.EndTime,
+		Attributes:     maps.Clone(t.Attributes),
+		RequestHeaders: maps.Clone(t.RequestHeaders),
+		PluginLogs:     append([]PluginLogEntry(nil), t.PluginLogs...),
+	}
+	spans := append([]*Span(nil), t.Spans...)
+	rootSpan := t.RootSpan
+	t.mu.Unlock()
+
+	spanCopies := make(map[*Span]*Span, len(spans))
+	clone.Spans = make([]*Span, 0, len(spans))
+	for _, span := range spans {
+		if span == nil {
+			continue
+		}
+		cp := span.snapshotForExport()
+		spanCopies[span] = cp
+		clone.Spans = append(clone.Spans, cp)
+	}
+	if rootSpan != nil {
+		if cp, ok := spanCopies[rootSpan]; ok {
+			clone.RootSpan = cp
+		} else {
+			clone.RootSpan = rootSpan.snapshotForExport()
+		}
+	}
+	return clone
+}
+
 // Reset clears the trace for reuse from pool
 func (t *Trace) Reset() {
 	t.mu.Lock()
@@ -267,6 +322,39 @@ func (s *Span) SetAttribute(key string, value any) {
 	s.Attributes[key] = value
 }
 
+// snapshotForExport returns a copy of the span whose Attributes (and Events)
+// are cloned under the span lock, so observability exporters can read them
+// concurrently while a late writer (streaming finalization, redaction) may still
+// mutate the original span. See Trace.SnapshotForExport. The returned span has a
+// fresh zero-value mutex and its attribute values are copied by reference.
+func (s *Span) snapshotForExport() *Span {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := &Span{
+		SpanID:     s.SpanID,
+		ParentID:   s.ParentID,
+		TraceID:    s.TraceID,
+		Name:       s.Name,
+		Kind:       s.Kind,
+		StartTime:  s.StartTime,
+		EndTime:    s.EndTime,
+		Status:     s.Status,
+		StatusMsg:  s.StatusMsg,
+		Attributes: maps.Clone(s.Attributes),
+	}
+	if len(s.Events) > 0 {
+		cp.Events = make([]SpanEvent, len(s.Events))
+		for i := range s.Events {
+			cp.Events[i] = SpanEvent{
+				Name:       s.Events[i].Name,
+				Timestamp:  s.Events[i].Timestamp,
+				Attributes: maps.Clone(s.Events[i].Attributes),
+			}
+		}
+	}
+	return cp
+}
+
 // AddEvent adds an event to the span in a thread-safe manner
 func (s *Span) AddEvent(event SpanEvent) {
 	s.mu.Lock()
@@ -283,8 +371,12 @@ func (s *Span) End(status SpanStatus, statusMsg string) {
 	s.StatusMsg = statusMsg
 }
 
-// Reset clears the span for reuse from pool
+// Reset clears the span for reuse from pool. It holds s.mu — like every other
+// Span mutator — so a straggling writer (e.g. streaming finalization) that races
+// pool release can't trigger a fatal concurrent map access on s.Attributes.
 func (s *Span) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.SpanID = ""
 	s.ParentID = ""
 	s.TraceID = ""

--- a/core/schemas/trace_snapshot_test.go
+++ b/core/schemas/trace_snapshot_test.go
@@ -1,0 +1,99 @@
+package schemas
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSnapshotForExport_ConcurrentWriter reproduces the crash observed by the
+// Datadog/OTEL exporters: an exporter iterating a span's live Attributes map
+// while a late writer (streaming finalization, redaction) mutates it via the
+// span lock triggers a fatal "concurrent map iteration and map write".
+//
+// SnapshotForExport must clone the maps under the span/trace locks so the
+// returned trace can be read freely while the original keeps being written.
+// Run with -race; without the snapshot, iterating trace.Spans[i].Attributes in
+// the reader goroutine below would fatal.
+func TestSnapshotForExport_ConcurrentWriter(t *testing.T) {
+	trace := &Trace{
+		TraceID:    "t1",
+		Attributes: map[string]any{"trace.k": "v"},
+	}
+	root := &Span{SpanID: "root", TraceID: "t1", Kind: SpanKindHTTPRequest}
+	child := &Span{SpanID: "llm", ParentID: "root", TraceID: "t1", Kind: SpanKindLLMCall}
+	root.SetAttribute("seed", "x")
+	child.SetAttribute("seed", "x")
+	trace.RootSpan = root
+	trace.Spans = []*Span{root, child}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: mimics completeDeferredSpan / redaction still mutating the span
+	// attributes (under the span lock) after the trace was handed to exporters.
+	wg.Go(func() {
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				child.SetAttribute("gen_ai.usage.output_tokens", i)
+				root.SetAttribute("http.status_code", i)
+				trace.SetAttribute("trace.k", i)
+				i++
+			}
+		}
+	})
+
+	// Reader: exporters take a snapshot and iterate its maps freely.
+	for range 4 {
+		wg.Go(func() {
+			for range 2000 {
+				snap := trace.SnapshotForExport()
+				for _, s := range snap.Spans {
+					for k, v := range s.Attributes { // must not race the writer
+						_, _ = k, v
+					}
+				}
+				for k, v := range snap.Attributes {
+					_, _ = k, v
+				}
+			}
+		})
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestSnapshotForExport_IsolatedCopy(t *testing.T) {
+	trace := &Trace{TraceID: "t1", Attributes: map[string]any{"a": 1}}
+	root := &Span{SpanID: "root", TraceID: "t1"}
+	root.SetAttribute("k", "v")
+	trace.RootSpan = root
+	trace.Spans = []*Span{root}
+
+	snap := trace.SnapshotForExport()
+
+	// Mutating the original after snapshot must not affect the snapshot.
+	root.SetAttribute("k", "changed")
+	trace.SetAttribute("a", 999)
+
+	if got := snap.Spans[0].Attributes["k"]; got != "v" {
+		t.Fatalf("snapshot span attr leaked mutation: got %v, want v", got)
+	}
+	if got := snap.Attributes["a"]; got != 1 {
+		t.Fatalf("snapshot trace attr leaked mutation: got %v, want 1", got)
+	}
+	// RootSpan identity must be preserved within the snapshot.
+	if snap.RootSpan != snap.Spans[0] {
+		t.Fatalf("snapshot RootSpan must alias its entry in Spans")
+	}
+	// The snapshot must not alias the original span pointers.
+	if snap.Spans[0] == root {
+		t.Fatalf("snapshot must copy spans, not alias the originals")
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -693,6 +693,14 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 
 		completedTrace.ApplyRedactionReplacements()
 
+		// Give every connector a private, lock-safe snapshot. Late writers may
+		// still mutate the pooled spans under the span lock (streaming
+		// finalization, redaction), and connectors iterate the attribute maps
+		// (directly or via Marshal) — racing them fatals with "concurrent map
+		// iteration and map write", which recover() can't catch. One snapshot
+		// here covers all connectors.
+		exportTrace := completedTrace.SnapshotForExport()
+
 		var obsPlugins []schemas.ObservabilityPlugin
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			obsPlugins = *loaded
@@ -716,7 +724,7 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 					return
 				}
 				seen[name] = struct{}{}
-				if err := plugin.Inject(context.Background(), completedTrace); err != nil && t.logger != nil {
+				if err := plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
 					t.logger.Warn("observability plugin %s failed to inject trace: %v", name, err)
 				}
 			}(plugin)


### PR DESCRIPTION
## Summary

Fixes a fatal `concurrent map iteration and map write` panic in observability exporters (Datadog, OTEL, etc.) that cannot be caught by `recover()`. When `CompleteAndFlushTrace` hands a trace to exporters, late writers (streaming span finalization, redaction) may still be mutating span attribute maps under the span lock. Exporters iterating those live maps — directly or via marshaling — race those writes and crash the process.

## Changes

- Added `Trace.SnapshotForExport()` which produces a deep copy of a trace with all attribute maps (trace-level, span-level, and span event-level) cloned under their respective locks, giving exporters a safe, immutable view of the trace.
- Added `Span.snapshotForExport()` as the per-span equivalent, cloning `Attributes` and `Events` under the span lock.
- `CompleteAndFlushTrace` now takes a single snapshot after redaction and passes `exportTrace` to all observability plugin `Inject` calls instead of the live `completedTrace`.
- `Span.Reset()` now acquires `s.mu` before clearing fields, preventing a straggling writer from triggering a fatal concurrent map access on `s.Attributes` during pool release.
- Span pointer identity is preserved within the snapshot (`RootSpan` and `Spans` entries refer to the same copied `*Span` values), so pointer-equality checks within exporters continue to work.
- Updated the `ObservabilityPlugin.Inject` doc comment to remove the misleading reference to pool-reuse races, since the snapshot now insulates exporters from that concern.
- Added `trace_snapshot_test.go` with a race-detector test (`TestSnapshotForExport_ConcurrentWriter`) that reproduces the original crash, and an isolation test (`TestSnapshotForExport_IsolatedCopy`) verifying mutations to the original do not bleed into the snapshot.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test -race ./core/schemas/... ./framework/tracing/...
```

The `TestSnapshotForExport_ConcurrentWriter` test will fatal without the fix when run with `-race`. With the fix, all tests should pass cleanly under the race detector.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Attribute maps containing PII or secrets are cloned by reference — values are not deep-copied. Redaction is applied before the snapshot is taken, so no new PII exposure is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable