### PR TITLE
fix: max reasoning effort in openai

### DIFF
--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -79,6 +79,24 @@ func TestOpenAIResponsesRequest_MarshalJSON_ReasoningMaxTokensAbsent(t *testing.
 			},
 			description: "When Reasoning is nil, reasoning field should not appear in output",
 		},
+		{
+			name: "reasoning context and mode are preserved while max_tokens is dropped",
+			request: &OpenAIResponsesRequest{
+				Model: "gpt-5.6",
+				Input: OpenAIResponsesRequestInput{
+					OpenAIResponsesRequestInputStr: schemas.Ptr("test"),
+				},
+				ResponsesParameters: schemas.ResponsesParameters{
+					Reasoning: &schemas.ResponsesParametersReasoning{
+						Effort:    schemas.Ptr("max"),
+						Context:   schemas.Ptr("current_turn"),
+						Mode:      schemas.Ptr("pro"),
+						MaxTokens: schemas.Ptr(1000),
+					},
+				},
+			},
+			description: "reasoning.context and reasoning.mode should pass through to output",
+		},
 	}
 
 	for _, tt := range tests {
@@ -117,12 +135,53 @@ func TestOpenAIResponsesRequest_MarshalJSON_ReasoningMaxTokensAbsent(t *testing.
 							t.Error("reasoning.generate_summary should be present in output")
 						}
 					}
+					if tt.request.Reasoning.Context != nil {
+						if got, exists := reasoning["context"]; !exists || got != *tt.request.Reasoning.Context {
+							t.Errorf("reasoning.context = %v, want %q", got, *tt.request.Reasoning.Context)
+						}
+					}
+					if tt.request.Reasoning.Mode != nil {
+						if got, exists := reasoning["mode"]; !exists || got != *tt.request.Reasoning.Mode {
+							t.Errorf("reasoning.mode = %v, want %q", got, *tt.request.Reasoning.Mode)
+						}
+					}
 				}
 			} else if tt.request.Reasoning != nil {
 				// If reasoning is set, it should appear in JSON (unless all fields are nil/omitted)
 				if tt.request.Reasoning.Effort != nil || tt.request.Reasoning.Summary != nil || tt.request.Reasoning.GenerateSummary != nil {
 					t.Error("reasoning field should be present in JSON when Reasoning is set with non-nil fields")
 				}
+			}
+		})
+	}
+}
+
+func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		effort   string
+		expected string
+	}{
+		{"minimal maps to low", "gpt-5", "minimal", "low"},
+		{"gpt-5.6 keeps max", "gpt-5.6", "max", "max"},
+		{"gpt-5.6 variant keeps max", "gpt-5.6-terra", "max", "max"},
+		{"gpt-5.6 keeps xhigh", "gpt-5.6", "xhigh", "xhigh"},
+		{"provider-prefixed gpt-5.6 keeps max", "openai/gpt-5.6", "max", "max"},
+		{"deepseek-v4 keeps max", "deepseek-v4", "max", "max"},
+		{"glm-5.2 keeps max", "glm-5.2", "max", "max"},
+		{"gpt-5.5 downgrades max to xhigh", "gpt-5.5", "max", "xhigh"},
+		{"gpt-5.2 downgrades max to xhigh", "gpt-5.2", "max", "xhigh"},
+		{"gpt-5.5 keeps xhigh", "gpt-5.5", "xhigh", "xhigh"},
+		{"gpt-5.1 downgrades max to high", "gpt-5.1", "max", "high"},
+		{"gpt-5.1 downgrades xhigh to high", "gpt-5.1", "xhigh", "high"},
+		{"standard effort passes through", "gpt-5.1", "medium", "medium"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeOpenAIReasoningEffort(tt.model, tt.effort); got != tt.expected {
+				t.Errorf("normalizeOpenAIReasoningEffort(%q, %q) = %q, want %q", tt.model, tt.effort, got, tt.expected)
 			}
 		})
 	}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -887,6 +887,8 @@ func (resp *OpenAIResponsesRequest) MarshalJSON() ([]byte, error) {
 			Effort:          resp.Reasoning.Effort,
 			GenerateSummary: resp.Reasoning.GenerateSummary,
 			Summary:         resp.Reasoning.Summary,
+			Context:         resp.Reasoning.Context,
+			Mode:            resp.Reasoning.Mode,
 			MaxTokens:       nil, // Always set to nil
 		}
 	}

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -162,17 +162,19 @@ func supportsOpenAIXHighReasoningEffort(model string) bool {
 	return strings.HasPrefix(modelLower, "gpt-5.2") ||
 		strings.HasPrefix(modelLower, "gpt-5.3-codex") ||
 		strings.HasPrefix(modelLower, "gpt-5.4") ||
-		strings.HasPrefix(modelLower, "gpt-5.5")
+		strings.HasPrefix(modelLower, "gpt-5.5") ||
+		strings.HasPrefix(modelLower, "gpt-5.6")
 }
 
-// supportsMaxReasoningEffort reports models that natively accept "max" effort (e.g. DeepSeek V4, GLM-5.2).
+// supportsMaxReasoningEffort reports models that natively accept "max" effort (e.g. GPT-5.6, DeepSeek V4, GLM-5.2).
 func supportsMaxReasoningEffort(model string) bool {
 	_, parsedModel := schemas.ParseModelString(model, schemas.OpenAI)
 	if parsedModel != "" {
 		model = parsedModel
 	}
 	modelLower := strings.ToLower(model)
-	return strings.HasPrefix(modelLower, "deepseek-v4") ||
+	return strings.HasPrefix(modelLower, "gpt-5.6") ||
+		strings.HasPrefix(modelLower, "deepseek-v4") ||
 		strings.HasPrefix(modelLower, "glm-5.2")
 }
 

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -876,8 +876,10 @@ type ResponsesPrompt struct {
 }
 
 type ResponsesParametersReasoning struct {
-	Effort          *string `json:"effort"`                     // "none" | "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
+	Context         *string `json:"context,omitempty"`          // "auto" | "current_turn" | "all_turns" (which reasoning items are rendered back to the model on later turns)
+	Effort          *string `json:"effort"`                     // "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" (any value other than "none" will enable reasoning)
 	GenerateSummary *string `json:"generate_summary,omitempty"` // Deprecated: use summary instead
+	Mode            *string `json:"mode,omitempty"`             // "standard" | "pro" (reasoning execution mode)
 	Summary         *string `json:"summary"`                    // "auto" | "concise" | "detailed"
 	MaxTokens       *int    `json:"max_tokens,omitempty"`       // Maximum number of tokens to generate for the reasoning output (required for anthropic)
 }


### PR DESCRIPTION
## Summary

Adds support for `context` and `mode` fields in the `ResponsesParametersReasoning` schema, and extends the reasoning effort normalization logic to treat `gpt-5.6` as a model that natively supports `"max"` effort (and `"xhigh"`), bypassing the downgrade path applied to earlier GPT-5.x models.

## Changes

- Added `Context` and `Mode` fields to `ResponsesParametersReasoning`, allowing callers to specify which reasoning items are rendered back to the model on later turns (`context`) and the reasoning execution mode (`mode`).
- Propagated `Context` and `Mode` through `MarshalJSON` on `OpenAIResponsesRequest` so they are included in the serialized output alongside the existing `Effort`, `GenerateSummary`, and `Summary` fields.
- Added `gpt-5.6` to `supportsXHighReasoningEffort` and `supportsMaxReasoningEffort`, so that `"max"` and `"xhigh"` efforts are passed through without downgrade for that model family.
- Added `TestNormalizeOpenAIReasoningEffort` to cover the effort normalization logic across multiple model prefixes and effort values.
- Extended the existing `MarshalJSON` test to assert that `reasoning.context` and `reasoning.mode` are preserved in the JSON output.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... ./core/schemas/...
```

- Verify `TestNormalizeOpenAIReasoningEffort` passes and covers `gpt-5.6` keeping `"max"` and `"xhigh"` without downgrade.
- Verify the `MarshalJSON` test case `"reasoning context and mode are preserved while max_tokens is dropped"` passes, confirming `context` and `mode` appear in the serialized JSON while `max_tokens` is omitted.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. These are additive schema fields passed through to the OpenAI Responses API.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable