### PR TITLE
fix(bedrock): preserve reasoning_config on cross-provider translation

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -6820,3 +6820,53 @@ func TestNoLeadingSystemBlockReminderInlined(t *testing.T) {
 	}
 	assert.True(t, inlined, "the mid-conversation reminder must be inlined as a wrapped user message")
 }
+
+// TestReasoningConfigSurvivesHTTPUnmarshal guards against reasoning_config /
+// thinking being silently dropped when a Bedrock Converse body is unmarshaled
+// from JSON (nested objects decode to *OrderedMap, not map[string]interface{})
+// and then translated to a non-Bedrock target.
+func TestReasoningConfigSurvivesHTTPUnmarshal(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	t.Run("reasoning_config", func(t *testing.T) {
+		body := []byte(`{
+			"messages": [{"role": "user", "content": [{"text": "Think step-by-step."}]}],
+			"inferenceConfig": {"maxTokens": 2012, "temperature": 1.0},
+			"additionalModelRequestFields": {
+				"reasoning_config": {"type": "enabled", "budget_tokens": 1500}
+			}
+		}`)
+
+		var req bedrock.BedrockConverseRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		req.ModelID = "anthropic/claude-sonnet-4-5-20250929"
+
+		out, err := req.ToBifrostResponsesRequest(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, out.Params, "Params is nil")
+		require.NotNil(t, out.Params.Reasoning, "reasoning_config was silently dropped")
+		require.NotNil(t, out.Params.Reasoning.MaxTokens)
+		assert.Equal(t, 1500, *out.Params.Reasoning.MaxTokens)
+	})
+
+	t.Run("nova_reasoningConfig", func(t *testing.T) {
+		body := []byte(`{
+			"messages": [{"role": "user", "content": [{"text": "Think step-by-step."}]}],
+			"inferenceConfig": {"maxTokens": 2012},
+			"additionalModelRequestFields": {
+				"reasoningConfig": {"type": "enabled", "maxReasoningEffort": "high"}
+			}
+		}`)
+
+		var req bedrock.BedrockConverseRequest
+		require.NoError(t, json.Unmarshal(body, &req))
+		req.ModelID = "amazon.nova-premier-v1:0"
+
+		out, err := req.ToBifrostResponsesRequest(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, out.Params, "Params is nil")
+		require.NotNil(t, out.Params.Reasoning, "nova reasoningConfig was silently dropped")
+		require.NotNil(t, out.Params.Reasoning.Effort)
+		assert.Equal(t, "high", *out.Params.Reasoning.Effort)
+	})
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2049,7 +2049,9 @@ func (request *BedrockConverseRequest) ToBifrostResponsesRequest(ctx *schemas.Bi
 			reasoningConfig, ok = request.AdditionalModelRequestFields.Get("reasoning_config")
 		}
 		if ok {
-			if reasoningConfigMap, ok := reasoningConfig.(map[string]interface{}); ok {
+			// May arrive as *OrderedMap (HTTP unmarshal) or map[string]interface{} (in-process)
+			if reasoningConfigOrderedMap, ok := schemas.SafeExtractOrderedMap(reasoningConfig); ok && reasoningConfigOrderedMap != nil {
+				reasoningConfigMap := reasoningConfigOrderedMap.ToMap()
 				if typeStr, ok := schemas.SafeExtractString(reasoningConfigMap["type"]); ok {
 					if typeStr == "enabled" || typeStr == "adaptive" {
 						var summary *string
@@ -2115,7 +2117,8 @@ func (request *BedrockConverseRequest) ToBifrostResponsesRequest(ctx *schemas.Bi
 
 		// Handle Nova reasoningConfig format (camelCase)
 		if novaReasoningConfig, ok := request.AdditionalModelRequestFields.Get("reasoningConfig"); ok {
-			if novaReasoningConfigMap, ok := novaReasoningConfig.(map[string]interface{}); ok {
+			if novaReasoningConfigOrderedMap, ok := schemas.SafeExtractOrderedMap(novaReasoningConfig); ok && novaReasoningConfigOrderedMap != nil {
+				novaReasoningConfigMap := novaReasoningConfigOrderedMap.ToMap()
 				if typeStr, ok := schemas.SafeExtractString(novaReasoningConfigMap["type"]); ok {
 					if typeStr == "enabled" {
 						// Extract maxReasoningEffort from Nova format


### PR DESCRIPTION
## Summary

Bedrock Converse `additionalModelRequestFields.reasoning_config` / `thinking`
(and the Nova `reasoningConfig` variant) was silently dropped when a request
body was unmarshaled from JSON and then translated to a **non-Bedrock**
provider (e.g. an `anthropic/...` fallback). The outbound request had no
thinking enabled, so the model returned no reasoning — extended thinking was
lost on cross-provider fallbacks. Fixes #5108.

## Changes

- `core/providers/bedrock/responses.go` — `ToBifrostResponsesRequest` extracted
  `reasoning_config`/`thinking` and Nova `reasoningConfig` with a raw
  `.(map[string]interface{})` type assertion. On the HTTP path, nested JSON
  objects decode to `*OrderedMap` (see `decodeOrderedValue`), so the assertion
  failed **silently** and `Params.Reasoning` was never populated. Both blocks
  now use `schemas.SafeExtractOrderedMap(...).ToMap()`, matching the sibling
  `output_config` block that already handles this shape.
- `core/providers/bedrock/bedrock_test.go` — added
  `TestReasoningConfigSurvivesHTTPUnmarshal`, which unmarshals a real JSON body
  (not a Go map literal, which is why existing tests missed the bug) and
  asserts `Params.Reasoning` is populated. Covers both the Anthropic
  `reasoning_config` and Nova `reasoningConfig` paths.

### Notes / trade-offs

- Bedrock→Bedrock was never affected: the `additionalModelRequestFieldPaths`
  merge in `utils.go` re-injects the raw fields verbatim for Bedrock targets,
  which masked the bug for primaries.
- No behavior change for in-process callers passing `map[string]interface{}` —
  `SafeExtractOrderedMap` handles both shapes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version

# Targeted regression test — fails on the pre-fix code, passes with the fix
go test ./core/providers/bedrock/ -run TestReasoningConfigSurvivesHTTPUnmarshal -v

# Full provider suite
go test ./core/providers/bedrock/
```

Expected: `TestReasoningConfigSurvivesHTTPUnmarshal/reasoning_config` and
`/nova_reasoningConfig` both PASS. Reverting the `responses.go` change makes
both fail with "reasoning_config was silently dropped".

No new configs or environment variables.

## Screenshots/Recordings

N/A — no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5108

## Security considerations

None. No changes to auth, secrets, PII handling, or sandboxing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (N/A)
- [x] I verified builds succeed (Go and UI) — Go build/tests pass; no UI changes
- [ ] I verified the CI pipeline passes locally if applicable
