### PR TITLE
fix: set octet-stream Content-Type on pprof endpoints for scraper compatibility

### DIFF
--- a/transports/bifrost-http/profiling/profiling.go
+++ b/transports/bifrost-http/profiling/profiling.go
@@ -2,6 +2,7 @@ package profiling
 
 import (
 	"crypto/subtle"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -43,8 +44,12 @@ func Start() *http.Server {
 
 	// heap, goroutine, allocs, block, mutex, threadcreate
 	mux.HandleFunc("/debug/pprof/", func(w http.ResponseWriter, r *http.Request) {
+		// Always disable content sniffing; the payload below is a gzipped
+		// protobuf and must not be reinterpreted by the client/proxy.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		name := strings.TrimPrefix(r.URL.Path, "/debug/pprof/")
 		if name == "" {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			_, _ = w.Write([]byte("profiles: heap goroutine allocs block mutex threadcreate; also /profile /trace\n"))
 			return
 		}
@@ -54,6 +59,17 @@ func Start() *http.Server {
 			return
 		}
 		debug, _ := strconv.Atoi(r.URL.Query().Get("debug"))
+		// pprof profiles are gzip-compressed protobuf. Set an explicit
+		// Content-Type before the first write so net/http doesn't sniff the
+		// gzip magic bytes and label the response application/x-gzip — pprof
+		// scrapers (Grafana Alloy / Pyroscope) require application/octet-stream
+		// and reject anything else. debug!=0 emits a human-readable text form.
+		if debug != 0 {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		} else {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
+		}
 		err := p.WriteTo(w, debug)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -69,6 +85,13 @@ func Start() *http.Server {
 		if sec > 60 {
 			sec = 60 // cap to bound how long the connection/goroutine is held
 		}
+		// StartCPUProfile begins streaming immediately on success, so set the
+		// Content-Type first. Without it net/http sniffs the gzip payload as
+		// application/x-gzip, which pprof scrapers reject. On failure http.Error
+		// overwrites these headers (nothing has been written yet).
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="profile"`)
 		if err := pprof.StartCPUProfile(w); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -93,6 +116,11 @@ func Start() *http.Server {
 		if sec > 30 {
 			sec = 30 // cap to bound how long the connection/goroutine is held
 		}
+		// trace.Start begins streaming immediately on success, so set the
+		// Content-Type first (same sniffing concern as the CPU profile above).
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="trace"`)
 		if err := trace.Start(w); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary
The custom pprof server wrote profile payloads without setting a Content-Type, so net/http sniffed the gzipped protobuf and labeled responses application/x-gzip. Pyroscope/Grafana Alloy scrapers require application/octet-stream and rejected every profile with "invalid profile data: unexpected Content-Type application/x-gzip".

## Changes
Explicitly set Content-Type (and X-Content-Type-Options: nosniff plus Content-Disposition) before the first write on the Lookup, CPU profile, and trace handlers, matching the standard net/http/pprof behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


