### PR TITLE
fix: show user popover when `userInfo` exists and include `preferred_username` as display name fallback

### DIFF
--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1492,7 +1492,7 @@ export default function AppSidebar() {
 									</a>
 								))}
 							<ThemeToggle />
-							{IS_ENTERPRISE && userInfo && (userInfo.name || userInfo.email) ? (
+							{IS_ENTERPRISE && userInfo ? (
 								<Popover open={userPopoverOpen} onOpenChange={setUserPopoverOpen}>
 									<PopoverTrigger asChild>
 										<button
@@ -1506,7 +1506,7 @@ export default function AppSidebar() {
 									<PopoverContent side="top" align="start" className="w-56 p-0">
 										<div className="flex flex-col">
 											<div className="px-4 py-3">
-												<p className="text-sm font-medium">{userInfo.name || userInfo.email || "User"}</p>
+												<p className="text-sm font-medium">{userInfo.name || userInfo.email || userInfo.preferred_username || "User"}</p>
 											</div>
 											<Separator />
 											<button


### PR DESCRIPTION
## Summary

The enterprise sidebar user popover was not displaying for users who only have a `preferred_username` set (i.e., no `name` or `email`). This fixes the visibility condition and adds `preferred_username` as a fallback display value.

## Changes

- Removed the `(userInfo.name || userInfo.email)` guard from the popover visibility condition so the user popover renders for any authenticated enterprise user, regardless of which identity fields are populated.
- Added `userInfo.preferred_username` as a fallback display name in the popover, between `email` and the hardcoded `"User"` string.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure an enterprise instance with an identity provider that returns `preferred_username` but not `name` or `email`.
2. Log in and verify the user popover appears in the sidebar.
3. Verify the popover displays the `preferred_username` value as the user's display name.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: User popover was hidden entirely for users with only `preferred_username`.
After: User popover is shown and displays `preferred_username` as the display name.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects display logic for already-authenticated enterprise users.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable