### PR TITLE
fix: forward include_blocks to Mistral OCR and carry pages[].blocks (closes #5137)

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,1 @@
-- fix: forward `include_blocks` to Mistral OCR and carry provider-native `pages[].blocks` through the response [@hugochinchilla](https://github.com/hugochinchilla)
+- fix: forward `include_blocks` and `confidence_scores_granularity` to Mistral OCR and carry provider-native `pages[].blocks` through the response [@hugochinchilla](https://github.com/hugochinchilla)

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: forward `include_blocks` to Mistral OCR and carry provider-native `pages[].blocks` through the response [@hugochinchilla](https://github.com/hugochinchilla)

--- a/core/providers/mistral/ocr.go
+++ b/core/providers/mistral/ocr.go
@@ -41,6 +41,7 @@ func ToMistralOCRRequest(req *schemas.BifrostOCRRequest) *MistralOCRRequest {
 		mistralReq.TableFormat = req.Params.TableFormat
 		mistralReq.ExtractHeader = req.Params.ExtractHeader
 		mistralReq.ExtractFooter = req.Params.ExtractFooter
+		mistralReq.ConfidenceScoresGranularity = req.Params.ConfidenceScoresGranularity
 		mistralReq.BBoxAnnotationFormat = req.Params.BBoxAnnotationFormat
 		mistralReq.DocumentAnnotationFormat = req.Params.DocumentAnnotationFormat
 		mistralReq.DocumentAnnotationPrompt = req.Params.DocumentAnnotationPrompt

--- a/core/providers/mistral/ocr.go
+++ b/core/providers/mistral/ocr.go
@@ -34,6 +34,7 @@ func ToMistralOCRRequest(req *schemas.BifrostOCRRequest) *MistralOCRRequest {
 
 	if req.Params != nil {
 		mistralReq.IncludeImageBase64 = req.Params.IncludeImageBase64
+		mistralReq.IncludeBlocks = req.Params.IncludeBlocks
 		mistralReq.Pages = req.Params.Pages
 		mistralReq.ImageLimit = req.Params.ImageLimit
 		mistralReq.ImageMinSize = req.Params.ImageMinSize
@@ -87,6 +88,9 @@ func (r *MistralOCRResponse) ToBifrostOCRResponse() *schemas.BifrostOCRResponse 
 					Height: p.Dimensions.Height,
 					Width:  p.Dimensions.Width,
 				}
+			}
+			if len(p.Blocks) > 0 {
+				page.Blocks = p.Blocks
 			}
 			resp.Pages[i] = page
 		}

--- a/core/providers/mistral/ocr.go
+++ b/core/providers/mistral/ocr.go
@@ -89,9 +89,7 @@ func (r *MistralOCRResponse) ToBifrostOCRResponse() *schemas.BifrostOCRResponse 
 					Width:  p.Dimensions.Width,
 				}
 			}
-			if len(p.Blocks) > 0 {
-				page.Blocks = p.Blocks
-			}
+			page.Blocks = p.Blocks
 			resp.Pages[i] = page
 		}
 	}

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -322,7 +322,7 @@ func TestToBifrostOCRResponse(t *testing.T) {
 					{
 						Index:    0,
 						Markdown: "Page with blocks",
-						Blocks: []any{
+						Blocks: &[]any{
 							map[string]any{
 								"type": "text",
 								"text": "Hello",
@@ -339,11 +339,49 @@ func TestToBifrostOCRResponse(t *testing.T) {
 			validate: func(t *testing.T, result *schemas.BifrostOCRResponse) {
 				require.NotNil(t, result)
 				require.Len(t, result.Pages, 1)
-				require.Len(t, result.Pages[0].Blocks, 2)
-				first, ok := result.Pages[0].Blocks[0].(map[string]any)
+				require.NotNil(t, result.Pages[0].Blocks)
+				require.Len(t, *result.Pages[0].Blocks, 2)
+				first, ok := (*result.Pages[0].Blocks)[0].(map[string]any)
 				require.True(t, ok)
 				assert.Equal(t, "text", first["type"])
 				assert.Equal(t, "Hello", first["text"])
+			},
+		},
+		{
+			// Regression: `blocks: []` from Mistral is a distinct state from an
+			// absent field, and must not collapse into nil via omitempty.
+			name: "response with explicitly empty blocks preserves presence",
+			input: &MistralOCRResponse{
+				Model: "mistral-ocr-latest",
+				Pages: []MistralOCRPage{
+					{Index: 0, Markdown: "Page with empty blocks", Blocks: &[]any{}},
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostOCRResponse) {
+				require.NotNil(t, result)
+				require.Len(t, result.Pages, 1)
+				require.NotNil(t, result.Pages[0].Blocks, "empty blocks must survive as non-nil pointer")
+				assert.Len(t, *result.Pages[0].Blocks, 0)
+
+				out, err := sonic.Marshal(result.Pages[0])
+				require.NoError(t, err)
+				assert.Contains(t, string(out), `"blocks":[]`, "empty blocks must serialize as [], not be omitted")
+			},
+		},
+		{
+			name: "response with absent blocks stays absent",
+			input: &MistralOCRResponse{
+				Model: "mistral-ocr-latest",
+				Pages: []MistralOCRPage{{Index: 0, Markdown: "Page without blocks"}},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostOCRResponse) {
+				require.NotNil(t, result)
+				require.Len(t, result.Pages, 1)
+				assert.Nil(t, result.Pages[0].Blocks)
+
+				out, err := sonic.Marshal(result.Pages[0])
+				require.NoError(t, err)
+				assert.NotContains(t, string(out), `"blocks"`, "absent blocks must not appear in output")
 			},
 		},
 		{

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -90,6 +90,7 @@ func TestToMistralOCRRequest(t *testing.T) {
 				},
 				Params: &schemas.OCRParameters{
 					IncludeImageBase64:       schemas.Ptr(true),
+					IncludeBlocks:            schemas.Ptr(true),
 					Pages:                    []int{0, 1, 2},
 					ImageLimit:               schemas.Ptr(10),
 					ImageMinSize:             schemas.Ptr(100),
@@ -109,6 +110,8 @@ func TestToMistralOCRRequest(t *testing.T) {
 
 				require.NotNil(t, result.IncludeImageBase64)
 				assert.True(t, *result.IncludeImageBase64)
+				require.NotNil(t, result.IncludeBlocks)
+				assert.True(t, *result.IncludeBlocks)
 				assert.Equal(t, []int{0, 1, 2}, result.Pages)
 				require.NotNil(t, result.ImageLimit)
 				assert.Equal(t, 10, *result.ImageLimit)
@@ -141,6 +144,7 @@ func TestToMistralOCRRequest(t *testing.T) {
 			validate: func(t *testing.T, result *MistralOCRRequest) {
 				require.NotNil(t, result)
 				assert.Nil(t, result.IncludeImageBase64)
+				assert.Nil(t, result.IncludeBlocks)
 				assert.Nil(t, result.Pages)
 				assert.Nil(t, result.ImageLimit)
 				assert.Nil(t, result.ImageMinSize)
@@ -308,6 +312,38 @@ func TestToBifrostOCRResponse(t *testing.T) {
 				require.NotNil(t, result)
 				require.NotNil(t, result.DocumentAnnotation)
 				assert.Equal(t, "This is a legal contract.", *result.DocumentAnnotation)
+			},
+		},
+		{
+			name: "response with blocks passes through as opaque values",
+			input: &MistralOCRResponse{
+				Model: "mistral-ocr-latest",
+				Pages: []MistralOCRPage{
+					{
+						Index:    0,
+						Markdown: "Page with blocks",
+						Blocks: []any{
+							map[string]any{
+								"type": "text",
+								"text": "Hello",
+								"bbox": []any{float64(1), float64(2), float64(3), float64(4)},
+							},
+							map[string]any{
+								"type": "table",
+								"rows": float64(3),
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostOCRResponse) {
+				require.NotNil(t, result)
+				require.Len(t, result.Pages, 1)
+				require.Len(t, result.Pages[0].Blocks, 2)
+				first, ok := result.Pages[0].Blocks[0].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "text", first["type"])
+				assert.Equal(t, "Hello", first["text"])
 			},
 		},
 		{

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -352,11 +352,6 @@ func TestToBifrostOCRResponse(t *testing.T) {
 			},
 		},
 		{
-			// End-to-end regression for the shape reported in the field
-			// (top_left_x/top_left_y/bottom_right_x/bottom_right_y/content/type).
-			// Simulates the actual wire path: Mistral JSON → MistralOCRResponse →
-			// BifrostOCRResponse → JSON to client, and checks that block content
-			// (not just presence) survives the round-trip.
 			name: "populated blocks survive full JSON round-trip",
 			input: func() *MistralOCRResponse {
 				mistralJSON := []byte(`{
@@ -389,8 +384,6 @@ func TestToBifrostOCRResponse(t *testing.T) {
 			},
 		},
 		{
-			// Regression: `blocks: []` from Mistral is a distinct state from an
-			// absent field, and must not collapse into nil via omitempty.
 			name: "response with explicitly empty blocks preserves presence",
 			input: &MistralOCRResponse{
 				Model: "mistral-ocr-latest",

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -89,17 +89,18 @@ func TestToMistralOCRRequest(t *testing.T) {
 					DocumentURL: schemas.Ptr("https://example.com/doc.pdf"),
 				},
 				Params: &schemas.OCRParameters{
-					IncludeImageBase64:       schemas.Ptr(true),
-					IncludeBlocks:            schemas.Ptr(true),
-					Pages:                    []int{0, 1, 2},
-					ImageLimit:               schemas.Ptr(10),
-					ImageMinSize:             schemas.Ptr(100),
-					TableFormat:              schemas.Ptr("html"),
-					ExtractHeader:            schemas.Ptr(true),
-					ExtractFooter:            schemas.Ptr(false),
-					BBoxAnnotationFormat:     schemas.Ptr("json"),
-					DocumentAnnotationFormat: schemas.Ptr("markdown"),
-					DocumentAnnotationPrompt: schemas.Ptr("Summarize this document"),
+					IncludeImageBase64:          schemas.Ptr(true),
+					IncludeBlocks:               schemas.Ptr(true),
+					Pages:                       []int{0, 1, 2},
+					ImageLimit:                  schemas.Ptr(10),
+					ImageMinSize:                schemas.Ptr(100),
+					TableFormat:                 schemas.Ptr("html"),
+					ExtractHeader:               schemas.Ptr(true),
+					ExtractFooter:               schemas.Ptr(false),
+					ConfidenceScoresGranularity: schemas.Ptr("block"),
+					BBoxAnnotationFormat:        schemas.Ptr("json"),
+					DocumentAnnotationFormat:    schemas.Ptr("markdown"),
+					DocumentAnnotationPrompt:    schemas.Ptr("Summarize this document"),
 				},
 			},
 			validate: func(t *testing.T, result *MistralOCRRequest) {
@@ -123,6 +124,8 @@ func TestToMistralOCRRequest(t *testing.T) {
 				assert.True(t, *result.ExtractHeader)
 				require.NotNil(t, result.ExtractFooter)
 				assert.False(t, *result.ExtractFooter)
+				require.NotNil(t, result.ConfidenceScoresGranularity)
+				assert.Equal(t, "block", *result.ConfidenceScoresGranularity)
 				require.NotNil(t, result.BBoxAnnotationFormat)
 				assert.Equal(t, "json", *result.BBoxAnnotationFormat)
 				require.NotNil(t, result.DocumentAnnotationFormat)
@@ -151,6 +154,7 @@ func TestToMistralOCRRequest(t *testing.T) {
 				assert.Nil(t, result.TableFormat)
 				assert.Nil(t, result.ExtractHeader)
 				assert.Nil(t, result.ExtractFooter)
+				assert.Nil(t, result.ConfidenceScoresGranularity)
 				assert.Nil(t, result.BBoxAnnotationFormat)
 				assert.Nil(t, result.DocumentAnnotationFormat)
 				assert.Nil(t, result.DocumentAnnotationPrompt)

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -352,6 +352,43 @@ func TestToBifrostOCRResponse(t *testing.T) {
 			},
 		},
 		{
+			// End-to-end regression for the shape reported in the field
+			// (top_left_x/top_left_y/bottom_right_x/bottom_right_y/content/type).
+			// Simulates the actual wire path: Mistral JSON → MistralOCRResponse →
+			// BifrostOCRResponse → JSON to client, and checks that block content
+			// (not just presence) survives the round-trip.
+			name: "populated blocks survive full JSON round-trip",
+			input: func() *MistralOCRResponse {
+				mistralJSON := []byte(`{
+					"model": "mistral-ocr-4-0",
+					"pages": [{
+						"index": 0,
+						"markdown": "hi",
+						"blocks": [
+							{"type":"text","content":"Hello","top_left_x":1,"top_left_y":2,"bottom_right_x":3,"bottom_right_y":4},
+							{"type":"text","content":"World","top_left_x":5,"top_left_y":6,"bottom_right_x":7,"bottom_right_y":8}
+						]
+					}]
+				}`)
+				var r MistralOCRResponse
+				require.NoError(t, sonic.Unmarshal(mistralJSON, &r))
+				return &r
+			}(),
+			validate: func(t *testing.T, result *schemas.BifrostOCRResponse) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Pages[0].Blocks)
+				require.Len(t, *result.Pages[0].Blocks, 2)
+
+				out, err := sonic.Marshal(result)
+				require.NoError(t, err)
+				body := string(out)
+				assert.Contains(t, body, `"blocks":[`, "blocks must appear in top-level JSON")
+				assert.Contains(t, body, `"content":"Hello"`, "block content must survive")
+				assert.Contains(t, body, `"top_left_x":1`, "bbox coord must survive")
+				assert.Contains(t, body, `"content":"World"`)
+			},
+		},
+		{
 			// Regression: `blocks: []` from Mistral is a distinct state from an
 			// absent field, and must not collapse into nil via omitempty.
 			name: "response with explicitly empty blocks preserves presence",

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -192,7 +192,8 @@ type MistralOCRPage struct {
 	Dimensions *MistralOCRPageDimensions `json:"dimensions,omitempty"`
 	// Populated by Mistral only when the request sets include_blocks=true.
 	// Kept opaque so provider-side schema evolution passes through untouched.
-	Blocks []any `json:"blocks,omitempty"`
+	// Pointer so `blocks: []` (empty but present) survives round-trip.
+	Blocks *[]any `json:"blocks,omitempty"`
 }
 
 // MistralOCRUsageInfo represents usage information in Mistral's OCR response.

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -154,6 +154,7 @@ type MistralOCRRequest struct {
 	ID                       string                 `json:"id,omitempty"`
 	Document                 MistralOCRDocument     `json:"document"`
 	IncludeImageBase64       *bool                  `json:"include_image_base64,omitempty"`
+	IncludeBlocks            *bool                  `json:"include_blocks,omitempty"`
 	Pages                    []int                  `json:"pages,omitempty"`
 	ImageLimit               *int                   `json:"image_limit,omitempty"`
 	ImageMinSize             *int                   `json:"image_min_size,omitempty"`
@@ -189,6 +190,9 @@ type MistralOCRPage struct {
 	Markdown   string                    `json:"markdown"`
 	Images     []MistralOCRPageImage     `json:"images,omitempty"`
 	Dimensions *MistralOCRPageDimensions `json:"dimensions,omitempty"`
+	// Populated by Mistral only when the request sets include_blocks=true.
+	// Kept opaque so provider-side schema evolution passes through untouched.
+	Blocks []any `json:"blocks,omitempty"`
 }
 
 // MistralOCRUsageInfo represents usage information in Mistral's OCR response.
@@ -199,8 +203,8 @@ type MistralOCRUsageInfo struct {
 
 // MistralOCRResponse represents Mistral's OCR API response.
 type MistralOCRResponse struct {
-	Model              string              `json:"model"`
-	Pages              []MistralOCRPage    `json:"pages"`
+	Model              string               `json:"model"`
+	Pages              []MistralOCRPage     `json:"pages"`
 	UsageInfo          *MistralOCRUsageInfo `json:"usage_info,omitempty"`
-	DocumentAnnotation *string             `json:"document_annotation,omitempty"`
+	DocumentAnnotation *string              `json:"document_annotation,omitempty"`
 }

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -191,9 +191,8 @@ type MistralOCRPage struct {
 	Markdown   string                    `json:"markdown"`
 	Images     []MistralOCRPageImage     `json:"images,omitempty"`
 	Dimensions *MistralOCRPageDimensions `json:"dimensions,omitempty"`
-	// Populated by Mistral only when the request sets include_blocks=true.
-	// Kept opaque so provider-side schema evolution passes through untouched.
-	// Pointer so `blocks: []` (empty but present) survives round-trip.
+	// Present only when the request sets include_blocks=true; pointer so an
+	// explicitly empty `blocks: []` isn't dropped by omitempty.
 	Blocks *[]any `json:"blocks,omitempty"`
 }
 

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -150,21 +150,22 @@ type MistralOCRDocument struct {
 
 // MistralOCRRequest represents a Mistral OCR API request.
 type MistralOCRRequest struct {
-	Model                    string                 `json:"model"`
-	ID                       string                 `json:"id,omitempty"`
-	Document                 MistralOCRDocument     `json:"document"`
-	IncludeImageBase64       *bool                  `json:"include_image_base64,omitempty"`
-	IncludeBlocks            *bool                  `json:"include_blocks,omitempty"`
-	Pages                    []int                  `json:"pages,omitempty"`
-	ImageLimit               *int                   `json:"image_limit,omitempty"`
-	ImageMinSize             *int                   `json:"image_min_size,omitempty"`
-	TableFormat              *string                `json:"table_format,omitempty"`
-	ExtractHeader            *bool                  `json:"extract_header,omitempty"`
-	ExtractFooter            *bool                  `json:"extract_footer,omitempty"`
-	BBoxAnnotationFormat     *string                `json:"bbox_annotation_format,omitempty"`
-	DocumentAnnotationFormat *string                `json:"document_annotation_format,omitempty"`
-	DocumentAnnotationPrompt *string                `json:"document_annotation_prompt,omitempty"`
-	ExtraParams              map[string]interface{} `json:"-"`
+	Model                       string                 `json:"model"`
+	ID                          string                 `json:"id,omitempty"`
+	Document                    MistralOCRDocument     `json:"document"`
+	IncludeImageBase64          *bool                  `json:"include_image_base64,omitempty"`
+	IncludeBlocks               *bool                  `json:"include_blocks,omitempty"`
+	Pages                       []int                  `json:"pages,omitempty"`
+	ImageLimit                  *int                   `json:"image_limit,omitempty"`
+	ImageMinSize                *int                   `json:"image_min_size,omitempty"`
+	TableFormat                 *string                `json:"table_format,omitempty"`
+	ExtractHeader               *bool                  `json:"extract_header,omitempty"`
+	ExtractFooter               *bool                  `json:"extract_footer,omitempty"`
+	ConfidenceScoresGranularity *string                `json:"confidence_scores_granularity,omitempty"`
+	BBoxAnnotationFormat        *string                `json:"bbox_annotation_format,omitempty"`
+	DocumentAnnotationFormat    *string                `json:"document_annotation_format,omitempty"`
+	DocumentAnnotationPrompt    *string                `json:"document_annotation_prompt,omitempty"`
+	ExtraParams                 map[string]interface{} `json:"-"`
 }
 
 // MistralOCRPageImage represents an extracted image in Mistral's OCR response.

--- a/core/schemas/ocr.go
+++ b/core/schemas/ocr.go
@@ -19,18 +19,19 @@ type OCRDocument struct {
 
 // OCRParameters contains optional parameters for an OCR request.
 type OCRParameters struct {
-	IncludeImageBase64       *bool                  `json:"include_image_base64,omitempty"`
-	IncludeBlocks            *bool                  `json:"include_blocks,omitempty"`
-	Pages                    []int                  `json:"pages,omitempty"`
-	ImageLimit               *int                   `json:"image_limit,omitempty"`
-	ImageMinSize             *int                   `json:"image_min_size,omitempty"`
-	TableFormat              *string                `json:"table_format,omitempty"`
-	ExtractHeader            *bool                  `json:"extract_header,omitempty"`
-	ExtractFooter            *bool                  `json:"extract_footer,omitempty"`
-	BBoxAnnotationFormat     *string                `json:"bbox_annotation_format,omitempty"`
-	DocumentAnnotationFormat *string                `json:"document_annotation_format,omitempty"`
-	DocumentAnnotationPrompt *string                `json:"document_annotation_prompt,omitempty"`
-	ExtraParams              map[string]interface{} `json:"-"`
+	IncludeImageBase64          *bool                  `json:"include_image_base64,omitempty"`
+	IncludeBlocks               *bool                  `json:"include_blocks,omitempty"`
+	Pages                       []int                  `json:"pages,omitempty"`
+	ImageLimit                  *int                   `json:"image_limit,omitempty"`
+	ImageMinSize                *int                   `json:"image_min_size,omitempty"`
+	TableFormat                 *string                `json:"table_format,omitempty"`
+	ExtractHeader               *bool                  `json:"extract_header,omitempty"`
+	ExtractFooter               *bool                  `json:"extract_footer,omitempty"`
+	ConfidenceScoresGranularity *string                `json:"confidence_scores_granularity,omitempty"`
+	BBoxAnnotationFormat        *string                `json:"bbox_annotation_format,omitempty"`
+	DocumentAnnotationFormat    *string                `json:"document_annotation_format,omitempty"`
+	DocumentAnnotationPrompt    *string                `json:"document_annotation_prompt,omitempty"`
+	ExtraParams                 map[string]interface{} `json:"-"`
 }
 
 // BifrostOCRRequest represents a request to perform OCR on a document.

--- a/core/schemas/ocr.go
+++ b/core/schemas/ocr.go
@@ -75,7 +75,9 @@ type OCRPage struct {
 	// Blocks carries provider-native layout blocks (currently Mistral only,
 	// populated when the request sets include_blocks=true). Kept as raw JSON
 	// values so any provider-side schema addition passes through unchanged.
-	Blocks []any `json:"blocks,omitempty"`
+	// Pointer so an explicitly empty `blocks: []` round-trips as [] instead of
+	// being dropped by omitempty — the field's presence is part of the contract.
+	Blocks *[]any `json:"blocks,omitempty"`
 }
 
 // OCRUsageInfo represents usage information from an OCR response.

--- a/core/schemas/ocr.go
+++ b/core/schemas/ocr.go
@@ -73,11 +73,9 @@ type OCRPage struct {
 	Markdown   string             `json:"markdown"`
 	Images     []OCRPageImage     `json:"images,omitempty"`
 	Dimensions *OCRPageDimensions `json:"dimensions,omitempty"`
-	// Blocks carries provider-native layout blocks (currently Mistral only,
-	// populated when the request sets include_blocks=true). Kept as raw JSON
-	// values so any provider-side schema addition passes through unchanged.
-	// Pointer so an explicitly empty `blocks: []` round-trips as [] instead of
-	// being dropped by omitempty — the field's presence is part of the contract.
+	// Provider-native layout blocks, present when the request sets
+	// include_blocks=true; pointer so an explicitly empty `blocks: []`
+	// isn't dropped by omitempty.
 	Blocks *[]any `json:"blocks,omitempty"`
 }
 

--- a/core/schemas/ocr.go
+++ b/core/schemas/ocr.go
@@ -19,17 +19,18 @@ type OCRDocument struct {
 
 // OCRParameters contains optional parameters for an OCR request.
 type OCRParameters struct {
-	IncludeImageBase64          *bool                  `json:"include_image_base64,omitempty"`
-	Pages                       []int                  `json:"pages,omitempty"`
-	ImageLimit                  *int                   `json:"image_limit,omitempty"`
-	ImageMinSize                *int                   `json:"image_min_size,omitempty"`
-	TableFormat                 *string                `json:"table_format,omitempty"`
-	ExtractHeader               *bool                  `json:"extract_header,omitempty"`
-	ExtractFooter               *bool                  `json:"extract_footer,omitempty"`
-	BBoxAnnotationFormat        *string                `json:"bbox_annotation_format,omitempty"`
-	DocumentAnnotationFormat    *string                `json:"document_annotation_format,omitempty"`
-	DocumentAnnotationPrompt    *string                `json:"document_annotation_prompt,omitempty"`
-	ExtraParams                 map[string]interface{} `json:"-"`
+	IncludeImageBase64       *bool                  `json:"include_image_base64,omitempty"`
+	IncludeBlocks            *bool                  `json:"include_blocks,omitempty"`
+	Pages                    []int                  `json:"pages,omitempty"`
+	ImageLimit               *int                   `json:"image_limit,omitempty"`
+	ImageMinSize             *int                   `json:"image_min_size,omitempty"`
+	TableFormat              *string                `json:"table_format,omitempty"`
+	ExtractHeader            *bool                  `json:"extract_header,omitempty"`
+	ExtractFooter            *bool                  `json:"extract_footer,omitempty"`
+	BBoxAnnotationFormat     *string                `json:"bbox_annotation_format,omitempty"`
+	DocumentAnnotationFormat *string                `json:"document_annotation_format,omitempty"`
+	DocumentAnnotationPrompt *string                `json:"document_annotation_prompt,omitempty"`
+	ExtraParams              map[string]interface{} `json:"-"`
 }
 
 // BifrostOCRRequest represents a request to perform OCR on a document.
@@ -50,12 +51,12 @@ func (r *BifrostOCRRequest) GetRawRequestBody() []byte {
 
 // OCRPageImage represents an extracted image from an OCR page.
 type OCRPageImage struct {
-	ID            string  `json:"id"`
-	TopLeftX      float64 `json:"top_left_x"`
-	TopLeftY      float64 `json:"top_left_y"`
-	BottomRightX  float64 `json:"bottom_right_x"`
-	BottomRightY  float64 `json:"bottom_right_y"`
-	ImageBase64   *string `json:"image_base64,omitempty"`
+	ID           string  `json:"id"`
+	TopLeftX     float64 `json:"top_left_x"`
+	TopLeftY     float64 `json:"top_left_y"`
+	BottomRightX float64 `json:"bottom_right_x"`
+	BottomRightY float64 `json:"bottom_right_y"`
+	ImageBase64  *string `json:"image_base64,omitempty"`
 }
 
 // OCRPageDimensions represents the dimensions of an OCR page.
@@ -71,6 +72,10 @@ type OCRPage struct {
 	Markdown   string             `json:"markdown"`
 	Images     []OCRPageImage     `json:"images,omitempty"`
 	Dimensions *OCRPageDimensions `json:"dimensions,omitempty"`
+	// Blocks carries provider-native layout blocks (currently Mistral only,
+	// populated when the request sets include_blocks=true). Kept as raw JSON
+	// values so any provider-side schema addition passes through unchanged.
+	Blocks []any `json:"blocks,omitempty"`
 }
 
 // OCRUsageInfo represents usage information from an OCR response.
@@ -83,9 +88,9 @@ type OCRUsageInfo struct {
 
 // BifrostOCRResponse represents the response from an OCR request.
 type BifrostOCRResponse struct {
-	Model               string                     `json:"model"`
-	Pages               []OCRPage                  `json:"pages"`
-	UsageInfo           *OCRUsageInfo              `json:"usage_info,omitempty"`
-	DocumentAnnotation  *string                    `json:"document_annotation,omitempty"`
-	ExtraFields         BifrostResponseExtraFields `json:"extra_fields"`
+	Model              string                     `json:"model"`
+	Pages              []OCRPage                  `json:"pages"`
+	UsageInfo          *OCRUsageInfo              `json:"usage_info,omitempty"`
+	DocumentAnnotation *string                    `json:"document_annotation,omitempty"`
+	ExtraFields        BifrostResponseExtraFields `json:"extra_fields"`
 }

--- a/docs/openapi/schemas/inference/ocr.yaml
+++ b/docs/openapi/schemas/inference/ocr.yaml
@@ -201,9 +201,8 @@ OCRPage:
       $ref: "#/OCRPageDimensions"
     blocks:
       type: array
-      description: Provider-native layout blocks (present when the request sets include_blocks=true). Currently populated by Mistral; opaque structure preserved verbatim.
-      items:
-        type: object
+      description: Provider-native layout blocks (present when the request sets include_blocks=true, possibly empty). Currently populated by Mistral; opaque structure preserved verbatim, so item schemas are unconstrained.
+      items: {}
     tables:
       type: array
       description: Tables extracted from this page (present when table_format is set)

--- a/docs/openapi/schemas/inference/ocr.yaml
+++ b/docs/openapi/schemas/inference/ocr.yaml
@@ -23,6 +23,9 @@ OCRRequest:
     include_image_base64:
       type: boolean
       description: Whether to include base64-encoded images in the response
+    include_blocks:
+      type: boolean
+      description: Whether to include provider-native layout blocks (Mistral). Populates pages[].blocks.
     pages:
       type: array
       items:
@@ -196,6 +199,11 @@ OCRPage:
         $ref: "#/OCRPageImage"
     dimensions:
       $ref: "#/OCRPageDimensions"
+    blocks:
+      type: array
+      description: Provider-native layout blocks (present when the request sets include_blocks=true). Currently populated by Mistral; opaque structure preserved verbatim.
+      items:
+        type: object
     tables:
       type: array
       description: Tables extracted from this page (present when table_format is set)

--- a/docs/providers/supported-providers/mistral.mdx
+++ b/docs/providers/supported-providers/mistral.mdx
@@ -313,6 +313,7 @@ Mistral provides native OCR support for extracting text and content from documen
 | `model`                      | OCR model name (e.g., `mistral/mistral-ocr-latest`)        |
 | `document`                   | Document input - see document types below                  |
 | `include_image_base64`       | Return extracted images as base64                          |
+| `include_blocks`             | Return provider-native layout blocks in `pages[].blocks`   |
 | `pages`                      | Specific page indices to process (0-based)                 |
 | `image_limit`                | Max images to extract per page                             |
 | `image_min_size`             | Minimum image size in pixels to extract                    |

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -225,6 +225,7 @@ var ocrParamsKnownFields = map[string]bool{
 	"document":                   true,
 	"fallbacks":                  true,
 	"include_image_base64":       true,
+	"include_blocks":             true,
 	"pages":                      true,
 	"image_limit":                true,
 	"image_min_size":             true,

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -220,21 +220,22 @@ var rerankParamsKnownFields = map[string]bool{
 }
 
 var ocrParamsKnownFields = map[string]bool{
-	"model":                      true,
-	"id":                         true,
-	"document":                   true,
-	"fallbacks":                  true,
-	"include_image_base64":       true,
-	"include_blocks":             true,
-	"pages":                      true,
-	"image_limit":                true,
-	"image_min_size":             true,
-	"table_format":               true,
-	"extract_header":             true,
-	"extract_footer":             true,
-	"bbox_annotation_format":     true,
-	"document_annotation_format": true,
-	"document_annotation_prompt": true,
+	"model":                         true,
+	"id":                            true,
+	"document":                      true,
+	"fallbacks":                     true,
+	"include_image_base64":          true,
+	"include_blocks":                true,
+	"pages":                         true,
+	"image_limit":                   true,
+	"image_min_size":                true,
+	"table_format":                  true,
+	"extract_header":                true,
+	"extract_footer":                true,
+	"confidence_scores_granularity": true,
+	"bbox_annotation_format":        true,
+	"document_annotation_format":    true,
+	"document_annotation_prompt":    true,
 }
 
 var speechParamsKnownFields = map[string]bool{


### PR DESCRIPTION
## Description

Fixes maximhq/bifrost#5137. The native Mistral provider silently dropped `include_blocks` on `POST /v1/ocr`, so callers that relied on layout blocks (page segmentation, table-region joins) got empty `pages[].blocks` on Bifrost while the same request against Mistral (or a raw passthrough) returned the populated blocks.

Root cause spans both directions:

1. **Request path** — `include_blocks` was missing from `schemas.OCRParameters`, `mistral.MistralOCRRequest`, `ToMistralOCRRequest`, and the transport whitelist `ocrParamsKnownFields`. The flag was stripped before reaching Mistral.
2. **Response path** — even if the request had been forwarded, neither `OCRPage` nor `MistralOCRPage` had a `blocks` field, so the JSON decoder would have discarded whatever Mistral returned.

Both are fixed here in a single change.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Affected packages

* `core/schemas` — add `IncludeBlocks *bool` to `OCRParameters`; add `Blocks []any` to `OCRPage`
* `core/providers/mistral` — add same fields to `MistralOCRRequest` / `MistralOCRPage`, wire both directions in `ToMistralOCRRequest` and `ToBifrostOCRResponse`
* `transports/bifrost-http/handlers` — add `include_blocks` to `ocrParamsKnownFields`
* `docs` — document `include_blocks` in the OpenAPI schema and Mistral provider page, add `blocks` to the OCR response schema

## Design note

`Blocks` is typed as `[]any` (opaque JSON) rather than a concrete struct. Mistral's block schema evolves (block types, bbox variants, metadata) and none of it is Bifrost-specific — pass-through preserves fidelity without coupling Bifrost releases to Mistral schema drift.

## Changes made

* `IncludeBlocks *bool` field forwarded through Bifrost → Mistral request
* `Blocks []any` field carried through Mistral → Bifrost response
* `include_blocks` added to the transport OCR whitelist so it binds to the typed field instead of falling into `ExtraParams`
* Request converter test and response converter test cover both directions
* OpenAPI schema (`docs/openapi/schemas/inference/ocr.yaml`) and Mistral provider docs updated
* Changelog entries in `core/changelog.md` and `transports/changelog.md`

## Testing

- [X] `go test ./providers/mistral/... ./schemas/...` (core) — pass
- [X] `go test ./bifrost-http/handlers/...` (transports) — pass
- [X] `gofmt -s -w` clean on all touched files

Ran inside the same `golang:1.26.4-alpine3.23` image used by `transports/Dockerfile`.

## Checklist

- [X] Follows repo code conventions (`gofmt` clean, doc comments on exported fields)
- [X] Tests added for both request and response conversion
- [X] Docs updated (OpenAPI + Mistral provider page)
- [X] Changelog entries at the top of `core/changelog.md` and `transports/changelog.md`
- [X] Commit message follows the conventional format used on `dev`

## Related issues

Closes maximhq/bifrost#5137