### PR TITLE
feat: add throughput (tokens/sec) to model rankings and trend data

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1751,14 +1751,16 @@ func (s *RDBLogStore) getDimensionLatencyHistogramFromMatView(ctx context.Contex
 // comparison to the previous period of equal duration from mv_logs_hourly.
 func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters SearchFilters) (*ModelRankingResult, error) {
 	var results []struct {
-		Model         string         `gorm:"column:model"`
-		CanonicalName sql.NullString `gorm:"column:canonical_name"`
-		Provider      string         `gorm:"column:provider"`
-		Total         int64          `gorm:"column:total"`
-		SuccessCount  int64          `gorm:"column:success_count"`
-		AvgLatency    float64        `gorm:"column:avg_lat"`
-		TotalTokens   int64          `gorm:"column:total_tkns"`
-		TotalCost     float64        `gorm:"column:total_cost"`
+		Model              string         `gorm:"column:model"`
+		CanonicalName      sql.NullString `gorm:"column:canonical_name"`
+		Provider           string         `gorm:"column:provider"`
+		Total              int64          `gorm:"column:total"`
+		SuccessCount       int64          `gorm:"column:success_count"`
+		AvgLatency         float64        `gorm:"column:avg_lat"`
+		TotalTokens        int64          `gorm:"column:total_tkns"`
+		TotalCost          float64        `gorm:"column:total_cost"`
+		TPCompletionTokens int64          `gorm:"column:tp_completion_tokens"`
+		TPLatencyMs        float64        `gorm:"column:tp_latency_ms"`
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
@@ -1770,7 +1772,9 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		SUM(success_count) AS success_count,
 		CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_lat,
 		SUM(total_tokens) AS total_tkns,
-		SUM(total_cost) AS total_cost
+		SUM(total_cost) AS total_cost,
+		COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_completion_tokens ELSE 0 END), 0) AS tp_completion_tokens,
+		COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_latency_ms ELSE 0 END), 0) AS tp_latency_ms
 	`).Group("model, provider").
 		Order("total DESC").
 		Find(&results).Error; err != nil {
@@ -1779,12 +1783,14 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 
 	// Previous period for trend (same duration, ending just before current start)
 	type prevRow struct {
-		Model       string  `gorm:"column:model"`
-		Provider    string  `gorm:"column:provider"`
-		Total       int64   `gorm:"column:total"`
-		AvgLatency  float64 `gorm:"column:avg_lat"`
-		TotalTokens int64   `gorm:"column:total_tkns"`
-		TotalCost   float64 `gorm:"column:total_cost"`
+		Model              string  `gorm:"column:model"`
+		Provider           string  `gorm:"column:provider"`
+		Total              int64   `gorm:"column:total"`
+		AvgLatency         float64 `gorm:"column:avg_lat"`
+		TotalTokens        int64   `gorm:"column:total_tkns"`
+		TotalCost          float64 `gorm:"column:total_cost"`
+		TPCompletionTokens int64   `gorm:"column:tp_completion_tokens"`
+		TPLatencyMs        float64 `gorm:"column:tp_latency_ms"`
 	}
 	var prevResults []prevRow
 	if filters.StartTime != nil && filters.EndTime != nil {
@@ -1813,7 +1819,9 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 			SUM(count) AS total,
 			CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_lat,
 			SUM(total_tokens) AS total_tkns,
-			SUM(total_cost) AS total_cost
+			SUM(total_cost) AS total_cost,
+			COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_completion_tokens ELSE 0 END), 0) AS tp_completion_tokens,
+			COALESCE(SUM(CASE WHEN status = 'success' THEN throughput_latency_ms ELSE 0 END), 0) AS tp_latency_ms
 		`).Group("model, provider").Find(&prevResults).Error; err != nil {
 			return nil, fmt.Errorf("failed to get previous period rankings: %w", err)
 		}
@@ -1840,6 +1848,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 			TotalTokens:   r.TotalTokens,
 			TotalCost:     r.TotalCost,
 			AvgLatency:    r.AvgLatency,
+			Throughput:    tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
 		}
 		if r.CanonicalName.Valid {
 			entry.CanonicalModelName = &r.CanonicalName.String
@@ -1853,6 +1862,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 				TokensTrend:       trendPct(float64(r.TotalTokens), float64(prev.TotalTokens)),
 				CostTrend:         trendPct(r.TotalCost, prev.TotalCost),
 				LatencyTrend:      trendPct(r.AvgLatency, prev.AvgLatency),
+				ThroughputTrend:   trendPct(entry.Throughput, tokensPerSecond(prev.TPCompletionTokens, prev.TPLatencyMs)),
 			}
 		}
 		rankings = append(rankings, mrt)

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -2099,7 +2099,9 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
 		SUM(total_tokens) as total_tokens,
 		COALESCE(SUM(cost), 0) as total_cost,
-		AVG(latency) as avg_latency
+		AVG(latency) as avg_latency,
+		COALESCE(SUM(CASE WHEN status = 'success' AND latency > 0 THEN completion_tokens ELSE 0 END), 0) as tp_completion_tokens,
+		COALESCE(SUM(CASE WHEN status = 'success' AND latency > 0 THEN latency ELSE 0 END), 0) as tp_latency_ms
 	`
 	// Only the current-period query scans canonical_name; keeping it out of the
 	// shared clause spares the previous-period query a discarded aggregate.
@@ -2112,14 +2114,16 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 	currentQuery = currentQuery.Where("model IS NOT NULL AND model != ''")
 
 	var currentResults []struct {
-		Model         string          `gorm:"column:model"`
-		CanonicalName sql.NullString  `gorm:"column:canonical_name"`
-		Provider      string          `gorm:"column:provider"`
-		TotalRequests int64           `gorm:"column:total_requests"`
-		SuccessCount  int64           `gorm:"column:success_count"`
-		TotalTokens   sql.NullInt64   `gorm:"column:total_tokens"`
-		TotalCost     sql.NullFloat64 `gorm:"column:total_cost"`
-		AvgLatency    sql.NullFloat64 `gorm:"column:avg_latency"`
+		Model              string          `gorm:"column:model"`
+		CanonicalName      sql.NullString  `gorm:"column:canonical_name"`
+		Provider           string          `gorm:"column:provider"`
+		TotalRequests      int64           `gorm:"column:total_requests"`
+		SuccessCount       int64           `gorm:"column:success_count"`
+		TotalTokens        sql.NullInt64   `gorm:"column:total_tokens"`
+		TotalCost          sql.NullFloat64 `gorm:"column:total_cost"`
+		AvgLatency         sql.NullFloat64 `gorm:"column:avg_latency"`
+		TPCompletionTokens int64           `gorm:"column:tp_completion_tokens"`
+		TPLatencyMs        float64         `gorm:"column:tp_latency_ms"`
 	}
 
 	if err := currentQuery.
@@ -2165,13 +2169,15 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		}
 
 		var prevResults []struct {
-			Model         string          `gorm:"column:model"`
-			Provider      string          `gorm:"column:provider"`
-			TotalRequests int64           `gorm:"column:total_requests"`
-			SuccessCount  int64           `gorm:"column:success_count"`
-			TotalTokens   sql.NullInt64   `gorm:"column:total_tokens"`
-			TotalCost     sql.NullFloat64 `gorm:"column:total_cost"`
-			AvgLatency    sql.NullFloat64 `gorm:"column:avg_latency"`
+			Model              string          `gorm:"column:model"`
+			Provider           string          `gorm:"column:provider"`
+			TotalRequests      int64           `gorm:"column:total_requests"`
+			SuccessCount       int64           `gorm:"column:success_count"`
+			TotalTokens        sql.NullInt64   `gorm:"column:total_tokens"`
+			TotalCost          sql.NullFloat64 `gorm:"column:total_cost"`
+			AvgLatency         sql.NullFloat64 `gorm:"column:avg_latency"`
+			TPCompletionTokens int64           `gorm:"column:tp_completion_tokens"`
+			TPLatencyMs        float64         `gorm:"column:tp_latency_ms"`
 		}
 
 		if err := prevQuery.
@@ -2190,6 +2196,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 				TotalTokens:   r.TotalTokens.Int64,
 				TotalCost:     r.TotalCost.Float64,
 				AvgLatency:    r.AvgLatency.Float64,
+				Throughput:    tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
 			}
 		}
 	}
@@ -2205,6 +2212,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 			TotalTokens:   r.TotalTokens.Int64,
 			TotalCost:     r.TotalCost.Float64,
 			AvgLatency:    r.AvgLatency.Float64,
+			Throughput:    tokensPerSecond(r.TPCompletionTokens, r.TPLatencyMs),
 		}
 		if r.CanonicalName.Valid {
 			entry.CanonicalModelName = &r.CanonicalName.String
@@ -2222,6 +2230,9 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 			trend.CostTrend = pctChange(prev.TotalCost, r.TotalCost.Float64)
 			if prev.AvgLatency > 0 {
 				trend.LatencyTrend = pctChange(prev.AvgLatency, r.AvgLatency.Float64)
+			}
+			if prev.Throughput > 0 {
+				trend.ThroughputTrend = pctChange(prev.Throughput, entry.Throughput)
 			}
 		}
 

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1713,6 +1713,10 @@ type ModelRankingEntry struct {
 	TotalTokens        int64   `json:"total_tokens"`
 	TotalCost          float64 `json:"total_cost"`
 	AvgLatency         float64 `json:"avg_latency"`
+	// Throughput is aggregate token-generation rate (tokens/sec) for this model:
+	// SUM(completion_tokens) / (SUM(latency_ms)/1000) over successful rows with
+	// latency > 0 — the same definition as the throughput histogram.
+	Throughput float64 `json:"throughput"`
 }
 
 // ModelRankingTrend represents the percentage change compared to the previous period.
@@ -1722,6 +1726,7 @@ type ModelRankingTrend struct {
 	TokensTrend       float64 `json:"tokens_trend"`
 	CostTrend         float64 `json:"cost_trend"`
 	LatencyTrend      float64 `json:"latency_trend"`
+	ThroughputTrend   float64 `json:"throughput_trend"`
 }
 
 // ModelRankingWithTrend combines ranking entry with trend data.

--- a/framework/logstore/throughput_test.go
+++ b/framework/logstore/throughput_test.go
@@ -93,4 +93,18 @@ func TestThroughputHistogramMath(t *testing.T) {
 	require.Equal(t, int64(2), stats["openai"].TotalRequests)
 	require.InDelta(t, 100.0, stats["anthropic"].TokensPerSecond, 1e-6)
 	require.Equal(t, int64(1), stats["anthropic"].TotalRequests)
+
+	// Model rankings expose the same per-model throughput. All rows use model
+	// "gpt-4o", so ranking groups by (model, provider): openai => 200 tok/s,
+	// anthropic => 100 tok/s. The latency-less / zero-latency / non-success rows
+	// (t4, t7, t5, t6) must be excluded from the rate exactly as above.
+	rankings, err := sq.GetModelRankings(ctx, window)
+	require.NoError(t, err)
+	tpByProvider := make(map[string]float64)
+	for _, r := range rankings.Rankings {
+		require.Equal(t, "gpt-4o", r.Model)
+		tpByProvider[r.Provider] = r.Throughput
+	}
+	require.InDelta(t, 200.0, tpByProvider["openai"], 1e-6)
+	require.InDelta(t, 100.0, tpByProvider["anthropic"], 1e-6)
 }


### PR DESCRIPTION
## Summary

Adds per-model throughput (tokens/second) to the model rankings API. Previously, rankings exposed request counts, latency, token totals, and cost, but had no throughput metric. This change computes aggregate token-generation rate using the same definition as the throughput histogram: `SUM(completion_tokens) / (SUM(latency_ms) / 1000)` over successful rows where latency > 0.

## Changes

- Added `tp_completion_tokens` and `tp_latency_ms` aggregates to both the current-period and previous-period queries in the raw log path (`rdb.go`) and the materialized view path (`matviews.go`), filtering to `status = 'success'` and `latency > 0` to match histogram semantics.
- Added `Throughput float64` to `ModelRankingEntry` and `ThroughputTrend float64` to `ModelRankingTrend`, computed via the shared `tokensPerSecond` helper.
- Throughput trend is calculated using `pctChange` against the previous period's throughput, consistent with how latency and cost trends are handled.
- Extended the existing throughput math test (`TestThroughputHistogramMath`) to assert that `GetModelRankings` returns the correct per-provider throughput values (`openai` → 200 tok/s, `anthropic` → 100 tok/s), confirming that zero-latency, missing-latency, and non-success rows are excluded.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestThroughputHistogramMath -v
go test ./framework/logstore/...
```

The updated `TestThroughputHistogramMath` test validates that model rankings return the correct throughput values and that rows with zero latency, null latency, or non-success status are excluded from the rate calculation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing implications. The new fields are additive to the existing rankings response.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable