### PR TITLE
feat: add per-alias `ProjectID` override for Bedrock, Bedrock Mantle, and Vertex providers

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -723,7 +723,7 @@ func (provider *BedrockProvider) listMantleModels(ctx *schemas.BifrostContext, k
 		provider.logger.Warn("failed to build mantle list-models request: %v", err)
 		return nil
 	}
-	providerUtils.SetExtraHeadersHTTP(ctx, req, WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(key)), nil)
+	providerUtils.SetExtraHeadersHTTP(ctx, req, WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)), nil)
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else if bifrostErr := signAWSRequest(ctx, req, key.BedrockKeyConfig, region, bedrockMantleSigningService); bifrostErr != nil {

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -39,15 +39,6 @@ func WithMantleProject(base map[string]string, headerName, projectID string) map
 	return out
 }
 
-// resolveMantleProjectID returns the Bedrock project configured for the mantle sub-surface of the
-// Bedrock provider, or "" when none is set (AWS then routes to the account's default project).
-func resolveMantleProjectID(key schemas.Key) string {
-	if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.ProjectID != nil {
-		return key.BedrockKeyConfig.ProjectID.GetValue()
-	}
-	return ""
-}
-
 // isMantleModel reports whether a model should be routed via the Bedrock Mantle
 // OpenAI-compatible endpoint. OpenAI-family (gpt-*) and Gemma 4 models are mantle-only
 // (they have no Converse equivalent). Gemma 3 is intentionally excluded: it only supports
@@ -166,7 +157,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 		url,
 		request,
 		openai.BearerAuthHeader(key),
-		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(key)),
+		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -200,7 +191,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
-		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(key)),
+		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
@@ -241,7 +232,7 @@ func (provider *BedrockProvider) mantleResponses(
 		url,
 		request,
 		openai.BearerAuthHeader(key),
-		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(key)),
+		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -275,7 +266,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
-		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(key)),
+		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),

--- a/core/providers/bedrock/mantle_project_test.go
+++ b/core/providers/bedrock/mantle_project_test.go
@@ -1,6 +1,7 @@
 package bedrock
 
 import (
+	"context"
 	"testing"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -50,24 +51,49 @@ func TestWithMantleProject(t *testing.T) {
 	})
 }
 
-// TestResolveMantleProjectID verifies precedence of the BedrockKeyConfig.ProjectID field.
+// TestResolveMantleProjectID verifies precedence: per-alias AliasConfig.ProjectID
+// overrides the key-level BedrockKeyConfig.ProjectID.
 func TestResolveMantleProjectID(t *testing.T) {
 	tests := []struct {
-		name string
-		key  schemas.Key
-		want string
+		name  string
+		alias *schemas.AliasConfig // nil = no resolved alias in context
+		key   schemas.Key
+		want  string
 	}{
 		{name: "no bedrock config", key: schemas.Key{}, want: ""},
 		{name: "config without project", key: schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{}}, want: ""},
 		{
-			name: "config with project",
-			key:  schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{ProjectID: schemas.NewSecretVar("proj_abc")}},
-			want: "proj_abc",
+			name: "key-level project",
+			key:  schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want: "proj_key",
+		},
+		{
+			name:  "alias override wins over key",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("proj_alias")},
+			key:   schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want:  "proj_alias",
+		},
+		{
+			name:  "empty alias override falls back to key",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("")},
+			key:   schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want:  "proj_key",
+		},
+		{
+			name:  "alias override with no key config",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("proj_alias")},
+			key:   schemas.Key{},
+			want:  "proj_alias",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveMantleProjectID(tt.key); got != tt.want {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			defer ctx.Cancel()
+			if tt.alias != nil {
+				ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: "chirp", Config: tt.alias})
+			}
+			if got := resolveMantleProjectID(ctx, tt.key); got != tt.want {
 				t.Fatalf("resolveMantleProjectID = %q, want %q", got, tt.want)
 			}
 		})

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -124,7 +124,7 @@ func (provider *BedrockMantleProvider) listModelsByKey(ctx *schemas.BifrostConte
 
 	// Scope the catalog to the configured project via the OpenAI-Project header (default project
 	// when unset). It is a plain header, so it does not need to be part of the SigV4 SignedHeaders.
-	extraHeaders := bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(key))
+	extraHeaders := bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key))
 	if key.Value.GetValue() == "" {
 		// SigV4: sign the GET and overlay the signed headers; OpenAI's ListModelsByKey only sets
 		// a Bearer header when the key carries a value, so the SigV4 Authorization wins here.
@@ -186,7 +186,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
 			openai.BearerAuthHeader(key),
-			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(key))),
+			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(ctx, key))),
 			provider.mantleSigner(ctx, key, url, "application/json", region),
 			provider.logger,
 		)
@@ -199,7 +199,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 		url,
 		request,
 		openai.BearerAuthHeader(key),
-		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(key)),
+		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -239,7 +239,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 			url,
 			jsonData,
 			openai.BearerAuthHeader(key),
-			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(key))),
+			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(ctx, key))),
 			provider.networkConfig.StreamIdleTimeoutInSeconds,
 			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -256,7 +256,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
-		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(key)),
+		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
@@ -292,7 +292,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
 			openai.BearerAuthHeader(key),
-			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(key))),
+			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(ctx, key))),
 			provider.mantleSigner(ctx, key, url, "application/json", region),
 			provider.logger,
 		)
@@ -305,7 +305,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 		url,
 		request,
 		openai.BearerAuthHeader(key),
-		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(key)),
+		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -345,7 +345,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 			url,
 			jsonData,
 			openai.BearerAuthHeader(key),
-			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(key))),
+			addAnthropicHeaders(bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleAnthropicProjectHeader, resolveProjectID(ctx, key))),
 			provider.networkConfig.StreamIdleTimeoutInSeconds,
 			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -362,7 +362,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 	url := mantleOpenAIURL(region, schemas.ResolveCanonicalModel(ctx, request.Model), "responses")
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
-		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(key)),
+		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),

--- a/core/providers/bedrockmantle/project_test.go
+++ b/core/providers/bedrockmantle/project_test.go
@@ -1,30 +1,56 @@
 package bedrockmantle
 
 import (
+	"context"
 	"testing"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
-// TestResolveProjectID verifies the BedrockMantleKeyConfig.ProjectID field is honoured and that an
-// absent project resolves to "" (AWS default project).
+// TestResolveProjectID verifies precedence: per-alias AliasConfig.ProjectID overrides the
+// key-level BedrockMantleKeyConfig.ProjectID, and an absent project resolves to "" (AWS
+// default project).
 func TestResolveProjectID(t *testing.T) {
 	tests := []struct {
-		name string
-		key  schemas.Key
-		want string
+		name  string
+		alias *schemas.AliasConfig // nil = no resolved alias in context
+		key   schemas.Key
+		want  string
 	}{
 		{name: "no mantle config", key: schemas.Key{}, want: ""},
 		{name: "config without project", key: schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{}}, want: ""},
 		{
-			name: "config with project",
-			key:  schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{ProjectID: schemas.NewSecretVar("proj_xyz")}},
-			want: "proj_xyz",
+			name: "key-level project",
+			key:  schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want: "proj_key",
+		},
+		{
+			name:  "alias override wins over key",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("proj_alias")},
+			key:   schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want:  "proj_alias",
+		},
+		{
+			name:  "empty alias override falls back to key",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("")},
+			key:   schemas.Key{BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{ProjectID: schemas.NewSecretVar("proj_key")}},
+			want:  "proj_key",
+		},
+		{
+			name:  "alias override with no key config",
+			alias: &schemas.AliasConfig{ModelID: "chirp", ProjectID: schemas.NewSecretVar("proj_alias")},
+			key:   schemas.Key{},
+			want:  "proj_alias",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveProjectID(tt.key); got != tt.want {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			defer ctx.Cancel()
+			if tt.alias != nil {
+				ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{Key: "chirp", Config: tt.alias})
+			}
+			if got := resolveProjectID(ctx, tt.key); got != tt.want {
 				t.Fatalf("resolveProjectID = %q, want %q", got, tt.want)
 			}
 		})

--- a/core/providers/bedrockmantle/utils.go
+++ b/core/providers/bedrockmantle/utils.go
@@ -26,10 +26,17 @@ func addAnthropicHeaders(headers map[string]string) map[string]string {
 	return out
 }
 
-// resolveProjectID returns the Bedrock project configured for this key, or "" when none is set
+// resolveProjectID returns the Bedrock project configured for this attempt, or "" when none is set
 // (AWS then routes to the account's default project). The value is sent as the OpenAI-Project or
 // anthropic-workspace-id header depending on the request surface.
-func resolveProjectID(key schemas.Key) string {
+// Priority: per-alias AliasConfig.ProjectID > key-level BedrockMantleKeyConfig.ProjectID. The
+// per-alias override lets one credential scope different aliased models to different projects.
+func resolveProjectID(ctx *schemas.BifrostContext, key schemas.Key) string {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.ProjectID != nil {
+		if v := ra.Config.ProjectID.GetValue(); v != "" {
+			return v
+		}
+	}
 	if key.BedrockMantleKeyConfig != nil && key.BedrockMantleKeyConfig.ProjectID != nil {
 		return key.BedrockMantleKeyConfig.ProjectID.GetValue()
 	}

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -15,9 +15,19 @@ import (
 // span deployments across distinct GCP projects (e.g. Anthropic models in
 // one project, Gemini in another).
 func resolveVertexProjectID(ctx *schemas.BifrostContext, key schemas.Key) string {
-	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.VertexAliasCfg != nil && ra.Config.VertexAliasCfg.ProjectID != nil {
-		if v := ra.Config.VertexAliasCfg.ProjectID.GetValue(); v != "" {
-			return v
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil {
+		// Shared top-level override (how project_id now arrives from JSON/UI).
+		if ra.Config.ProjectID != nil {
+			if v := ra.Config.ProjectID.GetValue(); v != "" {
+				return v
+			}
+		}
+		// Back-compat for Go-constructed VertexAliasCfg (e.g. tests); the JSON
+		// path always populates the top-level field above.
+		if ra.Config.VertexAliasCfg != nil && ra.Config.VertexAliasCfg.ProjectID != nil {
+			if v := ra.Config.VertexAliasCfg.ProjectID.GetValue(); v != "" {
+				return v
+			}
 		}
 	}
 	if key.VertexKeyConfig != nil {

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -189,8 +189,15 @@ type AzureAliasCfg struct {
 }
 
 // VertexAliasCfg holds Vertex-specific overrides that apply to a single alias.
+//
+// Deprecated for ProjectID: the per-alias project override now lives on the
+// shared top-level AliasConfig.ProjectID field (see below), so one alias key can
+// scope any provider (Vertex, Bedrock, Bedrock Mantle) to a project without a
+// JSON field-name collision between the embedded sub-configs. ProjectID is kept
+// here only so Go code that constructs VertexAliasCfg directly keeps compiling;
+// the Vertex resolver reads AliasConfig.ProjectID first and falls back to this.
 type VertexAliasCfg struct {
-	ProjectID         *SecretVar `json:"project_id,omitempty"`
+	ProjectID         *SecretVar `json:"-"` // superseded by AliasConfig.ProjectID; not (de)serialized to avoid colliding with the top-level project_id
 	ProjectNumber     *SecretVar `json:"project_number,omitempty"`
 	ForceSingleRegion *bool      `json:"force_single_region,omitempty"`
 }
@@ -216,6 +223,13 @@ type AliasConfig struct {
 	ModelFamily *ModelFamily `json:"model_family,omitempty"` // 1st-tier family routing enum
 	Description string       `json:"description,omitempty"`  // description of the alias for users to understand its purpose (not used by bifrost)
 	Region      *SecretVar   `json:"region,omitempty"`
+	// ProjectID is a per-alias project override shared across providers (like Region).
+	// Vertex uses it as the GCP project; Bedrock and Bedrock Mantle use it as the
+	// AWS project sent via the OpenAI-Project / anthropic-workspace-id header. Kept
+	// top-level (rather than inside each provider sub-config) so the flat "project_id"
+	// JSON key does not collide between embedded sub-configs — Go/sonic silently drop
+	// a field name shared by multiple same-depth anonymous structs.
+	ProjectID *SecretVar `json:"project_id,omitempty"`
 
 	*AzureAliasCfg
 	*VertexAliasCfg
@@ -232,6 +246,7 @@ func (ac AliasConfig) isLegacyShape() bool {
 		ac.ModelFamily == nil &&
 		ac.Description == "" &&
 		ac.Region == nil &&
+		ac.ProjectID == nil &&
 		ac.AzureAliasCfg == nil &&
 		ac.VertexAliasCfg == nil &&
 		ac.BedrockAliasCfg == nil &&
@@ -243,6 +258,14 @@ func (ac AliasConfig) isLegacyShape() bool {
 // change on the wire. When any other field is populated, the full object is
 // emitted.
 func (ac AliasConfig) MarshalJSON() ([]byte, error) {
+	// The deprecated VertexAliasCfg.ProjectID is json:"-" (it would otherwise collide
+	// with the top-level project_id on the wire). Promote it to the shared top-level
+	// ProjectID before serializing so Go-constructed aliases that set only the legacy
+	// field don't lose their project on a save/export round-trip (or drop it from the
+	// config hash). Value receiver: this mutates only the local copy, not the caller's.
+	if ac.ProjectID == nil && ac.VertexAliasCfg != nil && ac.VertexAliasCfg.ProjectID != nil {
+		ac.ProjectID = ac.VertexAliasCfg.ProjectID
+	}
 	if ac.isLegacyShape() {
 		return Marshal(ac.ModelID)
 	}

--- a/core/schemas/account_test.go
+++ b/core/schemas/account_test.go
@@ -52,6 +52,71 @@ func TestKeyAliasesUnmarshalRichShape(t *testing.T) {
 	}
 }
 
+// TestKeyAliasesProjectIDFlatRoundTrip verifies the per-alias project_id override is a single
+// top-level field: it deserializes from the flat {"model_id":..., "project_id":{...}} shape,
+// round-trips byte-stably, and (critically) is NOT dropped by an embedded-field name collision.
+// project_id lives on AliasConfig itself (like region) rather than inside each provider sub-config
+// precisely so multiple same-depth promoted fields don't silently cancel each other out.
+func TestKeyAliasesProjectIDFlatRoundTrip(t *testing.T) {
+	in := []byte(`{"chirp-alias":{"model_id":"chirp","project_id":{"value":"proj_elvsngya7ixv4dkb26xe","type":"plain_text"}}}`)
+	var ka KeyAliases
+	if err := json.Unmarshal(in, &ka); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := ka["chirp-alias"]
+	if got.ModelID != "chirp" {
+		t.Fatalf("ModelID mismatch: %q", got.ModelID)
+	}
+	if got.ProjectID == nil {
+		t.Fatalf("ProjectID was dropped on unmarshal (embedded field collision regression?)")
+	}
+	if v := got.ProjectID.GetValue(); v != "proj_elvsngya7ixv4dkb26xe" {
+		t.Fatalf("ProjectID value mismatch: %q", v)
+	}
+	out, err := json.Marshal(ka)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Re-unmarshal and compare structurally (map key order in the SecretVar object is not stable).
+	var back KeyAliases
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if bp := back["chirp-alias"].ProjectID; bp == nil || bp.GetValue() != "proj_elvsngya7ixv4dkb26xe" {
+		t.Fatalf("ProjectID did not survive marshal round-trip: %s", out)
+	}
+	// project_id alone (besides model_id) must force the rich object shape, not the legacy string.
+	if len(out) == 0 || !strings.Contains(string(out), `"project_id"`) {
+		t.Fatalf("expected project_id in serialized output, got %s", out)
+	}
+}
+
+// TestKeyAliasesLegacyVertexProjectIDPromotedOnMarshal guards the back-compat
+// shim: a Go-constructed alias that sets only the deprecated VertexAliasCfg.ProjectID
+// (json:"-") must not lose its project on a marshal/unmarshal round-trip. MarshalJSON
+// promotes it to the top-level project_id so it survives persistence and the config hash.
+func TestKeyAliasesLegacyVertexProjectIDPromotedOnMarshal(t *testing.T) {
+	ka := KeyAliases{"vtx-alias": {
+		ModelID:        "gemini-2.0-flash-001",
+		VertexAliasCfg: &VertexAliasCfg{ProjectID: NewSecretVar("legacy-gcp-project")},
+	}}
+	out, err := json.Marshal(ka)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"project_id"`) {
+		t.Fatalf("expected legacy VertexAliasCfg.ProjectID promoted to top-level project_id, got %s", out)
+	}
+	var back KeyAliases
+	if err := json.Unmarshal(out, &back); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	bp := back["vtx-alias"].ProjectID
+	if bp == nil || bp.GetValue() != "legacy-gcp-project" {
+		t.Fatalf("legacy Vertex project did not survive round-trip: %s", out)
+	}
+}
+
 func TestKeyAliasesUnmarshalMixedShape(t *testing.T) {
 	in := []byte(`{
         "legacy":  "gpt-4-deployment",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3654,7 +3654,7 @@
                   },
                   "project_id": {
                     "type": "string",
-                    "description": "Per-alias Vertex project ID override (can use env. prefix)."
+                    "description": "Per-alias project override shared across providers: Vertex uses it as the GCP project; Bedrock and Bedrock Mantle send it as the AWS project via the OpenAI-Project / anthropic-workspace-id header (can use env. prefix)."
                   },
                   "project_number": {
                     "type": "string",


### PR DESCRIPTION
## Summary

Adds a shared, top-level `project_id` field to `AliasConfig` that lets a single alias scope any provider (Vertex, Bedrock, Bedrock Mantle) to a specific project. Previously, Vertex had its own `VertexAliasCfg.ProjectID` and Bedrock/Bedrock Mantle had no per-alias project override at all. Because Go/sonic silently drop fields shared by multiple same-depth embedded structs, a provider-neutral `project_id` could not live inside each sub-config — it now lives directly on `AliasConfig` (alongside `Region`), mirroring how region overrides already work.

## Changes

- Added `ProjectID *SecretVar` to `AliasConfig` as a top-level field (`json:"project_id"`), shared across all providers.
- `VertexAliasCfg.ProjectID` is now tagged `json:"-"` (kept for Go backward-compat only); `resolveVertexProjectID` reads `AliasConfig.ProjectID` first and falls back to `VertexAliasCfg.ProjectID`.
- `resolveMantleProjectID` (Bedrock) and `resolveProjectID` (Bedrock Mantle) now accept a `*BifrostContext` and check the resolved alias's `ProjectID` before falling back to the key-level config, enabling per-alias project routing for Bedrock surfaces.
- `isLegacyShape` updated to treat a non-nil `ProjectID` as a rich alias shape.
- Tests extended to cover alias-override-wins, empty-alias-falls-back-to-key, and alias-with-no-key-config scenarios, as well as a JSON round-trip test confirming the flat `project_id` field survives marshal/unmarshal without being dropped by an embedded-field collision.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./core/providers/bedrockmantle/... ./core/providers/vertex/... ./core/schemas/...
```

Configure an alias with a `project_id` override and verify that requests to Bedrock, Bedrock Mantle, and Vertex carry the alias-level project rather than the key-level default. Confirm that an alias with an empty `project_id` correctly falls back to the key-level project.

## Breaking changes

- [x] Yes
- [ ] No

`VertexAliasCfg.ProjectID` is no longer serialized to/from JSON (`json:"-"`). Any configuration that set `project_id` inside a `VertexAliasCfg` JSON block will no longer be read from that location. Migrate by moving `project_id` to the top-level alias object (e.g. `{"model_id": "...", "project_id": {...}}`), which is the shape now produced and consumed by all providers.

## Related issues

## Security considerations

`ProjectID` values follow the existing `SecretVar` pattern and are resolved at request time the same way region and key values are, with no additional exposure surface.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable