### PR TITLE
add support for clickhouse for enterprise logstore tables

### DIFF
--- a/framework/logstore/clickhouseextension.go
+++ b/framework/logstore/clickhouseextension.go
@@ -1,0 +1,84 @@
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var clickHouseExtensionTableNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+var clickHouseReservedTableNames = map[string]struct{}{
+	strings.ToLower((AsyncJob{}).TableName()):   {},
+	strings.ToLower((Log{}).TableName()):        {},
+	strings.ToLower((MCPToolLog{}).TableName()): {},
+}
+
+// ClickHouseExtensionTableOptions defines the schema shape for an
+// extension-owned table. All DDL fragments are trusted, code-owned values and
+// must never be populated from configuration or user input.
+type ClickHouseExtensionTableOptions struct {
+	Table       string
+	PartitionBy string
+	OrderBy     string
+	TTL         string
+	SkipIndexes []string
+}
+
+type clickHouseSchemaStore interface {
+	EnsureClickHouseTable(ctx context.Context, model any, opts ClickHouseExtensionTableOptions) error
+}
+
+var (
+	_ clickHouseSchemaStore = (*ClickHouseLogStore)(nil)
+	_ clickHouseSchemaStore = (*HybridLogStore)(nil)
+)
+
+// EnsureClickHouseTable creates an extension table and reconciles newly added
+// model columns. It preserves the configured cluster and replication settings.
+func (s *ClickHouseLogStore) EnsureClickHouseTable(ctx context.Context, model any, opts ClickHouseExtensionTableOptions) error {
+	if s == nil || s.RDBLogStore == nil || s.db == nil {
+		return fmt.Errorf("clickhouse: logstore is not initialized")
+	}
+	if err := validateClickHouseExtensionTableOptions(opts); err != nil {
+		return err
+	}
+
+	tableOpts := chTableOpts{
+		table:       opts.Table,
+		partitionBy: opts.PartitionBy,
+		orderBy:     opts.OrderBy,
+		ttl:         opts.TTL,
+		skipIndexes: append([]string(nil), opts.SkipIndexes...),
+	}
+	if err := clickhouseCreateTable(ctx, s.db, model, tableOpts, s.cluster); err != nil {
+		return fmt.Errorf("clickhouse: create extension table %s: %w", opts.Table, err)
+	}
+	return clickhouseReconcileColumns(ctx, s.db, model, opts.Table, s.cluster, s.logger)
+}
+
+// EnsureClickHouseTable delegates extension-table schema management to a
+// ClickHouse logstore wrapped by hybrid object storage.
+func (h *HybridLogStore) EnsureClickHouseTable(ctx context.Context, model any, opts ClickHouseExtensionTableOptions) error {
+	schemaStore, ok := h.inner.(clickHouseSchemaStore)
+	if !ok {
+		return fmt.Errorf("logstore does not support ClickHouse extension tables")
+	}
+	return schemaStore.EnsureClickHouseTable(ctx, model, opts)
+}
+
+// validateClickHouseExtensionTableOptions validates identifiers and invariants
+// that can be checked without attempting to parse ClickHouse SQL expressions.
+func validateClickHouseExtensionTableOptions(opts ClickHouseExtensionTableOptions) error {
+	if !clickHouseExtensionTableNamePattern.MatchString(opts.Table) {
+		return fmt.Errorf("clickhouse: invalid extension table name %q", opts.Table)
+	}
+	if _, reserved := clickHouseReservedTableNames[strings.ToLower(opts.Table)]; reserved {
+		return fmt.Errorf("clickhouse: extension table name %q is reserved", opts.Table)
+	}
+	if strings.TrimSpace(opts.OrderBy) == "" {
+		return fmt.Errorf("clickhouse: extension table order by is required")
+	}
+	return nil
+}

--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -68,6 +68,85 @@ func chTestLog(id string, ts time.Time) *Log {
 	}
 }
 
+type clickHouseExtensionTestRow struct {
+	ID        string
+	Value     string
+	CreatedAt time.Time
+}
+
+func (clickHouseExtensionTestRow) TableName() string { return "extension_test_events" }
+
+func TestClickHouseEnsureExtensionTable(t *testing.T) {
+	store := trySetupClickHouseStore(t)
+	ctx := context.Background()
+	require.Error(t, store.EnsureClickHouseTable(ctx, &clickHouseExtensionTestRow{}, ClickHouseExtensionTableOptions{
+		Table: "invalid`; DROP TABLE logs", OrderBy: "id",
+	}))
+	require.NoError(t, store.db.Exec("DROP TABLE IF EXISTS extension_test_events").Error)
+	t.Cleanup(func() {
+		_ = store.db.Exec("DROP TABLE IF EXISTS extension_test_events").Error
+	})
+
+	opts := ClickHouseExtensionTableOptions{
+		Table:       "extension_test_events",
+		PartitionBy: "toYYYYMM(created_at)",
+		OrderBy:     "(created_at, id)",
+		TTL:         "toDateTime(created_at) + INTERVAL 30 DAY",
+		SkipIndexes: []string{"INDEX idx_extension_value lower(value) TYPE bloom_filter(0.01) GRANULARITY 1"},
+	}
+	require.NoError(t, store.EnsureClickHouseTable(ctx, &clickHouseExtensionTestRow{}, opts))
+	hybrid := &HybridLogStore{inner: store}
+	require.NoError(t, hybrid.EnsureClickHouseTable(ctx, &clickHouseExtensionTestRow{}, opts))
+
+	row := clickHouseExtensionTestRow{ID: "event-1", Value: "matched", CreatedAt: time.Now().UTC()}
+	require.NoError(t, store.db.WithContext(ctx).Create(&row).Error)
+
+	var count int64
+	require.NoError(t, store.db.WithContext(ctx).Model(&clickHouseExtensionTestRow{}).Where("value = ?", "matched").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+
+	var createQuery string
+	require.NoError(t, store.db.WithContext(ctx).
+		Raw("SELECT create_table_query FROM system.tables WHERE database = currentDatabase() AND name = ?", opts.Table).
+		Scan(&createQuery).Error)
+	assert.Contains(t, createQuery, "ReplacingMergeTree")
+	assert.Contains(t, createQuery, "TTL")
+	assert.Contains(t, createQuery, "idx_extension_value")
+}
+
+func TestHybridEnsureClickHouseExtensionTableRejectsUnsupportedInner(t *testing.T) {
+	hybrid := &HybridLogStore{inner: &RDBLogStore{}}
+	err := hybrid.EnsureClickHouseTable(context.Background(), &clickHouseExtensionTestRow{}, ClickHouseExtensionTableOptions{
+		Table: "extension_events", OrderBy: "id",
+	})
+	require.EqualError(t, err, "logstore does not support ClickHouse extension tables")
+}
+
+func TestValidateClickHouseExtensionTableOptions(t *testing.T) {
+	valid := ClickHouseExtensionTableOptions{Table: "extension_events", OrderBy: "(created_at, id)"}
+	require.NoError(t, validateClickHouseExtensionTableOptions(valid))
+	invalidName := valid
+	invalidName.Table = "invalid`; DROP TABLE logs"
+	require.ErrorContains(t, validateClickHouseExtensionTableOptions(invalidName), "invalid extension table name")
+
+	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs", "LOGS"} {
+		opts := valid
+		opts.Table = table
+		require.ErrorContains(t, validateClickHouseExtensionTableOptions(opts), "reserved")
+	}
+
+	missingOrderBy := valid
+	missingOrderBy.OrderBy = " "
+	require.ErrorContains(t, validateClickHouseExtensionTableOptions(missingOrderBy), "order by is required")
+
+	clickHouseSyntax := valid
+	clickHouseSyntax.TTL = "toDateTime(created_at) + INTERVAL 30 DAY TO VOLUME 'cold'"
+	clickHouseSyntax.SkipIndexes = []string{
+		"INDEX idx_lower_value lower(value) TYPE bloom_filter(0.01) GRANULARITY 1",
+	}
+	require.NoError(t, validateClickHouseExtensionTableOptions(clickHouseSyntax))
+}
+
 // chCountRows counts logical rows visible for an id; with the connection-level
 // final=1 setting, ReplacingMergeTree duplicates must collapse to one.
 func chCountRows(t *testing.T, db *gorm.DB, table, id string) int64 {


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


