### PR TITLE
chore: bump dompurify to 3.4.11

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5916,9 +5916,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.10",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optional": true,
 			"optionalDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -99,7 +99,7 @@
 		"vitest": "4.1.6"
 	},
 	"overrides": {
-		"dompurify": "3.4.10",
+		"dompurify": "3.4.11",
 		"esbuild": "0.28.1",
 		"follow-redirects": "1.16.0",
 		"tar": "7.5.3"


### PR DESCRIPTION
## Summary

Bumps DOMPurify from version 3.4.10 to 3.4.11 to pick up the latest patch release.

## Changes

- Updated the DOMPurify override and lock file entry to 3.4.11

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
npm i
npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

DOMPurify is an HTML sanitization library. Keeping it up to date ensures any security fixes in the latest patch release are applied.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable