### PR TITLE
fix: support GA transcription-type sessions in POST /v1/realtime/client_secrets

### DIFF
--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -320,14 +320,32 @@ func normalizeRealtimeClientSecretsRequest(
 	if marshalErr != nil {
 		return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized model", marshalErr)
 	}
-	session["model"] = modelJSON
-	StripNestedModelPrefixes(session)
-	if _, ok := session["type"]; !ok {
-		typeJSON, marshalErr := json.Marshal("realtime")
-		if marshalErr != nil {
-			return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode realtime session type", marshalErr)
+
+	if isGATranscriptionSession(session) {
+		// RealtimeTranscriptionSessionCreateRequestGA has no top-level session.model
+		// field at all — the model lives only at session.audio.input.transcription.model.
+		// Writing a bogus top-level session.model here would send OpenAI a field its
+		// transcription-session schema doesn't define.
+		if bifrostErr := writeGASessionTranscriptionModel(session, modelJSON); bifrostErr != nil {
+			return nil, "", bifrostErr
 		}
-		session["type"] = typeJSON
+		if _, ok := session["type"]; !ok {
+			typeJSON, marshalErr := json.Marshal("transcription")
+			if marshalErr != nil {
+				return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode transcription session type", marshalErr)
+			}
+			session["type"] = typeJSON
+		}
+	} else {
+		session["model"] = modelJSON
+		StripNestedModelPrefixes(session)
+		if _, ok := session["type"]; !ok {
+			typeJSON, marshalErr := json.Marshal("realtime")
+			if marshalErr != nil {
+				return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode realtime session type", marshalErr)
+			}
+			session["type"] = typeJSON
+		}
 	}
 	delete(root, "model")
 
@@ -343,6 +361,87 @@ func normalizeRealtimeClientSecretsRequest(
 	}
 
 	return normalizedBody, normalizedModel, nil
+}
+
+// isGATranscriptionSession reports whether session is shaped like
+// RealtimeTranscriptionSessionCreateRequestGA rather than a full realtime
+// session: either explicit session.type == "transcription", or (no explicit
+// type, no top-level model) session.audio.input.transcription is present —
+// the shape only a transcription-session client would send.
+func isGATranscriptionSession(session map[string]json.RawMessage) bool {
+	if typeJSON, ok := session["type"]; ok {
+		var sessionType string
+		if json.Unmarshal(typeJSON, &sessionType) == nil {
+			return sessionType == "transcription"
+		}
+		return false
+	}
+	if _, hasModel := session["model"]; hasModel {
+		return false
+	}
+	audioJSON, ok := session["audio"]
+	if !ok {
+		return false
+	}
+	var audio map[string]json.RawMessage
+	if json.Unmarshal(audioJSON, &audio) != nil {
+		return false
+	}
+	inputJSON, ok := audio["input"]
+	if !ok {
+		return false
+	}
+	var input map[string]json.RawMessage
+	if json.Unmarshal(inputJSON, &input) != nil {
+		return false
+	}
+	_, hasTranscription := input["transcription"]
+	return hasTranscription
+}
+
+// writeGASessionTranscriptionModel sets session.audio.input.transcription.model
+// to the already-bare, already-resolved model, creating the object if the
+// client's transcription config was otherwise empty.
+func writeGASessionTranscriptionModel(session map[string]json.RawMessage, modelJSON json.RawMessage) *schemas.BifrostError {
+	audioJSON, ok := session["audio"]
+	if !ok {
+		return newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio is required for transcription sessions", nil)
+	}
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(audioJSON, &audio); err != nil {
+		return newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio must be an object", err)
+	}
+	inputJSON, ok := audio["input"]
+	if !ok {
+		return newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input is required for transcription sessions", nil)
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(inputJSON, &input); err != nil {
+		return newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input must be an object", err)
+	}
+	transcription := map[string]json.RawMessage{}
+	if transJSON, ok := input["transcription"]; ok && len(transJSON) > 0 && !bytes.Equal(transJSON, []byte("null")) {
+		if err := json.Unmarshal(transJSON, &transcription); err != nil {
+			return newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input.transcription must be an object", err)
+		}
+	}
+	transcription["model"] = modelJSON
+	transcriptionJSON, err := json.Marshal(transcription)
+	if err != nil {
+		return newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode session.audio.input.transcription", err)
+	}
+	input["transcription"] = transcriptionJSON
+	inputJSON, err = json.Marshal(input)
+	if err != nil {
+		return newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode session.audio.input", err)
+	}
+	audio["input"] = inputJSON
+	audioJSON, err = json.Marshal(audio)
+	if err != nil {
+		return newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode session.audio", err)
+	}
+	session["audio"] = audioJSON
+	return nil
 }
 
 func normalizeRealtimeSessionsRequest(

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -321,11 +321,17 @@ func normalizeRealtimeClientSecretsRequest(
 		return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized model", marshalErr)
 	}
 
-	if isGATranscriptionSession(session) {
+	if schemas.IsGATranscriptionSessionBody(root) {
 		// RealtimeTranscriptionSessionCreateRequestGA has no top-level session.model
 		// field at all — the model lives only at session.audio.input.transcription.model.
 		// Writing a bogus top-level session.model here would send OpenAI a field its
-		// transcription-session schema doesn't define.
+		// transcription-session schema doesn't define. Also strip any stray
+		// session.model a permissive client sent alongside the transcription
+		// shape — IsGATranscriptionSessionBody's classification (checked
+		// against root, not session, before we ever get here) guarantees
+		// session.model was absent when the shape was decided, but delete it
+		// defensively in case a caller constructs the map directly.
+		delete(session, "model")
 		if bifrostErr := writeGASessionTranscriptionModel(session, modelJSON); bifrostErr != nil {
 			return nil, "", bifrostErr
 		}
@@ -361,42 +367,6 @@ func normalizeRealtimeClientSecretsRequest(
 	}
 
 	return normalizedBody, normalizedModel, nil
-}
-
-// isGATranscriptionSession reports whether session is shaped like
-// RealtimeTranscriptionSessionCreateRequestGA rather than a full realtime
-// session: either explicit session.type == "transcription", or (no explicit
-// type, no top-level model) session.audio.input.transcription is present —
-// the shape only a transcription-session client would send.
-func isGATranscriptionSession(session map[string]json.RawMessage) bool {
-	if typeJSON, ok := session["type"]; ok {
-		var sessionType string
-		if json.Unmarshal(typeJSON, &sessionType) == nil {
-			return sessionType == "transcription"
-		}
-		return false
-	}
-	if _, hasModel := session["model"]; hasModel {
-		return false
-	}
-	audioJSON, ok := session["audio"]
-	if !ok {
-		return false
-	}
-	var audio map[string]json.RawMessage
-	if json.Unmarshal(audioJSON, &audio) != nil {
-		return false
-	}
-	inputJSON, ok := audio["input"]
-	if !ok {
-		return false
-	}
-	var input map[string]json.RawMessage
-	if json.Unmarshal(inputJSON, &input) != nil {
-		return false
-	}
-	_, hasTranscription := input["transcription"]
-	return hasTranscription
 }
 
 // writeGASessionTranscriptionModel sets session.audio.input.transcription.model

--- a/core/providers/openai/realtime_test.go
+++ b/core/providers/openai/realtime_test.go
@@ -130,6 +130,98 @@ func TestNormalizeRealtimeClientSecretRequestGATranscriptionSessionNoExplicitTyp
 	}
 }
 
+// TestNormalizeRealtimeClientSecretRequestLegacyRootModelWithTranscriptionSibling
+// is a regression test for a codex-review-caught bug: a full realtime
+// session using the legacy top-level "model" field, with live input-audio
+// transcription enabled as a sibling feature, must keep its real
+// conversational model and must not be reclassified as a transcription-only
+// session.
+func TestNormalizeRealtimeClientSecretRequestLegacyRootModelWithTranscriptionSibling(t *testing.T) {
+	t.Parallel()
+
+	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
+		json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`),
+		schemas.OpenAI,
+		schemas.RealtimeSessionEndpointClientSecrets,
+	)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if model != "gpt-4o-realtime-preview" {
+		t.Fatalf("model = %q, want %q (the real conversational model, not the transcription sibling's)", model, "gpt-4o-realtime-preview")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to unmarshal normalized body: %v", err)
+	}
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	var sessionModel string
+	if err := json.Unmarshal(session["model"], &sessionModel); err != nil || sessionModel != "gpt-4o-realtime-preview" {
+		t.Fatalf("session.model = %v, want %q", session["model"], "gpt-4o-realtime-preview")
+	}
+	var sessionType string
+	if err := json.Unmarshal(session["type"], &sessionType); err != nil || sessionType != "realtime" {
+		t.Fatalf("session.type = %v, want %q (must not be reclassified as transcription)", session["type"], "realtime")
+	}
+	// The transcription sibling's model survives, with its provider prefix
+	// stripped by StripNestedModelPrefixes (existing behavior for all nested
+	// model fields in a full session, unrelated to which model is used for
+	// routing) — it's a different model than the routing one, just no longer
+	// carrying a Bifrost-style provider prefix upstream wouldn't understand.
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(session["audio"], &audio); err != nil {
+		t.Fatalf("failed to unmarshal session.audio: %v", err)
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(audio["input"], &input); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input: %v", err)
+	}
+	var transcription map[string]any
+	if err := json.Unmarshal(input["transcription"], &transcription); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input.transcription: %v", err)
+	}
+	if transcription["model"] != "whisper-1" {
+		t.Fatalf("session.audio.input.transcription.model = %v, want %q (sibling config survives, prefix stripped, unrelated to routing)", transcription["model"], "whisper-1")
+	}
+}
+
+// TestNormalizeRealtimeClientSecretRequestTranscriptionTypeDropsStaleSessionModel
+// is a regression test for a codex-review-caught bug: when a permissive
+// client sends both session.type=="transcription" AND a stray top-level
+// session.model, the transcription branch must delete it rather than leave
+// an un-stripped, schema-invalid field in the wire body.
+func TestNormalizeRealtimeClientSecretRequestTranscriptionTypeDropsStaleSessionModel(t *testing.T) {
+	t.Parallel()
+
+	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
+		json.RawMessage(`{"session":{"type":"transcription","model":"openai/gpt-4o-transcribe","audio":{"input":{"transcription":{}}}}}`),
+		schemas.OpenAI,
+		schemas.RealtimeSessionEndpointClientSecrets,
+	)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if model != "gpt-4o-transcribe" {
+		t.Fatalf("model = %q, want %q", model, "gpt-4o-transcribe")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to unmarshal normalized body: %v", err)
+	}
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	if _, hasModel := session["model"]; hasModel {
+		t.Fatal("stray session.model must be deleted for a transcription-type session, not left un-stripped in the wire body")
+	}
+}
+
 func TestNormalizeRealtimeClientSecretRequestUsesDefaultProvider(t *testing.T) {
 	t.Parallel()
 

--- a/core/providers/openai/realtime_test.go
+++ b/core/providers/openai/realtime_test.go
@@ -43,6 +43,93 @@ func TestNormalizeRealtimeClientSecretRequest(t *testing.T) {
 	}
 }
 
+func TestNormalizeRealtimeClientSecretRequestGATranscriptionSession(t *testing.T) {
+	t.Parallel()
+
+	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
+		json.RawMessage(`{"session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe","language":"en"},"format":{"type":"audio/pcm","rate":24000}}}}}`),
+		schemas.OpenAI,
+		schemas.RealtimeSessionEndpointClientSecrets,
+	)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if model != "gpt-4o-transcribe" {
+		t.Fatalf("model = %q, want %q", model, "gpt-4o-transcribe")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to unmarshal normalized body: %v", err)
+	}
+
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	if _, hasModel := session["model"]; hasModel {
+		t.Fatal("transcription-type session must not gain a top-level session.model field — not part of RealtimeTranscriptionSessionCreateRequestGA")
+	}
+	var sessionType string
+	if err := json.Unmarshal(session["type"], &sessionType); err != nil || sessionType != "transcription" {
+		t.Fatalf("session.type = %v, want %q", session["type"], "transcription")
+	}
+
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(session["audio"], &audio); err != nil {
+		t.Fatalf("failed to unmarshal session.audio: %v", err)
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(audio["input"], &input); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input: %v", err)
+	}
+	var transcription map[string]any
+	if err := json.Unmarshal(input["transcription"], &transcription); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input.transcription: %v", err)
+	}
+	if transcription["model"] != "gpt-4o-transcribe" {
+		t.Fatalf("session.audio.input.transcription.model = %v, want %q (provider prefix must be stripped)", transcription["model"], "gpt-4o-transcribe")
+	}
+	if transcription["language"] != "en" {
+		t.Fatalf("session.audio.input.transcription.language = %v, want %q (sibling fields must survive)", transcription["language"], "en")
+	}
+	if _, hasFormat := input["format"]; !hasFormat {
+		t.Fatal("session.audio.input.format must survive normalization")
+	}
+}
+
+func TestNormalizeRealtimeClientSecretRequestGATranscriptionSessionNoExplicitType(t *testing.T) {
+	t.Parallel()
+
+	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
+		json.RawMessage(`{"session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`),
+		schemas.OpenAI,
+		schemas.RealtimeSessionEndpointClientSecrets,
+	)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if model != "whisper-1" {
+		t.Fatalf("model = %q, want %q", model, "whisper-1")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to unmarshal normalized body: %v", err)
+	}
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	var sessionType string
+	if err := json.Unmarshal(session["type"], &sessionType); err != nil || sessionType != "transcription" {
+		t.Fatalf("session.type = %v, want %q (must be inferred and set even when the client omitted it)", session["type"], "transcription")
+	}
+	if _, hasModel := session["model"]; hasModel {
+		t.Fatal("transcription-type session must not gain a top-level session.model field")
+	}
+}
+
 func TestNormalizeRealtimeClientSecretRequestUsesDefaultProvider(t *testing.T) {
 	t.Parallel()
 

--- a/core/schemas/realtime_client_secrets.go
+++ b/core/schemas/realtime_client_secrets.go
@@ -17,7 +17,12 @@ func ParseRealtimeClientSecretBody(raw json.RawMessage) (map[string]json.RawMess
 }
 
 // ExtractRealtimeClientSecretModel extracts the model from either session.model
-// or the legacy top-level model field.
+// or the legacy top-level model field. Also falls back to the GA transcription
+// shape (session.audio.input.transcription.model) since /v1/realtime/client_secrets
+// mints both full realtime sessions (session.model) AND transcription-only
+// sessions (session.type == "transcription", RealtimeTranscriptionSessionCreateRequestGA
+// — which has no top-level session.model at all, only the nested transcription
+// model) through this same endpoint.
 func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, *BifrostError) {
 	if sessionJSON, ok := root["session"]; ok && len(sessionJSON) > 0 && !bytes.Equal(sessionJSON, []byte("null")) {
 		var session map[string]json.RawMessage
@@ -33,6 +38,9 @@ func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, 
 				return strings.TrimSpace(sessionModel), nil
 			}
 		}
+		if model, found, err := extractGATranscriptionModel(session); err != nil || found {
+			return model, err
+		}
 	}
 
 	if modelJSON, ok := root["model"]; ok {
@@ -46,6 +54,47 @@ func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, 
 	}
 
 	return "", NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.model or model is required", nil)
+}
+
+// extractGATranscriptionModel reads session.audio.input.transcription.model —
+// the GA transcription-session shape (RealtimeTranscriptionSessionCreateRequestGA),
+// which has no top-level session.model at all. The bool return distinguishes
+// "found a non-empty model" from "absent — not a transcription-shaped session".
+func extractGATranscriptionModel(session map[string]json.RawMessage) (string, bool, *BifrostError) {
+	audioJSON, ok := session["audio"]
+	if !ok || len(audioJSON) == 0 || bytes.Equal(audioJSON, []byte("null")) {
+		return "", false, nil
+	}
+	var audio map[string]json.RawMessage
+	if err := Unmarshal(audioJSON, &audio); err != nil {
+		return "", true, NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.audio must be an object", err)
+	}
+	inputJSON, ok := audio["input"]
+	if !ok || len(inputJSON) == 0 || bytes.Equal(inputJSON, []byte("null")) {
+		return "", false, nil
+	}
+	var input map[string]json.RawMessage
+	if err := Unmarshal(inputJSON, &input); err != nil {
+		return "", true, NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.audio.input must be an object", err)
+	}
+	transJSON, ok := input["transcription"]
+	if !ok || len(transJSON) == 0 || bytes.Equal(transJSON, []byte("null")) {
+		return "", false, nil
+	}
+	var transcription map[string]json.RawMessage
+	if err := Unmarshal(transJSON, &transcription); err != nil {
+		return "", true, NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.audio.input.transcription must be an object", err)
+	}
+	modelJSON, ok := transcription["model"]
+	if !ok {
+		return "", false, nil
+	}
+	var model string
+	if err := Unmarshal(modelJSON, &model); err != nil {
+		return "", true, NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.audio.input.transcription.model must be a string", err)
+	}
+	model = strings.TrimSpace(model)
+	return model, model != "", nil
 }
 
 // NewRealtimeClientSecretBodyError builds a standard invalid-request style error

--- a/core/schemas/realtime_client_secrets.go
+++ b/core/schemas/realtime_client_secrets.go
@@ -19,10 +19,14 @@ func ParseRealtimeClientSecretBody(raw json.RawMessage) (map[string]json.RawMess
 // ExtractRealtimeClientSecretModel extracts the model from either session.model
 // or the legacy top-level model field. Also falls back to the GA transcription
 // shape (session.audio.input.transcription.model) since /v1/realtime/client_secrets
-// mints both full realtime sessions (session.model) AND transcription-only
-// sessions (session.type == "transcription", RealtimeTranscriptionSessionCreateRequestGA
+// mints both full realtime sessions (session.model, or the legacy top-level
+// model field) AND transcription-only sessions (RealtimeTranscriptionSessionCreateRequestGA
 // — which has no top-level session.model at all, only the nested transcription
-// model) through this same endpoint.
+// model) through this same endpoint. The GA-nested fallback is only ever
+// consulted via IsGATranscriptionSessionBody, which itself requires both
+// session.model and the legacy root model to be absent — a full realtime
+// session must never be reclassified as transcription-only just because it
+// also enables live input-audio transcription as a sibling feature.
 func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, *BifrostError) {
 	if sessionJSON, ok := root["session"]; ok && len(sessionJSON) > 0 && !bytes.Equal(sessionJSON, []byte("null")) {
 		var session map[string]json.RawMessage
@@ -38,9 +42,6 @@ func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, 
 				return strings.TrimSpace(sessionModel), nil
 			}
 		}
-		if model, found, err := extractGATranscriptionModel(session); err != nil || found {
-			return model, err
-		}
 	}
 
 	if modelJSON, ok := root["model"]; ok {
@@ -53,7 +54,91 @@ func ExtractRealtimeClientSecretModel(root map[string]json.RawMessage) (string, 
 		}
 	}
 
+	if IsGATranscriptionSessionBody(root) {
+		if sessionJSON, ok := root["session"]; ok && len(sessionJSON) > 0 && !bytes.Equal(sessionJSON, []byte("null")) {
+			var session map[string]json.RawMessage
+			if err := Unmarshal(sessionJSON, &session); err == nil {
+				if model, found, err := extractGATranscriptionModel(session); err != nil || found {
+					return model, err
+				}
+			}
+		}
+	}
+
 	return "", NewRealtimeClientSecretBodyError(400, "invalid_request_error", "session.model or model is required", nil)
+}
+
+// IsGATranscriptionSessionBody reports whether root represents a GA
+// transcription-only session (RealtimeTranscriptionSessionCreateRequestGA)
+// rather than a full realtime session. This is the single canonical
+// classifier shared by extraction (above) and both normalization layers
+// (transports/bifrost-http/handlers and core/providers/openai) so they
+// cannot diverge on the same input — each layer previously ran its own
+// ad hoc classification logic, which could disagree.
+//
+// Priority (checked in order, first match wins):
+//  1. explicit session.type is present -> authoritative, since it's the
+//     schema's actual discriminator (oneOf RealtimeSessionCreateRequestGA /
+//     RealtimeTranscriptionSessionCreateRequestGA): "transcription" -> true,
+//     anything else -> false, regardless of what other fields are also
+//     present (e.g. a stray session.model alongside type=="transcription"
+//     is invalid input the normalizer should clean up, not a signal to
+//     reclassify the session).
+//  2. no explicit type: session.model present -> full realtime session (false).
+//  3. no explicit type: legacy top-level "model" present -> full realtime
+//     session (false). Checked before any transcription-shape inspection so
+//     a full session that also enables live input-audio transcription as a
+//     sibling feature is never misclassified.
+//  4. no explicit type, no model anywhere: session.audio.input.transcription
+//     is present and non-null -> transcription session (true); otherwise false.
+func IsGATranscriptionSessionBody(root map[string]json.RawMessage) bool {
+	var session map[string]json.RawMessage
+	if sessionJSON, ok := root["session"]; ok && len(sessionJSON) > 0 && !bytes.Equal(sessionJSON, []byte("null")) {
+		_ = Unmarshal(sessionJSON, &session)
+	}
+	if session == nil {
+		return false
+	}
+	if typeJSON, ok := session["type"]; ok {
+		var sessionType string
+		if Unmarshal(typeJSON, &sessionType) == nil {
+			return sessionType == "transcription"
+		}
+		return false
+	}
+	if _, hasModel := session["model"]; hasModel {
+		return false
+	}
+	if _, hasRootModel := root["model"]; hasRootModel {
+		return false
+	}
+	return hasNonNullAudioInputTranscription(session)
+}
+
+// hasNonNullAudioInputTranscription reports whether session.audio.input.transcription
+// is present and not explicitly null. Null must be excluded: a client can
+// send audio.input.transcription: null to explicitly disable transcription
+// on a full realtime session, which must not be misread as "this is a
+// transcription-only session."
+func hasNonNullAudioInputTranscription(session map[string]json.RawMessage) bool {
+	audioJSON, ok := session["audio"]
+	if !ok || len(audioJSON) == 0 || bytes.Equal(audioJSON, []byte("null")) {
+		return false
+	}
+	var audio map[string]json.RawMessage
+	if Unmarshal(audioJSON, &audio) != nil {
+		return false
+	}
+	inputJSON, ok := audio["input"]
+	if !ok || len(inputJSON) == 0 || bytes.Equal(inputJSON, []byte("null")) {
+		return false
+	}
+	var input map[string]json.RawMessage
+	if Unmarshal(inputJSON, &input) != nil {
+		return false
+	}
+	transJSON, ok := input["transcription"]
+	return ok && len(transJSON) > 0 && !bytes.Equal(transJSON, []byte("null"))
 }
 
 // extractGATranscriptionModel reads session.audio.input.transcription.model —

--- a/core/schemas/realtime_client_secrets_test.go
+++ b/core/schemas/realtime_client_secrets_test.go
@@ -93,3 +93,54 @@ func TestExtractRealtimeClientSecretModelFullSessionPrefersSessionModelOverAudio
 		t.Fatalf("model = %q, want %q (session.model must win)", model, "openai/gpt-realtime")
 	}
 }
+
+// TestExtractRealtimeClientSecretModelLegacyRootModelPrefersOverAudioSibling
+// is a regression test for a bug caught by codex review: a full realtime
+// session using the legacy top-level "model" field (no session.model), with
+// live input-audio transcription enabled as a completely standard sibling
+// feature, was having its model extraction hijacked by the nested
+// transcription model — losing the real conversational model entirely and
+// silently reclassifying the session as transcription-only.
+func TestExtractRealtimeClientSecretModelLegacyRootModelPrefersOverAudioSibling(t *testing.T) {
+	t.Parallel()
+
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+
+	model, bifrostErr := ExtractRealtimeClientSecretModel(root)
+	if bifrostErr != nil {
+		t.Fatalf("ExtractRealtimeClientSecretModel() error = %v", bifrostErr)
+	}
+	if model != "openai/gpt-4o-realtime-preview" {
+		t.Fatalf("model = %q, want %q (legacy root model must win over an audio.input.transcription sibling)", model, "openai/gpt-4o-realtime-preview")
+	}
+}
+
+func TestIsGATranscriptionSessionBodyExcludesNullTranscription(t *testing.T) {
+	t.Parallel()
+
+	// A full realtime session that explicitly disables input transcription
+	// (audio.input.transcription: null) with a legacy root model must not be
+	// misclassified as transcription-only.
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":null}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+	if IsGATranscriptionSessionBody(root) {
+		t.Fatal("explicit audio.input.transcription: null must not be classified as a GA transcription session")
+	}
+}
+
+func TestIsGATranscriptionSessionBodyRootModelWins(t *testing.T) {
+	t.Parallel()
+
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+	if IsGATranscriptionSessionBody(root) {
+		t.Fatal("a legacy root model must classify the body as a full realtime session, not transcription-only")
+	}
+}

--- a/core/schemas/realtime_client_secrets_test.go
+++ b/core/schemas/realtime_client_secrets_test.go
@@ -38,3 +38,58 @@ func TestExtractRealtimeClientSecretModelFallbackTopLevel(t *testing.T) {
 		t.Fatalf("model = %q, want %q", model, "gpt-4o-realtime-preview")
 	}
 }
+
+func TestExtractRealtimeClientSecretModelGATranscriptionShapeExplicitType(t *testing.T) {
+	t.Parallel()
+
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe"}}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+
+	model, bifrostErr := ExtractRealtimeClientSecretModel(root)
+	if bifrostErr != nil {
+		t.Fatalf("ExtractRealtimeClientSecretModel() error = %v", bifrostErr)
+	}
+	if model != "openai/gpt-4o-transcribe" {
+		t.Fatalf("model = %q, want %q", model, "openai/gpt-4o-transcribe")
+	}
+}
+
+func TestExtractRealtimeClientSecretModelGATranscriptionShapeNoExplicitType(t *testing.T) {
+	t.Parallel()
+
+	// Some clients may omit "type" and rely on the transcription shape alone
+	// to imply it — extraction must not require an explicit type field.
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+
+	model, bifrostErr := ExtractRealtimeClientSecretModel(root)
+	if bifrostErr != nil {
+		t.Fatalf("ExtractRealtimeClientSecretModel() error = %v", bifrostErr)
+	}
+	if model != "openai/whisper-1" {
+		t.Fatalf("model = %q, want %q", model, "openai/whisper-1")
+	}
+}
+
+func TestExtractRealtimeClientSecretModelFullSessionPrefersSessionModelOverAudio(t *testing.T) {
+	t.Parallel()
+
+	// A full realtime session (session.model set) must never be misread as a
+	// transcription session even if it also happens to carry an audio object.
+	root, err := ParseRealtimeClientSecretBody(json.RawMessage(`{"session":{"model":"openai/gpt-realtime","audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`))
+	if err != nil {
+		t.Fatalf("ParseRealtimeClientSecretBody() error = %v", err)
+	}
+
+	model, bifrostErr := ExtractRealtimeClientSecretModel(root)
+	if bifrostErr != nil {
+		t.Fatalf("ExtractRealtimeClientSecretModel() error = %v", bifrostErr)
+	}
+	if model != "openai/gpt-realtime" {
+		t.Fatalf("model = %q, want %q (session.model must win)", model, "openai/gpt-realtime")
+	}
+}

--- a/transports/bifrost-http/handlers/realtime_client_secrets.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets.go
@@ -286,6 +286,10 @@ func normalizeRealtimeClientSecretBody(root map[string]json.RawMessage, bareMode
 					return nil, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session", err)
 				}
 				root["session"] = rewritten
+			} else if rewritten, changed, err := rewriteGASessionTranscriptionModel(session, normalizedModel); err != nil {
+				return nil, err
+			} else if changed {
+				root["session"] = rewritten
 			}
 		}
 	}
@@ -299,6 +303,63 @@ func normalizeRealtimeClientSecretBody(root map[string]json.RawMessage, bareMode
 		return nil, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode body", marshalErr)
 	}
 	return normalized, nil
+}
+
+// rewriteGASessionTranscriptionModel updates session.audio.input.transcription.model
+// in place for a GA transcription-shaped session (RealtimeTranscriptionSessionCreateRequestGA,
+// which has no top-level session.model — the field this function's caller
+// already checked is absent). Needed so that alias resolution (which changes
+// the routing model after key selection) actually reaches the field the
+// provider layer reads, instead of silently leaving the pre-alias model in
+// the body. Returns changed=false when the session isn't transcription-shaped
+// (e.g. a full realtime session with no model set yet, which the caller
+// should leave untouched).
+func rewriteGASessionTranscriptionModel(session map[string]json.RawMessage, normalizedModel json.RawMessage) ([]byte, bool, *schemas.BifrostError) {
+	audioJSON, ok := session["audio"]
+	if !ok || len(audioJSON) == 0 || string(audioJSON) == "null" {
+		return nil, false, nil
+	}
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(audioJSON, &audio); err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio must be an object", err)
+	}
+	inputJSON, ok := audio["input"]
+	if !ok || len(inputJSON) == 0 || string(inputJSON) == "null" {
+		return nil, false, nil
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(inputJSON, &input); err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input must be an object", err)
+	}
+	transJSON, ok := input["transcription"]
+	if !ok || len(transJSON) == 0 || string(transJSON) == "null" {
+		return nil, false, nil
+	}
+	var transcription map[string]json.RawMessage
+	if err := json.Unmarshal(transJSON, &transcription); err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input.transcription must be an object", err)
+	}
+	transcription["model"] = normalizedModel
+	transcriptionJSON, err := json.Marshal(transcription)
+	if err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session.audio.input.transcription", err)
+	}
+	input["transcription"] = transcriptionJSON
+	inputJSON, err = json.Marshal(input)
+	if err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session.audio.input", err)
+	}
+	audio["input"] = inputJSON
+	audioJSON, err = json.Marshal(audio)
+	if err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session.audio", err)
+	}
+	session["audio"] = audioJSON
+	rewritten, err := json.Marshal(session)
+	if err != nil {
+		return nil, false, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session", err)
+	}
+	return rewritten, true, nil
 }
 
 const realtimeEphemeralKeyMappingPrefix = "realtime:ephemeral-key:"

--- a/transports/bifrost-http/handlers/realtime_client_secrets.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets.go
@@ -275,20 +275,31 @@ func normalizeRealtimeClientSecretBody(root map[string]json.RawMessage, bareMode
 		return nil, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized model", marshalErr)
 	}
 
+	// Classify once, via the same canonical classifier extraction and the
+	// provider-layer normalizer use (schemas.IsGATranscriptionSessionBody),
+	// so this pass can't disagree with them about which shape a body is —
+	// a full realtime session must never take the GA-transcription rewrite
+	// branch just because it also enables live input-audio transcription as
+	// a sibling feature (checked via root.model/session.model presence, not
+	// just whether session.model happens to be set).
+	isGATranscription := schemas.IsGATranscriptionSessionBody(root)
+
 	// Normalize session.model if present
 	if sessionJSON, ok := root["session"]; ok && len(sessionJSON) > 0 {
 		var session map[string]json.RawMessage
 		if err := json.Unmarshal(sessionJSON, &session); err == nil {
-			if _, hasModel := session["model"]; hasModel {
+			if isGATranscription {
+				if rewritten, changed, err := rewriteGASessionTranscriptionModel(session, normalizedModel); err != nil {
+					return nil, err
+				} else if changed {
+					root["session"] = rewritten
+				}
+			} else if _, hasModel := session["model"]; hasModel {
 				session["model"] = normalizedModel
 				rewritten, err := json.Marshal(session)
 				if err != nil {
 					return nil, newRealtimeClientSecretHandlerError(fasthttp.StatusInternalServerError, "server_error", "failed to re-encode session", err)
 				}
-				root["session"] = rewritten
-			} else if rewritten, changed, err := rewriteGASessionTranscriptionModel(session, normalizedModel); err != nil {
-				return nil, err
-			} else if changed {
 				root["session"] = rewritten
 			}
 		}

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -234,6 +234,54 @@ func TestGATranscriptionSessionEndToEndThroughFullNormalizationPath(t *testing.T
 	}
 }
 
+// TestFullRealtimeSessionWithTranscriptionSiblingEndToEnd is a regression
+// test for a codex-review-caught bug: a full realtime session using the
+// legacy top-level "model" field, with live input-audio transcription
+// enabled as a completely standard sibling feature, was being misclassified
+// as transcription-only by resolveRealtimeClientSecretTarget — the real
+// conversational model was lost entirely. Drives the exact same
+// handler->provider two-pass path as CreateRealtimeClientSecret does.
+func TestFullRealtimeSessionWithTranscriptionSiblingEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	var ctx fasthttp.RequestCtx
+	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets}
+	body := []byte(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`)
+
+	providerKey, model, handlerBody, err := resolveRealtimeClientSecretTarget(&ctx, &lib.Config{}, route, body)
+	if err != nil {
+		t.Fatalf("resolveRealtimeClientSecretTarget() error = %v", err)
+	}
+	if providerKey != schemas.OpenAI || model != "gpt-4o-realtime-preview" {
+		t.Fatalf("provider/model = %q/%q, want %q/%q", providerKey, model, schemas.OpenAI, "gpt-4o-realtime-preview")
+	}
+
+	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI, schemas.RealtimeSessionEndpointClientSecrets)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if finalModel != "gpt-4o-realtime-preview" {
+		t.Fatalf("final model = %q, want %q", finalModel, "gpt-4o-realtime-preview")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(finalBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal final body: %v", err)
+	}
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	var sessionModel string
+	if err := json.Unmarshal(session["model"], &sessionModel); err != nil || sessionModel != "gpt-4o-realtime-preview" {
+		t.Fatalf("session.model = %v, want %q", session["model"], "gpt-4o-realtime-preview")
+	}
+	var sessionType string
+	if err := json.Unmarshal(session["type"], &sessionType); err != nil || sessionType != "realtime" {
+		t.Fatalf("session.type = %v, want %q (must not be reclassified as transcription-only)", session["type"], "realtime")
+	}
+}
+
 // TestRewriteGASessionTranscriptionModelAppliesAliasResolution covers the
 // alias-resolution rewrite path (handleRequest calls this after key selection
 // when key.Aliases.Resolve changes the model) for a GA transcription session,

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
+	openaiProvider "github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/plugins/governance"
@@ -58,6 +59,13 @@ func TestResolveRealtimeClientSecretTarget(t *testing.T) {
 			route:   schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets, DefaultProvider: schemas.OpenAI},
 			body:    []byte(`{"session":{}}`),
 			wantErr: true,
+		},
+		{
+			name:         "GA transcription session resolves model from nested audio path",
+			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets},
+			body:         []byte(`{"session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe"}}}}}`),
+			wantProvider: schemas.OpenAI,
+			wantModel:    "gpt-4o-transcribe",
 		},
 	}
 
@@ -158,6 +166,139 @@ func TestResolveRealtimeClientSecretTarget_NormalizesModel(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGATranscriptionSessionEndToEndThroughFullNormalizationPath drives the
+// full request path: handler-level resolveRealtimeClientSecretTarget, then
+// feeds its output into the OpenAI provider's NormalizeRealtimeClientSecretRequest
+// exactly as CreateRealtimeClientSecret does. Regression test for the bug
+// where GA transcription-shaped sessions (session.type=="transcription",
+// model nested at session.audio.input.transcription.model) 400'd with
+// "session.model or model is required" because extraction only ever checked
+// session.model — confirmed live against real OpenAI before this fix.
+func TestGATranscriptionSessionEndToEndThroughFullNormalizationPath(t *testing.T) {
+	t.Parallel()
+
+	var ctx fasthttp.RequestCtx
+	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets}
+	body := []byte(`{"session":{"type":"transcription","audio":{"input":{"format":{"type":"audio/pcm","rate":24000},"transcription":{"model":"openai/whisper-1","language":"en"}}}}}`)
+
+	providerKey, model, handlerBody, err := resolveRealtimeClientSecretTarget(&ctx, &lib.Config{}, route, body)
+	if err != nil {
+		t.Fatalf("resolveRealtimeClientSecretTarget() error = %v", err)
+	}
+	if providerKey != schemas.OpenAI || model != "whisper-1" {
+		t.Fatalf("provider/model = %q/%q, want %q/%q", providerKey, model, schemas.OpenAI, "whisper-1")
+	}
+
+	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI, schemas.RealtimeSessionEndpointClientSecrets)
+	if bifrostErr != nil {
+		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
+	}
+	if finalModel != "whisper-1" {
+		t.Fatalf("model = %q, want %q", finalModel, "whisper-1")
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(finalBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal final body: %v", err)
+	}
+	var session map[string]json.RawMessage
+	if err := json.Unmarshal(payload["session"], &session); err != nil {
+		t.Fatalf("failed to unmarshal session: %v", err)
+	}
+	if _, hasModel := session["model"]; hasModel {
+		t.Fatal("transcription-type session must not gain a top-level session.model field")
+	}
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(session["audio"], &audio); err != nil {
+		t.Fatalf("failed to unmarshal session.audio: %v", err)
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(audio["input"], &input); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input: %v", err)
+	}
+	var transcription map[string]any
+	if err := json.Unmarshal(input["transcription"], &transcription); err != nil {
+		t.Fatalf("failed to unmarshal session.audio.input.transcription: %v", err)
+	}
+	if transcription["model"] != "whisper-1" {
+		t.Fatalf("session.audio.input.transcription.model = %v, want %q", transcription["model"], "whisper-1")
+	}
+	if transcription["language"] != "en" {
+		t.Fatalf("session.audio.input.transcription.language = %v, want %q (must survive the two-pass normalization)", transcription["language"], "en")
+	}
+	if _, hasFormat := input["format"]; !hasFormat {
+		t.Fatal("session.audio.input.format must survive normalization")
+	}
+}
+
+// TestRewriteGASessionTranscriptionModelAppliesAliasResolution covers the
+// alias-resolution rewrite path (handleRequest calls this after key selection
+// when key.Aliases.Resolve changes the model) for a GA transcription session,
+// which has no top-level session.model for the generic rewrite to target.
+func TestRewriteGASessionTranscriptionModelAppliesAliasResolution(t *testing.T) {
+	t.Parallel()
+
+	session := map[string]json.RawMessage{
+		"type":  json.RawMessage(`"transcription"`),
+		"audio": json.RawMessage(`{"input":{"transcription":{"model":"whisper-1","language":"en"}}}`),
+	}
+	normalizedModel, err := json.Marshal("gpt-4o-transcribe")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	rewritten, changed, bifrostErr := rewriteGASessionTranscriptionModel(session, normalizedModel)
+	if bifrostErr != nil {
+		t.Fatalf("rewriteGASessionTranscriptionModel() error = %v", bifrostErr)
+	}
+	if !changed {
+		t.Fatal("expected changed=true for a GA transcription session")
+	}
+
+	var rewrittenSession map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten, &rewrittenSession); err != nil {
+		t.Fatalf("failed to unmarshal rewritten session: %v", err)
+	}
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(rewrittenSession["audio"], &audio); err != nil {
+		t.Fatalf("failed to unmarshal audio: %v", err)
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(audio["input"], &input); err != nil {
+		t.Fatalf("failed to unmarshal input: %v", err)
+	}
+	var transcription map[string]any
+	if err := json.Unmarshal(input["transcription"], &transcription); err != nil {
+		t.Fatalf("failed to unmarshal transcription: %v", err)
+	}
+	if transcription["model"] != "gpt-4o-transcribe" {
+		t.Fatalf("model = %v, want %q (alias resolution must reach the nested field)", transcription["model"], "gpt-4o-transcribe")
+	}
+	if transcription["language"] != "en" {
+		t.Fatalf("language = %v, want %q", transcription["language"], "en")
+	}
+}
+
+func TestRewriteGASessionTranscriptionModelNoOpForFullRealtimeSession(t *testing.T) {
+	t.Parallel()
+
+	// A full realtime session with no audio.input.transcription at all should
+	// be left untouched (changed=false) — the caller's own session.model path
+	// handles that case.
+	session := map[string]json.RawMessage{
+		"instructions": json.RawMessage(`"be helpful"`),
+	}
+	normalizedModel, _ := json.Marshal("gpt-realtime")
+
+	_, changed, bifrostErr := rewriteGASessionTranscriptionModel(session, normalizedModel)
+	if bifrostErr != nil {
+		t.Fatalf("rewriteGASessionTranscriptionModel() error = %v", bifrostErr)
+	}
+	if changed {
+		t.Fatal("expected changed=false when session has no audio.input.transcription")
 	}
 }
 


### PR DESCRIPTION
## Summary

`POST /v1/realtime/client_secrets` mints both full realtime sessions and GA transcription-only sessions (`session.type: "transcription"`), but model extraction only checked `session.model` — the transcription schema has no such field, only `session.audio.input.transcription.model`. Every transcription-type request 400'd; confirmed live against real OpenAI.

## Changes

- `ExtractRealtimeClientSecretModel` falls back to the nested transcription model when `session.model` is absent.
- Added `schemas.IsGATranscriptionSessionBody`, a single classifier shared by extraction and both normalization layers (handler + provider), so they can't disagree on the same body. Explicit `session.type` wins when present; otherwise `session.model`/legacy root `model` beat the structural fallback, so a full session with transcription enabled as a sibling feature is never misclassified.
- Writes the model into the correct nested slot for transcription sessions instead of a bogus top-level `session.model`; the alias-resolution rewrite does the same.
- A first pass introduced its own classification bugs, caught by `codex --yolo` review and fixed in a follow-up commit.

## Type of change

- [x] Bug fix

## How to test

```sh
cd core && go test ./schemas/... ./providers/openai/... ./providers/azure/...
cd ../transports/bifrost-http && go test ./handlers/...
```

Also live-verified against real OpenAI's platform API using the `openai` Python SDK (and curl): minted a real GA transcription-session `client_secret`, and confirmed the regression scenario (full session + transcription sibling) keeps `type: "realtime"` and the correct model.

## Breaking changes

- [x] No
