### PR TITLE
fix: fixes telemetry plugin cardinality explosion risk

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -257,7 +257,7 @@ const (
 	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"              // int (to store the number of retries (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"                 // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
 	BifrostContextKeyResolvedAlias                       BifrostContextKey = "bifrost-resolved-alias"                 // *ResolvedAlias (set by bifrost after key-level alias resolution — providers read this for model_family routing and provider-specific overrides; nil/absent when no alias matched)
-	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyStreamGated                         BifrostContextKey = "bifrost-stream-gated"                   // bool (set by ctx.PauseStream/ResumeStream/EndStream when a plugin first engages the pause/resume gate; provider helpers use this as a fast-path check to skip Tracer.GateSend on streams that never engage the gate)
 	BifrostContextKeyStreamIdleTimeout                   BifrostContextKey = "bifrost-stream-idle-timeout"            // time.Duration (per-chunk idle timeout for streaming)
 	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"             // bool (will pass an empty key to the provider)
@@ -268,7 +268,7 @@ const (
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeyIntegrationType                     BifrostContextKey = "bifrost-integration-type"                         // integration used in gateway (e.g. openai, anthropic, bedrock, etc.)
-	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostMCPAgentOriginalRequestID                     BifrostContextKey = "bifrost-mcp-agent-original-request-id"            // string (to store the original request ID for MCP agent mode)
 	BifrostContextKeyParentMCPRequestID                  BifrostContextKey = "bf-parent-mcp-request-id"                         // string (parent request ID for nested tool calls from executeCode)
 	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
@@ -287,13 +287,13 @@ const (
 	BifrostContextKeyMCPCallbackBaseURL                  BifrostContextKey = "bifrost-mcp-callback-base-url"                    // string (base URL like "https://host" — set by HTTP middleware. OAuth resolver appends /api/oauth/callback; headers resolver appends the workspace submit path. Used for both per-user OAuth and per-user headers auth flows)
 	BifrostContextKeyIsMCPGateway                        BifrostContextKey = "bifrost-is-mcp-gateway"                           // bool (true when request is being handled via the MCP gateway path)
 	BifrostContextKeyHasEmittedMessageDelta              BifrostContextKey = "bifrost-has-emitted-message-delta"                // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
-	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyGovernancePluginName                BifrostContextKey = "governance-plugin-name"                           // string (name of the governance plugin that processed the request - set by bifrost)
 	BifrostContextKeyClusterNodeID                       BifrostContextKey = "bifrost-cluster-node-id"                          // string (cluster node ID for log attribution - set by enterprise server)
 	BifrostContextKeyGovernanceBudgetIDs                 BifrostContextKey = "bifrost-governance-budget-ids"                    // []string (budget IDs applicable to this request - set by governance plugin)
 	BifrostContextKeyGovernanceRateLimitIDs              BifrostContextKey = "bifrost-governance-rate-limit-ids"                // []string (rate limit IDs applicable to this request - set by governance plugin)
 	BifrostContextKeyPromptsPluginName                   BifrostContextKey = "prompts-plugin-name"                              // string (name of the prompts plugin to use - set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by internal bifrost components - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyStoreRawRequestResponse             BifrostContextKey = "bifrost-store-raw-request-response"               // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeyCaptureRawRequest                   BifrostContextKey = "bifrost-capture-raw-request"                      // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when providers should capture raw request bytes
@@ -301,9 +301,10 @@ const (
 	BifrostContextKeyDropRawRequestFromClient            BifrostContextKey = "bifrost-drop-raw-request-from-client"             // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request should be stripped from the client-facing response
 	BifrostContextKeyDropRawResponseFromClient           BifrostContextKey = "bifrost-drop-raw-response-from-client"            // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw response should be stripped from the client-facing response
 	BifrostContextKeyShouldStoreRawInLogs                BifrostContextKey = "bifrost-should-store-raw-in-logs"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request/response should be persisted in log records
-	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyHTTPRoute                           BifrostContextKey = "bifrost-http-route"                               // string (set by bifrost - DO NOT SET THIS MANUALLY — matched route template, set by HTTP transport; used as the low-cardinality metrics `path` label)
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
 	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries

--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -417,9 +417,8 @@ type ObservabilityPlugin interface {
 	// The context passed is a fresh background context, not the request context.
 	//
 	// Retention: implementations MUST NOT retain the *Trace pointer after Inject
-	// returns. The caller releases the trace back to a sync.Pool immediately after
-	// Inject completes, so any background goroutine that still references it will
-	// race with pool reuse. If a plugin needs to forward the trace asynchronously,
-	// it must copy the data it needs before returning.
+	// returns. The caller releases the underlying trace back to a sync.Pool
+	// immediately after Inject completes. If a plugin needs to forward the trace
+	// asynchronously, it must copy the data it needs before returning.
 	Inject(ctx context.Context, trace *Trace) error
 }

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -2,6 +2,7 @@
 package schemas
 
 import (
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -138,6 +139,60 @@ func (t *Trace) GetAttribute(key string) (any, bool) {
 	return value, ok
 }
 
+// SnapshotForExport returns a copy of the trace that is safe for concurrent
+// read-only use by observability exporters (Datadog, OTEL, ...) while the
+// original trace's spans may still be mutated.
+//
+// Trace- and span-level attribute maps are cloned under their respective locks,
+// so an exporter iterating the returned maps can never race a late writer — e.g.
+// streaming span finalization (completeDeferredSpan) or redaction replacement —
+// that legitimately holds the span lock. Without this, an exporter iterating the
+// live span.Attributes map (which cannot take the unexported span lock) triggers
+// a fatal "concurrent map iteration and map write" that recover() cannot catch.
+//
+// Span pointer identity is preserved *within* the returned trace: RootSpan and
+// the entries of Spans refer to the same copied *Span values, so pointer-equality
+// checks (e.g. span == finalAttempt) still work against the snapshot's own spans.
+// Attribute values are copied by reference and must be treated as read-only.
+func (t *Trace) SnapshotForExport() *Trace {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	clone := &Trace{
+		RequestID:      t.RequestID,
+		TraceID:        t.TraceID,
+		ParentID:       t.ParentID,
+		StartTime:      t.StartTime,
+		EndTime:        t.EndTime,
+		Attributes:     maps.Clone(t.Attributes),
+		RequestHeaders: maps.Clone(t.RequestHeaders),
+		PluginLogs:     append([]PluginLogEntry(nil), t.PluginLogs...),
+	}
+	spans := append([]*Span(nil), t.Spans...)
+	rootSpan := t.RootSpan
+	t.mu.Unlock()
+
+	spanCopies := make(map[*Span]*Span, len(spans))
+	clone.Spans = make([]*Span, 0, len(spans))
+	for _, span := range spans {
+		if span == nil {
+			continue
+		}
+		cp := span.snapshotForExport()
+		spanCopies[span] = cp
+		clone.Spans = append(clone.Spans, cp)
+	}
+	if rootSpan != nil {
+		if cp, ok := spanCopies[rootSpan]; ok {
+			clone.RootSpan = cp
+		} else {
+			clone.RootSpan = rootSpan.snapshotForExport()
+		}
+	}
+	return clone
+}
+
 // Reset clears the trace for reuse from pool
 func (t *Trace) Reset() {
 	t.mu.Lock()
@@ -267,6 +322,39 @@ func (s *Span) SetAttribute(key string, value any) {
 	s.Attributes[key] = value
 }
 
+// snapshotForExport returns a copy of the span whose Attributes (and Events)
+// are cloned under the span lock, so observability exporters can read them
+// concurrently while a late writer (streaming finalization, redaction) may still
+// mutate the original span. See Trace.SnapshotForExport. The returned span has a
+// fresh zero-value mutex and its attribute values are copied by reference.
+func (s *Span) snapshotForExport() *Span {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := &Span{
+		SpanID:     s.SpanID,
+		ParentID:   s.ParentID,
+		TraceID:    s.TraceID,
+		Name:       s.Name,
+		Kind:       s.Kind,
+		StartTime:  s.StartTime,
+		EndTime:    s.EndTime,
+		Status:     s.Status,
+		StatusMsg:  s.StatusMsg,
+		Attributes: maps.Clone(s.Attributes),
+	}
+	if len(s.Events) > 0 {
+		cp.Events = make([]SpanEvent, len(s.Events))
+		for i := range s.Events {
+			cp.Events[i] = SpanEvent{
+				Name:       s.Events[i].Name,
+				Timestamp:  s.Events[i].Timestamp,
+				Attributes: maps.Clone(s.Events[i].Attributes),
+			}
+		}
+	}
+	return cp
+}
+
 // AddEvent adds an event to the span in a thread-safe manner
 func (s *Span) AddEvent(event SpanEvent) {
 	s.mu.Lock()
@@ -283,8 +371,12 @@ func (s *Span) End(status SpanStatus, statusMsg string) {
 	s.StatusMsg = statusMsg
 }
 
-// Reset clears the span for reuse from pool
+// Reset clears the span for reuse from pool. It holds s.mu — like every other
+// Span mutator — so a straggling writer (e.g. streaming finalization) that races
+// pool release can't trigger a fatal concurrent map access on s.Attributes.
 func (s *Span) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.SpanID = ""
 	s.ParentID = ""
 	s.TraceID = ""

--- a/core/schemas/trace_snapshot_test.go
+++ b/core/schemas/trace_snapshot_test.go
@@ -1,0 +1,99 @@
+package schemas
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSnapshotForExport_ConcurrentWriter reproduces the crash observed by the
+// Datadog/OTEL exporters: an exporter iterating a span's live Attributes map
+// while a late writer (streaming finalization, redaction) mutates it via the
+// span lock triggers a fatal "concurrent map iteration and map write".
+//
+// SnapshotForExport must clone the maps under the span/trace locks so the
+// returned trace can be read freely while the original keeps being written.
+// Run with -race; without the snapshot, iterating trace.Spans[i].Attributes in
+// the reader goroutine below would fatal.
+func TestSnapshotForExport_ConcurrentWriter(t *testing.T) {
+	trace := &Trace{
+		TraceID:    "t1",
+		Attributes: map[string]any{"trace.k": "v"},
+	}
+	root := &Span{SpanID: "root", TraceID: "t1", Kind: SpanKindHTTPRequest}
+	child := &Span{SpanID: "llm", ParentID: "root", TraceID: "t1", Kind: SpanKindLLMCall}
+	root.SetAttribute("seed", "x")
+	child.SetAttribute("seed", "x")
+	trace.RootSpan = root
+	trace.Spans = []*Span{root, child}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: mimics completeDeferredSpan / redaction still mutating the span
+	// attributes (under the span lock) after the trace was handed to exporters.
+	wg.Go(func() {
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				child.SetAttribute("gen_ai.usage.output_tokens", i)
+				root.SetAttribute("http.status_code", i)
+				trace.SetAttribute("trace.k", i)
+				i++
+			}
+		}
+	})
+
+	// Reader: exporters take a snapshot and iterate its maps freely.
+	for range 4 {
+		wg.Go(func() {
+			for range 2000 {
+				snap := trace.SnapshotForExport()
+				for _, s := range snap.Spans {
+					for k, v := range s.Attributes { // must not race the writer
+						_, _ = k, v
+					}
+				}
+				for k, v := range snap.Attributes {
+					_, _ = k, v
+				}
+			}
+		})
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestSnapshotForExport_IsolatedCopy(t *testing.T) {
+	trace := &Trace{TraceID: "t1", Attributes: map[string]any{"a": 1}}
+	root := &Span{SpanID: "root", TraceID: "t1"}
+	root.SetAttribute("k", "v")
+	trace.RootSpan = root
+	trace.Spans = []*Span{root}
+
+	snap := trace.SnapshotForExport()
+
+	// Mutating the original after snapshot must not affect the snapshot.
+	root.SetAttribute("k", "changed")
+	trace.SetAttribute("a", 999)
+
+	if got := snap.Spans[0].Attributes["k"]; got != "v" {
+		t.Fatalf("snapshot span attr leaked mutation: got %v, want v", got)
+	}
+	if got := snap.Attributes["a"]; got != 1 {
+		t.Fatalf("snapshot trace attr leaked mutation: got %v, want 1", got)
+	}
+	// RootSpan identity must be preserved within the snapshot.
+	if snap.RootSpan != snap.Spans[0] {
+		t.Fatalf("snapshot RootSpan must alias its entry in Spans")
+	}
+	// The snapshot must not alias the original span pointers.
+	if snap.Spans[0] == root {
+		t.Fatalf("snapshot must copy spans, not alias the originals")
+	}
+}

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -192,6 +192,10 @@ The following metrics are available from both the `/metrics` endpoint and Push G
 | `http_request_size_bytes` | Histogram | Request body size |
 | `http_response_size_bytes` | Histogram | Response body size |
 
+<Note>
+The `path` label contains the matched route template (e.g. `/genai/v1beta/models/{model:*}`, `/v1/messages/batches/{batch_id}`), not the raw URL path. This keeps metric cardinality bounded by the number of registered routes instead of growing with every model name or resource ID that appears in a URL. For per-model breakdowns, use the `model` and `provider` labels on the `bifrost_*` metrics.
+</Note>
+
 ### Bifrost LLM Metrics
 
 | Metric | Type | Description |

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -693,6 +693,14 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 
 		completedTrace.ApplyRedactionReplacements()
 
+		// Give every connector a private, lock-safe snapshot. Late writers may
+		// still mutate the pooled spans under the span lock (streaming
+		// finalization, redaction), and connectors iterate the attribute maps
+		// (directly or via Marshal) — racing them fatals with "concurrent map
+		// iteration and map write", which recover() can't catch. One snapshot
+		// here covers all connectors.
+		exportTrace := completedTrace.SnapshotForExport()
+
 		var obsPlugins []schemas.ObservabilityPlugin
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			obsPlugins = *loaded
@@ -716,7 +724,7 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 					return
 				}
 				seen[name] = struct{}{}
-				if err := plugin.Inject(context.Background(), completedTrace); err != nil && t.logger != nil {
+				if err := plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
 					t.logger.Warn("observability plugin %s failed to inject trace: %v", name, err)
 				}
 			}(plugin)

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/valyala/fasthttp"
 )
@@ -33,6 +34,11 @@ func getPrometheusLabelValues(expectedLabels []string, headerValues map[string]s
 // Returns a map of all label values
 func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 	path := string(ctx.Path())
+	// Prefer the matched route template over the raw path, whose embedded model names
+	// and resource IDs would explode metric cardinality.
+	if route, ok := ctx.UserValue(string(schemas.BifrostContextKeyHTTPRoute)).(string); ok && route != "" {
+		path = route
+	}
 	method := string(ctx.Method())
 
 	// Initialize with default metrics

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1556,6 +1556,19 @@ func (s *BifrostHTTPServer) GetAllRedactedRoutingRules(ctx context.Context, ids 
 // PrepareCommonMiddlewares gets the common middlewares for the Bifrost HTTP server
 func (s *BifrostHTTPServer) PrepareCommonMiddlewares() []schemas.BifrostHTTPMiddleware {
 	commonMiddlewares := []schemas.BifrostHTTPMiddleware{}
+	// Copy the matched route template saved by the router (SaveMatchedRoutePath) into a
+	// stable, router-agnostic user value so metrics middlewares below can label by route
+	// template instead of the raw URL path.
+	commonMiddlewares = append(commonMiddlewares, func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			if route, ok := ctx.UserValue(router.MatchedRoutePathParam).(string); ok && route != "" {
+				ctx.SetUserValue(string(schemas.BifrostContextKeyHTTPRoute), route)
+				// Drop the router's randomized key so it doesn't leak into request PathParams.
+				ctx.RemoveUserValue(router.MatchedRoutePathParam)
+			}
+			next(ctx)
+		}
+	})
 	// Preparing middlewares
 	// Initializing prometheus plugin
 	prometheusPlugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
@@ -1577,8 +1590,14 @@ func (s *BifrostHTTPServer) PrepareCommonMiddlewares() []schemas.BifrostHTTPMidd
 			if err != nil {
 				return
 			}
+			// Label by the matched route template when available (set by the middleware
+			// above) so path params (model names, batch/file IDs) don't explode cardinality.
+			path := string(ctx.Path())
+			if route, ok := ctx.UserValue(string(schemas.BifrostContextKeyHTTPRoute)).(string); ok && route != "" {
+				path = route
+			}
 			otelPlugin.RecordHTTPMetrics(ctx,
-				string(ctx.Path()),
+				path,
 				string(ctx.Method()),
 				strconv.Itoa(ctx.Response.StatusCode()),
 				time.Since(start).Seconds(),
@@ -1752,6 +1771,9 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	s.Config.SetBifrostClient(s.Client)
 	// Initialize routes
 	s.Router = router.New()
+	// Save the matched route template on each request
+	// so metrics can use it as the `path` label instead of the raw URL path.
+	s.Router.SaveMatchedRoutePath = true
 	// Initialize CORS middleware
 	s.CORSMiddleware = handlers.NewCorsMiddleware(s.Config)
 	commonMiddlewares := s.PrepareCommonMiddlewares()


### PR DESCRIPTION
## Summary

Prometheus and OpenTelemetry HTTP metrics were using the raw URL path as the `path` label, causing metric cardinality to grow unboundedly as model names, batch IDs, file IDs, and other path parameters appeared in URLs. This PR replaces the raw path with the matched route template (e.g. `/v1/messages/batches/{batch_id}`) so cardinality is bounded by the number of registered routes.

## Changes

- Enabled `SaveMatchedRoutePath` on the fasthttp router so the matched route template is captured per request.
- Added a middleware in `PrepareCommonMiddlewares` that copies the router's matched route template into a stable, router-agnostic user value (`BifrostContextKeyHTTPRoute`) and removes the router's internal key to prevent it from leaking into request path params.
- Updated the OpenTelemetry plugin middleware in `server.go` to prefer the route template over the raw path when recording HTTP metrics.
- Updated `collectPrometheusKeyValues` in `plugins/telemetry/utils.go` to prefer the route template over the raw path.
- Added `BifrostContextKeyHTTPRoute` to the bifrost context key schema with documentation.
- Added a note to the Prometheus observability docs explaining that the `path` label reflects the route template, not the raw URL, and directing users to `model`/`provider` labels for per-model breakdowns.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

1. Start the Bifrost HTTP server with Prometheus metrics enabled.
2. Send requests to parameterized routes, e.g. `/v1/messages/batches/batch_abc123` and `/v1/messages/batches/batch_xyz789`.
3. Scrape `/metrics` and confirm both requests are recorded under a single `path="/v1/messages/batches/{batch_id}"` label value rather than two distinct raw paths.
4. Confirm `model` and `provider` labels on `bifrost_*` metrics still reflect per-model detail.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The route template is derived from the router's internal matched path and contains no user-supplied data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable