### PR TITLE
fix: pass container block from anthropic api

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4650,6 +4650,21 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 
+		case AnthropicContentBlockTypeContainerUpload:
+			if block.FileID != nil {
+				bifrostMsg := schemas.ResponsesMessage{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role: role,
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{block.toBifrostResponsesContainerUploadBlock()},
+					},
+				}
+				if isOutputMessage {
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+				}
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
+			}
+
 		case AnthropicContentBlockTypeThinking:
 			if block.Thinking != nil {
 				bifrostMsg := schemas.ResponsesMessage{
@@ -4958,6 +4973,20 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 					Role: role,
 					Content: &schemas.ResponsesMessageContent{
 						ContentBlocks: []schemas.ResponsesMessageContentBlock{block.toBifrostResponsesDocumentBlock()},
+					},
+				}
+				if isOutputMessage {
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
+				}
+				bifrostMessages = append(bifrostMessages, bifrostMsg)
+			}
+		case AnthropicContentBlockTypeContainerUpload:
+			if block.FileID != nil {
+				bifrostMsg := schemas.ResponsesMessage{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role: role,
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{block.toBifrostResponsesContainerUploadBlock()},
 					},
 				}
 				if isOutputMessage {
@@ -7124,6 +7153,14 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 			)
 			return &anthropicBlock
 		}
+	case schemas.ResponsesInputMessageContentBlockTypeContainer:
+		if block.FileID != nil {
+			return &AnthropicContentBlock{
+				Type:         AnthropicContentBlockTypeContainerUpload,
+				FileID:       block.FileID,
+				CacheControl: block.CacheControl,
+			}
+		}
 	case schemas.ResponsesOutputMessageContentTypeReasoning:
 		if block.Text != nil {
 			return &AnthropicContentBlock{
@@ -7159,6 +7196,14 @@ func (block AnthropicContentBlock) toBifrostResponsesImageBlock() schemas.Respon
 		ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
 			ImageURL: schemas.Ptr(getImageURLFromBlock(block)),
 		},
+		CacheControl: block.CacheControl,
+	}
+}
+
+func (block AnthropicContentBlock) toBifrostResponsesContainerUploadBlock() schemas.ResponsesMessageContentBlock {
+	return schemas.ResponsesMessageContentBlock{
+		Type:         schemas.ResponsesInputMessageContentBlockTypeContainer,
+		FileID:       block.FileID,
 		CacheControl: block.CacheControl,
 	}
 }

--- a/core/providers/anthropic/roundtrip_test.go
+++ b/core/providers/anthropic/roundtrip_test.go
@@ -426,3 +426,82 @@ func TestRoundTrip_ContentBlocks_Bedrock(t *testing.T) {
 		}
 	}
 }
+
+// --- container_upload -------------------------------------------------------
+
+// findContainerUploadBlocks collects every container_upload block across a
+// message slice.
+func findContainerUploadBlocks(msgs []AnthropicMessage) []AnthropicContentBlock {
+	var out []AnthropicContentBlock
+	for _, m := range msgs {
+		for _, b := range m.Content.ContentBlocks {
+			if b.Type == AnthropicContentBlockTypeContainerUpload {
+				out = append(out, b)
+			}
+		}
+	}
+	return out
+}
+
+// container_upload (file staged into the code-execution container) must survive
+// Anthropic → Bifrost → Anthropic, carrying file_id and cache_control.
+func TestRoundTrip_ContainerUpload(t *testing.T) {
+	fileID := "file_011CcpBQA2BV1gthmNPSYzkh"
+	messages := []AnthropicMessage{
+		{
+			Role: AnthropicMessageRoleUser,
+			Content: AnthropicContent{
+				ContentBlocks: []AnthropicContentBlock{
+					{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("analyse and share model names")},
+					{
+						Type:         AnthropicContentBlockTypeContainerUpload,
+						FileID:       &fileID,
+						CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+					},
+				},
+			},
+		},
+	}
+
+	outMsgs, _ := roundTrip(t, messages, nil, schemas.Anthropic, "claude-sonnet-4-6")
+
+	blocks := findContainerUploadBlocks(outMsgs)
+	if len(blocks) != 1 {
+		t.Fatalf("container_upload blocks = %d, want 1", len(blocks))
+	}
+	if blocks[0].FileID == nil || *blocks[0].FileID != fileID {
+		t.Errorf("file_id = %v, want %q", blocks[0].FileID, fileID)
+	}
+	if blocks[0].CacheControl == nil || blocks[0].CacheControl.Type != schemas.CacheControlTypeEphemeral {
+		t.Errorf("cache_control = %v, want ephemeral", blocks[0].CacheControl)
+	}
+}
+
+// The grouped converter (used for Bedrock-routed Anthropic models) must also
+// emit a neutral container_upload block rather than dropping it.
+func TestRoundTrip_ContainerUpload_Grouped(t *testing.T) {
+	fileID := "file_grouped_123"
+	role := schemas.ResponsesInputMessageRoleUser
+	msgs := convertAnthropicContentBlocksToResponsesMessagesGrouped(
+		[]AnthropicContentBlock{{Type: AnthropicContentBlockTypeContainerUpload, FileID: &fileID}},
+		&role, false,
+	)
+
+	var found *schemas.ResponsesMessageContentBlock
+	for i := range msgs {
+		if msgs[i].Content == nil {
+			continue
+		}
+		for j := range msgs[i].Content.ContentBlocks {
+			if msgs[i].Content.ContentBlocks[j].Type == schemas.ResponsesInputMessageContentBlockTypeContainer {
+				found = &msgs[i].Content.ContentBlocks[j]
+			}
+		}
+	}
+	if found == nil {
+		t.Fatalf("grouped converter dropped container_upload block")
+	}
+	if found.FileID == nil || *found.FileID != fileID {
+		t.Errorf("file_id = %v, want %q", found.FileID, fileID)
+	}
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1228,10 +1228,12 @@ func (rc *ResponsesMessageContent) UnmarshalJSON(data []byte) error {
 type ResponsesMessageContentBlockType string
 
 const (
-	ResponsesInputMessageContentBlockTypeText  ResponsesMessageContentBlockType = "input_text"
-	ResponsesInputMessageContentBlockTypeImage ResponsesMessageContentBlockType = "input_image"
-	ResponsesInputMessageContentBlockTypeFile  ResponsesMessageContentBlockType = "input_file"
-	ResponsesInputMessageContentBlockTypeAudio ResponsesMessageContentBlockType = "input_audio"
+	ResponsesInputMessageContentBlockTypeText      ResponsesMessageContentBlockType = "input_text"
+	ResponsesInputMessageContentBlockTypeImage     ResponsesMessageContentBlockType = "input_image"
+	ResponsesInputMessageContentBlockTypeFile      ResponsesMessageContentBlockType = "input_file"
+	ResponsesInputMessageContentBlockTypeAudio     ResponsesMessageContentBlockType = "input_audio"
+	ResponsesInputMessageContentBlockTypeContainer ResponsesMessageContentBlockType = "input_container" // Anthropic-only: file staged into the code-execution container input dir
+
 	ResponsesOutputMessageContentTypeText      ResponsesMessageContentBlockType = "output_text"
 	ResponsesOutputMessageContentTypeRefusal   ResponsesMessageContentBlockType = "refusal"
 	ResponsesOutputMessageContentTypeReasoning ResponsesMessageContentBlockType = "reasoning_text"

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -1,8 +1,10 @@
 package integrations
 
 import (
+	"context"
 	"testing"
 
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -75,5 +77,65 @@ func TestMustConvertInPassthrough(t *testing.T) {
 				t.Errorf("mustConvertInPassthrough(%s) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
+	}
+}
+
+// A user message containing a container_upload block must survive the full
+// Anthropic integration request pipeline (parse → Bifrost → normalize → Anthropic
+// wire) with its file_id intact, and must NOT be replaced by the "..." empty-content
+// placeholder that normalizeBifrostInputContentBlocks backfills for otherwise-empty
+// user messages.
+func TestAnthropicContainerUploadSurvivesNormalization(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	fileID := "file_011CcpBQA2BV1gthmNPSYzkh"
+	req := &anthropic.AnthropicMessageRequest{
+		Model:     "anthropic/claude-sonnet-4-6",
+		MaxTokens: 1024,
+		Messages: []anthropic.AnthropicMessage{
+			{
+				Role: anthropic.AnthropicMessageRoleUser,
+				Content: anthropic.AnthropicContent{
+					ContentBlocks: []anthropic.AnthropicContentBlock{
+						{Type: anthropic.AnthropicContentBlockTypeText, Text: schemas.Ptr("analyse and share model names")},
+						{Type: anthropic.AnthropicContentBlockTypeContainerUpload, FileID: &fileID},
+					},
+				},
+			},
+		},
+	}
+
+	bifrostReq := req.ToBifrostResponsesRequest(ctx)
+	normalizeBifrostInputContentBlocks(bifrostReq)
+
+	out, err := anthropic.ToAnthropicResponsesRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("ToAnthropicResponsesRequest: %v", err)
+	}
+
+	var containerFileID *string
+	sawPlaceholder := false
+	for _, m := range out.Messages {
+		for _, b := range m.Content.ContentBlocks {
+			switch b.Type {
+			case anthropic.AnthropicContentBlockTypeContainerUpload:
+				containerFileID = b.FileID
+			case anthropic.AnthropicContentBlockTypeText:
+				if b.Text != nil && *b.Text == "..." {
+					sawPlaceholder = true
+				}
+			}
+		}
+	}
+
+	if sawPlaceholder {
+		t.Errorf("container_upload was replaced by the \"...\" empty-content placeholder")
+	}
+	if containerFileID == nil {
+		t.Fatalf("container_upload block missing from Anthropic request")
+	}
+	if *containerFileID != fileID {
+		t.Errorf("file_id = %q, want %q", *containerFileID, fileID)
 	}
 }

--- a/transports/bifrost-http/integrations/cursor.go
+++ b/transports/bifrost-http/integrations/cursor.go
@@ -812,6 +812,10 @@ func isEffectivelyEmptyContent(content *schemas.ResponsesMessageContent) bool {
 			if block.ResponsesInputMessageContentBlockFile != nil {
 				return false
 			}
+		case schemas.ResponsesInputMessageContentBlockTypeContainer:
+			if block.FileID != nil {
+				return false
+			}
 		case schemas.ResponsesInputMessageContentBlockTypeAudio:
 			if block.Audio != nil {
 				return false


### PR DESCRIPTION
## Summary

Adds support for Anthropic's `container_upload` content block type, which is used to stage files into the code-execution container. Previously, these blocks were silently dropped during conversion between Anthropic and Bifrost formats.

## Changes

- Added `ResponsesInputMessageContentBlockTypeContainerUpload` (`"container_upload"`) to the Bifrost responses schema constants.
- Added handling for `AnthropicContentBlockTypeContainerUpload` in both the standard and grouped Anthropic→Bifrost responses converters, preserving `file_id` and `cache_control`.
- Added `toBifrostResponsesContainerUploadBlock()` helper on `AnthropicContentBlock` to mirror the existing image/document block converters.
- Added the reverse conversion path in `convertContentBlockToAnthropic` so `container_upload` blocks round-trip correctly from Bifrost→Anthropic.
- Updated `isEffectivelyEmptyContent` in the cursor integration to treat a message containing only a `container_upload` block (with a non-nil `file_id`) as non-empty, preventing it from being replaced by the `"..."` placeholder.
- Added round-trip tests covering the standard converter, the grouped (Bedrock-routed) converter, and the full integration normalization pipeline.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestRoundTrip_ContainerUpload
go test ./core/providers/anthropic/... -run TestRoundTrip_ContainerUpload_Grouped
go test ./transports/bifrost-http/integrations/... -run TestAnthropicContainerUploadSurvivesNormalization
go test ./...
```

The `container_upload` block should survive Anthropic→Bifrost→Anthropic conversion with its `file_id` and `cache_control` intact, and should not be replaced by the empty-content `"..."` placeholder during normalization.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. `file_id` values are opaque references to files already staged in Anthropic's infrastructure; no new secrets or PII are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable