### PR TITLE
adds legacy table fix

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -10470,10 +10470,19 @@ func migrationAddSidekiqTable(ctx context.Context, db *gorm.DB, logger schemas.L
 			default:
 				// Fall back to GORM for any other dialect so the migration does not
 				// hard-fail on an unsupported backend.
-				return tx.Migrator().CreateTable(&tables.TableSidekiqJob{})
+				err := tx.Migrator().AutoMigrate(&tables.TableSidekiqJob{})
+				if err != nil {
+					return err
+				}
 			}
-
 			if err := tx.Exec(createTable).Error; err != nil {
+				return err
+			}
+			// For existing enterprise table we will need to handle new column additions
+			if err := addColumnIfNotExists(tx, logger, &tables.TableSidekiqJob{}, "runner_id"); err != nil {
+				return err
+			}
+			if err := addColumnIfNotExists(tx, logger, &tables.TableSidekiqJob{}, "created_by_user_id"); err != nil {
 				return err
 			}
 			// idx_sidekiq_status_updated supports the reaper/recovery scan.


### PR DESCRIPTION
## Summary

Fixes a schema migration compatibility issue for Enterprise v2.0.0 instances that had the `sidekiq` table created by a since-removed `ent_add_sidekiq_table` migration. That legacy table was created without the `runner_id` and `created_by_user_id` columns. Because the current migration uses `CREATE TABLE IF NOT EXISTS`, it becomes a no-op on those instances, leaving the table missing those columns.

## Changes

- Added `addColumnIfNotExists` calls for `runner_id` and `created_by_user_id` on the `sidekiq` table within `migrationAddSidekiqTable`, ensuring the columns are present on legacy Enterprise v2.0.0 deployments before the `idx_sidekiq_status_updated` index is created.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Simulate an Enterprise v2.0.0 environment by pre-creating the `sidekiq` table without `runner_id` and `created_by_user_id`, then run migrations and verify both columns are added successfully without errors.

```sh
go test ./framework/configstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable