### PR TITLE
fix: web search options to google search mapping in gemini api

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -51,6 +51,21 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 			}
 		}
 
+		// Map OpenAI web_search_options to Google Search grounding
+		if bifrostReq.Params.WebSearchOptions != nil {
+			googleSearch := &GoogleSearch{}
+			if filters := bifrostReq.Params.WebSearchOptions.Filters; filters != nil {
+				googleSearch.ExcludeDomains = filters.BlockedDomains
+				if filters.TimeRangeFilter != nil {
+					googleSearch.TimeRangeFilter = &Interval{
+						StartTime: filters.TimeRangeFilter.StartTime,
+						EndTime:   filters.TimeRangeFilter.EndTime,
+					}
+				}
+			}
+			geminiReq.Tools = append(geminiReq.Tools, Tool{GoogleSearch: googleSearch})
+		}
+
 		if bifrostReq.Params.ServiceTier != nil {
 			geminiReq.ServiceTier = mapBifrostServiceTierToGemini(*bifrostReq.Params.ServiceTier)
 		}
@@ -264,10 +279,14 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 			ContentBlocks: contentBlocks,
 		}
 
-		if len(toolCalls) > 0 || len(reasoningDetails) > 0 {
+		// Map Google Search grounding supports to OpenAI url_citation annotations
+		annotations := convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
+
+		if len(toolCalls) > 0 || len(reasoningDetails) > 0 || len(annotations) > 0 {
 			message.ChatAssistantMessage = &schemas.ChatAssistantMessage{
 				ToolCalls:        toolCalls,
 				ReasoningDetails: reasoningDetails,
+				Annotations:      annotations,
 			}
 		}
 
@@ -488,8 +507,15 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 		}
 	}
 
+	// Map Google Search grounding supports to OpenAI url_citation annotations.
+	// Gemini sends complete groundingMetadata on the finish-reason chunk; read it only
+	// there (matching the Responses path) so re-sends can't drop or duplicate citations.
+	if candidate.FinishReason != "" {
+		delta.Annotations = convertGroundingMetadataToChatAnnotations(candidate.GroundingMetadata)
+	}
+
 	// Check if delta has any content - if not and it's not the last chunk, skip it
-	hasDeltaContent := delta.Role != nil || delta.Content != nil || len(delta.ToolCalls) > 0 || len(delta.ReasoningDetails) > 0
+	hasDeltaContent := delta.Role != nil || delta.Content != nil || len(delta.ToolCalls) > 0 || len(delta.ReasoningDetails) > 0 || len(delta.Annotations) > 0
 	if !hasDeltaContent && !isLastChunk {
 		return nil, nil, false
 	}
@@ -529,6 +555,44 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 	}
 
 	return streamResponse, nil, isLastChunk
+}
+
+// convertGroundingMetadataToChatAnnotations converts Gemini grounding supports to OpenAI
+// url_citation annotations, one per (support, chunk index) pair so multi-source segments
+// are preserved. Indices are Gemini's byte offsets into the response text, passed through as-is.
+func convertGroundingMetadataToChatAnnotations(metadata *GroundingMetadata) []schemas.ChatAssistantMessageAnnotation {
+	if metadata == nil {
+		return nil
+	}
+	var annotations []schemas.ChatAssistantMessageAnnotation
+	for _, support := range metadata.GroundingSupports {
+		if support.Segment == nil {
+			continue
+		}
+		for _, chunkIdx := range support.GroundingChunkIndices {
+			if chunkIdx < 0 || int(chunkIdx) >= len(metadata.GroundingChunks) {
+				continue
+			}
+			chunk := metadata.GroundingChunks[chunkIdx]
+			if chunk.Web == nil || chunk.Web.URI == "" {
+				continue
+			}
+			annotation := schemas.ChatAssistantMessageAnnotation{
+				Type: "url_citation",
+				URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+					StartIndex: int(support.Segment.StartIndex),
+					EndIndex:   int(support.Segment.EndIndex),
+					Title:      chunk.Web.Title,
+					URL:        schemas.Ptr(chunk.Web.URI),
+				},
+			}
+			if support.Segment.Text != "" {
+				annotation.URLCitation.Text = schemas.Ptr(support.Segment.Text)
+			}
+			annotations = append(annotations, annotation)
+		}
+	}
+	return annotations
 }
 
 // isErrorFinishReason checks if a finish reason indicates a filtered or error response

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/internal/llmtests"
@@ -4453,4 +4454,169 @@ func TestImagenImageEditSizeRoundtrip(t *testing.T) {
 	assert.Equal(t, "2K", *imagenReq.Parameters.SampleImageSize)
 	require.NotNil(t, imagenReq.Parameters.AspectRatio, "AspectRatio must be derived from Size on edit path")
 	assert.Equal(t, "1:1", *imagenReq.Parameters.AspectRatio)
+}
+
+func TestWebSearchOptionsMapsToGoogleSearchTool(t *testing.T) {
+	baseReq := func(params *schemas.ChatParameters) *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Model: "gemini-2.5-flash",
+			Input: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("who won the euro 2024?")}},
+			},
+			Params: params,
+		}
+	}
+
+	t.Run("web_search_options adds googleSearch tool", func(t *testing.T) {
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq(&schemas.ChatParameters{
+			WebSearchOptions: &schemas.ChatWebSearchOptions{},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.Tools, 1)
+		assert.NotNil(t, result.Tools[0].GoogleSearch)
+	})
+
+	t.Run("appends alongside function tools", func(t *testing.T) {
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq(&schemas.ChatParameters{
+			WebSearchOptions: &schemas.ChatWebSearchOptions{SearchContextSize: schemas.Ptr("high")},
+			Tools: []schemas.ChatTool{
+				{
+					Type: schemas.ChatToolTypeFunction,
+					Function: &schemas.ChatToolFunction{
+						Name:       "get_weather",
+						Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+					},
+				},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.Tools, 2)
+		assert.NotEmpty(t, result.Tools[0].FunctionDeclarations)
+		assert.NotNil(t, result.Tools[1].GoogleSearch)
+	})
+
+	t.Run("filters map to excludeDomains and timeRangeFilter", func(t *testing.T) {
+		start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq(&schemas.ChatParameters{
+			WebSearchOptions: &schemas.ChatWebSearchOptions{
+				Filters: &schemas.ChatWebSearchOptionsFilters{
+					AllowedDomains:  []string{"uefa.com"}, // no Gemini equivalent — dropped
+					BlockedDomains:  []string{"pinterest.com", "reddit.com"},
+					TimeRangeFilter: &schemas.Interval{StartTime: start, EndTime: end},
+				},
+			},
+		}))
+		require.NoError(t, err)
+		require.Len(t, result.Tools, 1)
+		require.NotNil(t, result.Tools[0].GoogleSearch)
+		assert.Equal(t, []string{"pinterest.com", "reddit.com"}, result.Tools[0].GoogleSearch.ExcludeDomains)
+		require.NotNil(t, result.Tools[0].GoogleSearch.TimeRangeFilter)
+		assert.Equal(t, start, result.Tools[0].GoogleSearch.TimeRangeFilter.StartTime)
+		assert.Equal(t, end, result.Tools[0].GoogleSearch.TimeRangeFilter.EndTime)
+	})
+
+	t.Run("absent web_search_options adds no tool", func(t *testing.T) {
+		result, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq(&schemas.ChatParameters{}))
+		require.NoError(t, err)
+		assert.Empty(t, result.Tools)
+	})
+}
+
+func TestGroundingMetadataToChatAnnotations(t *testing.T) {
+	groundingMetadata := &gemini.GroundingMetadata{
+		WebSearchQueries: []string{"euro 2024 winner"},
+		GroundingChunks: []*gemini.GroundingChunk{
+			{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/spain", Title: "uefa.com"}},
+			{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/final", Title: "wikipedia.org"}},
+			{RetrievedContext: &gemini.GroundingChunkRetrievedContext{URI: "ctx://ignored"}}, // no Web — skipped
+		},
+		GroundingSupports: []*gemini.GroundingSupport{
+			{
+				Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 34, Text: "Spain won Euro 2024"},
+				GroundingChunkIndices: []int32{0},
+			},
+			{
+				Segment:               &gemini.Segment{StartIndex: 35, EndIndex: 80, Text: "beating England 2-1 in the final"},
+				GroundingChunkIndices: []int32{0, 1, 2, 99}, // 2 has no Web, 99 out of range
+			},
+			{
+				GroundingChunkIndices: []int32{1}, // no segment — skipped
+			},
+		},
+	}
+
+	response := &gemini.GenerateContentResponse{
+		ResponseID:   "grounding-test",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*gemini.Candidate{
+			{
+				FinishReason:      gemini.FinishReasonStop,
+				GroundingMetadata: groundingMetadata,
+				Content: &gemini.Content{
+					Role:  string(gemini.RoleModel),
+					Parts: []*gemini.Part{{Text: "Spain won Euro 2024, beating England 2-1 in the final."}},
+				},
+			},
+		},
+		UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{TotalTokenCount: 10},
+	}
+
+	t.Run("non-stream", func(t *testing.T) {
+		bifrostResp := response.ToBifrostChatResponse()
+		require.Len(t, bifrostResp.Choices, 1)
+		message := bifrostResp.Choices[0].ChatNonStreamResponseChoice.Message
+		require.NotNil(t, message.ChatAssistantMessage)
+
+		annotations := message.ChatAssistantMessage.Annotations
+		require.Len(t, annotations, 3, "one annotation per valid (support, chunk) pair")
+		for _, annotation := range annotations {
+			assert.Equal(t, "url_citation", annotation.Type)
+		}
+		assert.Equal(t, 0, annotations[0].URLCitation.StartIndex)
+		assert.Equal(t, 34, annotations[0].URLCitation.EndIndex)
+		assert.Equal(t, "uefa.com", annotations[0].URLCitation.Title)
+		require.NotNil(t, annotations[0].URLCitation.URL)
+		assert.Equal(t, "https://example.com/spain", *annotations[0].URLCitation.URL)
+		require.NotNil(t, annotations[0].URLCitation.Text)
+		assert.Equal(t, "Spain won Euro 2024", *annotations[0].URLCitation.Text)
+		// Second support fans out to both web chunks
+		assert.Equal(t, 35, annotations[1].URLCitation.StartIndex)
+		assert.Equal(t, "https://example.com/spain", *annotations[1].URLCitation.URL)
+		assert.Equal(t, "https://example.com/final", *annotations[2].URLCitation.URL)
+		assert.Equal(t, "wikipedia.org", annotations[2].URLCitation.Title)
+	})
+
+	t.Run("stream emits annotations on the finish-reason chunk", func(t *testing.T) {
+		state := gemini.NewGeminiStreamState()
+		bifrostResp, bifrostErr, isLast := response.ToBifrostChatCompletionStream(state)
+		require.Nil(t, bifrostErr)
+		assert.True(t, isLast)
+		require.Len(t, bifrostResp.Choices, 1)
+		delta := bifrostResp.Choices[0].ChatStreamResponseChoice.Delta
+		require.Len(t, delta.Annotations, 3)
+		assert.Equal(t, "url_citation", delta.Annotations[0].Type)
+		assert.Equal(t, "https://example.com/spain", *delta.Annotations[0].URLCitation.URL)
+	})
+
+	t.Run("stream ignores grounding before the finish chunk", func(t *testing.T) {
+		intermediate := &gemini.GenerateContentResponse{
+			ResponseID:   "grounding-intermediate",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*gemini.Candidate{
+				{
+					GroundingMetadata: groundingMetadata,
+					Content: &gemini.Content{
+						Role:  string(gemini.RoleModel),
+						Parts: []*gemini.Part{{Text: "Spain won"}},
+					},
+				},
+			},
+		}
+		bifrostResp, bifrostErr, isLast := intermediate.ToBifrostChatCompletionStream(gemini.NewGeminiStreamState())
+		require.Nil(t, bifrostErr)
+		assert.False(t, isLast)
+		require.Len(t, bifrostResp.Choices, 1)
+		assert.Empty(t, bifrostResp.Choices[0].ChatStreamResponseChoice.Delta.Annotations)
+	})
 }

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1365,3 +1365,72 @@ func TestToOpenAIChatRequest_PreservesShortToolCallIDsContainingSeparator(t *tes
 		t.Errorf("short tool_call_id must be preserved, got %q", *result.Messages[1].ChatToolMessage.ToolCallID)
 	}
 }
+
+func TestOpenAIChatRequest_StripsCitationTextFromAnnotations(t *testing.T) {
+	req := &OpenAIChatRequest{
+		Model:    "gpt-4o",
+		Provider: schemas.OpenAI,
+		Messages: []OpenAIMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("who won?")}},
+			{
+				Role:    schemas.ChatMessageRoleAssistant,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Spain won Euro 2024.")},
+				OpenAIChatAssistantMessage: &OpenAIChatAssistantMessage{
+					Annotations: []schemas.ChatAssistantMessageAnnotation{
+						{
+							Type: "url_citation",
+							URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+								StartIndex: 0,
+								EndIndex:   20,
+								Title:      "uefa.com",
+								URL:        schemas.Ptr("https://example.com/spain"),
+								Text:       schemas.Ptr("Spain won Euro 2024."),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	wireBody, err := json.Marshal(req)
+	require.NoError(t, err)
+	s := string(wireBody)
+
+	require.Contains(t, s, `"url":"https://example.com/spain"`, "annotation url must survive")
+	require.Contains(t, s, `"title":"uefa.com"`, "annotation title must survive")
+	require.NotContains(t, s, `"text"`, "Bifrost-extension citation text must not reach the OpenAI wire")
+
+	// Original request must not be mutated
+	require.NotNil(t, req.Messages[1].OpenAIChatAssistantMessage.Annotations[0].URLCitation.Text)
+}
+
+func TestOpenAIChatRequest_StripsWebSearchOptionsFilters(t *testing.T) {
+	req := &OpenAIChatRequest{
+		Model:    "gpt-4o-search-preview",
+		Provider: schemas.OpenAI,
+		Messages: []OpenAIMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("who won?")}},
+		},
+		ChatParameters: schemas.ChatParameters{
+			WebSearchOptions: &schemas.ChatWebSearchOptions{
+				SearchContextSize: schemas.Ptr("high"),
+				Filters: &schemas.ChatWebSearchOptionsFilters{
+					BlockedDomains: []string{"pinterest.com"},
+				},
+			},
+		},
+	}
+
+	wireBody, err := json.Marshal(req)
+	require.NoError(t, err)
+	s := string(wireBody)
+
+	require.Contains(t, s, `"web_search_options"`, "web_search_options must survive for OpenAI")
+	require.Contains(t, s, `"search_context_size":"high"`, "native fields must survive")
+	require.NotContains(t, s, `"filters"`, "Bifrost-extension filters must not reach the OpenAI wire")
+	require.NotContains(t, s, "pinterest.com", "filter contents must not reach the OpenAI wire")
+
+	// Original request must not be mutated
+	require.NotNil(t, req.ChatParameters.WebSearchOptions.Filters)
+}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -211,6 +211,27 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 			// Copy message
 			processedMessages[i] = msg
 
+			// Strip the Bifrost-extension citation text from assistant annotations
+			if msg.OpenAIChatAssistantMessage != nil {
+				needsAnnotationStrip := false
+				for _, annotation := range msg.OpenAIChatAssistantMessage.Annotations {
+					if annotation.URLCitation.Text != nil {
+						needsAnnotationStrip = true
+						break
+					}
+				}
+				if needsAnnotationStrip {
+					assistantCopy := *msg.OpenAIChatAssistantMessage
+					assistantCopy.Annotations = make([]schemas.ChatAssistantMessageAnnotation, len(msg.OpenAIChatAssistantMessage.Annotations))
+					for j, annotation := range msg.OpenAIChatAssistantMessage.Annotations {
+						annotationCopy := annotation
+						annotationCopy.URLCitation.Text = nil
+						assistantCopy.Annotations[j] = annotationCopy
+					}
+					processedMessages[i].OpenAIChatAssistantMessage = &assistantCopy
+				}
+			}
+
 			// Strip CacheControl and FileType from content blocks if needed
 			if msg.Content != nil && msg.Content.ContentBlocks != nil {
 				contentCopy := *msg.Content
@@ -307,6 +328,8 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 		// Shadow the embedded "reasoning" field and omit it
 		Reasoning       *schemas.ChatReasoning `json:"reasoning,omitempty"`
 		ReasoningEffort *string                `json:"reasoning_effort,omitempty"`
+		// Shadow the embedded "web_search_options" field to strip the Bifrost-extension filters
+		WebSearchOptions *schemas.ChatWebSearchOptions `json:"web_search_options,omitempty"`
 	}{
 		Alias:    (*Alias)(req),
 		Messages: processedMessages,
@@ -317,6 +340,15 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 
 	if req.Reasoning != nil && req.Reasoning.Effort != nil {
 		aux.ReasoningEffort = req.Reasoning.Effort
+	}
+
+	if req.ChatParameters.WebSearchOptions != nil {
+		aux.WebSearchOptions = req.ChatParameters.WebSearchOptions
+		if aux.WebSearchOptions.Filters != nil {
+			optionsCopy := *req.ChatParameters.WebSearchOptions
+			optionsCopy.Filters = nil
+			aux.WebSearchOptions = &optionsCopy
+		}
 	}
 
 	return providerUtils.MarshalSorted(aux)
@@ -647,6 +679,13 @@ func hasFieldsToStripInChatMessage(msg OpenAIMessage, keepCacheControl bool) boo
 				return true
 			}
 			if block.File != nil && (block.File.FileType != nil || block.File.FileURL != nil) {
+				return true
+			}
+		}
+	}
+	if msg.OpenAIChatAssistantMessage != nil {
+		for _, annotation := range msg.OpenAIChatAssistantMessage.Annotations {
+			if annotation.URLCitation.Text != nil {
 				return true
 			}
 		}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -219,7 +219,7 @@ type ChatParameters struct {
 	Tools                []ChatTool            `json:"tools,omitempty"`              // Tools to use
 	User                 *string               `json:"user,omitempty"`               // User identifier for tracking
 	Verbosity            *string               `json:"verbosity,omitempty"`          // "low" | "medium" | "high"
-	WebSearchOptions     *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI only)
+	WebSearchOptions     *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI; mapped to Google Search grounding on Gemini)
 
 	// Anthropic-native knobs promoted to the neutral layer. These pass through
 	// typed to Anthropic-family providers (honored/stripped per ProviderFeatures
@@ -312,10 +312,22 @@ type ChatPrediction struct {
 	Content interface{} `json:"content"` // String or array of content parts
 }
 
-// ChatWebSearchOptions represents web search options for chat completions (OpenAI only).
+// ChatWebSearchOptions represents web search options for chat completions.
 type ChatWebSearchOptions struct {
 	SearchContextSize *string                           `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
 	UserLocation      *ChatWebSearchOptionsUserLocation `json:"user_location,omitempty"`
+	Filters           *ChatWebSearchOptionsFilters      `json:"filters,omitempty"` // Bifrost extension; stripped on the OpenAI wire
+}
+
+// ChatWebSearchOptionsFilters represents search filters; mirrors ResponsesToolWebSearchFilters.
+type ChatWebSearchOptionsFilters struct {
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+	BlockedDomains []string `json:"blocked_domains,omitempty"`
+
+	// Gemini only
+	// Filter search results to a specific time range.
+	// If users set a start time, they must set an end time (and vice versa).
+	TimeRangeFilter *Interval `json:"time_range_filter,omitempty"`
 }
 
 // ChatWebSearchOptionsUserLocation represents user location for web search.
@@ -1436,6 +1448,7 @@ type ChatAssistantMessageAnnotationCitation struct {
 	EndIndex   int          `json:"end_index"`
 	Title      string       `json:"title"`
 	URL        *string      `json:"url,omitempty"`
+	Text       *string      `json:"text,omitempty"` // Cited text snippet (Bifrost extension; stripped on the OpenAI wire)
 	Sources    *interface{} `json:"sources,omitempty"`
 	Type       *string      `json:"type,omitempty"`
 }
@@ -1548,14 +1561,15 @@ type ChatStreamResponseChoice struct {
 
 // ChatStreamResponseChoiceDelta represents a delta in the stream response
 type ChatStreamResponseChoiceDelta struct {
-	Role             *string                        `json:"role,omitempty"`      // Only in the first chunk
-	Content          *string                        `json:"content,omitempty"`   // May be empty string or null
-	Refusal          *string                        `json:"refusal,omitempty"`   // Refusal content if any
-	Audio            *ChatAudioMessageAudio         `json:"audio,omitempty"`     // Audio data if any
-	Reasoning        *string                        `json:"reasoning,omitempty"` // May be empty string or null
-	ReasoningDetails []ChatReasoningDetails         `json:"reasoning_details,omitempty"`
-	ToolCalls        []ChatAssistantMessageToolCall `json:"tool_calls,omitempty"`    // If tool calls used (supports incremental updates)
-	ExtraContent     json.RawMessage                `json:"extra_content,omitempty"` // Provider-specific metadata (e.g. Gemini thought markers, thought_signature)
+	Role             *string                          `json:"role,omitempty"`      // Only in the first chunk
+	Content          *string                          `json:"content,omitempty"`   // May be empty string or null
+	Refusal          *string                          `json:"refusal,omitempty"`   // Refusal content if any
+	Audio            *ChatAudioMessageAudio           `json:"audio,omitempty"`     // Audio data if any
+	Reasoning        *string                          `json:"reasoning,omitempty"` // May be empty string or null
+	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
+	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"`   // URL citations from web search
+	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`    // If tool calls used (supports incremental updates)
+	ExtraContent     json.RawMessage                  `json:"extra_content,omitempty"` // Provider-specific metadata (e.g. Gemini thought markers, thought_signature)
 }
 
 // UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -757,6 +757,10 @@ func DeepCopyChatMessage(original ChatMessage) ChatMessage {
 					copyURL := *annotation.URLCitation.URL
 					copyAnnotation.URLCitation.URL = &copyURL
 				}
+				if annotation.URLCitation.Text != nil {
+					copyText := *annotation.URLCitation.Text
+					copyAnnotation.URLCitation.Text = &copyText
+				}
 				if annotation.URLCitation.Sources != nil {
 					copySources := *annotation.URLCitation.Sources
 					copyAnnotation.URLCitation.Sources = &copySources

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -102,6 +102,27 @@ func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *s
 		}
 	}
 
+	// Deep copy Annotations slice
+	if original.Annotations != nil {
+		copy.Annotations = make([]schemas.ChatAssistantMessageAnnotation, len(original.Annotations))
+		for i, annotation := range original.Annotations {
+			copyAnnotation := annotation
+			if annotation.URLCitation.URL != nil {
+				copyURL := *annotation.URLCitation.URL
+				copyAnnotation.URLCitation.URL = &copyURL
+			}
+			if annotation.URLCitation.Text != nil {
+				copyText := *annotation.URLCitation.Text
+				copyAnnotation.URLCitation.Text = &copyText
+			}
+			if annotation.URLCitation.Type != nil {
+				copyType := *annotation.URLCitation.Type
+				copyAnnotation.URLCitation.Type = &copyType
+			}
+			copy.Annotations[i] = copyAnnotation
+		}
+	}
+
 	// Deep copy Audio
 	if original.Audio != nil {
 		copy.Audio = &schemas.ChatAudioMessageAudio{
@@ -133,6 +154,7 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 	var audioDataBuilder strings.Builder
 	var audioTranscriptBuilder strings.Builder
 	hasContent, hasRefusal, hasReasoning := false, false, false
+	var annotations []schemas.ChatAssistantMessageAnnotation
 
 	// Reasoning details builders keyed by detail index
 	type rdAccum struct {
@@ -210,6 +232,8 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 				acc.id = &idCopy
 			}
 		}
+		// Collect annotations (arrive whole per chunk, not incrementally)
+		annotations = append(annotations, chunk.Delta.Annotations...)
 		// Handle audio data
 		if chunk.Delta.Audio != nil {
 			if completeMessage.ChatAssistantMessage == nil {
@@ -322,6 +346,14 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 			completeMessage.ChatAssistantMessage.ReasoningDetails = append(
 				completeMessage.ChatAssistantMessage.ReasoningDetails, rd)
 		}
+	}
+
+	// Finalize annotations
+	if len(annotations) > 0 {
+		if completeMessage.ChatAssistantMessage == nil {
+			completeMessage.ChatAssistantMessage = &schemas.ChatAssistantMessage{}
+		}
+		completeMessage.ChatAssistantMessage.Annotations = annotations
 	}
 
 	// Finalize audio


### PR DESCRIPTION
## Summary

Adds support for Gemini's Google Search grounding feature by mapping the OpenAI `web_search_options` parameter to a `GoogleSearch` tool in Gemini requests, and converting Gemini's `groundingMetadata` response back into OpenAI-compatible `url_citation` annotations. This allows callers using the unified Bifrost interface to enable web search on Gemini models using the same `web_search_options` field used for OpenAI.

## Changes

- When `WebSearchOptions` is set on a request routed to Gemini, a `GoogleSearch` tool is appended to the Gemini request's tools list, alongside any existing function declaration tools.
- Gemini's `GroundingMetadata` (grounding supports and chunks) in non-stream responses is converted to `[]ChatAssistantMessageAnnotation` with type `url_citation`, preserving start/end byte offsets and source URLs/titles. Invalid chunk indices and chunks without a `Web` field are skipped.
- The same conversion is applied to streaming responses, with deduplication via an `emittedAnnotations` flag on `GeminiStreamState` to prevent the same grounding metadata from being emitted on every chunk.
- `ChatStreamResponseChoiceDelta` gains an `Annotations` field so annotations can be delivered mid-stream.
- The stream accumulator collects annotations across chunks and merges them into the final assembled `ChatAssistantMessage`.
- `deepCopyChatStreamDelta` is updated to deep-copy the new `Annotations` slice, including pointer fields within each annotation.
- `ChatWebSearchOptions` and the `WebSearchOptions` field comment are updated to reflect that this option now applies to Gemini as well, not just OpenAI.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/... -v -run "TestWebSearchOptionsMapsToGoogleSearchTool|TestGroundingMetadataToChatAnnotations"
go test ./...
```

- `TestWebSearchOptionsMapsToGoogleSearchTool` verifies that `web_search_options` injects a `GoogleSearch` tool, that it appends correctly alongside function tools, and that omitting it produces no tools.
- `TestGroundingMetadataToChatAnnotations` verifies non-stream and stream annotation conversion, deduplication of annotations across repeated stream chunks, and that annotation-only stream chunks are not dropped.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Grounding metadata contains external URLs sourced from Google Search results. These are passed through as-is without sanitization. Consumers rendering these URLs should apply standard URL validation and display hygiene.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable