### PR TITLE
edge documentation

### DIFF
--- a/docs/changelogs/edge-v0.1.0.mdx
+++ b/docs/changelogs/edge-v0.1.0.mdx
@@ -1,0 +1,13 @@
+---
+title: "v0.1.0"
+description: "v0.1.0 changelog - 2026-07-08"
+---
+
+<Update label="v0.1.0">
+🎉 First release
+
+- feat: adds support for ChatGPT and Claude website
+- feat: adds support for Claude Code, Codex CLI, opencode
+- feat: adds support for Claude desktop app, Codex desktop app, Conductor desktop app
+
+</Update>

--- a/docs/changelogs/edge-v0.2.0.mdx
+++ b/docs/changelogs/edge-v0.2.0.mdx
@@ -1,0 +1,11 @@
+---
+title: "v0.2.0"
+description: "v0.2.0 changelog - 2026-07-08"
+---
+
+<Update label="v0.2.0">
+- feat: improves binary version detection
+- feat: adds process harness to accurately detect spawned children by any process/harness
+- feat: reduced the edge overhead from &lt;5 ms to &lt;300 microseconds all the time
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -953,6 +953,14 @@
             ]
           },
           {
+            "item": "Edge",
+            "icon": "grip",
+            "pages": [
+              "changelogs/edge-v0.2.0",
+              "changelogs/edge-v0.1.0"
+            ]
+          },
+          {
             "item": "Bifrost CLI",
             "icon": "laptop-code",
             "pages": [


### PR DESCRIPTION
## Summary

Adds changelog documentation for the first two Edge releases (v0.1.0 and v0.2.0) and registers them in the docs navigation under a new "Edge" changelog section.

## Changes

- Added `edge-v0.1.0.mdx` documenting the first Edge release, including support for ChatGPT and Claude websites, Claude Code/Codex CLI/opencode, and Claude/Codex/Conductor desktop apps
- Added `edge-v0.2.0.mdx` documenting improvements to binary version detection, a process harness for accurately detecting spawned child processes, and a reduction in Edge overhead from <5ms to <300 microseconds
- Registered both changelogs in `docs.json` under a new "Edge" navigation group within the July 2026 section

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the docs site and verify the new "Edge" changelog section appears under the changelogs navigation with both v0.1.0 and v0.2.0 entries rendering correctly under "July 2026".

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable