### PR TITLE
fix: preserve active time period when applying dimension filters

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -279,13 +279,15 @@ export default function DashboardPage() {
 	// Adapter: converts a full LogFilters object to dashboard URL state
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
-			const newStartTime = newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined;
-			const newEndTime = newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined;
-			const timeChanged = newStartTime !== urlState.start_time || newEndTime !== urlState.end_time;
+			// The sidebar/header only manage dimension filters, never the time range: in
+			// period mode `newFilters` carries no start/end, so only touch time when an
+			// explicit range is actually provided — otherwise we'd clear the active period.
+			const hasExplicitTime = !!newFilters.start_time && !!newFilters.end_time;
+			const newStartTime = hasExplicitTime ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time!)) : undefined;
+			const newEndTime = hasExplicitTime ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time!)) : undefined;
+			const timeChanged = hasExplicitTime && (newStartTime !== urlState.start_time || newEndTime !== urlState.end_time);
 			setUrlState({
-				...(timeChanged && { period: "" }),
-				start_time: newStartTime,
-				end_time: newEndTime,
+				...(timeChanged && { period: "", start_time: newStartTime, end_time: newEndTime }),
 				providers: newFilters.providers || [],
 				models: newFilters.models || [],
 				selected_key_ids: newFilters.selected_key_ids || [],

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -192,15 +192,23 @@ export default function LogsPage() {
 	// Helper to update filters in URL
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
-			// Mark time range as user-modified only if start_time or end_time actually changed
-			const timeChanged = newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time;
+			// The sidebar/header only manage dimension filters, never the time range: in
+			// period mode `newFilters` carries no start/end, so only touch time when an
+			// explicit range is actually provided — otherwise we'd wipe the active period/range.
+			const hasExplicitTime = !!newFilters.start_time && !!newFilters.end_time;
+			const timeChanged =
+				hasExplicitTime && (newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time);
 			if (timeChanged) {
 				userModifiedTimeRange.current = true;
 			}
 
 			setUrlState({
-				// Clear the period whenever an absolute range is applied via setFilters
-				...(timeChanged && { period: "" }),
+				// Clear the period and apply the absolute range only when an explicit one is provided
+				...(timeChanged && {
+					period: "",
+					start_time: dateUtils.toUnixTimestamp(new Date(newFilters.start_time!)),
+					end_time: dateUtils.toUnixTimestamp(new Date(newFilters.end_time!)),
+				}),
 				parent_request_id: newFilters.parent_request_id || "",
 				providers: newFilters.providers || [],
 				models: newFilters.models || [],
@@ -217,8 +225,6 @@ export default function LogsPage() {
 				customer_ids: newFilters.customer_ids || [],
 				business_unit_ids: newFilters.business_unit_ids || [],
 				content_search: newFilters.content_search || "",
-				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
-				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
 				missing_cost_only: newFilters.missing_cost_only ?? false,
 				cache_hit_types: newFilters.cache_hit_types || [],
 				metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -743,7 +743,7 @@ export function LogDetailView({
 							{log.routing_rule && (
 								<Link
 									to="/workspace/logs"
-									search={{ routing_rule_ids: [log.routing_rule.id] }}
+									search={(prev) => ({ ...prev, offset: 0, selected_log: "", routing_rule_ids: [log.routing_rule!.id] })}
 									data-testid="logdetails-header-routing-rule-link"
 								>
 									<Badge variant="outline" className="bg-card text-muted-foreground rounded-sm px-2 py-0.5 font-normal hover:underline">
@@ -813,7 +813,7 @@ export function LogDetailView({
 								<div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">Rule</div>
 								<Link
 									to="/workspace/logs"
-									search={{ routing_rule_ids: [log.routing_rule.id] }}
+									search={(prev) => ({ ...prev, offset: 0, selected_log: "", routing_rule_ids: [log.routing_rule!.id] })}
 									className="truncate text-[13px] font-medium text-blue-600 hover:underline dark:text-blue-400"
 									data-testid="logdetails-header-rule-link"
 								>
@@ -826,7 +826,7 @@ export function LogDetailView({
 								<div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">Key</div>
 								<Link
 									to="/workspace/logs"
-									search={{ selected_key_ids: [log.selected_key_id] }}
+									search={(prev) => ({ ...prev, offset: 0, selected_log: "", selected_key_ids: [log.selected_key_id] })}
 									className="truncate font-mono text-[13px] text-blue-600 hover:underline dark:text-blue-400"
 									data-testid="logdetails-header-selected-key-link"
 								>
@@ -1026,7 +1026,7 @@ export function LogDetailView({
 									value={
 										<Link
 											to="/workspace/logs"
-											search={{ selected_key_ids: [log.selected_key_id] }}
+											search={(prev) => ({ ...prev, offset: 0, selected_log: "", selected_key_ids: [log.selected_key_id] })}
 											className="text-blue-600 hover:underline dark:text-blue-400"
 											data-testid="logdetails-selected-key-link"
 										>
@@ -1070,7 +1070,7 @@ export function LogDetailView({
 												<Link
 													key={t.id}
 													to="/workspace/logs"
-													search={{ team_ids: [t.id] }}
+													search={(prev) => ({ ...prev, offset: 0, selected_log: "", team_ids: [t.id] })}
 													className="text-blue-600 hover:underline dark:text-blue-400"
 													data-testid={`logdetails-team-link-${t.id}`}
 												>
@@ -1095,7 +1095,7 @@ export function LogDetailView({
 												<Link
 													key={c.id}
 													to="/workspace/logs"
-													search={{ customer_ids: [c.id] }}
+													search={(prev) => ({ ...prev, offset: 0, selected_log: "", customer_ids: [c.id] })}
 													className="text-blue-600 hover:underline dark:text-blue-400"
 													data-testid={`logdetails-customer-link-${c.id}`}
 												>
@@ -1120,7 +1120,7 @@ export function LogDetailView({
 												<Link
 													key={b.id}
 													to="/workspace/logs"
-													search={{ business_unit_ids: [b.id] }}
+													search={(prev) => ({ ...prev, offset: 0, selected_log: "", business_unit_ids: [b.id] })}
 													className="text-blue-600 hover:underline dark:text-blue-400"
 													data-testid={`logdetails-business-unit-link-${b.id}`}
 												>
@@ -1141,7 +1141,7 @@ export function LogDetailView({
 											<TooltipTrigger asChild>
 												<Link
 													to="/workspace/logs"
-													search={{ user_ids: [log.user_id] }}
+													search={(prev) => ({ ...prev, offset: 0, selected_log: "", user_ids: [log.user_id] })}
 													className={`block min-w-0 cursor-pointer text-sm font-normal break-all text-blue-600 underline-offset-2 hover:underline dark:text-blue-400${log.user_name ? "" : " font-mono"}`}
 													data-testid="logdetails-user-link"
 												>
@@ -1201,7 +1201,7 @@ export function LogDetailView({
 									value={
 										<Link
 											to="/workspace/logs"
-											search={{ routing_rule_ids: [log.routing_rule.id] }}
+											search={(prev) => ({ ...prev, offset: 0, selected_log: "", routing_rule_ids: [log.routing_rule!.id] })}
 											className="text-blue-600 hover:underline dark:text-blue-400"
 											data-testid="logdetails-routing-rule-link"
 										>


### PR DESCRIPTION
## Summary

Fixes a bug where applying dimension filters (providers, models, keys, etc.) from the sidebar or header would inadvertently clear the active time period. In period mode, `newFilters` carries no `start_time`/`end_time`, so the previous logic was unconditionally writing `undefined` for those values and wiping the selected period. Time state is now only updated when an explicit start and end time are both present.

Also fixes navigation links in the log detail view that were replacing the entire search state instead of merging into it, which caused the active time range and other filters to be lost when clicking through to filtered log views.

## Changes

- `setFilters` on both the dashboard and logs pages now checks for `hasExplicitTime` before touching time-related URL state. If no explicit range is provided, the existing `period`, `start_time`, and `end_time` values are left untouched.
- `start_time`/`end_time` are now written inside the conditional `timeChanged` block rather than unconditionally, removing the path that could set them to `undefined`.
- All `search={{ ... }}` props on filter links in `logDetailView.tsx` have been changed to `search={(prev) => ({ ...prev, ... })}` so that existing URL state (including the active time range) is preserved when navigating.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Set a relative time period (e.g. "Last 24 hours") on the Logs or Dashboard page.
2. Apply a dimension filter (e.g. select a provider or model) from the sidebar or header.
3. Verify the active time period is still selected and the data is filtered correctly — it should not revert to an empty/default time range.
4. Open a log detail view, click a filter link (e.g. a routing rule, key, team, or customer).
5. Verify the logs page opens with both the clicked filter and the previously active time range applied.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable