### PR TITLE
fix: preserve Codex Responses-Lite tools (#5103)

### DIFF
--- a/core/providers/openai/codexresponseslite_test.go
+++ b/core/providers/openai/codexresponseslite_test.go
@@ -1,9 +1,10 @@
 package openai
 
 import (
-	"encoding/json"
 	"testing"
 
+	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/tidwall/gjson"
 )
@@ -59,7 +60,7 @@ func TestCodexResponsesLiteAdditionalToolsRoundTrip(t *testing.T) {
 	}`)
 
 	var incoming OpenAIResponsesRequest
-	if err := json.Unmarshal(raw, &incoming); err != nil {
+	if err := sonic.Unmarshal(raw, &incoming); err != nil {
 		t.Fatalf("unmarshal Codex request: %v", err)
 	}
 
@@ -68,7 +69,7 @@ func TestCodexResponsesLiteAdditionalToolsRoundTrip(t *testing.T) {
 		bifrostRequest.Input[i] = schemas.DeepCopyResponsesMessage(item)
 	}
 	outgoing := ToOpenAIResponsesRequest(nil, bifrostRequest)
-	encoded, err := json.Marshal(outgoing)
+	encoded, err := providerUtils.MarshalSortedIndent(outgoing, "", "  ")
 	if err != nil {
 		t.Fatalf("marshal forwarded request: %v", err)
 	}

--- a/core/providers/openai/codexresponseslite_test.go
+++ b/core/providers/openai/codexresponseslite_test.go
@@ -1,0 +1,91 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexResponsesLiteAdditionalToolsRoundTrip(t *testing.T) {
+	raw := []byte(`{
+		"model": "gpt-5.6-sol",
+		"input": [
+			{
+				"type": "additional_tools",
+				"role": "developer",
+				"tools": [
+					{
+						"type": "custom",
+						"name": "exec",
+						"description": "Run JavaScript code",
+						"format": {
+							"type": "grammar",
+							"syntax": "lark",
+							"definition": "start: SOURCE"
+						}
+					},
+					{
+						"type": "namespace",
+						"name": "collaboration",
+						"description": "Tools for managing sub-agents.",
+						"tools": [
+							{
+								"type": "function",
+								"name": "spawn_agent",
+								"description": "Spawn an agent.",
+								"strict": false,
+								"parameters": {
+									"type": "object",
+									"properties": {
+										"task_name": {"type": "string"}
+									},
+									"required": ["task_name"],
+									"additionalProperties": false
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "input_text", "text": "Reply with exactly: OK"}
+				]
+			}
+		]
+	}`)
+
+	var incoming OpenAIResponsesRequest
+	if err := json.Unmarshal(raw, &incoming); err != nil {
+		t.Fatalf("unmarshal Codex request: %v", err)
+	}
+
+	bifrostRequest := incoming.ToBifrostResponsesRequest(nil)
+	for i, item := range bifrostRequest.Input {
+		bifrostRequest.Input[i] = schemas.DeepCopyResponsesMessage(item)
+	}
+	outgoing := ToOpenAIResponsesRequest(nil, bifrostRequest)
+	encoded, err := json.Marshal(outgoing)
+	if err != nil {
+		t.Fatalf("marshal forwarded request: %v", err)
+	}
+
+	if got := gjson.GetBytes(encoded, "input.0.type").String(); got != "additional_tools" {
+		t.Fatalf("expected additional_tools input item, got %q", got)
+	}
+	if got := gjson.GetBytes(encoded, "input.0.tools.0.type").String(); got != "custom" {
+		t.Fatalf("expected custom tool type to survive, got %q; request: %s", got, encoded)
+	}
+	if got := gjson.GetBytes(encoded, "input.0.tools.0.format.syntax").String(); got != "lark" {
+		t.Fatalf("expected custom tool format to survive, got %q; request: %s", got, encoded)
+	}
+	if got := gjson.GetBytes(encoded, "input.0.tools.1.type").String(); got != "namespace" {
+		t.Fatalf("expected namespace tool type to survive, got %q; request: %s", got, encoded)
+	}
+	if got := gjson.GetBytes(encoded, "input.0.tools.1.tools.0.type").String(); got != "function" {
+		t.Fatalf("expected nested function tool type to survive, got %q; request: %s", got, encoded)
+	}
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1075,6 +1075,9 @@ const (
 	ResponsesMessageTypeItemReference        ResponsesMessageType = "item_reference"
 	ResponsesMessageTypeRefusal              ResponsesMessageType = "refusal"
 	ResponsesMessageTypeCompaction           ResponsesMessageType = "compaction"
+	// Codex Responses-Lite sends an additional_tools developer item whose
+	// nested tools use the Responses API tool union, not MCP list-tools entries.
+	ResponsesMessageTypeAdditionalTools ResponsesMessageType = "additional_tools"
 	// Codex deferred-tool discovery (tool_search). OpenAI's Responses API
 	// supports these item types natively; Bifrost preserves them verbatim
 	// because its typed schema doesn't model them (the call's `arguments` is a
@@ -1112,43 +1115,41 @@ type ResponsesMessage struct {
 	// gpt-oss models include only reasoning_text content blocks in a message, while other openai models include summaries+encrypted_content
 	*ResponsesReasoning
 
-	// rawToolSearch preserves codex `tool_search_call` / `tool_search_output`
-	// items verbatim. OpenAI's Responses API accepts these natively, but
-	// Bifrost's typed schema doesn't model them (the call's `arguments` is a
-	// JSON object — unlike function_call's string — and the output carries a
-	// `tools` array). Rather than fail to deserialize the whole input array or
-	// drop/mangle these items, we round-trip the original bytes unchanged.
+	// rawOpaqueItem preserves Codex Responses extensions verbatim. The typed
+	// schema cannot represent these without ambiguity: tool_search_call uses
+	// object-form arguments, while additional_tools has a nested Responses tool
+	// union that otherwise decodes as an MCP list-tools result and loses each
+	// tool's type. Round-tripping the original bytes keeps the wire shape intact.
 	// Set by UnmarshalJSON, emitted by MarshalJSON; nil for every other type.
-	rawToolSearch []byte
+	rawOpaqueItem []byte
 }
 
-// isToolSearchItem reports whether t is a codex tool_search item type, which
+// isOpaqueResponsesItem reports whether t is a Codex Responses extension that
 // Bifrost preserves verbatim rather than modelling field-by-field.
-func isToolSearchItem(t string) bool {
-	return t == string(ResponsesMessageTypeToolSearchCall) ||
+func isOpaqueResponsesItem(t string) bool {
+	return t == string(ResponsesMessageTypeAdditionalTools) ||
+		t == string(ResponsesMessageTypeToolSearchCall) ||
 		t == string(ResponsesMessageTypeToolSearchOutput)
 }
 
-// UnmarshalJSON preserves codex tool_search items verbatim (see rawToolSearch)
-// and otherwise normalizes function/tool-call arguments before decoding the rest
-// of the item. OpenAI's Responses API serializes `function_call` `arguments` as
-// a JSON string, but `tool_search_call` items serialize `arguments` as a JSON
-// object — e.g. {} while in_progress and {"query":"...","limit":10} when
-// completed. The embedded ResponsesToolMessage.Arguments field is a *string, so
-// an object value makes a plain decode fail with "Mismatch type string with
-// value object", which silently drops the item mid-stream and hangs streaming
-// clients. We shadow `arguments` as raw JSON, decode everything else as usual,
-// then store the canonical stringified form.
+// UnmarshalJSON preserves opaque Codex Responses items verbatim (see
+// rawOpaqueItem) and otherwise normalizes function/tool-call arguments before
+// decoding the rest of the item. OpenAI's Responses API serializes
+// `function_call` `arguments` as a JSON string, but `tool_search_call` items
+// serialize `arguments` as a JSON object. The embedded
+// ResponsesToolMessage.Arguments field is a *string, so an object value makes a
+// plain decode fail. additional_tools also conflicts with the embedded
+// ResponsesMCPListTools.Tools field, which strips the nested tool discriminators.
 func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 	// Clear the receiver first so a reused instance never retains a stale
-	// rawToolSearch (or other fields) from a prior decode — unmarshalling a
-	// non-tool-search payload must not leave preserved bytes that MarshalJSON
+	// rawOpaqueItem (or other fields) from a prior decode — unmarshalling a
+	// regular payload must not leave preserved bytes that MarshalJSON
 	// would then re-emit.
 	*m = ResponsesMessage{}
-	if t := gjson.GetBytes(data, "type").String(); isToolSearchItem(t) {
+	if t := gjson.GetBytes(data, "type").String(); isOpaqueResponsesItem(t) {
 		mt := ResponsesMessageType(t)
 		m.Type = &mt
-		m.rawToolSearch = append([]byte(nil), data...)
+		m.rawOpaqueItem = append([]byte(nil), data...)
 		return nil
 	}
 
@@ -1175,11 +1176,11 @@ func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON re-emits preserved tool_search items verbatim and defers every
+// MarshalJSON re-emits preserved opaque items verbatim and defers every
 // other item type to the default (sorted-key) struct encoding.
 func (m ResponsesMessage) MarshalJSON() ([]byte, error) {
-	if m.rawToolSearch != nil {
-		return m.rawToolSearch, nil
+	if m.rawOpaqueItem != nil {
+		return m.rawOpaqueItem, nil
 	}
 	type alias ResponsesMessage
 	return MarshalSorted(alias(m))

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -232,7 +232,7 @@ func TestResponsesMessageToolCallArguments(t *testing.T) {
 	// Codex's request (which enables the `tool_search` tool). These are the exact
 	// frames that triggered the production "Mismatch type string with value
 	// object" failure. tool_search items are preserved verbatim (see
-	// rawToolSearch), so the item must decode without error and re-encode
+	// rawOpaqueItem), so the item must decode without error and re-encode
 	// byte-identically, object-form arguments included.
 	t.Run("real tool_search_call frames from openai", func(t *testing.T) {
 		items := map[string]string{

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1273,6 +1273,9 @@ func DeepCopyResponsesMessage(original ResponsesMessage) ResponsesMessage {
 	if original.Recipient != nil {
 		copy.Recipient = append(json.RawMessage(nil), original.Recipient...)
 	}
+	if original.rawOpaqueItem != nil {
+		copy.rawOpaqueItem = append([]byte(nil), original.rawOpaqueItem...)
+	}
 
 	if original.Content != nil {
 		copy.Content = &ResponsesMessageContent{}


### PR DESCRIPTION
## Summary

Backports the core Codex compatibility fix from #5103 to `main`, where the release branch still lacks it. This preserves Codex 0.144's `additional_tools` Responses input item across Bifrost's OpenAI conversion; without it, Bifrost decodes the nested Responses tool union as MCP list-tools data and strips required `type` discriminators before forwarding the request.

## Changes

- Treat `additional_tools` like existing Codex `tool_search` extensions and round-trip it as an opaque Responses item
- Preserve opaque item bytes when deep-copying Responses messages
- Add a regression test based on a captured Codex 0.144 request with custom and collaboration namespace tools

## Reproduction proof

A request captured directly from `@openai/codex@0.144.0` contains this Responses-Lite item:

```json
{
  "type": "additional_tools",
  "role": "developer",
  "tools": [
    { "type": "custom", "name": "exec", "format": { "type": "grammar", "syntax": "lark" } },
    { "type": "namespace", "name": "collaboration", "tools": [{ "type": "function", "name": "spawn_agent" }] }
  ]
}
```

Before the fix, the regression test reproduced the production failure: Bifrost forwarded those entries as `{"name":"exec","input_schema":null}` and `{"name":"collaboration","input_schema":null}`, dropping every required `type` discriminator. OpenAI then rejected the request with:

```text
Missing required parameter: input[0].tools[0].type
```

After the fix, the captured item survives Bifrost's Sonic HTTP parser, inbound conversion, deep-copy path, outbound conversion, and provider JSON encoder with the `custom`, `namespace`, nested `function`, and Lark grammar fields intact:

```text
$ go test ./providers/openai -run TestCodexResponsesLiteAdditionalToolsRoundTrip -count=1
ok  github.com/maximhq/bifrost/core/providers/openai  0.402s
```

### Real Codex acceptance test

Built `bifrost-http` from this branch using the local Go workspace, then ran Codex 0.144 against it with the bundled `gpt-5.6-sol` catalog metadata (Responses-Lite, tool mode, and multi-agent enabled). The local gateway's OpenAI provider used an upstream raw passthrough endpoint so this branch was the only Bifrost conversion layer.

```text
$ npx -y @openai/codex@0.144.0 exec ... -m gpt-5.6-sol \
    'Review main.go. You must use the collaboration tools to spawn one sub-agent ...'
...
The independent review found the same issue and no others. No files were modified.
tokens used: 11,480
exit status: 0
```

The run exercised the custom `exec` grammar, collaboration namespace, sub-agent spawn/wait, streaming responses, and multi-turn collaboration history. The gateway recorded eight `POST /openai/v1/responses` requests, all HTTP 200, with no parse errors.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./schemas ./providers/openai
go test ./schemas -run 'TestResponsesMessageToolCallArguments' -count=1
go test ./providers/openai -run 'TestCodexResponsesLiteAdditionalToolsRoundTrip|TestResponsesInputRoundTripsToolSearchItems' -count=1
```

The broad `go test ./...` reaches unrelated MCP integration tests that require generated `examples/mcps/test-tools-server/dist/index.js`; the packages changed by this PR pass.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Backports the core fix from #5103, which is already merged on the `dev` branch. This `main` backport also covers the opaque-item deep-copy and exact gateway JSON path.

Reproduced from a Codex 0.144 request rejected upstream with `Missing required parameter: input[0].tools[0].type`.

## Security considerations

No auth, secret, or PII changes. The fix preserves an OpenAI-native request extension instead of partially decoding and rewriting it.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
