### PR TITLE
fix: api key provider selection

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -52,14 +52,14 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 	// Credential UI keys off the base provider type for custom providers; the
 	// model list, deployments table, and API calls still use the real providerName.
 	const effectiveProvider = baseProviderType ?? providerName;
-	const isBedrock = providerName === "bedrock";
-	const isBedrockMantle = providerName === "bedrock_mantle";
-	const isVertex = providerName === "vertex";
-	const isAzure = providerName === "azure";
-	const isReplicate = providerName === "replicate";
-	const isVLLM = providerName === "vllm";
-	const isOllama = providerName === "ollama";
-	const isSGL = providerName === "sgl";
+	const isBedrock = effectiveProvider === "bedrock";
+	const isBedrockMantle = effectiveProvider === "bedrock_mantle";
+	const isVertex = effectiveProvider === "vertex";
+	const isAzure = effectiveProvider === "azure";
+	const isReplicate = effectiveProvider === "replicate";
+	const isVLLM = effectiveProvider === "vllm";
+	const isOllama = effectiveProvider === "ollama";
+	const isSGL = effectiveProvider === "sgl";
 	const isKeylessProvider = isOllama || isSGL;
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(effectiveProvider);
 


### PR DESCRIPTION
## Summary

Provider type checks for custom providers were incorrectly using `providerName` instead of `effectiveProvider`, causing credential UI logic to fail for custom providers that have a `baseProviderType`. Since `effectiveProvider` already resolves to `baseProviderType` when present (and falls back to `providerName` otherwise), all provider type flags should derive from it.

## Changes

- Provider identity flags (`isBedrock`, `isBedrockMantle`, `isVertex`, `isAzure`, `isReplicate`, `isVLLM`, `isOllama`, `isSGL`) now use `effectiveProvider` instead of `providerName`, ensuring custom providers correctly inherit credential UI behavior from their base provider type.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create a custom provider with a `baseProviderType` of, for example, `bedrock` or `azure`.
2. Navigate to the provider's credentials/API keys form in the workspace.
3. Verify that the correct credential fields (e.g., AWS credentials for Bedrock, Azure-specific fields) are rendered for the custom provider, matching what would appear for the base provider type.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects which credential input fields are displayed in the UI.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable