### PR TITLE
feat: add `BedrockMantleSection` UI component and `project_id` override for Bedrock deployments

### DIFF
--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -232,6 +232,41 @@ function BedrockSection({ config, onChange, disabled }: ProviderSectionProps) {
 					disabled={disabled}
 				/>
 			</FieldRow>
+			<FieldRow label="Project ID" hint="Scope this deployment's Bedrock Mantle (gpt-*/Gemma) calls to a specific project via the OpenAI-Project header. Leave blank to use the key's project.">
+				<SecretVarField
+					value={config.project_id}
+					onChange={(v) => onChange({ project_id: v })}
+					placeholder="proj_xxxxxxxx or env.BEDROCK_PROJECT_ID"
+					disabled={disabled}
+				/>
+			</FieldRow>
+		</div>
+	);
+}
+
+function BedrockMantleSection({ config, onChange, disabled }: ProviderSectionProps) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader
+				title="Bedrock Mantle overrides"
+				description="Override key-level Bedrock Mantle defaults for this deployment. Leave blank to use the key's settings."
+			/>
+			<FieldRow label="Region">
+				<SecretVarField
+					value={config.region}
+					onChange={(v) => onChange({ region: v })}
+					placeholder="us-east-1 or env.BEDROCK_REGION"
+					disabled={disabled}
+				/>
+			</FieldRow>
+			<FieldRow label="Project ID" hint="Scope this deployment to a specific project via the OpenAI-Project / anthropic-workspace-id header. Leave blank to use the key's project.">
+				<SecretVarField
+					value={config.project_id}
+					onChange={(v) => onChange({ project_id: v })}
+					placeholder="proj_xxxxxxxx or env.BEDROCK_PROJECT_ID"
+					disabled={disabled}
+				/>
+			</FieldRow>
 		</div>
 	);
 }
@@ -265,6 +300,8 @@ function ProviderSection({ providerName, ...props }: ProviderSectionProps & { pr
 			return <VertexSection {...props} />;
 		case "bedrock":
 			return <BedrockSection {...props} />;
+		case "bedrock_mantle":
+			return <BedrockMantleSection {...props} />;
 		case "replicate":
 			return <ReplicateSection {...props} />;
 		default:

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -62,8 +62,11 @@ export interface AliasConfig {
 	api_version?: string;
 	anthropic_version?: string;
 	endpoint?: SecretVar;
-	// Vertex overrides
+	// Shared per-alias project override (Vertex GCP project; Bedrock / Bedrock Mantle
+	// project sent via OpenAI-Project / anthropic-workspace-id). Kept top-level in Go
+	// so the flat project_id key doesn't collide across embedded sub-configs.
 	project_id?: SecretVar;
+	// Vertex overrides
 	project_number?: SecretVar;
 	force_single_region?: boolean;
 	// Bedrock overrides

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -293,8 +293,9 @@ const aliasConfigObjectSchema = z.object({
 	api_version: z.string().optional(),
 	anthropic_version: z.string().optional(),
 	endpoint: secretVarSchema.optional(),
-	// Vertex overrides
+	// Shared per-alias project override (Vertex / Bedrock / Bedrock Mantle)
 	project_id: secretVarSchema.optional(),
+	// Vertex overrides
 	project_number: secretVarSchema.optional(),
 	force_single_region: z.boolean().optional(),
 	// Bedrock overrides


### PR DESCRIPTION
## Summary

Adds UI support for a new `bedrock_mantle` provider type, including a dedicated configuration section with region and project ID overrides. Also clarifies that `project_id` is a shared per-alias field used across Vertex, Bedrock, and Bedrock Mantle providers, and adds a `project_id` field to the existing Bedrock section.

## Changes

- Added a `BedrockMantleSection` component that renders region and project ID override fields for `bedrock_mantle` deployments, mirroring the pattern used by other provider sections.
- Added a `project_id` field to the existing `BedrockSection` so Bedrock deployments can scope calls to a specific project via the `OpenAI-Project` header.
- Wired `bedrock_mantle` into the `ProviderSection` switch so the new section renders correctly.
- Updated comments in `config.ts` and `schemas.ts` to clarify that `project_id` is a shared top-level alias field used by Vertex, Bedrock, and Bedrock Mantle, avoiding confusion about its scope.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to a workspace provider deployment configuration in the UI.
2. Select `bedrock_mantle` as the provider type and confirm the **Bedrock Mantle overrides** section appears with **Region** and **Project ID** fields.
3. Select `bedrock` as the provider type and confirm the **Project ID** field appears alongside the existing fields.
4. Enter values (including `env.VAR` references) and verify they are saved and restored correctly.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the Bedrock and Bedrock Mantle deployment configuration panels._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Project ID and region values are handled via `SecretVarField`, consistent with how other sensitive deployment configuration fields are managed. No new secret storage mechanisms are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable