### PR TITLE
fix: emit output_item.added for reasoning deltas on Chat-Completions-fallback streaming path

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: emit output_item.added for reasoning deltas on the Chat-Completions-fallback streaming path so the Anthropic-compat SSE converter opens a matching content_block_start before any thinking_delta (closes #5169)
 - feat: add Sarvam AI provider with chat, text-to-speech, and speech-to-text support (thanks [@Purvi09](https://github.com/Purvi09)!)
 - feat: add ElevenLabs sound effects (text-to-sound) support (thanks [@SecretSun](https://github.com/SecretSun)!)
 - feat: add `ProjectID` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex

--- a/core/providers/anthropic/muxreasoningstream_test.go
+++ b/core/providers/anthropic/muxreasoningstream_test.go
@@ -1,0 +1,112 @@
+package anthropic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestMuxReasoningStream_ReproducesCrashWithoutFix drives Bifrost's
+// Chat-Completions-fallback streaming path (schemas.BifrostChatResponse.
+// ToBifrostResponsesStreamResponse — used by every provider whose ResponsesStream
+// falls back to ChatCompletionStream, e.g. Ollama, Groq, Cerebras, DeepSeek,
+// Mistral, Nebius, Parasail, SGL, VLLM) with reasoning-then-text deltas, exactly
+// as a local Ollama reasoning model (qwen3) streams them over its OpenAI-compatible
+// endpoint. It then feeds the resulting Bifrost Responses-stream events through
+// ToAnthropicResponsesStreamResponse — the same conversion the Anthropic-compat
+// transport (/anthropic/v1/messages) applies before writing SSE to the client.
+//
+// Before the fix: the reasoning delta never got an output_item.added of its own
+// (mux.go emitted only response.reasoning_summary_text.delta, with neither Item
+// nor ItemID set), so reverseStreamItemKey fell back to "oi:<index>" — a key
+// distinct from the text item's Item.ID key registered at its own
+// output_item.added. blockIndexFor("oi:0") therefore always missed and silently
+// allocated a fresh Anthropic content-block index with no content_block_start
+// ever emitted for it. A strict client — including the official anthropic-python
+// SDK's streaming accumulator (accumulate_event in
+// anthropic/lib/streaming/_messages.py), which appends to its content list only
+// on content_block_start and indexes it unchecked on content_block_delta — sees a
+// content_block_delta for a block it never opened and raises IndexError.
+func TestMuxReasoningStream_ReproducesCrashWithoutFix(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	role := string(schemas.ChatMessageRoleAssistant)
+	reasoning1 := "Okay, "
+	reasoning2 := "so the user is asking 2+2."
+	content1 := "2 + 2"
+	content2 := " = 4."
+	stop := string(schemas.BifrostFinishReasonStop)
+
+	makeChunk := func(role *string, reasoning *string, content *string, finishReason *string) *schemas.BifrostChatResponse {
+		return &schemas.BifrostChatResponse{
+			ID:    "chatcmpl-test",
+			Model: "qwen3:0.6b",
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					FinishReason: finishReason,
+					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+						Delta: &schemas.ChatStreamResponseChoiceDelta{
+							Role:      role,
+							Reasoning: reasoning,
+							Content:   content,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	chunks := []*schemas.BifrostChatResponse{
+		makeChunk(&role, nil, nil, nil),
+		makeChunk(nil, &reasoning1, nil, nil),
+		makeChunk(nil, &reasoning2, nil, nil),
+		makeChunk(nil, nil, &content1, nil),
+		makeChunk(nil, nil, &content2, nil),
+		makeChunk(nil, nil, nil, &stop),
+	}
+
+	var frames []ptFrame
+	var sawReasoningItemAdded bool
+	var sawTextItemAdded bool
+	for _, c := range chunks {
+		for _, r := range c.ToBifrostResponsesStreamResponse(state) {
+			if r == nil {
+				continue
+			}
+			if r.Type == schemas.ResponsesStreamResponseTypeOutputItemAdded && r.Item != nil && r.Item.Type != nil {
+				switch *r.Item.Type {
+				case schemas.ResponsesMessageTypeReasoning:
+					sawReasoningItemAdded = true
+				case schemas.ResponsesMessageTypeMessage:
+					sawTextItemAdded = true
+				}
+			}
+			for _, e := range ToAnthropicResponsesStreamResponse(ctx, r) {
+				idx := -1
+				if e.Index != nil {
+					idx = *e.Index
+				}
+				frames = append(frames, ptFrame{typ: string(e.Type), idx: idx, via: "conv"})
+			}
+		}
+	}
+
+	if !sawReasoningItemAdded {
+		t.Fatal("expected a response.output_item.added event with Item.Type == reasoning before any reasoning delta")
+	}
+	if !sawTextItemAdded {
+		t.Fatal("expected a response.output_item.added event with Item.Type == message for the text content")
+	}
+
+	if problems := blockFramingProblems(t, frames, false); len(problems) > 0 {
+		t.Errorf("mux reasoning stream is not well-formed (would crash a strict Anthropic SSE client, e.g. the official anthropic-python SDK's accumulate_event): %v", problems)
+	}
+
+	rs := getOrCreateAnthropicToResponsesStreamState(ctx)
+	if len(rs.blockIndexMisses) > 0 {
+		t.Errorf("reverse converter recorded block-index misses (content_block_delta/_stop for a block whose content_block_start was never emitted): %v", rs.blockIndexMisses)
+	}
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1524,6 +1524,10 @@ type ChatToResponsesStreamState struct {
 	TextItemClosed        bool              // Whether text item has been closed
 	TextItemHasContent    bool              // Whether text item has received any content deltas
 	TextBuffer            strings.Builder   // Accumulated text deltas for output_text.done/content_part.done
+	ReasoningItemAdded    bool              // Whether the reasoning item has been added
+	ReasoningItemClosed   bool              // Whether the reasoning item has been closed
+	ReasoningOutputIndex  int               // Output index assigned to the reasoning item
+	ReasoningBuffer       strings.Builder   // Accumulated reasoning deltas for reasoning_summary_text.done
 	CurrentOutputIndex    int               // Current output index counter
 	ToolCallOutputIndices map[string]int    // Maps tool call ID to output index
 	SequenceNumber        int               // Monotonic sequence number across all chunks
@@ -1547,6 +1551,10 @@ var chatToResponsesStreamStatePool = sync.Pool{
 			TextItemClosed:        false,
 			TextItemHasContent:    false,
 			TextBuffer:            strings.Builder{},
+			ReasoningItemAdded:    false,
+			ReasoningItemClosed:   false,
+			ReasoningOutputIndex:  0,
+			ReasoningBuffer:       strings.Builder{},
 		}
 	},
 }
@@ -1592,6 +1600,10 @@ func AcquireChatToResponsesStreamState() *ChatToResponsesStreamState {
 	state.TextItemClosed = false
 	state.TextItemHasContent = false
 	state.TextBuffer = strings.Builder{}
+	state.ReasoningItemAdded = false
+	state.ReasoningItemClosed = false
+	state.ReasoningOutputIndex = 0
+	state.ReasoningBuffer = strings.Builder{}
 	state.SequenceNumber = 0
 	return state
 }
@@ -1626,6 +1638,10 @@ func ReleaseChatToResponsesStreamState(state *ChatToResponsesStreamState) {
 		state.TextItemClosed = false
 		state.TextItemHasContent = false
 		state.TextBuffer = strings.Builder{}
+		state.ReasoningItemAdded = false
+		state.ReasoningItemClosed = false
+		state.ReasoningOutputIndex = 0
+		state.ReasoningBuffer = strings.Builder{}
 		state.SequenceNumber = 0
 		chatToResponsesStreamStatePool.Put(state)
 	}
@@ -1954,13 +1970,65 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 	}
 
 	if delta.Reasoning != nil && *delta.Reasoning != "" {
-		// Reasoning/thought content delta (for models that support reasoning)
+		// Reasoning/thought content delta (for models that support reasoning).
+		// The reasoning item gets its own output_item.added (type "reasoning"),
+		// mirroring the text-item pattern above, so downstream converters that
+		// key content-block bookkeeping off Item.ID (e.g. the Anthropic SSE
+		// converter's reverseStreamItemKey) see a start event before any delta
+		// — without it, deltas fell back to an "oi:<index>" key that never
+		// matched the text item's Item.ID key, leaving Anthropic clients with
+		// a content_block_delta for a block whose content_block_start was
+		// never emitted (crashes the official SDK's streaming accumulator).
+		if !state.ReasoningItemAdded {
+			outputIndex := state.CurrentOutputIndex
+			if outputIndex == 0 {
+				outputIndex = 1 // Skip 0 — reserved for the text item
+			}
+			state.CurrentOutputIndex = outputIndex + 1
+			state.ReasoningOutputIndex = outputIndex
+
+			var itemID string
+			if state.MessageID == nil {
+				itemID = fmt.Sprintf("reasoning_item_%d", outputIndex)
+			} else {
+				itemID = fmt.Sprintf("msg_%s_reasoning_item_%d", *state.MessageID, outputIndex)
+			}
+			state.ItemIDs["reasoning"] = itemID
+
+			reasoningType := ResponsesMessageTypeReasoning
+			role := ResponsesInputMessageRoleAssistant
+			item := &ResponsesMessage{
+				ID:   &itemID,
+				Type: &reasoningType,
+				Role: &role,
+				ResponsesReasoning: &ResponsesReasoning{
+					Summary: []ResponsesReasoningSummary{},
+				},
+			}
+
+			responses = append(responses, &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeOutputItemAdded,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				Item:           item,
+				ExtraFields:    cr.ExtraFields,
+			})
+			state.SequenceNumber++
+			state.ReasoningItemAdded = true
+		}
+
+		itemID := state.ItemIDs["reasoning"]
+		state.ReasoningBuffer.WriteString(*delta.Reasoning)
+
 		response := &BifrostResponsesStreamResponse{
 			Type:           ResponsesStreamResponseTypeReasoningSummaryTextDelta,
 			SequenceNumber: state.SequenceNumber,
-			OutputIndex:    Ptr(0),
+			OutputIndex:    Ptr(state.ReasoningOutputIndex),
 			Delta:          delta.Reasoning,
 			ExtraFields:    cr.ExtraFields,
+		}
+		if itemID != "" {
+			response.ItemID = &itemID
 		}
 		responses = append(responses, response)
 		state.SequenceNumber++
@@ -2058,6 +2126,53 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			state.TextItemClosed = true
 		}
 
+		// Close reasoning item if still open, mirroring the text-item close above
+		if state.ReasoningItemAdded && !state.ReasoningItemClosed {
+			outputIndex := state.ReasoningOutputIndex
+			itemID := state.ItemIDs["reasoning"]
+			finalReasoning := state.ReasoningBuffer.String()
+
+			responses = append(responses, &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeReasoningSummaryTextDone,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				ItemID:         &itemID,
+				Text:           &finalReasoning,
+				ExtraFields:    cr.ExtraFields,
+			})
+			state.SequenceNumber++
+
+			// Emit output_item.done
+			statusFinal := terminalStatus
+			reasoningType := ResponsesMessageTypeReasoning
+			role := ResponsesInputMessageRoleAssistant
+			doneReasoningItem := &ResponsesMessage{
+				Type:   &reasoningType,
+				Role:   &role,
+				Status: &statusFinal,
+				ResponsesReasoning: &ResponsesReasoning{
+					Summary: []ResponsesReasoningSummary{
+						{
+							Type: ResponsesReasoningContentBlockTypeSummaryText,
+							Text: finalReasoning,
+						},
+					},
+				},
+			}
+			if itemID != "" {
+				doneReasoningItem.ID = &itemID
+			}
+			responses = append(responses, &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeOutputItemDone,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				Item:           doneReasoningItem,
+				ExtraFields:    cr.ExtraFields,
+			})
+			state.SequenceNumber++
+			state.ReasoningItemClosed = true
+		}
+
 		// Close any open tool call items and emit function_call_arguments.done
 		for toolCallID, args := range state.ToolArgumentBuffers {
 			if args != "" {
@@ -2134,6 +2249,32 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			response.Model = *state.Model
 		}
 		var allOutput []ResponsesMessage
+
+		if state.ReasoningItemAdded {
+			statusFinal := terminalStatus
+			reasoningType := ResponsesMessageTypeReasoning
+			role := ResponsesInputMessageRoleAssistant
+			finalReasoning := state.ReasoningBuffer.String()
+			itemID := state.ItemIDs["reasoning"]
+
+			reasoningMsg := ResponsesMessage{
+				Type:   &reasoningType,
+				Role:   &role,
+				Status: &statusFinal,
+				ResponsesReasoning: &ResponsesReasoning{
+					Summary: []ResponsesReasoningSummary{
+						{
+							Type: ResponsesReasoningContentBlockTypeSummaryText,
+							Text: finalReasoning,
+						},
+					},
+				},
+			}
+			if itemID != "" {
+				reasoningMsg.ID = &itemID
+			}
+			allOutput = append(allOutput, reasoningMsg)
+		}
 
 		if state.TextItemAdded {
 			statusFinal := terminalStatus

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -2248,7 +2248,16 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		if state.Model != nil {
 			response.Model = *state.Model
 		}
-		var allOutput []ResponsesMessage
+		// Collect every output item alongside its streamed output_index, then sort
+		// ascending so response.completed.Output matches the order clients already
+		// saw via output_item.added — otherwise a client that reconciles the
+		// terminal snapshot against streamed output_index values (e.g. attaching
+		// late-arriving status) can pair the wrong item with the wrong index.
+		type outputEntry struct {
+			outputIndex int
+			msg         ResponsesMessage
+		}
+		var outputEntries []outputEntry
 
 		if state.ReasoningItemAdded {
 			statusFinal := terminalStatus
@@ -2273,7 +2282,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			if itemID != "" {
 				reasoningMsg.ID = &itemID
 			}
-			allOutput = append(allOutput, reasoningMsg)
+			outputEntries = append(outputEntries, outputEntry{outputIndex: state.ReasoningOutputIndex, msg: reasoningMsg})
 		}
 
 		if state.TextItemAdded {
@@ -2304,24 +2313,10 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			if itemID != "" {
 				msg.ID = &itemID
 			}
-			allOutput = append(allOutput, msg)
+			outputEntries = append(outputEntries, outputEntry{outputIndex: 0, msg: msg})
 		}
 
-		// Collect tool call IDs sorted by outputIndex for deterministic order
-		type toolCallEntry struct {
-			toolCallID  string
-			outputIndex int
-		}
-		var toolCallEntries []toolCallEntry
 		for toolCallID, outputIndex := range state.ToolCallOutputIndices {
-			toolCallEntries = append(toolCallEntries, toolCallEntry{toolCallID: toolCallID, outputIndex: outputIndex})
-		}
-		sort.Slice(toolCallEntries, func(i, j int) bool {
-			return toolCallEntries[i].outputIndex < toolCallEntries[j].outputIndex
-		})
-
-		for _, entry := range toolCallEntries {
-			toolCallID := entry.toolCallID
 			statusFinal := terminalStatus
 			messageType := ResponsesMessageTypeFunctionCall
 			callName, hasName := state.ToolCallNames[toolCallID]
@@ -2343,10 +2338,18 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			if itemID != "" {
 				fcMsg.ID = &itemID
 			}
-			allOutput = append(allOutput, fcMsg)
+			outputEntries = append(outputEntries, outputEntry{outputIndex: outputIndex, msg: fcMsg})
 		}
 
-		if len(allOutput) > 0 {
+		sort.Slice(outputEntries, func(i, j int) bool {
+			return outputEntries[i].outputIndex < outputEntries[j].outputIndex
+		})
+
+		if len(outputEntries) > 0 {
+			allOutput := make([]ResponsesMessage, len(outputEntries))
+			for i, entry := range outputEntries {
+				allOutput[i] = entry.msg
+			}
 			response.Output = allOutput
 		}
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -521,7 +521,7 @@ func TestToBifrostResponsesStreamResponse_CompletedOutputOrderMatchesOutputIndex
 	all = append(all, makeChunk(nil, nil, &content, nil).ToBifrostResponsesStreamResponse(state)...)
 	all = append(all, makeChunk(nil, nil, nil, &stop).ToBifrostResponsesStreamResponse(state)...)
 
-	// Reasoning streamed at output_index 0, text deferred to output_index 1
+	// Text streamed at output_index 0, reasoning deferred to output_index 1
 	// (mirrors the "skip 0" reservation tool calls already use for text).
 	var reasoningAddedIndex, textAddedIndex *int
 	for _, evt := range all {

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -477,6 +477,88 @@ func TestToBifrostResponsesStreamResponse_PopulatesFinalDoneTextAndCompletedOutp
 	}
 }
 
+// TestToBifrostResponsesStreamResponse_CompletedOutputOrderMatchesOutputIndex
+// guards against reordering response.completed.Output relative to the
+// output_index values already streamed via output_item.added: the text item
+// always claims output_index 0 (even for a reasoning-only-so-far response, an
+// empty placeholder message is opened on the first reasoning delta so the
+// envelope is never fully empty), so reasoning is always deferred to
+// output_index 1+. Output must list items in that same output_index order — a
+// client that reconciles the terminal snapshot against streamed output_index
+// (e.g. to attach late status) would otherwise pair the wrong item with the
+// wrong index.
+func TestToBifrostResponsesStreamResponse_CompletedOutputOrderMatchesOutputIndex(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	reasoning := "thinking..."
+	content := "the answer"
+	stop := string(BifrostFinishReasonStop)
+
+	makeChunk := func(role *string, reasoning *string, content *string, finishReason *string) *BifrostChatResponse {
+		return &BifrostChatResponse{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []BifrostResponseChoice{
+				{
+					FinishReason: finishReason,
+					ChatStreamResponseChoice: &ChatStreamResponseChoice{
+						Delta: &ChatStreamResponseChoiceDelta{
+							Role:      role,
+							Reasoning: reasoning,
+							Content:   content,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	var all []*BifrostResponsesStreamResponse
+	all = append(all, makeChunk(&role, nil, nil, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, &reasoning, nil, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, nil, &content, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, nil, nil, &stop).ToBifrostResponsesStreamResponse(state)...)
+
+	// Reasoning streamed at output_index 0, text deferred to output_index 1
+	// (mirrors the "skip 0" reservation tool calls already use for text).
+	var reasoningAddedIndex, textAddedIndex *int
+	for _, evt := range all {
+		if evt == nil || evt.Type != ResponsesStreamResponseTypeOutputItemAdded || evt.Item == nil || evt.Item.Type == nil {
+			continue
+		}
+		switch *evt.Item.Type {
+		case ResponsesMessageTypeReasoning:
+			reasoningAddedIndex = evt.OutputIndex
+		case ResponsesMessageTypeMessage:
+			textAddedIndex = evt.OutputIndex
+		}
+	}
+	if reasoningAddedIndex == nil || textAddedIndex == nil {
+		t.Fatal("expected both a reasoning and a text output_item.added event")
+	}
+	if *textAddedIndex >= *reasoningAddedIndex {
+		t.Fatalf("expected text output_index (%d) < reasoning output_index (%d)", *textAddedIndex, *reasoningAddedIndex)
+	}
+
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt != nil && evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+	if completed == nil || completed.Response == nil || len(completed.Response.Output) != 2 {
+		t.Fatal("expected response.completed with two output messages")
+	}
+	if completed.Response.Output[0].Type == nil || *completed.Response.Output[0].Type != ResponsesMessageTypeMessage {
+		t.Fatalf("expected Output[0] to be the text item (matching its lower output_index), got %v", completed.Response.Output[0].Type)
+	}
+	if completed.Response.Output[1].Type == nil || *completed.Response.Output[1].Type != ResponsesMessageTypeReasoning {
+		t.Fatalf("expected Output[1] to be the reasoning item (matching its higher output_index), got %v", completed.Response.Output[1].Type)
+	}
+}
+
 func TestToBifrostResponsesResponse_MapsLengthToIncomplete(t *testing.T) {
 	length := string(BifrostFinishReasonLength)
 	resp := (&BifrostChatResponse{


### PR DESCRIPTION
## Summary

Reasoning deltas on the Chat-Completions-fallback streaming path never got an `output_item.added`, so the Anthropic-compat SSE converter opened an unregistered content block — crashes the official `anthropic-python` SDK's streaming accumulator with `IndexError`. Fixes #5169.

## Changes

- `core/schemas/mux.go`: give the reasoning delta its own `output_item.added` (type `reasoning`, stable `Item.ID`) before the first delta, and set `ItemID` on subsequent deltas — mirrors the existing text-item lifecycle.
- Close the reasoning item on `finish_reason` and include it in `response.completed`'s `Output`, closing the remaining streaming-side gap from #1977.
- New regression test in `core/providers/anthropic/muxreasoningstream_test.go`.

## Type of change

- [x] Bug fix

## How to test

```sh
cd core
go test ./schemas/... ./providers/anthropic/... -run "Reasoning|MuxReasoningStream" -v
```

Repro + test report with before/after screenshots and raw logs attached in a comment below.

## Breaking changes

- [x] No
