### PR TITLE
fix: replace fan-out attribution with single-owner additive rollup and "Unassigned" bucket for dimension rankings

### DIFF
--- a/framework/logstore/multi_team_matview_test.go
+++ b/framework/logstore/multi_team_matview_test.go
@@ -91,18 +91,21 @@ func TestFilterBusinessUnitMatView_CollectsScalarAndArray(t *testing.T) {
 	assert.Equal(t, "BU One", byID["bu-arr1"], "array-only business unit must now appear")
 }
 
-// TestDimensionRankings_ActualVsAttributedTotals pins the semantics of the
-// server-side totals: a request attributed to two teams counts once in
-// TotalActualRequests (COUNT(DISTINCT id)) and twice in
-// TotalAttributedRequests (COUNT(*) over the fan-out), while the per-team
-// rows stay accurate per team.
-func TestDimensionRankings_ActualVsAttributedTotals(t *testing.T) {
+// TestDimensionRankings_SingleOwnerAdditive pins the additive attribution
+// semantics for the org-rollup dimensions: each request is credited to exactly
+// one owner — the scalar team_id — and requests with no scalar owner (e.g. the
+// enterprise user/AP path that only populates the JSON array) fall into a
+// synthetic "Unassigned" bucket rather than being fanned out to every team they
+// touch. This keeps the per-team spend additive so the Teams tab reconciles to
+// the org total, and TotalActualRequests == TotalAttributedRequests.
+func TestDimensionRankings_SingleOwnerAdditive(t *testing.T) {
 	store, db := setupPerfTestDB(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
 
-	// One request attributed to two teams + one scalar single-team request:
-	// 2 actual requests, 3 attributed team-credits.
+	// Row 1: array-only multi-team request with no scalar owner -> Unassigned.
+	// Row 2: single-team request with a scalar owner -> t-a.
+	// Additive: 2 requests total, each counted once.
 	insertTeamBULog(t, db, now, "u-1", "", "", `["t-a","t-b"]`, `["Team A","Team B"]`, "", "", "", "")
 	insertTeamBULog(t, db, now, "u-1", "t-a", "Team A", "", "", "", "", "", "")
 
@@ -111,15 +114,73 @@ func TestDimensionRankings_ActualVsAttributedTotals(t *testing.T) {
 	res, err := store.GetDimensionRankings(ctx, SearchFilters{StartTime: &start, EndTime: &end}, RankingDimensionTeam)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), res.TotalActualRequests, "actual must count distinct requests, not fan-out rows")
-	assert.Equal(t, int64(3), res.TotalAttributedRequests, "attributed must credit a request once per team it touches")
+	assert.Equal(t, int64(2), res.TotalActualRequests, "actual counts every terminal request, including Unassigned")
+	assert.Equal(t, int64(2), res.TotalAttributedRequests, "single-owner attribution is additive: attributed == actual")
 
 	requestsByID := make(map[string]int64, len(res.Rankings))
+	namesByID := make(map[string]string, len(res.Rankings))
+	var summedRequests int64
 	for _, r := range res.Rankings {
 		requestsByID[r.ID] = r.TotalRequests
+		namesByID[r.ID] = r.Name
+		summedRequests += r.TotalRequests
 	}
-	assert.Equal(t, int64(2), requestsByID["t-a"], "t-a is touched by both requests (array + scalar fallback)")
-	assert.Equal(t, int64(1), requestsByID["t-b"], "t-b is touched only by the multi-team request")
+	assert.Equal(t, int64(1), requestsByID["t-a"], "t-a owns exactly its one scalar-attributed request")
+	assert.Equal(t, int64(1), requestsByID[unassignedDimensionID], "the array-only request with no scalar owner is Unassigned")
+	assert.Equal(t, unassignedDimensionName, namesByID[unassignedDimensionID], "the unassigned bucket gets a stable display name")
+	_, hasTB := requestsByID["t-b"]
+	assert.False(t, hasTB, "no fan-out: t-b is never credited a request it doesn't scalar-own")
+	assert.Equal(t, res.TotalActualRequests, summedRequests, "rows must sum to the org total (additive rollup)")
+}
+
+// TestDimensionRankings_VirtualKeyUnassigned pins that the Unassigned bucket now
+// also applies to the non-org rollup dimensions (here virtual_key; user is
+// identical). Requests with no scalar virtual_key_id collapse into "Unassigned"
+// instead of being dropped, so the per-key breakdown stays additive and
+// reconciles to the org total.
+func TestDimensionRankings_VirtualKeyUnassigned(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Row 1: request through a virtual key -> vk-1. Row 2: direct API-key
+	// request with no virtual key -> Unassigned.
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			virtual_key_id, virtual_key_name, created_at, latency, cost,
+			prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			'vk-1', 'Prod Key', ?, 100, 0.01, 10, 5, 15)
+	`, uuid.New().String(), now, now).Error
+	require.NoError(t, err)
+	err = db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			?, 100, 0.01, 10, 5, 15)
+	`, uuid.New().String(), now, now).Error
+	require.NoError(t, err)
+
+	start := now.Add(-time.Hour)
+	end := now.Add(time.Hour)
+	res, err := store.GetDimensionRankings(ctx, SearchFilters{StartTime: &start, EndTime: &end}, RankingDimensionVirtualKey)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), res.TotalActualRequests, "additive total includes the Unassigned bucket")
+	assert.Equal(t, res.TotalActualRequests, res.TotalAttributedRequests, "single-owner attribution: attributed == actual")
+
+	requestsByID := make(map[string]int64, len(res.Rankings))
+	namesByID := make(map[string]string, len(res.Rankings))
+	var summed int64
+	for _, r := range res.Rankings {
+		requestsByID[r.ID] = r.TotalRequests
+		namesByID[r.ID] = r.Name
+		summed += r.TotalRequests
+	}
+	assert.Equal(t, int64(1), requestsByID["vk-1"], "the keyed request is credited to its virtual key")
+	assert.Equal(t, int64(1), requestsByID[unassignedDimensionID], "the keyless request falls into Unassigned")
+	assert.Equal(t, unassignedDimensionName, namesByID[unassignedDimensionID], "Unassigned gets a stable display name")
+	assert.Equal(t, res.TotalActualRequests, summed, "rows sum to the org total")
 }
 
 // TestFilterTeamMatView_DACScopeAppliesAfterFanout proves the visibility columns

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -145,6 +145,44 @@ func teamOrBUFanoutFrom(idCol string) (string, bool) {
 ) AS logs`, arrIDs, arrNames, idCol, scalarName), true
 }
 
+// Rollup dimensions (team / business unit / customer / user / virtual key)
+// attribute each request to exactly ONE owner — the scalar id column — so that
+// per-dimension spend sums to the org total (an additive finance rollup).
+// Requests with no owner are grouped under a synthetic "Unassigned" entry
+// rather than dropped, so the rollup still reconciles to total spend.
+//
+// This deliberately replaces the multi-value fan-out (teamOrBUFanoutFrom) for
+// the *aggregate* readers (rankings + cost/token histograms): fan-out credited a
+// request to every team it touched, which double-counted shared requests and
+// made the tab non-additive (a user in N overlapping IdP groups inflated every
+// group to the same total). Fan-out is still used for filter dropdowns, where
+// listing every team a request touches is the correct behaviour.
+const (
+	unassignedDimensionID   = "unassigned"
+	unassignedDimensionName = "Unassigned"
+)
+
+// isBucketedDimension reports whether a scalar id column is a rollup dimension
+// that uses single-owner attribution with an Unassigned bucket: each request is
+// credited to exactly one owner (the scalar id), and rows with no owner collapse
+// into a synthetic "Unassigned" entry so the per-dimension rollup stays additive
+// and reconciles to the org total. idCol is an internal constant.
+func isBucketedDimension(idCol string) bool {
+	switch idCol {
+	case "team_id", "business_unit_id", "customer_id", "user_id", "virtual_key_id":
+		return true
+	}
+	return false
+}
+
+// bucketedIDExpr maps the scalar dimension id to itself, or to the synthetic
+// unassigned id when NULL/empty, so unattributed traffic collapses into one
+// bucket. COALESCE + NULLIF are standard SQL (dialect-agnostic). idCol is an
+// internal constant, so the interpolation carries no user input.
+func bucketedIDExpr(idCol string) string {
+	return fmt.Sprintf("COALESCE(NULLIF(%s, ''), '%s')", idCol, unassignedDimensionID)
+}
+
 // applyFilters applies search filters to a GORM query. Callers are
 // responsible for starting from ScopedDB(ctx) when row visibility
 // should be respected; this helper only adds the per-call filter
@@ -2123,29 +2161,23 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		return nil, fmt.Errorf("invalid ranking dimension: %s", dimension)
 	}
 
-	// Multi-valued team / business-unit dimensions fan out over the JSON array
-	// (with scalar fallback for old / VK-team logs) so a request credits every
-	// team/BU it touches. Postgres-only; this forces the live path — the
-	// matview-accelerated equivalent is deferred to the partitioning work.
-	fanoutFrom := ""
-	if s.db.Dialector.Name() == "postgres" {
-		if f, isFanout := teamOrBUFanoutFrom(idCol); isFanout {
-			fanoutFrom = f
-			idCol, nameCol = "dim_id", "dim_name"
-		}
+	// Every rollup dimension (team / business unit / customer / user / virtual
+	// key) attributes each request to a single owner — the scalar id column — and
+	// buckets owner-less traffic under a synthetic "Unassigned" entry, so
+	// per-dimension spend is additive and reconciles to the org total.
+	bucketed := isBucketedDimension(idCol)
+	groupExpr := idCol
+	if bucketed {
+		groupExpr = bucketedIDExpr(idCol)
 	}
-	baseTable := func(q *gorm.DB) *gorm.DB {
-		if fanoutFrom != "" {
-			return q.Table(fanoutFrom)
-		}
-		return q.Model(&Log{})
-	}
+	baseTable := func(q *gorm.DB) *gorm.DB { return q.Model(&Log{}) }
 
 	// Fresh-aggregate gate (not bare canUseMatView): short windows go to the
 	// raw table because mv_logs_hourly rounds the window out to full hour
 	// buckets, which visibly inflates rankings against the raw-path stats and
-	// cost-histogram totals shown on the same dashboard.
-	if fanoutFrom == "" && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
+	// cost-histogram totals shown on the same dashboard. Bucketed dimensions
+	// always use the raw path — the matview reader has no Unassigned bucket.
+	if !bucketed && s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getDimensionRankingsFromMatView(ctx, filters, dimension)
 	}
 
@@ -2162,12 +2194,14 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		COUNT(*) as total_requests,
 		SUM(total_tokens) as total_tokens,
 		COALESCE(SUM(cost), 0) as total_cost
-	`, idCol, nameExpr)
+	`, groupExpr, nameExpr)
 
 	currentQuery := baseTable(s.ScopedDB(ctx))
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
-	currentQuery = currentQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
+	if !bucketed {
+		currentQuery = currentQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
+	}
 
 	var currentResults []struct {
 		ID            string          `gorm:"column:id"`
@@ -2179,7 +2213,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 
 	if err := currentQuery.
 		Select(selectClause).
-		Group(idCol).
+		Group(groupExpr).
 		Order("total_requests DESC").
 		Limit(defaultMaxRankingsLimit).
 		Find(&currentResults).Error; err != nil {
@@ -2193,25 +2227,23 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		}, nil
 	}
 
-	// For fan-out dimensions the per-row counts credit a request to every
-	// dimension value it touches, so their sum overstates real traffic. Compute
-	// both requestCounts in one pass over the same fanned population (identical
-	// predicate chain) so actual <= attributed always holds — summing the
-	// (limit-capped) rankings client-side could undercount attributed below it.
+	// Single-owner attribution is additive, so attributed == actual. Report the
+	// real total request count (including the Unassigned bucket) so the UI's
+	// totals reconcile to org-wide traffic.
 	var requestCounts struct {
 		ActualRequests     int64 `gorm:"column:actual_requests"`
 		AttributedRequests int64 `gorm:"column:attributed_requests"`
 	}
-	if fanoutFrom != "" {
-		requestsCountsQuery := baseTable(s.ScopedDB(ctx))
-		requestsCountsQuery = s.applyFilters(requestsCountsQuery, filters)
-		requestsCountsQuery = requestsCountsQuery.Where("status IN ?", terminalLogStatuses)
-		requestsCountsQuery = requestsCountsQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
-		if err := requestsCountsQuery.
-			Select("COUNT(DISTINCT id) as actual_requests, COUNT(*) as attributed_requests").
-			Scan(&requestCounts).Error; err != nil {
+	if bucketed {
+		countQuery := baseTable(s.ScopedDB(ctx))
+		countQuery = s.applyFilters(countQuery, filters)
+		countQuery = countQuery.Where("status IN ?", terminalLogStatuses)
+		var total int64
+		if err := countQuery.Count(&total).Error; err != nil {
 			return nil, fmt.Errorf("failed to get dimension ranking totals for %s: %w", dimension, err)
 		}
+		requestCounts.ActualRequests = total
+		requestCounts.AttributedRequests = total
 	}
 
 	prevMap := make(map[string]DimensionRankingEntry)
@@ -2227,14 +2259,16 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		prevQuery := baseTable(s.ScopedDB(ctx))
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
-		prevQuery = prevQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
+		if !bucketed {
+			prevQuery = prevQuery.Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", idCol, idCol))
+		}
 
 		if len(currentResults) > 0 {
 			ids := make([]string, len(currentResults))
 			for i, r := range currentResults {
 				ids[i] = r.ID
 			}
-			prevQuery = prevQuery.Where(fmt.Sprintf("%s IN ?", idCol), ids)
+			prevQuery = prevQuery.Where(fmt.Sprintf("%s IN ?", groupExpr), ids)
 		}
 
 		var prevResults []struct {
@@ -2249,11 +2283,11 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 			COUNT(*) as total_requests,
 			SUM(total_tokens) as total_tokens,
 			COALESCE(SUM(cost), 0) as total_cost
-		`, idCol)
+		`, groupExpr)
 
 		if err := prevQuery.
 			Select(prevSelect).
-			Group(idCol).
+			Group(groupExpr).
 			Find(&prevResults).Error; err != nil {
 			return nil, fmt.Errorf("failed to get previous period dimension rankings: %w", err)
 		}
@@ -2270,9 +2304,15 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 
 	rankings := make([]DimensionRankingWithTrend, len(currentResults))
 	for i, r := range currentResults {
+		name := r.Name
+		// Owner-less rows collapse into the synthetic unassigned bucket, whose
+		// scalar name column is empty; give it a stable display label.
+		if bucketed && r.ID == unassignedDimensionID {
+			name = unassignedDimensionName
+		}
 		entry := DimensionRankingEntry{
 			ID:            r.ID,
-			Name:          r.Name,
+			Name:          name,
 			TotalRequests: r.TotalRequests,
 			TotalTokens:   r.TotalTokens.Int64,
 			TotalCost:     r.TotalCost.Float64,
@@ -2867,27 +2907,22 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 	}
 	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
-	// Team / business-unit dimensions fan out over the JSON array (scalar
-	// fallback for old / VK-team logs). Postgres-only; forces the live path.
-	// NOTE: under fan-out the per-bucket *total* cost is the attributed total
-	// (≥ real, since a shared request counts toward each of its teams/BUs); the
-	// per-dimension breakdown is exact. Surface it as "attributed" in the UI.
-	fanoutFrom := ""
-	if dialect == "postgres" {
-		if f, isFanout := teamOrBUFanoutFrom(dimCol); isFanout {
-			fanoutFrom = f
-			dimCol = "dim_id"
-		}
+	// Rollup dimensions (team / business unit / customer / user / virtual key)
+	// attribute each request to a single owner and bucket owner-less traffic as
+	// "unassigned", so the per-dimension breakdown is additive and the bucket
+	// totals reconcile to org spend. Bucketed dimensions use the raw path — the
+	// matview reader has no unassigned bucket.
+	bucketed := isBucketedDimension(dimCol)
+	dimValueExpr := fmt.Sprintf("COALESCE(%s, '')", dimCol)
+	groupCol := dimCol
+	if bucketed {
+		dimValueExpr = bucketedIDExpr(dimCol)
+		groupCol = dimValueExpr
 	}
-	if fanoutFrom == "" && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		return s.getDimensionCostHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
-	baseQuery := s.ScopedDB(ctx)
-	if fanoutFrom != "" {
-		baseQuery = baseQuery.Table(fanoutFrom)
-	} else {
-		baseQuery = baseQuery.Model(&Log{})
-	}
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
@@ -2901,10 +2936,10 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 	}
 	if err := baseQuery.Select(fmt.Sprintf(`
 		%s AS bucket_timestamp,
-		COALESCE(%s, '') AS dim_value,
+		%s AS dim_value,
 		SUM(cost) AS cost
-	`, bucketExpr, dimCol)).
-		Group(fmt.Sprintf("bucket_timestamp, %s", dimCol)).
+	`, bucketExpr, dimValueExpr)).
+		Group(fmt.Sprintf("bucket_timestamp, %s", groupCol)).
 		Order("bucket_timestamp ASC").
 		Find(&results).Error; err != nil {
 		return nil, err
@@ -2973,24 +3008,21 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 	}
 	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
-	// Team / business-unit dimensions fan out over the JSON array (scalar
-	// fallback for old / VK-team logs). Postgres-only; forces the live path.
-	fanoutFrom := ""
-	if dialect == "postgres" {
-		if f, isFanout := teamOrBUFanoutFrom(dimCol); isFanout {
-			fanoutFrom = f
-			dimCol = "dim_id"
-		}
+	// Internal org-rollup dimensions (team / business unit / customer) attribute
+	// each request to a single owner and bucket owner-less traffic as
+	// "unassigned", so the per-dimension breakdown is additive. Bucketed
+	// dimensions use the raw path — the matview reader has no unassigned bucket.
+	bucketed := isBucketedDimension(dimCol)
+	dimValueExpr := fmt.Sprintf("COALESCE(%s, '')", dimCol)
+	groupCol := dimCol
+	if bucketed {
+		dimValueExpr = bucketedIDExpr(dimCol)
+		groupCol = dimValueExpr
 	}
-	if fanoutFrom == "" && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		return s.getDimensionTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
-	baseQuery := s.ScopedDB(ctx)
-	if fanoutFrom != "" {
-		baseQuery = baseQuery.Table(fanoutFrom)
-	} else {
-		baseQuery = baseQuery.Model(&Log{})
-	}
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -3005,12 +3037,12 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 	}
 	if err := baseQuery.Select(fmt.Sprintf(`
 		%s AS bucket_timestamp,
-		COALESCE(%s, '') AS dim_value,
+		%s AS dim_value,
 		COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
 		COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
 		COALESCE(SUM(total_tokens), 0) AS total_tkns
-	`, bucketExpr, dimCol)).
-		Group(fmt.Sprintf("bucket_timestamp, %s", dimCol)).
+	`, bucketExpr, dimValueExpr)).
+		Group(fmt.Sprintf("bucket_timestamp, %s", groupCol)).
 		Order("bucket_timestamp ASC").
 		Find(&results).Error; err != nil {
 		return nil, err

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1780,11 +1780,12 @@ type DimensionRankingWithTrend struct {
 type DimensionRankingResult struct {
 	Rankings  []DimensionRankingWithTrend `json:"rankings"`
 	Dimension RankingDimension            `json:"dimension"`
-	// TotalActualRequests / TotalAttributedRequests are only set for fan-out
-	// dimensions (team / business unit / customer) on Postgres. Attributed
-	// counts credit a request to every dimension value it touches, so their
-	// sum can exceed the real request count; actual is COUNT(DISTINCT id)
-	// over the same attributed population. Zero/omitted when not computed.
+	// TotalActualRequests / TotalAttributedRequests are set for every rollup
+	// dimension (team / business unit / customer / user / virtual key). These use
+	// single-owner attribution (one request → one owner, with owner-less traffic
+	// in an "Unassigned" bucket), so the rollup is additive and the two counts
+	// are equal — both report the real total request count over the window,
+	// including Unassigned.
 	TotalActualRequests     int64 `json:"total_actual_requests,omitempty"`
 	TotalAttributedRequests int64 `json:"total_attributed_requests,omitempty"`
 }

--- a/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
@@ -270,7 +270,9 @@ function DimensionRankingsTabImpl({ data, loading, dimensionLabel, testIdPrefix,
 									<TableCell>
 										<div className="flex flex-col">
 											<span className="font-medium">{entry.name || entry.id}</span>
-											{entry.name && entry.name !== entry.id && <span className="text-muted-foreground text-xs">{entry.id}</span>}
+											{entry.name && entry.name !== entry.id && entry.id !== "unassigned" && (
+												<span className="text-muted-foreground text-xs">{entry.id}</span>
+											)}
 										</div>
 									</TableCell>
 									<TableCell className="text-right">

--- a/ui/app/workspace/dashboard/components/tabViews/dimensionRankingsTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/dimensionRankingsTabView.tsx
@@ -46,7 +46,7 @@ export const DimensionRankingsTabView = forwardRef<DimensionRankingsTabViewHandl
 				loading={loading}
 				dimensionLabel={dimensionLabel}
 				testIdPrefix={testIdPrefix}
-				attributed={dimension === "team" || dimension === "business_unit" || dimension === "customer"}
+				attributed
 			/>
 		);
 	},


### PR DESCRIPTION
## Summary

Replaces the multi-value fan-out attribution model for dimension rankings (Teams, Business Units, Customers, Users, Virtual Keys) with a single-owner additive model. Previously, a request shared across multiple teams was credited to every team it touched, causing double-counting and making per-team spend non-additive relative to the org total. Now each request is attributed to exactly one owner (the scalar ID column), and requests with no scalar owner collapse into a synthetic "Unassigned" bucket instead of being dropped or fanned out.

## Changes

- Removed `teamOrBUFanoutFrom` usage from `GetDimensionRankings`, `GetDimensionCostHistogram`, and `GetDimensionTokenHistogram`. All rollup dimensions now use the raw `logs` table with a `COALESCE(NULLIF(id_col, ''), 'unassigned')` group expression.
- Introduced `isBucketedDimension` to identify the five rollup dimensions (team, business unit, customer, user, virtual key) and `bucketedIDExpr` to produce the SQL expression that maps NULL/empty owners to the synthetic `unassigned` bucket.
- `TotalActualRequests` and `TotalAttributedRequests` are now equal for all bucketed dimensions (single-owner attribution is additive), and both reflect the true org-wide request count including the Unassigned bucket.
- Bucketed dimensions are forced onto the raw query path; the matview reader has no Unassigned bucket and is bypassed for these dimensions.
- The `attributed` prop in `DimensionRankingsTabView` is now always `true` (all dimensions use the same attribution model), and the UI suppresses the raw `unassigned` ID sub-label in the rankings table.
- Renamed `TestDimensionRankings_ActualVsAttributedTotals` to `TestDimensionRankings_SingleOwnerAdditive` and updated its assertions to reflect the new semantics. Added `TestDimensionRankings_VirtualKeyUnassigned` to cover the virtual key dimension.

## Type of change

- [x] Refactor
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] UI (React)

## How to test

```sh
# Core
go test ./framework/logstore/... -run TestDimensionRankings
go test ./framework/logstore/... -run TestFilterBusinessUnitMatView

# UI
cd ui
pnpm i
pnpm build
```

Validate that the Teams dashboard tab sums per-team request counts to the org total, that requests with no scalar team owner appear under "Unassigned" rather than being dropped, and that no team is credited for a request it does not scalar-own.

## Breaking changes

- [x] Yes

The fan-out attribution model is removed. Callers that previously relied on `TotalAttributedRequests > TotalActualRequests` to detect shared requests will now always see them equal. Per-team request counts will decrease for teams that previously received fan-out credit for shared requests.

## Related issues

## Security considerations

No auth, secrets, or PII changes. The `bucketedIDExpr` function interpolates only internal constant strings, not user input.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable