### PR TITLE
feat: add `postgresql.external.port` string support and `bifrost.mcp.toolGroups[*].id` to Helm chart

### DIFF
--- a/docs/changelogs/helm-v2.1.27.mdx
+++ b/docs/changelogs/helm-v2.1.27.mdx
@@ -14,5 +14,7 @@ description: "Helm v2.1.27 changelog - 2026-07-09"
 - `calendar_aligned` on `bifrost.accessProfiles[*].budgets[*]` and `bifrost.accessProfiles[*].provider_configs[*].budgets[*]` — schema previously blocked this field; now matches parity with `governance.budgets[*].calendar_aligned`.
 - `calendar_aligned` on `bifrost.governance.virtualKeys[*]` — was accepted by schema but not rendered into config. Now correctly emits `virtual_keys[*].calendar_aligned` in the generated config.
 - `bifrost.alerting` for declarative alert channels and rules. Supports `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]` (slack, microsoft_teams, pagerduty, webhook), and `rules[]` (CEL-expression-based, governance-scope-aware). Renders into `alerting`.
+- `postgresql.external.port` now accepts a string in addition to an integer, enabling env-variable substitution via `env.VAR_NAME` references when mounting port from a Kubernetes secret. Renders into `postgres_config.port`.
+- `bifrost.mcp.toolGroups[*].id` — optional integer DB ID for an existing MCP tool group. When set, the reconciler updates the group by ID instead of matching by name. Renders into `mcp.tool_groups[*].id`.
 
 </Update>

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -18,6 +18,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Added `calendar_aligned` rendering for `bifrost.governance.virtualKeys[*].calendar_aligned`. Was in schema but not rendered into config. Now emits `virtual_keys[*].calendar_aligned` in the generated config.
 - Documented `calendar_aligned` in the `bifrost.governance.budgets[*]` example. Was already schema-supported; now shown in the `values.yaml` commented example.
 - Added `bifrost.alerting` for declarative alert channels and rules. Supports `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]` (slack, microsoft_teams, pagerduty, webhook), and `rules[]` (CEL-expression-based, governance-scope-aware). Renders into `alerting`.
+- `postgresql.external.port` now accepts a string in addition to an integer, enabling env-variable substitution via `env.VAR_NAME` references when mounting port from a Kubernetes secret. Renders into `postgres_config.port`.
+- `bifrost.mcp.toolGroups[*].id` — optional integer DB ID for an existing MCP tool group. When set, the reconciler updates the group by ID instead of matching by name. Renders into `mcp.tool_groups[*].id`.
 
 ### 2.1.26
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1190,6 +1190,7 @@ false
 {{- $toolGroups := list }}
 {{- range .Values.bifrost.mcp.toolGroups }}
 {{- $group := dict "name" .name }}
+{{- if .id }}{{- $_ := set $group "id" .id }}{{- end }}
 {{- if hasKey . "enabled" }}{{- $_ := set $group "enabled" .enabled }}{{- end }}
 {{- if .description }}{{- $_ := set $group "description" .description }}{{- end }}
 {{- if .tools }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4066,9 +4066,17 @@
               "type": "string"
             },
             "port": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 65535
+              "description": "PostgreSQL port. Accepts an integer (e.g. 5432) or an env.VAR_NAME string for environment-variable substitution.",
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                {
+                  "type": "string"
+                }
+              ]
             },
             "user": {
               "type": "string"
@@ -5671,6 +5679,11 @@
     "mcpToolGroupConfig": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "DB ID of this tool group. When set, the reconciler updates the existing group with this ID rather than matching by name. Maps to mcp.tool_groups[].id in config.json."
+        },
         "name": {
           "type": "string",
           "description": "Tool group name"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -492,6 +492,14 @@ bifrost:
       #   # If a virtual key has an explicit MCP config for this server, that config takes precedence.
       #   allowOnAllVirtualKeys: false
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
+    # Assign groups of MCP tools to virtual keys / access profiles.
+    # toolGroups:
+    #   - id: 5                        # Optional: DB ID of an existing group; when set, reconciler updates it by ID instead of name
+    #     name: "Platform Tools"
+    #     enabled: true
+    #     tools:
+    #       - mcpClientName: "github"
+    #         toolNames: ["create_pull_request", "list_issues"]
     # Tool manager configuration
     toolManagerConfig:
       toolExecutionTimeout: "30s"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4611,6 +4611,11 @@
     "mcp_tool_group_config": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "DB ID of this tool group. When set, the reconciler updates the existing group with this ID rather than matching by name."
+        },
         "name": {
           "type": "string",
           "description": "Tool group name"


### PR DESCRIPTION
## Summary

Adds two new schema fields to the Bifrost Helm chart: support for string-typed PostgreSQL port values (enabling env-variable substitution from Kubernetes secrets), and an optional integer `id` field on MCP tool groups (enabling the reconciler to update existing groups by DB ID rather than matching by name).

## Changes

- `postgresql.external.port` now accepts either an integer or a string. The string form supports `env.VAR_NAME` references, allowing the port to be sourced from a Kubernetes secret at runtime. The schema was updated from a plain `integer` type to an `anyOf` combining the existing integer constraints with a string alternative.
- `bifrost.mcp.toolGroups[*].id` is a new optional integer field. When provided, the reconciler targets the existing MCP tool group with that DB ID for updates instead of performing a name-based lookup. The field is rendered into `mcp.tool_groups[*].id` in the generated config. The `_helpers.tpl` template was updated to conditionally include `id` when set.
- Both fields are documented in the `helm-v2.1.27` changelog and the chart `README.md`.
- An example `toolGroups` block with the `id` field is added to `values.yaml` comments.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Render the Helm chart and verify the new fields appear correctly
helm template bifrost ./helm-charts/bifrost \
  --set postgresql.external.port="env.POSTGRES_PORT" \
  | grep -A2 "postgres_config"

helm template bifrost ./helm-charts/bifrost \
  --set 'bifrost.mcp.toolGroups[0].id=5' \
  --set 'bifrost.mcp.toolGroups[0].name=Platform Tools' \
  | grep -A5 "tool_groups"

# Validate schema accepts string port
helm lint ./helm-charts/bifrost --set postgresql.external.port="env.POSTGRES_PORT"

# Validate schema still accepts integer port
helm lint ./helm-charts/bifrost --set postgresql.external.port=5432
```

Expected: `postgres_config.port` renders the string value as-is; `mcp.tool_groups[*].id` renders the integer when provided and is omitted when absent.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The string form of `postgresql.external.port` is intended for use with `env.VAR_NAME` references backed by Kubernetes secrets. No secret values are stored in the chart itself; the substitution occurs at runtime within the Bifrost process.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable