### PR TITLE
fixes governance calendar based alignment qualifier

### DIFF
--- a/plugins/governance/ratelimitreset_test.go
+++ b/plugins/governance/ratelimitreset_test.go
@@ -154,6 +154,137 @@ func TestBackgroundRateLimitResetRefreshesReferences(t *testing.T) {
 	}
 }
 
+// TestRateLimitResetConvergesForCalendarAlignedSubDayDuration reproduces
+// issue #4851: an owner with calendar_aligned=true stamps IsCalendarAligned
+// onto a rate limit whose reset durations are sub-day ("1m"), for which
+// GetCalendarPeriodStart has no calendar boundary and returns now. The reset
+// target is then "due" again immediately after every reset, so the
+// reset-then-recheck loop in BumpRateLimitUsage never reaches its exit
+// condition and pins one postHookWorker goroutine per request at 100% CPU
+// on nanosecond-resolution clocks (Linux). This test asserts the exit
+// condition directly, which is deterministic on every platform: after one
+// reset, the reset target must no longer be due.
+func TestRateLimitResetConvergesForCalendarAlignedSubDayDuration(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	rateLimitID := "calendar-aligned-subday-converge-rate-limit"
+	rateLimit := buildRateLimit(rateLimitID, 1_000_000, 1_000_000) // "1m" durations
+	rateLimit.IsCalendarAligned = true
+	rateLimit.TokenLastReset = time.Now().Add(-2 * time.Minute)
+	rateLimit.RequestLastReset = time.Now().Add(-2 * time.Minute)
+	store.rateLimits.Store(rateLimitID, rateLimit)
+
+	tokenTarget, requestTarget := store.rateLimitResetTargets(rateLimit, time.Now())
+	if tokenTarget == nil && requestTarget == nil {
+		t.Fatal("expected expired rate limit to be due for reset before the first reset")
+	}
+	if reset := store.ResetExpiredRateLimitsInMemory(ctx, false, rateLimitID); len(reset) != 1 {
+		t.Fatalf("expected one rate limit reset, got %d", len(reset))
+	}
+
+	tokenTarget, requestTarget = store.rateLimitResetTargets(store.LoadRateLimit(ctx, rateLimitID), time.Now())
+	if tokenTarget != nil || requestTarget != nil {
+		t.Fatalf("reset target still due immediately after reset (token=%v request=%v): BumpRateLimitUsage would spin forever (issue #4851)", tokenTarget, requestTarget)
+	}
+}
+
+// TestBudgetResetConvergesForCalendarAlignedSubDayDuration covers the same
+// defect on the budget path: a calendar-aligned owner with a sub-day budget
+// reset duration ("5h") must not be due for reset again immediately after
+// resetting, or BumpBudgetUsage spins forever.
+func TestBudgetResetConvergesForCalendarAlignedSubDayDuration(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	budgetID := "calendar-aligned-subday-converge-budget"
+	budget := buildBudgetWithUsage(budgetID, 100, 42, "5h")
+	budget.IsCalendarAligned = true
+	budget.LastReset = time.Now().Add(-6 * time.Hour)
+	store.budgets.Store(budgetID, budget)
+
+	if store.budgetResetTarget(budget, time.Now()) == nil {
+		t.Fatal("expected expired budget to be due for reset before the first reset")
+	}
+	if reset := store.ResetExpiredBudgetsInMemory(ctx, false, budgetID); len(reset) != 1 {
+		t.Fatalf("expected one budget reset, got %d", len(reset))
+	}
+
+	if target := store.budgetResetTarget(store.LoadBudget(ctx, budgetID), time.Now()); target != nil {
+		t.Fatalf("reset target still due immediately after reset (%v): BumpBudgetUsage would spin forever (issue #4851)", target)
+	}
+}
+
+// TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates guards the
+// same defect end to end: BumpRateLimitUsage must return and apply the
+// increment. On microsecond-resolution clocks (darwin) the broken loop can
+// exit by luck when two consecutive time.Now() calls land on the same wall
+// tick, so the convergence test above is the deterministic reproduction;
+// this one catches the hang on nanosecond-resolution clocks (Linux CI).
+func TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	rateLimitID := "calendar-aligned-subday-rate-limit"
+	rateLimit := buildRateLimit(rateLimitID, 1_000_000, 1_000_000) // "1m" durations
+	rateLimit.IsCalendarAligned = true
+	store.rateLimits.Store(rateLimitID, rateLimit)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- store.BumpRateLimitUsage(ctx, rateLimitID, 10, true, true)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("BumpRateLimitUsage did not return within 5s: infinite request-time reset loop on calendar-aligned sub-day duration (issue #4851)")
+	}
+
+	bumped := store.LoadRateLimit(ctx, rateLimitID)
+	if bumped == nil {
+		t.Fatal("expected rate limit to remain loaded")
+	}
+	if bumped.TokenCurrentUsage != 10 {
+		t.Fatalf("expected token usage 10 after bump, got %d", bumped.TokenCurrentUsage)
+	}
+	if bumped.RequestCurrentUsage != 1 {
+		t.Fatalf("expected request usage 1 after bump, got %d", bumped.RequestCurrentUsage)
+	}
+}
+
+// TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates covers the same
+// defect on the budget path: calendar-aligned owner with a sub-day budget
+// reset duration ("5h") must not spin BumpBudgetUsage forever.
+func TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	budgetID := "calendar-aligned-subday-budget"
+	budget := buildBudgetWithUsage(budgetID, 100, 0, "5h")
+	budget.IsCalendarAligned = true
+	store.budgets.Store(budgetID, budget)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- store.BumpBudgetUsage(ctx, budgetID, 2.5)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("BumpBudgetUsage did not return within 5s: infinite request-time reset loop on calendar-aligned sub-day duration (issue #4851)")
+	}
+
+	bumped := store.LoadBudget(ctx, budgetID)
+	if bumped == nil {
+		t.Fatal("expected budget to remain loaded")
+	}
+	if bumped.CurrentUsage != 2.5 {
+		t.Fatalf("expected budget usage 2.5 after bump, got %f", bumped.CurrentUsage)
+	}
+}
+
 // newStandaloneStoreForResetBenchmark creates an in-memory-only store so benchmark
 // profiles isolate sync.Map/reference-update CPU rather than DB IO.
 func newStandaloneStoreForResetBenchmark() *LocalGovernanceStore {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1785,7 +1785,8 @@ func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.Tabl
 	if budget == nil || budget.ResetDuration == "" {
 		return nil
 	}
-	if budget.IsCalendarAligned {
+	// Sub-day durations have no calendar boundary; see rateLimitResetTarget.
+	if budget.IsCalendarAligned && configstoreTables.IsCalendarAlignableDuration(budget.ResetDuration) {
 		currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
 		if currentPeriodStart.After(budget.LastReset) {
 			return &currentPeriodStart
@@ -1862,11 +1863,16 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 }
 
 // rateLimitResetTarget returns the LastReset value to write when a rate-limit counter is expired.
+// Calendar alignment only applies to durations with a calendar boundary (d/w/M/Y);
+// sub-day durations fall back to rolling-window semantics even when the owner is
+// calendar-aligned, mirroring the handler-side snap logic. Without this guard
+// GetCalendarPeriodStart returns now for sub-day durations, making the reset
+// target perpetually due and spinning BumpRateLimitUsage forever (issue #4851).
 func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, calendarAligned bool, lastReset time.Time, now time.Time) *time.Time {
 	if resetDuration == nil {
 		return nil
 	}
-	if calendarAligned {
+	if calendarAligned && configstoreTables.IsCalendarAlignableDuration(*resetDuration) {
 		period := configstoreTables.GetCalendarPeriodStart(*resetDuration, now)
 		if period.After(lastReset) {
 			return &period


### PR DESCRIPTION
## Summary

Fixes an infinite reset loop (issue #4851) in `BumpRateLimitUsage` and `BumpBudgetUsage` when a governance owner has `calendar_aligned=true` but uses a sub-day reset duration (e.g. `"1m"` or `"5h"`). `GetCalendarPeriodStart` has no calendar boundary for sub-day durations and returns `now`, making the reset target perpetually due immediately after every reset. On nanosecond-resolution clocks (Linux), this pins a `postHookWorker` goroutine at 100% CPU indefinitely.

## Changes

- `rateLimitResetTarget` and `budgetResetTarget` now gate calendar-aligned logic behind `IsCalendarAlignableDuration`, which only returns true for durations with a real calendar boundary (day/week/month/year). Sub-day durations fall back to rolling-window semantics regardless of the `IsCalendarAligned` flag, matching the existing handler-side snap logic.
- Four regression tests were added:
  - `TestRateLimitResetConvergesForCalendarAlignedSubDayDuration` — deterministically asserts that after one reset the target is no longer due.
  - `TestBudgetResetConvergesForCalendarAlignedSubDayDuration` — same assertion on the budget path.
  - `TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates` — end-to-end guard that `BumpRateLimitUsage` returns within 5 seconds and correctly applies the usage increment.
  - `TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates` — same end-to-end guard on the budget path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run "TestRateLimitResetConvergesForCalendarAlignedSubDayDuration|TestBudgetResetConvergesForCalendarAlignedSubDayDuration|TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates|TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates" -v
```

All four tests should pass. On an unpatched build, `TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates` and `TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates` will time out after 5 seconds on Linux.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4851

## Security considerations

None. The fix is scoped to in-memory reset-target evaluation and does not affect auth, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable