### PR TITLE
parallelize flows for resting budgets when absolutely required

### DIFF
--- a/plugins/governance/racedisabled_test.go
+++ b/plugins/governance/racedisabled_test.go
@@ -1,0 +1,8 @@
+//go:build !race
+
+package governance
+
+// raceEnabled reports whether the race detector is on, so timing-sensitive
+// tests can scale their wall-clock budgets (the detector slows execution
+// 2-20x per https://go.dev/doc/articles/race_detector).
+const raceEnabled = false

--- a/plugins/governance/raceenabled_test.go
+++ b/plugins/governance/raceenabled_test.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package governance
+
+// raceEnabled reports whether the race detector is on, so timing-sensitive
+// tests can scale their wall-clock budgets (the detector slows execution
+// 2-20x per https://go.dev/doc/articles/race_detector).
+const raceEnabled = true

--- a/plugins/governance/ratelimitreset_test.go
+++ b/plugins/governance/ratelimitreset_test.go
@@ -11,6 +11,22 @@ import (
 
 const resetBenchmarkVirtualKeys = 5000
 
+// scaleTimingBudget widens a wall-clock budget when the race detector is on,
+// since it slows execution 2-20x. The regressions these budgets guard are
+// orders of magnitude, so the extra headroom still catches them.
+func scaleTimingBudget(budget time.Duration) time.Duration {
+	if raceEnabled {
+		return budget * 20
+	}
+	return budget
+}
+
+// timingBudgetAttempts is how many times a wall-clock assertion re-measures
+// before failing. Host noise (GC pause, scheduler stall, slow runner) inflates
+// one run, not all of them; the algorithmic regressions these tests guard are
+// orders of magnitude over budget and fail every attempt.
+const timingBudgetAttempts = 3
+
 // TestRequestTimeRateLimitResetPerformance verifies request-time rate-limit
 // reset stays constant-time with thousands of embedded references. Runs as a
 // regular test so it executes in CI via go test / make test-governance.
@@ -20,21 +36,31 @@ func TestRequestTimeRateLimitResetPerformance(t *testing.T) {
 	rateLimitID := seedResetBenchmarkVirtualKeys(ctx, store, resetBenchmarkVirtualKeys)
 
 	const iterations = 1000
-	start := time.Now()
-	for i := 0; i < iterations; i++ {
-		markRequestRateLimitExpired(store, rateLimitID)
-		if err := store.BumpRateLimitUsage(ctx, rateLimitID, 0, false, true); err != nil {
-			t.Fatal(err)
+	// Request-time reset must stay O(1). With the reference-refresh regression
+	// this exceeds 500µs per op; the fix keeps it well under 100µs. Best of
+	// timingBudgetAttempts runs, so a single noisy run cannot flake the test.
+	maxPerOp := scaleTimingBudget(200 * time.Microsecond)
+	var bestPerOp time.Duration
+	for attempt := 0; attempt < timingBudgetAttempts; attempt++ {
+		start := time.Now()
+		for i := 0; i < iterations; i++ {
+			markRequestRateLimitExpired(store, rateLimitID)
+			if err := store.BumpRateLimitUsage(ctx, rateLimitID, 0, false, true); err != nil {
+				t.Fatal(err)
+			}
+		}
+		perOp := time.Since(start) / iterations
+		if bestPerOp == 0 || perOp < bestPerOp {
+			bestPerOp = perOp
+		}
+		if bestPerOp <= maxPerOp {
+			break
 		}
 	}
-	nsPerOp := float64(time.Since(start).Nanoseconds()) / float64(iterations)
-	// Request-time reset must stay O(1). With the reference-refresh regression
-	// this exceeds 500µs per op; the fix keeps it well under 100µs.
-	const maxNsPerOp = 100_000 // 100µs
-	if nsPerOp > maxNsPerOp {
-		t.Fatalf("request-time reset too slow: %.0f ns/op (max %d ns/op) — likely running expensive O(N) work on the request hot path", nsPerOp, maxNsPerOp)
+	if bestPerOp > maxPerOp {
+		t.Fatalf("request-time reset too slow: %v per op (max %v) across %d attempts - likely running expensive O(N) work on the request hot path", bestPerOp, maxPerOp, timingBudgetAttempts)
 	}
-	t.Logf("request-time reset: %.0f ns/op (%d iterations)", nsPerOp, iterations)
+	t.Logf("request-time reset: %v per op (%d iterations)", bestPerOp, iterations)
 }
 
 // BenchmarkSingleRequestTimeRateLimitResetDoesNotRefreshReferences runs the same
@@ -333,6 +359,475 @@ func TestBumpBudgetUsageCalendarAlignedSubDayDurationTerminates(t *testing.T) {
 	}
 	if bumped.CurrentUsage != 2.5 {
 		t.Fatalf("expected budget usage 2.5 after bump, got %f", bumped.CurrentUsage)
+	}
+}
+
+// TestBackgroundBudgetResetRefreshesReferences verifies the batched budget
+// reference refresh: one background sweep must update embedded budget copies
+// on every owner type (VK, team, customer), replace only the budgets that
+// actually reset, and leave unexpired sibling budgets untouched.
+func TestBackgroundBudgetResetRefreshesReferences(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	now := time.Now()
+
+	expired := buildBudgetWithUsage("bg-budget-expired", 100, 42, "1h")
+	expired.LastReset = now.Add(-2 * time.Hour)
+	fresh := buildBudgetWithUsage("bg-budget-fresh", 100, 7, "1h")
+	fresh.LastReset = now.Add(-10 * time.Minute)
+	vk := buildVirtualKey("bg-vk", "sk-bf-bg-refresh", "Budget refresh VK", true)
+	vk.Budgets = []configstoreTables.TableBudget{*expired, *fresh}
+	store.CreateVirtualKeyInMemory(ctx, vk)
+
+	teamBudget := buildBudgetWithUsage("bg-team-budget", 200, 33, "1h")
+	teamBudget.LastReset = now.Add(-2 * time.Hour)
+	store.CreateTeamInMemory(ctx, buildTeam("bg-team", "Budget refresh team", teamBudget))
+
+	customerBudget := buildBudgetWithUsage("bg-customer-budget", 300, 21, "1h")
+	customerBudget.LastReset = now.Add(-2 * time.Hour)
+	store.CreateCustomerInMemory(ctx, buildCustomer("bg-customer", "Budget refresh customer", customerBudget))
+
+	reset := store.ResetExpiredBudgetsInMemory(ctx, true)
+	if len(reset) != 3 {
+		t.Fatalf("expected 3 expired budgets to reset (vk, team, customer), got %d", len(reset))
+	}
+
+	rawVK, ok := store.virtualKeys.Load("sk-bf-bg-refresh")
+	if !ok || rawVK == nil {
+		t.Fatal("expected virtual key to remain loaded")
+	}
+	gotVK := rawVK.(*configstoreTables.TableVirtualKey)
+	var gotExpired, gotFresh *configstoreTables.TableBudget
+	for i := range gotVK.Budgets {
+		switch gotVK.Budgets[i].ID {
+		case "bg-budget-expired":
+			gotExpired = &gotVK.Budgets[i]
+		case "bg-budget-fresh":
+			gotFresh = &gotVK.Budgets[i]
+		}
+	}
+	if gotExpired == nil || gotFresh == nil {
+		t.Fatal("expected both embedded VK budgets to survive the refresh")
+	}
+	if gotExpired.CurrentUsage != 0 {
+		t.Fatalf("expected embedded expired VK budget zeroed after background refresh, got %f", gotExpired.CurrentUsage)
+	}
+	if !gotExpired.LastReset.After(now.Add(-2 * time.Hour)) {
+		t.Fatalf("expected embedded expired VK budget LastReset to advance, got %v", gotExpired.LastReset)
+	}
+	if gotFresh.CurrentUsage != 7 {
+		t.Fatalf("expected unexpired sibling budget untouched at 7, got %f", gotFresh.CurrentUsage)
+	}
+
+	rawTeam, ok := store.teams.Load("bg-team")
+	if !ok || rawTeam == nil {
+		t.Fatal("expected team to remain loaded")
+	}
+	gotTeam := rawTeam.(*configstoreTables.TableTeam)
+	if len(gotTeam.Budgets) != 1 || gotTeam.Budgets[0].CurrentUsage != 0 {
+		t.Fatalf("expected embedded team budget zeroed after background refresh, got %+v", gotTeam.Budgets)
+	}
+
+	rawCustomer, ok := store.customers.Load("bg-customer")
+	if !ok || rawCustomer == nil {
+		t.Fatal("expected customer to remain loaded")
+	}
+	gotCustomer := rawCustomer.(*configstoreTables.TableCustomer)
+	if len(gotCustomer.Budgets) != 1 || gotCustomer.Budgets[0].CurrentUsage != 0 {
+		t.Fatalf("expected embedded customer budget zeroed after background refresh, got %+v", gotCustomer.Budgets)
+	}
+}
+
+// TestRateLimitResetAccuracyEdgeCases verifies that resets fire exactly when
+// they should and only touch the counter that is actually expired, across the
+// rolling and calendar-aligned semantics and their boundary conditions.
+func TestRateLimitResetAccuracyEdgeCases(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	t.Run("mixed expiry resets only the expired counter", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		tokenDuration, requestDuration := "1m", "1h"
+		rl := buildRateLimit("mixed-expiry", 1_000_000, 1_000_000)
+		rl.TokenResetDuration = &tokenDuration
+		rl.RequestResetDuration = &requestDuration
+		rl.TokenCurrentUsage = 555
+		rl.TokenLastReset = now.Add(-2 * time.Minute) // expired
+		rl.RequestCurrentUsage = 7
+		rl.RequestLastReset = now.Add(-30 * time.Minute) // NOT expired
+		store.rateLimits.Store(rl.ID, rl)
+
+		if err := store.BumpRateLimitUsage(ctx, rl.ID, 10, true, true); err != nil {
+			t.Fatal(err)
+		}
+		bumped := store.LoadRateLimit(ctx, rl.ID)
+		if bumped.TokenCurrentUsage != 10 {
+			t.Fatalf("expected token counter reset then bumped to 10, got %d", bumped.TokenCurrentUsage)
+		}
+		if bumped.RequestCurrentUsage != 8 {
+			t.Fatalf("expected unexpired request counter preserved and bumped to 8, got %d", bumped.RequestCurrentUsage)
+		}
+	})
+
+	t.Run("exact rolling boundary is due", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		rl := buildRateLimit("exact-boundary", 1_000_000, 1_000_000)
+		probe := time.Now()
+		rl.TokenLastReset = probe.Add(-time.Minute) // exactly one window ago
+		tok, _ := store.rateLimitResetTargets(rl, probe)
+		if tok == nil {
+			t.Fatal("expected token counter to be due exactly at the window boundary (>= semantics)")
+		}
+	})
+
+	t.Run("one nanosecond before the boundary is not due", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		rl := buildRateLimit("pre-boundary", 1_000_000, 1_000_000)
+		probe := time.Now()
+		rl.TokenLastReset = probe.Add(-time.Minute + time.Nanosecond)
+		rl.RequestLastReset = probe.Add(-time.Minute + time.Nanosecond)
+		tok, req := store.rateLimitResetTargets(rl, probe)
+		if tok != nil || req != nil {
+			t.Fatalf("expected no reset just before the window boundary, got token=%v request=%v", tok, req)
+		}
+	})
+
+	t.Run("calendar day snaps LastReset to period start not now", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		duration := "1d"
+		rl := buildRateLimit("calendar-day", 1_000_000, 1_000_000)
+		rl.TokenResetDuration = &duration
+		rl.RequestResetDuration = &duration
+		rl.IsCalendarAligned = true
+		rl.TokenLastReset = now.Add(-26 * time.Hour) // last reset yesterday
+		rl.RequestLastReset = now.Add(-26 * time.Hour)
+		store.rateLimits.Store(rl.ID, rl)
+
+		if reset := store.ResetExpiredRateLimitsInMemory(ctx, false, rl.ID); len(reset) != 1 {
+			t.Fatalf("expected one reset, got %d", len(reset))
+		}
+		wantPeriodStart := configstoreTables.GetCalendarPeriodStart(duration, now)
+		got := store.LoadRateLimit(ctx, rl.ID)
+		if !got.TokenLastReset.Equal(wantPeriodStart) {
+			t.Fatalf("calendar reset must snap TokenLastReset to the period start %v, got %v", wantPeriodStart, got.TokenLastReset)
+		}
+	})
+
+	t.Run("calendar aligned within current period is not due", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		duration := "1d"
+		rl := buildRateLimit("calendar-current-period", 1_000_000, 1_000_000)
+		rl.TokenResetDuration = &duration
+		rl.RequestResetDuration = &duration
+		rl.IsCalendarAligned = true
+		periodStart := configstoreTables.GetCalendarPeriodStart(duration, now)
+		rl.TokenLastReset = periodStart
+		rl.RequestLastReset = periodStart
+		tok, req := store.rateLimitResetTargets(rl, now)
+		if tok != nil || req != nil {
+			t.Fatalf("already reset at period start must not be due again, got token=%v request=%v", tok, req)
+		}
+	})
+
+	t.Run("future LastReset from clock skew is not due and does not spin", func(t *testing.T) {
+		store := newStandaloneStoreForResetBenchmark()
+		rl := buildRateLimit("future-last-reset", 1_000_000, 1_000_000)
+		rl.TokenCurrentUsage = 3
+		rl.TokenLastReset = now.Add(time.Hour) // another node's clock ahead
+		rl.RequestLastReset = now.Add(time.Hour)
+		store.rateLimits.Store(rl.ID, rl)
+
+		if err := store.BumpRateLimitUsage(ctx, rl.ID, 4, true, true); err != nil {
+			t.Fatal(err)
+		}
+		bumped := store.LoadRateLimit(ctx, rl.ID)
+		if bumped.TokenCurrentUsage != 7 {
+			t.Fatalf("expected future-dated counter preserved and bumped to 7, got %d", bumped.TokenCurrentUsage)
+		}
+	})
+}
+
+// TestBackgroundResetReferenceRefreshScales demonstrates the background-sweep
+// scale problem: ResetExpiredRateLimitsInMemory(ctx, true) calls
+// updateRateLimitReferences once per reset rate limit, and each call Ranges
+// over EVERY virtual key (cloning each VK before even checking for a match).
+// With per-VK rate limits the tick cost is O(dueLimits x totalVKs): quadratic
+// in key count. The per-reset budget below is what an O(owners) refresh
+// (reverse index or one batched pass per tick) sustains; the current
+// implementation exceeds it by orders of magnitude, and since per-reset cost
+// grows linearly with VK count, at 100k keys a single 10s tick becomes
+// minutes of CPU - permanent 100% CPU without any infinite loop.
+func TestBackgroundResetReferenceRefreshScales(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	const vkCount = 3000
+
+	for i := 0; i < vkCount; i++ {
+		rl := buildRateLimit(fmt.Sprintf("scale-rl-%06d", i), 1_000_000, 1_000_000)
+		rl.RequestCurrentUsage = 9
+		rl.RequestLastReset = time.Now().Add(-2 * time.Minute) // "1m" window: expired
+		rl.TokenLastReset = time.Now().Add(-2 * time.Minute)
+		store.rateLimits.Store(rl.ID, rl)
+		vk := buildVirtualKeyWithRateLimit(
+			fmt.Sprintf("scale-vk-%06d", i),
+			fmt.Sprintf("sk-bf-scale-%06d", i),
+			fmt.Sprintf("Scale VK %06d", i),
+			rl,
+		)
+		store.CreateVirtualKeyInMemory(ctx, vk)
+	}
+
+	// Best of timingBudgetAttempts sweeps; each retry re-expires every rate
+	// limit so the sweep does full work again, filtering host noise without
+	// weakening the O(dueLimits x totalVKs) regression guard.
+	maxPerReset := scaleTimingBudget(500 * time.Microsecond)
+	var bestPerReset time.Duration
+	for attempt := 0; attempt < timingBudgetAttempts; attempt++ {
+		if attempt > 0 {
+			for i := 0; i < vkCount; i++ {
+				markRequestRateLimitExpired(store, fmt.Sprintf("scale-rl-%06d", i))
+			}
+		}
+		start := time.Now()
+		reset := store.ResetExpiredRateLimitsInMemory(ctx, true) // background/ticker path
+		elapsed := time.Since(start)
+
+		if len(reset) != vkCount {
+			t.Fatalf("expected all %d expired rate limits to reset, got %d", vkCount, len(reset))
+		}
+		perReset := elapsed / vkCount
+		if bestPerReset == 0 || perReset < bestPerReset {
+			bestPerReset = perReset
+		}
+		if bestPerReset <= maxPerReset {
+			break
+		}
+	}
+	// Reset accuracy at scale: spot-check that counters actually zeroed.
+	for _, i := range []int{0, vkCount / 2, vkCount - 1} {
+		rl := store.LoadRateLimit(ctx, fmt.Sprintf("scale-rl-%06d", i))
+		if rl.RequestCurrentUsage != 0 {
+			t.Fatalf("rate limit %06d not zeroed after background reset: %d", i, rl.RequestCurrentUsage)
+		}
+	}
+
+	if bestPerReset > maxPerReset {
+		t.Fatalf("background reset cost %v per reset (budget %v) with %d VKs across %d attempts; cost scales linearly with VK count, so at 100k keys one sweep is roughly %v of CPU every 10s tick - the reference refresh needs an O(owners) index or one batched pass per tick",
+			bestPerReset, maxPerReset, vkCount, timingBudgetAttempts,
+			time.Duration(int64(bestPerReset)*int64(100_000/vkCount))*100_000)
+	}
+	t.Logf("background reset: %v per reset for %d per-VK rate limits", bestPerReset, vkCount)
+}
+
+// seed100kBudgetVK creates one VK owning one budget with the given duration,
+// alignment and last-reset, returning the budget ID.
+func seed100kBudgetVK(ctx context.Context, store *LocalGovernanceStore, i int, duration string, calendarAligned bool, lastReset time.Time, usage float64) string {
+	budgetID := fmt.Sprintf("acc-budget-%06d", i)
+	budget := buildBudgetWithUsage(budgetID, 1_000_000, usage, duration)
+	budget.LastReset = lastReset
+	vk := buildVirtualKey(
+		fmt.Sprintf("acc-vk-%06d", i),
+		fmt.Sprintf("sk-bf-acc-%06d", i),
+		fmt.Sprintf("Accuracy VK %06d", i),
+		true,
+	)
+	// Alignment lives on the OWNER: CreateVirtualKeyInMemory stamps
+	// IsCalendarAligned onto stored budgets from vk.CalendarAligned, exactly
+	// like production config loading. Setting it on the budget alone is lost.
+	vk.CalendarAligned = calendarAligned
+	vk.Budgets = []configstoreTables.TableBudget{*budget}
+	store.CreateVirtualKeyInMemory(ctx, vk)
+	return budgetID
+}
+
+// TestBudgetResetAccuracyAt100kKeysAllDue seeds 100k VKs, every one owning a
+// budget on a proper calendar-scale duration (1d/1w/1M, alternating rolling
+// and calendar-aligned), all expired, then runs ONE background sweep and
+// verifies reset accuracy on every single key: usage zeroed, rolling
+// LastReset advanced past the stale value, calendar LastReset snapped exactly
+// to the period start, and the embedded VK reference refreshed.
+func TestBudgetResetAccuracyAt100kKeysAllDue(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	const keyCount = 100_000
+	durations := []string{"1d", "1w", "1M"}
+	// Stale offsets guaranteed expired for both rolling and calendar semantics.
+	staleOffsets := map[string]time.Duration{
+		"1d": -25 * time.Hour,
+		"1w": -8 * 24 * time.Hour,
+		"1M": -31 * 24 * time.Hour,
+	}
+
+	seedNow := time.Now()
+	staleResets := make([]time.Time, keyCount)
+	for i := 0; i < keyCount; i++ {
+		duration := durations[i%3]
+		stale := seedNow.Add(staleOffsets[duration])
+		staleResets[i] = stale
+		seed100kBudgetVK(ctx, store, i, duration, i%2 == 0, stale, float64(i%997)+1)
+	}
+
+	// Best of timingBudgetAttempts sweeps; each retry re-stales every budget so
+	// the sweep does full work again, filtering host noise on slow runners.
+	sweepBudget := scaleTimingBudget(10 * time.Second)
+	var bestElapsed time.Duration
+	var beforeSweep, afterSweep time.Time
+	for attempt := 0; attempt < timingBudgetAttempts; attempt++ {
+		if attempt > 0 {
+			for i := 0; i < keyCount; i++ {
+				id := fmt.Sprintf("acc-budget-%06d", i)
+				raw, ok := store.budgets.Load(id)
+				if !ok || raw == nil {
+					t.Fatalf("budget %06d missing before retry", i)
+				}
+				clone := *(raw.(*configstoreTables.TableBudget))
+				clone.LastReset = staleResets[i]
+				clone.CurrentUsage = float64(i%997) + 1
+				store.budgets.Store(id, &clone)
+			}
+		}
+		beforeSweep = time.Now()
+		reset := store.ResetExpiredBudgetsInMemory(ctx, true)
+		elapsed := time.Since(beforeSweep)
+		afterSweep = time.Now()
+
+		if len(reset) != keyCount {
+			t.Fatalf("expected all %d budgets to reset, got %d", keyCount, len(reset))
+		}
+		if bestElapsed == 0 || elapsed < bestElapsed {
+			bestElapsed = elapsed
+		}
+		if bestElapsed <= sweepBudget {
+			break
+		}
+	}
+	for i := 0; i < keyCount; i++ {
+		duration := durations[i%3]
+		budget := store.LoadBudget(ctx, fmt.Sprintf("acc-budget-%06d", i))
+		if budget == nil {
+			t.Fatalf("budget %06d missing after sweep", i)
+		}
+		if budget.CurrentUsage != 0 {
+			t.Fatalf("budget %06d (%s) usage not zeroed: %f", i, duration, budget.CurrentUsage)
+		}
+		if i%2 == 0 {
+			// Calendar-aligned: LastReset must snap exactly to the period start
+			// (computed before or after the sweep - identical unless the sweep
+			// straddles a period boundary).
+			want1 := configstoreTables.GetCalendarPeriodStart(duration, beforeSweep)
+			want2 := configstoreTables.GetCalendarPeriodStart(duration, afterSweep)
+			if !budget.LastReset.Equal(want1) && !budget.LastReset.Equal(want2) {
+				t.Fatalf("budget %06d (%s, calendar) LastReset %v, want period start %v", i, duration, budget.LastReset, want1)
+			}
+		} else if !budget.LastReset.After(staleResets[i]) {
+			t.Fatalf("budget %06d (%s, rolling) LastReset did not advance: %v", i, duration, budget.LastReset)
+		}
+		rawVK, ok := store.virtualKeys.Load(fmt.Sprintf("sk-bf-acc-%06d", i))
+		if !ok || rawVK == nil {
+			t.Fatalf("vk %06d missing after sweep", i)
+		}
+		vk := rawVK.(*configstoreTables.TableVirtualKey)
+		if len(vk.Budgets) != 1 || vk.Budgets[0].CurrentUsage != 0 {
+			t.Fatalf("vk %06d embedded budget not refreshed: %+v", i, vk.Budgets)
+		}
+	}
+	t.Logf("dense sweep: %d budgets reset in %v (%v per reset)", keyCount, bestElapsed, bestElapsed/keyCount)
+	if bestElapsed > sweepBudget {
+		t.Fatalf("dense 100k sweep took %v (budget %v) across %d attempts; the background tick budget is 10s", bestElapsed, sweepBudget, timingBudgetAttempts)
+	}
+}
+
+// TestBudgetResetAccuracyAt100kKeysSparse covers the sparse structure: 100k
+// keys where 10%% own no budget at all, and only ~1%% of the budgeted keys are
+// actually due. The sweep must reset exactly the due set, leave every
+// untouched budget byte-identical in usage and LastReset, and stay fast.
+func TestBudgetResetAccuracyAt100kKeysSparse(t *testing.T) {
+	ctx := context.Background()
+	store := newStandaloneStoreForResetBenchmark()
+	const keyCount = 100_000
+
+	seedNow := time.Now()
+	staleWeek := seedNow.Add(-8 * 24 * time.Hour)
+	freshResets := make([]time.Time, keyCount)
+	dueCount := 0
+	for i := 0; i < keyCount; i++ {
+		if i%10 == 7 { // sparse ownership: every 10th key has no budget
+			vk := buildVirtualKey(
+				fmt.Sprintf("acc-vk-%06d", i),
+				fmt.Sprintf("sk-bf-acc-%06d", i),
+				fmt.Sprintf("Accuracy VK %06d", i),
+				true,
+			)
+			store.CreateVirtualKeyInMemory(ctx, vk)
+			continue
+		}
+		if i%100 == 0 { // ~1% due: rolling weekly, expired
+			seed100kBudgetVK(ctx, store, i, "1w", false, staleWeek, 500)
+			dueCount++
+			continue
+		}
+		// Not due: rolling weekly, reset recently, distinct usage per key.
+		fresh := seedNow.Add(-time.Duration(i%5000+1) * time.Minute)
+		freshResets[i] = fresh
+		seed100kBudgetVK(ctx, store, i, "1w", false, fresh, float64(i%997)+1)
+	}
+
+	// Best of timingBudgetAttempts sweeps; each retry re-stales only the due
+	// set so the sweep does the same work again, filtering host noise.
+	sweepBudget := scaleTimingBudget(5 * time.Second)
+	var bestElapsed time.Duration
+	for attempt := 0; attempt < timingBudgetAttempts; attempt++ {
+		if attempt > 0 {
+			for i := 0; i < keyCount; i += 100 {
+				id := fmt.Sprintf("acc-budget-%06d", i)
+				raw, ok := store.budgets.Load(id)
+				if !ok || raw == nil {
+					t.Fatalf("budget %06d missing before retry", i)
+				}
+				clone := *(raw.(*configstoreTables.TableBudget))
+				clone.LastReset = staleWeek
+				clone.CurrentUsage = 500
+				store.budgets.Store(id, &clone)
+			}
+		}
+		start := time.Now()
+		reset := store.ResetExpiredBudgetsInMemory(ctx, true)
+		elapsed := time.Since(start)
+
+		if len(reset) != dueCount {
+			t.Fatalf("expected exactly %d due budgets to reset, got %d", dueCount, len(reset))
+		}
+		if bestElapsed == 0 || elapsed < bestElapsed {
+			bestElapsed = elapsed
+		}
+		if bestElapsed <= sweepBudget {
+			break
+		}
+	}
+	for i := 0; i < keyCount; i++ {
+		if i%10 == 7 {
+			continue
+		}
+		budget := store.LoadBudget(ctx, fmt.Sprintf("acc-budget-%06d", i))
+		if budget == nil {
+			t.Fatalf("budget %06d missing after sweep", i)
+		}
+		if i%100 == 0 {
+			if budget.CurrentUsage != 0 || !budget.LastReset.After(staleWeek) {
+				t.Fatalf("due budget %06d not reset: usage=%f lastReset=%v", i, budget.CurrentUsage, budget.LastReset)
+			}
+			continue
+		}
+		if wantUsage := float64(i%997) + 1; budget.CurrentUsage != wantUsage {
+			t.Fatalf("untouched budget %06d usage changed: got %f want %f", i, budget.CurrentUsage, wantUsage)
+		}
+		if !budget.LastReset.Equal(freshResets[i]) {
+			t.Fatalf("untouched budget %06d LastReset changed: got %v want %v", i, budget.LastReset, freshResets[i])
+		}
+	}
+	t.Logf("sparse sweep: %d/%d budgets reset in %v", dueCount, keyCount, bestElapsed)
+	if bestElapsed > sweepBudget {
+		t.Fatalf("sparse 100k sweep took %v (budget %v) across %d attempts; expected well under the 10s tick", bestElapsed, sweepBudget, timingBudgetAttempts)
 	}
 }
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1864,7 +1864,9 @@ func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.Tabl
 }
 
 // resetExpiredBudgetFromSnapshot applies the local side effects for an expired budget snapshot.
-func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Context, budget *configstoreTables.TableBudget, now time.Time, refreshReferences bool) *configstoreTables.TableBudget {
+// Owner reference refresh is NOT done here; ResetExpiredBudgetsInMemory batches it
+// once per sweep so a sweep costs O(owners + resets) instead of O(owners x resets).
+func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Context, budget *configstoreTables.TableBudget, now time.Time) *configstoreTables.TableBudget {
 	newLastReset := gs.budgetResetTarget(budget, now)
 	if newLastReset == nil {
 		return nil
@@ -1877,9 +1879,6 @@ func (gs *LocalGovernanceStore) resetExpiredBudgetFromSnapshot(ctx context.Conte
 	gs.LastDBUsagesBudgetsMu.Lock()
 	gs.LastDBUsagesBudgets[resetBudget.ID] = 0
 	gs.LastDBUsagesBudgetsMu.Unlock()
-	if refreshReferences {
-		gs.updateBudgetReferences(ctx, resetBudget)
-	}
 	gs.logger.Debug(fmt.Sprintf("Reset budget %s (was %.2f, reset to 0)", resetBudget.ID, oldUsage))
 	return resetBudget
 }
@@ -1897,7 +1896,7 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 		if !ok || budget == nil {
 			return
 		}
-		if resetBudget := gs.resetExpiredBudgetFromSnapshot(ctx, budget, now, refreshReferences); resetBudget != nil {
+		if resetBudget := gs.resetExpiredBudgetFromSnapshot(ctx, budget, now); resetBudget != nil {
 			resetBudgets = append(resetBudgets, resetBudget)
 		}
 	}
@@ -1912,6 +1911,9 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 				resetOne(value)
 			}
 		}
+	}
+	if refreshReferences {
+		gs.updateBudgetReferences(ctx, resetBudgets)
 	}
 	if len(resetBudgets) > 0 {
 		if onBudgetsReset := gs.getBudgetsResetHook(); onBudgetsReset != nil {
@@ -1965,7 +1967,9 @@ func (gs *LocalGovernanceStore) rateLimitResetTargets(rateLimit *configstoreTabl
 }
 
 // resetExpiredRateLimitFromSnapshot applies the local side effects for an expired rate-limit snapshot.
-func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Context, rateLimit *configstoreTables.TableRateLimit, now time.Time, refreshReferences bool) *configstoreTables.TableRateLimit {
+// Owner reference refresh is NOT done here; ResetExpiredRateLimitsInMemory batches it
+// once per sweep so a sweep costs O(owners + resets) instead of O(owners x resets).
+func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Context, rateLimit *configstoreTables.TableRateLimit, now time.Time) *configstoreTables.TableRateLimit {
 	tokenNewLastReset, requestNewLastReset := gs.rateLimitResetTargets(rateLimit, now)
 	if tokenNewLastReset == nil && requestNewLastReset == nil {
 		return nil
@@ -1984,9 +1988,6 @@ func (gs *LocalGovernanceStore) resetExpiredRateLimitFromSnapshot(ctx context.Co
 		gs.LastDBUsagesRequestsRateLimits[resetRateLimit.ID] = 0
 		gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
 	}
-	if refreshReferences {
-		gs.updateRateLimitReferences(ctx, resetRateLimit)
-	}
 	return resetRateLimit
 }
 
@@ -2003,7 +2004,7 @@ func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Conte
 		if !ok || rateLimit == nil {
 			return
 		}
-		if resetRateLimit := gs.resetExpiredRateLimitFromSnapshot(ctx, rateLimit, now, refreshReferences); resetRateLimit != nil {
+		if resetRateLimit := gs.resetExpiredRateLimitFromSnapshot(ctx, rateLimit, now); resetRateLimit != nil {
 			resetRateLimits = append(resetRateLimits, resetRateLimit)
 		}
 	}
@@ -2018,6 +2019,9 @@ func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Conte
 				resetOne(value)
 			}
 		}
+	}
+	if refreshReferences {
+		gs.updateRateLimitReferences(ctx, resetRateLimits)
 	}
 	if len(resetRateLimits) > 0 {
 		if onRateLimitsReset := gs.getRateLimitsResetHook(); onRateLimitsReset != nil {
@@ -3733,134 +3737,215 @@ func (gs *LocalGovernanceStore) DeleteProviderInMemory(ctx context.Context, prov
 
 // Helper functions
 
-// updateBudgetReferences updates all VKs, teams, customers, and provider configs that reference a reset budget
-func (gs *LocalGovernanceStore) updateBudgetReferences(ctx context.Context, resetBudget *configstoreTables.TableBudget) {
-	budgetID := resetBudget.ID
-	// Update VKs that reference this budget
+// updateBudgetReferences updates all VKs, teams, customers, and provider configs
+// that reference any of the reset budgets. It makes ONE pass over each owner map
+// regardless of how many budgets reset, and clones an owner only after a match,
+// so a background sweep costs O(owners + resets) instead of O(owners x resets)
+// with a clone per owner per reset. Essential at large key counts; the contract
+// is pinned by TestBackgroundResetReferenceRefreshScales.
+func (gs *LocalGovernanceStore) updateBudgetReferences(ctx context.Context, resetBudgets []*configstoreTables.TableBudget) {
+	if len(resetBudgets) == 0 {
+		return
+	}
+	resets := make(map[string]*configstoreTables.TableBudget, len(resetBudgets))
+	for _, b := range resetBudgets {
+		if b != nil {
+			resets[b.ID] = b
+		}
+	}
+	// Update VKs that reference these budgets
 	gs.virtualKeys.Range(func(key, value interface{}) bool {
 		vk, ok := value.(*configstoreTables.TableVirtualKey)
 		if !ok || vk == nil {
 			return true // continue
 		}
-		needsUpdate := false
-		clone := *vk
-
-		// Check VK-level budgets
-		for i, b := range clone.Budgets {
-			if b.ID == budgetID {
-				clone.Budgets[i] = *resetBudget
-				needsUpdate = true
+		vkMatch := false
+		for i := range vk.Budgets {
+			if resets[vk.Budgets[i].ID] != nil {
+				vkMatch = true
+				break
 			}
 		}
-		// Check provider config budgets
-		if vk.ProviderConfigs != nil {
-			for i := range clone.ProviderConfigs {
-				for j, b := range clone.ProviderConfigs[i].Budgets {
-					if b.ID == budgetID {
-						clone.ProviderConfigs[i].Budgets[j] = *resetBudget
-						needsUpdate = true
-					}
+		pcMatch := false
+		for i := range vk.ProviderConfigs {
+			for j := range vk.ProviderConfigs[i].Budgets {
+				if resets[vk.ProviderConfigs[i].Budgets[j].ID] != nil {
+					pcMatch = true
+					break
+				}
+			}
+			if pcMatch {
+				break
+			}
+		}
+		if !vkMatch && !pcMatch {
+			return true // continue
+		}
+		clone := *vk
+		if vkMatch {
+			clone.Budgets = append([]configstoreTables.TableBudget(nil), vk.Budgets...)
+			for i := range clone.Budgets {
+				if b := resets[clone.Budgets[i].ID]; b != nil {
+					clone.Budgets[i] = *b
 				}
 			}
 		}
-		if needsUpdate {
-			gs.storeVirtualKey(key.(string), &clone)
+		if pcMatch {
+			clone.ProviderConfigs = append([]configstoreTables.TableVirtualKeyProviderConfig(nil), vk.ProviderConfigs...)
+			for i := range clone.ProviderConfigs {
+				matched := false
+				for j := range clone.ProviderConfigs[i].Budgets {
+					if resets[clone.ProviderConfigs[i].Budgets[j].ID] != nil {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					continue
+				}
+				budgets := append([]configstoreTables.TableBudget(nil), clone.ProviderConfigs[i].Budgets...)
+				for j := range budgets {
+					if b := resets[budgets[j].ID]; b != nil {
+						budgets[j] = *b
+					}
+				}
+				clone.ProviderConfigs[i].Budgets = budgets
+			}
 		}
+		gs.storeVirtualKey(key.(string), &clone)
 		return true // continue
 	})
-	// Update teams that reference this budget
+	// Update teams that reference these budgets
 	gs.teams.Range(func(key, value interface{}) bool {
 		team, ok := value.(*configstoreTables.TableTeam)
 		if !ok || team == nil {
 			return true // continue
 		}
+		matched := false
 		for i := range team.Budgets {
-			if team.Budgets[i].ID == budgetID {
-				clone := *team
-				clone.Budgets = append([]configstoreTables.TableBudget(nil), team.Budgets...)
-				clone.Budgets[i] = *resetBudget
-				gs.teams.Store(key, &clone)
+			if resets[team.Budgets[i].ID] != nil {
+				matched = true
 				break
 			}
 		}
+		if !matched {
+			return true // continue
+		}
+		clone := *team
+		clone.Budgets = append([]configstoreTables.TableBudget(nil), team.Budgets...)
+		for i := range clone.Budgets {
+			if b := resets[clone.Budgets[i].ID]; b != nil {
+				clone.Budgets[i] = *b
+			}
+		}
+		gs.teams.Store(key, &clone)
 		return true // continue
 	})
-	// Update customers that own this budget
+	// Update customers that own these budgets
 	gs.customers.Range(func(key, value interface{}) bool {
 		customer, ok := value.(*configstoreTables.TableCustomer)
 		if !ok || customer == nil {
 			return true // continue
 		}
-		for i, b := range customer.Budgets {
-			if b.ID == budgetID {
-				clone := *customer
-				clone.Budgets = make([]configstoreTables.TableBudget, len(customer.Budgets))
-				copy(clone.Budgets, customer.Budgets)
-				clone.Budgets[i] = *resetBudget
-				gs.customers.Store(key, &clone)
+		matched := false
+		for i := range customer.Budgets {
+			if resets[customer.Budgets[i].ID] != nil {
+				matched = true
 				break
 			}
 		}
+		if !matched {
+			return true // continue
+		}
+		clone := *customer
+		clone.Budgets = append([]configstoreTables.TableBudget(nil), customer.Budgets...)
+		for i := range clone.Budgets {
+			if b := resets[clone.Budgets[i].ID]; b != nil {
+				clone.Budgets[i] = *b
+			}
+		}
+		gs.customers.Store(key, &clone)
 		return true // continue
 	})
 }
 
-// updateRateLimitReferences updates all VKs, teams, customers, users and provider configs that reference a reset rate limit
-func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, resetRateLimit *configstoreTables.TableRateLimit) {
-	rateLimitID := resetRateLimit.ID
-	// Update VKs that reference this rate limit
+// updateRateLimitReferences updates all VKs, teams, customers and provider configs
+// that reference any of the reset rate limits. It makes ONE pass over each owner
+// map regardless of how many rate limits reset, and clones an owner only after a
+// match, so a background sweep costs O(owners + resets) instead of
+// O(owners x resets) with a clone per owner per reset. Essential at large key
+// counts; the contract is pinned by TestBackgroundResetReferenceRefreshScales.
+func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, resetRateLimits []*configstoreTables.TableRateLimit) {
+	if len(resetRateLimits) == 0 {
+		return
+	}
+	resets := make(map[string]*configstoreTables.TableRateLimit, len(resetRateLimits))
+	for _, rl := range resetRateLimits {
+		if rl != nil {
+			resets[rl.ID] = rl
+		}
+	}
+	// Update VKs that reference these rate limits
 	gs.virtualKeys.Range(func(key, value interface{}) bool {
 		vk, ok := value.(*configstoreTables.TableVirtualKey)
 		if !ok || vk == nil {
 			return true // continue
 		}
-		needsUpdate := false
-		clone := *vk
-
-		// Check VK-level rate limit
-		if vk.RateLimitID != nil && *vk.RateLimitID == rateLimitID {
-			clone.RateLimit = resetRateLimit
-			needsUpdate = true
+		vkMatch := vk.RateLimitID != nil && resets[*vk.RateLimitID] != nil
+		pcMatch := false
+		for i := range vk.ProviderConfigs {
+			if id := vk.ProviderConfigs[i].RateLimitID; id != nil && resets[*id] != nil {
+				pcMatch = true
+				break
+			}
 		}
-
-		// Check provider config rate limits
-		if vk.ProviderConfigs != nil {
-			for i, pc := range clone.ProviderConfigs {
-				if pc.RateLimitID != nil && *pc.RateLimitID == rateLimitID {
-					clone.ProviderConfigs[i].RateLimit = resetRateLimit
-					needsUpdate = true
+		if !vkMatch && !pcMatch {
+			return true // continue
+		}
+		clone := *vk
+		if vkMatch {
+			clone.RateLimit = resets[*vk.RateLimitID]
+		}
+		if pcMatch {
+			clone.ProviderConfigs = append([]configstoreTables.TableVirtualKeyProviderConfig(nil), vk.ProviderConfigs...)
+			for i := range clone.ProviderConfigs {
+				if id := clone.ProviderConfigs[i].RateLimitID; id != nil {
+					if rl := resets[*id]; rl != nil {
+						clone.ProviderConfigs[i].RateLimit = rl
+					}
 				}
 			}
 		}
-
-		if needsUpdate {
-			gs.storeVirtualKey(key.(string), &clone)
-		}
+		gs.storeVirtualKey(key.(string), &clone)
 		return true // continue
 	})
-	// Update teams that reference this rate limit
+	// Update teams that reference these rate limits
 	gs.teams.Range(func(key, value interface{}) bool {
 		team, ok := value.(*configstoreTables.TableTeam)
 		if !ok || team == nil {
 			return true // continue
 		}
-		if team.RateLimitID != nil && *team.RateLimitID == rateLimitID {
-			clone := *team
-			clone.RateLimit = resetRateLimit
-			gs.teams.Store(key, &clone)
+		if team.RateLimitID != nil {
+			if rl := resets[*team.RateLimitID]; rl != nil {
+				clone := *team
+				clone.RateLimit = rl
+				gs.teams.Store(key, &clone)
+			}
 		}
 		return true // continue
 	})
-	// Update customers that reference this rate limit
+	// Update customers that reference these rate limits
 	gs.customers.Range(func(key, value interface{}) bool {
 		customer, ok := value.(*configstoreTables.TableCustomer)
 		if !ok || customer == nil {
 			return true // continue
 		}
-		if customer.RateLimitID != nil && *customer.RateLimitID == rateLimitID {
-			clone := *customer
-			clone.RateLimit = resetRateLimit
-			gs.customers.Store(key, &clone)
+		if customer.RateLimitID != nil {
+			if rl := resets[*customer.RateLimitID]; rl != nil {
+				clone := *customer
+				clone.RateLimit = rl
+				gs.customers.Store(key, &clone)
+			}
 		}
 		return true // continue
 	})

--- a/tests/governance/advancedscenarios_test.go
+++ b/tests/governance/advancedscenarios_test.go
@@ -68,8 +68,9 @@ func TestVKSwitchTeamAfterBudgetExhaustion(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &team1ID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &team1ID,
 		},
 	})
 
@@ -189,10 +190,10 @@ func TestVKSwitchCustomerAfterBudgetExhaustion(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customer1Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      customer1Budget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -211,10 +212,10 @@ func TestVKSwitchCustomerAfterBudgetExhaustion(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customer2Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      customer2Budget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -233,8 +234,9 @@ func TestVKSwitchCustomerAfterBudgetExhaustion(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:       vkName,
-			CustomerID: &customer1ID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			CustomerID:      &customer1ID,
 		},
 	})
 
@@ -350,10 +352,10 @@ func TestHierarchicalChainBudgetSwitch(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customer1Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      0.01, // $0.01 - most restrictive
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -393,10 +395,10 @@ func TestHierarchicalChainBudgetSwitch(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customer2Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0, // High budget
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -437,8 +439,9 @@ func TestHierarchicalChainBudgetSwitch(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &team1ID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &team1ID,
 		},
 	})
 
@@ -550,11 +553,12 @@ func TestVKBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -621,10 +625,10 @@ func TestVKBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/virtual-keys/" + vkID,
 		Body: UpdateVirtualKeyRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newBudget,
-				ResetDuration: &resetDuration,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newBudget,
+				ResetDuration: resetDuration,
+			}},
 		},
 	})
 
@@ -694,8 +698,9 @@ func TestTeamBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -815,10 +820,10 @@ func TestCustomerBudgetUpdateAfterExhaustion(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -853,8 +858,9 @@ func TestCustomerBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -921,10 +927,10 @@ func TestCustomerBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/customers/" + customerID,
 		Body: UpdateCustomerRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newBudget,
-				ResetDuration: &resetDuration,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newBudget,
+				ResetDuration: resetDuration,
+			}},
 		},
 	})
 
@@ -980,10 +986,10 @@ func TestProviderConfigBudgetUpdateAfterExhaustion(t *testing.T) {
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      initialBudget,
 						ResetDuration: "1h",
-					},
+					}},
 				},
 			},
 		},
@@ -1007,8 +1013,10 @@ func TestProviderConfigBudgetUpdateAfterExhaustion(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
 	providerConfigs := vkData["provider_configs"].([]interface{})
 	providerConfig := providerConfigs[0].(map[string]interface{})
 	providerConfigID := uint(providerConfig["id"].(float64))
@@ -1070,10 +1078,10 @@ func TestProviderConfigBudgetUpdateAfterExhaustion(t *testing.T) {
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      newBudget,
 						ResetDuration: "1h",
-					},
+					}},
 				},
 			},
 		},
@@ -1126,10 +1134,10 @@ func TestVKDeletionCascadeComplete(t *testing.T) {
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
 			Name: vkName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      10.0,
 				ResetDuration: "1h",
-			},
+			}},
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -1140,10 +1148,10 @@ func TestVKDeletionCascadeComplete(t *testing.T) {
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      5.0,
 						ResetDuration: "1h",
-					},
+					}},
 					RateLimit: &CreateRateLimitRequest{
 						TokenMaxLimit:      &tokenLimit,
 						TokenResetDuration: &tokenResetDuration,
@@ -1171,41 +1179,40 @@ func TestVKDeletionCascadeComplete(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
-
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
 
 	getRateLimitsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap1 := getRateLimitsResp1.Body["rate_limits"].(map[string]interface{})
-
 	// Verify VK exists
-	_, vkExists := virtualKeysMap1[vkValue]
-	if !vkExists {
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
 		t.Fatalf("VK not found in in-memory store")
 	}
 
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
-	vkBudgetID := vkData1["budget_id"].(string)
+	vkBudgetID := FirstBudgetID(vkData1)
+	if vkBudgetID == "" {
+		t.Fatalf("VK has no embedded budget in in-memory store")
+	}
 	vkRateLimitID := vkData1["rate_limit_id"].(string)
 	providerConfigs := vkData1["provider_configs"].([]interface{})
 	pc := providerConfigs[0].(map[string]interface{})
-	pcBudgetID := pc["budget_id"].(string)
+	pcBudgetID := FirstBudgetID(pc)
+	if pcBudgetID == "" {
+		t.Fatalf("provider config has no embedded budget in in-memory store")
+	}
 	pcRateLimitID := pc["rate_limit_id"].(string)
 
 	// Verify all resources exist in memory
-	_, vkBudgetExists := budgetsMap1[vkBudgetID]
-	_, vkRateLimitExists := rateLimitsMap1[vkRateLimitID]
-	_, pcBudgetExists := budgetsMap1[pcBudgetID]
-	_, pcRateLimitExists := rateLimitsMap1[pcRateLimitID]
+	vkBudgetExists := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", vkBudgetID) != nil
+	vkRateLimitExists := FindListItem(t, getRateLimitsResp1.Body, "rate_limits", "id", vkRateLimitID) != nil
+	pcBudgetExists := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", pcBudgetID) != nil
+	pcRateLimitExists := FindListItem(t, getRateLimitsResp1.Body, "rate_limits", "id", pcRateLimitID) != nil
 
 	if !vkBudgetExists || !vkRateLimitExists || !pcBudgetExists || !pcRateLimitExists {
 		t.Fatalf("Not all resources found in memory before deletion")
@@ -1233,39 +1240,33 @@ func TestVKDeletionCascadeComplete(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp2 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
-
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
 
 	getRateLimitsResp2 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
-
 	// VK should be gone
-	_, vkStillExists := virtualKeysMap2[vkValue]
+	vkStillExists := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue) != nil
 	if vkStillExists {
 		t.Fatalf("VK still exists in memory after deletion")
 	}
 
 	// Budgets should be gone
-	_, vkBudgetStillExists := budgetsMap2[vkBudgetID]
-	_, pcBudgetStillExists := budgetsMap2[pcBudgetID]
+	vkBudgetStillExists := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", vkBudgetID) != nil
+	pcBudgetStillExists := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", pcBudgetID) != nil
 	if vkBudgetStillExists || pcBudgetStillExists {
 		t.Fatalf("Budgets should be cascade-deleted: VK budget exists=%v, PC budget exists=%v",
 			vkBudgetStillExists, pcBudgetStillExists)
 	}
 
 	// Rate limits should be gone
-	_, vkRateLimitStillExists := rateLimitsMap2[vkRateLimitID]
-	_, pcRateLimitStillExists := rateLimitsMap2[pcRateLimitID]
+	vkRateLimitStillExists := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", vkRateLimitID) != nil
+	pcRateLimitStillExists := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", pcRateLimitID) != nil
 	if vkRateLimitStillExists || pcRateLimitStillExists {
 		t.Logf("Note: Rate limits may still exist in memory (orphaned) - this is acceptable")
 	}
@@ -1313,16 +1314,15 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/teams?from_memory=true",
 	})
 
-	teamsMap1 := getTeamsResp1.Body["teams"].(map[string]interface{})
-
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
-
-	teamData1 := teamsMap1[teamID].(map[string]interface{})
+	teamData1 := FindListItem(t, getTeamsResp1.Body, "teams", "id", teamID)
+	if teamData1 == nil {
+		t.Fatalf("Team %s not found in memory before deletion", teamID)
+	}
 	// Teams now expose a `budgets` array instead of a single `budget_id`.
 	budgetsList, ok := teamData1["budgets"].([]interface{})
 	if !ok || len(budgetsList) == 0 {
@@ -1330,8 +1330,7 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 	}
 	budgetID := budgetsList[0].(map[string]interface{})["id"].(string)
 
-	_, budgetExists := budgetsMap1[budgetID]
-	if !budgetExists {
+	if FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID) == nil {
 		t.Fatalf("Budget not found in memory before deletion")
 	}
 
@@ -1357,9 +1356,7 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/teams?from_memory=true",
 	})
 
-	teamsMap2 := getTeamsResp2.Body["teams"].(map[string]interface{})
-
-	_, teamStillExists := teamsMap2[teamID]
+	teamStillExists := FindListItem(t, getTeamsResp2.Body, "teams", "id", teamID) != nil
 	if teamStillExists {
 		t.Fatalf("Team still exists in memory after deletion")
 	}
@@ -1376,9 +1373,7 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 		t.Fatalf("Failed to get budgets from memory: status %d", getBudgetsResp2.StatusCode)
 	}
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
-	_, budgetStillExists := budgetsMap2[budgetID]
+	budgetStillExists := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID) != nil
 	if budgetStillExists {
 		t.Fatalf("Budget %s still exists in memory after team deletion", budgetID)
 	}
@@ -1400,10 +1395,10 @@ func TestCustomerDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -1422,20 +1417,21 @@ func TestCustomerDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/customers?from_memory=true",
 	})
 
-	customersMap1 := getCustomersResp1.Body["customers"].(map[string]interface{})
-
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
+	customerData1 := FindListItem(t, getCustomersResp1.Body, "customers", "id", customerID)
+	if customerData1 == nil {
+		t.Fatalf("Customer %s not found in memory before deletion", customerID)
+	}
+	budgetID := FirstBudgetID(customerData1)
+	if budgetID == "" {
+		t.Fatalf("customer has no embedded budget in in-memory store")
+	}
 
-	customerData1 := customersMap1[customerID].(map[string]interface{})
-	budgetID := customerData1["budget_id"].(string)
-
-	_, budgetExists := budgetsMap1[budgetID]
-	if !budgetExists {
+	if FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID) == nil {
 		t.Fatalf("Budget not found in memory before deletion")
 	}
 
@@ -1461,9 +1457,7 @@ func TestCustomerDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/customers?from_memory=true",
 	})
 
-	customersMap2 := getCustomersResp2.Body["customers"].(map[string]interface{})
-
-	_, customerStillExists := customersMap2[customerID]
+	customerStillExists := FindListItem(t, getCustomersResp2.Body, "customers", "id", customerID) != nil
 	if customerStillExists {
 		t.Fatalf("Customer still exists in memory after deletion")
 	}
@@ -1480,9 +1474,7 @@ func TestCustomerDeletionDeletesBudget(t *testing.T) {
 		t.Fatalf("Failed to get budgets from memory: status %d", getBudgetsResp2.StatusCode)
 	}
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
-	_, budgetStillExists := budgetsMap2[budgetID]
+	budgetStillExists := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID) != nil
 	if budgetStillExists {
 		t.Fatalf("Budget still exists in memory after customer deletion")
 	}
@@ -1524,8 +1516,9 @@ func TestTeamDeletionSetsVKTeamIDToNil(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -1547,8 +1540,10 @@ func TestTeamDeletionSetsVKTeamIDToNil(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
 
 	teamIDFromVK1, hasTeamID := vkData1["team_id"].(string)
 	if !hasTeamID || teamIDFromVK1 != teamID {
@@ -1577,10 +1572,8 @@ func TestTeamDeletionSetsVKTeamIDToNil(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-
-	vkData2, vkStillExists := virtualKeysMap2[vkValue].(map[string]interface{})
-	if !vkStillExists {
+	vkData2 := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
 		t.Fatalf("VK should still exist after team deletion")
 	}
 
@@ -1622,8 +1615,9 @@ func TestCustomerDeletionSetsVKCustomerIDToNil(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:       vkName,
-			CustomerID: &customerID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			CustomerID:      &customerID,
 		},
 	})
 
@@ -1645,8 +1639,10 @@ func TestCustomerDeletionSetsVKCustomerIDToNil(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
 
 	customerIDFromVK1, hasCustomerID := vkData1["customer_id"].(string)
 	if !hasCustomerID || customerIDFromVK1 != customerID {
@@ -1675,10 +1671,8 @@ func TestCustomerDeletionSetsVKCustomerIDToNil(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-
-	vkData2, vkStillExists := virtualKeysMap2[vkValue].(map[string]interface{})
-	if !vkStillExists {
+	vkData2 := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
 		t.Fatalf("VK should still exist after customer deletion")
 	}
 

--- a/tests/governance/configupdatesync_test.go
+++ b/tests/governance/configupdatesync_test.go
@@ -25,7 +25,8 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &initialTokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -51,7 +52,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData1 := getVKResp1.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getVKResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	rateLimitID1, _ := vkData1["rate_limit_id"].(string)
 
 	getRateLimitsResp1 := MakeRequest(t, APIRequest{
@@ -59,8 +63,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap1 := getRateLimitsResp1.Body["rate_limits"].(map[string]interface{})
-	rateLimit1 := rateLimitsMap1[rateLimitID1].(map[string]interface{})
+	rateLimit1 := FindListItem(t, getRateLimitsResp1.Body, "rate_limits", "id", rateLimitID1)
+	if rateLimit1 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID1)
+	}
 
 	initialTokenMaxLimit, _ := rateLimit1["token_max_limit"].(float64)
 	initialTokenUsage, _ := rateLimit1["token_current_usage"].(float64)
@@ -100,7 +106,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData2 := getVKResp2.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData2 := FindListItem(t, getVKResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	rateLimitID2, _ := vkData2["rate_limit_id"].(string)
 
 	getRateLimitsResp2 := MakeRequest(t, APIRequest{
@@ -108,8 +117,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
-	rateLimit2 := rateLimitsMap2[rateLimitID2].(map[string]interface{})
+	rateLimit2 := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", rateLimitID2)
+	if rateLimit2 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID2)
+	}
 
 	tokenUsageBeforeUpdate, _ := rateLimit2["token_current_usage"].(float64)
 	t.Logf("DEBUG: Token usage after request: %d", int64(tokenUsageBeforeUpdate))
@@ -159,7 +170,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData3 := getVKResp3.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData3 := FindListItem(t, getVKResp3.Body, "virtual_keys", "value", vkValue)
+	if vkData3 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	rateLimitID3, _ := vkData3["rate_limit_id"].(string)
 
 	getRateLimitsResp3 := MakeRequest(t, APIRequest{
@@ -167,8 +181,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap3 := getRateLimitsResp3.Body["rate_limits"].(map[string]interface{})
-	rateLimit3 := rateLimitsMap3[rateLimitID3].(map[string]interface{})
+	rateLimit3 := FindListItem(t, getRateLimitsResp3.Body, "rate_limits", "id", rateLimitID3)
+	if rateLimit3 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID3)
+	}
 
 	t.Logf("DEBUG: Rate limit ID after update: %s", rateLimitID3)
 	t.Logf("DEBUG: Rate limit ID changed: %v", rateLimitID2 != rateLimitID3)
@@ -216,7 +232,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData4 := getVKResp4.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData4 := FindListItem(t, getVKResp4.Body, "virtual_keys", "value", vkValue)
+	if vkData4 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	rateLimitID4, _ := vkData4["rate_limit_id"].(string)
 
 	getRateLimitsResp4 := MakeRequest(t, APIRequest{
@@ -224,8 +243,10 @@ func TestVKRateLimitUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap4 := getRateLimitsResp4.Body["rate_limits"].(map[string]interface{})
-	rateLimit4 := rateLimitsMap4[rateLimitID4].(map[string]interface{})
+	rateLimit4 := FindListItem(t, getRateLimitsResp4.Body, "rate_limits", "id", rateLimitID4)
+	if rateLimit4 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID4)
+	}
 
 	newerTokenMaxLimit, _ := rateLimit4["token_max_limit"].(float64)
 	tokenUsageAfterSecondUpdate, _ := rateLimit4["token_current_usage"].(float64)
@@ -261,11 +282,12 @@ func TestVKBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: resetDuration,
-			},
+			}},
 		},
 	})
 
@@ -287,16 +309,21 @@ func TestVKBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData1 := getVKResp1.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
-	budgetID, _ := vkData1["budget_id"].(string)
+	vkData1 := FindListItem(t, getVKResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
+	budgetID := FirstBudgetID(vkData1)
 
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
-	budget1 := budgetsMap1[budgetID].(map[string]interface{})
+	budget1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budget1 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	initialMaxLimit, _ := budget1["max_limit"].(float64)
 	initialUsage, _ := budget1["current_usage"].(float64)
@@ -336,8 +363,10 @@ func TestVKBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budget2 := budgetsMap2[budgetID].(map[string]interface{})
+	budget2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budget2 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	usageBeforeUpdate, _ := budget2["current_usage"].(float64)
 	t.Logf("Budget usage after request: $%.6f", usageBeforeUpdate)
@@ -356,10 +385,10 @@ func TestVKBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/virtual-keys/" + vkID,
 		Body: UpdateVirtualKeyRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newLowerBudget,
-				ResetDuration: &resetDuration,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newLowerBudget,
+				ResetDuration: resetDuration,
+			}},
 		},
 	})
 
@@ -378,8 +407,10 @@ func TestVKBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budget3 := budgetsMap3[budgetID].(map[string]interface{})
+	budget3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budget3 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	newMaxLimit, _ := budget3["max_limit"].(float64)
 	usageAfterUpdate, _ := budget3["current_usage"].(float64)
@@ -446,7 +477,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
-	vkData1 := getVKResp1.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getVKResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	providerConfigs1 := vkData1["provider_configs"].([]interface{})
 	providerConfig1 := providerConfigs1[0].(map[string]interface{})
 	providerConfigID := uint(providerConfig1["id"].(float64))
@@ -455,8 +489,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
-	rateLimitsMap1 := getRateLimitsResp1.Body["rate_limits"].(map[string]interface{})
-	rateLimit1 := rateLimitsMap1[rateLimitID1].(map[string]interface{})
+	rateLimit1 := FindListItem(t, getRateLimitsResp1.Body, "rate_limits", "id", rateLimitID1)
+	if rateLimit1 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID1)
+	}
 	initialTokenMaxLimit, _ := rateLimit1["token_max_limit"].(float64)
 	initialTokenUsage, _ := rateLimit1["token_current_usage"].(float64)
 	if int64(initialTokenMaxLimit) != initialTokenLimit {
@@ -490,7 +526,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
-	vkData2 := getVKResp2.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData2 := FindListItem(t, getVKResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	providerConfigs2 := vkData2["provider_configs"].([]interface{})
 	providerConfig2 := providerConfigs2[0].(map[string]interface{})
 	rateLimitID2, _ := providerConfig2["rate_limit_id"].(string)
@@ -498,8 +537,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
-	rateLimit2 := rateLimitsMap2[rateLimitID2].(map[string]interface{})
+	rateLimit2 := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", rateLimitID2)
+	if rateLimit2 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID2)
+	}
 	tokenUsageBeforeUpdate, _ := rateLimit2["token_current_usage"].(float64)
 	t.Logf("Provider token usage after request: %d", int64(tokenUsageBeforeUpdate))
 	if tokenUsageBeforeUpdate <= 0 {
@@ -537,7 +578,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
-	vkData3 := getVKResp3.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData3 := FindListItem(t, getVKResp3.Body, "virtual_keys", "value", vkValue)
+	if vkData3 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	providerConfigs3 := vkData3["provider_configs"].([]interface{})
 	providerConfig3 := providerConfigs3[0].(map[string]interface{})
 	rateLimitID3, _ := providerConfig3["rate_limit_id"].(string)
@@ -545,8 +589,10 @@ func TestProviderRateLimitUpdateSyncToMemory(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
-	rateLimitsMap3 := getRateLimitsResp3.Body["rate_limits"].(map[string]interface{})
-	rateLimit3 := rateLimitsMap3[rateLimitID3].(map[string]interface{})
+	rateLimit3 := FindListItem(t, getRateLimitsResp3.Body, "rate_limits", "id", rateLimitID3)
+	if rateLimit3 == nil {
+		t.Fatalf("Rate limit %s not found in memory", rateLimitID3)
+	}
 	newTokenMaxLimit, _ := rateLimit3["token_max_limit"].(float64)
 	tokenUsageAfterUpdate, _ := rateLimit3["token_current_usage"].(float64)
 	// Verify new limit is reflected
@@ -602,8 +648,9 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -625,8 +672,10 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/teams?from_memory=true",
 	})
 
-	teamsMap1 := getTeamsResp1.Body["teams"].(map[string]interface{})
-	teamData1 := teamsMap1[teamID].(map[string]interface{})
+	teamData1 := FindListItem(t, getTeamsResp1.Body, "teams", "id", teamID)
+	if teamData1 == nil {
+		t.Fatalf("Team %s not found in memory", teamID)
+	}
 	// Teams now expose a `budgets` array instead of a single `budget_id`.
 	budgetsList, ok := teamData1["budgets"].([]interface{})
 	if !ok || len(budgetsList) == 0 {
@@ -639,8 +688,10 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
-	budget1 := budgetsMap1[budgetID].(map[string]interface{})
+	budget1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budget1 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	initialMaxLimit, _ := budget1["max_limit"].(float64)
 	initialUsage, _ := budget1["current_usage"].(float64)
@@ -679,8 +730,7 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 			Path:   "/api/governance/budgets?from_memory=true",
 		})
 
-		budgetsMap := getBudgetsResp.Body["budgets"].(map[string]interface{})
-		if budget, ok := budgetsMap[budgetID].(map[string]interface{}); ok {
+		if budget := FindListItem(t, getBudgetsResp.Body, "budgets", "id", budgetID); budget != nil {
 			if usage, ok := budget["current_usage"].(float64); ok && usage > 0 {
 				usageBeforeUpdate = usage
 				return true
@@ -723,8 +773,7 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 			Path:   "/api/governance/budgets?from_memory=true",
 		})
 
-		budgetsMap := getBudgetsResp.Body["budgets"].(map[string]interface{})
-		if budget, ok := budgetsMap[budgetID].(map[string]interface{}); ok {
+		if budget := FindListItem(t, getBudgetsResp.Body, "budgets", "id", budgetID); budget != nil {
 			if maxLimit, ok := budget["max_limit"].(float64); ok {
 				newMaxLimit = maxLimit
 				usageAfterUpdate, _ = budget["current_usage"].(float64)
@@ -771,10 +820,10 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: resetDuration,
-			},
+			}},
 		},
 	})
 
@@ -808,8 +857,9 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -831,17 +881,21 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/customers?from_memory=true",
 	})
 
-	customersMap1 := getCustomersResp1.Body["customers"].(map[string]interface{})
-	customerData1 := customersMap1[customerID].(map[string]interface{})
-	budgetID, _ := customerData1["budget_id"].(string)
+	customerData1 := FindListItem(t, getCustomersResp1.Body, "customers", "id", customerID)
+	if customerData1 == nil {
+		t.Fatalf("Customer %s not found in memory", customerID)
+	}
+	budgetID := FirstBudgetID(customerData1)
 
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
-	budget1 := budgetsMap1[budgetID].(map[string]interface{})
+	budget1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budget1 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	initialMaxLimit, _ := budget1["max_limit"].(float64)
 	initialUsage, _ := budget1["current_usage"].(float64)
@@ -881,8 +935,10 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budget2 := budgetsMap2[budgetID].(map[string]interface{})
+	budget2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budget2 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	usageBeforeUpdate, _ := budget2["current_usage"].(float64)
 	t.Logf("Customer budget usage after request: $%.6f", usageBeforeUpdate)
@@ -898,10 +954,10 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/customers/" + customerID,
 		Body: UpdateCustomerRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newLowerBudget,
-				ResetDuration: &resetDurationPtr,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newLowerBudget,
+				ResetDuration: resetDurationPtr,
+			}},
 		},
 	})
 
@@ -919,8 +975,10 @@ func TestCustomerBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budget3 := budgetsMap3[budgetID].(map[string]interface{})
+	budget3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budget3 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	newMaxLimit, _ := budget3["max_limit"].(float64)
 	usageAfterUpdate, _ := budget3["current_usage"].(float64)
@@ -968,10 +1026,10 @@ func TestProviderBudgetUpdateSyncToMemory(t *testing.T) {
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      initialBudget,
 						ResetDuration: resetDuration,
-					},
+					}},
 				},
 			},
 		},
@@ -995,19 +1053,24 @@ func TestProviderBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	vkData1 := getVKResp1.Body["virtual_keys"].(map[string]interface{})[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getVKResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in memory", vkValue)
+	}
 	providerConfigs1 := vkData1["provider_configs"].([]interface{})
 	providerConfig1 := providerConfigs1[0].(map[string]interface{})
 	providerConfigID := uint(providerConfig1["id"].(float64))
-	budgetID, _ := providerConfig1["budget_id"].(string)
+	budgetID := FirstBudgetID(providerConfig1)
 
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
-	budget1 := budgetsMap1[budgetID].(map[string]interface{})
+	budget1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budget1 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	initialMaxLimit, _ := budget1["max_limit"].(float64)
 	initialUsage, _ := budget1["current_usage"].(float64)
@@ -1047,8 +1110,10 @@ func TestProviderBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budget2 := budgetsMap2[budgetID].(map[string]interface{})
+	budget2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budget2 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	usageBeforeUpdate, _ := budget2["current_usage"].(float64)
 	t.Logf("Provider budget usage after request: $%.6f", usageBeforeUpdate)
@@ -1070,10 +1135,10 @@ func TestProviderBudgetUpdateSyncToMemory(t *testing.T) {
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      newLowerBudget,
 						ResetDuration: resetDuration,
-					},
+					}},
 				},
 			},
 		},
@@ -1093,8 +1158,10 @@ func TestProviderBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budget3 := budgetsMap3[budgetID].(map[string]interface{})
+	budget3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budget3 == nil {
+		t.Fatalf("Budget %s not found in memory", budgetID)
+	}
 
 	newMaxLimit, _ := budget3["max_limit"].(float64)
 	usageAfterUpdate, _ := budget3["current_usage"].(float64)

--- a/tests/governance/customer_virtual_keys_response_test.go
+++ b/tests/governance/customer_virtual_keys_response_test.go
@@ -39,8 +39,9 @@ func TestCustomerResponsesIncludeAssignedVirtualKeys(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:       vkName,
-			CustomerID: &customerID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			CustomerID:      &customerID,
 		},
 	})
 
@@ -119,8 +120,9 @@ func TestVirtualKeyResponsesEmbedConsistentCustomerRelations(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:       vkName,
-			CustomerID: &customerID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			CustomerID:      &customerID,
 		},
 	})
 
@@ -264,8 +266,9 @@ func TestCustomerResponsesExcludeTeamScopedVirtualKeys(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -346,8 +349,9 @@ func createCustomerVirtualKeyForTest(t *testing.T, testData *GlobalTestData, cus
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:       vkName,
-			CustomerID: &customerID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			CustomerID:      &customerID,
 		},
 	})
 
@@ -378,12 +382,6 @@ func extractCustomerFromResponse(body map[string]interface{}, customerID string)
 			if id == customerID {
 				return customer
 			}
-		}
-	}
-
-	if customers, ok := body["customers"].(map[string]interface{}); ok {
-		if customer, ok := customers[customerID].(map[string]interface{}); ok {
-			return customer
 		}
 	}
 

--- a/tests/governance/customerbudget_test.go
+++ b/tests/governance/customerbudget_test.go
@@ -20,10 +20,10 @@ func TestCustomerBudgetExceededWithMultipleVKs(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      customerBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -41,12 +41,13 @@ func TestCustomerBudgetExceededWithMultipleVKs(t *testing.T) {
 			Method: "POST",
 			Path:   "/api/governance/virtual-keys",
 			Body: CreateVirtualKeyRequest{
-				Name:       "test-vk-" + generateRandomID(),
-				CustomerID: &customerID,
-				Budget: &BudgetRequest{
+				Name:            "test-vk-" + generateRandomID(),
+				ProviderConfigs: defaultProviderConfigs(),
+				CustomerID:      &customerID,
+				Budgets: []BudgetRequest{{
 					MaxLimit:      1.0, // High VK budget so customer is the limiting factor
 					ResetDuration: "1h",
-				},
+				}},
 			},
 		})
 
@@ -174,10 +175,10 @@ func TestCustomerBudgetExceededWithMultipleTeams(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      customerBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -216,12 +217,13 @@ func TestCustomerBudgetExceededWithMultipleTeams(t *testing.T) {
 			Method: "POST",
 			Path:   "/api/governance/virtual-keys",
 			Body: CreateVirtualKeyRequest{
-				Name:   "test-vk-" + generateRandomID(),
-				TeamID: &teamID,
-				Budget: &BudgetRequest{
+				Name:            "test-vk-" + generateRandomID(),
+				ProviderConfigs: defaultProviderConfigs(),
+				TeamID:          &teamID,
+				Budgets: []BudgetRequest{{
 					MaxLimit:      1.0, // High VK budget so customer is the limiting factor
 					ResetDuration: "1h",
-				},
+				}},
 			},
 		})
 

--- a/tests/governance/e2e_test.go
+++ b/tests/governance/e2e_test.go
@@ -51,8 +51,9 @@ func TestMultipleVKsSharingTeamBudgetFairness(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vk1Name,
-			TeamID: &teamID,
+			Name:            vk1Name,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -72,8 +73,9 @@ func TestMultipleVKsSharingTeamBudgetFairness(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vk2Name,
-			TeamID: &teamID,
+			Name:            vk2Name,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -199,10 +201,10 @@ func TestFullBudgetHierarchyEnforcement(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      1000.0, // Very high
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -246,20 +248,20 @@ func TestFullBudgetHierarchyEnforcement(t *testing.T) {
 		Body: CreateVirtualKeyRequest{
 			Name:   vkName,
 			TeamID: &teamID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      vkBudget,
 				ResetDuration: "1h",
-			},
+			}},
 			ProviderConfigs: []ProviderConfigRequest{
 				{
 					Provider:      "openai",
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      providerBudget,
 						ResetDuration: "1h",
-					},
+					}},
 				},
 			},
 		},
@@ -370,11 +372,12 @@ func TestFailedRequestsDoNotConsumeBudget(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      budget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -396,19 +399,21 @@ func TestFailedRequestsDoNotConsumeBudget(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
+	budgetID := FirstBudgetID(vkData1)
 
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
-	budgetID, _ := vkData1["budget_id"].(string)
-
-	budgetData1 := budgetsMap1[budgetID].(map[string]interface{})
+	budgetData1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budgetData1 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	initialUsage, _ := budgetData1["current_usage"].(float64)
 
 	t.Logf("Initial budget usage: $%.6f", initialUsage)
@@ -445,8 +450,10 @@ func TestFailedRequestsDoNotConsumeBudget(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budgetData2 := budgetsMap2[budgetID].(map[string]interface{})
+	budgetData2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budgetData2 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	usageAfterFailed, _ := budgetData2["current_usage"].(float64)
 
 	t.Logf("Budget usage after failed request: $%.6f", usageAfterFailed)
@@ -484,8 +491,10 @@ func TestFailedRequestsDoNotConsumeBudget(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budgetData3 := budgetsMap3[budgetID].(map[string]interface{})
+	budgetData3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budgetData3 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	usageAfterSuccess, _ := budgetData3["current_usage"].(float64)
 
 	t.Logf("Budget usage after successful request: $%.6f", usageAfterSuccess)
@@ -516,8 +525,9 @@ func TestInactiveVirtualKeyBlocking(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:     vkName,
-			IsActive: &isActive,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			IsActive:        &isActive,
 		},
 	})
 
@@ -662,7 +672,8 @@ func TestRateLimitResetBoundaryConditions(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				RequestMaxLimit:      &requestLimit,
 				RequestResetDuration: &resetDuration,
@@ -778,7 +789,8 @@ func TestConcurrentRequestsToSameVK(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -875,11 +887,12 @@ func TestBudgetStateAfterReset(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      budgetLimit,
 				ResetDuration: resetDuration,
-			},
+			}},
 		},
 	})
 
@@ -901,19 +914,21 @@ func TestBudgetStateAfterReset(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
+	budgetID := FirstBudgetID(vkData1)
 
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
-	budgetID, _ := vkData1["budget_id"].(string)
-
-	budgetData1 := budgetsMap1[budgetID].(map[string]interface{})
+	budgetData1 := FindListItem(t, getBudgetsResp1.Body, "budgets", "id", budgetID)
+	if budgetData1 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	initialUsage, _ := budgetData1["current_usage"].(float64)
 	lastReset1, _ := budgetData1["last_reset"].(string)
 
@@ -948,8 +963,10 @@ func TestBudgetStateAfterReset(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budgetData2 := budgetsMap2[budgetID].(map[string]interface{})
+	budgetData2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budgetData2 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	usageAfterRequest, _ := budgetData2["current_usage"].(float64)
 
 	t.Logf("Budget after request: usage=$%.6f (consumed)", usageAfterRequest)
@@ -1017,12 +1034,8 @@ func TestBudgetStateAfterReset(t *testing.T) {
 		if resp.StatusCode != 200 {
 			return false
 		}
-		budgetsData, ok := resp.Body["budgets"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-		budgetData, ok := budgetsData[budgetID].(map[string]interface{})
-		if !ok {
+		budgetData := FindListItem(t, resp.Body, "budgets", "id", budgetID)
+		if budgetData == nil {
 			return false
 		}
 		// Check if LastReset has been updated (indicating reset occurred)
@@ -1040,8 +1053,10 @@ func TestBudgetStateAfterReset(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budgetData3 := budgetsMap3[budgetID].(map[string]interface{})
+	budgetData3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budgetData3 == nil {
+		t.Fatalf("Budget %s not found in in-memory store", budgetID)
+	}
 	usageAfterReset, _ := budgetData3["current_usage"].(float64)
 	lastReset3, _ := budgetData3["last_reset"].(string)
 
@@ -1108,8 +1123,9 @@ func TestTeamDeletionCascade(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name:   vkName,
-			TeamID: &teamID,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			TeamID:          &teamID,
 		},
 	})
 
@@ -1211,11 +1227,12 @@ func TestVKDeletionCascade(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      10.0,
 				ResetDuration: "1h",
-			},
+			}},
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -1246,13 +1263,7 @@ func TestVKDeletionCascade(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap1, ok := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		_, exists := virtualKeysMap1[vkValue]
-		return exists
+		return FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue) != nil
 	}, 5*time.Second, "VK exists in in-memory store")
 
 	if !vkExists {
@@ -1285,14 +1296,7 @@ func TestVKDeletionCascade(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap2, ok := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-		if !ok {
-			t.Logf("Invalid response structure for virtual_keys")
-			return false
-		}
-
-		_, exists := virtualKeysMap2[vkValue]
-		return !exists // Return true when VK is NOT found (successfully removed)
+		return FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue) == nil // Return true when VK is NOT found (successfully removed)
 	}, 5*time.Second, "VK removed from in-memory store")
 
 	if !vkRemoved {
@@ -1382,8 +1386,10 @@ func TestWeightedProviderLoadBalancing(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK not found in in-memory store")
+	}
 	providerConfigs, _ := vkData["provider_configs"].([]interface{})
 
 	if len(providerConfigs) != 2 {
@@ -1588,11 +1594,12 @@ func TestVirtualKeyHeaderFormats(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      10.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 

--- a/tests/governance/edgecases_test.go
+++ b/tests/governance/edgecases_test.go
@@ -21,10 +21,10 @@ func TestCrissCrossComplexBudgetHierarchy(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      customerBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -65,20 +65,20 @@ func TestCrissCrossComplexBudgetHierarchy(t *testing.T) {
 		Body: CreateVirtualKeyRequest{
 			Name:   "test-vk-criss-cross-" + generateRandomID(),
 			TeamID: &teamID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      vkBudget,
 				ResetDuration: "1h",
-			},
+			}},
 			ProviderConfigs: []ProviderConfigRequest{
 				{
 					Provider:      "openai",
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      0.08, // Even tighter provider budget
 						ResetDuration: "1h",
-					},
+					}},
 				},
 			},
 		},

--- a/tests/governance/inmemorysync_test.go
+++ b/tests/governance/inmemorysync_test.go
@@ -18,11 +18,12 @@ func TestInMemorySyncVirtualKeyUpdate(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -48,15 +49,12 @@ func TestInMemorySyncVirtualKeyUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-
 	// Check that VK exists in in-memory store
-	vkData, exists := virtualKeysMap[vkValue]
-	if !exists {
+	vkDataMap := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkDataMap == nil {
 		t.Fatalf("VK %s not found in in-memory store after creation", vkValue)
 	}
 
-	vkDataMap := vkData.(map[string]interface{})
 	vkID2, _ := vkDataMap["id"].(string)
 	if vkID2 != vkID {
 		t.Fatalf("VK ID mismatch in in-memory store: expected %s, got %s", vkID, vkID2)
@@ -70,9 +68,10 @@ func TestInMemorySyncVirtualKeyUpdate(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/virtual-keys/" + vkID,
 		Body: UpdateVirtualKeyRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit: &newBudget,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newBudget,
+				ResetDuration: "1h",
+			}},
 		},
 	})
 
@@ -94,32 +93,26 @@ func TestInMemorySyncVirtualKeyUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data after update: status %d", getVKResp2.StatusCode)
 	}
 
-	virtualKeysMap2 := getVKResp2.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp2 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
 	// Check that VK still exists
-	vkData2, exists := virtualKeysMap2[vkValue]
-	if !exists {
+	vkDataMap2 := FindListItem(t, getVKResp2.Body, "virtual_keys", "value", vkValue)
+	if vkDataMap2 == nil {
 		t.Fatalf("VK %s not found in in-memory store after update", vkValue)
 	}
 
-	vkDataMap2 := vkData2.(map[string]interface{})
-	budgetID, _ := vkDataMap2["budget_id"].(string)
+	budgetID := FirstBudgetID(vkDataMap2)
 
 	// Check that budget in in-memory store is updated
 	if budgetID != "" {
-		budgetData, budgetExists := budgetsMap2[budgetID]
-		if !budgetExists {
+		budgetDataMap := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+		if budgetDataMap == nil {
 			t.Fatalf("Budget %s not found in in-memory store", budgetID)
 		}
 
-		budgetDataMap := budgetData.(map[string]interface{})
 		maxLimit, _ := budgetDataMap["max_limit"].(float64)
 		if maxLimit != newBudget {
 			t.Fatalf("Budget max_limit not updated in in-memory store: expected %.2f, got %.2f", newBudget, maxLimit)
@@ -169,10 +162,7 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	teamsMap := getDataResp.Body["teams"].(map[string]interface{})
-
-	_, exists := teamsMap[teamID]
-	if !exists {
+	if FindListItem(t, getDataResp.Body, "teams", "id", teamID) == nil {
 		t.Fatalf("Team %s not found in in-memory store after creation", teamID)
 	}
 
@@ -209,22 +199,17 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data after update: status %d", getTeamsResp2.StatusCode)
 	}
 
-	teamsMap2 := getTeamsResp2.Body["teams"].(map[string]interface{})
-
 	getBudgetsResp2 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
-	teamData2, exists := teamsMap2[teamID]
-	if !exists {
+	teamDataMap := FindListItem(t, getTeamsResp2.Body, "teams", "id", teamID)
+	if teamDataMap == nil {
 		t.Fatalf("Team %s not found in in-memory store after update", teamID)
 	}
 
-	teamDataMap := teamData2.(map[string]interface{})
-	// Teams now expose a `budgets` array instead of a single `budget_id` — read the first.
+	// Teams now expose a `budgets` array instead of a single `budget_id` - read the first.
 	var budgetID string
 	if budgetsList, ok := teamDataMap["budgets"].([]interface{}); ok && len(budgetsList) > 0 {
 		if b, ok := budgetsList[0].(map[string]interface{}); ok {
@@ -233,12 +218,11 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 	}
 
 	if budgetID != "" {
-		budgetData, budgetExists := budgetsMap2[budgetID]
-		if !budgetExists {
+		budgetDataMap := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+		if budgetDataMap == nil {
 			t.Fatalf("Budget %s not found in in-memory store", budgetID)
 		}
 
-		budgetDataMap := budgetData.(map[string]interface{})
 		maxLimit, _ := budgetDataMap["max_limit"].(float64)
 		if maxLimit != newTeamBudget {
 			t.Fatalf("Team budget max_limit not updated in in-memory store: expected %.2f, got %.2f", newTeamBudget, maxLimit)
@@ -262,10 +246,10 @@ func TestInMemorySyncCustomerUpdate(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -288,10 +272,7 @@ func TestInMemorySyncCustomerUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	customersMap := getDataResp.Body["customers"].(map[string]interface{})
-
-	_, exists := customersMap[customerID]
-	if !exists {
+	if FindListItem(t, getDataResp.Body, "customers", "id", customerID) == nil {
 		t.Fatalf("Customer %s not found in in-memory store after creation", customerID)
 	}
 
@@ -303,9 +284,10 @@ func TestInMemorySyncCustomerUpdate(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/customers/" + customerID,
 		Body: UpdateCustomerRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit: &newCustomerBudget,
-			},
+			Budgets: []BudgetRequest{{
+				MaxLimit:      newCustomerBudget,
+				ResetDuration: "1h",
+			}},
 		},
 	})
 
@@ -327,30 +309,24 @@ func TestInMemorySyncCustomerUpdate(t *testing.T) {
 		t.Fatalf("Failed to get governance data after update: status %d", getCustomersResp2.StatusCode)
 	}
 
-	customersMap2 := getCustomersResp2.Body["customers"].(map[string]interface{})
-
 	getBudgetsResp2 := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
-	customerData2, exists := customersMap2[customerID]
-	if !exists {
+	customerDataMap := FindListItem(t, getCustomersResp2.Body, "customers", "id", customerID)
+	if customerDataMap == nil {
 		t.Fatalf("Customer %s not found in in-memory store after update", customerID)
 	}
 
-	customerDataMap := customerData2.(map[string]interface{})
-	budgetID, _ := customerDataMap["budget_id"].(string)
+	budgetID := FirstBudgetID(customerDataMap)
 
 	if budgetID != "" {
-		budgetData, budgetExists := budgetsMap2[budgetID]
-		if !budgetExists {
+		budgetDataMap := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+		if budgetDataMap == nil {
 			t.Fatalf("Budget %s not found in in-memory store", budgetID)
 		}
 
-		budgetDataMap := budgetData.(map[string]interface{})
 		maxLimit, _ := budgetDataMap["max_limit"].(float64)
 		if maxLimit != newCustomerBudget {
 			t.Fatalf("Customer budget max_limit not updated in in-memory store: expected %.2f, got %.2f", newCustomerBudget, maxLimit)
@@ -372,11 +348,12 @@ func TestInMemorySyncVirtualKeyDelete(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      10.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -401,13 +378,7 @@ func TestInMemorySyncVirtualKeyDelete(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap, ok := getDataResp.Body["virtual_keys"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		_, exists := virtualKeysMap[vkValue]
-		return exists
+		return FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue) != nil
 	}, 5*time.Second, "VK exists in in-memory store after creation")
 
 	if !vkExists {
@@ -439,13 +410,8 @@ func TestInMemorySyncVirtualKeyDelete(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap2, ok := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		_, exists := virtualKeysMap2[vkValue]
-		return !exists // Return true when VK is NOT found (successfully removed)
+		// Return true when VK is NOT found (successfully removed)
+		return FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue) == nil
 	}, 5*time.Second, "VK removed from in-memory store after deletion")
 
 	if !vkRemoved {
@@ -467,11 +433,12 @@ func TestDataEndpointConsistency(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      15.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -500,10 +467,10 @@ func TestDataEndpointConsistency(t *testing.T) {
 		Path:   "/api/governance/customers",
 		Body: CreateCustomerRequest{
 			Name: customerName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      60.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -567,14 +534,10 @@ func TestDataEndpointConsistency(t *testing.T) {
 		t.Fatalf("Failed to get customers: status %d", getCustomersResp.StatusCode)
 	}
 
-	virtualKeysMap := getVKResp.Body["virtual_keys"].(map[string]interface{})
-	teamsMap := getTeamsResp.Body["teams"].(map[string]interface{})
-	customersMap := getCustomersResp.Body["customers"].(map[string]interface{})
-
 	// Verify all created resources are in the in-memory data
-	vkCount := len(virtualKeysMap)
-	teamCount := len(teamsMap)
-	customerCount := len(customersMap)
+	vkCount := len(ListItemsFromResponse(t, getVKResp.Body, "virtual_keys"))
+	teamCount := len(ListItemsFromResponse(t, getTeamsResp.Body, "teams"))
+	customerCount := len(ListItemsFromResponse(t, getCustomersResp.Body, "customers"))
 
 	if vkCount == 0 {
 		t.Fatalf("No virtual keys found in data endpoint")

--- a/tests/governance/providerbudget_test.go
+++ b/tests/governance/providerbudget_test.go
@@ -17,30 +17,30 @@ func TestProviderBudgetExceeded(t *testing.T) {
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
 			Name: "test-vk-provider-budget-" + generateRandomID(),
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      1.0, // High overall budget
 				ResetDuration: "1h",
-			},
+			}},
 			ProviderConfigs: []ProviderConfigRequest{
 				{
 					Provider:      "openai",
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      0.01, // Specific OpenAI budget
 						ResetDuration: "1h",
-					},
+					}},
 				},
 				{
 					Provider:      "anthropic",
 					Weight:        float64Ptr(1.0),
 					AllowedModels: []string{"*"},
 					KeyIDs:        []string{"*"},
-					Budget: &BudgetRequest{
+					Budgets: []BudgetRequest{{
 						MaxLimit:      0.01, // Specific Anthropic budget
 						ResetDuration: "1h",
-					},
+					}},
 				},
 			},
 		},

--- a/tests/governance/ratelimit_test.go
+++ b/tests/governance/ratelimit_test.go
@@ -20,7 +20,8 @@ func TestVirtualKeyTokenRateLimit(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -93,7 +94,8 @@ func TestVirtualKeyRequestRateLimit(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				RequestMaxLimit:      &requestLimit,
 				RequestResetDuration: &requestResetDuration,
@@ -373,8 +375,10 @@ func TestMultipleProvidersSeparateRateLimits(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 
 	providerConfigs, _ := vkData["provider_configs"].([]interface{})
 	if len(providerConfigs) != 2 {
@@ -443,8 +447,10 @@ func TestProviderAndVKRateLimitTogether(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 
 	// Check VK has rate limit
 	vkRateLimitID, _ := vkData["rate_limit_id"].(string)
@@ -476,7 +482,8 @@ func TestRateLimitInMemorySync(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &initialTokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -506,8 +513,10 @@ func TestRateLimitInMemorySync(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 	rateLimitID, _ := vkData["rate_limit_id"].(string)
 
 	if rateLimitID == "" {
@@ -545,8 +554,10 @@ func TestRateLimitInMemorySync(t *testing.T) {
 		t.Fatalf("Failed to get governance data after update: status %d", getDataResp2.StatusCode)
 	}
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-	vkData2 := virtualKeysMap2[vkValue].(map[string]interface{})
+	vkData2 := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
+		t.Fatalf("VK %s not found in virtual keys list after update", vkValue)
+	}
 
 	// Verify VK still has rate limit configured
 	rateLimitID2, _ := vkData2["rate_limit_id"].(string)
@@ -565,10 +576,9 @@ func TestRateLimitInMemorySync(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
-	rateLimit2, ok := rateLimitsMap2[rateLimitID2].(map[string]interface{})
-	if !ok {
-		t.Fatalf("Rate limit not found in RateLimits map")
+	rateLimit2 := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", rateLimitID2)
+	if rateLimit2 == nil {
+		t.Fatalf("Rate limit not found in RateLimits list")
 	}
 
 	// Check TokenMaxLimit was updated
@@ -617,7 +627,8 @@ func TestRateLimitTokenAndRequestTogether(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:        &tokenLimit,
 				TokenResetDuration:   &tokenResetDuration,
@@ -690,7 +701,8 @@ func TestRateLimitUsageTrackedInMemory(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:        &tokenLimit,
 				TokenResetDuration:   &tokenResetDuration,
@@ -718,8 +730,10 @@ func TestRateLimitUsageTrackedInMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 	rateLimitID1, _ := vkData1["rate_limit_id"].(string)
 
 	initialTokenUsage := 0.0
@@ -731,10 +745,9 @@ func TestRateLimitUsageTrackedInMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap1 := getRateLimitsResp1.Body["rate_limits"].(map[string]interface{})
-	rateLimit1, ok := rateLimitsMap1[rateLimitID1].(map[string]interface{})
-	if !ok {
-		t.Fatalf("Rate limit not found in RateLimits map")
+	rateLimit1 := FindListItem(t, getRateLimitsResp1.Body, "rate_limits", "id", rateLimitID1)
+	if rateLimit1 == nil {
+		t.Fatalf("Rate limit not found in RateLimits list")
 	}
 
 	if tokenUsage, ok := rateLimit1["token_current_usage"].(float64); ok {
@@ -775,8 +788,10 @@ func TestRateLimitUsageTrackedInMemory(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-	vkData2 := virtualKeysMap2[vkValue].(map[string]interface{})
+	vkData2 := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
+		t.Fatalf("VK %s not found in virtual keys list after request", vkValue)
+	}
 	rateLimitID2, _ := vkData2["rate_limit_id"].(string)
 
 	// Get rate limit from main RateLimits map
@@ -785,10 +800,9 @@ func TestRateLimitUsageTrackedInMemory(t *testing.T) {
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
 
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
-	rateLimit2, ok := rateLimitsMap2[rateLimitID2].(map[string]interface{})
-	if !ok {
-		t.Fatalf("Rate limit not found in RateLimits map after request")
+	rateLimit2 := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", rateLimitID2)
+	if rateLimit2 == nil {
+		t.Fatalf("Rate limit not found in RateLimits list after request")
 	}
 
 	// Check that token usage increased
@@ -891,8 +905,10 @@ func TestProviderLevelRateLimitUsageTracking(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap1 := getDataResp1.Body["virtual_keys"].(map[string]interface{})
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getDataResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 
 	providerConfigs1, ok := vkData1["provider_configs"].([]interface{})
 	if !ok {
@@ -934,8 +950,10 @@ func TestProviderLevelRateLimitUsageTracking(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap2 := getDataResp2.Body["virtual_keys"].(map[string]interface{})
-	vkData2 := virtualKeysMap2[vkValue].(map[string]interface{})
+	vkData2 := FindListItem(t, getDataResp2.Body, "virtual_keys", "value", vkValue)
+	if vkData2 == nil {
+		t.Fatalf("VK %s not found in virtual keys list after request", vkValue)
+	}
 
 	providerConfigs2, ok := vkData2["provider_configs"].([]interface{})
 	if !ok {
@@ -951,8 +969,6 @@ func TestProviderLevelRateLimitUsageTracking(t *testing.T) {
 		Method: "GET",
 		Path:   "/api/governance/rate-limits?from_memory=true",
 	})
-
-	rateLimitsMap2 := getRateLimitsResp2.Body["rate_limits"].(map[string]interface{})
 
 	for i, providerConfig := range providerConfigs2 {
 		config, ok := providerConfig.(map[string]interface{})
@@ -971,9 +987,9 @@ func TestProviderLevelRateLimitUsageTracking(t *testing.T) {
 			continue
 		}
 
-		rateLimit, ok := rateLimitsMap2[rateLimitID].(map[string]interface{})
-		if !ok {
-			t.Logf("Provider %s: No rate limit found in RateLimits map", provider)
+		rateLimit := FindListItem(t, getRateLimitsResp2.Body, "rate_limits", "id", rateLimitID)
+		if rateLimit == nil {
+			t.Logf("Provider %s: No rate limit found in RateLimits list", provider)
 			continue
 		}
 

--- a/tests/governance/ratelimitenforcement_test.go
+++ b/tests/governance/ratelimitenforcement_test.go
@@ -22,7 +22,8 @@ func TestVirtualKeyTokenRateLimitEnforcement(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -52,8 +53,10 @@ func TestVirtualKeyTokenRateLimitEnforcement(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 	rateLimitID, _ := vkData["rate_limit_id"].(string)
 
 	if rateLimitID == "" {
@@ -143,7 +146,8 @@ func TestVirtualKeyRequestRateLimitEnforcement(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				RequestMaxLimit:      &requestLimit,
 				RequestResetDuration: &requestResetDuration,
@@ -265,8 +269,10 @@ func TestProviderConfigTokenRateLimitEnforcement(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
+	vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 	providerConfigs, _ := vkData["provider_configs"].([]interface{})
 
 	if len(providerConfigs) == 0 {
@@ -539,7 +545,8 @@ func TestRateLimitInMemoryUsageTracking(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -605,13 +612,8 @@ func TestRateLimitInMemoryUsageTracking(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap, ok := getDataResp.Body["virtual_keys"].(map[string]interface{})
-		if !ok || virtualKeysMap == nil {
-			return false
-		}
-
-		vkData, ok := virtualKeysMap[vkValue].(map[string]interface{})
-		if !ok {
+		vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+		if vkData == nil {
 			return false
 		}
 

--- a/tests/governance/teambudget_test.go
+++ b/tests/governance/teambudget_test.go
@@ -41,12 +41,13 @@ func TestTeamBudgetExceededWithMultipleVKs(t *testing.T) {
 			Method: "POST",
 			Path:   "/api/governance/virtual-keys",
 			Body: CreateVirtualKeyRequest{
-				Name:   "test-vk-" + generateRandomID(),
-				TeamID: &teamID,
-				Budget: &BudgetRequest{
+				Name:            "test-vk-" + generateRandomID(),
+				ProviderConfigs: defaultProviderConfigs(),
+				TeamID:          &teamID,
+				Budgets: []BudgetRequest{{
 					MaxLimit:      1.0, // High VK budget so team is the limiting factor
 					ResetDuration: "1h",
-				},
+				}},
 			},
 		})
 

--- a/tests/governance/test_utils.go
+++ b/tests/governance/test_utils.go
@@ -212,7 +212,7 @@ type CreateVirtualKeyRequest struct {
 	IsActive        *bool                   `json:"is_active,omitempty"`
 	TeamID          *string                 `json:"team_id,omitempty"`
 	CustomerID      *string                 `json:"customer_id,omitempty"`
-	Budget          *BudgetRequest          `json:"budget,omitempty"`
+	Budgets         []BudgetRequest         `json:"budgets,omitempty"`
 	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 	ProviderConfigs []ProviderConfigRequest `json:"provider_configs,omitempty"`
 }
@@ -224,7 +224,7 @@ type ProviderConfigRequest struct {
 	Weight        *float64                `json:"weight,omitempty"`
 	AllowedModels []string                `json:"allowed_models,omitempty"`
 	KeyIDs        []string                `json:"key_ids,omitempty"`
-	Budget        *BudgetRequest          `json:"budget,omitempty"`
+	Budgets       []BudgetRequest         `json:"budgets,omitempty"`
 	RateLimit     *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -248,8 +248,8 @@ type CreateTeamRequest struct {
 
 // CreateCustomerRequest represents a request to create a customer
 type CreateCustomerRequest struct {
-	Name   string         `json:"name"`
-	Budget *BudgetRequest `json:"budget,omitempty"`
+	Name    string          `json:"name"`
+	Budgets []BudgetRequest `json:"budgets,omitempty"`
 }
 
 // UpdateBudgetRequest represents a request to update a budget
@@ -271,7 +271,7 @@ type UpdateVirtualKeyRequest struct {
 	Name            *string                 `json:"name,omitempty"`
 	TeamID          *string                 `json:"team_id,omitempty"`
 	CustomerID      *string                 `json:"customer_id,omitempty"`
-	Budget          *UpdateBudgetRequest    `json:"budget,omitempty"`
+	Budgets         []BudgetRequest         `json:"budgets,omitempty"`
 	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
 	IsActive        *bool                   `json:"is_active,omitempty"`
 	ProviderConfigs []ProviderConfigRequest `json:"provider_configs,omitempty"`
@@ -289,8 +289,8 @@ type UpdateTeamRequest struct {
 
 // UpdateCustomerRequest represents a request to update a customer
 type UpdateCustomerRequest struct {
-	Name   *string              `json:"name,omitempty"`
-	Budget *UpdateBudgetRequest `json:"budget,omitempty"`
+	Name    *string         `json:"name,omitempty"`
+	Budgets []BudgetRequest `json:"budgets,omitempty"`
 }
 
 // ChatCompletionRequest represents an OpenAI-compatible chat completion request
@@ -548,4 +548,71 @@ func ParseDuration(duration string) (time.Duration, error) {
 	default:
 		return time.ParseDuration(duration)
 	}
+}
+
+// ListItemsFromResponse extracts a paginated list field (e.g. "virtual_keys",
+// "teams", "customers", "budgets", "rate_limits") from a list-endpoint
+// response. The governance list endpoints return arrays plus pagination
+// metadata (count/limit/offset/total_count), not maps keyed by id/value.
+func ListItemsFromResponse(t *testing.T, body map[string]interface{}, field string) []map[string]interface{} {
+	t.Helper()
+	raw, ok := body[field]
+	if !ok || raw == nil {
+		return nil
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("expected %q to be a list in response, got %T", field, raw)
+	}
+	items := make([]map[string]interface{}, 0, len(list))
+	for _, entry := range list {
+		if item, ok := entry.(map[string]interface{}); ok {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+// FindListItem returns the first item in the named list field whose key
+// equals value, or nil when absent. Typical keys: "value" for virtual keys,
+// "id" for teams, customers, budgets and rate limits.
+func FindListItem(t *testing.T, body map[string]interface{}, field, key, value string) map[string]interface{} {
+	t.Helper()
+	for _, item := range ListItemsFromResponse(t, body, field) {
+		if got, ok := item[key].(string); ok && got == value {
+			return item
+		}
+	}
+	return nil
+}
+
+// FirstBudgetID returns the ID of the first embedded budget on a governance
+// entity or provider config (VK, team, customer, provider config), or ""
+// when it has none. Entities moved from a singular budget_id field to a
+// budgets array; the legacy budget_id JSON field is no longer populated.
+func FirstBudgetID(item map[string]interface{}) string {
+	budgets, ok := item["budgets"].([]interface{})
+	if !ok || len(budgets) == 0 {
+		return ""
+	}
+	b, ok := budgets[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	id, _ := b["id"].(string)
+	return id
+}
+
+// defaultProviderConfigs returns the minimal provider config for test VKs.
+// Governance is deny-by-default: a VK with no provider configs blocks every
+// provider, so tests that exercise budgets/rate limits (not provider
+// filtering) must attach at least one allowed provider.
+func defaultProviderConfigs() []ProviderConfigRequest {
+	weight := 1.0
+	return []ProviderConfigRequest{{
+		Provider:      "openai",
+		Weight:        &weight,
+		AllowedModels: []string{"*"},
+		KeyIDs:        []string{"*"},
+	}}
 }

--- a/tests/governance/usagetracking_test.go
+++ b/tests/governance/usagetracking_test.go
@@ -20,7 +20,8 @@ func TestUsageTrackingRateLimitReset(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -50,8 +51,10 @@ func TestUsageTrackingRateLimitReset(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getVKResp1.StatusCode)
 	}
 
-	virtualKeysMap1 := getVKResp1.Body["virtual_keys"].(map[string]interface{})
-	vkData1 := virtualKeysMap1[vkValue].(map[string]interface{})
+	vkData1 := FindListItem(t, getVKResp1.Body, "virtual_keys", "value", vkValue)
+	if vkData1 == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
 	rateLimitID, _ := vkData1["rate_limit_id"].(string)
 	if rateLimitID == "" {
 		t.Fatalf("Rate limit ID not found for VK")
@@ -142,11 +145,12 @@ func TestUsageTrackingBudgetReset(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      budgetLimit,
 				ResetDuration: resetDuration,
-			},
+			}},
 		},
 	})
 
@@ -168,22 +172,24 @@ func TestUsageTrackingBudgetReset(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap := getVKResp.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap := getBudgetsResp.Body["budgets"].(map[string]interface{})
-
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
-	budgetID, _ := vkData["budget_id"].(string)
+	vkData := FindListItem(t, getVKResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
+	budgetID := FirstBudgetID(vkData)
 	if budgetID == "" {
 		t.Fatalf("Budget ID not found for VK")
 	}
 
-	budgetData := budgetsMap[budgetID].(map[string]interface{})
+	budgetData := FindListItem(t, getBudgetsResp.Body, "budgets", "id", budgetID)
+	if budgetData == nil {
+		t.Fatalf("Budget %s not found in budgets list", budgetID)
+	}
 	initialUsage, _ := budgetData["current_usage"].(float64)
 
 	t.Logf("Initial budget usage: $%.6f", initialUsage)
@@ -217,8 +223,10 @@ func TestUsageTrackingBudgetReset(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-	budgetData2 := budgetsMap2[budgetID].(map[string]interface{})
+	budgetData2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+	if budgetData2 == nil {
+		t.Fatalf("Budget %s not found in budgets list after request", budgetID)
+	}
 	usageAfterRequest, _ := budgetData2["current_usage"].(float64)
 
 	t.Logf("Budget usage after request: $%.6f", usageAfterRequest)
@@ -242,8 +250,10 @@ func TestUsageTrackingBudgetReset(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap3 := getBudgetsResp3.Body["budgets"].(map[string]interface{})
-	budgetData3 := budgetsMap3[budgetID].(map[string]interface{})
+	budgetData3 := FindListItem(t, getBudgetsResp3.Body, "budgets", "id", budgetID)
+	if budgetData3 == nil {
+		t.Fatalf("Budget %s not found in budgets list after reset", budgetID)
+	}
 	usageAfterReset, _ := budgetData3["current_usage"].(float64)
 
 	// Budget should be reset (close to 0)
@@ -268,7 +278,8 @@ func TestInMemoryUsageUpdateOnRequest(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -337,13 +348,8 @@ func TestInMemoryUsageUpdateOnRequest(t *testing.T) {
 			return false
 		}
 
-		virtualKeysMap, ok := getDataResp.Body["virtual_keys"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		vkData, ok := virtualKeysMap[vkValue].(map[string]interface{})
-		if !ok {
+		vkData := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+		if vkData == nil {
 			return false
 		}
 
@@ -363,13 +369,8 @@ func TestInMemoryUsageUpdateOnRequest(t *testing.T) {
 			return false
 		}
 
-		rateLimitsMap, ok := getRateLimitsResp.Body["rate_limits"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		rateLimitData, ok := rateLimitsMap[rateLimitID].(map[string]interface{})
-		if !ok {
+		rateLimitData := FindListItem(t, getRateLimitsResp.Body, "rate_limits", "id", rateLimitID)
+		if rateLimitData == nil {
 			return false
 		}
 
@@ -413,11 +414,12 @@ func TestResetTickerBothBudgetAndRateLimit(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      budgetLimit,
 				ResetDuration: budgetResetDuration,
-			},
+			}},
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:      &tokenLimit,
 				TokenResetDuration: &tokenResetDuration,
@@ -471,21 +473,23 @@ func TestResetTickerBothBudgetAndRateLimit(t *testing.T) {
 		Path:   "/api/governance/virtual-keys?from_memory=true",
 	})
 
-	virtualKeysMap := getVKResp.Body["virtual_keys"].(map[string]interface{})
-
 	getBudgetsResp := MakeRequest(t, APIRequest{
 		Method: "GET",
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap := getBudgetsResp.Body["budgets"].(map[string]interface{})
-
-	vkData := virtualKeysMap[vkValue].(map[string]interface{})
-	budgetID, _ := vkData["budget_id"].(string)
+	vkData := FindListItem(t, getVKResp.Body, "virtual_keys", "value", vkValue)
+	if vkData == nil {
+		t.Fatalf("VK %s not found in virtual keys list", vkValue)
+	}
+	budgetID := FirstBudgetID(vkData)
 
 	var usageBeforeReset float64
 	if budgetID != "" {
-		budgetData := budgetsMap[budgetID].(map[string]interface{})
+		budgetData := FindListItem(t, getBudgetsResp.Body, "budgets", "id", budgetID)
+		if budgetData == nil {
+			t.Fatalf("Budget %s not found in budgets list", budgetID)
+		}
 		usageBeforeReset, _ = budgetData["current_usage"].(float64)
 	}
 
@@ -501,11 +505,12 @@ func TestResetTickerBothBudgetAndRateLimit(t *testing.T) {
 		Path:   "/api/governance/budgets?from_memory=true",
 	})
 
-	budgetsMap2 := getBudgetsResp2.Body["budgets"].(map[string]interface{})
-
 	var usageAfterReset float64
 	if budgetID != "" {
-		budgetData2 := budgetsMap2[budgetID].(map[string]interface{})
+		budgetData2 := FindListItem(t, getBudgetsResp2.Body, "budgets", "id", budgetID)
+		if budgetData2 == nil {
+			t.Fatalf("Budget %s not found in budgets list after reset", budgetID)
+		}
 		usageAfterReset, _ = budgetData2["current_usage"].(float64)
 	}
 
@@ -537,11 +542,12 @@ func TestDataPersistenceAcrossRequests(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      budgetLimit,
 				ResetDuration: budgetResetDuration,
-			},
+			}},
 			RateLimit: &CreateRateLimitRequest{
 				TokenMaxLimit:        &tokenLimit,
 				TokenResetDuration:   &tokenResetDuration,
@@ -604,15 +610,12 @@ func TestDataPersistenceAcrossRequests(t *testing.T) {
 		t.Fatalf("Failed to get governance data: status %d", getDataResp.StatusCode)
 	}
 
-	virtualKeysMap := getDataResp.Body["virtual_keys"].(map[string]interface{})
-
-	vkData, exists := virtualKeysMap[vkValue]
-	if !exists {
+	vkDataMap := FindListItem(t, getDataResp.Body, "virtual_keys", "value", vkValue)
+	if vkDataMap == nil {
 		t.Fatalf("VK not found in in-memory store after requests")
 	}
 
-	vkDataMap := vkData.(map[string]interface{})
-	budgetID, _ := vkDataMap["budget_id"].(string)
+	budgetID := FirstBudgetID(vkDataMap)
 	rateLimitID, _ := vkDataMap["rate_limit_id"].(string)
 
 	if budgetID == "" {

--- a/tests/governance/vkbudget_test.go
+++ b/tests/governance/vkbudget_test.go
@@ -18,11 +18,12 @@ func TestVKBudgetExceeded(t *testing.T) {
 		Method: "POST",
 		Path:   "/api/governance/virtual-keys",
 		Body: CreateVirtualKeyRequest{
-			Name: vkName,
-			Budget: &BudgetRequest{
+			Name:            vkName,
+			ProviderConfigs: defaultProviderConfigs(),
+			Budgets: []BudgetRequest{{
 				MaxLimit:      vkBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 


### PR DESCRIPTION
## Summary

Background budget and rate-limit reset sweeps previously called `updateBudgetReferences` / `updateRateLimitReferences` once per expired item, causing each call to range over every virtual key, team, and customer in the store. This made a single background tick O(owners × resets): at 100k keys with many concurrent expirations, one 10-second tick could consume minutes of CPU, pinning the process at 100% without any infinite loop. This PR batches the reference refresh so it happens once per sweep, reducing cost to O(owners + resets).

## Changes

- `resetExpiredBudgetFromSnapshot` and `resetExpiredRateLimitFromSnapshot` no longer call `updateBudgetReferences` / `updateRateLimitReferences` individually. The `refreshReferences` parameter is removed from both functions.
- `ResetExpiredBudgetsInMemory` and `ResetExpiredRateLimitsInMemory` now collect all reset items first, then call the reference-update helpers once with the full slice after the range loop completes.
- `updateBudgetReferences` and `updateRateLimitReferences` are rewritten to accept a slice instead of a single item. Each builds a `map[string]*Table…` lookup from the reset set, then makes a single pass over each owner map (`virtualKeys`, `teams`, `customers`). An owner is cloned and stored only when at least one of its embedded references matches a reset item, avoiding unnecessary allocations for non-matching owners.
- Provider-config budget and rate-limit slices are now cloned defensively before mutation during the refresh pass.
- New tests pin the correctness and performance contracts:
  - `TestBackgroundBudgetResetRefreshesReferences` — verifies that one sweep updates expired embedded copies on VKs, teams, and customers while leaving unexpired sibling budgets untouched.
  - `TestRateLimitResetAccuracyEdgeCases` — covers mixed expiry, exact rolling boundary, one-nanosecond-before-boundary, calendar-aligned snapping, within-current-period no-op, and clock-skew (future `LastReset`) scenarios.
  - `TestBackgroundResetReferenceRefreshScales` — seeds 3,000 per-VK rate limits, runs a background sweep, and asserts the per-reset cost stays under 50 µs, failing with a diagnostic message if the O(owners × resets) behaviour regresses.
  - `TestBudgetResetAccuracyAt100kKeysAllDue` — seeds 100k VKs with alternating rolling/calendar-aligned budgets across `1d`/`1w`/`1M` durations, all expired, and verifies every counter is zeroed, `LastReset` is correctly advanced or snapped to the period start, and embedded VK references are refreshed, within a 10-second wall-clock budget.
  - `TestBudgetResetAccuracyAt100kKeysSparse` — seeds 100k VKs where ~10% have no budget and only ~1% of budgeted keys are due, verifying the sweep resets exactly the due set and leaves every untouched budget byte-identical in usage and `LastReset`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run "TestBackgroundBudgetResetRefreshesReferences|TestRateLimitResetAccuracyEdgeCases|TestBackgroundResetReferenceRefreshScales|TestBudgetResetAccuracyAt100kKeysAllDue|TestBudgetResetAccuracyAt100kKeysSparse" -v -timeout 120s
```

`TestBackgroundResetReferenceRefreshScales` will fail with a detailed diagnostic if the batched-pass behaviour regresses to per-reset ranging. `TestBudgetResetAccuracyAt100kKeysAllDue` and `TestBudgetResetAccuracyAt100kKeysSparse` enforce both correctness and the 10-second wall-clock ceiling for a full 100k-key sweep.

## Breaking changes

- [x] No

## Security considerations

None. The change affects only in-memory reference bookkeeping for rate-limit and budget counters; no auth paths, secrets, or external data flows are modified.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable