### PR TITLE
migration fixes

### DIFF
--- a/.github/workflows/scripts/detect-all-changes.sh
+++ b/.github/workflows/scripts/detect-all-changes.sh
@@ -346,6 +346,95 @@ if [ "$DOCKER_TAG_EXISTS" = "false" ]; then
 fi
 
 
+# Validate that every bifrost module package imported by transports exists in
+# the tag pinned by its version file. `go mod tidy` silently falls back to
+# @latest when the pinned release lacks an imported package, so catch
+# version-file drift here with a clear error instead of mid-release.
+if [ "$BIFROST_HTTP_NEEDS_RELEASE" = "true" ] || [ "$DOCKER_NEEDS_RELEASE" = "true" ]; then
+  echo ""
+  echo "🔒 Validating transports imports against pinned version tags..."
+  IMPORT_VALIDATION_FAILED="false"
+  while IFS= read -r pkg; do
+    subpath="${pkg#github.com/maximhq/bifrost/}"
+    top="${subpath%%/*}"
+    case "$top" in
+      core)
+        # Skip modules being released in this run - their tag is cut from HEAD
+        [ "$CORE_NEEDS_RELEASE" = "true" ] && continue
+        pinned_tag="core/v${CORE_VERSION}"
+        bump_hint="core/version"
+        ;;
+      framework)
+        [ "$FRAMEWORK_NEEDS_RELEASE" = "true" ] && continue
+        pinned_tag="framework/v${FRAMEWORK_VERSION}"
+        bump_hint="framework/version"
+        ;;
+      plugins)
+        plugin_name=$(echo "$subpath" | cut -d'/' -f2)
+        [ -f "plugins/${plugin_name}/version" ] || continue
+        plugin_skip="false"
+        for changed_plugin in ${PLUGIN_CHANGES[@]+"${PLUGIN_CHANGES[@]}"}; do
+          [ "$changed_plugin" = "$plugin_name" ] && plugin_skip="true"
+        done
+        [ "$plugin_skip" = "true" ] && continue
+        pinned_tag="plugins/${plugin_name}/v$(tr -d '\n\r' < "plugins/${plugin_name}/version")"
+        bump_hint="plugins/${plugin_name}/version"
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    # Tag missing entirely is handled by the release-needed checks above
+    git rev-parse --verify "$pinned_tag" >/dev/null 2>&1 || continue
+    if ! git cat-file -e "${pinned_tag}:${subpath}" 2>/dev/null; then
+      echo "::error::transports imports ${pkg}, but pinned tag ${pinned_tag} does not contain ${subpath}. Bump ${bump_hint} so a release containing it is cut before bifrost-http."
+      IMPORT_VALIDATION_FAILED="true"
+    fi
+  done < <(grep -rhoE '"github\.com/maximhq/bifrost/(core|framework|plugins)[^"]*"' transports --include="*.go" | tr -d '"' | sort -u)
+  # Verify every pinned plugin release was built against the pinned core and
+  # framework versions. go mod edit -require is only a minimum: a plugin tag
+  # requiring a higher core/framework silently wins MVS and drags transports
+  # off the version-file versions.
+  echo "🔒 Validating pinned plugin releases against pinned core/framework..."
+  for plugin_dir in plugins/*/; do
+    plugin_name=$(basename "$plugin_dir")
+    [ -f "${plugin_dir}version" ] || continue
+    grep -q "github.com/maximhq/bifrost/plugins/${plugin_name} " transports/go.mod || continue
+
+    plugin_skip="false"
+    for changed_plugin in ${PLUGIN_CHANGES[@]+"${PLUGIN_CHANGES[@]}"}; do
+      [ "$changed_plugin" = "$plugin_name" ] && plugin_skip="true"
+    done
+    # Plugins re-released this run are rebuilt against the version files
+    [ "$plugin_skip" = "true" ] && continue
+
+    plugin_version=$(tr -d '\n\r' < "${plugin_dir}version")
+    plugin_tag="plugins/${plugin_name}/v${plugin_version}"
+    git rev-parse --verify "$plugin_tag" >/dev/null 2>&1 || continue
+    plugin_gomod=$(git show "${plugin_tag}:plugins/${plugin_name}/go.mod" 2>/dev/null) || continue
+
+    for dep in core framework; do
+      if [ "$dep" = "core" ]; then
+        pinned_dep_version="v${CORE_VERSION}"
+      else
+        pinned_dep_version="v${FRAMEWORK_VERSION}"
+      fi
+      required_dep_version=$(echo "$plugin_gomod" | grep -oE "github\.com/maximhq/bifrost/${dep} v[^ /]+" | awk '{print $2}' | head -1)
+      [ -n "$required_dep_version" ] || continue
+      if [ "$required_dep_version" != "$pinned_dep_version" ] && \
+         [ "$(printf '%s\n' "$pinned_dep_version" "$required_dep_version" | sort -V | tail -1)" = "$required_dep_version" ]; then
+        echo "::error::${plugin_tag} requires ${dep} ${required_dep_version}, which is higher than pinned ${dep} ${pinned_dep_version} from the version file. MVS will override the pin - bump plugins/${plugin_name}/version so it is re-released against ${dep} ${pinned_dep_version}."
+        IMPORT_VALIDATION_FAILED="true"
+      fi
+    done
+  done
+
+  if [ "$IMPORT_VALIDATION_FAILED" = "true" ]; then
+    exit 1
+  fi
+  echo "   ✅ All transports imports exist in pinned version tags"
+fi
+
 # Convert plugin array to JSON (compact format)
 if [ ${#PLUGIN_CHANGES[@]} -eq 0 ]; then
   CHANGED_PLUGINS_JSON="[]"

--- a/.github/workflows/scripts/release-bifrost-http-prep.sh
+++ b/.github/workflows/scripts/release-bifrost-http-prep.sh
@@ -60,7 +60,7 @@ while IFS= read -r plugin_line; do
     echo "   📦 $plugin_name: $current_version (from transport go.mod)"
     PLUGIN_VERSIONS["$plugin_name"]="$current_version"
   fi
-done < <(grep "github.com/maximhq/bifrost/plugins/" go.mod)
+done < <(grep "github.com/maximhq/bifrost/plugins/" go.mod | sed 's|//.*||')
 cd ..
 
 echo "🔧 Using versions:"
@@ -103,6 +103,26 @@ go mod edit -require="github.com/maximhq/bifrost/framework@$FRAMEWORK_VERSION"
 # Re-normalize before tidy in case any edit reintroduced a toolchain line
 go mod edit -go=1.26.4 -toolchain=none
 go mod tidy
+
+# go mod tidy silently upgrades a pinned module to @latest when the pinned
+# release lacks an imported package - assert every version-file pin survived.
+echo "🔒 Verifying pinned versions survived go mod tidy..."
+verify_pinned_version() {
+  local module_path="$1" expected="$2" actual
+  actual=$(go list -m -f '{{.Version}}' "$module_path" 2>/dev/null || echo "<missing>")
+  if [ "$actual" != "$expected" ]; then
+    echo "::error::$module_path resolved to $actual, expected $expected from version file. go mod tidy escaped the pin - the pinned release is likely missing a package imported by transports."
+    exit 1
+  fi
+}
+verify_pinned_version "github.com/maximhq/bifrost/core" "$CORE_VERSION"
+verify_pinned_version "github.com/maximhq/bifrost/framework" "$FRAMEWORK_VERSION"
+for plugin_name in "${!PLUGIN_VERSIONS[@]}"; do
+  if grep -q "github.com/maximhq/bifrost/plugins/$plugin_name " go.mod; then
+    verify_pinned_version "github.com/maximhq/bifrost/plugins/$plugin_name" "${PLUGIN_VERSIONS[$plugin_name]}"
+  fi
+done
+echo "✅ All pinned versions intact"
 
 cd ..
 

--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -746,6 +746,7 @@ append_dynamic_mcp_clients_insert() {
     generate_pricing_overrides_insert_postgres "$now" "$faker_sql"
     generate_mcp_library_insert_postgres "$now" "$faker_sql"
     generate_skills_repo_tables_insert_postgres "$now" "$faker_sql"
+    generate_oauth2_issuance_tables_insert_postgres "$now" "$faker_sql"
     append_dynamic_columns_postgres "$now" "$past" "$faker_sql"
   else
     now="datetime('now')"
@@ -763,6 +764,7 @@ append_dynamic_mcp_clients_insert() {
     generate_pricing_overrides_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_mcp_library_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_skills_repo_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_oauth2_issuance_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
     append_dynamic_columns_sqlite "$now" "$past" "$faker_sql" "$config_db"
   fi
 }
@@ -1902,6 +1904,42 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.6.3 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  # config_keys bedrock_mantle_* columns (Bedrock Mantle auth config, all nullable secrets)
+  # bedrock_mantle_project_id is newer than v1.6.3 but guarded the same way
+  for mantle_col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name bedrock_mantle_project_id; do
+    if column_exists_postgres "config_keys" "$mantle_col"; then
+      echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+  done
+
+  # governance_model_pricing.is_deprecated (added in v1.6.3)
+  if column_exists_postgres "governance_model_pricing" "is_deprecated"; then
+    echo "UPDATE governance_model_pricing SET is_deprecated = false WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET is_deprecated = false WHERE id = 2;" >> "$output_file"
+  fi
+
+  # governance_virtual_keys.expires_at (added in v1.6.3 - NULL means never expires;
+  # kept NULL so the current version doesn't treat the seeded VKs as expired)
+  if column_exists_postgres "governance_virtual_keys" "expires_at"; then
+    echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # config_client.mcp_server_auth_mode, oauth2_server_config_json (added in v1.6.3)
+  # 'headers' is the column default; '' is what BeforeSave persists for a nil
+  # OAuth2ServerConfig, so config sync on the current version won't diff these.
+  if column_exists_postgres "config_client" "mcp_server_auth_mode"; then
+    echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+  fi
+  if column_exists_postgres "config_client" "oauth2_server_config_json"; then
+    echo "UPDATE config_client SET oauth2_server_config_json = '' WHERE id = 1;" >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -2989,6 +3027,44 @@ append_dynamic_columns_sqlite() {
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.6.3 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  if [ -f "$config_db" ]; then
+    # config_keys bedrock_mantle_* columns (Bedrock Mantle auth config, all nullable secrets)
+    # bedrock_mantle_project_id is newer than v1.6.3 but guarded the same way
+    for mantle_col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name bedrock_mantle_project_id; do
+      if column_exists_sqlite "$config_db" "config_keys" "$mantle_col"; then
+        echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+        echo "UPDATE config_keys SET $mantle_col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+      fi
+    done
+
+    # governance_model_pricing.is_deprecated (added in v1.6.3)
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "is_deprecated"; then
+      echo "UPDATE governance_model_pricing SET is_deprecated = 0 WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET is_deprecated = 0 WHERE id = 2;" >> "$output_file"
+    fi
+
+    # governance_virtual_keys.expires_at (added in v1.6.3 - NULL means never expires;
+    # kept NULL so the current version doesn't treat the seeded VKs as expired)
+    if column_exists_sqlite "$config_db" "governance_virtual_keys" "expires_at"; then
+      echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_keys SET expires_at = NULL WHERE id = 'vk-migration-test-2';" >> "$output_file"
+    fi
+
+    # config_client.mcp_server_auth_mode, oauth2_server_config_json (added in v1.6.3)
+    # 'headers' is the column default; '' is what BeforeSave persists for a nil
+    # OAuth2ServerConfig, so config sync on the current version won't diff these.
+    if column_exists_sqlite "$config_db" "config_client" "mcp_server_auth_mode"; then
+      echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "config_client" "oauth2_server_config_json"; then
+      echo "UPDATE config_client SET oauth2_server_config_json = '' WHERE id = 1;" >> "$output_file"
+    fi
+  fi
 }
 
 # ============================================================================
@@ -3005,15 +3081,17 @@ extract_faker_columns() {
 
   # Extract INSERT statements and parse table/columns
   # Handles both "INSERT INTO table (cols)" and "INSERT INTO table (cols) SELECT ..."
-  grep -E "^INSERT INTO [a-z_]+ \(" "$faker_sql" | \
-    sed -E 's/INSERT INTO ([a-z_]+) \(([^)]+)\).*/\1:\2/' | \
+  # Note: Table names can contain digits (e.g., oauth2_clients)
+  grep -E "^INSERT INTO [a-z0-9_]+ \(" "$faker_sql" | \
+    sed -E 's/INSERT INTO ([a-z0-9_]+) \(([^)]+)\).*/\1:\2/' | \
     tr -d ' ' | sort -u > "$output_file"
 
   # Also extract UPDATE SET columns (for dynamically added columns)
   # Pattern: UPDATE table SET col = value WHERE ...
-  # Note: Column names can contain digits (e.g., input_cost_per_token_above_128k_tokens)
-  grep -E "^UPDATE [a-z_]+ SET [a-z0-9_]+" "$faker_sql" | \
-    sed -E 's/UPDATE ([a-z_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
+  # Note: Table and column names can contain digits (e.g., oauth2_clients,
+  # input_cost_per_token_above_128k_tokens)
+  grep -E "^UPDATE [a-z0-9_]+ SET [a-z0-9_]+" "$faker_sql" | \
+    sed -E 's/UPDATE ([a-z0-9_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
     tr -d ' ' | sort -u >> "$output_file"
 }
 
@@ -3119,6 +3197,13 @@ generate_mcp_clients_insert_postgres() {
     cols="$cols, per_user_header_keys_json"
     # Non-default JSON so preservation of this field is verified by snapshot comparison.
     vals="$vals, '[\"X-Tenant-Id\",\"X-Request-Id\"]'"
+  fi
+
+  # config_mcp_clients.tool_execution_timeout (added in v1.6.3 - per-client override in seconds, 0 = use global)
+  if column_exists_postgres "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    # Non-default value so preservation of this field is verified by snapshot comparison.
+    vals="$vals, 45"
   fi
 
   # Append the dynamic INSERT to the output file
@@ -3385,6 +3470,13 @@ generate_mcp_clients_insert_sqlite() {
     cols="$cols, per_user_header_keys_json"
     # Non-default JSON so preservation of this field is verified by snapshot comparison.
     vals="$vals, '[\"X-Tenant-Id\",\"X-Request-Id\"]'"
+  fi
+
+  # config_mcp_clients.tool_execution_timeout (added in v1.6.3 - per-client override in seconds, 0 = use global)
+  if column_exists_sqlite "$config_db" "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    # Non-default value so preservation of this field is verified by snapshot comparison.
+    vals="$vals, 45"
   fi
 
   # Append the dynamic INSERT to the output file
@@ -3886,6 +3978,51 @@ generate_temp_tokens_insert_sqlite() {
   echo "" >> "$output_file"
   echo "-- temp_tokens (short-lived narrow-scope credentials - added in v1.5.3, dynamically generated)" >> "$output_file"
   echo "INSERT INTO temp_tokens (id, token, token_hash, scope, resource_id, expires_at, created_at, updated_at, encryption_status) VALUES ('temp-token-migration-test-001', 'migration-test-temp-token-value-001', 'a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3', 'mcp_auth', 'oauth-config-migration-test-001', datetime('now', '+15 minutes'), $now, $now, 'plain_text') ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate OAuth2 issuance tables INSERTs for PostgreSQL (oauth2_clients,
+# oauth2_authorize_requests, oauth2_refresh_tokens - added in v1.6.3).
+# Rows are crafted to survive the current version's boot-time OAuth2 sweep worker:
+#   - authorize requests carry a future expires_at (expired non-code_issued rows are swept)
+#   - the revoked refresh token is well inside the 30-day revoked-token retention window
+#   - the client is backed by refresh token rows, so the orphaned-client sweep keeps it
+generate_oauth2_issuance_tables_insert_postgres() {
+  local now="$1"
+  local output_file="$2"
+
+  # All three tables are created together by the same migration; guard on one.
+  if ! column_exists_postgres "oauth2_clients" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- oauth2 issuance tables (DCR clients, authorize requests, refresh tokens - added in v1.6.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'oauth2-client-id-migration-001', 'Migration Test OAuth2 Client', '[\"https://client.example.com/callback\"]', '[\"authorization_code\", \"refresh_token\"]', 'mcp', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authreq-migration-test-001', 'oauth2-client-id-migration-001', 'https://client.example.com/callback', 'state-oauth2-migration-001', 'mcp', 'https://bifrost.example.com/mcp', 'migration-test-code-challenge-001', 'S256', 'pending', '', '', NULL, $now + INTERVAL '1 hour', $now, $now), ('oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'https://client.example.com/callback', 'state-oauth2-migration-002', 'mcp', 'https://bifrost.example.com/mcp', 'migration-test-code-challenge-002', 'S256', 'code_issued', 'vk', 'vk-migration-test-1', 'migration-test-code-hash-002', $now + INTERVAL '1 hour', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-rt-migration-test-001', 'migration-test-refresh-token-hash-001', 'oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'vk', 'vk-migration-test-1', 'mcp', 'https://bifrost.example.com/mcp', NULL, $now - INTERVAL '1 day', $now), ('oauth2-rt-migration-test-002', 'migration-test-refresh-token-hash-002', 'oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'vk', 'vk-migration-test-1', 'mcp', 'https://bifrost.example.com/mcp', $now - INTERVAL '1 day', $now - INTERVAL '1 day', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate OAuth2 issuance tables INSERTs for SQLite (see the PostgreSQL variant
+# for the sweep-survival constraints on the seeded rows)
+generate_oauth2_issuance_tables_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
+
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  # All three tables are created together by the same migration; guard on one.
+  if ! column_exists_sqlite "$config_db" "oauth2_clients" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- oauth2 issuance tables (DCR clients, authorize requests, refresh tokens - added in v1.6.3, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'oauth2-client-id-migration-001', 'Migration Test OAuth2 Client', '[\"https://client.example.com/callback\"]', '[\"authorization_code\", \"refresh_token\"]', 'mcp', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authreq-migration-test-001', 'oauth2-client-id-migration-001', 'https://client.example.com/callback', 'state-oauth2-migration-001', 'mcp', 'https://bifrost.example.com/mcp', 'migration-test-code-challenge-001', 'S256', 'pending', '', '', NULL, datetime('now', '+1 hour'), $now, $now), ('oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'https://client.example.com/callback', 'state-oauth2-migration-002', 'mcp', 'https://bifrost.example.com/mcp', 'migration-test-code-challenge-002', 'S256', 'code_issued', 'vk', 'vk-migration-test-1', 'migration-test-code-hash-002', datetime('now', '+1 hour'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-rt-migration-test-001', 'migration-test-refresh-token-hash-001', 'oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'vk', 'vk-migration-test-1', 'mcp', 'https://bifrost.example.com/mcp', NULL, datetime('now', '-1 day'), $now), ('oauth2-rt-migration-test-002', 'migration-test-refresh-token-hash-002', 'oauth2-authreq-migration-test-002', 'oauth2-client-id-migration-001', 'vk', 'vk-migration-test-1', 'mcp', 'https://bifrost.example.com/mcp', datetime('now', '-1 day'), datetime('now', '-1 day'), $now) ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Generate governance_model_parameters INSERT for PostgreSQL


### PR DESCRIPTION
## Summary

Hardens the release pipeline against silent `go mod tidy` version-pin escapes and extends migration test coverage to the v1.6.3 schema additions (OAuth2 issuance tables, Bedrock Mantle columns, virtual key expiry, MCP client auth mode, and per-client tool execution timeout).

## Changes

- **Import validation in `detect-all-changes.sh`**: Before a `bifrost-http` or Docker release, every `github.com/maximhq/bifrost/{core,framework,plugins}` package imported by `transports` is checked against the pinned version tag. If the pinned tag does not contain the imported path, the build fails with an actionable error instead of silently resolving to `@latest`. Modules being released in the same run are skipped since their tag is cut from HEAD.
- **MVS override detection**: For each plugin pinned in `transports/go.mod`, the script reads the plugin tag's own `go.mod` and fails if the plugin requires a higher `core` or `framework` version than the version files pin, which would cause MVS to silently override the pin.
- **Post-`go mod tidy` pin verification in `release-bifrost-http-prep.sh`**: After `go mod tidy` runs, `go list -m` asserts that `core`, `framework`, and every pinned plugin resolved to exactly the version-file version. A mismatch exits with a clear error.
- **Comment stripping for plugin version parsing**: `grep` over `go.mod` now pipes through `sed 's|//.*||'` to strip inline comments before extracting plugin versions, preventing malformed version strings.
- **v1.6.3 migration test coverage**: `run-migration-tests.sh` gains dynamic seed data and column guards for:
  - `oauth2_clients`, `oauth2_authorize_requests`, `oauth2_refresh_tokens` (new PostgreSQL and SQLite generator functions, wired into the main seed flow). Rows are crafted to survive the boot-time OAuth2 sweep worker (future `expires_at`, revoked token within the 30-day retention window, client backed by refresh token rows).
  - `config_keys` Bedrock Mantle columns (`bedrock_mantle_*`).
  - `governance_model_pricing.is_deprecated`.
  - `governance_virtual_keys.expires_at` (set to NULL so seeded keys are not treated as expired).
  - `config_client.mcp_server_auth_mode` and `oauth2_server_config_json`.
  - `config_mcp_clients.tool_execution_timeout` (set to a non-default value so snapshot comparison verifies field preservation).
- **Regex fix in `extract_faker_columns`**: Table-name patterns updated from `[a-z_]+` to `[a-z0-9_]+` so tables with digits in their names (e.g., `oauth2_clients`) are correctly parsed in both `INSERT` and `UPDATE` extraction.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The changes are exercised by the CI pipeline itself. To validate locally:

```sh
# Trigger detect-all-changes with a bifrost-http or Docker release condition and
# confirm the import validation block runs and exits cleanly.
bash .github/workflows/scripts/detect-all-changes.sh

# Run migration tests against a local Postgres and SQLite setup to confirm the
# new v1.6.3 seed rows are inserted and survive snapshot comparison.
bash .github/workflows/scripts/run-migration-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new secrets, auth flows, or PII handling introduced. The OAuth2 seed rows use synthetic hashes and non-sensitive placeholder values scoped to the test environment.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable