### PR TITLE
docs: clarify that Level 1 LB always runs for pinned providers, appending healthy fallbacks instead of skipping

### DIFF
--- a/docs/enterprise/adaptive-load-balancing.mdx
+++ b/docs/enterprise/adaptive-load-balancing.mdx
@@ -156,9 +156,9 @@ Adaptive load balancing ships **pre-tuned** - the scoring weights, thresholds, a
 
 | Setting | Default | Effect |
 |---------|---------|--------|
-| **Provider selection** (`direction_selection_enabled`) | On | Whether the system picks the provider (Level 1). Off ⇒ the request's provider is honored as-is. |
+| **Provider selection** (`direction_selection_enabled`) | On | Whether the system picks the provider (Level 1). A request that already carries a provider keeps it as the primary, but still gets the healthy providers eligible for its model appended as fallbacks behind any it configured. Off ⇒ Level 1 leaves the request's provider and fallback list untouched (key selection is toggled separately). |
 | **Key selection** (`route_selection_enabled`) | On | Whether per-key (Level 2) selection is adaptive. Off ⇒ keys are chosen by static weighted-random (metrics are still tracked). |
-| **Re-route failed providers** (`reroute_failed_directions`) | Off | If a pinned provider's direction is circuit-broken, re-route the request to a healthy provider for the same model. |
+| **Re-route failed providers** (`reroute_failed_directions`) | Off | If a pinned provider's direction is circuit-broken, re-route the request to a healthy provider for the same model. When no healthier provider exists, the pinned provider is kept. |
 | **Prune failed fallbacks** (`prune_failed_fallbacks`) | Off | Drop circuit-broken providers from a request's configured fallback list. |
 
 The two selection switches default **on**; the two failed-direction behaviors are **opt-in**. All four take effect live (no restart) and propagate across the cluster.
@@ -223,6 +223,7 @@ Unlike the API, this block is presence-aware: omitted fields keep their current 
 
 ## Scope & Limitations
 
+- **Pinned requests still get fallbacks**: With provider selection on, a request that pins a provider — even one that configures no fallbacks of its own — receives the healthy providers eligible for its model as a fallback chain, so a failing primary fails over instead of failing fast. To keep a request's provider and fallback list untouched, turn provider selection off (key selection within the provider is governed by its own switch).
 - **Per-node weights**: Each node load-balances on its own observed metrics. The only signal shared across nodes is a rate-limit (TPM) backoff, and only within the same region - there is no global weight consensus or cross-region coordination. This is deliberate: latency and error profiles differ per region, so importing another region's metrics would pollute a node's view of route health.
 - **~5-second adaptation**: Weight and state changes lag live traffic by up to one recompute cycle. Immediate per-request resilience (key rotation and fallback failover) is handled separately and is not subject to this delay.
 - **Optimistic cold start**: A brand-new key or provider enters at full weight and competes at roughly fair share before it has been measured, then self-corrects within a cycle or two.

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -1075,7 +1075,7 @@ flowchart TB
 
 ### Level 1: Direction (Provider Selection)
 
-**When it runs**: Only when no provider has been selected yet — i.e. the request has no `provider/` prefix and no earlier layer (governance, routing rules) pinned one
+**When it runs**: **Always** (while the provider-selection switch is on). When no provider has been selected yet, it picks one. When an earlier layer (governance, routing rules, or an explicit `provider/` prefix) already pinned one, that provider keeps the primary slot — but Level 1 still appends its sorted healthy providers as fallbacks behind any the request configured, and, when the re-route toggle is on, moves a circuit-broken pinned provider to a healthy one
 
 **How it works**:
 
@@ -1087,7 +1087,7 @@ flowchart TB
    - **Error rate** — the primary, time-decayed signal
    - **Token-aware latency** — secondary, comparing the provider both to its peers for the model and to its own recent baseline
 4. **Smooth selection**: Concentrate traffic on the best-scoring providers while keeping a small exploration share for the rest, so a recovered provider keeps getting re-probed
-5. **Fallbacks created**: Remaining healthy providers sorted by performance score (descending) are added as fallbacks
+5. **Fallbacks created**: Remaining healthy providers sorted by performance score (descending) are appended as fallbacks after any the request already carries, deduplicated. With the prune toggle on, circuit-broken configured fallbacks are removed first and never re-added
 
 ### Level 2: Route (Key Selection)
 
@@ -1193,7 +1193,7 @@ When both methods are available in your Bifrost deployment, they work together i
 
 <Warning>
 **Key Insight**: Load balancing has **two levels**:
-- **Level 1 (Direction/Provider)**: Skipped when provider is already specified
+- **Level 1 (Direction/Provider)**: Always runs. A pre-specified provider keeps the primary slot, but Level 1 still appends its healthy providers as fallbacks — and can re-route a circuit-broken pinned provider when that toggle is on
 - **Level 2 (Route/Key)**: **Always runs**, even when provider is specified
 
 This means key-level optimization works regardless of how the provider was chosen!
@@ -1212,6 +1212,7 @@ flowchart TD
         AddPrefix["Set req.Provider/Model:<br/>azure/gpt-4o"]
         PrefixCheck{"req.Provider<br/>already set?"}
         LBProvider["Enterprise LB:<br/>Performance-based selection"]
+        LBPinned["Enterprise LB:<br/>Keep pinned provider,<br/>append healthy fallbacks"]
         AddLBPrefix["Set req.Provider/Model:<br/>openai/gpt-4o"]
         Resolver["model-catalog-resolver:<br/>Fill from catalog (last fallback)"]
     end
@@ -1225,7 +1226,7 @@ flowchart TD
     Start --> HasVK
     HasVK -->|Yes| GovRoute --> AddPrefix --> PrefixCheck
     HasVK -->|No| PrefixCheck
-    PrefixCheck -->|Yes, skip LB Level 1| Resolver
+    PrefixCheck -->|Yes| LBPinned --> Resolver
     PrefixCheck -->|No| LBProvider --> AddLBPrefix --> Resolver
     Resolver --> GetKeys
     GetKeys --> ScoreKeys --> SelectKey --> Execute["Execute request<br/>with selected provider + key"]
@@ -1241,10 +1242,10 @@ All three routing layers (governance, enterprise LB Level 1, model-catalog-resol
    - **Result**: `req.Provider`/`req.Model` set; `req.Fallbacks` populated
 
 2. **Enterprise Load Balancer Level 1** (PreRequestHook, builtin)
-   - Runs after governance
-   - If `req.Provider` is already set (by governance or by an explicit `provider/model` prefix from the user): **skips provider selection**
+   - Runs after governance and always evaluates the eligible provider set for the model
+   - If `req.Provider` is already set (by governance or by an explicit `provider/model` prefix from the user): keeps it as the primary and appends its healthy providers as fallbacks behind any configured ones; with the re-route toggle on, a circuit-broken pinned provider is moved to a healthy one (kept when nothing healthier exists)
    - If not: performs performance-based provider selection across catalog providers
-   - **Result**: `req.Provider`/`req.Model` set if previously empty
+   - **Result**: `req.Provider`/`req.Model` set; `req.Fallbacks` extended with the sorted healthy fallback chain
 
 3. **model-catalog-resolver** (PreRequestHook, builtin order 9 — final fallback)
    - Runs last
@@ -1340,7 +1341,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 1. **Governance** applies first (respects explicit user config) → selects Azure provider
 2. Model becomes `azure/gpt-4o`
-3. **Load Balancing Level 1** sees "/" and **skips provider selection** (already decided)
+3. **Load Balancing Level 1** finds the provider already set (Azure, from governance) and keeps it as the primary, appending the healthy providers eligible for the model as fallbacks behind any governance-configured ones
 4. **Load Balancing Level 2** still runs! Selects best Azure key based on performance:
    - `azure-key-1`: 99% success rate, 150ms avg latency → score 0.95
    - `azure-key-2`: 85% success rate, 200ms avg latency → score 0.60 (degraded)
@@ -1368,8 +1369,8 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 **Behavior:**
 
-1. **Governance** sees "/" and skips
-2. **Load Balancing Level 1** sees "/" and **skips provider selection**
+1. **Governance** skips — no Virtual Key is attached, and the explicit `openai/` prefix already pinned the provider
+2. **Load Balancing Level 1** finds the provider already set (OpenAI, from the model prefix) and keeps it as the primary, appending the healthy providers eligible for the model as fallbacks behind it
 3. **Load Balancing Level 2** still runs! Selects best OpenAI key based on current metrics
 4. Request forwarded to OpenAI with optimal key
 
@@ -1385,7 +1386,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 | VK with provider_configs         | **Governance** (weighted random)                | **Standard** or **Adaptive** (if enabled)   |
 | VK without provider_configs + LB | **Blocked** (empty = no providers allowed)      | N/A                                         |
 | No VK + LB                       | **Load Balancing Level 1** (performance)        | **Load Balancing Level 2** (performance)    |
-| Model with provider prefix + LB  | **Skip** (already specified)                    | **Load Balancing Level 2** (performance) ✅ |
+| Model with provider prefix + LB  | **Honored** (kept as primary; healthy fallbacks appended) | **Load Balancing Level 2** (performance) ✅ |
 | No Load Balancing enabled        | **Governance** or **User** or **Model Catalog** | **Standard** (static weights)               |
 
 <Note>
@@ -1427,7 +1428,7 @@ flowchart TD
             VKValidation["Virtual Key Validation"]
             GovRouting["VK Provider Selection<br/>(weighted random)"]
         end
-        LB1["Enterprise LB Level 1:<br/>Provider Selection<br/>(skipped if provider already set)"]
+        LB1["Enterprise LB Level 1:<br/>Provider Selection<br/>(pinned provider kept,<br/>healthy fallbacks appended)"]
         Resolver["model-catalog-resolver:<br/>Fill provider from catalog<br/>(final fallback)"]
     end
 
@@ -1446,7 +1447,7 @@ All routing layers below execute inside the **PreRequestHook** phase in registra
 1. **Routing rules evaluate first** in scope precedence order (VirtualKey → Team → Customer → Global)
 2. **If a routing rule matches**: provider/model/fallbacks are overridden, the VK `provider_configs` weighted selection is skipped
 3. **If no routing rule matches**: VK provider selection runs (weighted random)
-4. **Enterprise LB Level 1**: skipped if `req.Provider` is already set; otherwise performs performance-based selection
+4. **Enterprise LB Level 1**: keeps a pre-set `req.Provider` as the primary while appending healthy fallbacks (re-routing it only when its direction is circuit-broken and the toggle is on); otherwise performs performance-based selection
 5. **model-catalog-resolver**: last fallback — fills `req.Provider` from the catalog if no earlier plugin set it
 6. **Empty-provider validation** (core): returns 400 if `req.Provider` is still empty after the phase
 7. **Load balancing Level 2** (key selection, core, per attempt): always runs to select the best key within the determined provider
@@ -1570,7 +1571,7 @@ Routing Rules work **before** load balancing:
 ```
 Routing Rules decide: openai/gpt-4o
                     ↓
-Load Balancing Level 1: Skipped (provider already determined)
+Load Balancing Level 1: Honors the routing-rule provider, appends healthy fallbacks
                     ↓
 Load Balancing Level 2: Selects best OpenAI key based on performance
 ```


### PR DESCRIPTION
## Summary

Clarifies how Enterprise Load Balancing Level 1 (provider selection) behaves when a provider has already been pinned by an earlier layer (governance, routing rules, or an explicit `provider/` prefix). Previously the docs stated Level 1 was skipped entirely for pinned requests; the actual behavior is that Level 1 always runs — it keeps the pinned provider as the primary but appends the system's healthy providers as a fallback chain behind any the request already configured.

## Changes

- Updated the `direction_selection_enabled` setting description to reflect that pinned requests still receive system-managed fallbacks appended behind them, and that turning the switch off is the way to pass requests through completely untouched.
- Updated the `reroute_failed_directions` description to note that when no healthier provider exists, the pinned provider is kept rather than dropped.
- Added a new "Scope & Limitations" bullet explaining that pinned requests receive fallbacks even when they configure none of their own, and how to opt out.
- Corrected the "When it runs" description for Level 1 from "only when no provider has been selected" to "always (while the switch is on)", with the distinction between the pinned and unpinned paths.
- Updated the fallback-creation step to clarify that healthy providers are appended after any the request already carries, deduplicated, and that the prune toggle removes circuit-broken configured fallbacks before this happens.
- Updated the routing flow diagram to replace the "skip LB Level 1" path with a `LBPinned` node that reflects the keep-and-append behavior.
- Updated the routing layer execution order description, the provider-selection table row for "Model with provider prefix + LB", and all inline examples and callouts to use "honored" / "kept as primary" language instead of "skipped".

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated pages in a local docs preview and confirm:

1. The routing flow diagram correctly shows the `LBPinned` node on the "provider already set" path rather than a direct skip to the resolver.
2. The settings table, scope/limitations section, and all inline examples consistently describe Level 1 as always running and appending fallbacks for pinned requests.
3. No references to Level 1 being "skipped" remain for pinned requests.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable