### PR TITLE
fix: preserve citation annotations in the accumulated streaming responses message

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,3 +1,4 @@
+[fix]: fold streamed output_text.annotation.added events into the accumulated responses message so citations survive in logging, observability, and cache (closes #5061) [@fus3r](https://github.com/fus3r)
 [fix]: keep the streaming finish_reason in the accumulated response when a provider forwards it on a content chunk, so logging and plugins record the real stop reason (closes #4963) [@fus3r](https://github.com/fus3r)
 [fix]: sweep orphaned deferred spans in trace store TTL cleanup [@citrocat](https://github.com/citrocat)
 [fix]: rebuild token usage from denormalized columns in hybrid log list [@G-XD](https://github.com/G-XD)

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -662,6 +662,33 @@ func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*Re
 				builderFor(getAccum(idx).cbText, *resp.ContentIndex, block.Text).WriteString(*resp.Delta)
 			}
 
+		case schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded:
+			// Attach a streamed annotation (citation) to its text content block so
+			// the accumulated message keeps the citation provenance that the
+			// non-stream path already preserves on
+			// ResponsesOutputMessageContentText.Annotations. Route by ItemID when
+			// present (parallel/multiple output items), else the most recent message.
+			if resp.Annotation != nil && resp.ContentIndex != nil {
+				idx := len(messages) - 1
+				if resp.ItemID != nil {
+					idx = -1
+					for i := len(messages) - 1; i >= 0; i-- {
+						if messages[i].ID != nil && *messages[i].ID == *resp.ItemID {
+							idx = i
+							break
+						}
+					}
+				}
+				if idx >= 0 {
+					ensureContentBlock(&messages[idx], *resp.ContentIndex, schemas.ResponsesOutputMessageContentTypeText)
+					block := &messages[idx].Content.ContentBlocks[*resp.ContentIndex]
+					if block.ResponsesOutputMessageContentText == nil {
+						block.ResponsesOutputMessageContentText = &schemas.ResponsesOutputMessageContentText{}
+					}
+					block.ResponsesOutputMessageContentText.Annotations = append(block.ResponsesOutputMessageContentText.Annotations, *resp.Annotation)
+				}
+			}
+
 		case schemas.ResponsesStreamResponseTypeRefusalDelta:
 			if len(messages) == 0 {
 				messages = append(messages, createNewMessage())

--- a/framework/streaming/responses_test.go
+++ b/framework/streaming/responses_test.go
@@ -157,6 +157,124 @@ func TestBuildResponsesMessageAccumulatesReasoningSummary(t *testing.T) {
 	}
 }
 
+// TestBuildResponsesMessageAccumulatesAnnotations verifies that streamed
+// output_text.annotation.added events (citations) are folded into the
+// accumulated message. Providers emit these during a streamed responses call
+// (e.g. Anthropic citations_delta -> convertAnthropicCitationToAnnotation) and
+// the non-stream path preserves them on
+// ResponsesOutputMessageContentText.Annotations, so the accumulated message
+// (which feeds logging, observability, and cache) must too.
+func TestBuildResponsesMessageAccumulatesAnnotations(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+	ci := 0
+	itemID := "msg_1"
+	chunks := []*ResponsesStreamChunk{
+		{
+			ChunkIndex: 0,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type: schemas.ResponsesStreamResponseTypeOutputItemAdded,
+				Item: &schemas.ResponsesMessage{ID: schemas.Ptr(itemID)},
+			},
+		},
+		{
+			ChunkIndex: 1,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta:        schemas.Ptr("The capital of France is Paris."),
+				ContentIndex: &ci,
+			},
+		},
+		{
+			ChunkIndex: 2,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
+				ItemID:       schemas.Ptr(itemID),
+				ContentIndex: &ci,
+				Annotation: &schemas.ResponsesOutputMessageContentTextAnnotation{
+					Type:  "url_citation",
+					URL:   schemas.Ptr("https://example.com/paris"),
+					Title: schemas.Ptr("Paris"),
+				},
+			},
+		},
+	}
+
+	msgs := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Content == nil || len(msgs[0].Content.ContentBlocks) == 0 {
+		t.Fatalf("want a content block, got %+v", msgs[0].Content)
+	}
+	block := msgs[0].Content.ContentBlocks[0]
+	// Text delta must still be preserved alongside the annotation.
+	if block.Text == nil || *block.Text != "The capital of France is Paris." {
+		t.Fatalf("text not preserved: %+v", block.Text)
+	}
+	if block.ResponsesOutputMessageContentText == nil {
+		t.Fatal("want ResponsesOutputMessageContentText, got nil")
+	}
+	ann := block.ResponsesOutputMessageContentText.Annotations
+	if len(ann) != 1 {
+		t.Fatalf("want 1 annotation, got %d", len(ann))
+	}
+	if ann[0].Type != "url_citation" || ann[0].URL == nil || *ann[0].URL != "https://example.com/paris" {
+		t.Fatalf("annotation not preserved: %+v", ann[0])
+	}
+
+	// Idempotent under the multi-plugin rebuild (this build runs once per plugin
+	// post-hook): a second build over the same chunks must yield the same single
+	// annotation, not a doubled one.
+	msgs2 := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	if len(msgs2) != 1 || msgs2[0].Content == nil || len(msgs2[0].Content.ContentBlocks) == 0 ||
+		msgs2[0].Content.ContentBlocks[0].ResponsesOutputMessageContentText == nil ||
+		len(msgs2[0].Content.ContentBlocks[0].ResponsesOutputMessageContentText.Annotations) != 1 {
+		t.Fatalf("second build not idempotent: %+v", msgs2)
+	}
+}
+
+// TestBuildResponsesMessageAccumulatesAnnotationsWithoutItemID covers the
+// fallback path used by providers that emit output_text.annotation.added
+// without an ItemID (e.g. Cohere): the annotation attaches to the most recent
+// message, mirroring how text deltas without an ItemID are routed.
+func TestBuildResponsesMessageAccumulatesAnnotationsWithoutItemID(t *testing.T) {
+	acc := testResponsesAccumulator(t)
+	ci := 0
+	chunks := []*ResponsesStreamChunk{
+		{
+			ChunkIndex: 0,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+				Delta:        schemas.Ptr("Grounded answer."),
+				ContentIndex: &ci,
+			},
+		},
+		{
+			ChunkIndex: 1,
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type:         schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
+				ContentIndex: &ci, // no ItemID -> route to the most recent message
+				Annotation: &schemas.ResponsesOutputMessageContentTextAnnotation{
+					Type: "url_citation",
+					URL:  schemas.Ptr("https://example.org/source"),
+				},
+			},
+		},
+	}
+
+	msgs := acc.buildCompleteMessageFromResponsesStreamChunks(chunks)
+	if len(msgs) != 1 || msgs[0].Content == nil || len(msgs[0].Content.ContentBlocks) == 0 {
+		t.Fatalf("unexpected message shape: %+v", msgs)
+	}
+	block := msgs[0].Content.ContentBlocks[0]
+	if block.ResponsesOutputMessageContentText == nil || len(block.ResponsesOutputMessageContentText.Annotations) != 1 {
+		t.Fatalf("want 1 annotation on the last message, got %+v", block.ResponsesOutputMessageContentText)
+	}
+	if got := block.ResponsesOutputMessageContentText.Annotations[0].URL; got == nil || *got != "https://example.org/source" {
+		t.Fatalf("annotation URL not preserved: %+v", got)
+	}
+}
+
 // TestForceCleanupStreamAccumulatorReapsRegardlessOfRefcount is the Tier-1 leak
 // guard: it reproduces a stream that ended without its per-plugin refcount being
 // driven to zero (e.g. a client abort, or multiple plugins that each Create but


### PR DESCRIPTION
## Summary

Fixes #5061. On a streamed `/v1/responses` request, citation annotations are dropped from the message Bifrost accumulates for logging, observability, and cache. The streaming client still receives the `output_text.annotation.added` events on the wire, but the accumulated message (which feeds the logging plugin, the maxim observability plugin, the semantic cache, and any post-hook) has an empty `annotations` array on its text content blocks. The identical non-streamed request keeps them, so only streaming is affected.

Root cause: `buildCompleteMessageFromResponsesStreamChunks` (`framework/streaming/responses.go`) switches over the stream event type but has no case for `output_text.annotation.added`, so annotation events contribute nothing to the accumulated message. Several providers emit these events (Anthropic, Cohere, Gemini, Bedrock); on the Anthropic path each `citations_delta` is converted into one, and the non-streaming path populates the same `ResponsesOutputMessageContentText.Annotations` field from the same converter, which is why the streamed and non-streamed results disagree.

## Changes

- Add an `output_text.annotation.added` case to `buildCompleteMessageFromResponsesStreamChunks` that appends the emitted annotation to its text content block, routing by `ItemID` when present (parallel/multiple output items) and falling back to the most recent message, mirroring the existing delta cases.
- Regression tests: one replaying the Anthropic emission shape (routed by `ItemID`) that also asserts idempotency under the per-plugin rebuild, and one for the no-`ItemID` fallback path that providers like Cohere use. Both fail on `dev`.
- Changelog entry.

Scoped to annotations only. `LogProbs` is the other field this switch never folds, but no provider currently emits real logprobs on the responses stream (every responses-path `LogProbs` is an empty init), so folding it would be dead code.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd framework
go test ./streaming/ -run 'TestBuildResponsesMessageAccumulatesAnnotations' -v
```

`TestBuildResponsesMessageAccumulatesAnnotations` fails on `dev` (`want 1 annotation, got 0`) and passes with this change. The full `./streaming/` package is green, including under the race detector.

Also verified end-to-end against a real Anthropic backend: a streamed `/v1/responses` `web_search` request logs an accumulated message with all its citations preserved with this change (15 `url_citation` annotations), versus 0 on `dev`, while the client SSE stream carries the `output_text.annotation.added` events in both cases.

## Breaking changes

- [ ] Yes
- [x] No

Additive: it only fills in annotations that were previously dropped from the accumulated message. Requests without citations are unchanged.

## Related issues

Fixes #5061

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally if applicable
