### PR TITLE
fix(gemini/vertex): always emit choices in non-streaming chat responses

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -5,6 +5,7 @@
 - feat: force single-region config in Vertex key config
 - feat: phase-scoped redaction and revealing with transient redaction data field, plus `ClearPausedStreamBuffer` for pause-accumulate stream flows
 - fix: complete visible thinking items on the streaming Responses surface so reasoning_summary_text.done, output_item.done, and response.completed carry the accumulated reasoning text and signature (thanks [@fus3r](https://github.com/fus3r)!)
+- fix: return Gemini/Vertex choices for empty chat candidates (thanks [@G-XD](https://github.com/G-XD)!)
 - fix: map web search options to Google Search grounding in the Gemini API
 - fix: parse `SecretVar` JSON with `ref`/`env_var` fields even when `value` is absent
 - fix: cap max reasoning effort in OpenAI

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -141,7 +141,8 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	var contentStr *string
 
 	// Process candidate content to extract text, tool calls, and reasoning
-	if candidate.Content != nil && len(candidate.Content.Parts) > 0 {
+	hasParts := candidate.Content != nil && len(candidate.Content.Parts) > 0
+	if hasParts {
 		for _, part := range candidate.Content.Parts {
 			// Handle thought/reasoning text separately - add to reasoning details
 			if part.Text != "" && part.Thought {
@@ -263,51 +264,63 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 				})
 			}
 		}
-
-		// Build the choice with message
-		message := &schemas.ChatMessage{
-			Role: schemas.ChatMessageRoleAssistant,
-		}
-
-		if len(contentBlocks) == 1 && contentBlocks[0].Type == schemas.ChatContentBlockTypeText {
-			contentStr = contentBlocks[0].Text
-			contentBlocks = nil
-		}
-
-		message.Content = &schemas.ChatMessageContent{
-			ContentStr:    contentStr,
-			ContentBlocks: contentBlocks,
-		}
-
-		// Map Google Search grounding supports to OpenAI url_citation annotations
-		annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
-
-		if len(toolCalls) > 0 || len(reasoningDetails) > 0 || len(annotations) > 0 {
-			message.ChatAssistantMessage = &schemas.ChatAssistantMessage{
-				ToolCalls:        toolCalls,
-				ReasoningDetails: reasoningDetails,
-				Annotations:      annotations,
-			}
-		}
-
-		// Convert finish reason to Bifrost format.
-		// Gemini uses "STOP" for both normal text completions and tool call responses —
-		// it has no dedicated finish reason for tool calls. Override to "tool_calls" when
-		// tool calls are present so downstream consumers see a uniform signal.
-		finishReason := ConvertGeminiFinishReasonToBifrost(candidate.FinishReason)
-		if len(toolCalls) > 0 && finishReason == "stop" {
-			finishReason = "tool_calls"
-		}
-
-		bifrostResp.Choices = append(bifrostResp.Choices, schemas.BifrostResponseChoice{
-			Index:        0,
-			FinishReason: &finishReason,
-			LogProbs:     ConvertGeminiLogprobsResultToBifrost(candidate.LogprobsResult),
-			ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
-				Message: message,
-			},
-		})
 	}
+
+	// Build the choice with message. This must happen even when the candidate has
+	// no visible output — e.g. nil/empty parts, thought-only parts, or MAX_TOKENS
+	// exhausted during thinking — because OpenAI-compatible clients require
+	// `choices` to be present. Mirror OpenAI's behavior: an empty assistant message
+	// with the real finish reason (MAX_TOKENS maps to "length").
+	message := &schemas.ChatMessage{
+		Role: schemas.ChatMessageRoleAssistant,
+	}
+
+	if len(contentBlocks) == 1 && contentBlocks[0].Type == schemas.ChatContentBlockTypeText {
+		contentStr = contentBlocks[0].Text
+		contentBlocks = nil
+	}
+	if contentStr == nil && len(contentBlocks) == 0 && len(toolCalls) == 0 {
+		contentStr = schemas.Ptr("")
+	}
+
+	message.Content = &schemas.ChatMessageContent{
+		ContentStr:    contentStr,
+		ContentBlocks: contentBlocks,
+	}
+
+	// Map Google Search grounding supports to OpenAI url_citation annotations
+	annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
+
+	if len(toolCalls) > 0 || len(reasoningDetails) > 0 || len(annotations) > 0 {
+		message.ChatAssistantMessage = &schemas.ChatAssistantMessage{
+			ToolCalls:        toolCalls,
+			ReasoningDetails: reasoningDetails,
+			Annotations:      annotations,
+		}
+	}
+
+	// Convert finish reason to Bifrost format.
+	// Gemini uses "STOP" for both normal text completions and tool call responses —
+	// it has no dedicated finish reason for tool calls. Override to "tool_calls" when
+	// tool calls are present so downstream consumers see a uniform signal.
+	finishReason := ConvertGeminiFinishReasonToBifrost(candidate.FinishReason)
+	if len(toolCalls) > 0 && finishReason == "stop" {
+		finishReason = "tool_calls"
+	}
+	if finishReason == "" {
+		// Non-streaming responses must carry a valid finish_reason; default to "stop"
+		// if Gemini omitted it (only seen on degenerate/empty candidates).
+		finishReason = "stop"
+	}
+
+	bifrostResp.Choices = append(bifrostResp.Choices, schemas.BifrostResponseChoice{
+		Index:        0,
+		FinishReason: &finishReason,
+		LogProbs:     ConvertGeminiLogprobsResultToBifrost(candidate.LogprobsResult),
+		ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+			Message: message,
+		},
+	})
 
 	// Set usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -203,6 +203,113 @@ func TestEmptyCandidatesRegression(t *testing.T) {
 	}
 }
 
+// TestNoContentCandidateRegression ensures candidates with no visible output
+// (nil/empty content parts, or thought-only parts) still produce an
+// OpenAI-compatible choice with empty string content. Strict clients reject
+// `"choices":null`, and some also reject `"message":{"content":null}`.
+func TestNoContentCandidateRegression(t *testing.T) {
+	tests := []struct {
+		name         string
+		candidate    *gemini.Candidate
+		expectFinish string
+		expectText   string
+	}{
+		{
+			name: "MaxTokensDuringThinking_NilContent",
+			candidate: &gemini.Candidate{
+				Index:        0,
+				FinishReason: gemini.FinishReasonMaxTokens,
+				Content:      nil, // budget burned on thoughts, no visible output
+			},
+			expectFinish: "length",
+		},
+		{
+			name: "MaxTokens_EmptyParts",
+			candidate: &gemini.Candidate{
+				Index:        0,
+				FinishReason: gemini.FinishReasonMaxTokens,
+				Content:      &gemini.Content{Role: string(gemini.RoleModel), Parts: []*gemini.Part{}},
+			},
+			expectFinish: "length",
+		},
+		{
+			name: "Stop_NilContent",
+			candidate: &gemini.Candidate{
+				Index:        0,
+				FinishReason: gemini.FinishReasonStop,
+				Content:      nil,
+			},
+			expectFinish: "stop",
+		},
+		{
+			name: "MissingFinishReason_NilContent",
+			candidate: &gemini.Candidate{
+				Index:   0,
+				Content: nil,
+			},
+			expectFinish: "stop", // defaulted; non-streaming must always carry a finish_reason
+		},
+		{
+			name: "ThoughtOnlyParts",
+			candidate: &gemini.Candidate{
+				Index:        0,
+				FinishReason: gemini.FinishReasonMaxTokens,
+				Content: &gemini.Content{
+					Role: string(gemini.RoleModel),
+					Parts: []*gemini.Part{
+						{Text: "internal reasoning", Thought: true},
+					},
+				},
+			},
+			expectFinish: "length",
+			expectText:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &gemini.GenerateContentResponse{
+				ResponseID:   "test-no-content",
+				ModelVersion: "gemini-2.5-pro",
+				Candidates:   []*gemini.Candidate{tt.candidate},
+				UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{
+					PromptTokenCount:     60,
+					CandidatesTokenCount: 32,
+					TotalTokenCount:      92,
+				},
+			}
+
+			bifrostResp := response.ToBifrostChatResponse()
+
+			require.NotNil(t, bifrostResp, "Response should not be nil")
+			require.Len(t, bifrostResp.Choices, 1, "Choices must be present even without visible output")
+
+			choice := bifrostResp.Choices[0]
+			require.NotNil(t, choice.FinishReason, "finish_reason must be set")
+			assert.Equal(t, tt.expectFinish, *choice.FinishReason)
+
+			require.NotNil(t, choice.ChatNonStreamResponseChoice, "Should have non-stream choice")
+			require.NotNil(t, choice.ChatNonStreamResponseChoice.Message, "Should have message object")
+			assert.Equal(t, schemas.ChatMessageRoleAssistant, choice.ChatNonStreamResponseChoice.Message.Role)
+			require.NotNil(t, choice.ChatNonStreamResponseChoice.Message.Content, "message.content should be present")
+			require.NotNil(t, choice.ChatNonStreamResponseChoice.Message.Content.ContentStr, "empty visible output should be an empty string, not null")
+			assert.Equal(t, tt.expectText, *choice.ChatNonStreamResponseChoice.Message.Content.ContentStr)
+
+			responseJSON, err := json.Marshal(bifrostResp)
+			require.NoError(t, err)
+			assert.NotContains(t, string(responseJSON), `"choices":null`)
+			assert.NotContains(t, string(responseJSON), `"content":null`)
+			assert.Contains(t, string(responseJSON), `"content":""`)
+
+			// Usage must still be intact alongside the choice
+			require.NotNil(t, bifrostResp.Usage)
+			assert.Equal(t, 60, bifrostResp.Usage.PromptTokens)
+			assert.Equal(t, 32, bifrostResp.Usage.CompletionTokens)
+			assert.Equal(t, 92, bifrostResp.Usage.TotalTokens)
+		})
+	}
+}
+
 func TestToBifrostEmbeddingResponsePreservesPrecision(t *testing.T) {
 	const want = 0.12345678901234568
 


### PR DESCRIPTION
## Summary

Fix Gemini/Vertex non-streaming chat responses when Gemini returns a valid candidate without visible content parts.

This can happen when a thinking-capable Gemini model exhausts the output token budget during reasoning, for example with `finishReason: MAX_TOKENS` and nil/empty `content.parts`. Before this change, Gemini chat conversion only appended `choices[0]` inside the content-parts branch, so these responses serialized as `"choices": null`, which breaks strict OpenAI-compatible clients.

This PR revives and completes the earlier attempted fix from #2630 on current main.

## Example

Gemini/Vertex can return a valid candidate with no visible content parts, for example when the output budget is exhausted during thinking:

  ```json
  {
    "candidates": [
      {
        "finishReason": "MAX_TOKENS"
      }
    ],
    "usageMetadata": {
      "promptTokenCount": 60,
      "candidatesTokenCount": 32,
      "totalTokenCount": 92
    }
  }
```
  Before this change, Bifrost serialized the OpenAI-compatible response with choices: null:
```json
  {
    "choices": null,
    "usage": {
      "prompt_tokens": 60,
      "completion_tokens": 32,
      "total_tokens": 92
    }
  }
```
  After this change, Bifrost emits a stable empty assistant choice and preserves usage:
```json
  {
    "choices": [
      {
        "index": 0,
        "finish_reason": "length",
        "message": {
          "role": "assistant",
          "content": ""
        }
      }
    ],
    "usage": {
      "prompt_tokens": 60,
      "completion_tokens": 32,
      "total_tokens": 92
    }
  }
```
## Changes

- Always emit a non-streaming chat choice for a valid, non-error Gemini candidate.
- Preserve finish reason mapping, including `MAX_TOKENS -> "length"`.
- Preserve usage metadata for no-content candidate responses.
- Return `message.content: ""` for zero-visible-output responses with no tool calls.
- Add regression tests for:
  - nil candidate content
  - empty candidate parts
  - thought-only parts
  - `MAX_TOKENS` with no visible output
  - missing finish reason fallback
  - JSON shape avoiding `"choices": null` and `"content": null`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core 

go test ./providers/gemini

```
Expected outcome: both commands pass.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related: #2630

## Security considerations

No.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


