### PR TITLE
fix: adjust bucket size thresholds for ~1 month duration range

### DIFF
--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -819,10 +819,10 @@ func calculateBucketSize(start, end *time.Time) int64 {
 		return 30 * 24 * 3600 // Monthly (30 days)
 	case duration >= 90*24*time.Hour: // >= 3 months
 		return 7 * 24 * 3600 // Weekly (7 days)
-	case duration >= 30*24*time.Hour: // >= 1 month
+	case duration > 31*24*time.Hour: // > ~1 month
 		return 3 * 24 * 3600 // 3 days
-	case duration >= 7*24*time.Hour: // >= 7 days
-		return 24 * 3600 // Daily
+	case duration >= 7*24*time.Hour: // >= 7 days, up to ~1 month
+		return 24 * 3600 // Daily (one bar per day)
 	case duration >= 3*24*time.Hour: // >= 3 days
 		return 8 * 3600 // 8 hours
 	case duration >= 24*time.Hour: // >= 24 hours


### PR DESCRIPTION
## Summary

Fixes an edge case in the log chart bucket size calculation where date ranges around 1 month were being assigned to the wrong bucket tier, causing incorrect granularity in the time-series display.

## Changes

- Changed the `>= 30 days` threshold to `> 31 days` for the 3-day bucket tier, ensuring that ranges right at or just over a calendar month don't prematurely fall into the coarser 3-day grouping.
- The daily bucket tier now correctly handles all ranges from 7 days up to approximately 1 month, with an updated comment to reflect this.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Query log data with a time range of exactly 30 or 31 days and verify that the chart renders with daily bars rather than 3-day bars.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable