### PR TITLE
fix: never persist masked provider key previews

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -462,6 +462,13 @@ func (e *SecretVar) ShouldPreserveStored() bool {
 	return e.GetValue() == "" || e.IsRedacted()
 }
 
+// IsMaskedPlaceholder reports whether the value is a client-side redaction
+// placeholder that must not overwrite a stored credential. Secret references
+// are intentional updates and are never treated as placeholders.
+func (e *SecretVar) IsMaskedPlaceholder() bool {
+	return e != nil && e.IsRedacted() && !e.IsFromSecret()
+}
+
 // IsSet returns true if the SecretVar has a resolved value or a secret reference.
 // Use instead of GetValue() != "" when checking whether a field was configured,
 // because references may have an empty Val before resolution.

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -661,6 +661,30 @@ func TestSecretVar_IsSet_VaultRef(t *testing.T) {
 	}
 }
 
+func TestSecretVar_IsMaskedPlaceholder(t *testing.T) {
+	tests := []struct {
+		name  string
+		value *SecretVar
+		want  bool
+	}{
+		{name: "nil", value: nil, want: false},
+		{name: "empty", value: NewSecretVar(""), want: false},
+		{name: "plain", value: NewSecretVar("sk-real-credential"), want: false},
+		{name: "masked", value: NewSecretVar("abcd************************wxyz"), want: true},
+		{name: "redacted sentinel", value: NewSecretVar("<redacted>"), want: true},
+		{name: "env reference", value: NewSecretVar("env.NEW_KEY"), want: false},
+		{name: "vault reference", value: NewSecretVar("vault.path/to/key"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.value.IsMaskedPlaceholder(); got != tt.want {
+				t.Fatalf("IsMaskedPlaceholder() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewSecretVar_VaultRef(t *testing.T) {
 	e := NewSecretVar("vault.bifrost/mykey")
 	if !e.IsFromVault() {

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -504,7 +504,10 @@ func getKeyIDFromCtx(ctx *fasthttp.RequestCtx) (string, error) {
 	return decoded, nil
 }
 
-// validateProviderKeyURL checks that Ollama/SGL keys have a server URL configured.
+// validateProviderKeyURL checks that provider keys carry the nested fields
+// config.schema.json marks as required, so a create or merge can never persist
+// a key missing them (a masked update against a stored key lacking the section
+// would otherwise only surface later as a downstream 500).
 func validateProviderKeyURL(provider schemas.ModelProvider, key schemas.Key) error {
 	switch provider {
 	case schemas.Ollama:
@@ -514,6 +517,25 @@ func validateProviderKeyURL(provider schemas.ModelProvider, key schemas.Key) err
 	case schemas.SGL:
 		if key.SGLKeyConfig == nil || !key.SGLKeyConfig.URL.IsSet() {
 			return fmt.Errorf("sgl_key_config.url is required for SGL keys")
+		}
+	case schemas.Azure:
+		if key.AzureKeyConfig == nil || !key.AzureKeyConfig.Endpoint.IsSet() {
+			return fmt.Errorf("azure_key_config.endpoint is required for Azure keys")
+		}
+	case schemas.Bedrock:
+		if key.BedrockKeyConfig == nil || key.BedrockKeyConfig.Region == nil || !key.BedrockKeyConfig.Region.IsSet() {
+			return fmt.Errorf("bedrock_key_config.region is required for Bedrock keys")
+		}
+	case schemas.BedrockMantle:
+		if key.BedrockMantleKeyConfig == nil || key.BedrockMantleKeyConfig.Region == nil || !key.BedrockMantleKeyConfig.Region.IsSet() {
+			return fmt.Errorf("bedrock_mantle_key_config.region is required for Bedrock Mantle keys")
+		}
+	case schemas.VLLM:
+		if key.VLLMKeyConfig == nil || !key.VLLMKeyConfig.URL.IsSet() {
+			return fmt.Errorf("vllm_key_config.url is required for VLLM keys")
+		}
+		if key.VLLMKeyConfig.ModelName == "" {
+			return fmt.Errorf("vllm_key_config.model_name is required for VLLM keys")
 		}
 	}
 	return nil

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -338,149 +338,139 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey s
 	}
 
 	if updateKey.AzureKeyConfig != nil && oldRedactedKey.AzureKeyConfig != nil && oldRawKey.AzureKeyConfig != nil {
-		if updateKey.AzureKeyConfig.Endpoint.IsRedacted() &&
-			updateKey.AzureKeyConfig.Endpoint.Equals(&oldRedactedKey.AzureKeyConfig.Endpoint) {
+		if updateKey.AzureKeyConfig.Endpoint.IsRedacted() && !updateKey.AzureKeyConfig.Endpoint.IsFromSecret() {
 			mergedKey.AzureKeyConfig.Endpoint = oldRawKey.AzureKeyConfig.Endpoint
 		}
 		if updateKey.AzureKeyConfig.ClientID != nil &&
 			oldRedactedKey.AzureKeyConfig.ClientID != nil &&
 			oldRawKey.AzureKeyConfig != nil &&
 			updateKey.AzureKeyConfig.ClientID.IsRedacted() &&
-			updateKey.AzureKeyConfig.ClientID.Equals(oldRedactedKey.AzureKeyConfig.ClientID) {
+			!updateKey.AzureKeyConfig.ClientID.IsFromSecret() {
 			mergedKey.AzureKeyConfig.ClientID = oldRawKey.AzureKeyConfig.ClientID
 		}
 		if updateKey.AzureKeyConfig.ClientSecret != nil &&
 			oldRedactedKey.AzureKeyConfig.ClientSecret != nil &&
 			oldRawKey.AzureKeyConfig != nil &&
 			updateKey.AzureKeyConfig.ClientSecret.IsRedacted() &&
-			updateKey.AzureKeyConfig.ClientSecret.Equals(oldRedactedKey.AzureKeyConfig.ClientSecret) {
+			!updateKey.AzureKeyConfig.ClientSecret.IsFromSecret() {
 			mergedKey.AzureKeyConfig.ClientSecret = oldRawKey.AzureKeyConfig.ClientSecret
 		}
 		if updateKey.AzureKeyConfig.TenantID != nil &&
 			oldRedactedKey.AzureKeyConfig.TenantID != nil &&
 			oldRawKey.AzureKeyConfig != nil &&
 			updateKey.AzureKeyConfig.TenantID.IsRedacted() &&
-			updateKey.AzureKeyConfig.TenantID.Equals(oldRedactedKey.AzureKeyConfig.TenantID) {
+			!updateKey.AzureKeyConfig.TenantID.IsFromSecret() {
 			mergedKey.AzureKeyConfig.TenantID = oldRawKey.AzureKeyConfig.TenantID
 		}
 	}
 
 	if updateKey.VertexKeyConfig != nil && oldRedactedKey.VertexKeyConfig != nil && oldRawKey.VertexKeyConfig != nil {
-		if updateKey.VertexKeyConfig.ProjectID.IsRedacted() &&
-			updateKey.VertexKeyConfig.ProjectID.Equals(&oldRedactedKey.VertexKeyConfig.ProjectID) {
+		if updateKey.VertexKeyConfig.ProjectID.IsRedacted() && !updateKey.VertexKeyConfig.ProjectID.IsFromSecret() {
 			mergedKey.VertexKeyConfig.ProjectID = oldRawKey.VertexKeyConfig.ProjectID
 		}
-		if updateKey.VertexKeyConfig.ProjectNumber.IsRedacted() &&
-			updateKey.VertexKeyConfig.ProjectNumber.Equals(&oldRedactedKey.VertexKeyConfig.ProjectNumber) {
+		if updateKey.VertexKeyConfig.ProjectNumber.IsRedacted() && !updateKey.VertexKeyConfig.ProjectNumber.IsFromSecret() {
 			mergedKey.VertexKeyConfig.ProjectNumber = oldRawKey.VertexKeyConfig.ProjectNumber
 		}
-		if updateKey.VertexKeyConfig.Region.IsRedacted() &&
-			updateKey.VertexKeyConfig.Region.Equals(&oldRedactedKey.VertexKeyConfig.Region) {
+		if updateKey.VertexKeyConfig.Region.IsRedacted() && !updateKey.VertexKeyConfig.Region.IsFromSecret() {
 			mergedKey.VertexKeyConfig.Region = oldRawKey.VertexKeyConfig.Region
 		}
-		if updateKey.VertexKeyConfig.AuthCredentials.IsRedacted() &&
-			updateKey.VertexKeyConfig.AuthCredentials.Equals(&oldRedactedKey.VertexKeyConfig.AuthCredentials) {
+		if updateKey.VertexKeyConfig.AuthCredentials.IsRedacted() && !updateKey.VertexKeyConfig.AuthCredentials.IsFromSecret() {
 			mergedKey.VertexKeyConfig.AuthCredentials = oldRawKey.VertexKeyConfig.AuthCredentials
 		}
 	}
 
 	if updateKey.BedrockKeyConfig != nil && oldRedactedKey.BedrockKeyConfig != nil && oldRawKey.BedrockKeyConfig != nil {
-		if updateKey.BedrockKeyConfig.AccessKey.IsRedacted() &&
-			updateKey.BedrockKeyConfig.AccessKey.Equals(&oldRedactedKey.BedrockKeyConfig.AccessKey) {
+		if updateKey.BedrockKeyConfig.AccessKey.IsRedacted() && !updateKey.BedrockKeyConfig.AccessKey.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.AccessKey = oldRawKey.BedrockKeyConfig.AccessKey
 		}
-		if updateKey.BedrockKeyConfig.SecretKey.IsRedacted() &&
-			updateKey.BedrockKeyConfig.SecretKey.Equals(&oldRedactedKey.BedrockKeyConfig.SecretKey) {
+		if updateKey.BedrockKeyConfig.SecretKey.IsRedacted() && !updateKey.BedrockKeyConfig.SecretKey.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.SecretKey = oldRawKey.BedrockKeyConfig.SecretKey
 		}
 		if updateKey.BedrockKeyConfig.SessionToken != nil &&
 			oldRedactedKey.BedrockKeyConfig.SessionToken != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.SessionToken.IsRedacted() &&
-			updateKey.BedrockKeyConfig.SessionToken.Equals(oldRedactedKey.BedrockKeyConfig.SessionToken) {
+			!updateKey.BedrockKeyConfig.SessionToken.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.SessionToken = oldRawKey.BedrockKeyConfig.SessionToken
 		}
 		if updateKey.BedrockKeyConfig.Region != nil &&
 			oldRedactedKey.BedrockKeyConfig.Region != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.Region.IsRedacted() &&
-			updateKey.BedrockKeyConfig.Region.Equals(oldRedactedKey.BedrockKeyConfig.Region) {
+			!updateKey.BedrockKeyConfig.Region.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.Region = oldRawKey.BedrockKeyConfig.Region
 		}
 		if updateKey.BedrockKeyConfig.ARN != nil &&
 			oldRedactedKey.BedrockKeyConfig.ARN != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.ARN.IsRedacted() &&
-			updateKey.BedrockKeyConfig.ARN.Equals(oldRedactedKey.BedrockKeyConfig.ARN) {
+			!updateKey.BedrockKeyConfig.ARN.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.ARN = oldRawKey.BedrockKeyConfig.ARN
 		}
 		if updateKey.BedrockKeyConfig.RoleARN != nil &&
 			oldRedactedKey.BedrockKeyConfig.RoleARN != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.RoleARN.IsRedacted() &&
-			updateKey.BedrockKeyConfig.RoleARN.Equals(oldRedactedKey.BedrockKeyConfig.RoleARN) {
+			!updateKey.BedrockKeyConfig.RoleARN.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.RoleARN = oldRawKey.BedrockKeyConfig.RoleARN
 		}
 		if updateKey.BedrockKeyConfig.ExternalID != nil &&
 			oldRedactedKey.BedrockKeyConfig.ExternalID != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.ExternalID.IsRedacted() &&
-			updateKey.BedrockKeyConfig.ExternalID.Equals(oldRedactedKey.BedrockKeyConfig.ExternalID) {
+			!updateKey.BedrockKeyConfig.ExternalID.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.ExternalID = oldRawKey.BedrockKeyConfig.ExternalID
 		}
 		if updateKey.BedrockKeyConfig.RoleSessionName != nil &&
 			oldRedactedKey.BedrockKeyConfig.RoleSessionName != nil &&
 			oldRawKey.BedrockKeyConfig != nil &&
 			updateKey.BedrockKeyConfig.RoleSessionName.IsRedacted() &&
-			updateKey.BedrockKeyConfig.RoleSessionName.Equals(oldRedactedKey.BedrockKeyConfig.RoleSessionName) {
+			!updateKey.BedrockKeyConfig.RoleSessionName.IsFromSecret() {
 			mergedKey.BedrockKeyConfig.RoleSessionName = oldRawKey.BedrockKeyConfig.RoleSessionName
 		}
 	}
 
 	if updateKey.BedrockMantleKeyConfig != nil && oldRedactedKey.BedrockMantleKeyConfig != nil && oldRawKey.BedrockMantleKeyConfig != nil {
-		if updateKey.BedrockMantleKeyConfig.AccessKey.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.AccessKey.Equals(&oldRedactedKey.BedrockMantleKeyConfig.AccessKey) {
+		if updateKey.BedrockMantleKeyConfig.AccessKey.IsRedacted() && !updateKey.BedrockMantleKeyConfig.AccessKey.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.AccessKey = oldRawKey.BedrockMantleKeyConfig.AccessKey
 		}
-		if updateKey.BedrockMantleKeyConfig.SecretKey.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.SecretKey.Equals(&oldRedactedKey.BedrockMantleKeyConfig.SecretKey) {
+		if updateKey.BedrockMantleKeyConfig.SecretKey.IsRedacted() && !updateKey.BedrockMantleKeyConfig.SecretKey.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.SecretKey = oldRawKey.BedrockMantleKeyConfig.SecretKey
 		}
 		if updateKey.BedrockMantleKeyConfig.SessionToken != nil &&
 			oldRedactedKey.BedrockMantleKeyConfig.SessionToken != nil &&
 			updateKey.BedrockMantleKeyConfig.SessionToken.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.SessionToken.Equals(oldRedactedKey.BedrockMantleKeyConfig.SessionToken) {
+			!updateKey.BedrockMantleKeyConfig.SessionToken.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.SessionToken = oldRawKey.BedrockMantleKeyConfig.SessionToken
 		}
 		if updateKey.BedrockMantleKeyConfig.Region != nil &&
 			oldRedactedKey.BedrockMantleKeyConfig.Region != nil &&
 			updateKey.BedrockMantleKeyConfig.Region.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.Region.Equals(oldRedactedKey.BedrockMantleKeyConfig.Region) {
+			!updateKey.BedrockMantleKeyConfig.Region.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.Region = oldRawKey.BedrockMantleKeyConfig.Region
 		}
 		if updateKey.BedrockMantleKeyConfig.RoleARN != nil &&
 			oldRedactedKey.BedrockMantleKeyConfig.RoleARN != nil &&
 			updateKey.BedrockMantleKeyConfig.RoleARN.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.RoleARN.Equals(oldRedactedKey.BedrockMantleKeyConfig.RoleARN) {
+			!updateKey.BedrockMantleKeyConfig.RoleARN.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.RoleARN = oldRawKey.BedrockMantleKeyConfig.RoleARN
 		}
 		if updateKey.BedrockMantleKeyConfig.ExternalID != nil &&
 			oldRedactedKey.BedrockMantleKeyConfig.ExternalID != nil &&
 			updateKey.BedrockMantleKeyConfig.ExternalID.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.ExternalID.Equals(oldRedactedKey.BedrockMantleKeyConfig.ExternalID) {
+			!updateKey.BedrockMantleKeyConfig.ExternalID.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.ExternalID = oldRawKey.BedrockMantleKeyConfig.ExternalID
 		}
 		if updateKey.BedrockMantleKeyConfig.RoleSessionName != nil &&
 			oldRedactedKey.BedrockMantleKeyConfig.RoleSessionName != nil &&
 			updateKey.BedrockMantleKeyConfig.RoleSessionName.IsRedacted() &&
-			updateKey.BedrockMantleKeyConfig.RoleSessionName.Equals(oldRedactedKey.BedrockMantleKeyConfig.RoleSessionName) {
+			!updateKey.BedrockMantleKeyConfig.RoleSessionName.IsFromSecret() {
 			mergedKey.BedrockMantleKeyConfig.RoleSessionName = oldRawKey.BedrockMantleKeyConfig.RoleSessionName
 		}
 	}
 
 	if updateKey.VLLMKeyConfig != nil && oldRedactedKey.VLLMKeyConfig != nil && oldRawKey.VLLMKeyConfig != nil {
-		if updateKey.VLLMKeyConfig.URL.IsRedacted() &&
-			updateKey.VLLMKeyConfig.URL.Equals(&oldRedactedKey.VLLMKeyConfig.URL) {
+		if updateKey.VLLMKeyConfig.URL.IsRedacted() && !updateKey.VLLMKeyConfig.URL.IsFromSecret() {
 			mergedKey.VLLMKeyConfig.URL = oldRawKey.VLLMKeyConfig.URL
 		}
 	}
@@ -491,15 +481,13 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey s
 	}
 
 	if updateKey.OllamaKeyConfig != nil && oldRedactedKey.OllamaKeyConfig != nil && oldRawKey.OllamaKeyConfig != nil {
-		if updateKey.OllamaKeyConfig.URL.IsRedacted() &&
-			updateKey.OllamaKeyConfig.URL.Equals(&oldRedactedKey.OllamaKeyConfig.URL) {
+		if updateKey.OllamaKeyConfig.URL.IsRedacted() && !updateKey.OllamaKeyConfig.URL.IsFromSecret() {
 			mergedKey.OllamaKeyConfig.URL = oldRawKey.OllamaKeyConfig.URL
 		}
 	}
 
 	if updateKey.SGLKeyConfig != nil && oldRedactedKey.SGLKeyConfig != nil && oldRawKey.SGLKeyConfig != nil {
-		if updateKey.SGLKeyConfig.URL.IsRedacted() &&
-			updateKey.SGLKeyConfig.URL.Equals(&oldRedactedKey.SGLKeyConfig.URL) {
+		if updateKey.SGLKeyConfig.URL.IsRedacted() && !updateKey.SGLKeyConfig.URL.IsFromSecret() {
 			mergedKey.SGLKeyConfig.URL = oldRawKey.SGLKeyConfig.URL
 		}
 	}

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -325,7 +325,15 @@ func (h *ProviderHandler) deleteProviderKey(ctx *fasthttp.RequestCtx) {
 func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey schemas.Key) schemas.Key {
 	mergedKey := updateKey
 
-	if updateKey.Value.IsRedacted() && updateKey.Value.Equals(&oldRedactedKey.Value) {
+	// Never persist a masked preview as the real key value. A redacted, non-secret
+	// incoming value can only be the GET-render placeholder echoed back by a client,
+	// so keep the stored credential instead of writing the mask. Matching the exact
+	// current redaction is deliberately NOT required: a stale or differently-masked
+	// preview (e.g. a different asterisk count, or a render from another replica)
+	// must be rejected too, otherwise the mask lands in the store and later breaks
+	// JSON re-parsing on reload ("invalid character '*'"). Genuine env/vault refs
+	// report IsRedacted() but are intentional, so IsFromSecret() lets them through.
+	if updateKey.Value.IsRedacted() && !updateKey.Value.IsFromSecret() {
 		mergedKey.Value = oldRawKey.Value
 	}
 

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -198,18 +198,12 @@ func (h *ProviderHandler) updateProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	oldRedactedKey, err := h.inMemoryStore.GetProviderKeyRedacted(provider, keyID)
+	updateKey.ID = keyID
+	mergedKey, err := h.mergeUpdatedKey(*oldRawKey, updateKey)
 	if err != nil {
-		if errors.Is(err, lib.ErrNotFound) {
-			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider key not found: %v", err))
-			return
-		}
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider key: %v", err))
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
-
-	updateKey.ID = keyID
-	mergedKey := h.mergeUpdatedKey(*oldRawKey, *oldRedactedKey, updateKey)
 
 	baseProvider := provider
 	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.BaseProviderType != "" {
@@ -320,158 +314,143 @@ func (h *ProviderHandler) deleteProviderKey(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, redactedKey)
 }
 
-// mergeUpdatedKey merges an updated key with the old raw/redacted versions,
-// preserving real values for fields that were sent back in redacted form.
-func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey schemas.Key) schemas.Key {
+// mergeUpdatedKey merges an updated key with the old raw version, preserving
+// stored values for masked placeholders. A placeholder without a stored
+// counterpart is rejected so it can never reach persistence.
+func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, updateKey schemas.Key) (schemas.Key, error) {
 	mergedKey := updateKey
-
-	// Never persist a masked preview as the real key value. A redacted, non-secret
-	// incoming value can only be the GET-render placeholder echoed back by a client,
-	// so keep the stored credential instead of writing the mask. Matching the exact
-	// current redaction is deliberately NOT required: a stale or differently-masked
-	// preview (e.g. a different asterisk count, or a render from another replica)
-	// must be rejected too, otherwise the mask lands in the store and later breaks
-	// JSON re-parsing on reload ("invalid character '*'"). Genuine env/vault refs
-	// report IsRedacted() but are intentional, so IsFromSecret() lets them through.
-	if updateKey.Value.IsRedacted() && !updateKey.Value.IsFromSecret() {
-		mergedKey.Value = oldRawKey.Value
+	preserve := func(incoming, stored *schemas.SecretVar, field string) error {
+		if !incoming.IsMaskedPlaceholder() {
+			return nil
+		}
+		if stored == nil || !stored.IsSet() {
+			return fmt.Errorf("masked preview cannot be used for %s without a stored value", field)
+		}
+		*incoming = *stored
+		return nil
 	}
 
-	if updateKey.AzureKeyConfig != nil && oldRedactedKey.AzureKeyConfig != nil && oldRawKey.AzureKeyConfig != nil {
-		if updateKey.AzureKeyConfig.Endpoint.IsRedacted() && !updateKey.AzureKeyConfig.Endpoint.IsFromSecret() {
-			mergedKey.AzureKeyConfig.Endpoint = oldRawKey.AzureKeyConfig.Endpoint
-		}
-		if updateKey.AzureKeyConfig.ClientID != nil &&
-			oldRedactedKey.AzureKeyConfig.ClientID != nil &&
-			oldRawKey.AzureKeyConfig != nil &&
-			updateKey.AzureKeyConfig.ClientID.IsRedacted() &&
-			!updateKey.AzureKeyConfig.ClientID.IsFromSecret() {
-			mergedKey.AzureKeyConfig.ClientID = oldRawKey.AzureKeyConfig.ClientID
-		}
-		if updateKey.AzureKeyConfig.ClientSecret != nil &&
-			oldRedactedKey.AzureKeyConfig.ClientSecret != nil &&
-			oldRawKey.AzureKeyConfig != nil &&
-			updateKey.AzureKeyConfig.ClientSecret.IsRedacted() &&
-			!updateKey.AzureKeyConfig.ClientSecret.IsFromSecret() {
-			mergedKey.AzureKeyConfig.ClientSecret = oldRawKey.AzureKeyConfig.ClientSecret
-		}
-		if updateKey.AzureKeyConfig.TenantID != nil &&
-			oldRedactedKey.AzureKeyConfig.TenantID != nil &&
-			oldRawKey.AzureKeyConfig != nil &&
-			updateKey.AzureKeyConfig.TenantID.IsRedacted() &&
-			!updateKey.AzureKeyConfig.TenantID.IsFromSecret() {
-			mergedKey.AzureKeyConfig.TenantID = oldRawKey.AzureKeyConfig.TenantID
-		}
+	if err := preserve(&mergedKey.Value, &oldRawKey.Value, "value"); err != nil {
+		return schemas.Key{}, err
 	}
 
-	if updateKey.VertexKeyConfig != nil && oldRedactedKey.VertexKeyConfig != nil && oldRawKey.VertexKeyConfig != nil {
-		if updateKey.VertexKeyConfig.ProjectID.IsRedacted() && !updateKey.VertexKeyConfig.ProjectID.IsFromSecret() {
-			mergedKey.VertexKeyConfig.ProjectID = oldRawKey.VertexKeyConfig.ProjectID
+	if mergedKey.AzureKeyConfig != nil {
+		var endpoint, clientID, clientSecret, tenantID *schemas.SecretVar
+		if oldRawKey.AzureKeyConfig != nil {
+			endpoint = &oldRawKey.AzureKeyConfig.Endpoint
+			clientID = oldRawKey.AzureKeyConfig.ClientID
+			clientSecret = oldRawKey.AzureKeyConfig.ClientSecret
+			tenantID = oldRawKey.AzureKeyConfig.TenantID
 		}
-		if updateKey.VertexKeyConfig.ProjectNumber.IsRedacted() && !updateKey.VertexKeyConfig.ProjectNumber.IsFromSecret() {
-			mergedKey.VertexKeyConfig.ProjectNumber = oldRawKey.VertexKeyConfig.ProjectNumber
-		}
-		if updateKey.VertexKeyConfig.Region.IsRedacted() && !updateKey.VertexKeyConfig.Region.IsFromSecret() {
-			mergedKey.VertexKeyConfig.Region = oldRawKey.VertexKeyConfig.Region
-		}
-		if updateKey.VertexKeyConfig.AuthCredentials.IsRedacted() && !updateKey.VertexKeyConfig.AuthCredentials.IsFromSecret() {
-			mergedKey.VertexKeyConfig.AuthCredentials = oldRawKey.VertexKeyConfig.AuthCredentials
+		for _, item := range []struct {
+			incoming *schemas.SecretVar
+			stored   *schemas.SecretVar
+			field    string
+		}{
+			{&mergedKey.AzureKeyConfig.Endpoint, endpoint, "azure_key_config.endpoint"},
+			{mergedKey.AzureKeyConfig.ClientID, clientID, "azure_key_config.client_id"},
+			{mergedKey.AzureKeyConfig.ClientSecret, clientSecret, "azure_key_config.client_secret"},
+			{mergedKey.AzureKeyConfig.TenantID, tenantID, "azure_key_config.tenant_id"},
+		} {
+			if err := preserve(item.incoming, item.stored, item.field); err != nil {
+				return schemas.Key{}, err
+			}
 		}
 	}
 
-	if updateKey.BedrockKeyConfig != nil && oldRedactedKey.BedrockKeyConfig != nil && oldRawKey.BedrockKeyConfig != nil {
-		if updateKey.BedrockKeyConfig.AccessKey.IsRedacted() && !updateKey.BedrockKeyConfig.AccessKey.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.AccessKey = oldRawKey.BedrockKeyConfig.AccessKey
+	if mergedKey.VertexKeyConfig != nil {
+		var projectID, projectNumber, region, authCredentials *schemas.SecretVar
+		if oldRawKey.VertexKeyConfig != nil {
+			projectID = &oldRawKey.VertexKeyConfig.ProjectID
+			projectNumber = &oldRawKey.VertexKeyConfig.ProjectNumber
+			region = &oldRawKey.VertexKeyConfig.Region
+			authCredentials = &oldRawKey.VertexKeyConfig.AuthCredentials
 		}
-		if updateKey.BedrockKeyConfig.SecretKey.IsRedacted() && !updateKey.BedrockKeyConfig.SecretKey.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.SecretKey = oldRawKey.BedrockKeyConfig.SecretKey
-		}
-		if updateKey.BedrockKeyConfig.SessionToken != nil &&
-			oldRedactedKey.BedrockKeyConfig.SessionToken != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.SessionToken.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.SessionToken.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.SessionToken = oldRawKey.BedrockKeyConfig.SessionToken
-		}
-		if updateKey.BedrockKeyConfig.Region != nil &&
-			oldRedactedKey.BedrockKeyConfig.Region != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.Region.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.Region.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.Region = oldRawKey.BedrockKeyConfig.Region
-		}
-		if updateKey.BedrockKeyConfig.ARN != nil &&
-			oldRedactedKey.BedrockKeyConfig.ARN != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.ARN.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.ARN.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.ARN = oldRawKey.BedrockKeyConfig.ARN
-		}
-		if updateKey.BedrockKeyConfig.RoleARN != nil &&
-			oldRedactedKey.BedrockKeyConfig.RoleARN != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.RoleARN.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.RoleARN.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.RoleARN = oldRawKey.BedrockKeyConfig.RoleARN
-		}
-		if updateKey.BedrockKeyConfig.ExternalID != nil &&
-			oldRedactedKey.BedrockKeyConfig.ExternalID != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.ExternalID.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.ExternalID.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.ExternalID = oldRawKey.BedrockKeyConfig.ExternalID
-		}
-		if updateKey.BedrockKeyConfig.RoleSessionName != nil &&
-			oldRedactedKey.BedrockKeyConfig.RoleSessionName != nil &&
-			oldRawKey.BedrockKeyConfig != nil &&
-			updateKey.BedrockKeyConfig.RoleSessionName.IsRedacted() &&
-			!updateKey.BedrockKeyConfig.RoleSessionName.IsFromSecret() {
-			mergedKey.BedrockKeyConfig.RoleSessionName = oldRawKey.BedrockKeyConfig.RoleSessionName
+		for _, item := range []struct {
+			incoming *schemas.SecretVar
+			stored   *schemas.SecretVar
+			field    string
+		}{
+			{&mergedKey.VertexKeyConfig.ProjectID, projectID, "vertex_key_config.project_id"},
+			{&mergedKey.VertexKeyConfig.ProjectNumber, projectNumber, "vertex_key_config.project_number"},
+			{&mergedKey.VertexKeyConfig.Region, region, "vertex_key_config.region"},
+			{&mergedKey.VertexKeyConfig.AuthCredentials, authCredentials, "vertex_key_config.auth_credentials"},
+		} {
+			if err := preserve(item.incoming, item.stored, item.field); err != nil {
+				return schemas.Key{}, err
+			}
 		}
 	}
 
-	if updateKey.BedrockMantleKeyConfig != nil && oldRedactedKey.BedrockMantleKeyConfig != nil && oldRawKey.BedrockMantleKeyConfig != nil {
-		if updateKey.BedrockMantleKeyConfig.AccessKey.IsRedacted() && !updateKey.BedrockMantleKeyConfig.AccessKey.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.AccessKey = oldRawKey.BedrockMantleKeyConfig.AccessKey
+	if mergedKey.BedrockKeyConfig != nil {
+		var accessKey, secretKey, sessionToken, region, arn, roleARN, externalID, sessionName *schemas.SecretVar
+		if oldRawKey.BedrockKeyConfig != nil {
+			accessKey = &oldRawKey.BedrockKeyConfig.AccessKey
+			secretKey = &oldRawKey.BedrockKeyConfig.SecretKey
+			sessionToken = oldRawKey.BedrockKeyConfig.SessionToken
+			region = oldRawKey.BedrockKeyConfig.Region
+			arn = oldRawKey.BedrockKeyConfig.ARN
+			roleARN = oldRawKey.BedrockKeyConfig.RoleARN
+			externalID = oldRawKey.BedrockKeyConfig.ExternalID
+			sessionName = oldRawKey.BedrockKeyConfig.RoleSessionName
 		}
-		if updateKey.BedrockMantleKeyConfig.SecretKey.IsRedacted() && !updateKey.BedrockMantleKeyConfig.SecretKey.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.SecretKey = oldRawKey.BedrockMantleKeyConfig.SecretKey
-		}
-		if updateKey.BedrockMantleKeyConfig.SessionToken != nil &&
-			oldRedactedKey.BedrockMantleKeyConfig.SessionToken != nil &&
-			updateKey.BedrockMantleKeyConfig.SessionToken.IsRedacted() &&
-			!updateKey.BedrockMantleKeyConfig.SessionToken.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.SessionToken = oldRawKey.BedrockMantleKeyConfig.SessionToken
-		}
-		if updateKey.BedrockMantleKeyConfig.Region != nil &&
-			oldRedactedKey.BedrockMantleKeyConfig.Region != nil &&
-			updateKey.BedrockMantleKeyConfig.Region.IsRedacted() &&
-			!updateKey.BedrockMantleKeyConfig.Region.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.Region = oldRawKey.BedrockMantleKeyConfig.Region
-		}
-		if updateKey.BedrockMantleKeyConfig.RoleARN != nil &&
-			oldRedactedKey.BedrockMantleKeyConfig.RoleARN != nil &&
-			updateKey.BedrockMantleKeyConfig.RoleARN.IsRedacted() &&
-			!updateKey.BedrockMantleKeyConfig.RoleARN.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.RoleARN = oldRawKey.BedrockMantleKeyConfig.RoleARN
-		}
-		if updateKey.BedrockMantleKeyConfig.ExternalID != nil &&
-			oldRedactedKey.BedrockMantleKeyConfig.ExternalID != nil &&
-			updateKey.BedrockMantleKeyConfig.ExternalID.IsRedacted() &&
-			!updateKey.BedrockMantleKeyConfig.ExternalID.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.ExternalID = oldRawKey.BedrockMantleKeyConfig.ExternalID
-		}
-		if updateKey.BedrockMantleKeyConfig.RoleSessionName != nil &&
-			oldRedactedKey.BedrockMantleKeyConfig.RoleSessionName != nil &&
-			updateKey.BedrockMantleKeyConfig.RoleSessionName.IsRedacted() &&
-			!updateKey.BedrockMantleKeyConfig.RoleSessionName.IsFromSecret() {
-			mergedKey.BedrockMantleKeyConfig.RoleSessionName = oldRawKey.BedrockMantleKeyConfig.RoleSessionName
+		for _, item := range []struct {
+			incoming *schemas.SecretVar
+			stored   *schemas.SecretVar
+			field    string
+		}{
+			{&mergedKey.BedrockKeyConfig.AccessKey, accessKey, "bedrock_key_config.access_key"},
+			{&mergedKey.BedrockKeyConfig.SecretKey, secretKey, "bedrock_key_config.secret_key"},
+			{mergedKey.BedrockKeyConfig.SessionToken, sessionToken, "bedrock_key_config.session_token"},
+			{mergedKey.BedrockKeyConfig.Region, region, "bedrock_key_config.region"},
+			{mergedKey.BedrockKeyConfig.ARN, arn, "bedrock_key_config.arn"},
+			{mergedKey.BedrockKeyConfig.RoleARN, roleARN, "bedrock_key_config.role_arn"},
+			{mergedKey.BedrockKeyConfig.ExternalID, externalID, "bedrock_key_config.external_id"},
+			{mergedKey.BedrockKeyConfig.RoleSessionName, sessionName, "bedrock_key_config.session_name"},
+		} {
+			if err := preserve(item.incoming, item.stored, item.field); err != nil {
+				return schemas.Key{}, err
+			}
 		}
 	}
 
-	if updateKey.VLLMKeyConfig != nil && oldRedactedKey.VLLMKeyConfig != nil && oldRawKey.VLLMKeyConfig != nil {
-		if updateKey.VLLMKeyConfig.URL.IsRedacted() && !updateKey.VLLMKeyConfig.URL.IsFromSecret() {
-			mergedKey.VLLMKeyConfig.URL = oldRawKey.VLLMKeyConfig.URL
+	if mergedKey.BedrockMantleKeyConfig != nil {
+		var accessKey, secretKey, sessionToken, region, roleARN, externalID, sessionName *schemas.SecretVar
+		if oldRawKey.BedrockMantleKeyConfig != nil {
+			accessKey = &oldRawKey.BedrockMantleKeyConfig.AccessKey
+			secretKey = &oldRawKey.BedrockMantleKeyConfig.SecretKey
+			sessionToken = oldRawKey.BedrockMantleKeyConfig.SessionToken
+			region = oldRawKey.BedrockMantleKeyConfig.Region
+			roleARN = oldRawKey.BedrockMantleKeyConfig.RoleARN
+			externalID = oldRawKey.BedrockMantleKeyConfig.ExternalID
+			sessionName = oldRawKey.BedrockMantleKeyConfig.RoleSessionName
+		}
+		for _, item := range []struct {
+			incoming *schemas.SecretVar
+			stored   *schemas.SecretVar
+			field    string
+		}{
+			{&mergedKey.BedrockMantleKeyConfig.AccessKey, accessKey, "bedrock_mantle_key_config.access_key"},
+			{&mergedKey.BedrockMantleKeyConfig.SecretKey, secretKey, "bedrock_mantle_key_config.secret_key"},
+			{mergedKey.BedrockMantleKeyConfig.SessionToken, sessionToken, "bedrock_mantle_key_config.session_token"},
+			{mergedKey.BedrockMantleKeyConfig.Region, region, "bedrock_mantle_key_config.region"},
+			{mergedKey.BedrockMantleKeyConfig.RoleARN, roleARN, "bedrock_mantle_key_config.role_arn"},
+			{mergedKey.BedrockMantleKeyConfig.ExternalID, externalID, "bedrock_mantle_key_config.external_id"},
+			{mergedKey.BedrockMantleKeyConfig.RoleSessionName, sessionName, "bedrock_mantle_key_config.session_name"},
+		} {
+			if err := preserve(item.incoming, item.stored, item.field); err != nil {
+				return schemas.Key{}, err
+			}
+		}
+	}
+
+	if mergedKey.VLLMKeyConfig != nil {
+		var stored *schemas.SecretVar
+		if oldRawKey.VLLMKeyConfig != nil {
+			stored = &oldRawKey.VLLMKeyConfig.URL
+		}
+		if err := preserve(&mergedKey.VLLMKeyConfig.URL, stored, "vllm_key_config.url"); err != nil {
+			return schemas.Key{}, err
 		}
 	}
 
@@ -480,22 +459,30 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey s
 		mergedKey.ReplicateKeyConfig = oldRawKey.ReplicateKeyConfig
 	}
 
-	if updateKey.OllamaKeyConfig != nil && oldRedactedKey.OllamaKeyConfig != nil && oldRawKey.OllamaKeyConfig != nil {
-		if updateKey.OllamaKeyConfig.URL.IsRedacted() && !updateKey.OllamaKeyConfig.URL.IsFromSecret() {
-			mergedKey.OllamaKeyConfig.URL = oldRawKey.OllamaKeyConfig.URL
+	if mergedKey.OllamaKeyConfig != nil {
+		var stored *schemas.SecretVar
+		if oldRawKey.OllamaKeyConfig != nil {
+			stored = &oldRawKey.OllamaKeyConfig.URL
+		}
+		if err := preserve(&mergedKey.OllamaKeyConfig.URL, stored, "ollama_key_config.url"); err != nil {
+			return schemas.Key{}, err
 		}
 	}
 
-	if updateKey.SGLKeyConfig != nil && oldRedactedKey.SGLKeyConfig != nil && oldRawKey.SGLKeyConfig != nil {
-		if updateKey.SGLKeyConfig.URL.IsRedacted() && !updateKey.SGLKeyConfig.URL.IsFromSecret() {
-			mergedKey.SGLKeyConfig.URL = oldRawKey.SGLKeyConfig.URL
+	if mergedKey.SGLKeyConfig != nil {
+		var stored *schemas.SecretVar
+		if oldRawKey.SGLKeyConfig != nil {
+			stored = &oldRawKey.SGLKeyConfig.URL
+		}
+		if err := preserve(&mergedKey.SGLKeyConfig.URL, stored, "sgl_key_config.url"); err != nil {
+			return schemas.Key{}, err
 		}
 	}
 
 	mergedKey.ConfigHash = oldRawKey.ConfigHash
 	mergedKey.Status = oldRawKey.Status
 
-	return mergedKey
+	return mergedKey, nil
 }
 
 func getKeyIDFromCtx(ctx *fasthttp.RequestCtx) (string, error) {

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -103,7 +103,7 @@ func (h *ProviderHandler) createProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if err := validateProviderKeyURL(provider, key); err != nil {
+	if err := validateProviderKeyURL(baseProvider, key); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
@@ -225,7 +225,7 @@ func (h *ProviderHandler) updateProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if err := validateProviderKeyURL(provider, mergedKey); err != nil {
+	if err := validateProviderKeyURL(baseProvider, mergedKey); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestMergeUpdatedKey_Value locks in the invariant that a masked key preview can
+// never be persisted as the real key value. The provider keys API renders keys
+// redacted on GET; when a client echoes that placeholder back on update, the
+// stored credential must be preserved. This is the write-side guard for
+// issue #4353 (a masked "*"-laden preview leaking into the config store and
+// later breaking JSON re-parsing on governance reload).
+func TestMergeUpdatedKey_Value(t *testing.T) {
+	h := &ProviderHandler{}
+
+	const rawValue = "sk-realkey1234567890abcdefghij"
+
+	newRaw := func() schemas.Key {
+		return schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar(rawValue)}
+	}
+	redactedOf := func(raw schemas.Key) schemas.Key {
+		return schemas.Key{ID: "key-1", Value: *raw.Value.Redacted()}
+	}
+
+	t.Run("echoed current redaction preserves stored value", func(t *testing.T) {
+		oldRaw := newRaw()
+		oldRedacted := redactedOf(oldRaw)
+		// Client sends back exactly what GET rendered.
+		update := schemas.Key{ID: "key-1", Value: oldRedacted.Value}
+
+		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		if merged.Value.GetValue() != rawValue {
+			t.Fatalf("expected stored raw value preserved, got %q", merged.Value.GetValue())
+		}
+	})
+
+	t.Run("mismatched mask still preserves stored value", func(t *testing.T) {
+		// A redacted preview whose bytes differ from the server's current
+		// redaction (e.g. a stale render, a different asterisk count, or a
+		// preview from another replica). The old exact-match guard let this
+		// through and persisted the mask; the fix must still preserve.
+		oldRaw := newRaw()
+		oldRedacted := redactedOf(oldRaw)
+		mismatched := "diff" + strings.Repeat("*", 24) + "XYZW" // redacted-shaped, != oldRedacted
+		if !schemas.NewSecretVar(mismatched).IsRedacted() {
+			t.Fatalf("test setup: %q is not recognized as redacted", mismatched)
+		}
+		if mismatched == oldRedacted.Value.GetValue() {
+			t.Fatalf("test setup: mismatched mask unexpectedly equals current redaction")
+		}
+		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar(mismatched)}
+
+		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		if merged.Value.GetValue() != rawValue {
+			t.Fatalf("masked preview must not be persisted; expected %q, got %q", rawValue, merged.Value.GetValue())
+		}
+		if strings.Contains(merged.Value.GetValue(), "*") {
+			t.Fatalf("merged value still contains mask characters: %q", merged.Value.GetValue())
+		}
+	})
+
+	t.Run("genuine new plaintext value is applied", func(t *testing.T) {
+		oldRaw := newRaw()
+		oldRedacted := redactedOf(oldRaw)
+		const newValue = "sk-brandnewkey0987654321zyxwvu"
+		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar(newValue)}
+
+		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		if merged.Value.GetValue() != newValue {
+			t.Fatalf("expected new plaintext value applied, got %q", merged.Value.GetValue())
+		}
+	})
+
+	t.Run("genuine env ref is applied not preserved", func(t *testing.T) {
+		oldRaw := newRaw()
+		oldRedacted := redactedOf(oldRaw)
+		// env refs report IsRedacted() but are an intentional change.
+		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("env.SOME_NEW_KEY")}
+
+		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		if !merged.Value.IsFromEnv() || merged.Value.GetRawRef() != "env.SOME_NEW_KEY" {
+			t.Fatalf("expected env ref applied, got ref=%q fromEnv=%v", merged.Value.GetRawRef(), merged.Value.IsFromEnv())
+		}
+		if merged.Value.GetValue() == rawValue {
+			t.Fatalf("stored raw value leaked into an env-ref update")
+		}
+	})
+
+	t.Run("empty value is not treated as redacted", func(t *testing.T) {
+		// Empty non-secret values must stay empty so the downstream
+		// "must not be empty" validation still fires — the merge must not
+		// silently resurrect the stored value here.
+		oldRaw := newRaw()
+		oldRedacted := redactedOf(oldRaw)
+		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("")}
+
+		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		if merged.Value.GetValue() != "" {
+			t.Fatalf("expected empty value preserved for validation, got %q", merged.Value.GetValue())
+		}
+	})
+}

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
 )
 
 // TestMergeUpdatedKey_Value locks in the invariant that a masked key preview can
@@ -281,5 +284,37 @@ func TestValidateProviderKeyRequiredNestedFields(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
 			}
 		})
+	}
+}
+
+// Regression for the custom-provider path: required-field validation must run
+// against the resolved BASE provider, not the custom route name, or a custom
+// provider based on Bedrock would skip the region requirement entirely.
+func TestCreateProviderKey_CustomBedrockRequiresRegion(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"aws-custom": {
+					CustomProviderConfig: &schemas.CustomProviderConfig{
+						BaseProviderType: schemas.Bedrock,
+					},
+				},
+			},
+		},
+		modelsManager: &mockModelsManager{},
+	}
+
+	ctx := newTestRequestCtx(`{"value":"AKIAEXAMPLEKEY","weight":1.0,"bedrock_key_config":{}}`)
+	ctx.SetUserValue("provider", "aws-custom")
+
+	h.createProviderKey(ctx)
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("custom-bedrock create without region: status got %d, want 400; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if body := string(ctx.Response.Body()); !strings.Contains(body, "bedrock_key_config.region") {
+		t.Fatalf("expected bedrock_key_config.region error, got %s", body)
 	}
 }

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -15,6 +15,14 @@ import (
 // later breaking JSON re-parsing on governance reload).
 func TestMergeUpdatedKey_Value(t *testing.T) {
 	h := &ProviderHandler{}
+	merge := func(oldRaw, update schemas.Key) schemas.Key {
+		t.Helper()
+		merged, err := h.mergeUpdatedKey(oldRaw, update)
+		if err != nil {
+			t.Fatalf("mergeUpdatedKey returned error: %v", err)
+		}
+		return merged
+	}
 
 	const rawValue = "sk-realkey1234567890abcdefghij"
 
@@ -31,7 +39,7 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 		// Client sends back exactly what GET rendered.
 		update := schemas.Key{ID: "key-1", Value: oldRedacted.Value}
 
-		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		merged := merge(oldRaw, update)
 		if merged.Value.GetValue() != rawValue {
 			t.Fatalf("expected stored raw value preserved, got %q", merged.Value.GetValue())
 		}
@@ -53,7 +61,7 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 		}
 		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar(mismatched)}
 
-		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		merged := merge(oldRaw, update)
 		if merged.Value.GetValue() != rawValue {
 			t.Fatalf("masked preview must not be persisted; expected %q, got %q", rawValue, merged.Value.GetValue())
 		}
@@ -64,11 +72,10 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 
 	t.Run("genuine new plaintext value is applied", func(t *testing.T) {
 		oldRaw := newRaw()
-		oldRedacted := redactedOf(oldRaw)
 		const newValue = "sk-brandnewkey0987654321zyxwvu"
 		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar(newValue)}
 
-		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		merged := merge(oldRaw, update)
 		if merged.Value.GetValue() != newValue {
 			t.Fatalf("expected new plaintext value applied, got %q", merged.Value.GetValue())
 		}
@@ -76,11 +83,10 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 
 	t.Run("genuine env ref is applied not preserved", func(t *testing.T) {
 		oldRaw := newRaw()
-		oldRedacted := redactedOf(oldRaw)
 		// env refs report IsRedacted() but are an intentional change.
 		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("env.SOME_NEW_KEY")}
 
-		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		merged := merge(oldRaw, update)
 		if !merged.Value.IsFromEnv() || merged.Value.GetRawRef() != "env.SOME_NEW_KEY" {
 			t.Fatalf("expected env ref applied, got ref=%q fromEnv=%v", merged.Value.GetRawRef(), merged.Value.IsFromEnv())
 		}
@@ -91,13 +97,12 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 
 	t.Run("empty value is not treated as redacted", func(t *testing.T) {
 		// Empty non-secret values must stay empty so the downstream
-		// "must not be empty" validation still fires — the merge must not
+		// "must not be empty" validation still fires. The merge must not
 		// silently resurrect the stored value here.
 		oldRaw := newRaw()
-		oldRedacted := redactedOf(oldRaw)
 		update := schemas.Key{ID: "key-1", Value: *schemas.NewSecretVar("")}
 
-		merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+		merged := merge(oldRaw, update)
 		if merged.Value.GetValue() != "" {
 			t.Fatalf("expected empty value preserved for validation, got %q", merged.Value.GetValue())
 		}
@@ -106,6 +111,14 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 
 func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
 	h := &ProviderHandler{}
+	merge := func(oldRaw, update schemas.Key) schemas.Key {
+		t.Helper()
+		merged, err := h.mergeUpdatedKey(oldRaw, update)
+		if err != nil {
+			t.Fatalf("mergeUpdatedKey returned error: %v", err)
+		}
+		return merged
+	}
 	secret := func(value string) schemas.SecretVar { return *schemas.NewSecretVar(value) }
 	secretPtr := func(value string) *schemas.SecretVar { return schemas.NewSecretVar(value) }
 	staleMaskValue := func(prefix, suffix string) string {
@@ -134,25 +147,6 @@ func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
 		OllamaKeyConfig: &schemas.OllamaKeyConfig{URL: secret("https://current.ollama.example.com")},
 		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: secret("https://current.sgl.example.com")},
 	}
-	oldRedacted := schemas.Key{
-		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:     *oldRaw.AzureKeyConfig.Endpoint.Redacted(),
-			ClientSecret: oldRaw.AzureKeyConfig.ClientSecret.Redacted(),
-		},
-		VertexKeyConfig: &schemas.VertexKeyConfig{
-			AuthCredentials: *oldRaw.VertexKeyConfig.AuthCredentials.Redacted(),
-		},
-		BedrockKeyConfig: &schemas.BedrockKeyConfig{
-			AccessKey:    *oldRaw.BedrockKeyConfig.AccessKey.Redacted(),
-			SessionToken: oldRaw.BedrockKeyConfig.SessionToken.Redacted(),
-		},
-		BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
-			SecretKey: *oldRaw.BedrockMantleKeyConfig.SecretKey.Redacted(),
-		},
-		VLLMKeyConfig:   &schemas.VLLMKeyConfig{URL: *oldRaw.VLLMKeyConfig.URL.Redacted()},
-		OllamaKeyConfig: &schemas.OllamaKeyConfig{URL: *oldRaw.OllamaKeyConfig.URL.Redacted()},
-		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: *oldRaw.SGLKeyConfig.URL.Redacted()},
-	}
 	update := schemas.Key{
 		AzureKeyConfig: &schemas.AzureKeyConfig{
 			Endpoint:     staleMask("azur", "0001"),
@@ -173,7 +167,7 @@ func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
 		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: staleMask("sgla", "0009")},
 	}
 
-	merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+	merged := merge(oldRaw, update)
 	checks := []struct {
 		name string
 		got  string
@@ -196,8 +190,57 @@ func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
 	}
 
 	update.VLLMKeyConfig.URL = secret("env.NEW_VLLM_URL")
-	merged = h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+	merged = merge(oldRaw, update)
 	if !merged.VLLMKeyConfig.URL.IsFromEnv() || merged.VLLMKeyConfig.URL.GetRawRef() != "env.NEW_VLLM_URL" {
 		t.Fatalf("expected nested env ref applied, got ref=%q", merged.VLLMKeyConfig.URL.GetRawRef())
+	}
+}
+
+func TestMergeUpdatedKey_RejectsMaskWithoutStoredCounterpart(t *testing.T) {
+	h := &ProviderHandler{}
+	mask := *schemas.NewSecretVar("abcd" + strings.Repeat("*", 24) + "wxyz")
+
+	tests := []struct {
+		name    string
+		oldRaw  schemas.Key
+		update  schemas.Key
+		wantErr string
+	}{
+		{
+			name:    "missing config section",
+			oldRaw:  schemas.Key{},
+			update:  schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{URL: mask}},
+			wantErr: "vllm_key_config.url",
+		},
+		{
+			name: "missing optional field",
+			oldRaw: schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: *schemas.NewSecretVar("stored-access-key"),
+			}},
+			update: schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				SessionToken: schemas.NewSecretVar(mask.GetValue()),
+			}},
+			wantErr: "bedrock_key_config.session_token",
+		},
+		{
+			name: "empty stored value",
+			oldRaw: schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{
+				URL: *schemas.NewSecretVar(""),
+			}},
+			update:  schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{URL: mask}},
+			wantErr: "vllm_key_config.url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := h.mergeUpdatedKey(tt.oldRaw, tt.update)
+			if err == nil {
+				t.Fatal("expected masked preview without stored counterpart to fail")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error to name %q, got %q", tt.wantErr, err)
+			}
+		})
 	}
 }

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -244,3 +244,42 @@ func TestMergeUpdatedKey_RejectsMaskWithoutStoredCounterpart(t *testing.T) {
 		})
 	}
 }
+
+// validateProviderKeyURL must enforce every nested field config.schema.json
+// marks as required, so neither create nor a masked-update merge can persist a
+// key missing them.
+func TestValidateProviderKeyRequiredNestedFields(t *testing.T) {
+	region := schemas.NewSecretVar("us-east-1")
+	cases := []struct {
+		name     string
+		provider schemas.ModelProvider
+		key      schemas.Key
+		wantErr  string
+	}{
+		{"azure missing endpoint", schemas.Azure, schemas.Key{AzureKeyConfig: &schemas.AzureKeyConfig{}}, "azure_key_config.endpoint"},
+		{"azure nil config", schemas.Azure, schemas.Key{}, "azure_key_config.endpoint"},
+		{"azure ok", schemas.Azure, schemas.Key{AzureKeyConfig: &schemas.AzureKeyConfig{Endpoint: *schemas.NewSecretVar("https://x.openai.azure.com")}}, ""},
+		{"bedrock missing region", schemas.Bedrock, schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{}}, "bedrock_key_config.region"},
+		{"bedrock ok", schemas.Bedrock, schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{Region: region}}, ""},
+		{"mantle missing region", schemas.BedrockMantle, schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{}}, "bedrock_mantle_key_config.region"},
+		{"mantle ok", schemas.BedrockMantle, schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{Region: region}}, ""},
+		{"vllm missing url", schemas.VLLM, schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{ModelName: "m"}}, "vllm_key_config.url"},
+		{"vllm missing model_name", schemas.VLLM, schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{URL: *schemas.NewSecretVar("http://vllm:8000")}}, "vllm_key_config.model_name"},
+		{"vllm ok", schemas.VLLM, schemas.Key{VLLMKeyConfig: &schemas.VLLMKeyConfig{URL: *schemas.NewSecretVar("http://vllm:8000"), ModelName: "m"}}, ""},
+		{"openai unaffected", schemas.OpenAI, schemas.Key{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateProviderKeyURL(tc.provider, tc.key)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -103,3 +103,101 @@ func TestMergeUpdatedKey_Value(t *testing.T) {
 		}
 	})
 }
+
+func TestMergeUpdatedKey_ProviderConfigMaskedPreviews(t *testing.T) {
+	h := &ProviderHandler{}
+	secret := func(value string) schemas.SecretVar { return *schemas.NewSecretVar(value) }
+	secretPtr := func(value string) *schemas.SecretVar { return schemas.NewSecretVar(value) }
+	staleMaskValue := func(prefix, suffix string) string {
+		return prefix + strings.Repeat("*", 24) + suffix
+	}
+	staleMask := func(prefix, suffix string) schemas.SecretVar {
+		return secret(staleMaskValue(prefix, suffix))
+	}
+
+	oldRaw := schemas.Key{
+		AzureKeyConfig: &schemas.AzureKeyConfig{
+			Endpoint:     secret("https://current.azure.example.com"),
+			ClientSecret: secretPtr("azure-client-secret-current"),
+		},
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			AuthCredentials: secret("vertex-auth-credentials-current"),
+		},
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			AccessKey:    secret("bedrock-access-key-current"),
+			SessionToken: secretPtr("bedrock-session-token-current"),
+		},
+		BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+			SecretKey: secret("mantle-secret-key-current"),
+		},
+		VLLMKeyConfig:   &schemas.VLLMKeyConfig{URL: secret("https://current.vllm.example.com")},
+		OllamaKeyConfig: &schemas.OllamaKeyConfig{URL: secret("https://current.ollama.example.com")},
+		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: secret("https://current.sgl.example.com")},
+	}
+	oldRedacted := schemas.Key{
+		AzureKeyConfig: &schemas.AzureKeyConfig{
+			Endpoint:     *oldRaw.AzureKeyConfig.Endpoint.Redacted(),
+			ClientSecret: oldRaw.AzureKeyConfig.ClientSecret.Redacted(),
+		},
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			AuthCredentials: *oldRaw.VertexKeyConfig.AuthCredentials.Redacted(),
+		},
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			AccessKey:    *oldRaw.BedrockKeyConfig.AccessKey.Redacted(),
+			SessionToken: oldRaw.BedrockKeyConfig.SessionToken.Redacted(),
+		},
+		BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+			SecretKey: *oldRaw.BedrockMantleKeyConfig.SecretKey.Redacted(),
+		},
+		VLLMKeyConfig:   &schemas.VLLMKeyConfig{URL: *oldRaw.VLLMKeyConfig.URL.Redacted()},
+		OllamaKeyConfig: &schemas.OllamaKeyConfig{URL: *oldRaw.OllamaKeyConfig.URL.Redacted()},
+		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: *oldRaw.SGLKeyConfig.URL.Redacted()},
+	}
+	update := schemas.Key{
+		AzureKeyConfig: &schemas.AzureKeyConfig{
+			Endpoint:     staleMask("azur", "0001"),
+			ClientSecret: secretPtr(staleMaskValue("azcs", "0002")),
+		},
+		VertexKeyConfig: &schemas.VertexKeyConfig{
+			AuthCredentials: staleMask("vert", "0003"),
+		},
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			AccessKey:    staleMask("beda", "0004"),
+			SessionToken: secretPtr(staleMaskValue("beds", "0005")),
+		},
+		BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+			SecretKey: staleMask("mant", "0006"),
+		},
+		VLLMKeyConfig:   &schemas.VLLMKeyConfig{URL: staleMask("vllm", "0007")},
+		OllamaKeyConfig: &schemas.OllamaKeyConfig{URL: staleMask("olla", "0008")},
+		SGLKeyConfig:    &schemas.SGLKeyConfig{URL: staleMask("sgla", "0009")},
+	}
+
+	merged := h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"azure endpoint", merged.AzureKeyConfig.Endpoint.GetValue(), oldRaw.AzureKeyConfig.Endpoint.GetValue()},
+		{"azure client secret", merged.AzureKeyConfig.ClientSecret.GetValue(), oldRaw.AzureKeyConfig.ClientSecret.GetValue()},
+		{"vertex credentials", merged.VertexKeyConfig.AuthCredentials.GetValue(), oldRaw.VertexKeyConfig.AuthCredentials.GetValue()},
+		{"bedrock access key", merged.BedrockKeyConfig.AccessKey.GetValue(), oldRaw.BedrockKeyConfig.AccessKey.GetValue()},
+		{"bedrock session token", merged.BedrockKeyConfig.SessionToken.GetValue(), oldRaw.BedrockKeyConfig.SessionToken.GetValue()},
+		{"mantle secret key", merged.BedrockMantleKeyConfig.SecretKey.GetValue(), oldRaw.BedrockMantleKeyConfig.SecretKey.GetValue()},
+		{"vllm url", merged.VLLMKeyConfig.URL.GetValue(), oldRaw.VLLMKeyConfig.URL.GetValue()},
+		{"ollama url", merged.OllamaKeyConfig.URL.GetValue(), oldRaw.OllamaKeyConfig.URL.GetValue()},
+		{"sgl url", merged.SGLKeyConfig.URL.GetValue(), oldRaw.SGLKeyConfig.URL.GetValue()},
+	}
+	for _, check := range checks {
+		if check.got != check.want {
+			t.Errorf("%s: expected stored value %q, got %q", check.name, check.want, check.got)
+		}
+	}
+
+	update.VLLMKeyConfig.URL = secret("env.NEW_VLLM_URL")
+	merged = h.mergeUpdatedKey(oldRaw, oldRedacted, update)
+	if !merged.VLLMKeyConfig.URL.IsFromEnv() || merged.VLLMKeyConfig.URL.GetRawRef() != "env.NEW_VLLM_URL" {
+		t.Fatalf("expected nested env ref applied, got ref=%q", merged.VLLMKeyConfig.URL.GetRawRef())
+	}
+}


### PR DESCRIPTION
## Summary

Prevents provider-key updates from persisting a redacted preview as the real credential. A stale or differently rendered mask could previously bypass the exact-match check, land in config storage, and trigger repeated JSON parse failures and governance reload outages.

## Changes

- Preserve the stored credential for every recognized redacted, non-secret update value, without requiring byte equality with the current server-rendered mask.
- Continue accepting genuine plaintext rotations and env/vault secret references.
- Add regression coverage for current masks, stale/different masks, plaintext rotations, env references, and empty-value validation behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports
go test ./bifrost-http/handlers -count=1
```

Expected: the handler package passes, including `TestMergeUpdatedKey_Value`.

## Screenshots/Recordings

Not applicable; no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #4353

## Security considerations

This closes a credential write-path integrity issue: display-only masked values can no longer replace stored provider credentials. Secret references and genuine plaintext rotations remain supported.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable