### PR TITLE
core changelog

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,40 @@
+- feat: add Sarvam AI provider with chat, text-to-speech, and speech-to-text support (thanks [@Purvi09](https://github.com/Purvi09)!)
+- feat: add ElevenLabs sound effects (text-to-sound) support (thanks [@SecretSun](https://github.com/SecretSun)!)
+- feat: add `ProjectID` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex
+- feat: add `additional_tools` message type support
+- feat: force single-region config in Vertex key config
+- feat: phase-scoped redaction and revealing with transient redaction data field, plus `ClearPausedStreamBuffer` for pause-accumulate stream flows
+- fix: map web search options to Google Search grounding in the Gemini API
+- fix: parse `SecretVar` JSON with `ref`/`env_var` fields even when `value` is absent
+- fix: cap max reasoning effort in OpenAI
+- fix: honor service tier in OpenAI chat completion
+- fix: support GA transcription-type sessions in POST /v1/realtime/client_secrets (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- fix: support diarized_json transcription segments and ElevenLabs speaker passthrough (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- fix: sanitize tool_use/tool_result ids to Anthropic's charset (thanks [@Shaik-Sirajuddin](https://github.com/Shaik-Sirajuddin)!)
+- fix: never persist masked provider key previews (thanks [@eyeveil](https://github.com/eyeveil)!)
+- fix: make tracing span lookup nil-safe to prevent panic on streaming errors (thanks [@eyeveil](https://github.com/eyeveil)!)
+- fix: enable rerank for custom OpenAI-compatible providers (thanks [@eyeveil](https://github.com/eyeveil)!)
+- fix: forward and rebuild Anthropic server-side tool_search on the Responses path (thanks [@ws4charlie](https://github.com/ws4charlie)!)
+- fix: zero pooled ChannelMessage references on release to avoid pinning request bodies (thanks [@citrocat](https://github.com/citrocat)!)
+- fix: round-trip Anthropic `redacted_thinking` blocks on the responses surface so multi-turn tool use with redacted reasoning can be replayed (thanks [@fus3r](https://github.com/fus3r)!)
+- fix: reset `HasEmittedWebSearch` when recycling pooled Gemini responses stream state so grounded streaming requests keep emitting `web_search_call` items (thanks [@fus3r](https://github.com/fus3r)!)
+- fix: omit role from OpenAI Responses non-message items (thanks [@nettee](https://github.com/nettee)!)
+- fix: serialize OpenAI compaction request `input` correctly (thanks [@mcclurmc](https://github.com/mcclurmc)!)
+- fix: preserve `reasoning_config` on Bedrock cross-provider translation (thanks [@Purvi09](https://github.com/Purvi09)!)
+- fix: preserve Gemini file upload MIME types for GenAI file URI completions
+- fix: Gemini video reference fields map to instances (thanks [@vojthor](https://github.com/vojthor)!)
+- fix: accept object-valued tool-call arguments (e.g. tool_search_call) on the Responses API streaming path
+- fix: recover from idle-timeout timer-goroutine panic that could crash the process
+- fix: deterministic MCP tool ordering for prompt cache stability
+- fix: pass through `gs://` image URLs on Vertex Gemini
+- fix: signal Bedrock max_output_tokens truncation on Responses API (thanks [@jeremym-tanium](https://github.com/jeremym-tanium)!)
+- fix: warn callers not to truncate the `#t=` temp-token fragment on MCP inline-auth links (thanks [@MarcusPeng](https://github.com/MarcusPeng)!)
+- fix: add `ExtraContent` to ChatStreamResponseChoiceDelta (thanks [@nghodkicisco](https://github.com/nghodkicisco)!)
+- fix: correct inference geo cost on Anthropic and cache rate for fast mode
+- fix: send MIME type when specified
+- fix: send status code on OTEL metrics
+- fix: reduce telemetry metrics cardinality explosion risk
+- fix: race conditions in tracer span locks
+- fix: pass container block from Anthropic API
+- fix: pass Azure auth headers in helpers
+- chore: upgrade ClickHouse client library


### PR DESCRIPTION
## Summary

This PR consolidates a batch of new provider integrations, feature additions, and bug fixes across the core gateway. It introduces Sarvam AI and ElevenLabs sound effects as new providers, expands configuration options for Bedrock and Vertex, and resolves a wide range of correctness and stability issues across streaming, tracing, transcription, and provider translation paths.

## Changes

- Added Sarvam AI provider with chat, text-to-speech, and speech-to-text support
- Added ElevenLabs text-to-sound (sound effects) support
- Added `ProjectID` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex
- Added `additional_tools` message type support
- Added phase-scoped redaction and revealing with transient redaction data field and `ClearPausedStreamBuffer` for pause-accumulate stream flows
- Forced single-region config in Vertex key config
- Mapped web search options to Google Search grounding in the Gemini API
- Fixed `SecretVar` JSON parsing when `value` is absent but `ref`/`env_var` fields are present
- Fixed max reasoning effort cap in OpenAI and honored service tier in OpenAI chat completion
- Fixed GA transcription-type session support in `POST /v1/realtime/client_secrets`
- Fixed diarized JSON transcription segments and ElevenLabs speaker passthrough
- Fixed tool_use/tool_result ID sanitization to Anthropic's charset
- Fixed masked provider key previews from being persisted
- Fixed nil-safe tracing span lookup to prevent panics on streaming errors
- Fixed rerank support for custom OpenAI-compatible providers
- Fixed Anthropic server-side `tool_search` forwarding on the Responses path
- Fixed pooled `ChannelMessage` references being zeroed on release to avoid pinning request bodies
- Fixed round-tripping of Anthropic `redacted_thinking` blocks on the Responses surface for multi-turn tool use replay
- Fixed `HasEmittedWebSearch` reset when recycling pooled Gemini response stream state
- Fixed role omission from OpenAI Responses non-message items
- Fixed OpenAI compaction request `input` serialization
- Fixed `reasoning_config` preservation on Bedrock cross-provider translation
- Fixed Gemini file upload MIME type preservation for GenAI file URI completions
- Fixed Gemini video reference fields mapping to instances
- Fixed object-valued tool-call arguments on the Responses API streaming path
- Fixed idle-timeout timer-goroutine panic that could crash the process
- Fixed deterministic MCP tool ordering for prompt cache stability
- Fixed `gs://` image URL passthrough on Vertex Gemini
- Fixed Bedrock `max_output_tokens` truncation signaling on the Responses API
- Fixed MCP inline-auth link temp-token fragment truncation warning
- Fixed `ExtraContent` addition to `ChatStreamResponseChoiceDelta`
- Fixed inference geo cost on Anthropic and cache rate for fast mode
- Fixed MIME type sending when specified
- Fixed status code forwarding on OTEL metrics
- Reduced telemetry metrics cardinality explosion risk
- Fixed race conditions in tracer span locks
- Fixed container block passthrough from Anthropic API
- Fixed Azure auth header forwarding in helpers
- Upgraded ClickHouse client library

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

- Validate Sarvam AI chat, TTS, and STT endpoints respond correctly with a configured Sarvam key.
- Validate ElevenLabs sound effects generation via the text-to-sound endpoint.
- Confirm Bedrock and Vertex requests respect `ProjectID` and per-alias overrides.
- Confirm streaming Gemini requests with grounding continue emitting `web_search_call` items across multiple turns.
- Confirm Anthropic multi-turn tool use with `redacted_thinking` blocks replays correctly on the Responses surface.
- Confirm no panic occurs on streaming errors or idle-timeout expiry.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

See individual contributor references in the changelog entries.

## Security considerations

- Masked provider key previews are no longer persisted, preventing accidental secret exposure.
- `SecretVar` parsing is hardened to handle missing `value` fields without error.
- MCP inline-auth links now warn callers against truncating the `#t=` temp-token fragment, preventing broken auth flows.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable