### PR TITLE
feat: pass `createdBy` user ID to sidekiq enqueue and add runner ID to job lifecycle methods

### DIFF
--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -1764,7 +1764,8 @@ func (h *LoggingHandler) recalculateLogCosts(ctx *fasthttp.RequestCtx) {
 	}
 
 	jobID := uuid.NewString()
-	if err := h.sidekiqRunner.Enqueue(ctx, jobID, logging.CostRecalcJobKind, metaJSON); err != nil {
+	createdBy, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+	if err := h.sidekiqRunner.Enqueue(ctx, jobID, logging.CostRecalcJobKind, metaJSON, createdBy); err != nil {
 		logger.Error("failed to enqueue recalculate-cost job: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to start recalculation: %v", err))
 		return

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -157,7 +157,7 @@ func TestRecalculateLogCostsResolvesPeriodFilter(t *testing.T) {
 
 	mgr := &dashboardLogManager{}
 	store := newFakeSidekiqStore()
-	runner := sidekiq.New(store, &mockLogger{}, 1)
+	runner := sidekiq.New(store, &mockLogger{}, 1, "")
 	h := &LoggingHandler{logManager: mgr}
 	h.SetSidekiqBackend(runner, store)
 
@@ -201,7 +201,7 @@ func TestRecalculateLogCostsRejectsDuplicateJob(t *testing.T) {
 		Status:   tables.SidekiqStatusRunning,
 		Metadata: "{}",
 	}
-	runner := sidekiq.New(store, &mockLogger{}, 1)
+	runner := sidekiq.New(store, &mockLogger{}, 1, "")
 	h := &LoggingHandler{logManager: mgr}
 	h.SetSidekiqBackend(runner, store)
 
@@ -272,21 +272,23 @@ func (s *fakeSidekiqStore) GetInFlightSidekiqJobByKind(ctx context.Context, kind
 	return nil, nil
 }
 
-func (s *fakeSidekiqStore) MarkSidekiqJobRunning(ctx context.Context, id string) error { return nil }
-func (s *fakeSidekiqStore) UpdateSidekiqJobProgress(ctx context.Context, id, metadata string) error {
+func (s *fakeSidekiqStore) ClaimSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time) (bool, error) {
+	return true, nil
+}
+func (s *fakeSidekiqStore) HeartbeatSidekiqJob(ctx context.Context, id, runnerID string) (bool, error) {
+	return true, nil
+}
+func (s *fakeSidekiqStore) UpdateSidekiqJobProgress(ctx context.Context, id, runnerID, metadata string) error {
 	return nil
 }
-func (s *fakeSidekiqStore) CompleteSidekiqJob(ctx context.Context, id, metadata string) error {
+func (s *fakeSidekiqStore) CompleteSidekiqJob(ctx context.Context, id, runnerID, metadata string) error {
 	return nil
 }
-func (s *fakeSidekiqStore) FailSidekiqJob(ctx context.Context, id, metadata, lastErr string) error {
+func (s *fakeSidekiqStore) FailSidekiqJob(ctx context.Context, id, runnerID, metadata, lastErr string) error {
 	return nil
 }
-func (s *fakeSidekiqStore) ListIncompleteSidekiqJobs(ctx context.Context) ([]tables.TableSidekiqJob, error) {
+func (s *fakeSidekiqStore) ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error) {
 	return nil, nil
-}
-func (s *fakeSidekiqStore) MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error) {
-	return 0, nil
 }
 
 type dashboardLogManager struct {


### PR DESCRIPTION
## Summary

This PR introduces runner identity tracking to the Sidekiq job system. Jobs are now claimed and heartbeated by a specific runner ID, replacing the previous approach of simply marking jobs as running. The cost recalculation endpoint also now captures the requesting user's ID and passes it along when enqueuing jobs.

## Changes

- `recalculateLogCosts` now extracts the authenticated user ID from the request context and passes it as `createdBy` when enqueuing the cost recalculation job.
- `sidekiq.New` now accepts a runner ID parameter, used to identify which runner instance owns a given job.
- `MarkSidekiqJobRunning` replaced by `ClaimSidekiqJob`, which accepts a runner ID and a stale-before timestamp, returning a boolean indicating whether the claim succeeded (enabling safe concurrent runner environments).
- `HeartbeatSidekiqJob` added to allow runners to signal liveness for jobs they own.
- `UpdateSidekiqJobProgress`, `CompleteSidekiqJob`, and `FailSidekiqJob` now require the runner ID to be passed, scoping mutations to the owning runner.
- `ListIncompleteSidekiqJobs` replaced by `ListClaimableSidekiqJobs`, which accepts a stale-before timestamp to filter out jobs already actively owned.
- `MarkStaleSidekiqJobsFailed` removed, as stale job detection is now handled via the claimable jobs query and heartbeat mechanism.
- Test fakes updated to match the new store interface.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that cost recalculation jobs are enqueued with the correct `createdBy` user ID, and that concurrent runners do not double-claim the same job.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

The `SidekiqStore` interface has changed. Any implementations of this interface outside this repository must be updated to replace `MarkSidekiqJobRunning` with `ClaimSidekiqJob`, add `HeartbeatSidekiqJob`, update the signatures of `UpdateSidekiqJobProgress`, `CompleteSidekiqJob`, and `FailSidekiqJob` to include a `runnerID` parameter, replace `ListIncompleteSidekiqJobs` with `ListClaimableSidekiqJobs`, and remove `MarkStaleSidekiqJobsFailed`. `sidekiq.New` also requires a new runner ID string argument.

## Related issues

## Security considerations

The runner ID scoping ensures that only the runner that claimed a job can update or complete it, reducing the risk of race conditions or unintended job state mutations in multi-runner deployments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable