### PR TITLE
changelog fixes

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,16 @@
+- feat: add durable background-job `sidekiq` table, store methods, and runner with recovery and reaper
+- feat: pass created-by user ID and runner ID through sidekiq job lifecycle, add `GetInFlightSidekiqJobByKind` to config store interface
+- feat: show canonical model names in dashboard model rankings (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)
+- feat: redact trace content before connector export with transient redaction data field
+- feat: force single-region config in Vertex key config
+- fix: persist Responses stream usage when providers omit or reuse sequence numbers (thanks [@eyeveil](https://github.com/eyeveil)!)
+- fix: fold streamed output_text.annotation.added events into the accumulated responses message so citations survive in logging, observability, and cache (thanks [@fus3r](https://github.com/fus3r)!)
+- fix: keep the streaming finish_reason in the accumulated response when a provider forwards it on a content chunk (thanks [@fus3r](https://github.com/fus3r)!)
+- fix: sweep orphaned deferred spans in trace store TTL cleanup (thanks [@citrocat](https://github.com/citrocat)!)
+- fix: rebuild token usage from denormalized columns in hybrid log list (thanks [@G-XD](https://github.com/G-XD)!)
+- fix: repair bare wildcard allowed_models rows that break admin provider updates (thanks [@eyeveil](https://github.com/eyeveil)!)
+- fix: use AutoMigrate and add `runner_id`/`created_by_user_id` columns to sidekiq table migration
+- fix: match model filter on canonical_model_name and restore routing info for cost recalculation
+- fix: forward ScopedDB from HybridLogStore
+- fix: race conditions in tracer span locks
+- chore: upgrade ClickHouse client library

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,87 @@
+## ✨ Features
+
+- **Sarvam AI Provider** - Added Sarvam AI as a first-class provider with chat, text-to-speech, and speech-to-text support (thanks [@Purvi09](https://github.com/Purvi09)!)
+- **ElevenLabs Sound Effects** - Added text-to-sound generation support via `/v1/sound-generation` (thanks [@SecretSun](https://github.com/SecretSun)!)
+- **Bedrock Project Scoping** - Added optional `project_id` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex, plus UI support
+- **Trace Redaction** - Phase-scoped redaction and revealing, transient redaction data field for guardrails, and trace content redaction before connector export
+- **Durable Background Jobs** - New `sidekiq` background-job table, store methods, and runner with recovery and reaper; cost recalculation migrated to a durable, resumable job with polling instead of SSE
+- **Audit Log Object Storage** - S3/GCS object storage config schema for audit log archival
+- **Alerting Configuration** - Alerting schema in `config.schema.json` with declarative channels and CEL-based rules, Helm chart support, and enterprise fallback pages
+- **Model Catalog Pricing** - Added pricing data to the model catalog (thanks [@johnbrett](https://github.com/johnbrett)!)
+- **Canonical Model Names** - Dashboard model rankings now show canonical model names instead of inference-profile IDs (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)
+- **OAuth2 Hardening** - Allowlist for private-use redirect URI schemes (RFC 8252 §7.1) and a `shouldSweep` gate on the OAuth2 sweep worker
+- **Mirrored Schema Support** - `schema_url` / `BIFROST_SCHEMA_URL` for mirrored schema locations in isolated deployments
+- **Vertex Single-Region Config** - Enforce single-region configuration in Vertex key config
+- **Helm Chart Updates** - `bifrost.alerting`, audit-log object storage, `postgresql.external.port` string support, and `bifrost.mcp.toolGroups[*].id`
+
+## 🐞 Fixed
+
+- **Governance Rate-Limit Reset CPU** - Guards against invalid reset timeouts, parallelized resting-budget flows only when absolutely required, and fixed the calendar-based alignment qualifier
+- **Masked Key Persistence** - Never persist masked provider key previews to config storage (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **OpenShift Arbitrary UIDs** - Build-time group-0 ownership with no runtime chown (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Passthrough Virtual Key Attribution** - Passthrough calls via the Azure `api-key` header now attribute to the virtual key (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Rerank for Custom Providers** - `/v1/rerank` now works with custom OpenAI-compatible providers (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Responses Stream Usage** - Persist stream usage when providers omit or reuse sequence numbers (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Wildcard allowed_models Repair** - Repair bare wildcard `allowed_models` rows that broke admin provider updates (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Streaming Error Panic** - Nil-safe tracing span lookup prevents panics on streaming errors (thanks [@eyeveil](https://github.com/eyeveil)!)
+- **Anthropic Tool ID Sanitization** - Sanitize `tool_use`/`tool_result` ids to Anthropic's charset (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- **Realtime Transcription Sessions** - Support GA transcription-type sessions in `POST /v1/realtime/client_secrets` (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- **Diarized Transcription** - Support `diarized_json` segments and ElevenLabs speaker passthrough (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- **Model Discovery** - Skip disabled keys when scheduling model-discovery fetches (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- **MCP Timeout Placeholder** - Show the real global default in the MCP tool execution timeout placeholder (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- **Redacted Thinking Round-Trip** - Round-trip Anthropic `redacted_thinking` blocks on the Responses surface (thanks [@fus3r](https://github.com/fus3r)!)
+- **Streaming Accumulation** - Preserve citation annotations and `finish_reason` in the accumulated streaming response (thanks [@fus3r](https://github.com/fus3r)!)
+- **Gemini Grounded Streaming** - Reset web-search flag when recycling pooled stream state so `web_search_call` items keep emitting (thanks [@fus3r](https://github.com/fus3r)!)
+- **Vertex gs:// Images** - Pass through `gs://` image URLs on Vertex Gemini
+- **Bedrock Truncation Signal** - Signal `max_output_tokens` truncation on the Responses API (thanks [@jeremym-tanium](https://github.com/jeremym-tanium)!)
+- **Bedrock Reasoning Config** - Preserve `reasoning_config` on cross-provider translation so fallbacks keep extended thinking (thanks [@Purvi09](https://github.com/Purvi09)!)
+- **Anthropic tool_search** - Forward and rebuild server-side `tool_search` on the Responses path (thanks [@ws4charlie](https://github.com/ws4charlie)!)
+- **OpenAI Responses Input** - Strip `role` from non-message input items (thanks [@nettee](https://github.com/nettee)!) and serialize compaction request `input` correctly (thanks [@mcclurmc](https://github.com/mcclurmc)!)
+- **additional_tools Support** - Added `additional_tools` message type support, preserving nested tool types on `/v1/responses`
+- **Plugin Stream Errors** - Emit structured plugin stream errors on integration routes (thanks [@jeffhos](https://github.com/jeffhos)!)
+- **Pooled Object Hygiene** - Zero pooled ChannelMessage references on release and sweep orphaned deferred spans in trace store TTL cleanup (thanks [@citrocat](https://github.com/citrocat)!)
+- **Hybrid Log Token Usage** - Rebuild token usage from denormalized columns in hybrid log list (thanks [@G-XD](https://github.com/G-XD)!)
+- **MCP Tool Ordering** - Deterministic MCP tool ordering for prompt cache stability
+- **MCP Inline-Auth Links** - Warn callers not to truncate the `#t=` temp-token fragment (thanks [@MarcusPeng](https://github.com/MarcusPeng)!)
+- **Gemini Fixes** - Web search options map to Google Search grounding, file upload MIME types preserved, and video reference fields map to instances (thanks [@vojthor](https://github.com/vojthor)!)
+- **OpenAI Parameters** - Honor service tier in chat completion and cap max reasoning effort
+- **Anthropic Costing** - Correct inference geo cost and cache rate for fast mode
+- **SecretVar Parsing** - Parse `SecretVar` JSON with `ref`/`env_var` fields even when `value` is absent
+- **Telemetry** - Forward request id and trace id, reduce metrics cardinality explosion risk, and send status codes on OTEL metrics
+- **Dashboard** - Preserve active time period when applying dimension filters, adjust bucket size thresholds for month-range durations, show user popover with `preferred_username` fallback, and filter provider-level keys from the prompt manager selector (thanks [@rlex](https://github.com/rlex)!)
+- **API Key Provider Selection** - Fixed provider selection for API keys
+- **Azure Auth Headers** - Pass Azure auth headers in helpers
+- **Stream Delta Schema** - Added `ExtraContent` to `ChatStreamResponseChoiceDelta` (thanks [@nghodkicisco](https://github.com/nghodkicisco)!)
+
+## 🐙 Closed GitHub Issues
+
+- [#2347](https://github.com/maximhq/bifrost/issues/2347) - MCP tool ordering is non-deterministic, breaking prefix-based prompt caching
+- [#3455](https://github.com/maximhq/bifrost/issues/3455) - Segfault/nil dereference panic in Bedrock provider
+- [#4318](https://github.com/maximhq/bifrost/issues/4318) - allowed_models persisted as bare "*" string blocks subsequent provider updates
+- [#4353](https://github.com/maximhq/bifrost/issues/4353) - config.db corruption from masked-key preview in provider_configs JSON column
+- [#4367](https://github.com/maximhq/bifrost/issues/4367) - Image incompatible with OpenShift arbitrary UIDs
+- [#4402](https://github.com/maximhq/bifrost/issues/4402) - Vertex provider drops image blocks whose URL uses gs:// scheme
+- [#4477](https://github.com/maximhq/bifrost/issues/4477) - Passthrough calls using a Virtual Key log as actual key
+- [#4679](https://github.com/maximhq/bifrost/issues/4679) - Bedrock Responses API does not signal max_output_tokens truncation
+- [#4689](https://github.com/maximhq/bifrost/issues/4689) - Custom providers cannot set budget
+- [#4712](https://github.com/maximhq/bifrost/issues/4712) - ElevenLabs sound effects (/v1/sound-generation)
+- [#4780](https://github.com/maximhq/bifrost/issues/4780) - Anthropic server-side tool_search results are dropped on /v1/responses
+- [#4834](https://github.com/maximhq/bifrost/issues/4834) - /v1/rerank is not available with custom providers
+- [#4846](https://github.com/maximhq/bifrost/issues/4846) - Responses stream usage present in response.completed but not persisted in LLM Logs
+- [#4851](https://github.com/maximhq/bifrost/issues/4851) - Governance rate-limit reset causes high CPU in BumpRateLimitUsage
+- [#4870](https://github.com/maximhq/bifrost/issues/4870) - Pooled ChannelMessage retains request body, context, and undelivered response while idle
+- [#4940](https://github.com/maximhq/bifrost/issues/4940) - Show canonical model names instead of Bedrock inference-profile IDs in Model Rankings
+- [#4963](https://github.com/maximhq/bifrost/issues/4963) - Streaming finish_reason dropped from the accumulated (logged) response
+- [#5002](https://github.com/maximhq/bifrost/issues/5002) - gpt-4o-transcribe-diarize transcription fails due to string segment IDs
+- [#5013](https://github.com/maximhq/bifrost/issues/5013) - OpenAI /responses/compact input serialized as a JSON object causing 400
+- [#5027](https://github.com/maximhq/bifrost/issues/5027) - MCP Tool Execution Timeout placeholder shows 0 instead of real global default
+- [#5036](https://github.com/maximhq/bifrost/issues/5036) - Plugin StreamInterceptionError is flattened on integration routes
+- [#5037](https://github.com/maximhq/bifrost/issues/5037) - Disabled keys break provider model discovery
+- [#5051](https://github.com/maximhq/bifrost/issues/5051) - Add Sarvam AI provider (chat + TTS/STT)
+- [#5061](https://github.com/maximhq/bifrost/issues/5061) - Streaming responses drop citation annotations from the accumulated message
+- [#5093](https://github.com/maximhq/bifrost/issues/5093) - Streaming /v1/responses drops Anthropic redacted_thinking blocks
+- [#5097](https://github.com/maximhq/bifrost/issues/5097) - Anthropic rejects replayed tool_use/tool_result ids from non-conforming upstream providers
+- [#5100](https://github.com/maximhq/bifrost/issues/5100) - additional_tools loses nested tool types on /v1/responses
+- [#5101](https://github.com/maximhq/bifrost/issues/5101) - Chat-to-Responses tool replay sends role on function_call input items
+- [#5108](https://github.com/maximhq/bifrost/issues/5108) - Bedrock reasoning_config silently dropped on cross-provider translation
+- [#5113](https://github.com/maximhq/bifrost/issues/5113) - Gemini/Vertex streaming stops emitting web_search_call items after first grounded request


### PR DESCRIPTION
## Summary

This release bundles a large set of new provider integrations, durable background-job infrastructure, trace redaction, alerting configuration, and a broad sweep of bug fixes across streaming accumulation, governance rate-limiting, pooled-object hygiene, and provider-specific edge cases.

## Changes

- **Sarvam AI provider** added with chat, TTS, and STT support
- **ElevenLabs sound effects** endpoint (`/v1/sound-generation`) added
- **Durable background jobs** (`sidekiq` table, store methods, runner with recovery and reaper); cost recalculation migrated from SSE to a durable, resumable polling job; `runner_id` and `created_by_user_id` threaded through the job lifecycle
- **Bedrock project scoping** via optional `project_id` in Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex
- **Trace redaction** extended with phase-scoped redaction/revealing, a transient redaction data field for guardrails, and redaction before connector export
- **Audit log object storage** schema (S3/GCS) for archival
- **Alerting configuration** schema with declarative channels and CEL-based rules, Helm chart support, and enterprise fallback pages
- **Model catalog pricing** data added
- **Canonical model names** shown in dashboard model rankings instead of inference-profile IDs
- **OAuth2 hardening** with an allowlist for private-use redirect URI schemes (RFC 8252 §7.1) and a `shouldSweep` gate on the sweep worker
- **Mirrored schema support** via `schema_url` / `BIFROST_SCHEMA_URL`
- **Vertex single-region config** enforcement
- **Governance rate-limit CPU fix** — guards against invalid reset timeouts, parallelizes resting-budget flows only when required, and fixes the calendar-based alignment qualifier
- **Masked key persistence** — provider key previews are never written to config storage
- **Passthrough virtual key attribution** — Azure `api-key` passthrough calls now attribute to the virtual key
- **Rerank for custom providers** — `/v1/rerank` now works with custom OpenAI-compatible providers
- **Responses stream usage** — persisted when providers omit or reuse sequence numbers
- **Wildcard `allowed_models` repair** — bare `*` rows no longer break admin provider updates
- **Streaming accumulation** — citation annotations and `finish_reason` preserved in the accumulated response; `redacted_thinking` blocks round-tripped on the Responses surface
- **Gemini grounded streaming** — web-search flag reset when recycling pooled stream state so `web_search_call` items keep emitting
- **Bedrock truncation signal** — `max_output_tokens` truncation signalled on the Responses API
- **Bedrock `reasoning_config`** — preserved on cross-provider translation so fallbacks keep extended thinking
- **Anthropic `tool_search`** — forwarded and rebuilt on the Responses path
- **Anthropic tool ID sanitization** — `tool_use`/`tool_result` IDs sanitized to Anthropic's charset
- **OpenAI Responses input** — `role` stripped from non-message input items; compaction request `input` serialized correctly
- **`additional_tools` support** — nested tool types preserved on `/v1/responses`
- **Pooled object hygiene** — pooled `ChannelMessage` references zeroed on release; orphaned deferred spans swept in trace store TTL cleanup
- **Hybrid log token usage** — rebuilt from denormalized columns
- **MCP tool ordering** — deterministic ordering for prompt cache stability
- **Telemetry** — request/trace IDs forwarded, metrics cardinality risk reduced, status codes sent on OTEL metrics
- **Dashboard** — active time period preserved when applying dimension filters, bucket size thresholds adjusted for month-range durations, user popover shows `preferred_username` fallback, provider-level keys filtered from prompt manager selector
- **ClickHouse client library** upgraded

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

New environment variable: `BIFROST_SCHEMA_URL` (or `schema_url` in config) for mirrored schema locations in isolated deployments.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2347, #3455, #4318, #4353, #4367, #4402, #4477, #4679, #4689, #4712, #4780, #4834, #4846, #4851, #4870, #4940, #4963, #5002, #5013, #5027, #5036, #5037, #5051, #5061, #5093, #5097, #5100, #5101, #5108, #5113

## Security considerations

- Provider key previews (masked values) are no longer persisted to config storage, preventing accidental credential leakage.
- OAuth2 redirect URI scheme allowlist enforces RFC 8252 §7.1, restricting private-use scheme abuse.
- Trace redaction now applies before connector export, ensuring PII/sensitive content does not leave the system unredacted.
- MCP inline-auth `#t=` temp-token fragments must not be truncated; callers are now warned explicitly.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable