### PR TITLE
feat: add optional `project_id` field to Bedrock and Bedrock Mantle key configs

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -673,8 +673,8 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								<div className="space-y-1.5">
 									<FormLabel>Force single region</FormLabel>
 									<FormDescription>
-										Always call the region set above and skip automatic promotion of multi-region-only models to a
-										multi-region endpoint. Enable when serving these models from a single region via provisioned throughput.
+										Always call the region set above and skip automatic promotion of multi-region-only models to a multi-region endpoint.
+										Enable when serving these models from a single region via provisioned throughput.
 									</FormDescription>
 								</div>
 								<FormControl>
@@ -894,6 +894,27 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							</FormItem>
 						)}
 					/>
+					<FormField
+						control={control}
+						name={`key.bedrock_key_config.project_id`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Mantle Project ID (Optional)</FormLabel>
+								<FormDescription>
+									Scopes Bedrock Mantle-routed models (OpenAI-family / Gemma) to a specific project via the OpenAI-Project header. Leave
+									empty to use the account&apos;s default project.
+								</FormDescription>
+								<FormControl>
+									<SecretVarInput
+										data-testid="apikey-bedrock-project-id-input"
+										placeholder="proj_xxxxxxxx or env.BEDROCK_PROJECT_ID"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
 					{bedrockAuthType !== "api_key" && (
 						<>
 							<FormField
@@ -1094,6 +1115,28 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 								<FormLabel>Region (Required)</FormLabel>
 								<FormControl>
 									<SecretVarInput placeholder="us-east-1 or env.AWS_REGION" {...field} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					<FormField
+						control={control}
+						name={`key.bedrock_mantle_key_config.project_id`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Project ID (Optional)</FormLabel>
+								<FormDescription>
+									Scopes inference and model listing to a specific Bedrock project (sent as the OpenAI-Project / anthropic-workspace-id
+									header). Leave empty to use the account&apos;s default project.
+								</FormDescription>
+								<FormControl>
+									<SecretVarInput
+										data-testid="apikey-bedrock-mantle-project-id-input"
+										placeholder="proj_xxxxxxxx or env.BEDROCK_PROJECT_ID"
+										{...field}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -113,6 +113,7 @@ const BedrockKeyConfigSchema = z
 		external_id: z.string().optional(),
 		session_name: z.string().optional(),
 		arn: z.string().optional(),
+		project_id: z.string().optional(),
 		batch_s3_config: BatchS3ConfigSchema.optional(),
 	})
 	.refine(
@@ -150,6 +151,7 @@ const BedrockMantleKeyConfigSchema = z
 		role_arn: z.string().optional(),
 		external_id: z.string().optional(),
 		session_name: z.string().optional(),
+		project_id: z.string().optional(),
 	})
 	.refine(
 		(data) => {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -123,6 +123,7 @@ export interface BedrockKeyConfig {
 	session_token?: SecretVar;
 	region?: SecretVar;
 	arn?: SecretVar;
+	project_id?: SecretVar;
 	batch_s3_config?: BatchS3Config;
 }
 
@@ -133,6 +134,7 @@ export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
 	session_token: undefined as unknown as SecretVar,
 	region: { value: "us-east-1", ref: "" },
 	arn: { value: "", ref: "" },
+	project_id: { value: "", ref: "" },
 	batch_s3_config: undefined as unknown as BatchS3Config,
 } as const satisfies Required<BedrockKeyConfig>;
 
@@ -145,6 +147,7 @@ export interface BedrockMantleKeyConfig {
 	role_arn?: SecretVar;
 	external_id?: SecretVar;
 	session_name?: SecretVar;
+	project_id?: SecretVar;
 }
 
 // Default BedrockMantleKeyConfig
@@ -156,6 +159,7 @@ export const DefaultBedrockMantleKeyConfig: BedrockMantleKeyConfig = {
 	role_arn: undefined as unknown as SecretVar,
 	external_id: undefined as unknown as SecretVar,
 	session_name: undefined as unknown as SecretVar,
+	project_id: undefined as unknown as SecretVar,
 } as const satisfies Required<BedrockMantleKeyConfig>;
 
 // VLLMKeyConfig matching Go's schemas.VLLMKeyConfig
@@ -432,9 +436,9 @@ export interface UpdateProviderRequest {
 	openai_config?: OpenAIConfig;
 }
 
-export interface CreateProviderKeyRequest extends ModelProviderKey { }
+export interface CreateProviderKeyRequest extends ModelProviderKey {}
 
-export interface UpdateProviderKeyRequest extends ModelProviderKey { }
+export interface UpdateProviderKeyRequest extends ModelProviderKey {}
 
 export interface ListProviderKeysResponse {
 	keys: ModelProviderKey[];

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -163,6 +163,7 @@ export const bedrockKeyConfigSchema = z
 		external_id: secretVarSchema.optional(),
 		session_name: secretVarSchema.optional(),
 		arn: secretVarSchema.optional(),
+		project_id: secretVarSchema.optional(),
 		batch_s3_config: batchS3ConfigSchema.optional(),
 	})
 	.refine(
@@ -204,6 +205,7 @@ export const bedrockMantleKeyConfigSchema = z
 		role_arn: secretVarSchema.optional(),
 		external_id: secretVarSchema.optional(),
 		session_name: secretVarSchema.optional(),
+		project_id: secretVarSchema.optional(),
 	})
 	.refine((data) => isSecretVarSet(data.region), {
 		message: "Region is required",


### PR DESCRIPTION
## Summary

Adds an optional `project_id` field to both `BedrockKeyConfig` and `BedrockMantleKeyConfig`, allowing users to scope Bedrock Mantle-routed models (OpenAI-family / Gemma) to a specific project via the `OpenAI-Project` / `anthropic-workspace-id` header. When left empty, the account's default project is used.

## Changes

- Added `project_id` as an optional `SecretVar` field to `BedrockKeyConfig` and `BedrockMantleKeyConfig` types and their corresponding defaults.
- Extended the Zod validation schemas (`bedrockKeyConfigSchema`, `bedrockMantleKeyConfigSchema`, `BedrockKeyConfigSchema`, `BedrockMantleKeyConfigSchema`) to include the optional `project_id` field.
- Added UI form fields for `project_id` in both the Bedrock and Bedrock Mantle provider configuration sections, accepting a project ID or an environment variable reference (e.g., `proj_xxxxxxxx` or `env.BEDROCK_PROJECT_ID`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Bedrock or Bedrock Mantle provider configuration in the workspace settings.
2. Verify the new **Mantle Project ID (Optional)** / **Project ID (Optional)** field appears in the form.
3. Enter a project ID (e.g., `proj_xxxxxxxx`) or an environment variable reference (e.g., `env.BEDROCK_PROJECT_ID`) and save.
4. Confirm the value is persisted and sent correctly when routing requests to Mantle-backed models.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the Bedrock and Bedrock Mantle provider configuration forms showing the new Project ID field._

## Breaking changes

- [x] No

## Related issues

## Security considerations

The `project_id` field is handled as a `SecretVar`, consistent with other sensitive Bedrock configuration values, supporting both inline values and environment variable references.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable