### PR TITLE
fix(ui): correct MCP tool execution timeout placeholder

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -97,6 +97,7 @@ export default function MCPClientSheet({
 
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const globalToolSyncInterval = bifrostConfig?.client_config?.mcp_tool_sync_interval ?? 10;
+	const globalToolExecutionTimeout = bifrostConfig?.client_config?.mcp_tool_execution_timeout ?? 30;
 	const { toast } = useToast();
 	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
@@ -824,7 +825,7 @@ export default function MCPClientSheet({
 														<Input
 															type="number"
 															className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
-															placeholder="0"
+															placeholder={String(globalToolExecutionTimeout)}
 															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
 															onChange={(e) => {
 																if (e.target.value === "") {


### PR DESCRIPTION
Fixes #5027

## Summary
Small fix: the Tool Execution Timeout field placeholder in the MCP client edit sheet was hardcoded to `0` instead of showing the real global default (`30`), unlike the sibling Tool Sync Interval field which already reflects the fetched global value.

## Changes
- `ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx`: added `globalToolExecutionTimeout` derived from `bifrostConfig.client_config.mcp_tool_execution_timeout` (fallback `30`) and used it as the input placeholder instead of the hardcoded `"0"`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Affected areas
- UI (React) — MCP client edit sheet

## How to test
1. Open the edit sheet for an MCP client with no per-client Tool Execution Timeout set.
2. Confirm the placeholder now shows the real global default (`30` by default, or the configured `mcp_tool_execution_timeout` value) instead of `0`.

## Screenshots
N/A — placeholder text change only.

## Breaking changes
None.

## Security considerations
None — display-only change.

## Checklist
- [x] Verified locally (`tsc --noEmit` passes for the changed file)
- [x] No unrelated changes