### PR TITLE
feat: add throughput (tokens/sec) charts to overview and provider usage dashboard tabs

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
@@ -1,0 +1,233 @@
+import type { ProviderThroughputHistogramResponse } from "@/lib/types/logs";
+import { memo, useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { formatFullTimestamp, formatTimestamp, formatTokensPerSecond, getModelColor, pickTopSeries, THROUGHPUT_COLOR } from "../../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface ProviderThroughputChartProps {
+	data: ProviderThroughputHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+	selectedProvider: string;
+}
+
+function AllProvidersTooltip({ active, payload, displayProviders: providers }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				{providers.map((provider: string, idx: number) => {
+					const stats = data.by_provider?.[provider];
+					if (!stats || stats.tokens_per_second === 0) return null;
+					return (
+						<div key={provider} className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(idx) }} />
+								<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{provider}</span>
+							</span>
+							<span className="font-medium">{formatTokensPerSecond(stats.tokens_per_second)}</span>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+function SingleProviderTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: THROUGHPUT_COLOR }} />
+						<span className="text-zinc-600 dark:text-zinc-400">Throughput</span>
+					</span>
+					<span className="font-medium">{formatTokensPerSecond(data.tokens_per_second)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="text-zinc-600 dark:text-zinc-400">Completion tokens</span>
+					<span className="font-medium">{data.total_completion_tokens?.toLocaleString() || 0}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+					<span className="text-zinc-600 dark:text-zinc-400">Requests</span>
+					<span className="font-medium">{data.total_requests?.toLocaleString() || 0}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ProviderThroughputChartImpl({ data, chartType, startTime, endTime, selectedProvider }: ProviderThroughputChartProps) {
+	const { chartData, mode, displayProviders } = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return { chartData: [], mode: "all" as const, displayProviders: [] };
+		}
+
+		const isSingleProvider = selectedProvider !== "all";
+		// Rank by total_requests so we keep the highest-volume providers visible.
+		const providers = isSingleProvider
+			? [selectedProvider]
+			: pickTopSeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_requests ?? 0);
+
+		const processed = data.buckets.map((bucket, index) => {
+			const item: any = {
+				...bucket,
+				index,
+				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+			};
+
+			if (isSingleProvider) {
+				const stats = bucket.by_provider?.[selectedProvider];
+				item.tokens_per_second = stats?.tokens_per_second || 0;
+				item.total_completion_tokens = stats?.total_completion_tokens || 0;
+				item.total_requests = stats?.total_requests || 0;
+			} else {
+				providers.forEach((provider, idx) => {
+					item[`provider_${idx}`] = bucket.by_provider?.[provider]?.tokens_per_second || 0;
+				});
+			}
+
+			return item;
+		});
+
+		return { chartData: processed, mode: isSingleProvider ? ("single" as const) : ("all" as const), displayProviders: providers };
+	}, [data, selectedProvider]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+		margin: { top: 6, right: 4, left: 4, bottom: 0 },
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}-${selectedProvider}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={70}
+							tickFormatter={formatTokensPerSecond}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						{mode === "single" ? (
+							<>
+								<Tooltip content={<SingleProviderTooltip provider={selectedProvider} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+								<Bar
+									isAnimationActive={false}
+									dataKey="tokens_per_second"
+									fill={THROUGHPUT_COLOR}
+									fillOpacity={0.9}
+									barSize={8}
+									radius={[2, 2, 0, 0]}
+								/>
+							</>
+						) : (
+							<>
+								<Tooltip
+									content={<AllProvidersTooltip displayProviders={displayProviders} />}
+									cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
+								/>
+								{displayProviders.map((provider, idx) => (
+									<Bar
+										key={provider}
+										dataKey={`provider_${idx}`}
+										fill={getModelColor(idx)}
+										isAnimationActive={false}
+										fillOpacity={0.9}
+										barSize={8}
+										radius={[2, 2, 0, 0]}
+									/>
+								))}
+							</>
+						)}
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={70}
+							tickFormatter={formatTokensPerSecond}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						{mode === "single" ? (
+							<>
+								<Tooltip content={<SingleProviderTooltip provider={selectedProvider} />} />
+								<Area
+									isAnimationActive={false}
+									type="monotone"
+									dataKey="tokens_per_second"
+									stroke={THROUGHPUT_COLOR}
+									fill={THROUGHPUT_COLOR}
+									fillOpacity={0.4}
+								/>
+							</>
+						) : (
+							<>
+								<Tooltip content={<AllProvidersTooltip displayProviders={displayProviders} />} />
+								{displayProviders.map((provider, idx) => (
+									<Area
+										key={provider}
+										type="monotone"
+										isAnimationActive={false}
+										dataKey={`provider_${idx}`}
+										stroke={getModelColor(idx)}
+										fill={getModelColor(idx)}
+										fillOpacity={0.3}
+									/>
+								))}
+							</>
+						)}
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}
+
+export const ProviderThroughputChart = memo(ProviderThroughputChartImpl);

--- a/ui/app/workspace/dashboard/components/charts/throughputChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/throughputChart.tsx
@@ -1,0 +1,139 @@
+import type { ThroughputHistogramResponse } from "@/lib/types/logs";
+import { memo, useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { formatFullTimestamp, formatTimestamp, formatTokensPerSecond, THROUGHPUT_COLOR } from "../../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface ThroughputChartProps {
+	data: ThroughputHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+}
+
+function CustomTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: THROUGHPUT_COLOR }} />
+						<span className="text-zinc-600 dark:text-zinc-400">Throughput</span>
+					</span>
+					<span className="font-medium">{formatTokensPerSecond(data.tokens_per_second)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="text-zinc-600 dark:text-zinc-400">Completion tokens</span>
+					<span className="font-medium">{data.total_completion_tokens.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+					<span className="text-zinc-600 dark:text-zinc-400">Requests</span>
+					<span className="font-medium">{data.total_requests.toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ThroughputChartImpl({ data, chartType, startTime, endTime }: ThroughputChartProps) {
+	const chartData = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return [];
+		}
+
+		return data.buckets.map((bucket, index) => ({
+			...bucket,
+			index,
+			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+		}));
+	}, [data]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+		margin: { top: 6, right: 4, left: 4, bottom: 0 },
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={70}
+							tickFormatter={formatTokensPerSecond}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Bar
+							isAnimationActive={false}
+							dataKey="tokens_per_second"
+							fill={THROUGHPUT_COLOR}
+							fillOpacity={0.9}
+							barSize={8}
+							radius={[2, 2, 0, 0]}
+						/>
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={70}
+							tickFormatter={formatTokensPerSecond}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Area
+							isAnimationActive={false}
+							type="monotone"
+							dataKey="tokens_per_second"
+							stroke={THROUGHPUT_COLOR}
+							fill={THROUGHPUT_COLOR}
+							fillOpacity={0.4}
+						/>
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}
+export const ThroughputChart = memo(ThroughputChartImpl);

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -5,17 +5,19 @@ import type {
 	LogStats,
 	LogsHistogramResponse,
 	ModelHistogramResponse,
+	ThroughputHistogramResponse,
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
 import NumberFlow from "@number-flow/react";
 import { memo, useMemo } from "react";
-import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, getModelColor } from "../utils/chartUtils";
+import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, THROUGHPUT_COLOR, formatTokensPerSecond, getModelColor } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { CostChart } from "./charts/costChart";
 import ExternalCacheTokenMeterChart from "./charts/externalCacheTokenMeterChart";
 import { LatencyChart } from "./charts/latencyChart";
+import { ThroughputChart } from "./charts/throughputChart";
 import LocalCacheTokenMeterChart from "./charts/localCacheTokenMeterChart";
 import { LogVolumeChart } from "./charts/logVolumeChart";
 import { ModelFilterSelect } from "./charts/modelFilterSelect";
@@ -29,6 +31,7 @@ export interface OverviewTabProps {
 	costData: CostHistogramResponse | null;
 	modelData: ModelHistogramResponse | null;
 	latencyData: LatencyHistogramResponse | null;
+	throughputData: ThroughputHistogramResponse | null;
 	logsStats: LogStats | null;
 
 	// Loading states
@@ -37,6 +40,7 @@ export interface OverviewTabProps {
 	loadingCost: boolean;
 	loadingModels: boolean;
 	loadingLatency: boolean;
+	loadingThroughput: boolean;
 	loadingStats: boolean;
 
 	// Time range
@@ -49,6 +53,7 @@ export interface OverviewTabProps {
 	costChartType: ChartType;
 	modelChartType: ChartType;
 	latencyChartType: ChartType;
+	throughputChartType: ChartType;
 
 	// Model selections
 	costModel: string;
@@ -65,6 +70,7 @@ export interface OverviewTabProps {
 	onCostChartToggle: (type: ChartType) => void;
 	onModelChartToggle: (type: ChartType) => void;
 	onLatencyChartToggle: (type: ChartType) => void;
+	onThroughputChartToggle: (type: ChartType) => void;
 
 	// Filter callbacks
 	onCostModelChange: (model: string) => void;
@@ -77,12 +83,14 @@ function OverviewTabImpl({
 	costData,
 	modelData,
 	latencyData,
+	throughputData,
 	logsStats,
 	loadingHistogram,
 	loadingTokens,
 	loadingCost,
 	loadingModels,
 	loadingLatency,
+	loadingThroughput,
 	loadingStats,
 	startTime,
 	endTime,
@@ -91,6 +99,7 @@ function OverviewTabImpl({
 	costChartType,
 	modelChartType,
 	latencyChartType,
+	throughputChartType,
 	costModel,
 	usageModel,
 	costModels,
@@ -101,6 +110,7 @@ function OverviewTabImpl({
 	onCostChartToggle,
 	onModelChartToggle,
 	onLatencyChartToggle,
+	onThroughputChartToggle,
 	onCostModelChange,
 	onUsageModelChange,
 }: OverviewTabProps) {
@@ -147,6 +157,21 @@ function OverviewTabImpl({
 		}
 		return count > 0 ? weighted / count : null;
 	}, [latencyData]);
+
+	// Weighted-average throughput across buckets (weighted by request count) so
+	// the header figure matches how the aggregate rate is computed per bucket.
+	const throughputAvg = useMemo(() => {
+		if (!throughputData?.buckets || throughputData.buckets.length === 0) return null;
+		let weighted = 0;
+		let count = 0;
+		for (const b of throughputData.buckets) {
+			const reqs = b.total_requests ?? 0;
+			if (reqs === 0) continue;
+			weighted += (b.tokens_per_second ?? 0) * reqs;
+			count += reqs;
+		}
+		return count > 0 ? weighted / count : null;
+	}, [throughputData]);
 
 	return (
 		<>
@@ -424,6 +449,31 @@ function OverviewTabImpl({
 					}
 				>
 					<LatencyChart data={latencyData} chartType={latencyChartType} startTime={startTime} endTime={endTime} />
+				</ChartCard>
+
+				{/* Throughput (tokens/sec) Chart */}
+				<ChartCard
+					title="Throughput"
+					loading={loadingThroughput}
+					testId="chart-throughput"
+					totalLabel="Avg"
+					total={throughputAvg !== null ? <span className="truncate whitespace-nowrap">{formatTokensPerSecond(throughputAvg)}</span> : undefined}
+					totalTooltip={
+						throughputAvg !== null ? `${throughputAvg.toLocaleString("en-US", { maximumFractionDigits: 2 })} tokens/sec` : undefined
+					}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: THROUGHPUT_COLOR }} />
+								<span className="text-muted-foreground">Tokens/sec</span>
+							</span>
+						</div>
+					}
+					controls={
+						<ChartTypeToggle chartType={throughputChartType} onToggle={onThroughputChartToggle} data-testid="dashboard-throughput-chart-toggle" />
+					}
+				>
+					<ThroughputChart data={throughputData} chartType={throughputChartType} startTime={startTime} endTime={endTime} />
 				</ChartCard>
 			</div>
 		</>

--- a/ui/app/workspace/dashboard/components/providerUsageTab.tsx
+++ b/ui/app/workspace/dashboard/components/providerUsageTab.tsx
@@ -2,13 +2,19 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
 import NumberFlow from "@number-flow/react";
 import { memo, useMemo } from "react";
-import type { ProviderCostHistogramResponse, ProviderLatencyHistogramResponse, ProviderTokenHistogramResponse } from "@/lib/types/logs";
-import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, getModelColor } from "../utils/chartUtils";
+import type {
+	ProviderCostHistogramResponse,
+	ProviderLatencyHistogramResponse,
+	ProviderThroughputHistogramResponse,
+	ProviderTokenHistogramResponse,
+} from "@/lib/types/logs";
+import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, THROUGHPUT_COLOR, formatTokensPerSecond, getModelColor } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { ProviderCostChart } from "./charts/providerCostChart";
 import { ProviderFilterSelect } from "./charts/providerFilterSelect";
 import { ProviderLatencyChart } from "./charts/providerLatencyChart";
+import { ProviderThroughputChart } from "./charts/providerThroughputChart";
 import { ProviderTokenChart } from "./charts/providerTokenChart";
 
 export interface ProviderUsageTabProps {
@@ -16,11 +22,13 @@ export interface ProviderUsageTabProps {
 	providerCostData: ProviderCostHistogramResponse | null;
 	providerTokenData: ProviderTokenHistogramResponse | null;
 	providerLatencyData: ProviderLatencyHistogramResponse | null;
+	providerThroughputData: ProviderThroughputHistogramResponse | null;
 
 	// Loading states
 	loadingProviderCost: boolean;
 	loadingProviderTokens: boolean;
 	loadingProviderLatency: boolean;
+	loadingProviderThroughput: boolean;
 
 	// Time range
 	startTime: number;
@@ -30,54 +38,66 @@ export interface ProviderUsageTabProps {
 	providerCostChartType: ChartType;
 	providerTokenChartType: ChartType;
 	providerLatencyChartType: ChartType;
+	providerThroughputChartType: ChartType;
 
 	// Provider selections
 	providerCostProvider: string;
 	providerTokenProvider: string;
 	providerLatencyProvider: string;
+	providerThroughputProvider: string;
 
 	// Derived provider lists
 	availableProviders: string[];
 	providerCostProviders: string[];
 	providerTokenProviders: string[];
 	providerLatencyProviders: string[];
+	providerThroughputProviders: string[];
 
 	// Chart type toggle callbacks
 	onProviderCostChartToggle: (type: ChartType) => void;
 	onProviderTokenChartToggle: (type: ChartType) => void;
 	onProviderLatencyChartToggle: (type: ChartType) => void;
+	onProviderThroughputChartToggle: (type: ChartType) => void;
 
 	// Filter callbacks
 	onProviderCostProviderChange: (provider: string) => void;
 	onProviderTokenProviderChange: (provider: string) => void;
 	onProviderLatencyProviderChange: (provider: string) => void;
+	onProviderThroughputProviderChange: (provider: string) => void;
 }
 
 function ProviderUsageTabImpl({
 	providerCostData,
 	providerTokenData,
 	providerLatencyData,
+	providerThroughputData,
 	loadingProviderCost,
 	loadingProviderTokens,
 	loadingProviderLatency,
+	loadingProviderThroughput,
 	startTime,
 	endTime,
 	providerCostChartType,
 	providerTokenChartType,
 	providerLatencyChartType,
+	providerThroughputChartType,
 	providerCostProvider,
 	providerTokenProvider,
 	providerLatencyProvider,
+	providerThroughputProvider,
 	availableProviders,
 	providerCostProviders,
 	providerTokenProviders,
 	providerLatencyProviders,
+	providerThroughputProviders,
 	onProviderCostChartToggle,
 	onProviderTokenChartToggle,
 	onProviderLatencyChartToggle,
+	onProviderThroughputChartToggle,
 	onProviderCostProviderChange,
 	onProviderTokenProviderChange,
 	onProviderLatencyProviderChange,
+	onProviderThroughputProviderChange,
 }: ProviderUsageTabProps) {
 	const providerCostTotal = useMemo(() => {
 		if (!providerCostData?.buckets) return null;
@@ -117,6 +137,23 @@ function ProviderUsageTabImpl({
 		}
 		return count > 0 ? weighted / count : null;
 	}, [providerLatencyData, providerLatencyProvider]);
+
+	const providerThroughputAvg = useMemo(() => {
+		if (!providerThroughputData?.buckets) return null;
+		let weighted = 0;
+		let count = 0;
+		for (const b of providerThroughputData.buckets) {
+			if (!b.by_provider) continue;
+			const providers = providerThroughputProvider === "all" ? providerThroughputData.providers : [providerThroughputProvider];
+			for (const p of providers) {
+				const s = b.by_provider[p];
+				if (!s || !s.total_requests) continue;
+				weighted += (s.tokens_per_second ?? 0) * s.total_requests;
+				count += s.total_requests;
+			}
+		}
+		return count > 0 ? weighted / count : null;
+	}, [providerThroughputData, providerThroughputProvider]);
 
 	return (
 		<div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
@@ -396,6 +433,95 @@ function ProviderUsageTabImpl({
 					startTime={startTime}
 					endTime={endTime}
 					selectedProvider={providerLatencyProvider}
+				/>
+			</ChartCard>
+
+			{/* Provider Throughput (tokens/sec) Chart */}
+			<ChartCard
+				title="Provider Throughput"
+				loading={loadingProviderThroughput}
+				testId="chart-provider-throughput"
+				totalLabel="Avg"
+				total={
+					providerThroughputAvg !== null ? <span className="truncate whitespace-nowrap">{formatTokensPerSecond(providerThroughputAvg)}</span> : undefined
+				}
+				totalTooltip={
+					providerThroughputAvg !== null ? `${providerThroughputAvg.toLocaleString("en-US", { maximumFractionDigits: 2 })} tokens/sec` : undefined
+				}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						{providerThroughputProvider === "all" ? (
+							providerThroughputProviders.length > 0 && (
+								<>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span data-testid="provider-throughput-legend-trigger" className="flex items-center gap-1">
+												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+												<span className="text-muted-foreground max-w-[100px] truncate">{providerThroughputProviders[0]}</span>
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>{providerThroughputProviders[0]}</TooltipContent>
+									</Tooltip>
+									{providerThroughputProviders.length > 1 && (
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<button
+													type="button"
+													data-testid="provider-throughput-legend-more-trigger"
+													className="text-muted-foreground cursor-default"
+												>
+													+{providerThroughputProviders.length - 1} more
+												</button>
+											</TooltipTrigger>
+											<TooltipContent>
+												<div className="flex flex-col gap-1">
+													{providerThroughputProviders.slice(1).map((provider, idx) => (
+														<span key={provider} className="flex items-center gap-1">
+															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
+															{provider}
+														</span>
+													))}
+												</div>
+											</TooltipContent>
+										</Tooltip>
+									)}
+								</>
+							)
+						) : (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span data-testid="provider-throughput-legend-single-trigger" className="flex items-center gap-1">
+										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: THROUGHPUT_COLOR }} />
+										<span className="text-muted-foreground max-w-[100px] truncate">{providerThroughputProvider}</span>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>{providerThroughputProvider}</TooltipContent>
+							</Tooltip>
+						)}
+					</div>
+				}
+				controls={
+					<>
+						<ProviderFilterSelect
+							providers={availableProviders}
+							selectedProvider={providerThroughputProvider}
+							onProviderChange={onProviderThroughputProviderChange}
+							data-testid="dashboard-provider-throughput-filter"
+						/>
+						<ChartTypeToggle
+							chartType={providerThroughputChartType}
+							onToggle={onProviderThroughputChartToggle}
+							data-testid="dashboard-provider-throughput-chart-toggle"
+						/>
+					</>
+				}
+			>
+				<ProviderThroughputChart
+					data={providerThroughputData}
+					chartType={providerThroughputChartType}
+					startTime={startTime}
+					endTime={endTime}
+					selectedProvider={providerThroughputProvider}
 				/>
 			</ChartCard>
 		</div>

--- a/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
@@ -4,12 +4,14 @@ import {
 	useGetLogsLatencyHistogramQuery,
 	useGetLogsModelHistogramQuery,
 	useGetLogsStatsQuery,
+	useGetLogsThroughputHistogramQuery,
 	useGetLogsTokenHistogramQuery,
 	useLazyGetLogsCostHistogramQuery,
 	useLazyGetLogsHistogramQuery,
 	useLazyGetLogsLatencyHistogramQuery,
 	useLazyGetLogsModelHistogramQuery,
 	useLazyGetLogsStatsQuery,
+	useLazyGetLogsThroughputHistogramQuery,
 	useLazyGetLogsTokenHistogramQuery,
 } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
@@ -39,6 +41,7 @@ interface OverviewTabViewProps {
 	costChartType: ChartType;
 	modelChartType: ChartType;
 	latencyChartType: ChartType;
+	throughputChartType: ChartType;
 	costModel: string;
 	usageModel: string;
 	onVolumeChartToggle: (type: ChartType) => void;
@@ -46,6 +49,7 @@ interface OverviewTabViewProps {
 	onCostChartToggle: (type: ChartType) => void;
 	onModelChartToggle: (type: ChartType) => void;
 	onLatencyChartToggle: (type: ChartType) => void;
+	onThroughputChartToggle: (type: ChartType) => void;
 	onCostModelChange: (model: string) => void;
 	onUsageModelChange: (model: string) => void;
 }
@@ -61,6 +65,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 		costChartType,
 		modelChartType,
 		latencyChartType,
+		throughputChartType,
 		costModel,
 		usageModel,
 		onVolumeChartToggle,
@@ -68,6 +73,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 		onCostChartToggle,
 		onModelChartToggle,
 		onLatencyChartToggle,
+		onThroughputChartToggle,
 		onCostModelChange,
 		onUsageModelChange,
 	},
@@ -81,6 +87,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 	const { data: costData, isLoading: loadingCost } = useGetLogsCostHistogramQuery(fetchArg, skipOpts);
 	const { data: modelData, isLoading: loadingModels } = useGetLogsModelHistogramQuery(fetchArg, skipOpts);
 	const { data: latencyData, isLoading: loadingLatency } = useGetLogsLatencyHistogramQuery(fetchArg, skipOpts);
+	const { data: throughputData, isLoading: loadingThroughput } = useGetLogsThroughputHistogramQuery(fetchArg, skipOpts);
 	const { data: logsStats, isLoading: loadingStats } = useGetLogsStatsQuery(fetchArg, skipOpts);
 
 	const [triggerHistogram] = useLazyGetLogsHistogramQuery();
@@ -88,6 +95,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 	const [triggerCost] = useLazyGetLogsCostHistogramQuery();
 	const [triggerModels] = useLazyGetLogsModelHistogramQuery();
 	const [triggerLatency] = useLazyGetLogsLatencyHistogramQuery();
+	const [triggerThroughput] = useLazyGetLogsThroughputHistogramQuery();
 	const [triggerStats] = useLazyGetLogsStatsQuery();
 
 	const loadData = useCallback(async () => {
@@ -97,9 +105,10 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			triggerCost(fetchArg, true),
 			triggerModels(fetchArg, true),
 			triggerLatency(fetchArg, true),
+			triggerThroughput(fetchArg, true),
 			triggerStats(fetchArg, true),
 		]);
-	}, [fetchArg, triggerHistogram, triggerTokens, triggerCost, triggerModels, triggerLatency, triggerStats]);
+	}, [fetchArg, triggerHistogram, triggerTokens, triggerCost, triggerModels, triggerLatency, triggerThroughput, triggerStats]);
 
 	useImperativeHandle(
 		ref,
@@ -130,12 +139,14 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			costData={costData ?? null}
 			modelData={modelData ?? null}
 			latencyData={latencyData ?? null}
+			throughputData={throughputData ?? null}
 			logsStats={logsStats ?? null}
 			loadingHistogram={loadingHistogram}
 			loadingTokens={loadingTokens}
 			loadingCost={loadingCost}
 			loadingModels={loadingModels}
 			loadingLatency={loadingLatency}
+			loadingThroughput={loadingThroughput}
 			loadingStats={loadingStats}
 			startTime={startTime}
 			endTime={endTime}
@@ -144,6 +155,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			costChartType={costChartType}
 			modelChartType={modelChartType}
 			latencyChartType={latencyChartType}
+			throughputChartType={throughputChartType}
 			costModel={costModel}
 			usageModel={usageModel}
 			costModels={costModels}
@@ -154,6 +166,7 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 			onCostChartToggle={onCostChartToggle}
 			onModelChartToggle={onModelChartToggle}
 			onLatencyChartToggle={onLatencyChartToggle}
+			onThroughputChartToggle={onThroughputChartToggle}
 			onCostModelChange={onCostModelChange}
 			onUsageModelChange={onUsageModelChange}
 		/>

--- a/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
@@ -1,9 +1,11 @@
 import {
 	useGetLogsProviderCostHistogramQuery,
 	useGetLogsProviderLatencyHistogramQuery,
+	useGetLogsProviderThroughputHistogramQuery,
 	useGetLogsProviderTokenHistogramQuery,
 	useLazyGetLogsProviderCostHistogramQuery,
 	useLazyGetLogsProviderLatencyHistogramQuery,
+	useLazyGetLogsProviderThroughputHistogramQuery,
 	useLazyGetLogsProviderTokenHistogramQuery,
 } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
@@ -31,15 +33,19 @@ interface ProviderUsageTabViewProps {
 	providerCostChartType: ChartType;
 	providerTokenChartType: ChartType;
 	providerLatencyChartType: ChartType;
+	providerThroughputChartType: ChartType;
 	providerCostProvider: string;
 	providerTokenProvider: string;
 	providerLatencyProvider: string;
+	providerThroughputProvider: string;
 	onProviderCostChartToggle: (type: ChartType) => void;
 	onProviderTokenChartToggle: (type: ChartType) => void;
 	onProviderLatencyChartToggle: (type: ChartType) => void;
+	onProviderThroughputChartToggle: (type: ChartType) => void;
 	onProviderCostProviderChange: (provider: string) => void;
 	onProviderTokenProviderChange: (provider: string) => void;
 	onProviderLatencyProviderChange: (provider: string) => void;
+	onProviderThroughputProviderChange: (provider: string) => void;
 }
 
 export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, ProviderUsageTabViewProps>(function ProviderUsageTabView(
@@ -51,15 +57,19 @@ export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, Provi
 		providerCostChartType,
 		providerTokenChartType,
 		providerLatencyChartType,
+		providerThroughputChartType,
 		providerCostProvider,
 		providerTokenProvider,
 		providerLatencyProvider,
+		providerThroughputProvider,
 		onProviderCostChartToggle,
 		onProviderTokenChartToggle,
 		onProviderLatencyChartToggle,
+		onProviderThroughputChartToggle,
 		onProviderCostProviderChange,
 		onProviderTokenProviderChange,
 		onProviderLatencyProviderChange,
+		onProviderThroughputProviderChange,
 	},
 	ref,
 ) {
@@ -69,14 +79,21 @@ export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, Provi
 	const { data: providerCostData, isLoading: loadingProviderCost } = useGetLogsProviderCostHistogramQuery(fetchArg, skipOpts);
 	const { data: providerTokenData, isLoading: loadingProviderTokens } = useGetLogsProviderTokenHistogramQuery(fetchArg, skipOpts);
 	const { data: providerLatencyData, isLoading: loadingProviderLatency } = useGetLogsProviderLatencyHistogramQuery(fetchArg, skipOpts);
+	const { data: providerThroughputData, isLoading: loadingProviderThroughput } = useGetLogsProviderThroughputHistogramQuery(fetchArg, skipOpts);
 
 	const [triggerProviderCost] = useLazyGetLogsProviderCostHistogramQuery();
 	const [triggerProviderTokens] = useLazyGetLogsProviderTokenHistogramQuery();
 	const [triggerProviderLatency] = useLazyGetLogsProviderLatencyHistogramQuery();
+	const [triggerProviderThroughput] = useLazyGetLogsProviderThroughputHistogramQuery();
 
 	const loadData = useCallback(async () => {
-		await Promise.all([triggerProviderCost(fetchArg, true), triggerProviderTokens(fetchArg, true), triggerProviderLatency(fetchArg, true)]);
-	}, [fetchArg, triggerProviderCost, triggerProviderTokens, triggerProviderLatency]);
+		await Promise.all([
+			triggerProviderCost(fetchArg, true),
+			triggerProviderTokens(fetchArg, true),
+			triggerProviderLatency(fetchArg, true),
+			triggerProviderThroughput(fetchArg, true),
+		]);
+	}, [fetchArg, triggerProviderCost, triggerProviderTokens, triggerProviderLatency, triggerProviderThroughput]);
 
 	useImperativeHandle(
 		ref,
@@ -97,39 +114,51 @@ export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, Provi
 				...(providerCostData?.providers ?? []),
 				...(providerTokenData?.providers ?? []),
 				...(providerLatencyData?.providers ?? []),
+				...(providerThroughputData?.providers ?? []),
 			]),
-		[providerCostData?.providers, providerTokenData?.providers, providerLatencyData?.providers],
+		[providerCostData?.providers, providerTokenData?.providers, providerLatencyData?.providers, providerThroughputData?.providers],
 	);
 	const providerCostProviders = useMemo(() => sanitizeSeriesLabels(providerCostData?.providers), [providerCostData?.providers]);
 	const providerTokenProviders = useMemo(() => sanitizeSeriesLabels(providerTokenData?.providers), [providerTokenData?.providers]);
 	const providerLatencyProviders = useMemo(() => sanitizeSeriesLabels(providerLatencyData?.providers), [providerLatencyData?.providers]);
+	const providerThroughputProviders = useMemo(
+		() => sanitizeSeriesLabels(providerThroughputData?.providers),
+		[providerThroughputData?.providers],
+	);
 
 	return (
 		<ProviderUsageTab
 			providerCostData={providerCostData ?? null}
 			providerTokenData={providerTokenData ?? null}
 			providerLatencyData={providerLatencyData ?? null}
+			providerThroughputData={providerThroughputData ?? null}
 			loadingProviderCost={loadingProviderCost}
 			loadingProviderTokens={loadingProviderTokens}
 			loadingProviderLatency={loadingProviderLatency}
+			loadingProviderThroughput={loadingProviderThroughput}
 			startTime={startTime}
 			endTime={endTime}
 			providerCostChartType={providerCostChartType}
 			providerTokenChartType={providerTokenChartType}
 			providerLatencyChartType={providerLatencyChartType}
+			providerThroughputChartType={providerThroughputChartType}
 			providerCostProvider={providerCostProvider}
 			providerTokenProvider={providerTokenProvider}
 			providerLatencyProvider={providerLatencyProvider}
+			providerThroughputProvider={providerThroughputProvider}
 			availableProviders={availableProviders}
 			providerCostProviders={providerCostProviders}
 			providerTokenProviders={providerTokenProviders}
 			providerLatencyProviders={providerLatencyProviders}
+			providerThroughputProviders={providerThroughputProviders}
 			onProviderCostChartToggle={onProviderCostChartToggle}
 			onProviderTokenChartToggle={onProviderTokenChartToggle}
 			onProviderLatencyChartToggle={onProviderLatencyChartToggle}
+			onProviderThroughputChartToggle={onProviderThroughputChartToggle}
 			onProviderCostProviderChange={onProviderCostProviderChange}
 			onProviderTokenProviderChange={onProviderTokenProviderChange}
 			onProviderLatencyProviderChange={onProviderLatencyProviderChange}
+			onProviderThroughputProviderChange={onProviderThroughputProviderChange}
 		/>
 	);
 });

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -56,14 +56,17 @@ export default function DashboardPage() {
 			cost_chart: parseAsString.withDefault("bar"),
 			model_chart: parseAsString.withDefault("bar"),
 			latency_chart: parseAsString.withDefault("bar"),
+			throughput_chart: parseAsString.withDefault("bar"),
 			cost_model: parseAsString.withDefault("all"),
 			usage_model: parseAsString.withDefault("all"),
 			provider_cost_chart: parseAsString.withDefault("bar"),
 			provider_token_chart: parseAsString.withDefault("bar"),
 			provider_latency_chart: parseAsString.withDefault("bar"),
+			provider_throughput_chart: parseAsString.withDefault("bar"),
 			provider_cost_provider: parseAsString.withDefault("all"),
 			provider_token_provider: parseAsString.withDefault("all"),
 			provider_latency_provider: parseAsString.withDefault("all"),
+			provider_throughput_provider: parseAsString.withDefault("all"),
 			mcp_volume_chart: parseAsString.withDefault("bar"),
 			mcp_cost_chart: parseAsString.withDefault("bar"),
 			mcp_tool_names: parseAsString.withDefault(""),
@@ -254,9 +257,11 @@ export default function DashboardPage() {
 	const handleCostChartToggle = useCallback((type: ChartType) => setUrlState({ cost_chart: type }), [setUrlState]);
 	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
 	const handleLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ latency_chart: type }), [setUrlState]);
+	const handleThroughputChartToggle = useCallback((type: ChartType) => setUrlState({ throughput_chart: type }), [setUrlState]);
 	const handleProviderCostChartToggle = useCallback((type: ChartType) => setUrlState({ provider_cost_chart: type }), [setUrlState]);
 	const handleProviderTokenChartToggle = useCallback((type: ChartType) => setUrlState({ provider_token_chart: type }), [setUrlState]);
 	const handleProviderLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ provider_latency_chart: type }), [setUrlState]);
+	const handleProviderThroughputChartToggle = useCallback((type: ChartType) => setUrlState({ provider_throughput_chart: type }), [setUrlState]);
 	const handleMcpVolumeChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_volume_chart: type }), [setUrlState]);
 	const handleMcpCostChartToggle = useCallback((type: ChartType) => setUrlState({ mcp_cost_chart: type }), [setUrlState]);
 
@@ -273,6 +278,10 @@ export default function DashboardPage() {
 	);
 	const handleProviderLatencyProviderChange = useCallback(
 		(provider: string) => setUrlState({ provider_latency_provider: provider }),
+		[setUrlState],
+	);
+	const handleProviderThroughputProviderChange = useCallback(
+		(provider: string) => setUrlState({ provider_throughput_provider: provider }),
 		[setUrlState],
 	);
 
@@ -530,6 +539,7 @@ export default function DashboardPage() {
 									costChartType={toChartType(urlState.cost_chart)}
 									modelChartType={toChartType(urlState.model_chart)}
 									latencyChartType={toChartType(urlState.latency_chart)}
+									throughputChartType={toChartType(urlState.throughput_chart)}
 									costModel={urlState.cost_model}
 									usageModel={urlState.usage_model}
 									onVolumeChartToggle={handleVolumeChartToggle}
@@ -537,6 +547,7 @@ export default function DashboardPage() {
 									onCostChartToggle={handleCostChartToggle}
 									onModelChartToggle={handleModelChartToggle}
 									onLatencyChartToggle={handleLatencyChartToggle}
+									onThroughputChartToggle={handleThroughputChartToggle}
 									onCostModelChange={handleCostModelChange}
 									onUsageModelChange={handleUsageModelChange}
 								/>
@@ -555,15 +566,19 @@ export default function DashboardPage() {
 									providerCostChartType={toChartType(urlState.provider_cost_chart)}
 									providerTokenChartType={toChartType(urlState.provider_token_chart)}
 									providerLatencyChartType={toChartType(urlState.provider_latency_chart)}
+									providerThroughputChartType={toChartType(urlState.provider_throughput_chart)}
 									providerCostProvider={urlState.provider_cost_provider}
 									providerTokenProvider={urlState.provider_token_provider}
 									providerLatencyProvider={urlState.provider_latency_provider}
+									providerThroughputProvider={urlState.provider_throughput_provider}
 									onProviderCostChartToggle={handleProviderCostChartToggle}
 									onProviderTokenChartToggle={handleProviderTokenChartToggle}
 									onProviderLatencyChartToggle={handleProviderLatencyChartToggle}
+									onProviderThroughputChartToggle={handleProviderThroughputChartToggle}
 									onProviderCostProviderChange={handleProviderCostProviderChange}
 									onProviderTokenProviderChange={handleProviderTokenProviderChange}
 									onProviderLatencyProviderChange={handleProviderLatencyProviderChange}
+									onProviderThroughputProviderChange={handleProviderThroughputProviderChange}
 								/>
 							</div>
 						</TabsContent>

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -1,4 +1,5 @@
 // Chart utility functions for the dashboard
+import { formatCompactNumber } from "@/lib/utils/numbers";
 
 // Format timestamp based on bucket size
 export function formatTimestamp(timestamp: string, bucketSizeSeconds: number): string {
@@ -109,6 +110,16 @@ export const LATENCY_COLORS = {
 	p95: "#f59e0b", // amber-500
 	p99: "#ef4444", // red-500
 };
+
+// Format token-generation throughput (tokens/sec) with compact units (1k, 5k, 1M).
+// Uses a non-breaking space so the value and unit never wrap onto two lines.
+export function formatTokensPerSecond(tps: number): string {
+	if (!Number.isFinite(tps) || tps <= 0) return "0 tok/s";
+	return `${formatCompactNumber(tps, 1)} tok/s`;
+}
+
+// Throughput chart color
+export const THROUGHPUT_COLOR = "#10b981"; // emerald-500
 
 // Shared CSS class constants for chart card headers
 export const CHART_HEADER_ACTIONS_CLASS = "flex min-w-0 w-full flex-col-reverse gap-2";

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -14,10 +14,12 @@ import {
 	Pagination,
 	ProviderCostHistogramResponse,
 	ProviderLatencyHistogramResponse,
+	ProviderThroughputHistogramResponse,
 	ProviderTokenHistogramResponse,
 	RankingDimension,
 	RecalcJobStatus,
 	RecalculateCostResponse,
+	ThroughputHistogramResponse,
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
 import { baseApi } from "./baseApi";
@@ -233,6 +235,34 @@ export const logsApi = baseApi.injectEndpoints({
 			providesTags: ["Logs"],
 		}),
 
+		// Get throughput (tokens/sec) histogram
+		getLogsThroughputHistogram: builder.query<
+			ThroughputHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/throughput",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
+		// Get provider throughput (tokens/sec) histogram with provider breakdown
+		getLogsProviderThroughputHistogram: builder.query<
+			ProviderThroughputHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/throughput/by-provider",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
 		// Get provider cost histogram with provider breakdown
 		getLogsProviderCostHistogram: builder.query<
 			ProviderCostHistogramResponse,
@@ -393,6 +423,8 @@ export const {
 	useGetLogsProviderCostHistogramQuery,
 	useGetLogsProviderTokenHistogramQuery,
 	useGetLogsProviderLatencyHistogramQuery,
+	useGetLogsThroughputHistogramQuery,
+	useGetLogsProviderThroughputHistogramQuery,
 	useGetLogSessionSummaryByIdQuery,
 	useGetDroppedRequestsQuery,
 	useGetAvailableFilterDataQuery,
@@ -407,6 +439,8 @@ export const {
 	useLazyGetLogsProviderCostHistogramQuery,
 	useLazyGetLogsProviderTokenHistogramQuery,
 	useLazyGetLogsProviderLatencyHistogramQuery,
+	useLazyGetLogsThroughputHistogramQuery,
+	useLazyGetLogsProviderThroughputHistogramQuery,
 	useGetModelRankingsQuery,
 	useGetDimensionRankingsQuery,
 	useLazyGetModelRankingsQuery,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -779,6 +779,38 @@ export interface ProviderLatencyHistogramResponse {
 	providers: string[];
 }
 
+// Throughput (tokens/sec) histogram types
+// tokens_per_second is the aggregate rate for the bucket: total completion tokens
+// divided by total generation latency in seconds.
+export interface ThroughputHistogramBucket {
+	timestamp: string;
+	tokens_per_second: number;
+	total_completion_tokens: number;
+	total_requests: number;
+}
+
+export interface ThroughputHistogramResponse {
+	buckets: ThroughputHistogramBucket[];
+	bucket_size_seconds: number;
+}
+
+export interface ProviderThroughputStats {
+	tokens_per_second: number;
+	total_completion_tokens: number;
+	total_requests: number;
+}
+
+export interface ProviderThroughputHistogramBucket {
+	timestamp: string;
+	by_provider: Record<string, ProviderThroughputStats>;
+}
+
+export interface ProviderThroughputHistogramResponse {
+	buckets: ProviderThroughputHistogramBucket[];
+	bucket_size_seconds: number;
+	providers: string[];
+}
+
 export interface LogsResponse {
 	logs: LogEntry[];
 	pagination: Pagination;


### PR DESCRIPTION
## Summary

Adds throughput (tokens/sec) charts to both the Overview and Provider Usage dashboard tabs. The charts visualize aggregate token generation rates over time, computed as total completion tokens divided by total generation latency per bucket.

## Changes

- Added `ThroughputChart` and `ProviderThroughputChart` Recharts components supporting both bar and area chart types, with custom tooltips showing throughput, completion tokens, and request counts.
- Added `ThroughputHistogramBucket`, `ThroughputHistogramResponse`, `ProviderThroughputStats`, `ProviderThroughputHistogramBucket`, and `ProviderThroughputHistogramResponse` TypeScript types.
- Wired up two new RTK Query endpoints — `getLogsThroughputHistogram` (`/logs/histogram/throughput`) and `getLogsProviderThroughputHistogram` (`/logs/histogram/throughput/by-provider`) — with both eager and lazy query hooks exported.
- Added `formatTokensPerSecond` utility and `THROUGHPUT_COLOR` constant to `chartUtils.ts`.
- The header stat for each throughput chart shows a request-weighted average tokens/sec across all buckets in the selected time range.
- Provider throughput chart supports filtering by a single provider or viewing all providers simultaneously, using `pickTopSeries` to surface the highest-volume providers when in "all" mode.
- Chart type and provider filter selections are persisted in URL state via `throughput_chart`, `provider_throughput_chart`, and `provider_throughput_provider` query params.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the dashboard Overview tab and confirm a "Throughput" chart card appears showing tokens/sec over time with a weighted-average header stat.
2. Switch to the Provider Usage tab and confirm a "Provider Throughput" chart card appears with a provider filter dropdown.
3. Toggle between bar and area chart types on both charts and verify the URL updates accordingly.
4. Select a specific provider in the Provider Throughput filter and confirm the chart and header stat update to reflect only that provider.
5. Verify the "all providers" view renders stacked series with per-provider colors and a tooltip listing each provider's rate.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the new throughput chart cards on both tabs._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The new endpoints follow the same authentication and filter patterns as existing histogram endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable