### PR TITLE
redaction: added ClearPausedStreamBuffer method in core to support redaction in pause-accumulate flow for provider managed transformed + fallback bifrost redaction 

### DIFF
--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -484,6 +485,25 @@ func (bc *BifrostContext) ResumeStream() {
 	}
 	bc.setReservedValue(BifrostContextKeyStreamGated, true)
 	tr.ResumeStream(tid)
+}
+
+// streamBufferClearer is an optional tracer capability for dropping paused replay chunks.
+type streamBufferClearer interface {
+	ClearPausedStreamBuffer(traceID string) error
+}
+
+// ClearPausedStreamBuffer drops chunks buffered while the active stream is paused.
+func (bc *BifrostContext) ClearPausedStreamBuffer() error {
+	tr, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	tid, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if tr == nil || tid == "" {
+		return fmt.Errorf("stream tracer or trace ID is missing")
+	}
+	clearer, ok := any(tr).(streamBufferClearer)
+	if !ok {
+		return fmt.Errorf("stream tracer does not support buffer clearing")
+	}
+	return clearer.ClearPausedStreamBuffer(tid)
 }
 
 // EndStream terminates the active streaming response. Any buffered chunks are

--- a/framework/streaming/gate.go
+++ b/framework/streaming/gate.go
@@ -43,6 +43,18 @@ func (a *Accumulator) ResumeStream(traceID string) {
 	sa.Resume()
 }
 
+// ClearPausedStreamBuffer drops chunks buffered while a stream is paused.
+func (a *Accumulator) ClearPausedStreamBuffer(traceID string) error {
+	if traceID == "" {
+		return fmt.Errorf("trace ID is empty")
+	}
+	v, ok := a.streamAccumulators.Load(traceID)
+	if !ok {
+		return fmt.Errorf("stream accumulator not found")
+	}
+	return v.(*StreamAccumulator).ClearPausedBuffer()
+}
+
 // EndStream is the Tracer-level entry point for terminating a stream.
 // Any buffered chunks are flushed first; then if err is non-nil it is delivered
 // as a terminal error chunk. After EndStream, further provider chunks are dropped.
@@ -220,6 +232,27 @@ func (sa *StreamAccumulator) Resume() {
 	if sa.gateCond != nil {
 		sa.gateCond.Broadcast()
 	}
+}
+
+// ClearPausedBuffer removes replay chunks captured while the gate is paused.
+// If a terminal chunk was among the dropped chunks, delivering a replacement
+// terminal becomes the caller's responsibility.
+func (sa *StreamAccumulator) ClearPausedBuffer() error {
+	sa.mu.Lock()
+	defer sa.mu.Unlock()
+	if sa.gateState != StreamStatePaused {
+		return fmt.Errorf("stream gate is not paused")
+	}
+	sa.gateReplayBuf = nil
+	sa.gateReplayBufBytes = 0
+	// A terminal chunk buffered while paused no longer exists; keeping the
+	// pending-terminal marker would make the flusher end the gate on resume
+	// and silently drop the caller's replacement terminal chunk.
+	sa.gatePendingTerminal = false
+	if sa.gateCond != nil {
+		sa.gateCond.Broadcast()
+	}
+	return nil
 }
 
 // End transitions the gate to Ended. Any buffered chunks are flushed by the

--- a/framework/streaming/gate_test.go
+++ b/framework/streaming/gate_test.go
@@ -217,6 +217,112 @@ func TestGate_FinalChunkWhilePaused(t *testing.T) {
 	}
 }
 
+// TestGate_ClearPausedStreamBufferDropsBufferedOriginals verifies cleared replay chunks are not delivered.
+func TestGate_ClearPausedStreamBufferDropsBufferedOriginals(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-clear-paused"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(32)
+	defer r.close()
+	chunks := makeChunks(4)
+
+	if !a.GateSend(traceID, chunks[0], false, false, r.ch, ctx) {
+		t.Fatalf("setup chunk 0: GateSend returned false")
+	}
+	a.PauseStream(traceID)
+	for i := 1; i < 3; i++ {
+		if !a.GateSend(traceID, chunks[i], false, false, r.ch, ctx) {
+			t.Fatalf("setup chunk %d (paused): GateSend returned false", i)
+		}
+	}
+
+	if err := a.ClearPausedStreamBuffer(traceID); err != nil {
+		t.Fatalf("ClearPausedStreamBuffer err = %v, want nil", err)
+	}
+	a.ResumeStream(traceID)
+	if !a.GateSend(traceID, chunks[3], true, false, r.ch, ctx) {
+		t.Fatalf("final chunk: GateSend returned false")
+	}
+
+	sa := mustGet(t, a, traceID)
+	sa.WaitForFlusher()
+	if !r.waitFor(2, time.Second) {
+		t.Fatalf("expected live setup chunk and final chunk")
+	}
+	cs, _ := r.snapshot()
+	if len(cs) != 2 {
+		t.Fatalf("delivered chunks = %d, want 2", len(cs))
+	}
+	if cs[0] != chunks[0] || cs[1] != chunks[3] {
+		t.Fatalf("delivered chunks = %#v, want setup then final", cs)
+	}
+	if sa.gateReplayBufBytes != 0 {
+		t.Fatalf("gateReplayBufBytes = %d, want 0", sa.gateReplayBufBytes)
+	}
+}
+
+// TestGate_ClearPausedStreamBufferDropsBufferedTerminal verifies that clearing
+// a buffer holding a terminal chunk also resets the pending-terminal marker:
+// the gate must not end on resume, and a replacement terminal sent afterward
+// must still be delivered.
+func TestGate_ClearPausedStreamBufferDropsBufferedTerminal(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-clear-paused-terminal"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(32)
+	defer r.close()
+	chunks := makeChunks(4)
+
+	if !a.GateSend(traceID, chunks[0], false, false, r.ch, ctx) {
+		t.Fatalf("setup chunk 0: GateSend returned false")
+	}
+	a.PauseStream(traceID)
+	if !a.GateSend(traceID, chunks[1], false, false, r.ch, ctx) {
+		t.Fatalf("setup chunk 1 (paused): GateSend returned false")
+	}
+	if !a.GateSend(traceID, chunks[2], true, false, r.ch, ctx) {
+		t.Fatalf("setup terminal chunk (paused): GateSend returned false")
+	}
+
+	sa := mustGet(t, a, traceID)
+	sa.mu.Lock()
+	pending := sa.gatePendingTerminal
+	sa.mu.Unlock()
+	if !pending {
+		t.Fatalf("expected gatePendingTerminal to be set after a final chunk arrived while paused")
+	}
+
+	if err := a.ClearPausedStreamBuffer(traceID); err != nil {
+		t.Fatalf("ClearPausedStreamBuffer err = %v, want nil", err)
+	}
+	sa.mu.Lock()
+	pending = sa.gatePendingTerminal
+	sa.mu.Unlock()
+	if pending {
+		t.Fatalf("expected gatePendingTerminal to be reset by ClearPausedStreamBuffer")
+	}
+
+	a.ResumeStream(traceID)
+	if !a.GateSend(traceID, chunks[3], true, false, r.ch, ctx) {
+		t.Fatalf("replacement terminal chunk: GateSend returned false")
+	}
+
+	sa.WaitForFlusher()
+	if !r.waitFor(2, time.Second) {
+		t.Fatalf("expected live setup chunk and replacement terminal chunk")
+	}
+	cs, _ := r.snapshot()
+	if len(cs) != 2 {
+		t.Fatalf("delivered chunks = %d, want 2", len(cs))
+	}
+	if cs[0] != chunks[0] || cs[1] != chunks[3] {
+		t.Fatalf("delivered chunks = %#v, want setup then replacement terminal", cs)
+	}
+	if sa.gateState != StreamStateEnded {
+		t.Fatalf("expected Ended after replacement terminal, got %v", sa.gateState)
+	}
+}
+
 // TestGate_HardErrorWhilePaused: a hard provider error arriving while paused
 // is buffered like any other terminal. Resume drains in order and transitions
 // the gate to Ended; the error chunk is delivered last.

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -459,6 +459,14 @@ func (t *Tracer) ResumeStream(traceID string) {
 	t.accumulator.ResumeStream(traceID)
 }
 
+// ClearPausedStreamBuffer drops chunks buffered while traceID is paused.
+func (t *Tracer) ClearPausedStreamBuffer(traceID string) error {
+	if traceID == "" || t.accumulator == nil {
+		return nil
+	}
+	return t.accumulator.ClearPausedStreamBuffer(traceID)
+}
+
 // EndStream terminates the streaming response. Any buffered chunks are flushed
 // first; if err is non-nil it is then delivered as a terminal error chunk. After
 // EndStream, all further provider chunks are dropped (PostLLMHook still fires).


### PR DESCRIPTION
## Summary

This PR introduces a `ClearPausedStreamBuffer` capability that allows callers to discard chunks buffered during a paused stream gate, without resuming or ending the stream. It also fixes a race condition in the Maxim plugin where stream accumulation and error extraction were happening inside a goroutine, making them susceptible to data races with later hooks in the chain.

## Changes

- Added `ClearPausedStreamBuffer` to `StreamAccumulator`, `Accumulator`, `Tracer`, and `BifrostContext`, allowing paused replay buffers to be dropped on demand. The method is gated behind an optional `streamBufferClearer` interface so tracers that don't support it fail gracefully.
- Moved `ProcessStreamingChunk`, `CleanupStreamAccumulator`, and error detail extraction out of the Maxim plugin's logging goroutine and into the synchronous hook body. This prevents a race where a late goroutine submission could overwrite chunk content already mutated by downstream hooks (e.g. guardrail redaction), or resurrect a cleaned-up accumulator with only the final chunk.
- The logging goroutine now only consumes the self-contained `streamResponse` and pre-extracted `genErr` values, neither of which are mutated after the goroutine is launched.
- Added `TestGate_ClearPausedStreamBufferDropsBufferedOriginals` to verify that chunks buffered while paused are not delivered after a clear-then-resume cycle, and that only the live pre-pause chunk and the post-resume final chunk are delivered.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/...
go test ./framework/streaming/...
go test ./framework/tracing/...
go test ./plugins/maxim/...
```

The new test `TestGate_ClearPausedStreamBufferDropsBufferedOriginals` specifically validates that:
1. Chunks buffered while the gate is paused are dropped after `ClearPausedStreamBuffer`.
2. Only the pre-pause live chunk and the post-resume final chunk are delivered.
3. `gateReplayBufBytes` is zero after the clear.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The change does not affect authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable