### PR TITLE
adds guards against invaalid reset timeouts

### DIFF
--- a/plugins/governance/ratelimitreset_test.go
+++ b/plugins/governance/ratelimitreset_test.go
@@ -213,6 +213,57 @@ func TestBudgetResetConvergesForCalendarAlignedSubDayDuration(t *testing.T) {
 	}
 }
 
+// TestNonPositiveDurationsAreNeverDue covers the second spin route of issue
+// #4851: "0s" and negative durations parse successfully, and on the rolling
+// path now.Sub(lastReset) >= duration is then true on every check, making the
+// reset target perpetually due. Such durations must be treated as invalid
+// (never due), and BumpRateLimitUsage/BumpBudgetUsage must still terminate
+// and apply the increment.
+func TestNonPositiveDurationsAreNeverDue(t *testing.T) {
+	ctx := context.Background()
+	for _, duration := range []string{"0s", "-5m"} {
+		t.Run(duration, func(t *testing.T) {
+			store := newStandaloneStoreForResetBenchmark()
+			d := duration
+
+			rateLimitID := "non-positive-duration-rate-limit-" + duration
+			rateLimit := buildRateLimit(rateLimitID, 1_000_000, 1_000_000)
+			rateLimit.TokenResetDuration = &d
+			rateLimit.RequestResetDuration = &d
+			rateLimit.TokenLastReset = time.Now().Add(-time.Hour)
+			rateLimit.RequestLastReset = time.Now().Add(-time.Hour)
+			store.rateLimits.Store(rateLimitID, rateLimit)
+
+			tokenTarget, requestTarget := store.rateLimitResetTargets(rateLimit, time.Now())
+			if tokenTarget != nil || requestTarget != nil {
+				t.Fatalf("non-positive duration %q must never be due (token=%v request=%v): a due target here spins BumpRateLimitUsage forever (issue #4851)", duration, tokenTarget, requestTarget)
+			}
+			if err := store.BumpRateLimitUsage(ctx, rateLimitID, 7, true, true); err != nil {
+				t.Fatal(err)
+			}
+			bumped := store.LoadRateLimit(ctx, rateLimitID)
+			if bumped.TokenCurrentUsage != 7 || bumped.RequestCurrentUsage != 1 {
+				t.Fatalf("expected usage 7/1 after bump, got %d/%d", bumped.TokenCurrentUsage, bumped.RequestCurrentUsage)
+			}
+
+			budgetID := "non-positive-duration-budget-" + duration
+			budget := buildBudgetWithUsage(budgetID, 100, 5, duration)
+			budget.LastReset = time.Now().Add(-time.Hour)
+			store.budgets.Store(budgetID, budget)
+
+			if target := store.budgetResetTarget(budget, time.Now()); target != nil {
+				t.Fatalf("non-positive duration %q must never be due (%v): a due target here spins BumpBudgetUsage forever (issue #4851)", duration, target)
+			}
+			if err := store.BumpBudgetUsage(ctx, budgetID, 1.5); err != nil {
+				t.Fatal(err)
+			}
+			if bumpedBudget := store.LoadBudget(ctx, budgetID); bumpedBudget.CurrentUsage != 6.5 {
+				t.Fatalf("expected budget usage 6.5 after bump, got %f", bumpedBudget.CurrentUsage)
+			}
+		})
+	}
+}
+
 // TestBumpRateLimitUsageCalendarAlignedSubDayDurationTerminates guards the
 // same defect end to end: BumpRateLimitUsage must return and apply the
 // increment. On microsecond-resolution clocks (darwin) the broken loop can

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -402,6 +402,12 @@ func (gs *LocalGovernanceStore) SetRateLimitDBBaseline(rateLimitID string, token
 	gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
 }
 
+// maxRequestTimeResetAttempts bounds how many times a Bump* usage loop defers
+// to the shared reset path before falling back to an inline reset. A converging
+// target needs exactly one attempt; the bound exists so a non-converging target
+// (issue #4851 class) can never spin a request-path goroutine at 100% CPU.
+const maxRequestTimeResetAttempts = 3
+
 // BumpBudgetUsage atomically increments CurrentUsage on the budget identified
 // by budgetID and, as a side effect, zeros CurrentUsage / advances LastReset
 // when the rolling ResetDuration has elapsed. Uses sync.Map.CompareAndSwap so
@@ -413,6 +419,7 @@ func (gs *LocalGovernanceStore) SetRateLimitDBBaseline(rateLimitID string, token
 // Update*BudgetUsageInMemory wrappers) rather than doing a plain
 // Load → clone → mutate → Store, which races.
 func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID string, cost float64) error {
+	resetAttempts := 0
 	for {
 		raw, exists := gs.budgets.Load(budgetID)
 		if !exists || raw == nil {
@@ -422,11 +429,29 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 		if !ok || old == nil {
 			return nil
 		}
-		if gs.budgetResetTarget(old, time.Now()) != nil {
+		target := gs.budgetResetTarget(old, time.Now())
+		if target != nil && resetAttempts < maxRequestTimeResetAttempts {
+			resetAttempts++
 			gs.ResetExpiredBudgetsInMemory(ctx, false, budgetID)
 			continue
 		}
 		clone := *old
+		if target != nil {
+			// The reset target is still due after maxRequestTimeResetAttempts
+			// shared-path resets, so it is not converging (issue #4851 class:
+			// a target function bug or bad duration slipped past validation).
+			// Reset inline in the clone so this loop always terminates,
+			// zeroing the LastDB baseline exactly like
+			// resetExpiredBudgetFromSnapshot so DB delta folding stays
+			// consistent. Only the reset hook (DB persistence of LastReset)
+			// is skipped on the request path.
+			gs.logger.Error("budget %s reset target not converging after %d resets; applying inline reset to avoid request-path spin", budgetID, resetAttempts)
+			clone.CurrentUsage = 0
+			clone.LastReset = *target
+			gs.LastDBUsagesBudgetsMu.Lock()
+			gs.LastDBUsagesBudgets[budgetID] = 0
+			gs.LastDBUsagesBudgetsMu.Unlock()
+		}
 		clone.CurrentUsage += cost
 		if gs.budgets.CompareAndSwap(budgetID, raw, &clone) {
 			return nil
@@ -441,6 +466,7 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 // contract as BumpBudgetUsage — no increment is ever dropped under
 // concurrent callers. No-op when the rate limit is absent.
 func (gs *LocalGovernanceStore) BumpRateLimitUsage(ctx context.Context, rateLimitID string, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
+	resetAttempts := 0
 	for {
 		raw, exists := gs.rateLimits.Load(rateLimitID)
 		if !exists || raw == nil {
@@ -450,11 +476,38 @@ func (gs *LocalGovernanceStore) BumpRateLimitUsage(ctx context.Context, rateLimi
 		if !ok || old == nil {
 			return nil
 		}
-		if tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(old, time.Now()); tokenNewLastReset != nil || requestNewLastReset != nil {
+		tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(old, time.Now())
+		if (tokenNewLastReset != nil || requestNewLastReset != nil) && resetAttempts < maxRequestTimeResetAttempts {
+			resetAttempts++
 			gs.ResetExpiredRateLimitsInMemory(ctx, false, rateLimitID)
 			continue
 		}
 		clone := *old
+		if tokenNewLastReset != nil || requestNewLastReset != nil {
+			// The reset target is still due after maxRequestTimeResetAttempts
+			// shared-path resets, so it is not converging (issue #4851 class:
+			// a target function bug or bad duration slipped past validation).
+			// Reset inline in the clone so this loop always terminates,
+			// zeroing the LastDB baselines exactly like
+			// resetExpiredRateLimitFromSnapshot so DB delta folding stays
+			// consistent. Only the reset hook (DB persistence of LastReset)
+			// is skipped on the request path.
+			gs.logger.Error("rate limit %s reset target not converging after %d resets; applying inline reset to avoid request-path spin", rateLimitID, resetAttempts)
+			if tokenNewLastReset != nil {
+				clone.TokenCurrentUsage = 0
+				clone.TokenLastReset = *tokenNewLastReset
+				gs.LastDBUsagesRateLimitsTokensMu.Lock()
+				gs.LastDBUsagesTokensRateLimits[rateLimitID] = 0
+				gs.LastDBUsagesRateLimitsTokensMu.Unlock()
+			}
+			if requestNewLastReset != nil {
+				clone.RequestCurrentUsage = 0
+				clone.RequestLastReset = *requestNewLastReset
+				gs.LastDBUsagesRateLimitsRequestsMu.Lock()
+				gs.LastDBUsagesRequestsRateLimits[rateLimitID] = 0
+				gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
+			}
+		}
 		if shouldUpdateTokens {
 			clone.TokenCurrentUsage += tokensUsed
 		}
@@ -1798,6 +1851,12 @@ func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.Tabl
 		gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
 		return nil
 	}
+	// A non-positive duration would be perpetually due, spinning BumpBudgetUsage
+	// forever (issue #4851 class); treat it as invalid, same as unparseable.
+	if duration <= 0 {
+		gs.logger.Error("non-positive budget reset duration %s: budget will not auto-reset", budget.ResetDuration)
+		return nil
+	}
 	if now.Sub(budget.LastReset) >= duration {
 		return &now
 	}
@@ -1882,6 +1941,12 @@ func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, cale
 	duration, err := configstoreTables.ParseDuration(*resetDuration)
 	if err != nil {
 		gs.logger.Error("invalid rate limit reset duration %s: %v", *resetDuration, err)
+		return nil
+	}
+	// A non-positive duration would be perpetually due, spinning BumpRateLimitUsage
+	// forever (issue #4851 class); treat it as invalid, same as unparseable.
+	if duration <= 0 {
+		gs.logger.Error("non-positive rate limit reset duration %s: counter will not auto-reset", *resetDuration)
 		return nil
 	}
 	if now.Sub(lastReset) >= duration {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -471,8 +471,8 @@ func (h *GovernanceHandler) reconcileModelConfigBudgets(ctx context.Context, tx 
 		if b.MaxLimit < 0 {
 			return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
 		}
-		if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-			return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+		if d, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil || d <= 0 {
+			return &badRequestError{err: fmt.Errorf("invalid reset duration (must be a positive duration): %s", b.ResetDuration)}
 		}
 		if seenDurations[b.ResetDuration] {
 			return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
@@ -539,8 +539,8 @@ func (h *GovernanceHandler) reconcileCustomerBudgets(ctx context.Context, tx *go
 		if b.MaxLimit < 0 {
 			return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
 		}
-		if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-			return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+		if d, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil || d <= 0 {
+			return &badRequestError{err: fmt.Errorf("invalid reset duration (must be a positive duration): %s", b.ResetDuration)}
 		}
 		if seenDurations[b.ResetDuration] {
 			return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
@@ -1284,8 +1284,8 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", b.MaxLimit))
 				return
 			}
-			if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-				SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", b.ResetDuration))
+			if d, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil || d <= 0 {
+				SendError(ctx, 400, fmt.Sprintf("Invalid reset duration (must be a positive duration): %s", b.ResetDuration))
 				return
 			}
 			if seenDurations[b.ResetDuration] {
@@ -2192,8 +2192,8 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 			if b.MaxLimit < 0 {
 				return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
 			}
-			if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-				return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+			if d, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil || d <= 0 {
+				return &badRequestError{err: fmt.Errorf("invalid reset duration (must be a positive duration): %s", b.ResetDuration)}
 			}
 			if seenDurations[b.ResetDuration] {
 				return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
@@ -2328,8 +2328,8 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				if b.MaxLimit < 0 {
 					return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
 				}
-				if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
-					return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+				if d, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil || d <= 0 {
+					return &badRequestError{err: fmt.Errorf("invalid reset duration (must be a positive duration): %s", b.ResetDuration)}
 				}
 				if seenDurations[b.ResetDuration] {
 					return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
@@ -2949,8 +2949,8 @@ func validateRateLimit(rateLimit *configstoreTables.TableRateLimit) error {
 		if rateLimit.TokenResetDuration == nil {
 			return fmt.Errorf("rate limit token reset duration is required")
 		}
-		if _, err := configstoreTables.ParseDuration(*rateLimit.TokenResetDuration); err != nil {
-			return fmt.Errorf("invalid rate limit token reset duration format: %s", *rateLimit.TokenResetDuration)
+		if d, err := configstoreTables.ParseDuration(*rateLimit.TokenResetDuration); err != nil || d <= 0 {
+			return fmt.Errorf("invalid rate limit token reset duration (must be a positive duration): %s", *rateLimit.TokenResetDuration)
 		}
 	}
 	if rateLimit.RequestMaxLimit != nil && (*rateLimit.RequestMaxLimit < 0 || *rateLimit.RequestMaxLimit == 0) {
@@ -2961,8 +2961,8 @@ func validateRateLimit(rateLimit *configstoreTables.TableRateLimit) error {
 		if rateLimit.RequestResetDuration == nil {
 			return fmt.Errorf("rate limit request reset duration is required")
 		}
-		if _, err := configstoreTables.ParseDuration(*rateLimit.RequestResetDuration); err != nil {
-			return fmt.Errorf("invalid rate limit request reset duration format: %s", *rateLimit.RequestResetDuration)
+		if d, err := configstoreTables.ParseDuration(*rateLimit.RequestResetDuration); err != nil || d <= 0 {
+			return fmt.Errorf("invalid rate limit request reset duration (must be a positive duration): %s", *rateLimit.RequestResetDuration)
 		}
 	}
 	return nil
@@ -2992,8 +2992,8 @@ func validateBudget(budget *configstoreTables.TableBudget) error {
 	if budget.ResetDuration == "" {
 		return fmt.Errorf("budget reset duration is required")
 	}
-	if _, err := configstoreTables.ParseDuration(budget.ResetDuration); err != nil {
-		return fmt.Errorf("invalid budget reset duration format: %s", budget.ResetDuration)
+	if d, err := configstoreTables.ParseDuration(budget.ResetDuration); err != nil || d <= 0 {
+		return fmt.Errorf("invalid budget reset duration (must be a positive duration): %s", budget.ResetDuration)
 	}
 	return nil
 }
@@ -3278,8 +3278,8 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budgets[i].MaxLimit))
 			return
 		}
-		if _, err := configstoreTables.ParseDuration(req.Budgets[i].ResetDuration); err != nil {
-			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budgets[i].ResetDuration))
+		if d, err := configstoreTables.ParseDuration(req.Budgets[i].ResetDuration); err != nil || d <= 0 {
+			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration (must be a positive duration): %s", req.Budgets[i].ResetDuration))
 			return
 		}
 		if seenDurations[req.Budgets[i].ResetDuration] {


### PR DESCRIPTION
## Summary

Fixes a class of infinite-loop bugs (issue #4851) where `"0s"` or negative reset durations passed duration parsing but caused `BumpRateLimitUsage` and `BumpBudgetUsage` to spin at 100% CPU indefinitely. Because `now.Sub(lastReset) >= duration` is always true for non-positive durations, the reset target was perpetually due, and the bump loops never made forward progress.

## Changes

- `budgetResetTarget` and `rateLimitResetTarget` now return `nil` (never due) for any parsed duration `<= 0`, treating it the same as an unparseable duration and logging an error.
- `BumpBudgetUsage` and `BumpRateLimitUsage` now cap shared-path reset attempts at `maxRequestTimeResetAttempts = 3`. If the reset target is still due after that many attempts, an inline reset is applied directly to the clone so the loop always terminates. This is a degraded mode (skips the reset hook and LastDB baseline zeroing until the next background sweep) but prevents request-path goroutine spin.
- All budget and rate limit validation call sites — `validateRateLimit`, `validateBudget`, `reconcileModelConfigBudgets`, `reconcileCustomerBudgets`, `createVirtualKey`, `createTeam`, `updateTeam`, and `createModelConfig` — now reject durations that parse successfully but are `<= 0`, returning a `400` with the message `"must be a positive duration"`.
- A new test `TestNonPositiveDurationsAreNeverDue` verifies that `rateLimitResetTargets` and `budgetResetTarget` return `nil` for `"0s"` and `"-5m"`, and that `BumpRateLimitUsage`/`BumpBudgetUsage` still terminate and correctly apply their increments.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins

## How to test

```sh
go test ./plugins/governance/... -run TestNonPositiveDurationsAreNeverDue -v
go test ./plugins/governance/... -v
go test ./transports/bifrost-http/handlers/... -v
```

Attempting to create a budget or rate limit with `reset_duration: "0s"` or `reset_duration: "-5m"` via the API should now return a `400` error with the message `invalid reset duration (must be a positive duration)`.

## Breaking changes

- [x] Yes

Any existing budget or rate limit records stored with a `"0s"` or negative `ResetDuration` will no longer auto-reset (they will log an error and remain static until corrected). New API requests supplying non-positive durations are now rejected with a `400`.

## Related issues

Closes #4851

## Security considerations

None beyond the availability fix — a non-positive duration could previously be used to pin a request-path goroutine at 100% CPU, which is now prevented at both the validation and runtime layers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable