### PR TITLE
chore: test fixes

### DIFF
--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -17074,6 +17074,7 @@ func getSchemaTypeMappings() []schemaTypeMapping {
 var enterpriseSchemaPaths = map[string]bool{
 	"$schema":                    true,
 	"access_profiles":            true,
+	"alerting":                   true,
 	"audit_logs":                 true,
 	"circuit_breaker_config":     true,
 	"cluster_config":             true,
@@ -17470,6 +17471,7 @@ func TestConfigSchemaSyncTopLevel(t *testing.T) {
 	enterpriseSchemaFields := map[string]bool{
 		"$schema":                    true,
 		"access_profiles":            true,
+		"alerting":                   true,
 		"audit_logs":                 true,
 		"circuit_breaker_config":     true,
 		"cluster_config":             true,


### PR DESCRIPTION
## Summary

Adds `alerting` to the list of enterprise schema fields recognized in the HTTP transport config schema tests, ensuring it is correctly classified as an enterprise-level configuration path.

## Changes

- Added `alerting` to the `enterpriseSchemaPaths` map and the `enterpriseSchemaFields` map in the config schema sync test, so that the `alerting` top-level field is properly validated as an enterprise schema field.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/...
```

The `TestConfigSchemaSyncTopLevel` test should pass with `alerting` recognized as an enterprise schema field.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects schema classification in tests.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable