### PR TITLE
fix: parse `SecretVar` JSON with `ref`/`env_var` fields even when `value` is absent

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -50,7 +50,14 @@ func parseSecretRef(value string) *SecretVar {
 	}
 	if sonic.Valid([]byte(value)) {
 		valueNode, _ := sonic.Get([]byte(val), "value")
-		if valueNode.Exists() {
+		refNode, _ := sonic.Get([]byte(val), "ref")
+		typeNode, _ := sonic.Get([]byte(val), "type")
+		envVarNode, _ := sonic.Get([]byte(val), "env_var")
+		fromEnvNode, _ := sonic.Get([]byte(val), "from_env")
+		isSecretVarJSON := valueNode.Exists() ||
+			(refNode.Exists() && typeNode.Exists()) ||
+			(envVarNode.Exists() && fromEnvNode.Exists())
+		if isSecretVarJSON {
 			type secretVarCompat struct {
 				Val        string     `json:"value"`
 				Ref        string     `json:"ref"`
@@ -299,7 +306,14 @@ func (e *SecretVar) UnmarshalJSON(data []byte) error {
 	}
 	if sonic.Valid(data) {
 		valueNode, _ := sonic.Get(data, "value")
-		if valueNode.Exists() {
+		refNode, _ := sonic.Get(data, "ref")
+		typeNode, _ := sonic.Get(data, "type")
+		envVarNode, _ := sonic.Get(data, "env_var")
+		fromEnvNode, _ := sonic.Get(data, "from_env")
+		isSecretVarJSON := valueNode.Exists() ||
+			(refNode.Exists() && typeNode.Exists()) ||
+			(envVarNode.Exists() && fromEnvNode.Exists())
+		if isSecretVarJSON {
 			type secretVarCompat struct {
 				Val        string     `json:"value"`
 				Ref        string     `json:"ref"`

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -114,6 +114,68 @@ func TestSecretVar_UnmarshalJSON_BackwardCompat(t *testing.T) {
 	os.Setenv("MY_KEY", "resolved-value")
 	defer os.Unsetenv("MY_KEY")
 
+	t.Run("from_env without value field", func(t *testing.T) {
+		input := `{"env_var":"MY_KEY","from_env":true}`
+		var sv SecretVar
+		if err := sv.UnmarshalJSON([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if sv.GetRawRef() != "env.MY_KEY" {
+			t.Errorf("expected ref %q, got %q", "env.MY_KEY", sv.GetRawRef())
+		}
+		if !sv.IsFromSecret() {
+			t.Error("expected IsFromSecret=true")
+		}
+		if sv.Val != "resolved-value" {
+			t.Errorf("expected Val=%q, got %q", "resolved-value", sv.Val)
+		}
+	})
+
+	t.Run("ref+type without value field", func(t *testing.T) {
+		input := `{"ref":"env.MY_KEY","type":"env"}`
+		var sv SecretVar
+		if err := sv.UnmarshalJSON([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if sv.GetRawRef() != "env.MY_KEY" {
+			t.Errorf("expected ref %q, got %q", "env.MY_KEY", sv.GetRawRef())
+		}
+		if !sv.IsFromSecret() {
+			t.Error("expected IsFromSecret=true")
+		}
+		if sv.Val != "resolved-value" {
+			t.Errorf("expected Val=%q, got %q", "resolved-value", sv.Val)
+		}
+	})
+
+	t.Run("ref without type is treated as literal JSON, not a secret", func(t *testing.T) {
+		input := `{"ref":"project-id"}`
+		var sv SecretVar
+		if err := sv.UnmarshalJSON([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if sv.IsFromSecret() {
+			t.Error("expected IsFromSecret=false for ref-only without type")
+		}
+		if sv.Val != `{"ref":"project-id"}` {
+			t.Errorf("expected Val to be raw JSON string, got %q", sv.Val)
+		}
+	})
+
+	t.Run("env_var without from_env is treated as literal JSON, not a secret", func(t *testing.T) {
+		input := `{"env_var":"MY_KEY"}`
+		var sv SecretVar
+		if err := sv.UnmarshalJSON([]byte(input)); err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if sv.IsFromSecret() {
+			t.Error("expected IsFromSecret=false for env_var without from_env")
+		}
+		if sv.Val != `{"env_var":"MY_KEY"}` {
+			t.Errorf("expected Val to be raw JSON string, got %q", sv.Val)
+		}
+	})
+
 	t.Run("old env_var/from_env format", func(t *testing.T) {
 		input := `{"value":"my-api-key","env_var":"env.MY_KEY","from_env":true}`
 		var secretVar SecretVar
@@ -218,6 +280,22 @@ func TestNewSecretVar_SecretVarReference(t *testing.T) {
 				t.Errorf("Expected IsFromSecret()=%v, got %v", tt.expectedFromSecret, secretVar.IsFromSecret())
 			}
 		})
+	}
+}
+
+func TestNewSecretVar_FromEnvWithoutValueField(t *testing.T) {
+	os.Setenv("MY_KEY", "resolved-value")
+	defer os.Unsetenv("MY_KEY")
+
+	sv := NewSecretVar(`{"env_var":"MY_KEY","from_env":true}`)
+	if sv.GetRawRef() != "env.MY_KEY" {
+		t.Errorf("expected ref %q, got %q", "env.MY_KEY", sv.GetRawRef())
+	}
+	if !sv.IsFromSecret() {
+		t.Error("expected IsFromSecret=true")
+	}
+	if sv.Val != "resolved-value" {
+		t.Errorf("expected Val=%q, got %q", "resolved-value", sv.Val)
 	}
 }
 


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


