### PR TITLE
fix: send mime type when specified

### DIFF
--- a/core/providers/gemini/filedata_mime_test.go
+++ b/core/providers/gemini/filedata_mime_test.go
@@ -1,0 +1,125 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for the fileData MIME-injection bug.
+//
+// Bifrost used to default a referenced file's MIME to "application/pdf" whenever the
+// caller's fileData carried no mimeType. That wrong type propagated to the outgoing
+// generateContent request, so a PNG/CSV got sent to Gemini labeled as a PDF and Gemini
+// rejected it with 400 INVALID_ARGUMENT. The MIME must be preserved verbatim — omitted
+// when the caller didn't provide one — so Gemini uses the file's stored type.
+
+const testFileURI = "https://generativelanguage.googleapis.com/v1beta/files/abc"
+
+func sptr(s string) *string { return &s }
+
+// Incoming (Gemini -> Bifrost): no MIME must NOT be fabricated.
+func TestConvertGeminiFileDataToContentBlock_DoesNotFabricateMime(t *testing.T) {
+	// No MIME provided -> FileType stays nil (was wrongly defaulted to application/pdf).
+	block := convertGeminiFileDataToContentBlock(&FileData{FileURI: testFileURI})
+	require.NotNil(t, block)
+	require.NotNil(t, block.ResponsesInputMessageContentBlockFile)
+	assert.Nil(t, block.ResponsesInputMessageContentBlockFile.FileType,
+		"MIME must not be fabricated when the caller did not provide one")
+
+	// Explicit non-image MIME -> preserved.
+	csv := convertGeminiFileDataToContentBlock(&FileData{FileURI: testFileURI, MIMEType: "text/csv"})
+	require.NotNil(t, csv.ResponsesInputMessageContentBlockFile)
+	require.NotNil(t, csv.ResponsesInputMessageContentBlockFile.FileType)
+	assert.Equal(t, "text/csv", *csv.ResponsesInputMessageContentBlockFile.FileType)
+
+	// Image MIME -> routed to an image block.
+	img := convertGeminiFileDataToContentBlock(&FileData{FileURI: testFileURI, MIMEType: "image/png"})
+	require.NotNil(t, img)
+	assert.Equal(t, schemas.ResponsesInputMessageContentBlockTypeImage, img.Type)
+}
+
+// Outgoing (Bifrost -> Gemini), Responses path: omit MIME when FileType is unset.
+func TestConvertContentBlockToGeminiPart_OmitsMimeWhenUnset(t *testing.T) {
+	part, err := convertContentBlockToGeminiPart(schemas.ResponsesMessageContentBlock{
+		Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+		ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+			FileURL: sptr(testFileURI),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, part)
+	require.NotNil(t, part.FileData)
+	assert.Empty(t, part.FileData.MIMEType, "MIME must be omitted when FileType is unset")
+	assert.Equal(t, testFileURI, part.FileData.FileURI)
+
+	// FileType provided -> preserved.
+	part2, err := convertContentBlockToGeminiPart(schemas.ResponsesMessageContentBlock{
+		Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+		ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+			FileURL:  sptr(testFileURI),
+			FileType: sptr("text/csv"),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, part2.FileData)
+	assert.Equal(t, "text/csv", part2.FileData.MIMEType)
+}
+
+// Outgoing (Bifrost -> Gemini), Chat path: omit MIME when FileType is unset.
+func TestConvertBifrostMessagesToGemini_OmitsFileMimeWhenUnset(t *testing.T) {
+	msgs := []schemas.ChatMessage{{
+		Role: schemas.ChatMessageRoleUser,
+		Content: &schemas.ChatMessageContent{
+			ContentBlocks: []schemas.ChatContentBlock{{
+				Type: schemas.ChatContentBlockTypeFile,
+				File: &schemas.ChatInputFile{FileURL: sptr(testFileURI)},
+			}},
+		},
+	}}
+	contents, _, err := convertBifrostMessagesToGemini(msgs)
+	require.NoError(t, err)
+	require.Len(t, contents, 1)
+	require.Len(t, contents[0].Parts, 1)
+	require.NotNil(t, contents[0].Parts[0].FileData)
+	assert.Empty(t, contents[0].Parts[0].FileData.MIMEType, "MIME must be omitted when FileType is unset")
+}
+
+// End-to-end: a generateContent request whose fileData has no MIME must round-trip
+// (Gemini -> Bifrost -> Gemini) without a MIME being injected. This is the exact path
+// that produced the INVALID_ARGUMENT.
+func TestGenerateContentRoundTrip_NoMimeInjectionForFileData(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	in := &GeminiGenerationRequest{
+		Model: "gemini-2.5-flash",
+		Contents: []Content{{
+			Role: "user",
+			Parts: []*Part{
+				{Text: "What is in this file?"},
+				{FileData: &FileData{FileURI: testFileURI}},
+			},
+		}},
+	}
+
+	bifrostReq := in.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+
+	out, err := ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	var found *FileData
+	for _, c := range out.Contents {
+		for _, p := range c.Parts {
+			if p.FileData != nil {
+				found = p.FileData
+			}
+		}
+	}
+	require.NotNil(t, found, "outgoing request must contain a fileData part")
+	assert.Equal(t, testFileURI, found.FileURI)
+	assert.Empty(t, found.MIMEType, "no MIME should be injected when the caller didn't provide one")
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2281,10 +2281,10 @@ func convertGeminiFileDataToContentBlock(fileData *FileData) *schemas.ResponsesM
 		return nil
 	}
 
+	// Preserve the caller's MIME as-is; do NOT fabricate a default. A wrong default
+	// (application/pdf) on a non-PDF file propagates to the outgoing request and makes
+	// Gemini reject it with INVALID_ARGUMENT. An empty MIME lets Gemini use the stored type.
 	mimeType := fileData.MIMEType
-	if mimeType == "" {
-		mimeType = "application/pdf"
-	}
 
 	// Handle images
 	if isImageMimeType(mimeType) {
@@ -2304,8 +2304,10 @@ func convertGeminiFileDataToContentBlock(fileData *FileData) *schemas.ResponsesM
 		},
 	}
 
-	// Set FileType if available
-	block.ResponsesInputMessageContentBlockFile.FileType = &mimeType
+	// Only carry a MIME type when the caller actually provided one.
+	if mimeType != "" {
+		block.ResponsesInputMessageContentBlockFile.FileType = &mimeType
+	}
 
 	return block
 }
@@ -3525,19 +3527,12 @@ func convertContentBlockToGeminiPart(block schemas.ResponsesMessageContentBlock,
 
 			// Handle FileURL (URI-based file)
 			if fileBlock.FileURL != nil {
-				mimeType := "application/pdf"
+				// Only set MIMEType when the caller provided one
+				fileData := &FileData{FileURI: *fileBlock.FileURL}
 				if fileBlock.FileType != nil {
-					mimeType = *fileBlock.FileType
+					fileData.MIMEType = *fileBlock.FileType
 				}
-
-				part := &Part{
-					FileData: &FileData{
-						MIMEType: mimeType,
-						FileURI:  *fileBlock.FileURL,
-					},
-				}
-
-				return part, nil
+				return &Part{FileData: fileData}, nil
 			}
 
 			// Handle FileData (inline file data)

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1981,16 +1981,12 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage, allowedImage
 					} else if block.File != nil {
 						// Handle file blocks - use FileURL if available (uploaded file)
 						if block.File.FileURL != nil && *block.File.FileURL != "" {
-							mimeType := "application/pdf"
+							// Only set MIMEType when the caller actually provided one
+							fileData := &FileData{FileURI: *block.File.FileURL}
 							if block.File.FileType != nil {
-								mimeType = *block.File.FileType
+								fileData.MIMEType = *block.File.FileType
 							}
-							parts = append(parts, &Part{
-								FileData: &FileData{
-									FileURI:  *block.File.FileURL,
-									MIMEType: mimeType,
-								},
-							})
+							parts = append(parts, &Part{FileData: fileData})
 						} else if block.File.FileData != nil {
 							// Inline file data - convert to InlineData (Blob)
 							fileData := *block.File.FileData


### PR DESCRIPTION
## Summary

Fixes a bug where Bifrost was defaulting a file's MIME type to `application/pdf` whenever the caller did not explicitly provide one. This fabricated MIME type propagated to outgoing `generateContent` requests, causing Gemini to reject non-PDF files (e.g., PNGs, CSVs) with `400 INVALID_ARGUMENT`. The fix preserves the caller's MIME type verbatim and omits it entirely when not provided, allowing Gemini to use the file's stored type.

## Changes

- Removed the `application/pdf` fallback default in `convertGeminiFileDataToContentBlock`, `convertContentBlockToGeminiPart`, and `convertBifrostMessagesToGemini` — MIME is now only set when the caller explicitly provides one.
- `convertGeminiFileDataToContentBlock` no longer sets `FileType` on the returned block unless a non-empty MIME was present in the incoming `FileData`.
- Added regression tests covering the incoming (Gemini → Bifrost), outgoing Responses path (Bifrost → Gemini), outgoing Chat path, and a full round-trip to confirm no MIME injection occurs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/... -run "TestConvertGeminiFileDataToContentBlock_DoesNotFabricateMime|TestConvertContentBlockToGeminiPart_OmitsMimeWhenUnset|TestConvertBifrostMessagesToGemini_OmitsFileMimeWhenUnset|TestGenerateContentRoundTrip_NoMimeInjectionForFileData" -v
```

To validate end-to-end, send a request referencing a non-PDF file (e.g., a PNG or CSV) via a Gemini `generateContent` call without specifying a MIME type. The request should succeed rather than returning `400 INVALID_ARGUMENT`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable