### PR TITLE
compilation fixes

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -274,10 +274,9 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_recreate_filter_customers_matview_multivalue"}, run: migrationRecreateFilterCustomersMatView},
 	{IDs: []string{"logs_add_canonical_model_columns_v2"}, run: migrationAddCanonicalModelColumns},
 	{IDs: []string{"logs_add_redaction_mapping_column"}, run: migrationAddRedactionMappingColumn},
-	{IDs: []string{"logs_recreate_matviews_with_user_agent_column"}, run: migrationRecreateMatViewsWithUserAgentColumn},
 	{IDs: []string{"logs_add_user_agent_column"}, run: migrationAddUserAgentColumn},
 	{IDs: []string{"mcp_tool_logs_add_user_agent_column"}, run: migrationAddUserAgentColumnToMCPToolLogs},
-	{IDs: []string{"logs_recreate_matviews_with_app_column"}, run: migrationRecreateMatViewsWithAppColumn},
+	{IDs: []string{"logs_recreate_matviews_with_app_column"}, run: migrationRecreateMatViewsWithUserAgentColumn},
 	{IDs: []string{"mcp_tool_logs_add_endpoint_columns"}, run: migrationAddEndpointColumnsToMCPToolLogs},
 }
 
@@ -3098,7 +3097,7 @@ func migrationAddUserAgentColumnToMCPToolLogs(ctx context.Context, db *gorm.DB, 
 // rolling deploys on large logs tables. The user_agent_mappings table guard
 // also runs here for local DBs that already recorded the edited column migration
 // before the table was added to it.
-func migrationRecreateMatViewsWithAppColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+func migrationRecreateMatViewsWithUserAgentColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
 	opts := *migrator.DefaultOptions
 	opts.UseTransaction = true
 	m := migrator.New(db, &opts, []*migrator.Migration{{


### PR DESCRIPTION
## Summary

Fixes a migration ordering issue where `migrationRecreateMatViewsWithUserAgentColumn` was being skipped and `migrationRecreateMatViewsWithAppColumn` was running in its place. The fix consolidates these into a single migration step that correctly runs the user agent matview recreation logic under the app column migration ID, ensuring existing environments that already recorded the earlier migration ID don't re-run it while still applying the correct function.

## Changes

- Removed the `logs_recreate_matviews_with_user_agent_column` migration step, which was previously a separate entry in the migration list.
- Reused the `logs_recreate_matviews_with_app_column` migration ID but pointed it to `migrationRecreateMatViewsWithUserAgentColumn`, so the correct matview recreation logic runs without introducing a new migration ID that could conflict with already-migrated environments.
- Renamed the underlying function `migrationRecreateMatViewsWithAppColumn` to `migrationRecreateMatViewsWithUserAgentColumn` to accurately reflect what it does.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the migration against a local database and verify that:
1. The `logs_recreate_matviews_with_user_agent_column` migration ID is no longer recorded.
2. The `logs_recreate_matviews_with_app_column` migration runs the user agent matview recreation logic successfully.
3. No duplicate or missing matview columns result from the migration sequence.

```sh
go test ./framework/logstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable