### PR TITLE
[fix]: strip role from non-message OpenAI Responses input items

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: omit role from OpenAI Responses non-message items [@nettee](https://github.com/nettee)

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -108,7 +108,8 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		}
 
 		// OpenAI accepts role only on message input items.
-		if message.Type != nil && *message.Type != schemas.ResponsesMessageTypeMessage {
+		if (message.Type != nil && *message.Type != schemas.ResponsesMessageTypeMessage) ||
+			(message.Type == nil && message.ResponsesReasoning != nil) {
 			message.Role = nil
 		}
 

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -107,6 +107,11 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			}
 		}
 
+		// OpenAI accepts role only on message input items.
+		if message.Type != nil && *message.Type != schemas.ResponsesMessageTypeMessage {
+			message.Role = nil
+		}
+
 		if message.ResponsesReasoning != nil {
 			isGptOss := strings.Contains(capModel, "gpt-oss")
 			isReasoning := isOpenAIReasoningModel(capModel)
@@ -148,8 +153,6 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 				// Clone the embedded pointer to avoid mutating the original input
 				reasoningCopy := *message.ResponsesReasoning
 				message.ResponsesReasoning = &reasoningCopy
-				// OpenAI's Responses API does not accept 'role' on reasoning items
-				message.Role = nil
 				// Strip cross-provider encrypted content that non-reasoning models cannot decrypt.
 				// Reasoning models (o1/o3/o4/GPT-5) may use EncryptedContent for multi-turn state.
 				// Compaction items always carry encrypted_content and must never be stripped.

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -2078,5 +2079,79 @@ func TestToOpenAIResponsesRequest_StripsThoughtSignatureFromCallID(t *testing.T)
 	}
 	if *req.Input[1].ResponsesToolMessage.CallID != embeddedID {
 		t.Error("original function_call_output call_id was mutated")
+	}
+}
+
+func TestToOpenAIResponsesRequest_OmitsRoleFromNonMessageInputItems(t *testing.T) {
+	assistant := schemas.ResponsesInputMessageRoleAssistant
+	user := schemas.ResponsesInputMessageRoleUser
+	messageType := schemas.ResponsesMessageTypeMessage
+	functionCallType := schemas.ResponsesMessageTypeFunctionCall
+	req := &schemas.BifrostResponsesRequest{
+		Model: "gpt-4o",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type:    &messageType,
+				Role:    &user,
+				Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+			},
+			{
+				Type: &functionCallType,
+				Role: &assistant,
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    schemas.Ptr("call_123"),
+					Name:      schemas.Ptr("search"),
+					Arguments: schemas.Ptr(`{"query":"bifrost"}`),
+				},
+			},
+		},
+	}
+
+	converted := ToOpenAIResponsesRequest(nil, req)
+	if converted == nil {
+		t.Fatal("ToOpenAIResponsesRequest returned nil")
+	}
+	wire, err := sonic.Marshal(converted)
+	if err != nil {
+		t.Fatalf("marshal wire request: %v", err)
+	}
+
+	var payload struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if err := sonic.Unmarshal(wire, &payload); err != nil {
+		t.Fatalf("unmarshal wire request: %v", err)
+	}
+
+	items := make(map[string]map[string]json.RawMessage, len(payload.Input))
+	for _, raw := range payload.Input {
+		var item map[string]json.RawMessage
+		if err := sonic.Unmarshal(raw, &item); err != nil {
+			t.Fatalf("unmarshal input item: %v", err)
+		}
+		var itemType string
+		if err := sonic.Unmarshal(item["type"], &itemType); err != nil {
+			t.Fatalf("unmarshal input item type: %v", err)
+		}
+		items[itemType] = item
+	}
+
+	message := items["message"]
+	var messageRole string
+	if err := sonic.Unmarshal(message["role"], &messageRole); err != nil || messageRole != "user" {
+		t.Errorf("message role: got %q, want %q (err=%v)", messageRole, "user", err)
+	}
+	functionCall := items["function_call"]
+	if _, ok := functionCall["role"]; ok {
+		t.Error("function_call role present in wire request")
+	}
+	for field, want := range map[string]string{"call_id": "call_123", "name": "search", "arguments": `{"query":"bifrost"}`} {
+		var got string
+		if err := sonic.Unmarshal(functionCall[field], &got); err != nil || got != want {
+			t.Errorf("function_call %s: got %q, want %q (err=%v)", field, got, want, err)
+		}
+	}
+	if req.Input[0].Role == nil || req.Input[1].Role == nil {
+		t.Error("original input roles were mutated")
 	}
 }


### PR DESCRIPTION
## Summary

Fixes Chat-to-Responses tool-call replay against the OpenAI Responses API.

Vercel AI SDK automatically replays an assistant tool call and its tool result on the second step of `generateText`. Bifrost converts the assistant tool call into a Responses `function_call` input item, but the item currently retains `role: "assistant"`. OpenAI rejects that wire shape with:

```text
invalid_request_error: Unknown parameter: input[1].role
```

This PR enforces the OpenAI wire invariant at the provider seam: modeled input items with an explicit type other than `message` do not carry `role`.

This PR is intentionally scoped to the role bug. It does not include reasoning-summary normalization.

## Changes

- Clear `role` from modeled OpenAI Responses input items whose explicit type is not `message`.
- Preserve role on normal `message` items.
- Preserve caller input immutability by normalizing the per-item value copy.
- Add a focused wire regression test for a replayed `function_call` with an assistant role.
- Add the required Core changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

### Go regression tests

```bash
cd core
go test ./providers/openai -count=1
```

The regression test verifies that:

- a `message` item retains its role;
- a `function_call` item omits role on the final wire request;
- call ID, function name, and arguments remain unchanged;
- caller-owned input roles are not mutated.

### Real-provider black-box reproduction

The full sanitized reproduction is in #5101. It uses:

```text
Vercel AI SDK
  -> local Bifrost /v1/chat/completions
  -> compat Chat-to-Responses conversion
  -> real OpenAI /v1/responses
```

The SDK receives only an initial prompt and one executable local tool. It automatically constructs request two with the assistant tool call and matching tool result.

Base `dev@e0d2ac178`:

```json
{
  "requestCount": 2,
  "request1ReplayAbsent": true,
  "validSecondReplay": true,
  "secondStatus": 400,
  "errorType": "invalid_request_error",
  "errorParam": "input[1].role",
  "errorCode": "unknown_parameter"
}
```

With this commit, using the identical locked harness and request topology:

```json
{
  "requestCount": 2,
  "request1ReplayAbsent": true,
  "validSecondReplay": true,
  "secondStatus": 200,
  "errorType": null,
  "errorParam": null,
  "errorCode": null
}
```

The same run also builds the current `bifrost-http` checkout before starting the local server.

`golangci-lint` was not available in the local environment, so the lint target was not run.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

The change only removes a field that OpenAI rejects on non-message Responses input items. Role-bearing `message` items are unchanged.

## Related issues

Closes #5101

Possibly related context: #1977. This PR does not assume that issue is a duplicate.

## Security considerations

- No credentials or secret values are added.
- The live reproduction supplied `OPENAI_API_KEY` only to the local Bifrost process.
- No authentication, authorization, storage, or logging behavior changes.

## Checklist

- [x] I read the contribution guidelines and followed the commit, changelog, and branch conventions.
- [x] I added a focused wire regression test.
- [x] I added the required Core changelog entry.
- [x] I verified the focused OpenAI provider package tests pass.
- [x] I verified the current Bifrost binary builds and the real-provider reproduction succeeds.
- [x] I reviewed the final diff for unrelated files and secrets.
- [x] `git diff --check` passes.
- [ ] I ran `golangci-lint` locally (tool unavailable).
