### PR TITLE
feat: add throughput column and trend to model rankings tab and CSV export

### DIFF
--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -11,6 +11,7 @@ import {
 	displayModelLabel,
 	formatFullTimestamp,
 	formatTimestamp,
+	formatTokensPerSecond,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
@@ -20,7 +21,7 @@ import { ChartCard } from "./charts/chartCard";
 import { ChartErrorBoundary } from "./charts/chartErrorBoundary";
 import { formatCost, SortableHeader, TrendBadge } from "./rankingsShared";
 
-type SortField = "total_requests" | "success_rate" | "total_tokens" | "total_cost" | "avg_latency";
+type SortField = "total_requests" | "success_rate" | "total_tokens" | "total_cost" | "avg_latency" | "throughput";
 type SortOrder = "asc" | "desc";
 
 interface ModelRankingsTabProps {
@@ -336,6 +337,15 @@ function ModelRankingsTabImpl({ rankingsData, loading, modelData, loadingModels,
 										onSort={handleSort}
 									/>
 								</TableHead>
+								<TableHead className="text-right">
+									<SortableHeader
+										label="Throughput"
+										field="throughput"
+										currentSort={sortField}
+										currentOrder={sortOrder}
+										onSort={handleSort}
+									/>
+								</TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -390,6 +400,12 @@ function ModelRankingsTabImpl({ rankingsData, loading, modelData, loadingModels,
 										<div className="flex items-center justify-end gap-2">
 											<span>{formatLatency(entry.avg_latency)}</span>
 											<TrendBadge value={entry.trend.latency_trend} positiveIsGood={false} isNew={!entry.trend.has_previous_period} />
+										</div>
+									</TableCell>
+									<TableCell className="text-right">
+										<div className="flex items-center justify-end gap-2">
+											<span>{formatTokensPerSecond(entry.throughput)}</span>
+											<TrendBadge value={entry.trend.throughput_trend} isNew={!entry.trend.has_previous_period} />
 										</div>
 									</TableCell>
 								</TableRow>

--- a/ui/app/workspace/dashboard/utils/exportUtils.ts
+++ b/ui/app/workspace/dashboard/utils/exportUtils.ts
@@ -115,10 +115,12 @@ export function modelRankingsToCSV(data: ModelRankingsResponse | null): CSVData 
 		"Total Tokens",
 		"Total Cost ($)",
 		"Avg Latency (ms)",
+		"Throughput (tok/s)",
 		"Requests Trend (%)",
 		"Tokens Trend (%)",
 		"Cost Trend (%)",
 		"Latency Trend (%)",
+		"Throughput Trend (%)",
 	];
 	const rows = (data?.rankings ?? []).map((r) => [
 		r.model,
@@ -130,10 +132,12 @@ export function modelRankingsToCSV(data: ModelRankingsResponse | null): CSVData 
 		r.total_tokens,
 		r.total_cost,
 		r.avg_latency,
+		r.throughput,
 		r.trend.has_previous_period ? r.trend.requests_trend : "N/A",
 		r.trend.has_previous_period ? r.trend.tokens_trend : "N/A",
 		r.trend.has_previous_period ? r.trend.cost_trend : "N/A",
 		r.trend.has_previous_period ? r.trend.latency_trend : "N/A",
+		r.trend.has_previous_period ? r.trend.throughput_trend : "N/A",
 	]);
 	return { headers, rows };
 }

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1220,6 +1220,7 @@ export interface ModelRankingTrend {
 	tokens_trend: number;
 	cost_trend: number;
 	latency_trend: number;
+	throughput_trend: number;
 }
 
 export interface ModelRankingEntry {
@@ -1232,6 +1233,7 @@ export interface ModelRankingEntry {
 	total_tokens: number;
 	total_cost: number;
 	avg_latency: number;
+	throughput: number; // tokens/sec
 	trend: ModelRankingTrend;
 }
 


### PR DESCRIPTION
## Summary

Adds throughput (tokens/second) as a new metric to the model rankings table, enabling users to compare model output speed alongside existing metrics like latency, cost, and token usage.

## Changes

- Added `throughput` field to `ModelRankingEntry` and `throughput_trend` to `ModelRankingTrend` types
- Added a sortable "Throughput" column to the model rankings table, displaying tokens/sec with a trend badge
- Included throughput and throughput trend columns in the CSV export output

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the workspace dashboard and open the Model Rankings tab. Verify:

1. A "Throughput" column appears and displays tokens/sec values with trend badges
2. Clicking the "Throughput" column header sorts the table correctly
3. Exporting the rankings as CSV includes "Throughput (tok/s)" and "Throughput Trend (%)" columns with correct values

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the model rankings table showing the new Throughput column._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues  
https://github.com/maximhq/bifrost/issues/1992  
https://github.com/maximhq/bifrost/issues/5160

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable