### PR TITLE
fix: reset web search flag when recycling pooled gemini responses stream state

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: reset `HasEmittedWebSearch` when recycling pooled Gemini responses stream state so grounded streaming requests keep emitting `web_search_call` items (closes #5113) [@fus3r](https://github.com/fus3r)

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -935,6 +935,7 @@ func (state *GeminiResponsesStreamState) flush() {
 	state.TextItemClosed = false
 	state.HasStartedText = false
 	state.HasStartedToolCall = false
+	state.HasEmittedWebSearch = false
 	state.TextBuffer.Reset()
 }
 

--- a/core/providers/gemini/websearchstreamstate_test.go
+++ b/core/providers/gemini/websearchstreamstate_test.go
@@ -1,0 +1,137 @@
+package gemini
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// groundedStreamChunks returns a minimal grounded stream: a text chunk followed
+// by a final chunk carrying finishReason plus groundingMetadata, which is how
+// the Gemini API delivers google_search results on streaming responses.
+func groundedStreamChunks() []*GenerateContentResponse {
+	return []*GenerateContentResponse{
+		{
+			ResponseID:   "resp-grounded",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				Content: &Content{
+					Role:  "model",
+					Parts: []*Part{{Text: "The Eiffel Tower is 330 metres tall."}},
+				},
+			}},
+		},
+		{
+			ResponseID:   "resp-grounded",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				FinishReason: FinishReasonStop,
+				GroundingMetadata: &GroundingMetadata{
+					WebSearchQueries: []string{"eiffel tower height"},
+					GroundingChunks: []*GroundingChunk{{
+						Web: &GroundingChunkWeb{
+							URI:   "https://vertexaisearch.cloud.google.com/grounding-api-redirect/example",
+							Title: "toureiffel.paris",
+						},
+					}},
+					GroundingSupports: []*GroundingSupport{{
+						Segment: &Segment{
+							StartIndex: 0,
+							EndIndex:   36,
+							Text:       "The Eiffel Tower is 330 metres tall.",
+						},
+						GroundingChunkIndices: []int32{0},
+					}},
+					SearchEntryPoint: &SearchEntryPoint{
+						RenderedContent: "<div>Google Search Suggestions</div>",
+					},
+				},
+			}},
+			UsageMetadata: &GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     8,
+				CandidatesTokenCount: 12,
+				TotalTokenCount:      20,
+			},
+		},
+	}
+}
+
+// driveGroundedResponsesStream replays the grounded chunk sequence through
+// ToBifrostResponsesStream against the given state, mirroring the
+// sequence-number accounting of HandleGeminiResponsesStream.
+func driveGroundedResponsesStream(t *testing.T, state *GeminiResponsesStreamState) []*schemas.BifrostResponsesStreamResponse {
+	t.Helper()
+
+	var out []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for _, chunk := range groundedStreamChunks() {
+		responses, bifrostErr := chunk.ToBifrostResponsesStream(seq, state)
+		require.Nil(t, bifrostErr, "unexpected conversion error")
+		out = append(out, responses...)
+		seq += len(responses)
+	}
+	return out
+}
+
+func responsesStreamEventTypes(responses []*schemas.BifrostResponsesStreamResponse) []schemas.ResponsesStreamResponseType {
+	types := make([]schemas.ResponsesStreamResponseType, 0, len(responses))
+	for _, r := range responses {
+		types = append(types, r.Type)
+	}
+	return types
+}
+
+func findCompletedWebSearchCallItem(responses []*schemas.BifrostResponsesStreamResponse) *schemas.ResponsesMessage {
+	for _, r := range responses {
+		if r.Type != schemas.ResponsesStreamResponseTypeOutputItemDone || r.Item == nil {
+			continue
+		}
+		if r.Item.Type != nil && *r.Item.Type == schemas.ResponsesMessageTypeWebSearchCall {
+			return r.Item
+		}
+	}
+	return nil
+}
+
+func TestGeminiResponsesStreamStateFlushResetsWebSearchFlag(t *testing.T) {
+	state := &GeminiResponsesStreamState{HasEmittedWebSearch: true}
+
+	state.flush()
+
+	assert.False(t, state.HasEmittedWebSearch,
+		"flush must clear HasEmittedWebSearch so a recycled state can emit web search events again")
+}
+
+func TestGeminiResponsesStreamWebSearchEmittedAfterStateRecycle(t *testing.T) {
+	state := &GeminiResponsesStreamState{}
+	state.flush()
+
+	first := driveGroundedResponsesStream(t, state)
+	require.NotNil(t, findCompletedWebSearchCallItem(first),
+		"fresh state must emit the web_search_call lifecycle")
+
+	// Between two streaming requests the pool recycles the state through
+	// releaseGeminiResponsesStreamState and acquireGeminiResponsesStreamState.
+	// flush is the only reset either of them runs (twice in total across the
+	// two calls, and it is idempotent), so a single flush here is equivalent
+	// to that recycle path.
+	state.flush()
+
+	second := driveGroundedResponsesStream(t, state)
+
+	assert.Equal(t, responsesStreamEventTypes(first), responsesStreamEventTypes(second),
+		"a recycled state must produce the same grounded stream lifecycle as a fresh one")
+
+	done := findCompletedWebSearchCallItem(second)
+	require.NotNil(t, done,
+		"recycled state must still emit the completed web_search_call item")
+	require.NotNil(t, done.ResponsesToolMessage)
+	require.NotNil(t, done.ResponsesToolMessage.Action)
+	action := done.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
+	require.NotNil(t, action)
+	assert.Equal(t, []string{"eiffel tower height"}, action.Queries)
+	require.Len(t, action.Sources, 1)
+	assert.Equal(t, "https://vertexaisearch.cloud.google.com/grounding-api-redirect/example", action.Sources[0].URL)
+}


### PR DESCRIPTION
## Summary

Fixes #5113. The Gemini responses stream converter emits grounding metadata as a `web_search_call` output item (queries, source list, lifecycle events) plus a rendered content message, guarded by a `HasEmittedWebSearch` flag on the pooled `GeminiResponsesStreamState` so a stream emits the item only once. `flush()`, the reset both `acquireGeminiResponsesStreamState` and `releaseGeminiResponsesStreamState` run when recycling a state object, clears every field of the struct except that flag: it was added with the web search tool support in #1371 after `flush()` was last touched. The result is that only the first grounded streaming request served by a pooled object ever emits the web search lifecycle; every later grounded stream on a recycled object silently loses the `web_search_call` item, the sources, and the search suggestions block, both on the client SSE stream and in the accumulated message that feeds logging (items are appended on `output_item.added`). Vertex is affected too since it shares `HandleGeminiResponsesStream`. The non-streaming path and the chat completions surface are unaffected.

A CodeRabbit review comment on #2590 flagged this missing reset back in April with the same one-line suggestion, but that PR targets a different problem (safety filtering), is based on `main`, has been inactive since April, and never picked the suggestion up, so this PR carries the fix on `dev` with regression tests and a live reproduction.

## Changes

- Reset `HasEmittedWebSearch` in `GeminiResponsesStreamState.flush()`, alongside the other lifecycle flags, so a recycled state object emits web search events again. The flag keeps its in-stream deduplication role: it is still set after the first emission within a stream and only cleared when the state is recycled.
- Regression tests, both failing on `dev`: a direct flush contract test (a state with the flag set is fully reset), and a recycle test that replays the same grounded chunk sequence twice through `ToBifrostResponsesStream` with a `flush()` in between (equivalent to the reset both release and acquire run) and asserts the second stream produces the same event lifecycle as the first, including the completed `web_search_call` item with its queries and sources. On `dev` the second stream emits 10 events instead of 17, dropping the whole web search lifecycle and the rendered content pair.
- Changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/gemini/ -run 'TestGeminiResponsesStream' -v
```

Both tests fail on `dev` and pass with this change: the flush test because the flag survives the reset, the recycle test because the second grounded stream is missing all seven web-search-related events (`output_item.added`, the three `web_search_call.*` lifecycle events, the `output_item.done` carrying queries and sources, and the rendered content added/done pair). The full `./providers/gemini/` suite is green, including the new tests under the race detector.

Also verified end to end against a real Gemini backend (gemini-2.5-flash with the `google_search` tool, gateway run with `GOMAXPROCS=1` so pool reuse is deterministic for back-to-back requests): on `dev` the first grounded streamed request carries 8 `web_search_call` occurrences on the client SSE plus the rendered content message, the second and third identical requests carry zero of each, and the logged accumulated message loses the item the same way, while the identical non-streamed request keeps the item every time. With this change all three streamed runs carry the full web search lifecycle, and non-streamed behavior is unchanged.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The change is one flag reset on the pool recycle path. Streams without grounding are unchanged, and within a single stream the flag still deduplicates web search emission exactly as before.

## Related issues

Fixes #5113

The missing reset was previously flagged in a review comment on #2590, which never picked it up.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go)
- [ ] I verified the CI pipeline passes locally if applicable
