### PR TITLE
chore: additional harness tests

### DIFF
--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -42,7 +42,7 @@ Sources:
 - [ ] **Service tier** (`service_tier: "scale" | "default" | "priority"`)
 - [ ] **Audio input** (`input_audio` content block, gpt-4o-audio-preview)
 - [ ] **Audio output** (`modalities: ["text","audio"], audio: {voice, format}`)
-- [ ] **Web search options** (`web_search_options` for chat-completions web search)
+- [x] **Web search options** (`web_search_options` for chat-completions web search)
 - [ ] **Predicted outputs** (`prediction: { type: "content", content: "..." }`)
 - [ ] **Store + metadata for evals** (`store: true, metadata: {...}`)
 

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -37545,6 +37545,271 @@
           }
         }
       ]
+    },
+    {
+      "name": "22. Gemini web_search_options → googleSearch (PR #5139)",
+      "description": "PR #5139: OpenAI `web_search_options` on /v1/chat/completions is mapped to a Gemini GoogleSearch tool, and Gemini groundingMetadata is converted back into OpenAI-compatible `url_citation` annotations (non-streaming and streaming, deduplicated via GeminiStreamState). Before the fix the option was silently dropped on Gemini routes: the request returned 200 with no grounding and no annotations, so a plain status assertion cannot pin this. These cases require url_citation annotations to be present.",
+      "item": [
+        {
+          "name": "gemini/gemini-2.5-flash web_search_options → url_citation annotations (non-streaming) - PR #5139",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"max_tokens\": 300\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('web_search_options non-streaming: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var msg = pm.response.json().choices[0].message;",
+                  "pm.test('web_search_options non-streaming: content non-empty', function () {",
+                  "  pm.expect(msg.content, 'empty content: ' + pm.response.text()).to.be.a('string').and.not.empty;",
+                  "});",
+                  "pm.test('web_search_options non-streaming: url_citation annotations present (dropped before PR #5139)', function () {",
+                  "  pm.expect(msg.annotations, 'no annotations: ' + pm.response.text()).to.be.an('array').and.not.empty;",
+                  "  msg.annotations.forEach(function (a) {",
+                  "    pm.expect(a.type).to.eql('url_citation');",
+                  "    pm.expect(a.url_citation && a.url_citation.url, 'annotation missing url').to.be.a('string').and.not.empty;",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "gemini/gemini-2.5-flash web_search_options → streamed url_citation annotations (SSE) - PR #5139",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"stream\": true,\n  \"max_tokens\": 300\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('web_search_options streaming: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var annotations = [];",
+                  "var finished = false;",
+                  "pm.response.text().split('\\n').forEach(function (line) {",
+                  "  if (line.indexOf('data:') !== 0) { return; }",
+                  "  var payload = line.slice(5).trim();",
+                  "  if (!payload || payload === '[DONE]') { return; }",
+                  "  var chunk;",
+                  "  try { chunk = JSON.parse(payload); } catch (e) { return; }",
+                  "  var choice = chunk.choices && chunk.choices[0];",
+                  "  if (!choice) { return; }",
+                  "  if (choice.finish_reason) { finished = true; }",
+                  "  if (choice.delta && choice.delta.annotations) { annotations = annotations.concat(choice.delta.annotations); }",
+                  "});",
+                  "pm.test('web_search_options streaming: stream reached finish_reason', function () {",
+                  "  pm.expect(finished, 'no finish_reason in stream').to.be.true;",
+                  "});",
+                  "pm.test('web_search_options streaming: delta url_citation annotations present (dropped before PR #5139)', function () {",
+                  "  pm.expect(annotations.length, 'no annotations in any delta').to.be.greaterThan(0);",
+                  "  annotations.forEach(function (a) { pm.expect(a.type).to.eql('url_citation'); });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "23. OpenAI Responses reasoning.effort max normalization (PR #5130)",
+      "description": "PR #5130: `normalizeOpenAIReasoningEffort` treats gpt-5.6 as natively supporting reasoning.effort \"max\"/\"xhigh\" (passed through unchanged), while earlier GPT-5.x models get \"max\" downgraded (gpt-5.2/5.5 → xhigh, others → high) instead of forwarding a value the upstream rejects. Also adds `reasoning.context` and `reasoning.mode` schema fields that are now serialized to OpenAI instead of being stripped. The response reasoning object echoes what OpenAI actually received, which is what these cases assert on.",
+      "item": [
+        {
+          "name": "openai/gpt-5.6 native /v1/responses reasoning.effort=max passes through (echoed as max) - PR #5130",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5.6\",\n  \"input\": \"Reply with the single word: ok\",\n  \"reasoning\": {\n    \"effort\": \"max\"\n  },\n  \"max_output_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gpt-5.6 effort max: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var r = pm.response.json();",
+                  "pm.test('gpt-5.6 effort max: echoed as max (was downgraded before PR #5130)', function () {",
+                  "  pm.expect(r.reasoning, 'no reasoning echo: ' + pm.response.text()).to.be.an('object');",
+                  "  pm.expect(r.reasoning.effort).to.eql('max');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "openai/gpt-5 native /v1/responses reasoning.effort=max downgraded to high (no upstream 400) - PR #5130",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5\",\n  \"input\": \"Reply with the single word: ok\",\n  \"reasoning\": {\n    \"effort\": \"max\"\n  },\n  \"max_output_tokens\": 512\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gpt-5 effort max: 2xx (a 400 means max was forwarded to a model that rejects it)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var r = pm.response.json();",
+                  "pm.test('gpt-5 effort max: normalized to high', function () {",
+                  "  pm.expect(r.reasoning, 'no reasoning echo: ' + pm.response.text()).to.be.an('object');",
+                  "  pm.expect(r.reasoning.effort).to.eql('high');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "openai/gpt-5.6 native /v1/responses reasoning.context + reasoning.mode forwarded - PR #5130",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5.6\",\n  \"input\": \"Reply with the single word: ok\",\n  \"reasoning\": {\n    \"effort\": \"low\",\n    \"context\": \"current_turn\",\n    \"mode\": \"standard\"\n  },\n  \"max_output_tokens\": 256\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('gpt-5.6 reasoning.context/mode: accepted upstream (2xx)', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var r = pm.response.json();",
+                  "pm.test('gpt-5.6 reasoning.context/mode: echo consistent when present', function () {",
+                  "  if (r.reasoning && r.reasoning.context) { pm.expect(r.reasoning.context).to.eql('current_turn'); }",
+                  "  if (r.reasoning && r.reasoning.mode) { pm.expect(r.reasoning.mode).to.eql('standard'); }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds E2E harness test coverage for two recently merged PRs: Gemini `web_search_options` → `googleSearch` tool mapping with `url_citation` annotation passback (PR #5139), and OpenAI Responses API `reasoning.effort` normalization for `max`/`xhigh` values across GPT-5.x model variants (PR #5130). The backlog item for `web_search_options` is also marked as complete.

## Changes

- Marks `web_search_options` as covered in `HARNESS_COVERAGE_BACKLOG.md`
- Adds harness collection group **22** covering Gemini `web_search_options` → `googleSearch` translation, asserting that `url_citation` annotations are present in both non-streaming and SSE streaming responses (previously the option was silently dropped and no annotations were returned)
- Adds harness collection group **23** covering `normalizeOpenAIReasoningEffort` behavior:
  - `gpt-5.6` passes `effort: "max"` through unchanged and the response echoes it back as `"max"`
  - `gpt-5` downgrades `effort: "max"` to `"high"` so the upstream does not return a 400
  - `gpt-5.6` accepts and echoes `reasoning.context` and `reasoning.mode` fields that were previously stripped before serialization

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Import `tests/e2e/api/collections/provider-harness.json` into Postman or Newman and run groups 22 and 23 against a live environment with valid API keys for Gemini and OpenAI.

```sh
newman run tests/e2e/api/collections/provider-harness.json \
  --env-var baseUrl=<your-proxy-url> \
  --folder "22. Gemini web_search_options → googleSearch (PR #5139)" \
  --folder "23. OpenAI Responses reasoning.effort max normalization (PR #5130)"
```

Each test skips gracefully on 401/403/429/5xx so transient upstream errors do not cause false failures. A passing run confirms annotations are present for Gemini grounding responses and that `reasoning.effort` values are correctly normalized or passed through depending on the model.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

Closes coverage tracking for PR #5139 and PR #5130.

## Security considerations

None. Tests only assert on response shape; no credentials are stored in the collection.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable