### PR TITLE
feat: add generic OIDC SCIM/SSO provider support to Helm chart

### DIFF
--- a/docs/changelogs/helm-v2.1.29.mdx
+++ b/docs/changelogs/helm-v2.1.29.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.29"
+description: "Helm v2.1.29 changelog - 2026-07-15"
+---
+
+<Update label="Bifrost Helm" description="v2.1.29">
+
+## Changelog
+
+- Added generic OIDC SCIM/SSO provider support (`bifrost.scim.provider: generic`) for any standards-compliant OIDC IdP. Configure via `bifrost.scim.config` (`issuerUrl` and `clientId` required; optional `clientSecret`, `audience`, endpoint overrides, `teamIdsField`, `rolesField`, `scopes`, and attribute/claim mappings). Endpoints are resolved via OIDC discovery unless overridden. Renders into `scim_config.config`.
+
+</Update>

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1912,6 +1912,14 @@ Call this template at the beginning of deployment/stateful templates
 {{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is Google Workspace." }}
 {{- end }}
 {{- end }}
+{{- if eq $scimValidation.provider "generic" }}
+{{- if not $scimValidation.config.issuerUrl }}
+{{- fail "ERROR: bifrost.scim.config.issuerUrl is required when SCIM provider is a generic OIDC provider. Example: https://idp.company.com" }}
+{{- end }}
+{{- if not $scimValidation.config.clientId }}
+{{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is a generic OIDC provider." }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/* Validate cluster config when enabled */}}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -898,7 +898,7 @@ bifrost:
   # SCIM/SSO configuration for enterprise SSO
   scim:
     enabled: false
-    # Provider: okta, entra, keycloak, zitadel, google
+    # Provider: okta, entra, keycloak, zitadel, google, sailpoint, generic
     provider: ""
     config: {}
       # Okta configuration:
@@ -998,6 +998,22 @@ bifrost:
       # impersonateServiceAccount: ""             # optional, for Workload Identity
       # audience: ""
       # teamIdsField: "groups"
+      # attributeRoleMappings: []
+      # attributeTeamMappings: []
+      # attributeBusinessUnitMappings: []
+      #
+      # Generic OIDC configuration (any standards-compliant OIDC IdP):
+      # issuerUrl: "https://idp.company.com"        # required; endpoints resolved via OIDC discovery (.well-known/openid-configuration)
+      # clientId: ""                                # required
+      # clientSecret: "env.OIDC_CLIENT_SECRET"      # optional, for confidential clients; supports env. prefix
+      # audience: ""                                # optional, JWT audience for token validation
+      # # Optional manual endpoint overrides (used in preference to discovery when the IdP has no compliant discovery document):
+      # authorizationEndpoint: "https://idp.company.com/oauth2/authorize"
+      # tokenEndpoint: "https://idp.company.com/oauth2/token"
+      # userinfoEndpoint: "https://idp.company.com/oauth2/userinfo"
+      # teamIdsField: "groups"                      # JWT claim for team/group IDs (default: "groups")
+      # rolesField: "roles"                         # JWT claim for role names (optional)
+      # scopes: []                                  # override the default OIDC scopes requested during login
       # attributeRoleMappings: []
       # attributeTeamMappings: []
       # attributeBusinessUnitMappings: []

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.12
+    created: "2026-07-14T15:06:42.147711+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: f0f864342c284140130e944e61e3dd05be3edba4df004762716048573d650c73
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.28/bifrost-2.1.28.tgz
+    version: 2.1.28
+  - apiVersion: v2
+    appVersion: 1.5.12
     created: "2026-07-10T17:11:35.672608+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -1156,4 +1180,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-07-10T17:11:35.669091+05:30"
+generated: "2026-07-14T15:06:42.143799+05:30"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5144,7 +5144,7 @@
         },
         "provider": {
           "type": "string",
-          "enum": ["okta", "entra", "keycloak"],
+          "enum": ["okta", "entra", "keycloak", "zitadel", "google", "sailpoint", "generic"],
           "description": "SCIM provider type"
         },
         "config": {
@@ -5211,6 +5211,86 @@
             "properties": {
               "config": {
                 "$ref": "#/$defs/keycloak_config"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "provider": {
+                "const": "generic"
+              }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/$defs/generic_config"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "provider": {
+                "const": "zitadel"
+              }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/$defs/zitadel_config"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "provider": {
+                "const": "google"
+              }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/$defs/google_config"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "provider": {
+                "const": "sailpoint"
+              }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/$defs/sailpoint_config"
               }
             }
           }
@@ -5368,6 +5448,271 @@
       },
       "required": ["serverUrl", "realm", "clientId", "clientSecret"],
       "additionalProperties": false
+    },
+    "generic_config": {
+      "type": "object",
+      "description": "Generic OIDC authentication configuration for any standards-compliant OIDC identity provider. Endpoints are resolved via OIDC discovery (.well-known/openid-configuration) from issuerUrl unless overridden.",
+      "properties": {
+        "issuerUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "OIDC issuer URL (e.g., https://idp.company.com)"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "OAuth2/OIDC application client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "OAuth2/OIDC client secret (optional, for confidential clients). Supports env. prefix for environment variable references."
+        },
+        "audience": {
+          "type": "string",
+          "description": "JWT audience for token validation (optional)"
+        },
+        "authorizationEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "Manual override for the authorization endpoint (used in preference to discovery when set)"
+        },
+        "tokenEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "Manual override for the token endpoint (used in preference to discovery when set)"
+        },
+        "userinfoEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "Manual override for the userinfo endpoint (used in preference to discovery when set)"
+        },
+        "teamIdsField": {
+          "type": "string",
+          "description": "JWT claim field for team/group IDs (default: 'groups')",
+          "default": "groups"
+        },
+        "rolesField": {
+          "type": "string",
+          "description": "JWT claim field for role names (optional)"
+        },
+        "scopes": {
+          "type": "array",
+          "description": "Override the default OIDC scopes requested during login",
+          "items": { "type": "string" }
+        },
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+      },
+      "required": ["issuerUrl", "clientId"],
+      "additionalProperties": false
+    },
+    "zitadel_config": {
+      "type": "object",
+      "description": "Zitadel OIDC authentication configuration",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "format": "hostname",
+          "pattern": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$",
+          "description": "Zitadel instance domain (e.g., 'my-instance.zitadel.cloud' or 'auth.company.com'). Bare host only - do NOT include the scheme, port, or path."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Zitadel application client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "Zitadel client secret (optional, required for confidential clients and token revocation)"
+        },
+        "projectId": {
+          "type": "string",
+          "description": "Optional Zitadel project ID for project-scoped role claims"
+        },
+        "audience": {
+          "type": "string",
+          "description": "Access-token audience override (default: clientId)"
+        },
+        "serviceAccountClientId": {
+          "type": "string",
+          "description": "Service account client ID for Zitadel Management API (required for user provisioning - web apps cannot use client_credentials)"
+        },
+        "serviceAccountClientSecret": {
+          "type": "string",
+          "description": "Service account client secret for Zitadel Management API"
+        },
+        "teamIdsField": {
+          "type": "string",
+          "description": "JWT claim field for team/group IDs (default: 'groups')",
+          "default": "groups"
+        },
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+      },
+      "required": ["domain", "clientId"],
+      "additionalProperties": false
+    },
+    "google_config": {
+      "type": "object",
+      "description": "Google Workspace OIDC authentication configuration",
+      "properties": {
+        "domain": {
+          "type": "string",
+          "format": "hostname",
+          "pattern": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$",
+          "description": "Google Workspace primary domain (e.g., 'company.com'). Bare host only - do NOT include the scheme, port, or path."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Google OAuth2 client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "Google client secret (optional, used for token revocation)"
+        },
+        "credentialMode": {
+          "type": "string",
+          "enum": ["", "inherit", "env", "file"],
+          "description": "How Directory API credentials are sourced. 'inherit' uses Application Default Credentials; 'env' uses serviceAccountEnvVar; 'file' uses serviceAccountFile."
+        },
+        "serviceAccountEnvVar": {
+          "type": "string",
+          "description": "Name of the environment variable containing the service account JSON (used when credentialMode is 'env'). Required for Directory API access without ADC."
+        },
+        "serviceAccountFile": {
+          "type": "string",
+          "description": "Filesystem path to the service account JSON key file (used when credentialMode is 'file')."
+        },
+        "adminEmail": {
+          "type": "string",
+          "format": "email",
+          "description": "Admin email for domain-wide delegation. Required whenever Directory API access is configured."
+        },
+        "impersonateServiceAccount": {
+          "type": "string",
+          "description": "GCP service account email to impersonate when using ADC (Workload Identity); must have domain-wide delegation configured."
+        },
+        "audience": {
+          "type": "string",
+          "description": "JWT audience override (default: clientId)"
+        },
+        "teamIdsField": {
+          "type": "string",
+          "description": "Claim field for team/group IDs (default: 'groups')",
+          "default": "groups"
+        },
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+      },
+      "required": ["domain", "clientId"],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "credentialMode": { "const": "env" }
+            },
+            "required": ["credentialMode"]
+          },
+          "then": {
+            "required": ["serviceAccountEnvVar"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "credentialMode": { "const": "file" }
+            },
+            "required": ["credentialMode"]
+          },
+          "then": {
+            "required": ["serviceAccountFile"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "credentialMode": {
+                "enum": ["inherit", "env", "file"]
+              }
+            },
+            "required": ["credentialMode"]
+          },
+          "then": {
+            "required": ["adminEmail"]
+          }
+        }
+      ]
+    },
+    "sailpoint_config": {
+      "type": "object",
+      "description": "SailPoint identity security platform configuration",
+      "properties": {
+        "product": {
+          "type": "string",
+          "enum": ["isc", "iiq"],
+          "description": "SailPoint product type: 'isc' for Identity Security Cloud, 'iiq' for IdentityIQ"
+        },
+        "tenant": {
+          "type": "string",
+          "description": "ISC tenant identifier (required for ISC product)"
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "IdentityIQ base URL (required for IIQ product)"
+        },
+        "username": {
+          "type": "string",
+          "description": "Username for IdentityIQ authentication"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for IdentityIQ authentication"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "OAuth2 client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "OAuth2 client secret"
+        },
+        "teamIdsField": {
+          "type": "string",
+          "description": "JWT claim field for team IDs"
+        },
+        "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+      },
+      "required": ["product"],
+      "additionalProperties": false
+    },
+    "scim_claim_attributes": {
+      "type": "object",
+      "description": "Per-claim SCIM interpretation. Maps each claim name to its SCIM source type and attribute key.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "attributeType": {
+            "type": "string",
+            "enum": ["user", "group"],
+            "description": "'user' reads from SCIM User resource attributes; 'group' matches SCIM Group resource."
+          },
+          "attributeValue": {
+            "type": "string",
+            "description": "SCIM attribute key or group match field for this claim."
+          }
+        },
+        "required": ["attributeType", "attributeValue"],
+        "additionalProperties": false
+      }
     },
     "load_balancer_config": {
       "type": "object",

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -408,6 +408,77 @@ func TestSchemaSCIMConfigValidation(t *testing.T) {
 				}
 			}`,
 		},
+		{
+			name:      "enabled generic with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"generic","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:      "enabled zitadel with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"zitadel","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:   "enabled zitadel with required config is valid",
+			config: `{"scim_config":{"enabled":true,"provider":"zitadel","config":{"domain":"acme.zitadel.cloud","clientId":"bifrost"}}}`,
+		},
+		{
+			name:      "enabled google with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"google","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:   "enabled google with required config is valid",
+			config: `{"scim_config":{"enabled":true,"provider":"google","config":{"domain":"company.com","clientId":"bifrost"}}}`,
+		},
+		{
+			name:      "enabled google with credentialMode env but no serviceAccountEnvVar is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"google","config":{"domain":"company.com","clientId":"bifrost","credentialMode":"env"}}}`,
+			wantError: true,
+		},
+		{
+			name:      "enabled sailpoint with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"sailpoint","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:   "enabled sailpoint with required config is valid",
+			config: `{"scim_config":{"enabled":true,"provider":"sailpoint","config":{"product":"isc","tenant":"acme"}}}`,
+		},
+		{
+			name:      "unknown provider is rejected",
+			config:    `{"scim_config":{"enabled":true,"provider":"pingfederate","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name: "enabled generic with required config is valid",
+			config: `{
+				"scim_config": {
+					"enabled": true,
+					"provider": "generic",
+					"config": {
+						"issuerUrl": "https://idp.company.com",
+						"clientId": "bifrost"
+					}
+				}
+			}`,
+		},
+		{
+			name: "enabled generic with claim SCIM attributes is valid",
+			config: `{
+				"scim_config": {
+					"enabled": true,
+					"provider": "generic",
+					"config": {
+						"issuerUrl": "https://idp.company.com",
+						"clientId": "bifrost",
+						"claimScimAttributes": {
+							"department": {"attributeType": "user", "attributeValue": "department"}
+						}
+					}
+				}
+			}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds a `generic` OIDC provider option to Bifrost's SCIM/SSO configuration, enabling integration with any standards-compliant OIDC identity provider beyond the existing named providers (Okta, Entra, Keycloak, Zitadel, Google, SailPoint).

## Changes

- Introduced `bifrost.scim.provider: generic` as a new supported SCIM provider value in `values.yaml`, with documented configuration fields including `issuerUrl` (required), `clientId` (required), and optional fields such as `clientSecret`, `audience`, endpoint overrides (`authorizationEndpoint`, `tokenEndpoint`, `userinfoEndpoint`), `teamIdsField`, `rolesField`, `scopes`, and attribute/claim mappings.
- Added Helm template validation in `_helpers.tpl` that enforces `issuerUrl` and `clientId` are present when `provider: generic` is set, failing fast with descriptive error messages.
- Endpoints are resolved via OIDC discovery (`.well-known/openid-configuration`) unless manually overridden, accommodating IdPs that do not expose a compliant discovery document.
- Updated the changelog (`helm-v2.1.27.mdx`) and `README.md` to document the new provider support.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy Bifrost with the following `values.yaml` snippet and verify the rendered `scim_config.config` contains the expected OIDC fields:

```yaml
bifrost:
  scim:
    enabled: true
    provider: generic
    config:
      issuerUrl: "https://idp.company.com"
      clientId: "my-client-id"
      clientSecret: "env.OIDC_CLIENT_SECRET"
      teamIdsField: "groups"
      rolesField: "roles"
```

Validate that omitting `issuerUrl` or `clientId` causes `helm template` to fail with the appropriate error message:

```sh
helm template bifrost ./helm-charts/bifrost -f values-generic-oidc.yaml
# Expected: ERROR: bifrost.scim.config.issuerUrl is required when SCIM provider is a generic OIDC provider.
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- `clientSecret` supports the `env.` prefix for referencing Kubernetes secrets via environment variables, avoiding plaintext secrets in `values.yaml`.
- Token validation relies on the `audience` field when set; operators should ensure the correct audience is configured to prevent token misuse.
- Endpoint overrides should only be used when the IdP lacks a compliant OIDC discovery document, as manual configuration bypasses automatic endpoint validation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable