### PR TITLE
fix: warn callers not to truncate the #t= temp-token fragment on MCP inline-auth links

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: warn callers not to truncate the `#t=` temp-token fragment on MCP inline-auth links [@MarcusPeng](https://github.com/MarcusPeng)

--- a/core/mcp/credstore/per_user_headers.go
+++ b/core/mcp/credstore/per_user_headers.go
@@ -97,6 +97,10 @@ func (r *perUserHeadersResolver) buildAuthRequiredError(ctx *schemas.BifrostCont
 	if err != nil {
 		return fmt.Errorf("failed to initiate per-user headers submission flow for %s: %w", config.Name, err)
 	}
+	message := fmt.Sprintf("Authentication required for %s. Visit %s to submit the required headers.", config.Name, initiation.FrontendURL)
+	if schemas.MCPAuthURLHasTempTokenFragment(initiation.FrontendURL) {
+		message += schemas.MCPAuthTempTokenReminder
+	}
 	return &schemas.MCPAuthRequiredError{
 		Kind:               schemas.MCPAuthRequiredKindHeaders,
 		MCPClientID:        config.ID,
@@ -108,7 +112,7 @@ func (r *perUserHeadersResolver) buildAuthRequiredError(ctx *schemas.BifrostCont
 		// Include the URL in the message so plain-text clients (curl, basic
 		// SDK wrappers) that don't parse extra_fields still get an actionable
 		// hint. Matches per_user_oauth.go's behavior.
-		Message: fmt.Sprintf("Authentication required for %s. Visit %s to submit the required headers.", config.Name, initiation.FrontendURL),
+		Message: message,
 	}
 }
 

--- a/core/mcp/credstore/per_user_headers_test.go
+++ b/core/mcp/credstore/per_user_headers_test.go
@@ -1,0 +1,86 @@
+package credstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// fakeMCPHeadersProvider implements schemas.MCPHeadersProvider. Only
+// GetCredentialByMode and InitiateUserSubmissionFlow need real behavior for
+// the ConnectionHeaders re-auth path exercised here; the rest are unused.
+type fakeMCPHeadersProvider struct {
+	frontendURL string
+}
+
+func (f *fakeMCPHeadersProvider) GetCredentialByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*schemas.MCPHeadersUserCredential, error) {
+	return nil, schemas.ErrHeadersCredentialNotFound
+}
+
+func (f *fakeMCPHeadersProvider) UpsertCredential(ctx context.Context, cred *schemas.MCPHeadersUserCredential) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeMCPHeadersProvider) DeleteCredential(ctx context.Context, id string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeMCPHeadersProvider) InitiateUserSubmissionFlow(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID, baseURL string) (*schemas.MCPHeadersFlowInitiation, error) {
+	return &schemas.MCPHeadersFlowInitiation{FlowID: "flow-1", FrontendURL: f.frontendURL}, nil
+}
+
+func newTestHeadersContext() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyMCPSessionID, "sess-1")
+	ctx.SetValue(schemas.BifrostContextKeyMCPCallbackBaseURL, "https://host")
+	return ctx
+}
+
+func TestPerUserHeadersResolverConnectionHeadersTempTokenReminder(t *testing.T) {
+	config := &schemas.MCPClientConfig{
+		ID:                "client-1",
+		Name:              "Test Client",
+		PerUserHeaderKeys: []string{"authorization"},
+	}
+
+	tests := []struct {
+		name         string
+		frontendURL  string
+		wantReminder bool
+	}{
+		{
+			name:         "frontend URL with temp-token fragment includes reminder",
+			frontendURL:  "https://host/workspace/mcp-sessions/auth?flow=abc123#t=xyz",
+			wantReminder: true,
+		},
+		{
+			name:         "frontend URL without fragment omits reminder",
+			frontendURL:  "https://host/workspace/mcp-sessions/auth?flow=abc123",
+			wantReminder: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &perUserHeadersResolver{provider: &fakeMCPHeadersProvider{frontendURL: tt.frontendURL}}
+			ctx := newTestHeadersContext()
+
+			_, err := resolver.ConnectionHeaders(ctx, config)
+			if err == nil {
+				t.Fatalf("expected an MCPAuthRequiredError, got nil")
+			}
+			authErr, ok := err.(*schemas.MCPAuthRequiredError)
+			if !ok {
+				t.Fatalf("expected *schemas.MCPAuthRequiredError, got %T: %v", err, err)
+			}
+
+			gotReminder := strings.Contains(authErr.Message, schemas.MCPAuthTempTokenReminder)
+			if gotReminder != tt.wantReminder {
+				t.Errorf("Message = %q, contains reminder = %v, want %v", authErr.Message, gotReminder, tt.wantReminder)
+			}
+		})
+	}
+}

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -68,6 +68,10 @@ func (r *perUserOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, co
 		if flowErr != nil {
 			return nil, fmt.Errorf("failed to initiate per-user OAuth flow for %s: %w", config.Name, flowErr)
 		}
+		message := fmt.Sprintf("Authentication required for %s. Visit %s to connect your account.", config.Name, flowInitiation.AuthorizeURL)
+		if schemas.MCPAuthURLHasTempTokenFragment(flowInitiation.AuthorizeURL) {
+			message += schemas.MCPAuthTempTokenReminder
+		}
 		return nil, &schemas.MCPAuthRequiredError{
 			Kind:          schemas.MCPAuthRequiredKindOAuth,
 			MCPClientID:   config.ID,
@@ -80,7 +84,7 @@ func (r *perUserOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, co
 			// to them. The URL is already exposed via
 			// extra_fields.mcp_auth_required.authorize_url, so embedding it
 			// here doesn't widen the surface.
-			Message: fmt.Sprintf("Authentication required for %s. Visit %s to connect your account.", config.Name, flowInitiation.AuthorizeURL),
+			Message: message,
 		}
 	}
 

--- a/core/mcp/credstore/per_user_oauth_test.go
+++ b/core/mcp/credstore/per_user_oauth_test.go
@@ -1,0 +1,103 @@
+package credstore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// fakeOAuth2Provider implements schemas.OAuth2Provider. Only
+// GetUserAccessTokenByMode and InitiateUserOAuthFlow need real behavior for
+// the ConnectionHeaders re-auth path exercised here; the rest are unused.
+type fakeOAuth2Provider struct {
+	authorizeURL string
+}
+
+func (f *fakeOAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *fakeOAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeOAuth2Provider) ValidateToken(ctx context.Context, oauthConfigID string) (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (f *fakeOAuth2Provider) RevokeToken(ctx context.Context, oauthConfigID string) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeOAuth2Provider) GetUserAccessTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (string, error) {
+	return "", schemas.ErrOAuth2TokenNotFound
+}
+
+func (f *fakeOAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigID string, mcpClientID string, redirectURI string, flowMode schemas.MCPAuthMode) (*schemas.OAuth2FlowInitiation, string, error) {
+	return &schemas.OAuth2FlowInitiation{AuthorizeURL: f.authorizeURL}, "flow-session-id", nil
+}
+
+func (f *fakeOAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string, code string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (f *fakeOAuth2Provider) RefreshUserAccessToken(ctx context.Context, tokenID string) error {
+	return errors.New("not implemented")
+}
+
+func newTestOAuthContext() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyMCPSessionID, "sess-1")
+	ctx.SetValue(schemas.BifrostContextKeyMCPCallbackBaseURL, "https://host")
+	return ctx
+}
+
+func TestPerUserOAuthResolverConnectionHeadersTempTokenReminder(t *testing.T) {
+	oauthConfigID := "oauth-config-1"
+	config := &schemas.MCPClientConfig{
+		ID:            "client-1",
+		Name:          "Test Client",
+		OauthConfigID: &oauthConfigID,
+	}
+
+	tests := []struct {
+		name         string
+		authorizeURL string
+		wantReminder bool
+	}{
+		{
+			name:         "authorize URL with temp-token fragment includes reminder",
+			authorizeURL: "https://host/workspace/mcp-sessions/auth?flow=abc123#t=xyz",
+			wantReminder: true,
+		},
+		{
+			name:         "authorize URL without fragment omits reminder",
+			authorizeURL: "https://host/workspace/mcp-sessions/auth?flow=abc123",
+			wantReminder: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := &perUserOAuthResolver{provider: &fakeOAuth2Provider{authorizeURL: tt.authorizeURL}}
+			ctx := newTestOAuthContext()
+
+			_, err := resolver.ConnectionHeaders(ctx, config)
+			if err == nil {
+				t.Fatalf("expected an MCPAuthRequiredError, got nil")
+			}
+			authErr, ok := err.(*schemas.MCPAuthRequiredError)
+			if !ok {
+				t.Fatalf("expected *schemas.MCPAuthRequiredError, got %T: %v", err, err)
+			}
+
+			gotReminder := strings.Contains(authErr.Message, schemas.MCPAuthTempTokenReminder)
+			if gotReminder != tt.wantReminder {
+				t.Errorf("Message = %q, contains reminder = %v, want %v", authErr.Message, gotReminder, tt.wantReminder)
+			}
+		})
+	}
+}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -85,6 +85,26 @@ func (e *MCPAuthRequiredError) Error() string {
 	return e.Message
 }
 
+// MCPAuthTempTokenReminder is appended to MCPAuthRequiredError.Message when the
+// auth URL carries a `#t=<token>` temp-token fragment (see
+// MCPAuthURLHasTempTokenFragment). The fragment is deliberately never sent to
+// the server (unlike a query param, it's not logged or forwarded as a
+// Referer), but that also makes it easy for an LLM relaying the link to a
+// human to mistake it for a non-essential anchor and drop it, breaking the
+// link. Spelling this out in the message itself is the cheapest way to stop
+// that from happening.
+const MCPAuthTempTokenReminder = " IMPORTANT: this link includes a required fragment after the '#' character (a one-time auth token). Copy and share the ENTIRE URL exactly as given, including everything after the '#' — the link will not work without it."
+
+// MCPAuthURLHasTempTokenFragment reports whether authURL carries the `#t=`
+// temp-token fragment minted by InitiateUserOAuthFlow /
+// InitiateUserSubmissionFlow. Callers use this to decide whether
+// MCPAuthTempTokenReminder applies — the mint is best-effort (see those
+// functions' docs), so the fragment isn't always present even when
+// MCPEnableTempTokenAuth is on.
+func MCPAuthURLHasTempTokenFragment(authURL string) bool {
+	return strings.Contains(authURL, "#t=")
+}
+
 // MCPUserOAuthRequiredError is an alias retained for backward compatibility
 // with callers that referenced the OAuth-only error type before headers auth
 // was added. New code should use MCPAuthRequiredError directly.

--- a/core/schemas/mcp_test.go
+++ b/core/schemas/mcp_test.go
@@ -1,0 +1,42 @@
+//go:build !tinygo && !wasm
+
+package schemas
+
+import "testing"
+
+func TestMCPAuthURLHasTempTokenFragment(t *testing.T) {
+	tests := []struct {
+		name    string
+		authURL string
+		want    bool
+	}{
+		{
+			name:    "url with temp-token fragment",
+			authURL: "https://host/workspace/mcp-sessions/auth?flow=abc123#t=xyz",
+			want:    true,
+		},
+		{
+			name:    "url with no fragment",
+			authURL: "https://host/workspace/mcp-sessions/auth?flow=abc123",
+			want:    false,
+		},
+		{
+			name:    "url with a different fragment",
+			authURL: "https://host/workspace/mcp-sessions/auth?flow=abc123#nope",
+			want:    false,
+		},
+		{
+			name:    "empty string",
+			authURL: "",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MCPAuthURLHasTempTokenFragment(tt.authURL); got != tt.want {
+				t.Errorf("MCPAuthURLHasTempTokenFragment(%q) = %v, want %v", tt.authURL, got, tt.want)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -425,10 +425,14 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 						url = authReq.SubmitURL
 						action = "submit the required headers"
 					}
-					return mcp.NewToolResultError(fmt.Sprintf(
+					message := fmt.Sprintf(
 						"Authentication required for %s. Open this URL to %s: %s",
 						authReq.MCPClientName, action, url,
-					)), nil
+					)
+					if schemas.MCPAuthURLHasTempTokenFragment(url) {
+						message += schemas.MCPAuthTempTokenReminder
+					}
+					return mcp.NewToolResultError(message), nil
 				}
 				return mcp.NewToolResultError(fmt.Sprintf("Tool execution failed: %v", bifrost.GetErrorMessage(err))), nil
 			}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[fix]: warn callers not to truncate the `#t=` temp-token fragment on MCP inline-auth links [@MarcusPeng](https://github.com/MarcusPeng)


### PR DESCRIPTION
## Summary

When `MCPEnableTempTokenAuth` is on, per-user MCP auth flows (OAuth and headers) mint a one-time temp token embedded as a `#t=<token>` URL fragment on the auth link returned to the caller. Fragments never reach the server, so the token can't leak into access logs or get forwarded as a Referer header — but an AI agent relaying the link to a human frequently drops everything after the `#`, treating it as a non-essential anchor, which breaks the link.

## Changes

- Added `schemas.MCPAuthURLHasTempTokenFragment` and `schemas.MCPAuthTempTokenReminder`
- Wired them into the inline-auth `Message` wherever it's built (per-user OAuth resolver, per-user headers resolver, bifrost-http's MCP server tool-call error path), only appending the reminder when the URL actually carries the `#t=` fragment
- Added unit tests covering both resolvers and the fragment-detection helper

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./core/schemas/... ./core/mcp/credstore/... ./transports/bifrost-http/handlers/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None — the fragment was already never sent to the server; this only changes the accompanying human-readable message text.