### PR TITLE
fix: repair bare wildcard model-list rows

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -441,6 +441,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_sidekiq_kind_status_created_index"}, run: migrationAddSidekiqKindStatusCreatedIndex},
 	{IDs: []string{"add_fast_mode_cache_pricing_columns"}, run: migrationAddFastModeCachePricingColumns},
 	{IDs: []string{"add_inference_geo_multiplier_column"}, run: migrationAddInferenceGeoMultiplierColumn},
+	{IDs: []string{"repair_bare_wildcard_allowed_models"}, run: migrationRepairBareWildcardAllowedModels},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -6438,6 +6439,51 @@ func migrationBackfillAllowedModelsWildcard(ctx context.Context, db *gorm.DB, lo
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running backfill_allowed_models_wildcard migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationRepairBareWildcardAllowedModels repairs governance_virtual_key_provider_configs
+// rows whose allowed_models / blacklisted_models column holds the bare one-character
+// string '*' instead of the JSON array '["*"]'. Such rows abort the GORM json
+// deserializer ("invalid character '*' ...") when the VK is loaded, which poisons the
+// whole provider admin surface (see issue #4318). The repair rewrites the column to the
+// canonical '["*"]' form the serializer:json tag is supposed to produce; the intended
+// value at write time was already the WhiteList ["*"], so the config_hash — computed
+// from the in-memory slice — stays consistent and needs no recomputation.
+func migrationRepairBareWildcardAllowedModels(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "repair_bare_wildcard_allowed_models"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Match the documented manual workaround exactly: bare '*' → '["*"]'.
+			// Covers both whitelist columns on the provider config, which share the
+			// serializer:json tag and the same corruption class.
+			for _, column := range []string{"allowed_models", "blacklisted_models"} {
+				res := tx.Model(&tables.TableVirtualKeyProviderConfig{}).
+					Where(column+" = ?", "*").
+					Update(column, `["*"]`)
+				if res.Error != nil {
+					return fmt.Errorf("failed to repair bare wildcard %s: %w", column, res.Error)
+				}
+				if res.RowsAffected > 0 {
+					logger.Info("[configstore] %s: repaired %d rows with bare wildcard %s", migrationName, res.RowsAffected, column)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Rollback is a no-op: reverting '["*"]' back to '*' would re-introduce
+			// the value that breaks the deserializer.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1904,6 +1904,94 @@ func TestMigrationBackfillAllowedModelsWildcard(t *testing.T) {
 	assert.NotEmpty(t, keyHash, "key config_hash should be recomputed")
 }
 
+// TestProviderConfigWildcardRoundTrip verifies the current write path persists a
+// WhiteList/BlackList wildcard as the JSON array '["*"]' (never the bare byte '*')
+// and reads it back intact — the round-trip that issue #4318's corrupted rows broke.
+func TestProviderConfigWildcardRoundTrip(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&tables.TableVirtualKeyProviderConfig{}))
+
+	pc := tables.TableVirtualKeyProviderConfig{
+		VirtualKeyID:      "vk-roundtrip",
+		Provider:          "zai",
+		AllowedModels:     schemas.WhiteList{"*"},
+		BlacklistedModels: schemas.BlackList{"*"},
+	}
+	require.NoError(t, db.Create(&pc).Error)
+
+	// Raw column bytes must be the JSON array, not the bare character.
+	var allowedRaw, blacklistedRaw string
+	require.NoError(t, db.Table("governance_virtual_key_provider_configs").
+		Select("allowed_models").Where("virtual_key_id = ?", "vk-roundtrip").Scan(&allowedRaw).Error)
+	require.NoError(t, db.Table("governance_virtual_key_provider_configs").
+		Select("blacklisted_models").Where("virtual_key_id = ?", "vk-roundtrip").Scan(&blacklistedRaw).Error)
+	assert.Equal(t, `["*"]`, allowedRaw)
+	assert.Equal(t, `["*"]`, blacklistedRaw)
+
+	// Model read must deserialize cleanly back to the wildcard slice.
+	var got tables.TableVirtualKeyProviderConfig
+	require.NoError(t, db.Where("virtual_key_id = ?", "vk-roundtrip").First(&got).Error)
+	assert.True(t, got.AllowedModels.IsUnrestricted())
+	assert.True(t, got.BlacklistedModels.IsBlockAll())
+}
+
+// TestMigrationRepairBareWildcardAllowedModels verifies the repair migration heals
+// legacy rows whose allowed_models / blacklisted_models column holds the bare byte
+// '*' (issue #4318). Without the repair, loading such a row aborts the GORM json
+// deserializer and poisons the provider admin surface.
+func TestMigrationRepairBareWildcardAllowedModels(t *testing.T) {
+	_, db := setupFullMigrationDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Clear migration tracking so it runs again against the seeded rows.
+	db.Exec(`DELETE FROM migrations WHERE id = 'repair_bare_wildcard_allowed_models'`)
+
+	err := db.Exec(`INSERT INTO governance_virtual_keys (id, name, value, is_active, encryption_status, created_at, updated_at)
+		VALUES ('vk-bare-1', 'bare-vk', 'vk-val', true, 'plain_text', ?, ?)`, now, now).Error
+	require.NoError(t, err)
+
+	// Row A: corrupted allowed_models, valid blacklisted_models.
+	err = db.Exec(`INSERT INTO governance_virtual_key_provider_configs (virtual_key_id, provider, allowed_models, blacklisted_models, allow_all_keys)
+		VALUES ('vk-bare-1', 'zai', '*', '[]', true)`).Error
+	require.NoError(t, err)
+	// Row B: valid allowed_models, corrupted blacklisted_models.
+	err = db.Exec(`INSERT INTO governance_virtual_key_provider_configs (virtual_key_id, provider, allowed_models, blacklisted_models, allow_all_keys)
+		VALUES ('vk-bare-1', 'openai', '["*"]', '*', true)`).Error
+	require.NoError(t, err)
+
+	// Pre-condition: the bare '*' rows cannot be loaded through the GORM model.
+	var pre []tables.TableVirtualKeyProviderConfig
+	preErr := db.Where("virtual_key_id = ?", "vk-bare-1").Find(&pre).Error
+	require.Error(t, preErr, "bare '*' rows should fail to deserialize before repair")
+
+	require.NoError(t, migrationRepairBareWildcardAllowedModels(ctx, db, testMigrationLogger))
+
+	// Both columns are now canonical JSON arrays.
+	var allowedA, blacklistedB string
+	require.NoError(t, db.Table("governance_virtual_key_provider_configs").
+		Select("allowed_models").Where("virtual_key_id = ? AND provider = ?", "vk-bare-1", "zai").Scan(&allowedA).Error)
+	require.NoError(t, db.Table("governance_virtual_key_provider_configs").
+		Select("blacklisted_models").Where("virtual_key_id = ? AND provider = ?", "vk-bare-1", "openai").Scan(&blacklistedB).Error)
+	assert.Equal(t, `["*"]`, allowedA, "bare '*' allowed_models should be repaired to wildcard array")
+	assert.Equal(t, `["*"]`, blacklistedB, "bare '*' blacklisted_models should be repaired to wildcard array")
+
+	// Post-condition: the rows now load cleanly through the GORM model.
+	var post []tables.TableVirtualKeyProviderConfig
+	require.NoError(t, db.Where("virtual_key_id = ?", "vk-bare-1").Find(&post).Error,
+		"repaired rows should deserialize without error")
+	require.Len(t, post, 2)
+	byProvider := map[string]tables.TableVirtualKeyProviderConfig{}
+	for _, pc := range post {
+		byProvider[pc.Provider] = pc
+	}
+	assert.True(t, byProvider["zai"].AllowedModels.IsUnrestricted(), "repaired allowed_models should be unrestricted")
+	assert.True(t, byProvider["openai"].BlacklistedModels.IsBlockAll(), "repaired blacklisted_models should block all")
+}
+
 func TestMigrationRemoveServerPrefixFromMCPTools(t *testing.T) {
 	_, db := setupFullMigrationDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Repairs legacy virtual-key provider-config rows that contain a bare `*` in JSON-serialized model-list columns. Those rows cannot be deserialized by GORM and can block the provider administration surface until the database is repaired manually.

## Changes

- Add an idempotent data-repair migration converting bare `*` values to canonical `["*"]` JSON in `allowed_models` and `blacklisted_models`.
- Leave valid JSON and all other values untouched.
- Add regression coverage for the current serializer round trip and for loading both repaired legacy corruption variants.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

Framework/configstore is affected.

## How to test

```sh
cd framework
go test ./configstore -count=1
```

Expected: the configstore package passes, including the wildcard round-trip and repair migration tests.

## Screenshots/Recordings

Not applicable; no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #4318

## Security considerations

No credential material is read or changed. The migration only canonicalizes two malformed model-list values so affected configuration rows can be loaded again.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable