### PR TITLE
fix: match model filter on canonical_model_name and restore routing info for cost recalc

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -2489,6 +2489,14 @@ var performanceIndexes = []performanceIndexDef{
 	},
 	{
 		table: "logs",
+		name:  "idx_logs_canonical_model_name",
+		// Filtering by model matches either `model` or `canonical_model_name`
+		// (see applyFilters). This single-column index lets Postgres BitmapOr it
+		// with idx_logs_model instead of scanning the whole table for the OR branch.
+		sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_canonical_model_name ON logs(canonical_model_name) WHERE canonical_model_name IS NOT NULL",
+	},
+	{
+		table: "logs",
 		name:  "idx_logs_team_id",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_team_id ON logs(team_id)",
 	},

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -154,7 +154,11 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		baseQuery = baseQuery.Where("provider IN ?", filters.Providers)
 	}
 	if len(filters.Models) > 0 {
-		baseQuery = baseQuery.Where("model IN ?", filters.Models)
+		// Match either the wire model or the canonical model name so that
+		// filtering by a canonical model (e.g. gpt-4o-mini) also surfaces
+		// requests routed through an alias whose wire model differs. Parens
+		// keep the OR grouped when GORM ANDs this with the other predicates.
+		baseQuery = baseQuery.Where("(model IN ? OR canonical_model_name IN ?)", filters.Models, filters.Models)
 	}
 	if len(filters.Aliases) > 0 {
 		baseQuery = baseQuery.Where("alias IN ?", filters.Aliases)

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1439,6 +1439,22 @@ func (p *LoggerPlugin) calculateCostForLog(logEntry *logstore.Log) (float64, err
 		OriginalModelRequested: originalModelRequested,
 		ResolvedModelUsed:      logEntry.Model,
 		CacheDebug:             cacheDebug,
+		RoutingInfo: schemas.RoutingInfo{
+			Provider: schemas.ModelProvider(logEntry.Provider),
+			Model:    originalModelRequested,
+		},
+	}
+
+	// Reconstruct the resolved alias from the stored log columns so recalc feeds
+	// pricing the same routing info live logging had. Without this the canonical
+	// model name is dropped and pricing only tries the wire model / alias name,
+	// nulling costs that live logging resolved via the canonical name.
+	if logEntry.CanonicalModelName != nil && *logEntry.CanonicalModelName != "" {
+		canonical := *logEntry.CanonicalModelName
+		extraFields.RoutingInfo.ResolvedKeyAlias = &schemas.ResolvedKeyAlias{
+			ModelID:   logEntry.Model,
+			ModelName: &canonical,
+		}
 	}
 
 	resp := buildResponseForRequestType(requestType, usage, extraFields)


### PR DESCRIPTION
## Summary

Model filtering in the log store only matched against the wire model column, so filtering by a canonical model name (e.g. `gpt-4o-mini`) would miss requests routed through an alias whose wire model differed. Similarly, cost recalculation for stored logs dropped the canonical model name, causing pricing lookups to fail and return null costs for those entries.

## Changes

- Updated `applyFilters` in `rdb.go` to match against both `model` and `canonical_model_name` when filtering by model, so alias-routed requests surface correctly under their canonical name.
- In `calculateCostForLog`, the `RoutingInfo` field is now populated with provider and model from the log entry. When a `canonical_model_name` is present, a `ResolvedKeyAlias` is reconstructed so that cost recalculation has the same routing context that live logging used, preventing null costs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Create a key alias that maps to a model with a different wire model name (e.g. an alias for `gpt-4o-mini` that routes to a provider-specific wire model).
2. Send a request through that alias and confirm the log entry is stored with both `model` and `canonical_model_name` populated.
3. Filter logs by the canonical model name and verify the aliased request appears in results.
4. Trigger a cost recalculation for that log entry and confirm a non-null cost is returned.

```sh
go test ./framework/logstore/...
go test ./plugins/logging/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Changes are scoped to log filtering and cost recalculation logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable