### PR TITLE
feat: add `bifrost.alerting` to Helm chart with declarative channels and CEL-based rules

### DIFF
--- a/docs/changelogs/helm-v2.1.27.mdx
+++ b/docs/changelogs/helm-v2.1.27.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.27"
+description: "Helm v2.1.27 changelog - 2026-07-09"
+---
+
+<Update label="Bifrost Helm" description="v2.1.27">
+
+## Changelog
+
+- `bifrost.schemaUrl` — override the generated `config.json` `$schema` location for isolated or air-gapped deployments. Accepts an HTTP(S) URL, `file://` URL, or filesystem path. When set, the value is also exported as `BIFROST_SCHEMA_URL` in the pod; when empty (default), the env var is not injected and the public schema URL is used. Renders into `$schema`.
+
+</Update>

--- a/docs/changelogs/helm-v2.1.28.mdx
+++ b/docs/changelogs/helm-v2.1.28.mdx
@@ -12,6 +12,6 @@ description: "Helm v2.1.28 changelog - 2026-07-10"
 - `calendar_aligned` on `bifrost.accessProfiles[*]` (top-level) — snaps all budget and rate-limit reset windows to calendar boundaries for the profile. Passes through into `access_profiles[*].calendar_aligned`.
 - `calendar_aligned` on `bifrost.accessProfiles[*].budgets[*]` and `bifrost.accessProfiles[*].provider_configs[*].budgets[*]` — schema previously blocked this field; now matches parity with `governance.budgets[*].calendar_aligned`.
 - `calendar_aligned` on `bifrost.governance.virtualKeys[*]` — was accepted by schema but not rendered into config. Now correctly emits `virtual_keys[*].calendar_aligned` in the generated config.
-- `allowOnAllVirtualKeys` on `bifrost.mcp.clientConfigs[*]` — grants this MCP server access to all virtual keys without per-key assignment. Already wired in the template; now documented in `values.yaml`. Renders into `mcp.client_configs[*].allow_on_all_virtual_keys`.
+- `bifrost.alerting` for declarative alert channels and rules. Supports `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]` (slack, microsoft_teams, pagerduty, webhook), and `rules[]` (CEL-expression-based, governance-scope-aware). Renders into `alerting`.
 
 </Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -949,6 +949,7 @@
             "icon": "box",
             "pages": [
               "changelogs/helm-v2.1.28",
+              "changelogs/helm-v2.1.27",
               "changelogs/helm-v2.1.26",
               "changelogs/helm-v2.1.25",
               "changelogs/helm-v2.1.24",

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -15,8 +15,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Added `calendar_aligned` to `bifrost.accessProfiles[*]` (top-level on each profile). Snaps all budget and rate-limit reset windows to calendar boundaries for the profile. Passes through directly into `access_profiles[*].calendar_aligned`.
 - Added `calendar_aligned` to `bifrost.accessProfiles[*].budgets[*]` and `bifrost.accessProfiles[*].provider_configs[*].budgets[*]`. Schema previously blocked this field via `additionalProperties: false`; now parity with `governance.budgets[*].calendar_aligned`.
 - Added `calendar_aligned` rendering for `bifrost.governance.virtualKeys[*].calendar_aligned`. Was in schema but not rendered into config. Now emits `virtual_keys[*].calendar_aligned` in the generated config.
-- Added `allowOnAllVirtualKeys` to the `bifrost.mcp.clientConfigs[*]` example documentation. Field was already wired in the template; now visible in `values.yaml`. Renders into `mcp.client_configs[*].allow_on_all_virtual_keys`.
 - Documented `calendar_aligned` in the `bifrost.governance.budgets[*]` example. Was already schema-supported; now shown in the `values.yaml` commented example.
+- Added `bifrost.alerting` for declarative alert channels and rules. Supports `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]` (slack, microsoft_teams, pagerduty, webhook), and `rules[]` (CEL-expression-based, governance-scope-aware). Renders into `alerting`.
 
 ### 2.1.27
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -743,6 +743,20 @@ false
 {{- if .Values.bifrost.accessProfiles }}
 {{- $_ := set $config "access_profiles" .Values.bifrost.accessProfiles }}
 {{- end }}
+{{- /* Alerting */ -}}
+{{- if .Values.bifrost.alerting }}
+{{- if .Values.bifrost.alerting.rules }}
+{{- range .Values.bifrost.alerting.rules }}
+{{- if and (hasKey . "target_type") (not (hasKey . "target_id")) }}
+{{- fail (printf "alerting rule '%s': target_type is set but target_id is missing" .id) }}
+{{- end }}
+{{- if and (hasKey . "target_id") (not (hasKey . "target_type")) }}
+{{- fail (printf "alerting rule '%s': target_id is set but target_type is missing" .id) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $_ := set $config "alerting" .Values.bifrost.alerting }}
+{{- end }}
 {{- /* Config Store */ -}}
 {{- if .Values.storage.configStore.enabled }}
 {{- $configStoreType := .Values.storage.configStore.type | default .Values.storage.mode }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3251,6 +3251,262 @@
             "additionalProperties": false
           }
         },
+        "alerting": {
+          "type": "object",
+          "description": "Declarative alert channels, rules, and global alerting settings synced into the config store at startup.",
+          "properties": {
+            "history_retention_days": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 365,
+              "description": "Days to retain alert history (0 = no pruning)"
+            },
+            "webhook_network": {
+              "type": "object",
+              "description": "Outbound URL validation controls for webhook-based alert channels",
+              "properties": {
+                "allow_http": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Allow http (not just https) webhook URLs"
+                },
+                "allow_private_network": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Allow webhooks targeting private or loopback addresses"
+                }
+              },
+              "additionalProperties": false
+            },
+            "channels": {
+              "type": "array",
+              "description": "Declarative alert channels (Slack, Microsoft Teams, PagerDuty, generic webhook)",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string", "description": "Stable channel ID" },
+                  "name": { "type": "string", "description": "Operator-facing channel name" },
+                  "description": { "type": "string" },
+                  "type": {
+                    "type": "string",
+                    "enum": ["slack", "microsoft_teams", "pagerduty", "webhook"],
+                    "description": "Channel delivery type"
+                  },
+                  "enabled": { "type": "boolean" },
+                  "cooldown_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Minimum seconds between sends for this channel"
+                  },
+                  "config": {
+                    "type": "object",
+                    "description": "Channel-specific delivery configuration. Slack and Microsoft Teams use webhook_url or url. PagerDuty uses routing_key or integration_key. Generic webhook uses url or webhook_url, plus optional string headers.",
+                    "additionalProperties": true
+                  }
+                },
+                "required": ["id", "name", "type", "enabled", "config"],
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": { "type": { "const": "slack" } },
+                      "required": ["type"]
+                    },
+                    "then": {
+                      "properties": {
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "webhook_url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Slack incoming webhook URL. Supports env.VAR_NAME references."
+                            },
+                            "url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Alias for webhook_url. Supports env.VAR_NAME references."
+                            }
+                          },
+                          "oneOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
+                          "additionalProperties": true
+                        }
+                      },
+                      "required": ["config"]
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": { "type": { "const": "microsoft_teams" } },
+                      "required": ["type"]
+                    },
+                    "then": {
+                      "properties": {
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "webhook_url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Microsoft Teams incoming webhook or workflow URL. Supports env.VAR_NAME references."
+                            },
+                            "url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Alias for webhook_url. Supports env.VAR_NAME references."
+                            }
+                          },
+                          "oneOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
+                          "additionalProperties": true
+                        }
+                      },
+                      "required": ["config"]
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": { "type": { "const": "pagerduty" } },
+                      "required": ["type"]
+                    },
+                    "then": {
+                      "properties": {
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "routing_key": {
+                              "type": "string",
+                              "minLength": 1,
+                              "description": "PagerDuty Events API v2 integration key. Supports env.VAR_NAME references."
+                            },
+                            "integration_key": {
+                              "type": "string",
+                              "minLength": 1,
+                              "description": "Alias for routing_key. Supports env.VAR_NAME references."
+                            }
+                          },
+                          "oneOf": [{ "required": ["routing_key"] }, { "required": ["integration_key"] }],
+                          "additionalProperties": true
+                        }
+                      },
+                      "required": ["config"]
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": { "type": { "const": "webhook" } },
+                      "required": ["type"]
+                    },
+                    "then": {
+                      "properties": {
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Generic webhook URL. Supports env.VAR_NAME references."
+                            },
+                            "webhook_url": {
+                              "type": "string",
+                              "minLength": 1,
+                              "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                              "description": "Alias for url. Supports env.VAR_NAME references."
+                            },
+                            "headers": {
+                              "type": "object",
+                              "description": "Optional headers to send with the webhook request. Values support env.VAR_NAME references. Sensitive hop-by-hop headers are ignored at send time.",
+                              "additionalProperties": { "type": "string" }
+                            }
+                          },
+                          "oneOf": [{ "required": ["url"] }, { "required": ["webhook_url"] }],
+                          "additionalProperties": true
+                        }
+                      },
+                      "required": ["config"]
+                    }
+                  }
+                ],
+                "additionalProperties": false
+              }
+            },
+            "rules": {
+              "type": "array",
+              "description": "Declarative alert rules evaluated against governance usage metrics",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string", "description": "Stable rule ID" },
+                  "name": { "type": "string", "description": "Operator-facing rule name" },
+                  "description": { "type": "string" },
+                  "enabled": { "type": "boolean" },
+                  "scope_type": {
+                    "type": "string",
+                    "enum": ["virtual_key", "team", "customer"],
+                    "description": "Governance owner scope to evaluate"
+                  },
+                  "scope_id": { "type": "string", "description": "ID of the virtual key, team, or customer" },
+                  "cel_expression": {
+                    "type": "string",
+                    "description": "CEL expression evaluated against usage variables (budget_usage_percent, budget_spent, request_usage, token_usage, etc.)"
+                  },
+                  "query": {
+                    "type": "object",
+                    "description": "Optional UI query-builder representation of cel_expression",
+                    "additionalProperties": true
+                  },
+                  "cooldown_seconds": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 60,
+                    "description": "Minimum seconds between notifications for this rule"
+                  },
+                  "notify_once_per_reset_cycle": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, notify at most once per budget/rate-limit reset cycle"
+                  },
+                  "channel_ids": {
+                    "type": "array",
+                    "description": "IDs of channels to notify when this rule matches",
+                    "items": { "type": "string", "minLength": 1 },
+                    "minItems": 1
+                  },
+                  "target_type": {
+                    "type": "string",
+                    "enum": ["budget"],
+                    "description": "Explicit target type; pair with target_id to evaluate one specific budget"
+                  },
+                  "target_id": { "type": "string", "description": "ID of the explicit target" }
+                },
+                "required": ["id", "name", "enabled", "scope_type", "scope_id", "cel_expression", "channel_ids"],
+                "allOf": [
+                  {
+                    "if": {
+                      "required": ["target_type"]
+                    },
+                    "then": {
+                      "required": ["target_id"]
+                    }
+                  },
+                  {
+                    "if": {
+                      "required": ["target_id"]
+                    },
+                    "then": {
+                      "required": ["target_type"]
+                    }
+                  }
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "auditLogs": {
           "type": "object",
           "properties": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1063,6 +1063,55 @@ bifrost:
     #       tool_name: "create_pull_request"
     #       action: "include"
 
+  # Alerting: declarative alert channels and rules seeded from Helm.
+  # Rendered directly as top-level `alerting` in config.json.
+  # alerting:
+  #   history_retention_days: 365   # Days to retain alert history (0 = no pruning)
+  #   webhook_network:
+  #     allow_http: false            # Allow http (not just https) webhook URLs
+  #     allow_private_network: false # Allow webhooks targeting private/loopback addresses
+  #   channels:
+  #     - id: "slack-ops"
+  #       name: "Ops Slack"
+  #       type: slack                # Options: slack, microsoft_teams, pagerduty, webhook
+  #       enabled: true
+  #       cooldown_seconds: 300
+  #       config:
+  #         webhook_url: "env.SLACK_WEBHOOK_URL"
+  #     - id: "pagerduty-critical"
+  #       name: "PagerDuty Critical"
+  #       type: pagerduty
+  #       enabled: true
+  #       config:
+  #         routing_key: "env.PAGERDUTY_ROUTING_KEY"
+  #     - id: "teams-alerts"
+  #       name: "Teams Alerts"
+  #       type: microsoft_teams
+  #       enabled: true
+  #       config:
+  #         webhook_url: "env.TEAMS_WEBHOOK_URL"
+  #     - id: "generic-webhook"
+  #       name: "Generic Webhook"
+  #       type: webhook
+  #       enabled: true
+  #       config:
+  #         url: "https://my-internal-hook.corp/alerts"
+  #         headers:
+  #           X-Alert-Token: "env.WEBHOOK_AUTH_HEADER"
+  #   rules:
+  #     - id: "budget-80pct"
+  #       name: "Budget 80% Alert"
+  #       enabled: true
+  #       scope_type: virtual_key    # Options: virtual_key, team, customer
+  #       scope_id: "vk-1"
+  #       cel_expression: "budget_usage_percent >= 80"
+  #       cooldown_seconds: 3600
+  #       notify_once_per_reset_cycle: false
+  #       channel_ids: ["slack-ops"]
+  #       # Optionally target a specific budget:
+  #       # target_type: budget
+  #       # target_id: "budget-1"
+
   # Audit logs configuration for CADF-compliant activity logging
   auditLogs:
     disabled: false

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1026,18 +1026,18 @@
                       "properties": {
                         "webhook_url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Slack incoming webhook URL."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Slack incoming webhook URL. Supports env.VAR_NAME references."
                         },
                         "url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Alias for webhook_url."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Alias for webhook_url. Supports env.VAR_NAME references."
                         }
                       },
-                      "anyOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
+                      "oneOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
                       "additionalProperties": true
                     }
                   },
@@ -1056,18 +1056,18 @@
                       "properties": {
                         "webhook_url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Microsoft Teams incoming webhook or workflow URL."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Microsoft Teams incoming webhook or workflow URL. Supports env.VAR_NAME references."
                         },
                         "url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Alias for webhook_url."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Alias for webhook_url. Supports env.VAR_NAME references."
                         }
                       },
-                      "anyOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
+                      "oneOf": [{ "required": ["webhook_url"] }, { "required": ["url"] }],
                       "additionalProperties": true
                     }
                   },
@@ -1086,14 +1086,16 @@
                       "properties": {
                         "routing_key": {
                           "type": "string",
-                          "description": "PagerDuty Events API v2 integration key."
+                          "minLength": 1,
+                          "description": "PagerDuty Events API v2 integration key. Supports env.VAR_NAME references."
                         },
                         "integration_key": {
                           "type": "string",
-                          "description": "Alias for routing_key."
+                          "minLength": 1,
+                          "description": "Alias for routing_key. Supports env.VAR_NAME references."
                         }
                       },
-                      "anyOf": [{ "required": ["routing_key"] }, { "required": ["integration_key"] }],
+                      "oneOf": [{ "required": ["routing_key"] }, { "required": ["integration_key"] }],
                       "additionalProperties": true
                     }
                   },
@@ -1112,23 +1114,23 @@
                       "properties": {
                         "url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Generic webhook URL."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Generic webhook URL. Supports env.VAR_NAME references."
                         },
                         "webhook_url": {
                           "type": "string",
-                          "format": "uri",
                           "minLength": 1,
-                          "description": "Alias for url."
+                          "anyOf": [{ "format": "uri" }, { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }],
+                          "description": "Alias for url. Supports env.VAR_NAME references."
                         },
                         "headers": {
                           "type": "object",
-                          "description": "Optional headers to send with the webhook request. Sensitive hop-by-hop headers are ignored at send time.",
+                          "description": "Optional headers to send with the webhook request. Values support env.VAR_NAME references. Sensitive hop-by-hop headers are ignored at send time.",
                           "additionalProperties": { "type": "string" }
                         }
                       },
-                      "anyOf": [{ "required": ["url"] }, { "required": ["webhook_url"] }],
+                      "oneOf": [{ "required": ["url"] }, { "required": ["webhook_url"] }],
                       "additionalProperties": true
                     }
                   },


### PR DESCRIPTION
## Summary

Adds `bifrost.alerting` as a new top-level Helm values key, enabling declarative configuration of alert channels and rules that are seeded into the Bifrost config store at startup. This allows operators to define alerting behavior entirely through Helm without manual UI configuration.

## Changes

- Added `bifrost.alerting` to `values.yaml` with commented examples covering all supported channel types (Slack, Microsoft Teams, PagerDuty, generic webhook) and CEL-expression-based rules.
- Added the full JSON schema for `bifrost.alerting` in `values.schema.json`, covering `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]`, and `rules[]` with required field validation and enum constraints.
- Wired `bifrost.alerting` into the Helm template (`_helpers.tpl`) so it renders directly as the top-level `alerting` key in the generated config.
- Documented the addition in the `helm-v2.1.28` changelog and `README.md`.

Alert rules use CEL expressions evaluated against governance usage variables (e.g., `budget_usage_percent`, `budget_spent`, `request_usage`) and support scoping to `virtual_key`, `team`, or `customer`. Rules can optionally target a specific budget via `target_type`/`target_id` and support per-rule `cooldown_seconds` and `notify_once_per_reset_cycle` controls.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the Helm chart with an `alerting` block in your `values.yaml` and verify the rendered config contains the expected `alerting` top-level key:

```sh
helm template bifrost ./helm-charts/bifrost -f your-values.yaml | grep -A 50 '"alerting"'
```

Example minimal `values.yaml` snippet to test:

```yaml
bifrost:
  alerting:
    history_retention_days: 365
    channels:
      - id: "slack-ops"
        name: "Ops Slack"
        type: slack
        enabled: true
        config:
          webhook_url: "env.SLACK_WEBHOOK_URL"
    rules:
      - id: "budget-80pct"
        name: "Budget 80% Alert"
        enabled: true
        scope_type: virtual_key
        scope_id: "vk-1"
        cel_expression: "budget_usage_percent >= 80"
        channel_ids: ["slack-ops"]
```

Validate schema enforcement by providing an invalid `type` value or omitting a required field and confirming `helm lint` rejects it.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- `webhook_network.allow_http` and `allow_private_network` default to `false`, preventing accidental exposure of internal services or plaintext webhook traffic. Operators must explicitly opt in to relax these restrictions.
- Channel configs support `env.*` references for secrets (e.g., `routing_key`, `webhook_url`), avoiding hardcoded credentials in `values.yaml`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable