### PR TITLE
feat: add throughput (tokens/sec) histogram endpoints and dashboard metrics

### DIFF
--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -677,6 +677,18 @@ func (h *HybridLogStore) GetProviderLatencyHistogram(ctx context.Context, filter
 	return h.inner.GetProviderLatencyHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetThroughputHistogram delegates to the inner store and returns a
+// token-generation throughput (tokens/sec) histogram bucketed by bucketSizeSeconds.
+func (h *HybridLogStore) GetThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ThroughputHistogramResult, error) {
+	return h.inner.GetThroughputHistogram(ctx, filters, bucketSizeSeconds)
+}
+
+// GetProviderThroughputHistogram delegates to the inner store and returns a
+// per-provider throughput (tokens/sec) histogram bucketed by bucketSizeSeconds.
+func (h *HybridLogStore) GetProviderThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderThroughputHistogramResult, error) {
+	return h.inner.GetProviderThroughputHistogram(ctx, filters, bucketSizeSeconds)
+}
+
 // GetModelRankings delegates to the inner store and returns ranked usage
 // aggregates per model for the matching log rows.
 func (h *HybridLogStore) GetModelRankings(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error) {

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -598,6 +598,12 @@ func TestLogStoreParity(t *testing.T) {
 		"provider_latency": func(ctx context.Context, s LogStore) (any, error) {
 			return s.GetProviderLatencyHistogram(ctx, window, 60)
 		},
+		"throughput": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetThroughputHistogram(ctx, window, 60)
+		},
+		"provider_throughput": func(ctx context.Context, s LogStore) (any, error) {
+			return s.GetProviderThroughputHistogram(ctx, window, 60)
+		},
 		"dimension_cost": func(ctx context.Context, s LogStore) (any, error) {
 			return s.GetDimensionCostHistogram(ctx, window, 60, DimensionProvider)
 		},

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -53,6 +53,13 @@ SELECT
     COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY latency), 0) AS p99_latency,
     COALESCE(SUM(prompt_tokens), 0) AS total_prompt_tokens,
     COALESCE(SUM(completion_tokens), 0) AS total_completion_tokens,
+    -- Throughput measures restricted to rows with a positive measured latency,
+    -- so the tokens/sec matview path matches the raw path exactly (which filters
+    -- latency > 0). Without this, a latency=0 success row would add completion
+    -- tokens to the numerator with nothing in the denominator and inflate the rate.
+    COALESCE(SUM(completion_tokens) FILTER (WHERE latency > 0), 0) AS throughput_completion_tokens,
+    COALESCE(SUM(latency) FILTER (WHERE latency > 0), 0) AS throughput_latency_ms,
+    COALESCE(COUNT(*) FILTER (WHERE latency > 0), 0) AS throughput_request_count,
     COALESCE(SUM(total_tokens), 0) AS total_tokens,
     COALESCE(SUM(cached_read_tokens), 0) AS total_cached_read_tokens,
     COALESCE(SUM(cost), 0) AS total_cost
@@ -88,6 +95,9 @@ var mvLogsHourlyRequiredColumns = []string{
 	"alias",
 	"canonical_model_name",
 	"cancelled_count",
+	"throughput_completion_tokens",
+	"throughput_latency_ms",
+	"throughput_request_count",
 }
 
 // legacyMatViewNames are matviews from previous schema versions that no longer
@@ -1243,6 +1253,115 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 		buckets = append(buckets, b)
 	}
 	return &LatencyHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds}, nil
+}
+
+// getThroughputHistogramFromMatView returns time-bucketed token-generation
+// throughput (tokens/sec) from mv_logs_hourly. It sums the precomputed
+// positive-latency measures (throughput_completion_tokens / throughput_latency_ms
+// / throughput_request_count), which the matview restricts to rows with
+// latency > 0 exactly as the raw path does — so both paths return the same value.
+func (s *RDBLogStore) getThroughputHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ThroughputHistogramResult, error) {
+	var results []struct {
+		BucketTimestamp  int64   `gorm:"column:bucket_timestamp"`
+		CompletionTokens int64   `gorm:"column:completion_tokens"`
+		SumLatency       float64 `gorm:"column:sum_latency"`
+		TotalRequests    int64   `gorm:"column:total_requests"`
+	}
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
+	// Successful requests only: status is a matview dimension, so this restricts
+	// the summed tokens/latency/count to success rows (see GetThroughputHistogram).
+	q = q.Where("status = ?", "success")
+	if err := q.Select(fmt.Sprintf(`
+		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
+		COALESCE(SUM(throughput_completion_tokens), 0) AS completion_tokens,
+		COALESCE(SUM(throughput_latency_ms), 0) AS sum_latency,
+		COALESCE(SUM(throughput_request_count), 0) AS total_requests
+	`, bucketSizeSeconds, bucketSizeSeconds)).
+		Group("bucket_timestamp").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, err
+	}
+
+	resultMap := make(map[int64]int, len(results))
+	for i, r := range results {
+		resultMap[r.BucketTimestamp] = i
+	}
+
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+	buckets := make([]ThroughputHistogramBucket, 0, len(allTimestamps))
+	for _, ts := range allTimestamps {
+		b := ThroughputHistogramBucket{Timestamp: time.Unix(ts, 0).UTC()}
+		if idx, ok := resultMap[ts]; ok {
+			r := results[idx]
+			b.TokensPerSecond = tokensPerSecond(r.CompletionTokens, r.SumLatency)
+			b.TotalCompletionTokens = r.CompletionTokens
+			b.TotalRequests = r.TotalRequests
+		}
+		buckets = append(buckets, b)
+	}
+	return &ThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds}, nil
+}
+
+// getProviderThroughputHistogramFromMatView returns time-bucketed tokens/sec
+// with per-provider breakdown from mv_logs_hourly.
+func (s *RDBLogStore) getProviderThroughputHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderThroughputHistogramResult, error) {
+	var results []struct {
+		BucketTimestamp  int64   `gorm:"column:bucket_timestamp"`
+		Provider         string  `gorm:"column:provider"`
+		CompletionTokens int64   `gorm:"column:completion_tokens"`
+		SumLatency       float64 `gorm:"column:sum_latency"`
+		TotalRequests    int64   `gorm:"column:total_requests"`
+	}
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
+	// Successful requests only — see getThroughputHistogramFromMatView.
+	q = q.Where("status = ?", "success")
+	if err := q.Select(fmt.Sprintf(`
+		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
+		provider,
+		COALESCE(SUM(throughput_completion_tokens), 0) AS completion_tokens,
+		COALESCE(SUM(throughput_latency_ms), 0) AS sum_latency,
+		COALESCE(SUM(throughput_request_count), 0) AS total_requests
+	`, bucketSizeSeconds, bucketSizeSeconds)).
+		Group("bucket_timestamp, provider").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, err
+	}
+
+	type bucketAgg struct {
+		byProvider map[string]ProviderThroughputStats
+	}
+	grouped := make(map[int64]*bucketAgg)
+	providersSet := make(map[string]struct{})
+	for _, r := range results {
+		a, ok := grouped[r.BucketTimestamp]
+		if !ok {
+			a = &bucketAgg{byProvider: make(map[string]ProviderThroughputStats)}
+			grouped[r.BucketTimestamp] = a
+		}
+		a.byProvider[r.Provider] = ProviderThroughputStats{
+			TokensPerSecond:       tokensPerSecond(r.CompletionTokens, r.SumLatency),
+			TotalCompletionTokens: r.CompletionTokens,
+			TotalRequests:         r.TotalRequests,
+		}
+		providersSet[r.Provider] = struct{}{}
+	}
+
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+	buckets := make([]ProviderThroughputHistogramBucket, 0, len(allTimestamps))
+	for _, ts := range allTimestamps {
+		b := ProviderThroughputHistogramBucket{Timestamp: time.Unix(ts, 0).UTC(), ByProvider: make(map[string]ProviderThroughputStats)}
+		if a, ok := grouped[ts]; ok {
+			b.ByProvider = a.byProvider
+		}
+		buckets = append(buckets, b)
+	}
+
+	providers := sortedStringKeys(providersSet)
+	return &ProviderThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds, Providers: providers}, nil
 }
 
 // getProviderCostHistogramFromMatView returns time-bucketed cost data with

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1382,6 +1382,199 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 	}, nil
 }
 
+// tokensPerSecond computes aggregate token-generation throughput for a bucket:
+// total completion tokens divided by total latency in seconds. latencyMs is the
+// sum of per-request latencies (milliseconds). Returns 0 when latency is absent.
+func tokensPerSecond(completionTokens int64, latencyMs float64) float64 {
+	if latencyMs <= 0 {
+		return 0
+	}
+	return float64(completionTokens) / (latencyMs / 1000.0)
+}
+
+// GetThroughputHistogram returns time-bucketed token-generation throughput
+// (tokens/sec) for the given filters. TokensPerSecond is the aggregate rate for
+// each bucket: SUM(completion_tokens) / (SUM(latency_ms)/1000), computed over
+// terminal rows that recorded a latency > 0.
+func (s *RDBLogStore) GetThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ThroughputHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600 // Default to 1 hour
+	}
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+		return s.getThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	// Only successful requests contribute to throughput: failed/cancelled rows
+	// spend latency but produce no (or partial) completion tokens, which would
+	// inflate the denominator and understate the true generation rate. This
+	// intersects with any caller-supplied status filter rather than overriding it,
+	// so throughput honors the same status filter as the sibling histograms; a
+	// filter that excludes success (e.g. status=error) correctly yields empty
+	// throughput, since there is no successful-generation throughput in that set.
+	baseQuery = baseQuery.Where("status = ?", "success")
+	// Only rows with a measured latency contribute to throughput.
+	baseQuery = baseQuery.Where("latency > 0")
+
+	var results []struct {
+		BucketTimestamp  int64   `gorm:"column:bucket_timestamp"`
+		CompletionTokens int64   `gorm:"column:completion_tokens"`
+		SumLatency       float64 `gorm:"column:sum_latency"`
+		TotalRequests    int64   `gorm:"column:total_requests"`
+	}
+
+	selectClause := fmt.Sprintf(`
+			%s as bucket_timestamp,
+			COALESCE(SUM(completion_tokens), 0) as completion_tokens,
+			COALESCE(SUM(latency), 0) as sum_latency,
+			COUNT(*) as total_requests
+		`, unixBucketExpr(dialect, bucketSizeSeconds))
+
+	if err := baseQuery.
+		Select(selectClause).
+		Group("bucket_timestamp").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get throughput histogram: %w", err)
+	}
+
+	type agg struct {
+		completionTokens int64
+		sumLatency       float64
+		totalRequests    int64
+	}
+	resultMap := make(map[int64]agg, len(results))
+	for _, r := range results {
+		resultMap[r.BucketTimestamp] = agg{r.CompletionTokens, r.SumLatency, r.TotalRequests}
+	}
+
+	buildBucket := func(ts int64, a agg) ThroughputHistogramBucket {
+		return ThroughputHistogramBucket{
+			Timestamp:             time.Unix(ts, 0).UTC(),
+			TokensPerSecond:       tokensPerSecond(a.completionTokens, a.sumLatency),
+			TotalCompletionTokens: a.completionTokens,
+			TotalRequests:         a.totalRequests,
+		}
+	}
+
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+	if len(allTimestamps) == 0 {
+		buckets := make([]ThroughputHistogramBucket, len(results))
+		for i, r := range results {
+			buckets[i] = buildBucket(r.BucketTimestamp, agg{r.CompletionTokens, r.SumLatency, r.TotalRequests})
+		}
+		return &ThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds}, nil
+	}
+
+	buckets := make([]ThroughputHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if a, ok := resultMap[ts]; ok {
+			buckets[i] = buildBucket(ts, a)
+		} else {
+			buckets[i] = ThroughputHistogramBucket{Timestamp: time.Unix(ts, 0).UTC()}
+		}
+	}
+	return &ThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds}, nil
+}
+
+// GetProviderThroughputHistogram returns time-bucketed tokens/sec with a
+// per-provider breakdown for the given filters. See GetThroughputHistogram for
+// the throughput definition.
+func (s *RDBLogStore) GetProviderThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderThroughputHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600
+	}
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+		return s.getProviderThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	// Successful requests only — see GetThroughputHistogram.
+	baseQuery = baseQuery.Where("status = ?", "success")
+	baseQuery = baseQuery.Where("latency > 0")
+
+	var results []struct {
+		BucketTimestamp  int64   `gorm:"column:bucket_timestamp"`
+		Provider         string  `gorm:"column:provider"`
+		CompletionTokens int64   `gorm:"column:completion_tokens"`
+		SumLatency       float64 `gorm:"column:sum_latency"`
+		TotalRequests    int64   `gorm:"column:total_requests"`
+	}
+
+	selectClause := fmt.Sprintf(`
+			%s as bucket_timestamp,
+			provider,
+			COALESCE(SUM(completion_tokens), 0) as completion_tokens,
+			COALESCE(SUM(latency), 0) as sum_latency,
+			COUNT(*) as total_requests
+		`, unixBucketExpr(dialect, bucketSizeSeconds))
+
+	if err := baseQuery.
+		Select(selectClause).
+		Group("bucket_timestamp, provider").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get provider throughput histogram: %w", err)
+	}
+
+	bucketMap := make(map[int64]*ProviderThroughputHistogramBucket)
+	providersSet := make(map[string]bool)
+	for _, r := range results {
+		providersSet[r.Provider] = true
+		stats := ProviderThroughputStats{
+			TokensPerSecond:       tokensPerSecond(r.CompletionTokens, r.SumLatency),
+			TotalCompletionTokens: r.CompletionTokens,
+			TotalRequests:         r.TotalRequests,
+		}
+		if bucket, exists := bucketMap[r.BucketTimestamp]; exists {
+			bucket.ByProvider[r.Provider] = stats
+		} else {
+			bucketMap[r.BucketTimestamp] = &ProviderThroughputHistogramBucket{
+				Timestamp:  time.Unix(r.BucketTimestamp, 0).UTC(),
+				ByProvider: map[string]ProviderThroughputStats{r.Provider: stats},
+			}
+		}
+	}
+
+	providers := make([]string, 0, len(providersSet))
+	for provider := range providersSet {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+	if len(allTimestamps) == 0 {
+		buckets := make([]ProviderThroughputHistogramBucket, 0, len(bucketMap))
+		for _, bucket := range bucketMap {
+			buckets = append(buckets, *bucket)
+		}
+		sort.Slice(buckets, func(i, j int) bool {
+			return buckets[i].Timestamp.Before(buckets[j].Timestamp)
+		})
+		return &ProviderThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds, Providers: providers}, nil
+	}
+
+	buckets := make([]ProviderThroughputHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if bucket, exists := bucketMap[ts]; exists {
+			buckets[i] = *bucket
+		} else {
+			buckets[i] = ProviderThroughputHistogramBucket{
+				Timestamp:  time.Unix(ts, 0).UTC(),
+				ByProvider: make(map[string]ProviderThroughputStats),
+			}
+		}
+	}
+
+	return &ProviderThroughputHistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds, Providers: providers}, nil
+}
+
 // GetCostHistogram returns time-bucketed cost data with model breakdown for the given filters.
 func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*CostHistogramResult, error) {
 	if bucketSizeSeconds <= 0 {

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -43,6 +43,10 @@ type LogStore interface {
 	GetProviderCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderCostHistogramResult, error)
 	GetProviderTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderTokenHistogramResult, error)
 	GetProviderLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderLatencyHistogramResult, error)
+	// GetThroughputHistogram returns time-bucketed token-generation throughput (tokens/sec).
+	GetThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ThroughputHistogramResult, error)
+	// GetProviderThroughputHistogram returns time-bucketed tokens/sec with provider breakdown.
+	GetProviderThroughputHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ProviderThroughputHistogramResult, error)
 	GetModelRankings(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error)
 	GetUserRankings(ctx context.Context, filters SearchFilters) (*UserRankingResult, error)
 	GetDimensionRankings(ctx context.Context, filters SearchFilters, dimension RankingDimension) (*DimensionRankingResult, error)

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1541,6 +1541,48 @@ type ProviderLatencyHistogramResult struct {
 	Providers         []string                         `json:"providers"`
 }
 
+// Throughput (tokens/sec) histogram types
+//
+// TokensPerSecond is an aggregate rate for the bucket: total completion tokens
+// divided by total generation latency in seconds (SUM(completion_tokens) /
+// (SUM(latency_ms)/1000)), computed over terminal rows with latency > 0. It is
+// the "overall" throughput definition (not a mean of per-request rates), which
+// keeps it uniformly computable across streaming and non-streaming requests.
+
+// ThroughputHistogramBucket represents a single time bucket for token-generation throughput
+type ThroughputHistogramBucket struct {
+	Timestamp             time.Time `json:"timestamp"`
+	TokensPerSecond       float64   `json:"tokens_per_second"`
+	TotalCompletionTokens int64     `json:"total_completion_tokens"`
+	TotalRequests         int64     `json:"total_requests"`
+}
+
+// ThroughputHistogramResult represents the throughput histogram query result
+type ThroughputHistogramResult struct {
+	Buckets           []ThroughputHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                       `json:"bucket_size_seconds"`
+}
+
+// ProviderThroughputStats represents throughput statistics for a single provider
+type ProviderThroughputStats struct {
+	TokensPerSecond       float64 `json:"tokens_per_second"`
+	TotalCompletionTokens int64   `json:"total_completion_tokens"`
+	TotalRequests         int64   `json:"total_requests"`
+}
+
+// ProviderThroughputHistogramBucket represents a single time bucket for provider throughput data
+type ProviderThroughputHistogramBucket struct {
+	Timestamp  time.Time                          `json:"timestamp"`
+	ByProvider map[string]ProviderThroughputStats `json:"by_provider"`
+}
+
+// ProviderThroughputHistogramResult represents the provider throughput histogram query result
+type ProviderThroughputHistogramResult struct {
+	Buckets           []ProviderThroughputHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                               `json:"bucket_size_seconds"`
+	Providers         []string                            `json:"providers"`
+}
+
 // HistogramDimension represents a column that can be used as a grouping dimension in histograms
 type HistogramDimension string
 
@@ -1815,6 +1857,8 @@ type DashboardOverview struct {
 	Cost     *CostHistogramResult    `json:"cost"`     // Cost over time, broken down by model
 	Models   *ModelHistogramResult   `json:"models"`   // Per-model usage over time
 	Latency  *LatencyHistogramResult `json:"latency"`  // Latency percentiles over time
+	// Throughput holds tokens/sec over time (aggregate rate per bucket).
+	Throughput *ThroughputHistogramResult `json:"throughput"`
 }
 
 // DashboardProviderUsage holds the Provider Usage tab metrics.
@@ -1822,6 +1866,8 @@ type DashboardProviderUsage struct {
 	Cost    *ProviderCostHistogramResult    `json:"cost"`
 	Tokens  *ProviderTokenHistogramResult   `json:"tokens"`
 	Latency *ProviderLatencyHistogramResult `json:"latency"`
+	// Throughput holds per-provider tokens/sec over time.
+	Throughput *ProviderThroughputHistogramResult `json:"throughput"`
 }
 
 // DashboardModelRankings holds the Model Rankings tab data.

--- a/framework/logstore/throughput_test.go
+++ b/framework/logstore/throughput_test.go
@@ -1,0 +1,96 @@
+package logstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestThroughputHistogramMath verifies the aggregate tokens/sec computation:
+// SUM(completion_tokens) / (SUM(latency_ms)/1000), including the per-provider
+// breakdown, and that rows without a latency are excluded from the rate.
+func TestThroughputHistogramMath(t *testing.T) {
+	ctx := context.Background()
+	sq, err := newSqliteLogStore(ctx, &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "throughput.db"),
+	}, testLogger{})
+	require.NoError(t, err)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	// All rows land in the same 1h bucket.
+	mk := func(id, provider, status string, latencyMs float64, completion int, withLatency bool) *Log {
+		l := &Log{
+			ID:               id,
+			Timestamp:        base,
+			Object:           "chat.completion",
+			Provider:         provider,
+			Model:            "gpt-4o",
+			Status:           status,
+			SelectedKeyID:    "sk1",
+			CompletionTokens: completion,
+			TotalTokens:      completion,
+			CreatedAt:        base,
+		}
+		if withLatency {
+			l.Latency = f64PtrP(latencyMs)
+		}
+		return l
+	}
+
+	// openai: 100 tok / 1000ms and 300 tok / 1000ms => 400 tok / 2s = 200 tok/s
+	require.NoError(t, sq.Create(ctx, mk("t1", "openai", "success", 1000, 100, true)))
+	require.NoError(t, sq.Create(ctx, mk("t2", "openai", "success", 1000, 300, true)))
+	// anthropic: 50 tok / 500ms => 50 / 0.5s = 100 tok/s
+	require.NoError(t, sq.Create(ctx, mk("t3", "anthropic", "success", 500, 50, true)))
+	// row without latency must be ignored (would otherwise inflate token count)
+	require.NoError(t, sq.Create(ctx, mk("t4", "openai", "success", 0, 9999, false)))
+	// success row with a recorded latency of exactly 0 must ALSO be excluded: its
+	// tokens would land in the numerator with nothing in the denominator and
+	// inflate the rate to infinity. This mirrors the matview's throughput_* columns,
+	// which are computed with the same latency > 0 filter (see matviews.go).
+	require.NoError(t, sq.Create(ctx, mk("t7", "openai", "success", 0, 8888, true)))
+	// failed/cancelled rows must be excluded from BOTH numerator and denominator:
+	// they burn latency but generate no (or partial) tokens, which would otherwise
+	// deflate the rate. Each spends 10s here — enough to skew the result if counted.
+	require.NoError(t, sq.Create(ctx, mk("t5", "openai", "error", 10000, 0, true)))
+	require.NoError(t, sq.Create(ctx, mk("t6", "anthropic", "cancelled", 10000, 5, true)))
+
+	window := SearchFilters{
+		StartTime: timePtrP(base.Add(-time.Hour)),
+		EndTime:   timePtrP(base.Add(time.Hour)),
+	}
+
+	// Overall: (400 + 50) tokens / (2000 + 500 ms) = 450 / 2.5s = 180 tok/s
+	overall, err := sq.GetThroughputHistogram(ctx, window, 3600)
+	require.NoError(t, err)
+	var got *ThroughputHistogramBucket
+	for i := range overall.Buckets {
+		if overall.Buckets[i].TotalRequests > 0 {
+			got = &overall.Buckets[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "expected a non-empty bucket")
+	require.InDelta(t, 180.0, got.TokensPerSecond, 1e-6)
+	require.Equal(t, int64(450), got.TotalCompletionTokens)
+	require.Equal(t, int64(3), got.TotalRequests, "latency-less, error, and cancelled rows must be excluded")
+
+	// Per-provider breakdown.
+	byProv, err := sq.GetProviderThroughputHistogram(ctx, window, 3600)
+	require.NoError(t, err)
+	var stats map[string]ProviderThroughputStats
+	for i := range byProv.Buckets {
+		if len(byProv.Buckets[i].ByProvider) > 0 {
+			stats = byProv.Buckets[i].ByProvider
+			break
+		}
+	}
+	require.NotNil(t, stats)
+	require.InDelta(t, 200.0, stats["openai"].TokensPerSecond, 1e-6)
+	require.Equal(t, int64(2), stats["openai"].TotalRequests)
+	require.InDelta(t, 100.0, stats["anthropic"].TokensPerSecond, 1e-6)
+	require.Equal(t, int64(1), stats["anthropic"].TotalRequests)
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1072,6 +1072,16 @@ func (p *LoggerPlugin) GetProviderLatencyHistogram(ctx context.Context, filters 
 	return p.store.GetProviderLatencyHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetThroughputHistogram returns time-bucketed token-generation throughput (tokens/sec) for the given filters
+func (p *LoggerPlugin) GetThroughputHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ThroughputHistogramResult, error) {
+	return p.store.GetThroughputHistogram(ctx, filters, bucketSizeSeconds)
+}
+
+// GetProviderThroughputHistogram returns time-bucketed tokens/sec with provider breakdown for the given filters
+func (p *LoggerPlugin) GetProviderThroughputHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderThroughputHistogramResult, error) {
+	return p.store.GetProviderThroughputHistogram(ctx, filters, bucketSizeSeconds)
+}
+
 func (p *LoggerPlugin) GetModelRankings(ctx context.Context, filters logstore.SearchFilters) (*logstore.ModelRankingResult, error) {
 	return p.store.GetModelRankings(ctx, filters)
 }

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -61,6 +61,12 @@ type LogManager interface {
 	// GetProviderLatencyHistogram returns time-bucketed latency percentiles with provider breakdown for the given filters
 	GetProviderLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderLatencyHistogramResult, error)
 
+	// GetThroughputHistogram returns time-bucketed token-generation throughput (tokens/sec) for the given filters
+	GetThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ThroughputHistogramResult, error)
+
+	// GetProviderThroughputHistogram returns time-bucketed tokens/sec with provider breakdown for the given filters
+	GetProviderThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderThroughputHistogramResult, error)
+
 	// GetModelRankings returns models ranked by usage with trend comparison
 	GetModelRankings(ctx context.Context, filters *logstore.SearchFilters) (*logstore.ModelRankingResult, error)
 
@@ -260,6 +266,20 @@ func (p *PluginLogManager) GetProviderLatencyHistogram(ctx context.Context, filt
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.GetProviderLatencyHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ThroughputHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetThroughputHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetProviderThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderThroughputHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetProviderThroughputHistogram(ctx, *filters, bucketSizeSeconds)
 }
 
 func (p *PluginLogManager) GetModelRankings(ctx context.Context, filters *logstore.SearchFilters) (*logstore.ModelRankingResult, error) {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -278,6 +278,8 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/logs/histogram/cost/by-provider", lib.ChainMiddlewares(h.getLogsProviderCostHistogram, middlewares...))
 	r.GET("/api/logs/histogram/tokens/by-provider", lib.ChainMiddlewares(h.getLogsProviderTokenHistogram, middlewares...))
 	r.GET("/api/logs/histogram/latency/by-provider", lib.ChainMiddlewares(h.getLogsProviderLatencyHistogram, middlewares...))
+	r.GET("/api/logs/histogram/throughput", lib.ChainMiddlewares(h.getLogsThroughputHistogram, middlewares...))
+	r.GET("/api/logs/histogram/throughput/by-provider", lib.ChainMiddlewares(h.getLogsProviderThroughputHistogram, middlewares...))
 	r.GET("/api/logs/histogram/cost/by-dimension", lib.ChainMiddlewares(h.getLogsDimensionCostHistogram, middlewares...))
 	r.GET("/api/logs/histogram/tokens/by-dimension", lib.ChainMiddlewares(h.getLogsDimensionTokenHistogram, middlewares...))
 	r.GET("/api/logs/histogram/latency/by-dimension", lib.ChainMiddlewares(h.getLogsDimensionLatencyHistogram, middlewares...))
@@ -1050,6 +1052,36 @@ func (h *LoggingHandler) getLogsProviderLatencyHistogram(ctx *fasthttp.RequestCt
 	SendJSON(ctx, result)
 }
 
+// getLogsThroughputHistogram handles GET /api/logs/histogram/throughput - Get time-bucketed token-generation throughput (tokens/sec)
+func (h *LoggingHandler) getLogsThroughputHistogram(ctx *fasthttp.RequestCtx) {
+	filters := parseHistogramFilters(ctx)
+	bucketSizeSeconds := calculateBucketSize(filters.StartTime, filters.EndTime)
+
+	result, err := h.logManager.GetThroughputHistogram(ctx, filters, bucketSizeSeconds)
+	if err != nil {
+		logger.Error("failed to get throughput histogram: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Throughput histogram calculation failed: %v", err))
+		return
+	}
+
+	SendJSON(ctx, result)
+}
+
+// getLogsProviderThroughputHistogram handles GET /api/logs/histogram/throughput/by-provider - Get time-bucketed tokens/sec with provider breakdown
+func (h *LoggingHandler) getLogsProviderThroughputHistogram(ctx *fasthttp.RequestCtx) {
+	filters := parseHistogramFilters(ctx)
+	bucketSizeSeconds := calculateBucketSize(filters.StartTime, filters.EndTime)
+
+	result, err := h.logManager.GetProviderThroughputHistogram(ctx, filters, bucketSizeSeconds)
+	if err != nil {
+		logger.Error("failed to get provider throughput histogram: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Provider throughput histogram calculation failed: %v", err))
+		return
+	}
+
+	SendJSON(ctx, result)
+}
+
 // parseDimension extracts and validates the "dimension" query parameter.
 // Returns the validated HistogramDimension and true on success, or sends an error response and returns false.
 func parseDimension(ctx *fasthttp.RequestCtx) (logstore.HistogramDimension, bool) {
@@ -1256,6 +1288,14 @@ func (h *LoggingHandler) getDashboard(ctx *fasthttp.RequestCtx) {
 		result.Overview.Latency = res
 		return nil
 	})
+	g.Go(func() error {
+		res, err := h.logManager.GetThroughputHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("throughput histogram: %w", err)
+		}
+		result.Overview.Throughput = res
+		return nil
+	})
 
 	// modelHistogram backs both the Overview "Model Usage" card and the Model
 	// Rankings "Top Models" chart; compute it once and share the pointer.
@@ -1292,6 +1332,14 @@ func (h *LoggingHandler) getDashboard(ctx *fasthttp.RequestCtx) {
 			return fmt.Errorf("provider latency histogram: %w", err)
 		}
 		result.ProviderUsage.Latency = res
+		return nil
+	})
+	g.Go(func() error {
+		res, err := h.logManager.GetProviderThroughputHistogram(gCtx, filters, bucketSizeSeconds)
+		if err != nil {
+			return fmt.Errorf("provider throughput histogram: %w", err)
+		}
+		result.ProviderUsage.Throughput = res
 		return nil
 	})
 

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -342,6 +342,12 @@ func (m *dashboardLogManager) GetProviderTokenHistogram(ctx context.Context, fil
 func (m *dashboardLogManager) GetProviderLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderLatencyHistogramResult, error) {
 	return &logstore.ProviderLatencyHistogramResult{}, nil
 }
+func (m *dashboardLogManager) GetThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ThroughputHistogramResult, error) {
+	return &logstore.ThroughputHistogramResult{}, nil
+}
+func (m *dashboardLogManager) GetProviderThroughputHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ProviderThroughputHistogramResult, error) {
+	return &logstore.ProviderThroughputHistogramResult{}, nil
+}
 func (m *dashboardLogManager) GetModelRankings(ctx context.Context, filters *logstore.SearchFilters) (*logstore.ModelRankingResult, error) {
 	return &logstore.ModelRankingResult{}, nil
 }


### PR DESCRIPTION
## Summary

Adds token-generation throughput (tokens/sec) as a new histogram metric across the log store, plugin layer, and HTTP API. Throughput is defined as an aggregate rate per time bucket: `SUM(completion_tokens) / (SUM(latency_ms) / 1000)`, computed only over terminal log rows that recorded a latency greater than zero. This avoids inflating token counts with requests that have no measured latency and keeps the metric uniformly computable across streaming and non-streaming requests.

## Changes

- Added `ThroughputHistogramBucket`, `ThroughputHistogramResult`, `ProviderThroughputStats`, `ProviderThroughputHistogramBucket`, and `ProviderThroughputHistogramResult` types to `tables.go`.
- Implemented `GetThroughputHistogram` and `GetProviderThroughputHistogram` on `RDBLogStore` in `rdb.go`, with a `tokensPerSecond` helper. Both methods fall through to materialized-view-backed implementations (`matviews.go`) when running on Postgres with an eligible query window ≥ 1 hour.
- The matview path reconstructs total latency per bucket as `SUM(avg_latency * count)` to mirror how the latency histogram re-aggregates weighted values from `mv_logs_hourly`.
- Added `GetThroughputHistogram` and `GetProviderThroughputHistogram` to the `LogStore` interface and `HybridLogStore` delegation.
- Exposed both methods through `LoggerPlugin` and `PluginLogManager`, and added them to the `LogManager` interface.
- Registered `GET /api/logs/histogram/throughput` and `GET /api/logs/histogram/throughput/by-provider` HTTP endpoints.
- Included throughput in the `DashboardOverview` and `DashboardProviderUsage` structs, fetched concurrently in the dashboard handler alongside existing metrics.
- Added `TestThroughputHistogramMath` to verify the aggregate rate calculation, per-provider breakdown, and exclusion of latency-less rows.
- Added parity test cases for `throughput` and `provider_throughput` in `logstoreparity_test.go`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... ./plugins/logging/... ./transports/bifrost-http/handlers/...
```

- `TestThroughputHistogramMath` validates the aggregate tokens/sec math, per-provider breakdown, and that rows without a latency are excluded from the rate.
- `TestLogStoreParity` validates that the SQLite and Postgres implementations return consistent results for the new `throughput` and `provider_throughput` cases.
- The dashboard endpoint (`GET /api/dashboard`) now includes `overview.throughput` and `provider_usage.throughput` fields in its response.
- The standalone endpoints `GET /api/logs/histogram/throughput` and `GET /api/logs/histogram/throughput/by-provider` can be exercised directly with any valid time-range filter.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces. The new endpoints follow the same middleware chain as all existing histogram endpoints. No PII or secrets are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable