### PR TITLE
fix: use `AutoMigrate` and add `runner_id`/`created_by_user_id` columns to sidekiq table migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -10428,6 +10428,7 @@ func migrationAddSidekiqTable(ctx context.Context, db *gorm.DB, logger schemas.L
 	migrationName := "add_sidekiq_table"
 	logger.Info("[configstore] starting migration %s", migrationName)
 	defer logger.Info("[configstore] finished migration %s", migrationName)
+
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
@@ -10470,12 +10471,25 @@ func migrationAddSidekiqTable(ctx context.Context, db *gorm.DB, logger schemas.L
 			default:
 				// Fall back to GORM for any other dialect so the migration does not
 				// hard-fail on an unsupported backend.
-				return tx.Migrator().CreateTable(&tables.TableSidekiqJob{})
+				if err := tx.Migrator().AutoMigrate(&tables.TableSidekiqJob{}); err != nil {
+					return err
+				}
+				return nil
 			}
 
 			if err := tx.Exec(createTable).Error; err != nil {
 				return err
 			}
+
+			// For existing tables, add new columns that were not present in the
+			// original schema (no-op when the columns already exist).
+			if err := addColumnIfNotExists(tx, logger, &tables.TableSidekiqJob{}, "runner_id"); err != nil {
+				return err
+			}
+			if err := addColumnIfNotExists(tx, logger, &tables.TableSidekiqJob{}, "created_by_user_id"); err != nil {
+				return err
+			}
+
 			// idx_sidekiq_status_updated supports the reaper/recovery scan.
 			if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_sidekiq_status_updated ON sidekiq (status, updated_at)`).Error; err != nil {
 				return err
@@ -10485,6 +10499,7 @@ func migrationAddSidekiqTable(ctx context.Context, db *gorm.DB, logger schemas.L
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
+			// It is okay to drop the table
 			return tx.Exec(`DROP TABLE IF EXISTS sidekiq`).Error
 		},
 	}})


### PR DESCRIPTION
## Summary

The `migrationAddSidekiqTable` function previously used `CreateTable` for non-MySQL/PostgreSQL dialects, which would fail if the table already existed. This PR switches to `AutoMigrate` for the fallback dialect path and adds explicit column addition handling for `runner_id` and `created_by_user_id` on existing `TableSidekiqJob` tables.

## Changes

- Replaced `tx.Migrator().CreateTable()` with `tx.Migrator().AutoMigrate()` in the default dialect fallback branch so the migration is idempotent and won't hard-fail on pre-existing tables.
- Added `addColumnIfNotExists` calls for `runner_id` and `created_by_user_id` columns to ensure existing `sidekiq_jobs` tables receive the new columns without requiring a full table recreation.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the migration against an environment with a pre-existing `sidekiq_jobs` table (missing `runner_id` and `created_by_user_id` columns) and verify the migration completes without error and the new columns are present.

```sh
go test ./framework/configstore/...
```

Verify that after migration:
- The `sidekiq_jobs` table still exists with all original data intact.
- The `runner_id` and `created_by_user_id` columns are present.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects database schema migration logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable