### PR TITLE
fix: skip disabled keys when scheduling model-discovery fetches

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -713,6 +713,12 @@ func (s *BifrostHTTPServer) OnKeyAdded(ctx context.Context, provider schemas.Mod
 	if isKeylessProvider(provider, s.Config) {
 		keyID = ""
 	}
+	// Skip the fetch for a disabled key — core rejects list-models calls
+	// scoped to a disabled key's ID, so it would just fail and fall back
+	// onto the (usually empty, for custom providers) static datasheet.
+	if !keyEnabled(key) {
+		return nil
+	}
 	s.FetchAndStoreLiveForKey(ctx, provider, keyID)
 	return nil
 }
@@ -734,6 +740,11 @@ func (s *BifrostHTTPServer) OnKeyUpdated(ctx context.Context, provider schemas.M
 		keyID = ""
 	}
 	s.Config.ModelCatalog.InvalidateLive(provider, keyID)
+	// Skip the fetch for a disabled key — the invalidate above still clears
+	// its stale cached entries, but re-fetching would just fail against core.
+	if !keyEnabled(key) {
+		return nil
+	}
 	s.FetchAndStoreLiveForKey(ctx, provider, keyID)
 	return nil
 }
@@ -752,6 +763,16 @@ func (s *BifrostHTTPServer) OnKeyDeleted(ctx context.Context, provider schemas.M
 	s.Config.ModelCatalog.SetKeyConfigForProvider(provider, keys)
 	s.Config.ModelCatalog.InvalidateLive(provider, keyID)
 	return nil
+}
+
+// keyEnabled reports whether a key should be treated as active for
+// scheduling model-discovery fetches. Enabled defaults to true when nil,
+// matching the convention core.getAllSupportedKeys uses to filter keys for
+// ListModels requests — a key discovery schedules a fetch for must be one
+// core will actually accept, or the call is a guaranteed
+// "no key found with id..." failure.
+func keyEnabled(key schemas.Key) bool {
+	return key.Enabled == nil || *key.Enabled
 }
 
 // isKeylessProvider returns true when the provider's config marks it
@@ -973,12 +994,25 @@ func (s *BifrostHTTPServer) RefreshLiveModelsForProvider(ctx context.Context, pr
 		return
 	}
 	var wg sync.WaitGroup
+	enabledCount := 0
 	for _, key := range keys {
+		// Skip disabled keys — core rejects list-models calls scoped to a
+		// disabled key's ID ("no key found with id..."), so fetching for one
+		// is guaranteed to fail and only adds "falling back onto the static
+		// datasheet" log noise per disabled key.
+		if !keyEnabled(key) {
+			continue
+		}
+		enabledCount++
 		wg.Add(1)
 		go func(keyID string) {
 			defer wg.Done()
 			s.FetchAndStoreLiveForKey(ctx, provider, keyID)
 		}(key.ID)
+	}
+	if enabledCount == 0 {
+		logger.Warn("model discovery skipped for provider %s: no enabled keys configured", provider)
+		return
 	}
 	wg.Wait()
 }

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
@@ -121,6 +122,122 @@ func TestUpdateKeyStatus_EmptyKeyIDDoesNotOverwriteKeyedProviderStatus(t *testin
 	}
 	if store.calls[0].Provider != "openai" || store.calls[0].KeyID != "" {
 		t.Fatalf("expected DB status update to retain empty key ID, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
+	}
+}
+
+func TestKeyEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		key  schemas.Key
+		want bool
+	}{
+		{"nil Enabled defaults to enabled", schemas.Key{}, true},
+		{"explicit true is enabled", schemas.Key{Enabled: schemas.Ptr(true)}, true},
+		{"explicit false is disabled", schemas.Key{Enabled: schemas.Ptr(false)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keyEnabled(tt.key); got != tt.want {
+				t.Fatalf("keyEnabled(%+v) = %v, want %v", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRefreshLiveModelsForProvider_AllKeysDisabled cross-checks the "0
+// enabled keys" case for issue #5037: discovery must skip scheduling any
+// fetch (and therefore never touch s.Client, left nil here) rather than
+// attempting doomed-to-fail per-key calls.
+func TestRefreshLiveModelsForProvider_AllKeysDisabled(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalog(nil),
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"custom-provider": {},
+			},
+		},
+	}
+
+	keys := []schemas.Key{
+		{ID: "key-1", Enabled: schemas.Ptr(false)},
+		{ID: "key-2", Enabled: schemas.Ptr(false)},
+	}
+
+	// Must return without panicking: s.Client is nil, so any scheduled fetch
+	// would panic on the first ListModelsRequest call. Reaching the end of
+	// this test proves no fetch was scheduled for either disabled key.
+	server.RefreshLiveModelsForProvider(context.Background(), "custom-provider", keys)
+
+	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) != 0 {
+		t.Fatalf("expected no live models to be written when all keys are disabled, got %v", models)
+	}
+}
+
+// TestOnKeyAdded_DisabledKeySkipsFetch cross-checks that adding a key that
+// is already disabled never schedules a discovery fetch for it.
+func TestOnKeyAdded_DisabledKeySkipsFetch(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	disabledKey := schemas.Key{ID: "key-1", Enabled: schemas.Ptr(false)}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalog(nil),
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"custom-provider": {Keys: []schemas.Key{disabledKey}},
+			},
+		},
+	}
+
+	// s.Client is left nil: if the disabled-key guard regresses, the fetch
+	// goroutine would dereference it and panic, failing this test.
+	if err := server.OnKeyAdded(context.Background(), "custom-provider", disabledKey); err != nil {
+		t.Fatalf("OnKeyAdded returned unexpected error: %v", err)
+	}
+
+	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) != 0 {
+		t.Fatalf("expected no live models to be written for a disabled key, got %v", models)
+	}
+}
+
+// TestOnKeyUpdated_DisabledKeySkipsFetchButInvalidatesCache cross-checks
+// that toggling a key to disabled still evicts its stale cached models
+// (InvalidateLive) even though the refetch is correctly skipped.
+func TestOnKeyUpdated_DisabledKeySkipsFetchButInvalidatesCache(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("custom-provider", "key-1", false, []string{"custom-provider/some-model"})
+
+	disabledKey := schemas.Key{ID: "key-1", Enabled: schemas.Ptr(false)}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ModelCatalog: catalog,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"custom-provider": {Keys: []schemas.Key{disabledKey}},
+			},
+		},
+	}
+
+	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) == 0 {
+		t.Fatalf("expected seeded live model before update, got none")
+	}
+
+	// s.Client is left nil: if the disabled-key guard regresses, the fetch
+	// goroutine would dereference it and panic, failing this test.
+	if err := server.OnKeyUpdated(context.Background(), "custom-provider", disabledKey); err != nil {
+		t.Fatalf("OnKeyUpdated returned unexpected error: %v", err)
+	}
+
+	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) != 0 {
+		t.Fatalf("expected InvalidateLive to drop the disabled key's cached models, got %v", models)
 	}
 }
 


### PR DESCRIPTION
## Summary

Model-discovery scheduled a `list-models` fetch for every key on a provider, including disabled ones. Core already rejects disabled keys, so those fetches always failed and logged a misleading "falling back onto the static datasheet" warning per disabled key.

## Changes

- Added a `keyEnabled(key)` helper matching core's existing nil-means-enabled convention.
- Skip disabled keys in `RefreshLiveModelsForProvider`, `OnKeyAdded`, and `OnKeyUpdated` before scheduling a fetch.
- `OnKeyUpdated` still invalidates the stale cache for a key that becomes disabled; it just skips the doomed refetch.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/server/...
```

New tests cover:
- All keys on a provider disabled → no fetch scheduled, no live models written (the "0 enabled keys" case from the bug report).
- A newly added disabled key → fetch skipped.
- An updated key that becomes disabled → stale cache is still invalidated, but the refetch is skipped.

Manually verified the tests catch the regression: temporarily removing the new guards causes a nil-pointer panic (fetch reaching `s.Client` when it shouldn't), confirming the tests aren't vacuous.

## Breaking changes

- [x] No

## Related issues

Closes #5037

## Security considerations

None — this only changes which already-authorized provider keys are used for internal model-discovery scheduling; no new data exposure or auth surface.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable