### PR TITLE
fix: round-trip anthropic redacted_thinking blocks on the responses surface

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
+- fix: round-trip Anthropic `redacted_thinking` blocks on the responses surface so multi-turn tool use with redacted reasoning can be replayed (closes #5093) [@fus3r](https://github.com/fus3r)
 - fix: reset `HasEmittedWebSearch` when recycling pooled Gemini responses stream state so grounded streaming requests keep emitting `web_search_call` items (closes #5113) [@fus3r](https://github.com/fus3r)

--- a/core/providers/anthropic/redactedthinkingresponses_test.go
+++ b/core/providers/anthropic/redactedthinkingresponses_test.go
@@ -193,6 +193,27 @@ func TestToBifrostResponsesStream_RedactedThinkingWithoutDataSkipped(t *testing.
 			if len(state.ContentIndexToBlockType) != 0 {
 				t.Errorf("expected block-type tracking to be cleaned up on stop, got %d entries", len(state.ContentIndexToBlockType))
 			}
+			if state.CurrentOutputIndex != 0 {
+				t.Errorf("expected no output index to be reserved for a data-less block, got CurrentOutputIndex=%d", state.CurrentOutputIndex)
+			}
+
+			// A following block must keep its position: the skipped block did not
+			// shift output indices.
+			textStart := &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStart,
+				Index: schemas.Ptr(1),
+				ContentBlock: &AnthropicContentBlock{
+					Type: AnthropicContentBlockTypeText,
+					Text: schemas.Ptr(""),
+				},
+			}
+			responses, err, _ = textStart.ToBifrostResponsesStream(context.Background(), 0, state)
+			if err != nil {
+				t.Fatalf("unexpected error on following text start: %v", err)
+			}
+			if len(responses) == 0 || responses[0].OutputIndex == nil || *responses[0].OutputIndex != 0 {
+				t.Errorf("expected the following text block to take output index 0, got %+v", responses)
+			}
 		})
 	}
 }

--- a/core/providers/anthropic/redactedthinkingresponses_test.go
+++ b/core/providers/anthropic/redactedthinkingresponses_test.go
@@ -1,0 +1,481 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// driveResponsesStream replays a sequence of Anthropic SSE events through
+// ToBifrostResponsesStream against a fresh stream state and returns every
+// Bifrost stream response emitted, in order.
+func driveResponsesStream(t *testing.T, events []*AnthropicStreamEvent) []*schemas.BifrostResponsesStreamResponse {
+	t.Helper()
+
+	state := AcquireAnthropicResponsesStreamState()
+	defer ReleaseAnthropicResponsesStreamState(state)
+
+	var out []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for _, event := range events {
+		responses, err, _ := event.ToBifrostResponsesStream(context.Background(), seq, state)
+		if err != nil {
+			t.Fatalf("unexpected error converting %s: %v", event.Type, err)
+		}
+		out = append(out, responses...)
+		seq += len(responses)
+	}
+	return out
+}
+
+// redactedThinkingLifecycle returns the real Anthropic SSE shape of a response
+// whose only content block is a redacted_thinking block: the block arrives
+// complete in content_block_start (no deltas follow).
+func redactedThinkingLifecycle(data string) []*AnthropicStreamEvent {
+	stopReason := AnthropicStopReasonEndTurn
+	return []*AnthropicStreamEvent{
+		{
+			Type: AnthropicStreamEventTypeMessageStart,
+			Message: &AnthropicMessageResponse{
+				ID:    "msg_redacted_stream",
+				Model: "claude-sonnet-4-5-20250929",
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: schemas.Ptr(0),
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeRedactedThinking,
+				Data: schemas.Ptr(data),
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStop,
+			Index: schemas.Ptr(0),
+		},
+		{
+			Type:  AnthropicStreamEventTypeMessageDelta,
+			Delta: &AnthropicStreamDelta{StopReason: &stopReason},
+		},
+		{
+			Type: AnthropicStreamEventTypeMessageStop,
+		},
+	}
+}
+
+func findReasoningItemsWithEncryptedContent(responses []*schemas.BifrostResponsesStreamResponse, respType schemas.ResponsesStreamResponseType) []*schemas.ResponsesMessage {
+	var items []*schemas.ResponsesMessage
+	for _, r := range responses {
+		if r.Type != respType || r.Item == nil {
+			continue
+		}
+		if r.Item.Type == nil || *r.Item.Type != schemas.ResponsesMessageTypeReasoning {
+			continue
+		}
+		if r.Item.ResponsesReasoning == nil || r.Item.ResponsesReasoning.EncryptedContent == nil {
+			continue
+		}
+		items = append(items, r.Item)
+	}
+	return items
+}
+
+// TestToBifrostResponsesStream_RedactedThinkingLifecycle replays the streaming
+// shape Anthropic uses for redacted thinking and asserts the encrypted payload
+// survives into output_item.added, output_item.done, and response.completed.
+// Without the redacted_thinking case in the content_block_start handler, the
+// block contributes nothing to the converted stream.
+func TestToBifrostResponsesStream_RedactedThinkingLifecycle(t *testing.T) {
+	t.Parallel()
+
+	const encrypted = "EmwKAhgBEgy3vaFTgeKrzXhpwEr_TEST_PAYLOAD"
+	responses := driveResponsesStream(t, redactedThinkingLifecycle(encrypted))
+
+	// output_item.added carries the reasoning item with the encrypted payload
+	added := findReasoningItemsWithEncryptedContent(responses, schemas.ResponsesStreamResponseTypeOutputItemAdded)
+	if len(added) != 1 {
+		t.Fatalf("want 1 output_item.added reasoning item with encrypted content, got %d", len(added))
+	}
+	if got := *added[0].ResponsesReasoning.EncryptedContent; got != encrypted {
+		t.Errorf("output_item.added encrypted content = %q, want %q", got, encrypted)
+	}
+	if added[0].ID == nil || *added[0].ID == "" {
+		t.Error("output_item.added reasoning item should carry a stable ID")
+	}
+
+	// content_block_stop emits the matching output_item.done
+	done := findReasoningItemsWithEncryptedContent(responses, schemas.ResponsesStreamResponseTypeOutputItemDone)
+	if len(done) != 1 {
+		t.Fatalf("want 1 output_item.done reasoning item with encrypted content, got %d", len(done))
+	}
+	if got := *done[0].ResponsesReasoning.EncryptedContent; got != encrypted {
+		t.Errorf("output_item.done encrypted content = %q, want %q", got, encrypted)
+	}
+
+	// response.completed carries the item in its Output array
+	var completed *schemas.BifrostResponsesResponse
+	for _, r := range responses {
+		if r.Type == schemas.ResponsesStreamResponseTypeCompleted && r.Response != nil {
+			completed = r.Response
+		}
+	}
+	if completed == nil {
+		t.Fatal("expected a response.completed event")
+	}
+	foundInOutput := false
+	for _, item := range completed.Output {
+		if item.Type != nil && *item.Type == schemas.ResponsesMessageTypeReasoning &&
+			item.ResponsesReasoning != nil &&
+			item.ResponsesReasoning.EncryptedContent != nil &&
+			*item.ResponsesReasoning.EncryptedContent == encrypted {
+			foundInOutput = true
+		}
+	}
+	if !foundInOutput {
+		t.Errorf("response.completed output should contain the redacted reasoning item, got %d items", len(completed.Output))
+	}
+}
+
+// TestToBifrostResponsesStream_RedactedThinkingWithoutDataSkipped mirrors the
+// chat-surface guard: a redacted_thinking block with no data contributes
+// nothing at all. That includes its content_block_stop, which otherwise falls
+// into the generic done path and synthesizes an orphan output_item.done with
+// an empty message shell.
+func TestToBifrostResponsesStream_RedactedThinkingWithoutDataSkipped(t *testing.T) {
+	t.Parallel()
+
+	for name, data := range map[string]*string{
+		"nil data":   nil,
+		"empty data": schemas.Ptr(""),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			state := AcquireAnthropicResponsesStreamState()
+			defer ReleaseAnthropicResponsesStreamState(state)
+
+			start := &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStart,
+				Index: schemas.Ptr(0),
+				ContentBlock: &AnthropicContentBlock{
+					Type: AnthropicContentBlockTypeRedactedThinking,
+					Data: data,
+				},
+			}
+			responses, err, isLast := start.ToBifrostResponsesStream(context.Background(), 0, state)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if isLast {
+				t.Error("should not be last chunk")
+			}
+			if len(responses) != 0 {
+				t.Errorf("expected 0 responses for a redacted_thinking start without data, got %d", len(responses))
+			}
+			if len(state.OutputItems) != 0 {
+				t.Errorf("expected no stored output items, got %d", len(state.OutputItems))
+			}
+
+			stop := &AnthropicStreamEvent{
+				Type:  AnthropicStreamEventTypeContentBlockStop,
+				Index: schemas.Ptr(0),
+			}
+			responses, err, _ = stop.ToBifrostResponsesStream(context.Background(), 0, state)
+			if err != nil {
+				t.Fatalf("unexpected error on stop: %v", err)
+			}
+			if len(responses) != 0 {
+				t.Errorf("expected the data-less block's stop to emit nothing, got %d responses (orphan output_item.done)", len(responses))
+			}
+			if len(state.ContentIndexToBlockType) != 0 {
+				t.Errorf("expected block-type tracking to be cleaned up on stop, got %d entries", len(state.ContentIndexToBlockType))
+			}
+		})
+	}
+}
+
+// TestToBifrostResponsesStream_MixedRedactedAndVisibleThinking streams a
+// redacted block, a visible thinking block, and a text block in one response
+// and asserts each keeps its own output item: the redacted payload lands on
+// its own reasoning item and does not bleed into the visible reasoning or the
+// text message.
+func TestToBifrostResponsesStream_MixedRedactedAndVisibleThinking(t *testing.T) {
+	t.Parallel()
+
+	const encrypted = "ENC_MIXED_PAYLOAD"
+	stopReason := AnthropicStopReasonEndTurn
+	events := []*AnthropicStreamEvent{
+		{
+			Type: AnthropicStreamEventTypeMessageStart,
+			Message: &AnthropicMessageResponse{
+				ID:    "msg_mixed_stream",
+				Model: "claude-sonnet-4-5-20250929",
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: schemas.Ptr(0),
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeRedactedThinking,
+				Data: schemas.Ptr(encrypted),
+			},
+		},
+		{Type: AnthropicStreamEventTypeContentBlockStop, Index: schemas.Ptr(0)},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: schemas.Ptr(1),
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeThinking,
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockDelta,
+			Index: schemas.Ptr(1),
+			Delta: &AnthropicStreamDelta{
+				Type:     AnthropicStreamDeltaTypeThinking,
+				Thinking: schemas.Ptr("visible reasoning"),
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockDelta,
+			Index: schemas.Ptr(1),
+			Delta: &AnthropicStreamDelta{
+				Type:      AnthropicStreamDeltaTypeSignature,
+				Signature: schemas.Ptr("sig-1"),
+			},
+		},
+		{Type: AnthropicStreamEventTypeContentBlockStop, Index: schemas.Ptr(1)},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockStart,
+			Index: schemas.Ptr(2),
+			ContentBlock: &AnthropicContentBlock{
+				Type: AnthropicContentBlockTypeText,
+				Text: schemas.Ptr(""),
+			},
+		},
+		{
+			Type:  AnthropicStreamEventTypeContentBlockDelta,
+			Index: schemas.Ptr(2),
+			Delta: &AnthropicStreamDelta{
+				Type: AnthropicStreamDeltaTypeText,
+				Text: schemas.Ptr("final answer"),
+			},
+		},
+		{Type: AnthropicStreamEventTypeContentBlockStop, Index: schemas.Ptr(2)},
+		{
+			Type:  AnthropicStreamEventTypeMessageDelta,
+			Delta: &AnthropicStreamDelta{StopReason: &stopReason},
+		},
+		{Type: AnthropicStreamEventTypeMessageStop},
+	}
+
+	responses := driveResponsesStream(t, events)
+
+	// Exactly one added reasoning item carries the encrypted payload, on its own output index.
+	encryptedAdded := findReasoningItemsWithEncryptedContent(responses, schemas.ResponsesStreamResponseTypeOutputItemAdded)
+	if len(encryptedAdded) != 1 {
+		t.Fatalf("want exactly 1 added reasoning item with encrypted content, got %d", len(encryptedAdded))
+	}
+	if got := *encryptedAdded[0].ResponsesReasoning.EncryptedContent; got != encrypted {
+		t.Errorf("encrypted content = %q, want %q", got, encrypted)
+	}
+
+	// The visible thinking block still produces its own reasoning item, without the payload.
+	var visibleReasoningAdded int
+	var addedOutputIndices []int
+	for _, r := range responses {
+		if r.Type != schemas.ResponsesStreamResponseTypeOutputItemAdded || r.Item == nil {
+			continue
+		}
+		if r.OutputIndex != nil {
+			addedOutputIndices = append(addedOutputIndices, *r.OutputIndex)
+		}
+		if r.Item.Type != nil && *r.Item.Type == schemas.ResponsesMessageTypeReasoning &&
+			(r.Item.ResponsesReasoning == nil || r.Item.ResponsesReasoning.EncryptedContent == nil) {
+			visibleReasoningAdded++
+		}
+	}
+	if visibleReasoningAdded != 1 {
+		t.Errorf("want exactly 1 added reasoning item without encrypted content (the visible one), got %d", visibleReasoningAdded)
+	}
+
+	// Every added item keeps a distinct output index.
+	seen := map[int]bool{}
+	for _, idx := range addedOutputIndices {
+		if seen[idx] {
+			t.Errorf("output index %d used by more than one output_item.added", idx)
+		}
+		seen[idx] = true
+	}
+
+	// The text delta still flows through untouched.
+	textSeen := false
+	for _, r := range responses {
+		if r.Type == schemas.ResponsesStreamResponseTypeOutputTextDelta && r.Delta != nil && *r.Delta == "final answer" {
+			textSeen = true
+		}
+	}
+	if !textSeen {
+		t.Error("expected the text block's output_text.delta to be emitted")
+	}
+}
+
+// TestToAnthropicResponsesStreamResponse_RedactedThinkingEgress feeds the
+// output_item.added event produced by the inbound converter back through the
+// Bifrost→Anthropic stream converter and asserts the passthrough client gets a
+// redacted_thinking content_block_start with the payload, closing the loop for
+// the Anthropic integration route.
+func TestToAnthropicResponsesStreamResponse_RedactedThinkingEgress(t *testing.T) {
+	t.Parallel()
+
+	const encrypted = "ENC_EGRESS_PAYLOAD"
+	responses := driveResponsesStream(t, redactedThinkingLifecycle(encrypted))
+
+	var addedEvent *schemas.BifrostResponsesStreamResponse
+	for _, r := range responses {
+		if r.Type == schemas.ResponsesStreamResponseTypeOutputItemAdded {
+			addedEvent = r
+			break
+		}
+	}
+	if addedEvent == nil {
+		t.Fatal("expected an output_item.added event to feed the egress converter")
+	}
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	frames := ToAnthropicResponsesStreamResponse(ctx, addedEvent)
+
+	found := false
+	for _, frame := range frames {
+		if frame == nil || frame.ContentBlock == nil {
+			continue
+		}
+		if frame.Type == AnthropicStreamEventTypeContentBlockStart &&
+			frame.ContentBlock.Type == AnthropicContentBlockTypeRedactedThinking &&
+			frame.ContentBlock.Data != nil && *frame.ContentBlock.Data == encrypted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a content_block_start frame with a redacted_thinking block carrying the payload on the anthropic egress, got %d frames", len(frames))
+	}
+}
+
+// assertRedactedThinkingPrecedesToolUse asserts the outgoing Anthropic request
+// contains an assistant message whose first content block is the replayed
+// redacted_thinking block, followed by the tool_use block, which is the shape
+// Anthropic requires on multi-turn tool use with thinking.
+func assertRedactedThinkingPrecedesToolUse(t *testing.T, req *AnthropicMessageRequest, encrypted string) {
+	t.Helper()
+
+	for _, msg := range req.Messages {
+		if msg.Role != AnthropicMessageRoleAssistant {
+			continue
+		}
+		toolUseIdx := -1
+		redactedIdx := -1
+		for i, block := range msg.Content.ContentBlocks {
+			switch block.Type {
+			case AnthropicContentBlockTypeToolUse:
+				toolUseIdx = i
+			case AnthropicContentBlockTypeRedactedThinking:
+				if block.Data != nil && *block.Data == encrypted {
+					redactedIdx = i
+				}
+			}
+		}
+		if toolUseIdx == -1 {
+			continue
+		}
+		if redactedIdx == -1 {
+			t.Fatalf("assistant message with tool_use has no redacted_thinking block carrying the payload: %+v", msg.Content.ContentBlocks)
+		}
+		if redactedIdx > toolUseIdx {
+			t.Fatalf("redacted_thinking (idx %d) must precede tool_use (idx %d)", redactedIdx, toolUseIdx)
+		}
+		return
+	}
+	t.Fatalf("no assistant message with a tool_use block in the outgoing request (%d messages)", len(req.Messages))
+}
+
+func functionCallItem() schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID:    schemas.Ptr("toolu_replay_01"),
+			Name:      schemas.Ptr("get_weather"),
+			Arguments: schemas.Ptr(`{"city":"Paris"}`),
+		},
+	}
+}
+
+// TestToAnthropicResponsesRequest_ReplaysStreamedRedactedThinking closes the
+// multi-turn loop: the reasoning item emitted by the streaming ingress is
+// round-tripped through JSON the way a client echoes its history, then
+// converted back into an Anthropic request. The replayed assistant turn must
+// carry the redacted_thinking block before the tool_use block. The streamed
+// item carries an empty (non-nil) summary list next to encrypted_content, so
+// a nil-check on the summary list drops the payload from the request.
+func TestToAnthropicResponsesRequest_ReplaysStreamedRedactedThinking(t *testing.T) {
+	t.Parallel()
+
+	const encrypted = "ENC_REPLAY_PAYLOAD"
+	responses := driveResponsesStream(t, redactedThinkingLifecycle(encrypted))
+	added := findReasoningItemsWithEncryptedContent(responses, schemas.ResponsesStreamResponseTypeOutputItemAdded)
+	if len(added) != 1 {
+		t.Fatalf("want 1 streamed reasoning item to replay, got %d", len(added))
+	}
+
+	// Client echo: the item leaves and re-enters Bifrost as JSON.
+	wire, err := json.Marshal(added[0])
+	if err != nil {
+		t.Fatalf("marshal streamed item: %v", err)
+	}
+	var replayed schemas.ResponsesMessage
+	if err := json.Unmarshal(wire, &replayed); err != nil {
+		t.Fatalf("unmarshal client echo: %v", err)
+	}
+
+	req := &schemas.BifrostResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: []schemas.ResponsesMessage{replayed, functionCallItem()},
+	}
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	out, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToAnthropicResponsesRequest: %v", err)
+	}
+	assertRedactedThinkingPrecedesToolUse(t, out, encrypted)
+}
+
+// TestToAnthropicResponsesRequest_ReplaysRedactedItemWithEmptySummaryList pins
+// the request-converter half of the fix in isolation, using the exact item
+// shape the non-streaming converter produces for a redacted_thinking block
+// (empty non-nil summary list plus encrypted_content).
+func TestToAnthropicResponsesRequest_ReplaysRedactedItemWithEmptySummaryList(t *testing.T) {
+	t.Parallel()
+
+	const encrypted = "ENC_NONSTREAM_SHAPE"
+	item := schemas.ResponsesMessage{
+		ID:   schemas.Ptr("rs_nonstream_shape"),
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		ResponsesReasoning: &schemas.ResponsesReasoning{
+			Summary:          []schemas.ResponsesReasoningSummary{},
+			EncryptedContent: schemas.Ptr(encrypted),
+		},
+	}
+
+	req := &schemas.BifrostResponsesRequest{
+		Model: "claude-sonnet-4-5-20250929",
+		Input: []schemas.ResponsesMessage{item, functionCallItem()},
+	}
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	out, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToAnthropicResponsesRequest: %v", err)
+	}
+	assertRedactedThinkingPrecedesToolUse(t, out, encrypted)
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1136,6 +1136,56 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				})
 
 				return responses, nil, false
+			case AnthropicContentBlockTypeRedactedThinking:
+				// Redacted thinking blocks arrive complete in content_block_start (no
+				// deltas follow). Surface the encrypted payload as a reasoning item with
+				// encrypted_content, mirroring the non-streaming converter, so streaming
+				// clients can replay it on the next turn; Anthropic rejects tool-use
+				// follow-ups whose latest assistant message dropped it.
+				if chunk.ContentBlock.Data == nil || *chunk.ContentBlock.Data == "" {
+					// Track the index so this block's content_block_stop is skipped
+					// too: a data-less block contributes nothing at all, instead of
+					// leaving an orphan output_item.done with an empty message shell.
+					if chunk.Index != nil {
+						state.ContentIndexToBlockType[*chunk.Index] = AnthropicContentBlockTypeRedactedThinking
+					}
+					return nil, nil, false
+				}
+
+				messageType := schemas.ResponsesMessageTypeReasoning
+				role := schemas.ResponsesInputMessageRoleAssistant
+
+				// Generate stable ID for the reasoning item
+				var itemID string
+				if state.MessageID == nil {
+					itemID = fmt.Sprintf("reasoning_%d", outputIndex)
+				} else {
+					itemID = fmt.Sprintf("msg_%s_reasoning_%d", *state.MessageID, outputIndex)
+				}
+				state.ItemIDs[outputIndex] = itemID
+
+				item := &schemas.ResponsesMessage{
+					ID:   &itemID,
+					Type: &messageType,
+					Role: &role,
+					ResponsesReasoning: &schemas.ResponsesReasoning{
+						Summary:          []schemas.ResponsesReasoningSummary{},
+						EncryptedContent: chunk.ContentBlock.Data,
+					},
+				}
+
+				// Persist into OutputItems so the block's content_block_stop emits the
+				// matching output_item.done and response.completed carries the item.
+				itemCopy := *item
+				state.OutputItems[outputIndex] = &itemCopy
+
+				return []*schemas.BifrostResponsesStreamResponse{{
+					Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+					SequenceNumber: sequenceNumber,
+					OutputIndex:    schemas.Ptr(outputIndex),
+					ContentIndex:   chunk.Index,
+					Item:           item,
+				}}, nil, false
 			default:
 				// Send down an empty response only when integration type is anthropic
 				if ctx.Value(schemas.BifrostContextKeyIntegrationType) == "anthropic" {
@@ -1707,6 +1757,13 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					}
 					if blockType == AnthropicContentBlockTypeCompaction {
 						// Clean up the tracking
+						delete(state.ContentIndexToBlockType, *chunk.Index)
+						return nil, nil, false
+					}
+					if blockType == AnthropicContentBlockTypeRedactedThinking {
+						// Data-less redacted_thinking block: its start emitted
+						// nothing, so its stop must not synthesize an empty message
+						// shell either.
 						delete(state.ContentIndexToBlockType, *chunk.Index)
 						return nil, nil, false
 					}
@@ -5479,7 +5536,12 @@ func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage) [
 			}
 		}
 	} else if msg.ResponsesReasoning != nil {
-		if msg.ResponsesReasoning.Summary != nil {
+		// Redacted-only reasoning items carry an EMPTY (non-nil) summary list next
+		// to encrypted_content, in both the streaming and non-streaming converters,
+		// so gate on the list having entries rather than on nil: a nil-check sends
+		// such items through the summary loop, emits nothing, and drops the
+		// encrypted payload from the replayed request.
+		if len(msg.ResponsesReasoning.Summary) > 0 {
 			for _, reasoningContent := range msg.ResponsesReasoning.Summary {
 				thinkingBlock := AnthropicContentBlock{
 					Type:     AnthropicContentBlockTypeThinking,
@@ -5487,7 +5549,7 @@ func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage) [
 				}
 				thinkingBlocks = append(thinkingBlocks, thinkingBlock)
 			}
-		} else if msg.ResponsesReasoning.EncryptedContent != nil {
+		} else if msg.ResponsesReasoning.EncryptedContent != nil && *msg.ResponsesReasoning.EncryptedContent != "" {
 			thinkingBlock := AnthropicContentBlock{
 				Type: AnthropicContentBlockTypeRedactedThinking,
 				Data: msg.ResponsesReasoning.EncryptedContent,

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -550,6 +550,15 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 	case AnthropicStreamEventTypeContentBlockStart:
 		// Content block start - emit output_item.added (OpenAI-style)
 		if chunk.ContentBlock != nil && chunk.Index != nil {
+			// A data-less redacted_thinking block contributes nothing; skip it
+			// before reserving an output index so later items keep their
+			// positions in response.completed output.
+			if chunk.ContentBlock.Type == AnthropicContentBlockTypeRedactedThinking &&
+				(chunk.ContentBlock.Data == nil || *chunk.ContentBlock.Data == "") {
+				state.ContentIndexToBlockType[*chunk.Index] = AnthropicContentBlockTypeRedactedThinking
+				return nil, nil, false
+			}
+
 			outputIndex := state.getOrCreateOutputIndex(chunk.Index)
 
 			if chunk.ContentBlock.Type == AnthropicContentBlockTypeToolUse &&
@@ -1138,20 +1147,12 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				return responses, nil, false
 			case AnthropicContentBlockTypeRedactedThinking:
 				// Redacted thinking blocks arrive complete in content_block_start (no
-				// deltas follow). Surface the encrypted payload as a reasoning item with
-				// encrypted_content, mirroring the non-streaming converter, so streaming
-				// clients can replay it on the next turn; Anthropic rejects tool-use
-				// follow-ups whose latest assistant message dropped it.
-				if chunk.ContentBlock.Data == nil || *chunk.ContentBlock.Data == "" {
-					// Track the index so this block's content_block_stop is skipped
-					// too: a data-less block contributes nothing at all, instead of
-					// leaving an orphan output_item.done with an empty message shell.
-					if chunk.Index != nil {
-						state.ContentIndexToBlockType[*chunk.Index] = AnthropicContentBlockTypeRedactedThinking
-					}
-					return nil, nil, false
-				}
-
+				// deltas follow; data-less blocks were already skipped above, before
+				// an output index was reserved). Surface the encrypted payload as a
+				// reasoning item with encrypted_content, mirroring the non-streaming
+				// converter, so streaming clients can replay it on the next turn;
+				// Anthropic rejects tool-use follow-ups whose latest assistant
+				// message dropped it.
 				messageType := schemas.ResponsesMessageTypeReasoning
 				role := schemas.ResponsesInputMessageRoleAssistant
 
@@ -1379,6 +1380,14 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 	case AnthropicStreamEventTypeContentBlockStop:
 		// Content block is complete - emit output_item.done (OpenAI-style)
 		if chunk.Index != nil {
+			// Data-less redacted_thinking: its start reserved no output index, so
+			// its stop must not reserve one (or synthesize a done) either.
+			if blockType, exists := state.ContentIndexToBlockType[*chunk.Index]; exists &&
+				blockType == AnthropicContentBlockTypeRedactedThinking {
+				delete(state.ContentIndexToBlockType, *chunk.Index)
+				return nil, nil, false
+			}
+
 			outputIndex := state.getOrCreateOutputIndex(chunk.Index)
 
 			if inputJSON, inputKind, hasInputBuffer := state.finishInputJSONBuffer(chunk.Index); hasInputBuffer {
@@ -1757,13 +1766,6 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					}
 					if blockType == AnthropicContentBlockTypeCompaction {
 						// Clean up the tracking
-						delete(state.ContentIndexToBlockType, *chunk.Index)
-						return nil, nil, false
-					}
-					if blockType == AnthropicContentBlockTypeRedactedThinking {
-						// Data-less redacted_thinking block: its start emitted
-						// nothing, so its stop must not synthesize an empty message
-						// shell either.
 						delete(state.ContentIndexToBlockType, *chunk.Index)
 						return nil, nil, false
 					}


### PR DESCRIPTION
## Summary

Fixes #5093. When Anthropic's safety systems flag part of Claude's reasoning, the API returns it as a `redacted_thinking` block carrying an encrypted `data` payload and requires the block to be replayed unmodified on later turns; their docs call out dropping these blocks as the most common cause of the 400 `` `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified ``.

On the responses surface the blocks were lost twice. The inbound streaming converter dropped them: the `content_block_start` handler in `ToBifrostResponsesStream` has cases for text, tool_use, MCP, compaction, and thinking, but none for `redacted_thinking` (which arrives complete in the start event, with no deltas), so the block fell through to the default and was discarded. Streaming clients never received the item, and it was missing from `response.completed.output` and from the accumulated message that feeds logging, observability, and the semantic cache. The block's `content_block_stop` still went through the generic done path (the output index was allocated at the start event), so each dropped block also produced an orphan `output_item.done` with no matching added, carrying an empty assistant message shell. And the request converter dropped the payload again on replay: `convertBifrostReasoningToAnthropicThinking` checks `Summary != nil` before falling back to `encrypted_content`, while the reasoning items both response converters produce for redacted thinking carry an empty, non-nil summary list, so the encrypted branch was unreachable for exactly the items that need it and even the item the non-streaming path preserves was stripped from the outgoing request. The chat completions surface had the same class of bug, fixed in #4943; this is the responses equivalent.

## Changes

- Add a `redacted_thinking` case to the `content_block_start` handler that emits `output_item.added` with a reasoning item in the shape the non-streaming converter produces (`encrypted_content` carrying the payload), and stores the item so the block's `content_block_stop` emits the matching `output_item.done` and `response.completed` carries it in `output`, following the existing server-tool idiom in this handler.
- Fix the replay side: `convertBifrostReasoningToAnthropicThinking` now gates the summary loop on the list having entries instead of on nil, so reasoning items that carry an empty summary list next to a non-empty `encrypted_content` convert back into `redacted_thinking` blocks, placed before `tool_use` as Anthropic requires.
- Guard: blocks with no `data` contribute nothing at all, including their `content_block_stop` (no orphan done), mirroring the chat-surface guard from #4943.
- Regression tests, all six failing on `dev`: the full streamed lifecycle (added, done, and completed all carry the payload), the no-data guards including the stop, a mixed stream (redacted plus visible thinking plus text keep distinct output items and the payload does not bleed across), an egress round trip (the emitted item converts back to a `redacted_thinking` content block on the Anthropic-format egress), a full replay chain (stream ingress, a JSON round trip standing in for the client echo, then `ToAnthropicResponsesRequest` placing `redacted_thinking` before `tool_use`), and the same replay for the exact item shape the non-streaming converter produces.
- Changelog entry.

No framework change needed: the streaming accumulator already deep-copies `encrypted_content` on reasoning items, so the accumulated/logged message picks the block up once the converter emits it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/anthropic/ -run 'Redacted' -v
```

All six new tests fail on `dev` and pass with this change: the streamed lifecycle, mixed stream, and egress tests fail because the redacted block produces no output item at all, the two replay tests fail because the outgoing request carries the `tool_use` block with no `redacted_thinking` before it, and the no-data guard fails on the orphan `output_item.done` its stop used to synthesize. The full `./providers/anthropic/` suite is green, including under the race detector.

Also verified end to end against a real Anthropic backend (claude-sonnet-4-5, `reasoning` enabled, using the test string Anthropic documents to deterministically trigger redacted thinking, `ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB`): on `dev` the streamed request delivers zero `encrypted_content` occurrences on the client SSE and zero in the logged accumulated message, while the identical non-streamed request keeps the redacted block; with this change the streamed run carries the redacted reasoning items on the wire (18 `encrypted_content` occurrences across the added, done, and completed events for 6 blocks) and the logged accumulated message keeps all 6, with non-streamed behavior unchanged.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

It only emits items that were previously dropped from the converted stream and replays encrypted payloads that were previously stripped from outgoing requests. Streams and requests without redacted thinking are unchanged; reasoning items with a populated summary list keep their existing thinking-block mapping.

## Related issues

Fixes #5093

## Security considerations

None. The payload is opaque to Bifrost and already flows through the non-streaming response path; this change gives the streaming and replay paths the same behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go)
- [ ] I verified the CI pipeline passes locally if applicable
