### PR TITLE
adds new harness skill and updates based on merged PRs

### DIFF
--- a/.claude/skills/harness-test-writer/SKILL.md
+++ b/.claude/skills/harness-test-writer/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: harness-test-writer
+description: Add regression test cases to the Bifrost provider harness (the Postman collection run via `make run-provider-harness-test`) based on a merged PR or a GitHub issue. Fetches the PR/issue, traces the affected wire path in the codebase, checks existing harness coverage, designs cases following harness conventions, inserts them into tests/e2e/api/collections/provider-harness.json without reformatting the file, and validates via the augment and filter scripts. Invoked with /harness-test-writer <PR# | issue# | URL> or /harness-test-writer (prompts for a reference).
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Task, AskUserQuestion, TodoWrite, Edit, Write
+---
+
+# Provider Harness Test Writer
+
+Turn a PR or GitHub issue into regression coverage in the provider harness: the Postman
+collection at `tests/e2e/api/collections/provider-harness.json`, executed by newman via
+`make run-provider-harness-test`.
+
+This is NOT the Go test harness in `core/internal/llmtests/` (that one is run via
+`make test-core PROVIDER=...`). If the user seems to want Go-level scenario tests,
+confirm before proceeding.
+
+## Step 1 - Resolve the reference
+
+The argument may be a PR number, an issue number, or a GitHub URL.
+
+- URL containing `/pull/` => PR. URL containing `/issues/` => issue.
+- A bare number is ambiguous: try `gh pr view <N> --repo maximhq/bifrost` first; if it
+  404s, try `gh issue view <N>`. If BOTH exist and refer to different things, ask the
+  user which one they mean with AskUserQuestion.
+- No argument at all => ask the user for the PR/issue reference.
+
+Fetch full context:
+
+```bash
+gh pr view <N> --repo maximhq/bifrost --json title,body,state,files,baseRefName
+gh pr diff <N> --repo maximhq/bifrost
+# or
+gh issue view <N> --repo maximhq/bifrost --json title,body,state,labels,comments
+```
+
+For a PR, also note any `Closes #X` issue and fetch that issue too - the issue usually
+contains the client-visible reproduction (exact request shapes, error bodies, status
+codes) that the harness case must mirror.
+
+## Step 2 - Understand the wire-level behavior to pin
+
+The harness tests Bifrost from the outside: HTTP requests against gateway routes, with
+assertions on status codes and response/SSE bodies. Translate the PR/issue into that
+frame:
+
+1. Which route(s)? (`/v1/chat/completions`, `/v1/responses`, drop-ins like
+   `/openai`, `/anthropic`, `/bedrock`, `/genai`, passthrough routes, ...)
+2. Which provider(s) and model(s)?
+3. What request shape triggers the bug/feature? Reconstruct it from the issue repro or
+   from the code path in the diff (read the changed functions and their callers).
+4. What is the observable failure signature before the fix (status code, error body
+   substring) and the expected behavior after?
+
+Trace the chain in code with Grep/Read until you can state it in one sentence, e.g.:
+"`x-bf-compat` header -> compat plugin marks `ChangeRequestType=ResponsesRequest` ->
+`ToResponsesRequest()` -> `ToOpenAIResponsesRequest` strips role -> OpenAI 200".
+
+Useful switches the harness relies on:
+- `x-bf-compat` header: `true` enables all compat features; a JSON array like
+  `["convert_chat_to_responses"]` enables only specific ones (parsed in
+  `transports/bifrost-http/lib/ctx.go`, consumed by `plugins/compat/main.go`). Prefer
+  the targeted array form in regression cases so only the feature under test is active.
+  Note: when the suite runs with `COMPAT=on`, a collection-level prerequest script
+  upserts `x-bf-compat: true` over any per-request value - the targeted form matters
+  for `COMPAT=off` runs, which is exactly when a forced-conversion case needs it.
+- `x-bf-passthrough-extra-params: true` for passthrough extra-param cases.
+
+## Step 3 - Check existing coverage
+
+Search the collection for the feature's keywords before writing anything:
+
+```bash
+cd tests/e2e/api
+grep -c '<keyword>' collections/provider-harness.json
+node -e "
+const c = require('./collections/provider-harness.json');
+function walk(items, path) { for (const it of items) {
+  if (it.item) walk(it.item, path + '/' + it.name);
+  else if (JSON.stringify(it).includes('<keyword>')) console.log(path + ' :: ' + it.name);
+} }
+walk(c.item, '');"
+```
+
+Also skim `HARNESS_COVERAGE_BACKLOG.md` - if the gap is listed there as `[ ]`, flip it
+to `[x]` as part of the change (and if you find adjacent gaps worth noting, leave them,
+do not scope-creep).
+
+If coverage already exists, report where and stop - do not add duplicates.
+
+## Step 4 - Design the cases
+
+Conventions (match the existing collection exactly):
+
+- **Folder**: issue-pinned regressions get their own top-level folder named
+  `<N>. <Short Title> (#<issue> / PR #<pr>)` where `<N>` is the next unused top-level
+  number (folders 17, 18, 19 are prior examples). Give the folder a `description`
+  explaining the bug, the production path, and what each case pins.
+- **Case names** must contain the provider keyword and model so
+  `runners/filter-collection.mjs` PROVIDER filtering catches them - check
+  `PROVIDER_KEYWORDS` in that file (e.g. openai matches "openai", "gpt-"). Suffix each
+  name with ` - #<issue>`.
+- **Coverage shape**: typically 2-3 cases - the real production route (non-streaming),
+  a streaming variant if the route streams, and where applicable a second route that
+  pins the same invariant independently (e.g. native `/v1/responses` alongside the
+  converted `/v1/chat/completions` path).
+- **Test scripts** (Postman `event[].script.exec`, plain ES5 JavaScript):
+  - Start with an infra guard so auth/rate/server noise skips instead of false-failing:
+    `if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }`
+    Do NOT guard on 400 when a 400 IS the regression signature - that must fail loudly.
+  - Assert the specific failure signature is absent (error substring, param name) AND
+    that the happy path succeeded (status below 400, expected fields present).
+  - Include the response text in failure messages:
+    `pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);`
+- **Variables**: use `{{baseUrl}}` for the gateway. Inline `provider/model` strings
+  (e.g. `openai/gpt-4o-mini`) like the cross-cut folders do; only use variables such as
+  `{{bedrockModel}}`, `{{genaiModel}}`, `{{vertexModel}}` where existing folders do.
+- Keep request bodies minimal and cheap (small `max_tokens`/`max_output_tokens`,
+  gpt-4o-mini-class models) - the harness runs as a paid live sweep.
+
+Present the designed cases (names, route, body, assertions) to the user for approval
+before editing the collection.
+
+## Step 5 - Insert without reformatting
+
+CRITICAL: `provider-harness.json` is ~1.5MB and is NOT byte-stable under
+`JSON.stringify(JSON.parse(raw), null, 2)` (escape differences). Never rewrite the
+whole file - the diff must contain only your added lines.
+
+Use a Node script that appends the new folder textually before the closing `]` of the
+top-level `item` array:
+
+```js
+const raw = fs.readFileSync(PATH, 'utf8');
+const before = JSON.parse(raw);
+// abort if the folder already exists (idempotence)
+const indented = JSON.stringify(folder, null, 2).split('\n').map(l => '    ' + l).join('\n');
+const tail = '\n  ]\n}';
+if (!raw.endsWith(tail)) throw new Error('unexpected file tail');
+const out = raw.slice(0, -tail.length) + ',\n' + indented + tail;
+const after = JSON.parse(out); // must parse; item count must be before + 1
+fs.writeFileSync(PATH, out);
+```
+
+Adding cases INSIDE an existing folder is harder to do textually; if that is truly the
+right placement, locate the folder's closing bracket precisely and verify the diff is
+additions-only afterward. Default to a new top-level folder for issue regressions.
+
+## Step 6 - Validate
+
+All from `tests/e2e/api/`:
+
+```bash
+git diff --stat   # must show only additions in provider-harness.json (+ backlog md if touched)
+node runners/augment-provider-harness.mjs --source collections/provider-harness.json --out /tmp/aug.json
+node runners/filter-collection.mjs --source /tmp/aug.json --out /tmp/filtered.json --provider <provider>
+node -e "const c=require('/tmp/filtered.json'); const f=c.item.find(i=>i.name.startsWith('<N>.')); console.log('kept:', !!f, f && f.item.length);"
+```
+
+The augment script only regenerates its own "(generated)" folders, so a new top-level
+folder passes through untouched - but run it anyway to catch parse breakage.
+
+Do NOT auto-run the live suite: it starts a gateway and makes paid provider calls.
+Report the run command and offer to execute it:
+
+```bash
+make run-provider-harness-test PROVIDER=<provider> FEATURE="<distinctive keyword from your case names>"
+```
+
+## Step 7 - Report
+
+Summarize: what the PR/issue changed, the coverage gap found (cite evidence, e.g.
+"tool_call_id appeared zero times in the collection"), each added case and what it
+pins, validation results, and the run command. Leave the change unstaged - never
+commit.

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -37056,6 +37056,495 @@
           }
         }
       ]
+    },
+    {
+      "name": "19. Chat-to-Responses Tool Replay (#5101 / PR #5102)",
+      "description": "Regression coverage for PR #5102 (closes #5101): Vercel-AI-SDK-style clients replay an assistant tool call and its tool result on the second step of a run. When the compat plugin converts /v1/chat/completions to the OpenAI Responses API, the replayed tool call becomes a function_call input item that must NOT carry role - OpenAI rejects role on any non-message input item with 400 unknown_parameter input[N].role. Cases 1-2 drive the real conversion route (x-bf-compat forces convert_chat_to_responses); case 3 pins the wire invariant on the native /v1/responses route with a caller-supplied role-bearing function_call item.",
+      "item": [
+        {
+          "name": "openai/gpt-4o-mini compat chat->responses: replayed tool call accepted (non-streaming) - #5101",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('No unknown_parameter input[N].role error - #5101', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'OpenAI rejected a replayed function_call input item (regression of PR #5102)').to.not.match(/input\\[\\d+\\]\\.role/);",
+                  "  pm.expect(body).to.not.include('Unknown parameter');",
+                  "});",
+                  "pm.test('Replayed assistant tool call + tool result synthesized into an answer - #5101', function () {",
+                  "  pm.expect(pm.response.code, 'replay request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  var msg = j.choices && j.choices[0] && j.choices[0].message;",
+                  "  pm.expect(msg, 'no assistant message in response').to.exist;",
+                  "  var content = (msg.content || '').toString();",
+                  "  pm.expect(content.length, 'expected a synthesized answer from the tool result').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-compat",
+                "value": "[\"convert_chat_to_responses\"]"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in San Francisco? Answer in Celsius.\"},{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"call_replay_5101\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"San Francisco\\\"}\"}}]},{\"role\":\"tool\",\"tool_call_id\":\"call_replay_5101\",\"content\":\"{\\\"temperature\\\": \\\"22\\\", \\\"unit\\\": \\\"celsius\\\", \\\"description\\\": \\\"Sunny\\\"}\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-4o-mini compat chat->responses: replayed tool call accepted (streaming) - #5101",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('No unknown_parameter input[N].role error - #5101', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'OpenAI rejected a replayed function_call input item (regression of PR #5102)').to.not.match(/input\\[\\d+\\]\\.role/);",
+                  "  pm.expect(body).to.not.include('Unknown parameter');",
+                  "});",
+                  "pm.test('Streaming replay completes without wire rejection - #5101', function () {",
+                  "  pm.expect(pm.response.code, 'streaming replay request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'expected SSE data frames').to.include('data:');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-compat",
+                "value": "[\"convert_chat_to_responses\"]"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in San Francisco? Answer in Celsius.\"},{\"role\":\"assistant\",\"tool_calls\":[{\"id\":\"call_replay_5101\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"San Francisco\\\"}\"}}]},{\"role\":\"tool\",\"tool_call_id\":\"call_replay_5101\",\"content\":\"{\\\"temperature\\\": \\\"22\\\", \\\"unit\\\": \\\"celsius\\\", \\\"description\\\": \\\"Sunny\\\"}\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],\"stream\":true}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-4o-mini native /v1/responses: role-bearing function_call input item accepted - #5101",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('No unknown_parameter input[N].role error - #5101', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'OpenAI rejected a replayed function_call input item (regression of PR #5102)').to.not.match(/input\\[\\d+\\]\\.role/);",
+                  "  pm.expect(body).to.not.include('Unknown parameter');",
+                  "});",
+                  "pm.test('Role-bearing function_call input item stripped at the OpenAI seam - #5101', function () {",
+                  "  pm.expect(pm.response.code, 'responses replay request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.output, 'expected an output array').to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"input\":[{\"type\":\"message\",\"role\":\"user\",\"content\":\"What is the weather in San Francisco? Answer in Celsius.\"},{\"type\":\"function_call\",\"role\":\"assistant\",\"status\":\"completed\",\"call_id\":\"call_replay_5101\",\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"San Francisco\\\"}\"},{\"type\":\"function_call_output\",\"call_id\":\"call_replay_5101\",\"output\":\"{\\\"temperature\\\": \\\"22\\\", \\\"unit\\\": \\\"celsius\\\"}\"}],\"max_output_tokens\":200}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "20. Anthropic Redacted Thinking Round-Trip (#5093 / PR #5094)",
+      "description": "Regression coverage for PR #5094 (fixes #5093): Anthropic returns safety-flagged reasoning as redacted_thinking blocks (an encrypted data payload, arriving complete in content_block_start with no deltas) and requires them to be replayed unmodified in multi-turn tool use - dropping them is the documented top cause of the 400 'thinking or redacted_thinking blocks in the latest assistant message cannot be modified'. Pre-fix, the responses surface lost the blocks twice: ToBifrostResponsesStream had no content_block_start case for redacted_thinking (streaming clients received zero encrypted_content items), and convertBifrostReasoningToAnthropicThinking gated on Summary != nil, so items carrying an empty summary list next to encrypted_content were never converted back on replay. Cases use Anthropic's documented magic string to deterministically trigger redacted thinking. Case 1 pins the streaming emission; case 2 pins the non-streaming baseline and captures the replay input into a collection variable; case 3 replays the tool-use continuation, which 400s pre-fix.",
+      "item": [
+        {
+          "name": "anthropic/claude-sonnet-4-5 /v1/responses streaming carries redacted_thinking as encrypted reasoning items - #5093",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Streaming redacted thinking emitted as encrypted reasoning items - #5093', function () {",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'expected SSE frames').to.include('data:');",
+                  "  var occurrences = (body.match(/encrypted_content/g) || []).length;",
+                  "  pm.expect(occurrences, 'redacted_thinking blocks dropped from the converted stream (regression of PR #5094)').to.be.above(0);",
+                  "  pm.expect(body, 'expected reasoning output_item.added events').to.include('response.output_item.added');",
+                  "  pm.expect(body, 'expected the stream to complete').to.include('response.completed');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-sonnet-4-5\",\"input\":\"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB Think about why the sky is blue, then answer in one word.\",\"reasoning\":{\"max_tokens\":2048},\"max_output_tokens\":4096,\"stream\":true}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-sonnet-4-5 /v1/responses non-streaming preserves redacted_thinking + captures replay input - #5093",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Non-streaming redacted thinking preserved as encrypted reasoning item - #5093', function () {",
+                  "  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.output, 'expected output array').to.be.an('array').that.is.not.empty;",
+                  "  var reasoning = j.output.filter(function (o) { return o.type === 'reasoning'; });",
+                  "  pm.expect(reasoning.length, 'expected at least one reasoning output item').to.be.above(0);",
+                  "  pm.expect(pm.response.text(), 'expected the encrypted payload on the reasoning item').to.include('encrypted_content');",
+                  "});",
+                  "// Capture the replay input for the next request: original user turn, assistant",
+                  "// output echoed verbatim, and a tool result for the function call. Only set when",
+                  "// a tool call exists so the replay case skips instead of false-failing (Anthropic",
+                  "// rejects forced tool_choice with thinking enabled, so the call is prompted).",
+                  "try {",
+                  "  var body = pm.response.json();",
+                  "  var fc = (body.output || []).filter(function (o) { return o.type === 'function_call'; })[0];",
+                  "  if (fc && fc.call_id) {",
+                  "    var input = [{ type: 'message', role: 'user', content: \"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB What time is it? Use the get_time tool.\" }]",
+                  "      .concat(body.output)",
+                  "      .concat([{ type: 'function_call_output', call_id: fc.call_id, output: '{\"time\": \"12:00 UTC\"}' }]);",
+                  "    pm.collectionVariables.set('redactedReplayInput5093', JSON.stringify(input));",
+                  "  }",
+                  "} catch (e) {}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-sonnet-4-5\",\"input\":\"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB What time is it? Use the get_time tool.\",\"tools\":[{\"type\":\"function\",\"name\":\"get_time\",\"description\":\"Get the current time\",\"parameters\":{\"type\":\"object\",\"properties\":{\"timezone\":{\"type\":\"string\"}},\"required\":[]}}],\"reasoning\":{\"max_tokens\":2048},\"max_output_tokens\":4096}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-sonnet-4-5 /v1/responses replay of redacted_thinking accepted on tool-use continuation - #5093",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Skip when the capture step did not run or found no tool call: the body",
+                  "// placeholder stays unresolved, so there is nothing meaningful to replay.",
+                  "if (pm.request.body && pm.request.body.raw && pm.request.body.raw.indexOf('{{') !== -1) { return; }",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Replayed redacted_thinking accepted before tool_use (regression of PR #5094) - #5093', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'Anthropic rejected the replayed turn - redacted_thinking was stripped from the outgoing request').to.not.include('cannot be modified');",
+                  "  pm.expect(pm.response.code, 'replay request failed: ' + body).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.output, 'expected an output array').to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\": \"anthropic/claude-sonnet-4-5\", \"input\": {{redactedReplayInput5093}}, \"tools\": [{\"type\":\"function\",\"name\":\"get_time\",\"description\":\"Get the current time\",\"parameters\":{\"type\":\"object\",\"properties\":{\"timezone\":{\"type\":\"string\"}},\"required\":[]}}], \"reasoning\": {\"max_tokens\": 2048}, \"max_output_tokens\": 4096}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "21. Responses Stream Usage Persistence (#4846 / PR #4899)",
+      "description": "Regression coverage for PR #4899 (fixes #4846): the final response.completed SSE event of a Responses stream carries response.usage, but the streaming accumulator dedupes chunks by ChunkIndex and reads stream metadata from the highest index. OpenAI-compatible Responses streams set ChunkIndex from the provider's sequence_number (core/providers/openai/openai.go), so providers that omit or reuse sequence_number (e.g. Unsloth via Codex CLI) delivered the terminal event with an already-seen index - it was deduped away and LLM Logs persisted 0/0 tokens with no raw JSON. The fix remaps late terminal events to a reserved trailing index. These cases pin the end-to-end invariant (usage on the wire implies usage in the logs DB) via the dbverify reporter (x-request-id + x-bf-expect-cost, asserting cost>0 && total_tokens>0), across the native OpenAI Responses SSE path and the converted Anthropic path, with a non-streaming baseline to isolate streaming-specific failures. Note: live OpenAI numbers its events correctly, so the exact omitted-sequence_number trigger is pinned by the Go unit test in PR #4899; a faithful harness repro would need an OpenAI-compatible mock provider in the gateway config.",
+      "item": [
+        {
+          "name": "[Accounting] openai/gpt-4o-mini responses streaming records usage - #4846",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('OpenAI native Responses stream: stream completes with usage on the wire - #4846', function () {",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + pm.response.text()).to.equal(200);",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'expected SSE frames').to.include('data:');",
+                  "  pm.expect(body, 'expected a terminal response.completed event').to.include('response.completed');",
+                  "  pm.expect(body, 'expected response.usage on the terminal event').to.include('total_tokens');",
+                  "});",
+                  "// Persistence is asserted by the dbverify reporter: the logs row keyed on",
+                  "// x-request-id must have cost>0 && total_tokens>0. Pre-#4899, a provider that",
+                  "// omits or reuses sequence_number got its terminal event deduped by the stream",
+                  "// accumulator and the row persisted 0/0 despite usage being on the wire."
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "usage-responses-openai-stream-{{$guid}}"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"input\":\"Reply with the single word: pong.\",\"max_output_tokens\":64,\"stream\":true}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "[Accounting] anthropic/claude-haiku-4-5 responses streaming records usage - #4846",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Converted Anthropic Responses stream: stream completes with usage on the wire - #4846', function () {",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + pm.response.text()).to.equal(200);",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'expected SSE frames').to.include('data:');",
+                  "  pm.expect(body, 'expected a terminal response.completed event').to.include('response.completed');",
+                  "  pm.expect(body, 'expected response.usage on the terminal event').to.include('total_tokens');",
+                  "});",
+                  "// Persistence is asserted by the dbverify reporter: the logs row keyed on",
+                  "// x-request-id must have cost>0 && total_tokens>0. Pre-#4899, a provider that",
+                  "// omits or reuses sequence_number got its terminal event deduped by the stream",
+                  "// accumulator and the row persisted 0/0 despite usage being on the wire."
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "usage-responses-anthropic-stream-{{$guid}}"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-haiku-4-5\",\"input\":\"Reply with the single word: pong.\",\"max_output_tokens\":64,\"stream\":true}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "[Accounting] openai/gpt-4o-mini responses non-streaming records usage - #4846",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Non-streaming Responses baseline: usage in the response body - #4846', function () {",
+                  "  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.equal(200);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.usage, 'expected usage on the response').to.exist;",
+                  "  pm.expect(Number(j.usage.total_tokens || 0), 'expected total_tokens > 0').to.be.above(0);",
+                  "});",
+                  "// Baseline pair for the streaming cases: if this passes while a streaming",
+                  "// case fails dbverify, the regression is stream-accumulator-specific."
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-request-id",
+                "value": "usage-responses-openai-nonstream-{{$guid}}"
+              },
+              {
+                "key": "x-bf-expect-cost",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"input\":\"Reply with the single word: pong.\",\"max_output_tokens\":64}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds three new regression test folders (19–21) to the provider harness Postman collection, covering bugs fixed in PRs #5102, #5094, and #4899. Also introduces a reusable Claude skill (`harness-test-writer`) that automates the process of translating a PR or GitHub issue into harness coverage.

## Changes

- **Folder 19 – Chat-to-Responses Tool Replay (#5101 / PR #5102):** Three cases pin the fix for Vercel-AI-SDK-style clients replaying assistant tool calls through the compat plugin. The `convert_chat_to_responses` conversion was emitting `role` on `function_call` input items, which OpenAI rejects with `400 unknown_parameter input[N].role`. Cases cover non-streaming, streaming, and the native `/v1/responses` route with a caller-supplied role-bearing item.

- **Folder 20 – Anthropic Redacted Thinking Round-Trip (#5093 / PR #5094):** Three cases pin the fix for `redacted_thinking` blocks being dropped in two places: the streaming accumulator had no `content_block_start` handler for `redacted_thinking`, and the replay converter gated on `Summary != nil`, silently dropping items with only `encrypted_content`. Cases use Anthropic's documented magic string to deterministically trigger redacted thinking, cover streaming emission, non-streaming preservation, and multi-turn tool-use replay (the path that 400s pre-fix).

- **Folder 21 – Responses Stream Usage Persistence (#4846 / PR #4899):** Three cases pin the fix for the streaming accumulator deduplicating terminal `response.completed` events by `ChunkIndex`, causing providers that omit or reuse `sequence_number` to persist 0/0 tokens in LLM Logs. Cases cover OpenAI native Responses streaming, converted Anthropic Responses streaming, and a non-streaming baseline to isolate stream-accumulator-specific failures. Uses `x-request-id` + `x-bf-expect-cost` for dbverify reporter assertions.

- **`harness-test-writer` Claude skill:** A new skill definition at `.claude/skills/harness-test-writer/SKILL.md` that codifies the full workflow: resolving a PR/issue reference, tracing the wire-level behavior, checking existing coverage, designing cases following harness conventions, inserting them without reformatting the 1.5 MB JSON file, and validating via the augment and filter scripts.

- All test scripts include infra-noise guards (skipping on 401/403/429/5xx) and include response text in failure messages. Request bodies use cheap models (`gpt-4o-mini`, `claude-haiku-4-5`) with small token budgets.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd tests/e2e/api

# Validate the collection parses and the new folders survive augmentation
node runners/augment-provider-harness.mjs --source collections/provider-harness.json --out /tmp/aug.json

# Verify folder 19 is kept for openai
node runners/filter-collection.mjs --source /tmp/aug.json --out /tmp/filtered-openai.json --provider openai
node -e "const c=require('/tmp/filtered-openai.json'); const f=c.item.find(i=>i.name.startsWith('19.')); console.log('kept:', !!f, f && f.item.length);"

# Verify folder 20 is kept for anthropic
node runners/filter-collection.mjs --source /tmp/aug.json --out /tmp/filtered-anthropic.json --provider anthropic
node -e "const c=require('/tmp/filtered-anthropic.json'); const f=c.item.find(i=>i.name.startsWith('20.')); console.log('kept:', !!f, f && f.item.length);"

# Run the live harness (makes paid provider calls)
make run-provider-harness-test PROVIDER=openai FEATURE="5101"
make run-provider-harness-test PROVIDER=anthropic FEATURE="5093"
make run-provider-harness-test PROVIDER=openai FEATURE="4846"
```

## Breaking changes

- [x] No

## Related issues

Closes #5101, Closes #5093, Closes #4846

## Security considerations

None. No auth, secrets, or PII involved. Request bodies use only synthetic payloads and public model endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable