### PR TITLE
fix: inference geo cost on anthropic (#5072)

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -621,6 +621,26 @@ func accumulateAnthropicResponsesUsage(usage *schemas.ResponsesResponseUsage, bi
 	if usage == nil || usageToProcess == nil {
 		return
 	}
+	// Web search request count → billed as search queries (server tool use). The
+	// terminal chunk overwrites Response.Usage with this accumulator, so the count
+	// must live here (not only on the per-event message_delta usage).
+	if usageToProcess.ServerToolUse != nil && usageToProcess.ServerToolUse.WebSearchRequests > 0 {
+		n := usageToProcess.ServerToolUse.WebSearchRequests
+		if usage.OutputTokensDetails == nil {
+			usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{}
+		}
+		if usage.OutputTokensDetails.NumSearchQueries == nil || n > *usage.OutputTokensDetails.NumSearchQueries {
+			usage.OutputTokensDetails.NumSearchQueries = schemas.Ptr(n)
+		}
+		if billedUsage != nil {
+			if billedUsage.CompletionTokensDetails == nil {
+				billedUsage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+			}
+			if billedUsage.CompletionTokensDetails.NumSearchQueries == nil || n > *billedUsage.CompletionTokensDetails.NumSearchQueries {
+				billedUsage.CompletionTokensDetails.NumSearchQueries = schemas.Ptr(n)
+			}
+		}
+	}
 	if usageToProcess.InputTokens > usage.InputTokens {
 		usage.InputTokens = usageToProcess.InputTokens
 		if billedUsage != nil {
@@ -863,6 +883,10 @@ func HandleAnthropicChatCompletionStreaming(
 		var finishReason *string
 
 		usage := &schemas.BifrostLLMUsage{}
+		// Served billing modifiers (top-level response fields, not usage) captured
+		// across events and set on the final chunk: fast mode and data residency.
+		var servedSpeed *string
+		var servedInferenceGeo *string
 		// Register the accumulating usage handle so a mid-stream cancel/timeout
 		// can bill for tokens already processed Mutated in place below;
 		// the deferred HandleStreamCancellation/Timeout reads it from context.
@@ -938,6 +962,26 @@ func HandleAnthropicChatCompletionStreaming(
 				usageToProcess = event.Message.Usage
 			}
 			if usageToProcess != nil {
+				// Web search request count → billed as search queries (server tool use).
+				if usageToProcess.ServerToolUse != nil && usageToProcess.ServerToolUse.WebSearchRequests > 0 {
+					if usage.CompletionTokensDetails == nil {
+						usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+					}
+					if n := usageToProcess.ServerToolUse.WebSearchRequests; usage.CompletionTokensDetails.NumSearchQueries == nil || n > *usage.CompletionTokensDetails.NumSearchQueries {
+						usage.CompletionTokensDetails.NumSearchQueries = &n
+					}
+				}
+				// Capture served fast mode + inference geography (top-level response fields).
+				// Mirror onto the billing usage handle so a mid-stream cancel/timeout can
+				// still apply the served-tier multiplier (billed usage is otherwise bare).
+				if usageToProcess.Speed != nil {
+					servedSpeed = usageToProcess.Speed
+					usage.Speed = usageToProcess.Speed
+				}
+				if usageToProcess.InferenceGeo != nil {
+					servedInferenceGeo = usageToProcess.InferenceGeo
+					usage.InferenceGeo = usageToProcess.InferenceGeo
+				}
 				// Collect usage information and send at the end of the stream
 				// Here in some cases usage comes before final message
 				// So we need to check if the response.Usage is nil and then if usage != nil
@@ -1098,6 +1142,13 @@ func HandleAnthropicChatCompletionStreaming(
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				return
 			}
+		}
+		// Forward served fast mode + data residency so the final chunk bills correctly.
+		if servedSpeed != nil {
+			response.Speed = servedSpeed
+		}
+		if servedInferenceGeo != nil {
+			response.InferenceGeo = servedInferenceGeo
 		}
 		// Set raw request if enabled
 		if sendBackRawRequest {
@@ -1455,6 +1506,8 @@ func HandleAnthropicResponsesStream(
 		}
 
 		var modelName string
+		var servedSpeed *string
+		var servedInferenceGeo *string
 
 		for {
 			// If context was cancelled/timed out, let defer handle it
@@ -1503,6 +1556,20 @@ func HandleAnthropicResponsesStream(
 				// Also mirror it into billedUsage so cancellation/timeout paths can
 				// charge for provider-reported usage before the final chunk arrives.
 				accumulateAnthropicResponsesUsage(usage, billedUsage, usageToProcess)
+				// Mirror served tier onto billedUsage so a mid-stream cancel/timeout can
+				// still apply the served-tier multiplier (billed usage is otherwise bare).
+				if usageToProcess.Speed != nil {
+					servedSpeed = usageToProcess.Speed
+					if billedUsage != nil {
+						billedUsage.Speed = usageToProcess.Speed
+					}
+				}
+				if usageToProcess.InferenceGeo != nil {
+					servedInferenceGeo = usageToProcess.InferenceGeo
+					if billedUsage != nil {
+						billedUsage.InferenceGeo = usageToProcess.InferenceGeo
+					}
+				}
 			}
 
 			responses, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(ctx, chunkIndex, streamState)
@@ -1561,6 +1628,12 @@ func HandleAnthropicResponsesStream(
 							usage.TotalTokens = usage.TotalTokens + usage.InputTokensDetails.CachedReadTokens + usage.InputTokensDetails.CachedWriteTokens
 						}
 						response.Response.Usage = usage
+						if servedSpeed != nil {
+							response.Response.Speed = servedSpeed
+						}
+						if servedInferenceGeo != nil {
+							response.Response.InferenceGeo = servedInferenceGeo
+						}
 						// Set raw request if enabled
 						if sendBackRawRequest {
 							providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1033,6 +1033,13 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 			PromptTokensDetails: promptTokensDetails,
 			CompletionTokens:    response.Usage.OutputTokens,
 		}
+		// Forward web search request count so server-tool use is billed.
+		if response.Usage.ServerToolUse != nil && response.Usage.ServerToolUse.WebSearchRequests > 0 {
+			n := response.Usage.ServerToolUse.WebSearchRequests
+			bifrostResponse.Usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
+				NumSearchQueries: &n,
+			}
+		}
 		bifrostResponse.Usage.TotalTokens = bifrostResponse.Usage.PromptTokens + bifrostResponse.Usage.CompletionTokens
 		// Forward service tier from usage to response
 		if response.Usage.ServiceTier != nil {
@@ -1042,6 +1049,10 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 		// Forward the speed actually served (fast mode) — drives fast-mode billing.
 		if response.Usage.Speed != nil {
 			bifrostResponse.Speed = response.Usage.Speed
+		}
+		// Forward the inference geography served — drives the data-residency multiplier.
+		if response.Usage.InferenceGeo != nil {
+			bifrostResponse.InferenceGeo = response.Usage.InferenceGeo
 		}
 	}
 

--- a/core/providers/anthropic/passthrough_usage.go
+++ b/core/providers/anthropic/passthrough_usage.go
@@ -77,6 +77,9 @@ func buildAnthropicPassthroughUsage(au *AnthropicUsage) *schemas.BifrostPassthro
 	if au.Speed != nil {
 		u.Speed = au.Speed
 	}
+	if au.InferenceGeo != nil {
+		u.InferenceGeo = au.InferenceGeo
+	}
 	return u
 }
 
@@ -141,6 +144,9 @@ func (a *AnthropicPassthroughStreamUsage) ObserveEvent(event []byte) *schemas.Bi
 	}
 	if u.Speed != nil {
 		c.Speed = u.Speed
+	}
+	if u.InferenceGeo != nil {
+		c.InferenceGeo = u.InferenceGeo
 	}
 	return a.usage()
 }

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1989,6 +1989,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 			if bifrostUsage != nil {
 				response.Usage = bifrostUsage
 				response.Speed = chunk.Usage.Speed
+				response.InferenceGeo = chunk.Usage.InferenceGeo
 			}
 			// Carry the sandbox container on the message_delta event so the reverse
 			// converter can re-emit it (Anthropic delivers it here, not earlier).
@@ -3701,6 +3702,11 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 	// Forward the speed actually served (fast mode) — drives fast-mode billing.
 	if response.Usage != nil && response.Usage.Speed != nil {
 		bifrostResp.Speed = response.Usage.Speed
+	}
+
+	// Forward the inference geography served — drives the data-residency multiplier.
+	if response.Usage != nil && response.Usage.InferenceGeo != nil {
+		bifrostResp.InferenceGeo = response.Usage.InferenceGeo
 	}
 
 	// Forward cache diagnostics (cache-diagnosis-2026-04-07) to the client.

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -3476,11 +3476,11 @@ func TestStripEmptyThinkingBlocks(t *testing.T) {
 	}
 }
 
-// TestFastMode_StreamingForwardsSpeed verifies the streaming Responses converter
-// forwards the served speed onto the response, so streamed fast-mode requests
-// bill at fast rates (parity with the non-streaming ToBifrostResponsesResponse
-// path). Without this, tier.isFast is false for streams and cache/input/output
-// all bill at standard rates.
+// TestFastMode_StreamingForwardsSpeed verifies the per-event message_delta
+// converter surfaces the served speed on the emitted chunk (client-facing usage
+// visibility). NOTE: billing reads the terminal response.completed chunk, not
+// message_delta — that end-to-end billing contract is covered by
+// TestResponsesStream_TerminalChunkCarriesServedModifiers.
 func TestFastMode_StreamingForwardsSpeed(t *testing.T) {
 	ctx := schemas.NewBifrostContext(nil, time.Time{})
 	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
@@ -3516,5 +3516,201 @@ func TestFastMode_StreamingForwardsSpeed(t *testing.T) {
 	}
 	if !sawUsage {
 		t.Fatalf("no usage-bearing response emitted from message_delta")
+	}
+}
+
+// TestAccumulateResponsesUsage_BillsWebSearch verifies the streaming Responses
+// usage accumulator carries server-tool web search counts onto both the response
+// usage and the mirrored billed usage. The terminal chunk overwrites
+// Response.Usage with this accumulator, so without this the per-event search count
+// is lost and web search goes unbilled on streamed Responses requests.
+func TestAccumulateResponsesUsage_BillsWebSearch(t *testing.T) {
+	usage := &schemas.ResponsesResponseUsage{}
+	billed := &schemas.BifrostLLMUsage{}
+	accumulateAnthropicResponsesUsage(usage, billed, &AnthropicUsage{
+		InputTokens:   105,
+		OutputTokens:  6039,
+		ServerToolUse: &AnthropicServerToolUseUsage{WebSearchRequests: 2},
+	})
+
+	if usage.OutputTokensDetails == nil || usage.OutputTokensDetails.NumSearchQueries == nil {
+		t.Fatal("response usage NumSearchQueries not set")
+	}
+	if got := *usage.OutputTokensDetails.NumSearchQueries; got != 2 {
+		t.Fatalf("response usage NumSearchQueries = %d, want 2", got)
+	}
+	if billed.CompletionTokensDetails == nil || billed.CompletionTokensDetails.NumSearchQueries == nil {
+		t.Fatal("billed usage NumSearchQueries not set")
+	}
+	if got := *billed.CompletionTokensDetails.NumSearchQueries; got != 2 {
+		t.Fatalf("billed usage NumSearchQueries = %d, want 2", got)
+	}
+}
+
+// TestToBifrostChatResponse_ForwardsWebSearchAndInferenceGeo verifies the chat
+// converter surfaces server-tool web search counts (so they bill at
+// search_context_cost_per_query) and forwards the served inference geography (so
+// the data-residency multiplier applies) alongside fast-mode speed.
+func TestToBifrostChatResponse_ForwardsWebSearchAndInferenceGeo(t *testing.T) {
+	response := &AnthropicMessageResponse{
+		ID:    "msg_ws",
+		Type:  "message",
+		Role:  "assistant",
+		Model: "claude-opus-4-8",
+		Content: []AnthropicContentBlock{
+			{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("hi")},
+		},
+		StopReason: AnthropicStopReasonEndTurn,
+		Usage: &AnthropicUsage{
+			InputTokens:   105,
+			OutputTokens:  6039,
+			ServerToolUse: &AnthropicServerToolUseUsage{WebSearchRequests: 3},
+			InferenceGeo:  schemas.Ptr("us"),
+			Speed:         schemas.Ptr("fast"),
+		},
+	}
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	result := response.ToBifrostChatResponse(ctx)
+	if result == nil || result.Usage == nil {
+		t.Fatal("expected non-nil result with usage")
+	}
+	if result.Usage.CompletionTokensDetails == nil || result.Usage.CompletionTokensDetails.NumSearchQueries == nil {
+		t.Fatal("web search request count not forwarded to chat usage")
+	}
+	if got := *result.Usage.CompletionTokensDetails.NumSearchQueries; got != 3 {
+		t.Fatalf("chat usage NumSearchQueries = %d, want 3", got)
+	}
+	if result.InferenceGeo == nil || *result.InferenceGeo != "us" {
+		t.Fatalf("inference_geo not forwarded; got %v", result.InferenceGeo)
+	}
+	if result.Speed == nil || *result.Speed != "fast" {
+		t.Fatalf("speed not forwarded; got %v", result.Speed)
+	}
+}
+
+// TestToBifrostResponsesResponse_ForwardsInferenceGeo verifies the non-streaming
+// Responses converter forwards the served inference geography for data-residency
+// billing (parity with the streaming message_delta path).
+func TestToBifrostResponsesResponse_ForwardsInferenceGeo(t *testing.T) {
+	response := &AnthropicMessageResponse{
+		ID:    "msg_geo",
+		Type:  "message",
+		Role:  "assistant",
+		Model: "claude-opus-4-8",
+		Content: []AnthropicContentBlock{
+			{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("hi")},
+		},
+		StopReason: AnthropicStopReasonEndTurn,
+		Usage: &AnthropicUsage{
+			InputTokens:  10,
+			OutputTokens: 5,
+			InferenceGeo: schemas.Ptr("us"),
+		},
+	}
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	result := response.ToBifrostResponsesResponse(ctx)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.InferenceGeo == nil || *result.InferenceGeo != "us" {
+		t.Fatalf("inference_geo not forwarded; got %v", result.InferenceGeo)
+	}
+}
+
+// TestResponsesStream_TerminalChunkCarriesServedModifiers pins the streaming
+// Responses BILLING contract. Billing (framework/streaming/responses.go) prices
+// the terminal response.completed chunk — whose builder starts fresh with no
+// Speed/InferenceGeo/Usage. So the handler must (a) accumulate usage across events
+// and (b) re-apply the served fast mode + data residency captured from earlier
+// events onto that terminal chunk. This replays message_start → message_delta →
+// message_stop through the real converters + accumulator and reproduces the
+// handler's capture/apply, asserting the billed chunk carries speed=fast,
+// inference_geo=us, the web-search count, and the cache-creation tokens. Without
+// the re-apply, speed/geo silently fall back to standard/non-US rates.
+func TestResponsesStream_TerminalChunkCarriesServedModifiers(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyIntegrationType, "anthropic")
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
+
+	usage := &schemas.ResponsesResponseUsage{}
+	billed := &schemas.BifrostLLMUsage{}
+	var servedSpeed, servedInferenceGeo *string
+
+	events := []string{
+		`{"type":"message_start","message":{"id":"msg_1","model":"claude-opus-4-8","usage":{"input_tokens":2,"cache_creation_input_tokens":44667,"cache_creation":{"ephemeral_5m_input_tokens":44667}}}}`,
+		`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":135,"cache_creation_input_tokens":44667,"cache_creation":{"ephemeral_5m_input_tokens":44667},"server_tool_use":{"web_search_requests":4},"speed":"fast","inference_geo":"us"}}`,
+		`{"type":"message_stop"}`,
+	}
+
+	var finalResp *schemas.BifrostResponsesResponse
+	for _, raw := range events {
+		var event AnthropicStreamEvent
+		if err := sonic.Unmarshal([]byte(raw), &event); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// Handler step 1: extract usage (top-level or nested), accumulate, capture
+		// served modifiers — unconditionally, mirroring HandleAnthropicResponsesStream.
+		var usageToProcess *AnthropicUsage
+		if event.Usage != nil {
+			usageToProcess = event.Usage
+		} else if event.Message != nil && event.Message.Usage != nil {
+			usageToProcess = event.Message.Usage
+		}
+		if usageToProcess != nil {
+			accumulateAnthropicResponsesUsage(usage, billed, usageToProcess)
+			if usageToProcess.Speed != nil {
+				servedSpeed = usageToProcess.Speed
+			}
+			if usageToProcess.InferenceGeo != nil {
+				servedInferenceGeo = usageToProcess.InferenceGeo
+			}
+		}
+		// Handler step 2: convert + on the terminal chunk, attach usage and re-apply
+		// the captured served modifiers.
+		responses, bErr, isLastChunk := event.ToBifrostResponsesStream(ctx, 0, state)
+		if bErr != nil {
+			t.Fatalf("ToBifrostResponsesStream: %v", bErr)
+		}
+		if isLastChunk && len(responses) > 0 {
+			r := responses[len(responses)-1]
+			if r.Response == nil {
+				r.Response = &schemas.BifrostResponsesResponse{}
+			}
+			// Contract precondition: response.completed starts fresh (no served fields).
+			if r.Response.Speed != nil || r.Response.InferenceGeo != nil {
+				t.Fatal("expected fresh response.completed with no served modifiers")
+			}
+			r.Response.Usage = usage
+			if servedSpeed != nil {
+				r.Response.Speed = servedSpeed
+			}
+			if servedInferenceGeo != nil {
+				r.Response.InferenceGeo = servedInferenceGeo
+			}
+			finalResp = r.Response
+		}
+	}
+
+	if finalResp == nil {
+		t.Fatal("no terminal (isLastChunk) response produced")
+	}
+	if finalResp.Speed == nil || *finalResp.Speed != "fast" {
+		t.Fatalf("terminal billed chunk missing speed=fast; got %v", finalResp.Speed)
+	}
+	if finalResp.InferenceGeo == nil || *finalResp.InferenceGeo != "us" {
+		t.Fatalf("terminal billed chunk missing inference_geo=us; got %v", finalResp.InferenceGeo)
+	}
+	if finalResp.Usage == nil || finalResp.Usage.OutputTokensDetails == nil ||
+		finalResp.Usage.OutputTokensDetails.NumSearchQueries == nil ||
+		*finalResp.Usage.OutputTokensDetails.NumSearchQueries != 4 {
+		t.Fatal("terminal billed chunk missing web search count")
+	}
+	if finalResp.Usage.InputTokensDetails == nil || finalResp.Usage.InputTokensDetails.CachedWriteTokens != 44667 {
+		t.Fatal("terminal billed chunk missing cache-creation tokens")
 	}
 }

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -40,8 +40,9 @@ type BifrostChatResponse struct {
 	Model             string                     `json:"model"`
 	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
 	ServiceTier       *BifrostServiceTier        `json:"service_tier,omitempty"`
-	Speed             *string                    `json:"speed,omitempty"`       // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
-	Diagnostics       *CacheDiagnostics          `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
+	Speed             *string                    `json:"speed,omitempty"`         // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	InferenceGeo      *string                    `json:"inference_geo,omitempty"` // "us" | "global" — inference geography served (Anthropic data residency); drives the 1.1x US multiplier
+	Diagnostics       *CacheDiagnostics          `json:"diagnostics,omitempty"`   // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
@@ -1621,6 +1622,11 @@ type BifrostLLMUsage struct {
 	CompletionTokensDetails *ChatCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	TotalTokens             int                          `json:"total_tokens"`
 	Cost                    *BifrostCost                 `json:"cost,omitempty"` // Only for the providers which support cost calculation
+	// Served Anthropic tier (fast mode / data residency), carried internally so
+	// cancel/timeout billing (which reads a bare usage via BilledUsage) can apply
+	// the tier multiplier. json:"-" keeps them out of every serialized usage payload.
+	Speed        *string `json:"-"`
+	InferenceGeo *string `json:"-"`
 }
 
 type ChatPromptTokensDetails struct {

--- a/core/schemas/passthrough.go
+++ b/core/schemas/passthrough.go
@@ -15,9 +15,10 @@ type BifrostPassthroughRequest struct {
 // functions — no new pricing logic is required.
 type BifrostPassthroughUsage struct {
 	// Text / chat / responses / embeddings
-	LLMUsage    *BifrostLLMUsage
-	ServiceTier *BifrostServiceTier // "priority" | "flex" | nil (default)
-	Speed       *string             // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	LLMUsage     *BifrostLLMUsage
+	ServiceTier  *BifrostServiceTier // "priority" | "flex" | nil (default)
+	Speed        *string             // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	InferenceGeo *string             // "us" | "global" — inference geography served (Anthropic data residency); drives the 1.1x US multiplier
 
 	// Image generation / edit / variation
 	ImageUsage   *ImageUsage

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -230,10 +230,11 @@ type BifrostResponsesResponse struct {
 	Reasoning            *ResponsesParametersReasoning       `json:"reasoning"`         // Configuration options for reasoning models
 	SafetyIdentifier     *string                             `json:"safety_identifier"` // Safety identifier
 	ServiceTier          *BifrostServiceTier                 `json:"service_tier"`
-	Speed                *string                             `json:"speed,omitempty"`       // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
-	Diagnostics          *CacheDiagnostics                   `json:"diagnostics,omitempty"` // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
-	Container            *ResponsesResponseContainer         `json:"container,omitempty"`   // Code-execution sandbox container (Anthropic surfaces it on the response / final streaming message_delta). The neutral per-call id also lives on ResponsesCodeInterpreterToolCall.ContainerID.
-	Status               *string                             `json:"status,omitempty"`      // completed, failed, in_progress, cancelled, queued, or incomplete
+	Speed                *string                             `json:"speed,omitempty"`         // "fast" | "standard" — speed actually served (Anthropic fast mode); drives fast-mode billing
+	InferenceGeo         *string                             `json:"inference_geo,omitempty"` // "us" | "global" — inference geography served (Anthropic data residency); drives the 1.1x US multiplier
+	Diagnostics          *CacheDiagnostics                   `json:"diagnostics,omitempty"`   // Anthropic cache diagnostics (cache-diagnosis-2026-04-07); first prompt-cache prefix divergence point
+	Container            *ResponsesResponseContainer         `json:"container,omitempty"`     // Code-execution sandbox container (Anthropic surfaces it on the response / final streaming message_delta). The neutral per-call id also lives on ResponsesCodeInterpreterToolCall.ContainerID.
+	Status               *string                             `json:"status,omitempty"`        // completed, failed, in_progress, cancelled, queued, or incomplete
 	StreamOptions        *ResponsesStreamOptions             `json:"stream_options,omitempty"`
 	StopReason           *string                             `json:"stop_reason,omitempty"` // Not in OpenAI's spec, but sent by other providers
 	Store                *bool                               `json:"store,omitempty"`

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -437,6 +437,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_mcp_client_tool_execution_timeout_column"}, run: migrationAddMCPClientToolExecutionTimeoutColumn},
 	{IDs: []string{"add_virtual_key_expires_at_column"}, run: migrationAddVirtualKeyExpiresAtColumn},
 	{IDs: []string{"add_fast_mode_cache_pricing_columns"}, run: migrationAddFastModeCachePricingColumns},
+	{IDs: []string{"add_inference_geo_multiplier_column"}, run: migrationAddInferenceGeoMultiplierColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -7833,6 +7834,43 @@ func migrationAddFastModeCachePricingColumns(ctx context.Context, db *gorm.DB, l
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running fast mode cache pricing columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddInferenceGeoMultiplierColumn adds the inference_geo_us_multiplier
+// column for Anthropic data residency (inference_geo:"us" applies a 1.1x
+// multiplier stacking on top of all token/cache costs).
+func migrationAddInferenceGeoMultiplierColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_inference_geo_multiplier_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	columns := []string{
+		"inference_geo_us_multiplier",
+	}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, field := range columns {
+				if err := addColumnIfNotExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to add column %s: %w", field, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, field := range columns {
+				if err := dropColumnIfExists(tx, logger, &tables.TableModelPricing{}, field); err != nil {
+					return fmt.Errorf("failed to drop column %s: %w", field, err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running inference geo multiplier column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2494,6 +2494,7 @@ var pricingSyncUpdateColumns = []string{
 	"cache_creation_input_token_cost_fast",
 	"cache_creation_input_token_cost_above_1hr_fast",
 	"cache_read_input_token_cost_fast",
+	"inference_geo_us_multiplier",
 	// Costs - Image
 	"input_cost_per_image",
 	"input_cost_per_pixel",

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -101,6 +101,8 @@ type TableModelPricing struct {
 	// Costs - Other
 	SearchContextCostPerQuery     *float64 `gorm:"default:null;column:search_context_cost_per_query" json:"search_context_cost_per_query,omitempty"`
 	CodeInterpreterCostPerSession *float64 `gorm:"default:null;column:code_interpreter_cost_per_session" json:"code_interpreter_cost_per_session,omitempty"`
+	// Data-residency multiplier scaling all token/cache costs when Anthropic serves inference_geo:"us" (1.1x); nil = no multiplier.
+	InferenceGeoUSMultiplier *float64 `gorm:"default:null;column:inference_geo_us_multiplier" json:"inference_geo_us_multiplier,omitempty"`
 
 	// Costs - OCR
 	OCRCostPerPage        *float64 `gorm:"default:null;column:ocr_cost_per_page" json:"ocr_cost_per_page,omitempty"`

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -55,8 +55,13 @@ func (s *Store) CalculateCostForUsage(usage *schemas.BifrostLLMUsage, provider s
 		return usage.Cost.TotalCost
 	}
 
+	// Apply the served tier (fast mode / data residency) carried on the usage so
+	// cancelled/failed fast or US-residency streams keep their multiplier.
+	input := costInput{usage: usage}
+	input.tier = tierFromResponse(nil, usage.Speed, usage.InferenceGeo)
+
 	return s.computeCostFromInput(
-		costInput{usage: usage},
+		input,
 		schemas.RoutingInfo{Provider: provider, Model: model},
 		normalizeStreamRequestType(requestType),
 		lookupScopes,
@@ -225,18 +230,18 @@ func extractCostInput(result *schemas.BifrostResponse) costInput {
 
 	case result.ChatResponse != nil && result.ChatResponse.Usage != nil:
 		input.usage = result.ChatResponse.Usage
-		input.tier = tierFromResponse(result.ChatResponse.ServiceTier, result.ChatResponse.Speed)
+		input.tier = tierFromResponse(result.ChatResponse.ServiceTier, result.ChatResponse.Speed, result.ChatResponse.InferenceGeo)
 
 	case result.ResponsesResponse != nil && result.ResponsesResponse.Usage != nil:
 		input.usage = responsesUsageToBifrostUsage(result.ResponsesResponse.Usage)
-		input.tier = tierFromResponse(result.ResponsesResponse.ServiceTier, result.ResponsesResponse.Speed)
+		input.tier = tierFromResponse(result.ResponsesResponse.ServiceTier, result.ResponsesResponse.Speed, result.ResponsesResponse.InferenceGeo)
 
 	case result.CompactionResponse != nil && result.CompactionResponse.Usage != nil:
 		input.usage = responsesUsageToBifrostUsage(result.CompactionResponse.Usage)
 
 	case result.ResponsesStreamResponse != nil && result.ResponsesStreamResponse.Response != nil && result.ResponsesStreamResponse.Response.Usage != nil:
 		input.usage = responsesUsageToBifrostUsage(result.ResponsesStreamResponse.Response.Usage)
-		input.tier = tierFromResponse(result.ResponsesStreamResponse.Response.ServiceTier, result.ResponsesStreamResponse.Response.Speed)
+		input.tier = tierFromResponse(result.ResponsesStreamResponse.Response.ServiceTier, result.ResponsesStreamResponse.Response.Speed, result.ResponsesStreamResponse.Response.InferenceGeo)
 
 	case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 		input.usage = result.EmbeddingResponse.Usage
@@ -478,7 +483,15 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 		searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
 	}
 
-	return inputCost + outputCost + audioCost + searchCost
+	// Data residency (Anthropic inference_geo:"us") scales all token/cache costs
+	// by a flat multiplier; the per-search fee is not a token category, so it is
+	// excluded.
+	tokenCost := inputCost + outputCost + audioCost
+	if tier.inferenceGeoUS && pricing.InferenceGeoUSMultiplier != nil {
+		tokenCost *= *pricing.InferenceGeoUSMultiplier
+	}
+
+	return tokenCost + searchCost
 }
 
 // computeEmbeddingCost handles embedding requests (input-only).
@@ -777,7 +790,7 @@ func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPa
 // (fast mode). speed == "fast" means fast mode was actually served — the
 // provider echoes the served speed, so stripped/fell-back requests report
 // "standard" and bill at standard rates.
-func tierFromResponse(s *schemas.BifrostServiceTier, speed *string) serviceTier {
+func tierFromResponse(s *schemas.BifrostServiceTier, speed *string, inferenceGeo *string) serviceTier {
 	var tier serviceTier
 	if s != nil {
 		switch *s {
@@ -788,6 +801,7 @@ func tierFromResponse(s *schemas.BifrostServiceTier, speed *string) serviceTier 
 		}
 	}
 	tier.isFast = speed != nil && *speed == "fast"
+	tier.inferenceGeoUS = inferenceGeo != nil && strings.EqualFold(*inferenceGeo, "us")
 	return tier
 }
 
@@ -1419,7 +1433,7 @@ func passthroughUsageToCostInput(su *schemas.BifrostPassthroughUsage) costInput 
 	if su.LLMUsage != nil {
 		input.usage = su.LLMUsage
 	}
-	input.tier = tierFromResponse(su.ServiceTier, su.Speed)
+	input.tier = tierFromResponse(su.ServiceTier, su.Speed, su.InferenceGeo)
 	if su.ImageUsage != nil {
 		input.imageUsage = su.ImageUsage
 		input.imageSize = su.ImageSize

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -287,10 +287,60 @@ func TestComputeTextCost_FastMode_Opus48CacheRegression(t *testing.T) {
 	assert.InDelta(t, expected, fast, 1e-9)
 }
 
+// TestComputeTextCost_InferenceGeoUS_AppliesMultiplier verifies the Anthropic
+// data-residency multiplier (inference_geo:"us") scales every token/cache cost by
+// 1.1x while leaving the flat per-search fee untouched.
+func TestComputeTextCost_InferenceGeoUS_AppliesMultiplier(t *testing.T) {
+	p := chatPricing(0.00001, 0.00005)
+	p.CacheReadInputTokenCost = bifrost.Ptr(0.000001)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.0000125)
+	p.SearchContextCostPerQuery = bifrost.Ptr(0.01)
+	p.InferenceGeoUSMultiplier = bifrost.Ptr(1.1)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     1000, // 500 non-cached + 200 read + 300 write
+		CompletionTokens: 100,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  200,
+			CachedWriteTokens: 300,
+		},
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+			NumSearchQueries: bifrost.Ptr(2),
+		},
+	}
+
+	tokenCost := 500*0.00001 + 200*0.000001 + 300*0.0000125 + 100*0.00005
+	searchCost := 2 * 0.01
+
+	got := computeTextCost(&p, usage, serviceTier{inferenceGeoUS: true})
+	assert.InDelta(t, tokenCost*1.1+searchCost, got, 1e-9)
+
+	// Without US residency the multiplier is a no-op; the search fee is identical.
+	base := computeTextCost(&p, usage, serviceTier{})
+	assert.InDelta(t, tokenCost+searchCost, base, 1e-9)
+}
+
+// TestComputeTextCost_InferenceGeoUS_NoMultiplierColumn verifies US residency is a
+// safe no-op until the datasheet populates the multiplier column upstream.
+func TestComputeTextCost_InferenceGeoUS_NoMultiplierColumn(t *testing.T) {
+	p := chatPricing(0.00001, 0.00005)
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 100}
+	withUS := computeTextCost(&p, usage, serviceTier{inferenceGeoUS: true})
+	without := computeTextCost(&p, usage, serviceTier{})
+	assert.InDelta(t, without, withUS, 1e-9)
+}
+
 func TestTierFromResponse_Speed(t *testing.T) {
-	assert.False(t, tierFromResponse(nil, nil).isFast)
-	assert.False(t, tierFromResponse(nil, bifrost.Ptr("standard")).isFast)
-	assert.True(t, tierFromResponse(nil, bifrost.Ptr("fast")).isFast)
+	assert.False(t, tierFromResponse(nil, nil, nil).isFast)
+	assert.False(t, tierFromResponse(nil, bifrost.Ptr("standard"), nil).isFast)
+	assert.True(t, tierFromResponse(nil, bifrost.Ptr("fast"), nil).isFast)
+}
+
+func TestTierFromResponse_InferenceGeo(t *testing.T) {
+	assert.False(t, tierFromResponse(nil, nil, nil).inferenceGeoUS)
+	assert.False(t, tierFromResponse(nil, nil, bifrost.Ptr("global")).inferenceGeoUS)
+	assert.True(t, tierFromResponse(nil, nil, bifrost.Ptr("us")).inferenceGeoUS)
+	assert.True(t, tierFromResponse(nil, nil, bifrost.Ptr("US")).inferenceGeoUS)
 }
 
 func TestComputeTextCost_With1hrCacheCreationTokens(t *testing.T) {
@@ -2351,28 +2401,28 @@ func TestTieredCacheReadRate_FallbackOrder(t *testing.T) {
 
 func TestTierFromResponse_Priority(t *testing.T) {
 	s := schemas.BifrostServiceTierPriority
-	tier := tierFromResponse(&s, nil)
+	tier := tierFromResponse(&s, nil, nil)
 	assert.True(t, tier.isPriority)
 	assert.False(t, tier.isFlex)
 }
 
 func TestTierFromResponse_Flex(t *testing.T) {
 	s := schemas.BifrostServiceTierFlex
-	tier := tierFromResponse(&s, nil)
+	tier := tierFromResponse(&s, nil, nil)
 	assert.False(t, tier.isPriority)
 	assert.True(t, tier.isFlex)
 }
 
 func TestTierFromResponse_Default(t *testing.T) {
 	for _, s := range []schemas.BifrostServiceTier{schemas.BifrostServiceTierAuto, schemas.BifrostServiceTierDefault, ""} {
-		tier := tierFromResponse(&s, nil)
+		tier := tierFromResponse(&s, nil, nil)
 		assert.False(t, tier.isPriority, "expected no priority for %q", s)
 		assert.False(t, tier.isFlex, "expected no flex for %q", s)
 	}
 }
 
 func TestTierFromResponse_Nil(t *testing.T) {
-	tier := tierFromResponse(nil, nil)
+	tier := tierFromResponse(nil, nil, nil)
 	assert.False(t, tier.isPriority)
 	assert.False(t, tier.isFlex)
 }
@@ -3099,4 +3149,32 @@ func TestCalculateCostForUsage_NilUsageIsZero(t *testing.T) {
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
 	assert.Equal(t, 0.0, s.CalculateCostForUsage(nil, schemas.OpenAI, "gpt-4o", schemas.ChatCompletionRequest, nil))
+}
+
+// TestCalculateCostForUsage_AppliesServedTier verifies the cancel/failure billing
+// path honors the served Anthropic tier carried internally on the usage (fast mode
+// + data residency), so interrupted fast or US-residency streams keep their
+// multiplier instead of being billed as standard/global.
+func TestCalculateCostForUsage_AppliesServedTier(t *testing.T) {
+	p := chatPricing(0.000005, 0.000015) // base $5/$15 per MTok
+	p.InputCostPerTokenFast = bifrost.Ptr(0.00001)
+	p.OutputCostPerTokenFast = bifrost.Ptr(0.00003)
+	p.InferenceGeoUSMultiplier = bifrost.Ptr(1.1)
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("claude-x", "anthropic", "chat"): p,
+	})
+	mk := func(speed, geo *string) *schemas.BifrostLLMUsage {
+		return &schemas.BifrostLLMUsage{PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500, Speed: speed, InferenceGeo: geo}
+	}
+	cost := func(u *schemas.BifrostLLMUsage) float64 {
+		return s.CalculateCostForUsage(u, schemas.Anthropic, "claude-x", schemas.ChatCompletionRequest, nil)
+	}
+	fast, us := "fast", "us"
+
+	// No served tier → base rate.
+	assert.InDelta(t, 1000*0.000005+500*0.000015, cost(mk(nil, nil)), 1e-12)
+	// speed:"fast" → flat fast rate.
+	assert.InDelta(t, 1000*0.00001+500*0.00003, cost(mk(&fast, nil)), 1e-12)
+	// inference_geo:"us" → 1.1x on base.
+	assert.InDelta(t, (1000*0.000005+500*0.000015)*1.1, cost(mk(nil, &us)), 1e-12)
 }

--- a/framework/modelcatalog/datasheet/overrides.go
+++ b/framework/modelcatalog/datasheet/overrides.go
@@ -292,6 +292,7 @@ func patchPricing(pricing configstoreTables.TableModelPricing, override Options)
 		{dst: &patched.CacheCreationInputTokenCostFast, src: override.CacheCreationInputTokenCostFast},
 		{dst: &patched.CacheCreationInputTokenCostAbove1hrFast, src: override.CacheCreationInputTokenCostAbove1hrFast},
 		{dst: &patched.CacheReadInputTokenCostFast, src: override.CacheReadInputTokenCostFast},
+		{dst: &patched.InferenceGeoUSMultiplier, src: override.InferenceGeoUSMultiplier},
 		{dst: &patched.InputCostPerTokenBatches, src: override.InputCostPerTokenBatches},
 		{dst: &patched.OutputCostPerTokenBatches, src: override.OutputCostPerTokenBatches},
 		{dst: &patched.InputCostPerImageToken, src: override.InputCostPerImageToken},

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -178,6 +178,7 @@ type Options struct {
 	// represents it as a tiered object. See Entry.UnmarshalJSON.
 	SearchContextCostPerQuery     *float64 `json:"search_context_cost_per_query,omitempty"`
 	CodeInterpreterCostPerSession *float64 `json:"code_interpreter_cost_per_session,omitempty"`
+	InferenceGeoUSMultiplier      *float64 `json:"inference_geo_us_multiplier,omitempty"`
 
 	// Costs - OCR
 	OCRCostPerPage        *float64 `json:"ocr_cost_per_page,omitempty"`
@@ -256,6 +257,8 @@ type serviceTier struct {
 	isPriority bool // true when service_tier == "priority"
 	isFlex     bool // true when service_tier == "flex"
 	isFast     bool // true when usage.speed == "fast" (Anthropic fast mode)
+	// true when usage.inference_geo == "us" (Anthropic data residency 1.1x multiplier)
+	inferenceGeoUS bool
 }
 
 // costInput holds the extracted usage data from a BifrostResponse,
@@ -629,6 +632,7 @@ func convertEntryToTablePricing(modelKey string, entry Entry) configstoreTables.
 
 		SearchContextCostPerQuery:     entry.SearchContextCostPerQuery,
 		CodeInterpreterCostPerSession: entry.CodeInterpreterCostPerSession,
+		InferenceGeoUSMultiplier:      entry.InferenceGeoUSMultiplier,
 
 		OCRCostPerPage:        entry.OCRCostPerPage,
 		AnnotationCostPerPage: entry.AnnotationCostPerPage,
@@ -709,6 +713,7 @@ func convertTablePricingToEntry(pricing *configstoreTables.TableModelPricing) *E
 
 		SearchContextCostPerQuery:     pricing.SearchContextCostPerQuery,
 		CodeInterpreterCostPerSession: pricing.CodeInterpreterCostPerSession,
+		InferenceGeoUSMultiplier:      pricing.InferenceGeoUSMultiplier,
 
 		OCRCostPerPage:        pricing.OCRCostPerPage,
 		AnnotationCostPerPage: pricing.AnnotationCostPerPage,

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -188,6 +188,7 @@ export const PRICING_FIELDS = [
 	},
 	{ key: "search_context_cost_per_query", label: "Search context / query", group: "chat", requestTypeGroups: ["chat", "rerank"] },
 	{ key: "code_interpreter_cost_per_session", label: "Code interpreter / session", group: "chat", requestTypeGroups: ["chat"] },
+	{ key: "inference_geo_us_multiplier", label: "Inference geo US multiplier", group: "chat", requestTypeGroups: ["chat"] },
 	// Audio fields
 	{ key: "input_cost_per_character", label: "Input / character", group: "audio", requestTypeGroups: ["audio"] },
 	{ key: "input_cost_per_audio_token", label: "Input / audio token", group: "audio", requestTypeGroups: ["audio"] },

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -485,6 +485,7 @@ export interface PricingOverridePatch {
 	// Other
 	search_context_cost_per_query?: number;
 	code_interpreter_cost_per_session?: number;
+	inference_geo_us_multiplier?: number;
 	// OCR
 	ocr_cost_per_page?: number;
 	annotation_cost_per_page?: number;


### PR DESCRIPTION
## Summary

Adds end-to-end support for Anthropic's data-residency billing feature (`inference_geo`). When Anthropic serves a request with `inference_geo: "us"`, a 1.1× multiplier is applied to all token and cache costs. This PR propagates the `inference_geo` field from the Anthropic API response through all converter paths (chat, responses, streaming, passthrough) and wires it into the cost engine so US-residency requests bill correctly. It also fixes a related streaming bug where web search request counts were lost on the terminal chunk of streamed Responses requests, causing web search to go unbilled.

## Changes

- **`inference_geo` field propagation**: Added `InferenceGeo *string` to `BifrostChatResponse`, `BifrostResponsesResponse`, and `BifrostPassthroughUsage` schemas. All Anthropic converters (`ToBifrostChatResponse`, `ToBifrostResponsesResponse`, `ToBifrostResponsesStream`, passthrough usage) now forward `inference_geo` from the provider's usage block.
- **Streaming terminal chunk fix**: In both `HandleAnthropicChatCompletionStreaming` and `HandleAnthropicResponsesStream`, `servedSpeed` and `servedInferenceGeo` are captured across events and re-applied to the terminal chunk. The terminal `response.completed` chunk is built fresh with no served modifiers, so without this re-apply, fast-mode and data-residency billing silently fell back to standard rates.
- **Web search count accumulation fix**: `accumulateAnthropicResponsesUsage` now carries `ServerToolUse.WebSearchRequests` into both the response usage accumulator and the mirrored billed usage. Previously the per-event count was overwritten by the terminal chunk's fresh usage, causing web search to go unbilled on streamed Responses requests.
- **Cost engine**: `serviceTier` gains an `inferenceGeoUS bool` field. `tierFromResponse` accepts a third `inferenceGeo *string` argument and sets `inferenceGeoUS` when the value is `"us"` (case-insensitive). `computeTextCost` applies `InferenceGeoUSMultiplier` to all token/cache costs when `inferenceGeoUS` is true; the flat per-search fee is intentionally excluded from the multiplier.
- **Database migration**: Adds `inference_geo_us_multiplier` column to `TableModelPricing` via a new migration step. The column is included in pricing sync, override patching, and the entry↔table conversion helpers.
- **UI**: Exposes `inference_geo_us_multiplier` as a configurable field in the custom pricing override sheet.
- **Tests**: New unit tests cover the accumulator web-search fix, the chat and responses converters forwarding `inference_geo` and web search counts, the cost engine multiplier logic (including the safe no-op when the column is unpopulated), `tierFromResponse` for `inferenceGeoUS`, and an end-to-end streaming test (`TestResponsesStream_TerminalChunkCarriesServedModifiers`) that replays `message_start → message_delta → message_stop` and asserts the terminal billed chunk carries `speed`, `inference_geo`, web search count, and cache-creation tokens.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/anthropic/... ./framework/modelcatalog/datasheet/...

# UI
cd ui
pnpm i
pnpm build
```

To validate end-to-end: send a chat or responses request to an Anthropic model with data residency enabled. Confirm the response carries `inference_geo: "us"` and that the billed cost reflects the 1.1× multiplier on token/cache costs with the per-search fee unchanged. For streaming, confirm the terminal chunk carries both `speed` and `inference_geo` after `message_stop`.

The `inference_geo_us_multiplier` column must be populated in the model pricing datasheet for the multiplier to apply; if the column is `null`, billing is a safe no-op (standard rates).

## Breaking changes

- [x] No

`tierFromResponse` gains a third parameter but is an internal function. All call sites have been updated.

## Related issues

## Security considerations

No auth, secrets, or PII implications. The multiplier is a pricing configuration value stored in the existing model pricing table with the same access controls as other pricing columns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable