### PR TITLE
docs fixes

### DIFF
--- a/docs/changelogs/ent-v1.5.4.mdx
+++ b/docs/changelogs/ent-v1.5.4.mdx
@@ -1,0 +1,566 @@
+---
+title: "v1.5.4"
+description: "Enterprise v1.5.4 changelog - 2026-07-14"
+---
+
+<Update label="Bifrost Enterprise" description="v1.5.4">
+
+
+## Changelog
+
+Release on `transports/v1.6.4`. Ships a full guardrails redaction engine (PII, secrets, and custom regex redaction with logs-only and reversible modes plus RBAC-gated reveal), a new alerting system with declarative channels and CEL-based rules, and a major SCIM/OIDC provisioning overhaul including SailPoint support, wildcard/glob role mappings, and transactional team/BU mapping ownership transfers. Also picks up the new Sarvam AI provider and durable background jobs from OSS.
+
+## ✨ Features
+
+- **Guardrails Redaction** - New redaction pipeline for guardrails: detect, block, and redact actions for PII providers (Presidio and Azure Language PII, with multi-select entity search), secrets detection, and custom regex rules, with findings composed across guardrails into a single redaction result. [Docs](https://docs.getbifrost.ai/enterprise/guardrails/redaction)
+- **Redaction Modes and RBAC Reveal** - Redaction supports logs-only and reversible modes, configurable per guardrail in the UI. Reveal of redacted log content is RBAC-gated, redaction and reveal are phase-scoped, guardrail replacements are published to trace exporters, and raw request/response payloads in extra fields are redacted when redaction is enabled.
+- **Streaming Output Redaction** - Redaction now applies to streaming output for PII providers, including Responses API streams.
+- **Alerting** - New alerting system with declarative channels and CEL-based rules: channel registry with delivery logic, an evaluation layer sourcing metrics from governance, alert history stored in the log store, config.json loading and reconciliation, a leader-lifecycle-driven alerting manager, a dedicated RBAC resource, and a full management UI with channel icons in history.
+- **Wildcard and Glob Role Mappings** - Attribute-to-role mappings in OIDC/SCIM configuration now support wildcard and glob pattern matching on attribute values.
+- **SailPoint SCIM Provider** - SCIM provisioning support enabled for the SailPoint identity provider.
+- **Entra Provisioning Performance** - Entra group and user fetches are parallelized and batched via the Graph API, with progress reporting, live import counters in the sync UI, and role filtering support.
+- **Keycloak Group and Role Propagation** - Keycloak group names and roles are propagated to the idpUser during SCIM provisioning.
+- **Team/BU Mapping Ownership Management** - OIDC team mapping ownership moves are transactional with preflight collision detection, the UI warns on team/BU mapping ownership moves and renames before saving SCIM config, business unit lookup uses `source_id` with name fallback and backfill, and OIDC-owned team and BU names are reconciled on mapping changes during login and sync.
+- **SCIM Config Hot-Reload** - SCIM provider configuration changes are gossiped cluster-wide so all nodes hot-reload without a restart.
+- **WebSocket Propagation Progress** - Access profile propagation job progress is now pushed over WebSocket events instead of polling.
+- **Optional Google Workspace Admin Email** - Google Workspace `adminEmail` is now optional; bulk sync is disabled when it is absent or the Directory API is unreachable.
+- **MCP Tool Group Lookup by ID** - MCP tool groups can be referenced by ID in addition to name during config reconciliation.
+- **Leader-Gated OAuth2 Sweep Worker** - A leader-gated sweep worker purges expired authorize requests, revoked refresh tokens, and orphaned dynamic clients.
+- **Connector Attribution Attributes** - Connectors now carry previously missing attribution attributes, with expanded test coverage across the BigQuery, Kafka, Pub/Sub, and Datadog connectors.
+
+## 🌎 Open Source Features
+
+- **Sarvam AI Provider** - Sarvam AI added as a first-class provider with chat, text-to-speech, and speech-to-text support. [Docs](https://docs.getbifrost.ai/providers/supported-providers/sarvam)
+- **ElevenLabs Sound Effects** - Text-to-sound generation support via `/v1/sound-generation`. [Docs](https://docs.getbifrost.ai/providers/supported-providers/elevenlabs)
+- **Bedrock Project Scoping** - Optional `project_id` in Bedrock and Bedrock Mantle key configs, with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex, plus UI support.
+- **Trace Redaction** - Phase-scoped redaction and revealing, a transient redaction data field for guardrails, and trace content redaction before connector export.
+- **Durable Background Jobs** - New `sidekiq` background-job table, store methods, and runner with recovery; cost recalculation migrated to a durable, resumable job with polling instead of SSE.
+- **Audit Log Object Storage** - S3/GCS object storage config schema for audit log archival.
+- **Alerting Configuration Schema** - Alerting schema in `config.schema.json` with declarative channels and CEL-based rules, plus Helm chart support.
+- **Model Catalog Pricing** - Pricing data added to the model catalog.
+- **Canonical Model Names** - Dashboard model rankings show canonical model names instead of inference-profile IDs.
+- **OAuth2 Hardening** - Allowlist for private-use redirect URI schemes (RFC 8252 section 7.1) and a `shouldSweep` gate on the OAuth2 sweep worker.
+- **Mirrored Schema Support** - `schema_url` / `BIFROST_SCHEMA_URL` for mirrored schema locations in isolated deployments.
+- **Vertex Single-Region Config** - Single-region configuration is enforced in Vertex key config.
+- **Helm Chart Updates** - `bifrost.alerting`, audit-log object storage, `postgresql.external.port` string support, and `bifrost.mcp.toolGroups[*].id`.
+
+## 🐞 Fixed
+
+- **OIDC Token Endpoint** - Explicit `tokenEndpoint` is preferred over the auto-constructed URL in OIDC config.
+- **Redaction Shared References** - Request/response objects are copied before redaction to avoid shared reference mutation; cloning only happens for logs-only mode.
+- **Propagate Job Cancellation** - Context cancellation is respected when acquiring the semaphore in the propagate job.
+- **Access Profile Broadcast** - Removed redundant access profile change broadcast on update.
+- **BU Mapping Reassignment** - BU mapping ownership is transferred on SCIM group reassignment instead of erroring or duplicating.
+- **Duplicate Job Execution** - The sidekiq reaper was replaced with an atomic dispatcher, preventing duplicate job execution in multi-node clusters.
+- **Governance State Sync** - Governance no longer blocks on state sync; requests are served from DB state while leader sync retries, and state-sync baselines are snapshotted under lock to prevent concurrent map read/write.
+- **Token Refresh Race** - Fixed a race condition in token refresh.
+- **Prompt Logging** - The actual prompt is no longer logged back in responses.
+- **BigQuery Writer Double Close** - Fixed a double close of the managed writer in the BigQuery connector.
+- **Linked Scopes Cleanup** - Deleting a linked scope now deletes the linked rule.
+- **Sync Users Sheet** - The sync users sheet can be closed during the importing step.
+- **Governance Rate-Limit Reset CPU** (OSS) - Guards against invalid reset timeouts, parallelizes resting-budget flows only when required, and fixes the calendar-based alignment qualifier.
+- **Masked Key Persistence** (OSS) - Masked provider key previews are never persisted to config storage.
+- **OpenShift Arbitrary UIDs** (OSS) - Build-time group-0 ownership with no runtime chown.
+- **Passthrough Virtual Key Attribution** (OSS) - Passthrough calls via the Azure `api-key` header now attribute to the virtual key.
+- **Rerank for Custom Providers** (OSS) - `/v1/rerank` now works with custom OpenAI-compatible providers.
+- **Responses Stream Usage** (OSS) - Stream usage is persisted when providers omit or reuse sequence numbers.
+- **Wildcard allowed_models Repair** (OSS) - Bare wildcard `allowed_models` rows that broke admin provider updates are repaired.
+- **Streaming Error Panic** (OSS) - Nil-safe tracing span lookup prevents panics on streaming errors.
+- **Anthropic Tool ID Sanitization** (OSS) - `tool_use`/`tool_result` ids are sanitized to Anthropic's charset.
+- **Realtime Transcription Sessions** (OSS) - GA transcription-type sessions supported in `POST /v1/realtime/client_secrets`.
+- **Diarized Transcription** (OSS) - `diarized_json` segments and ElevenLabs speaker passthrough supported.
+- **Model Discovery** (OSS) - Disabled keys are skipped when scheduling model-discovery fetches.
+- **MCP Timeout Placeholder** (OSS) - The MCP tool execution timeout placeholder shows the real global default.
+- **Redacted Thinking Round-Trip** (OSS) - Anthropic `redacted_thinking` blocks round-trip on the Responses surface.
+- **Streaming Accumulation** (OSS) - Citation annotations and `finish_reason` are preserved in the accumulated streaming response.
+- **Gemini Grounded Streaming** (OSS) - Web-search flag is reset when recycling pooled stream state so `web_search_call` items keep emitting.
+- **Vertex gs:// Images** (OSS) - `gs://` image URLs pass through on Vertex Gemini.
+- **Bedrock Truncation Signal** (OSS) - `max_output_tokens` truncation is signaled on the Responses API.
+- **Bedrock Reasoning Config** (OSS) - `reasoning_config` is preserved on cross-provider translation so fallbacks keep extended thinking.
+- **Anthropic tool_search** (OSS) - Server-side `tool_search` is forwarded and rebuilt on the Responses path.
+- **OpenAI Responses Input** (OSS) - `role` is stripped from non-message input items and compaction request `input` is serialized correctly.
+- **additional_tools Support** (OSS) - `additional_tools` message type support added, preserving nested tool types on `/v1/responses`.
+- **Plugin Stream Errors** (OSS) - Structured plugin stream errors are emitted on integration routes.
+- **Pooled Object Hygiene** (OSS) - Pooled ChannelMessage references are zeroed on release and orphaned deferred spans are swept in trace store TTL cleanup.
+- **Hybrid Log Token Usage** (OSS) - Token usage is rebuilt from denormalized columns in hybrid log list.
+- **MCP Tool Ordering** (OSS) - Deterministic MCP tool ordering for prompt cache stability.
+- **MCP Inline-Auth Links** (OSS) - Callers are warned not to truncate the `#t=` temp-token fragment.
+- **Gemini Fixes** (OSS) - Web search options map to Google Search grounding, file upload MIME types are preserved, and video reference fields map to instances.
+- **OpenAI Parameters** (OSS) - Service tier honored in chat completion and max reasoning effort capped.
+- **Anthropic Costing** (OSS) - Corrected inference geo cost and cache rate for fast mode.
+- **SecretVar Parsing** (OSS) - `SecretVar` JSON with `ref`/`env_var` fields parses even when `value` is absent.
+- **Telemetry** (OSS) - Request id and trace id forwarded, metrics cardinality explosion risk reduced, and status codes sent on OTEL metrics.
+- **Dashboard** (OSS) - Active time period preserved when applying dimension filters, bucket size thresholds adjusted for month-range durations, user popover with `preferred_username` fallback, and provider-level keys filtered from the prompt manager selector.
+- **API Key Provider Selection** (OSS) - Fixed provider selection for API keys.
+- **Azure Auth Headers** (OSS) - Azure auth headers are passed in helpers.
+- **Stream Delta Schema** (OSS) - `ExtraContent` added to `ChatStreamResponseChoiceDelta`.
+
+## 🐙 Closed OSS Issues
+
+- [#2347](https://github.com/maximhq/bifrost/issues/2347) - MCP tool ordering is non-deterministic, breaking prefix-based prompt caching
+- [#3455](https://github.com/maximhq/bifrost/issues/3455) - Segfault/nil dereference panic in Bedrock provider
+- [#4318](https://github.com/maximhq/bifrost/issues/4318) - allowed_models persisted as bare "*" string blocks subsequent provider updates
+- [#4353](https://github.com/maximhq/bifrost/issues/4353) - config.db corruption from masked-key preview in provider_configs JSON column
+- [#4367](https://github.com/maximhq/bifrost/issues/4367) - Image incompatible with OpenShift arbitrary UIDs
+- [#4402](https://github.com/maximhq/bifrost/issues/4402) - Vertex provider drops image blocks whose URL uses gs:// scheme
+- [#4477](https://github.com/maximhq/bifrost/issues/4477) - Passthrough calls using a Virtual Key log as actual key
+- [#4679](https://github.com/maximhq/bifrost/issues/4679) - Bedrock Responses API does not signal max_output_tokens truncation
+- [#4689](https://github.com/maximhq/bifrost/issues/4689) - Custom providers cannot set budget
+- [#4712](https://github.com/maximhq/bifrost/issues/4712) - ElevenLabs sound effects (/v1/sound-generation)
+- [#4780](https://github.com/maximhq/bifrost/issues/4780) - Anthropic server-side tool_search results are dropped on /v1/responses
+- [#4834](https://github.com/maximhq/bifrost/issues/4834) - /v1/rerank is not available with custom providers
+- [#4846](https://github.com/maximhq/bifrost/issues/4846) - Responses stream usage present in response.completed but not persisted in LLM Logs
+- [#4851](https://github.com/maximhq/bifrost/issues/4851) - Governance rate-limit reset causes high CPU in BumpRateLimitUsage
+- [#4870](https://github.com/maximhq/bifrost/issues/4870) - Pooled ChannelMessage retains request body, context, and undelivered response while idle
+- [#4940](https://github.com/maximhq/bifrost/issues/4940) - Show canonical model names instead of Bedrock inference-profile IDs in Model Rankings
+- [#4963](https://github.com/maximhq/bifrost/issues/4963) - Streaming finish_reason dropped from the accumulated (logged) response
+- [#5002](https://github.com/maximhq/bifrost/issues/5002) - gpt-4o-transcribe-diarize transcription fails due to string segment IDs
+- [#5013](https://github.com/maximhq/bifrost/issues/5013) - OpenAI /responses/compact input serialized as a JSON object causing 400
+- [#5027](https://github.com/maximhq/bifrost/issues/5027) - MCP Tool Execution Timeout placeholder shows 0 instead of real global default
+- [#5036](https://github.com/maximhq/bifrost/issues/5036) - Plugin StreamInterceptionError is flattened on integration routes
+- [#5037](https://github.com/maximhq/bifrost/issues/5037) - Disabled keys break provider model discovery
+- [#5051](https://github.com/maximhq/bifrost/issues/5051) - Add Sarvam AI provider (chat + TTS/STT)
+- [#5061](https://github.com/maximhq/bifrost/issues/5061) - Streaming responses drop citation annotations from the accumulated message
+- [#5093](https://github.com/maximhq/bifrost/issues/5093) - Streaming /v1/responses drops Anthropic redacted_thinking blocks
+- [#5097](https://github.com/maximhq/bifrost/issues/5097) - Anthropic rejects replayed tool_use/tool_result ids from non-conforming upstream providers
+- [#5100](https://github.com/maximhq/bifrost/issues/5100) - additional_tools loses nested tool types on /v1/responses
+- [#5101](https://github.com/maximhq/bifrost/issues/5101) - Chat-to-Responses tool replay sends role on function_call input items
+- [#5108](https://github.com/maximhq/bifrost/issues/5108) - Bedrock reasoning_config silently dropped on cross-provider translation
+- [#5113](https://github.com/maximhq/bifrost/issues/5113) - Gemini/Vertex streaming stops emitting web_search_call items after first grounded request
+
+## 📀 Base OSS version
+
+`transports/v1.6.4`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```go
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.4
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	cloud.google.com/go/pubsub/v2 v2.4.0
+	cloud.google.com/go/secretmanager v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.1
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/cel-go v0.28.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.28.2
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/hashicorp/vault/api v1.23.0
+	github.com/klauspost/compress v1.18.6
+	github.com/maximhq/bifrost/core v1.7.1
+	github.com/maximhq/bifrost/framework v1.5.1
+	github.com/maximhq/bifrost/plugins/governance v1.6.5
+	github.com/maximhq/bifrost/plugins/logging v1.6.1
+	github.com/maximhq/bifrost/plugins/prompts v1.0.28
+	github.com/maximhq/bifrost/plugins/semanticcache v1.5.28
+	github.com/maximhq/bifrost/transports v1.6.4
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.71.0
+	github.com/zricethezav/gitleaks/v8 v8.30.1
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.282.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68
+	google.golang.org/grpc v1.81.1
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+
+require (
+	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/storage v1.62.1 // indirect
+	dario.cat/mergo v1.0.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
+	github.com/ClickHouse/ch-go v0.65.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.32.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/proto v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.73.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.71.0 // indirect
+	github.com/DataDog/go-libddwaf/v4 v4.6.1 // indirect
+	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
+	github.com/DataDog/go-sqllexer v0.1.8 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
+	github.com/DataDog/sketches-go v1.4.7 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/ProtonMail/go-crypto v1.1.6 // indirect
+	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/andybalholm/brotli v1.2.2 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.5 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
+	github.com/bodgit/plumbing v1.3.0 // indirect
+	github.com/bodgit/sevenzip v1.6.0 // indirect
+	github.com/bodgit/windows v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/lipgloss v0.5.0 // indirect
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/fasthttp/websocket v1.5.12 // indirect
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/semgroup v1.2.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
+	github.com/go-faster/city v1.0.1 // indirect
+	github.com/go-faster/errors v0.7.1 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.9.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/analysis v0.24.2 // indirect
+	github.com/go-openapi/errors v0.22.5 // indirect
+	github.com/go-openapi/jsonpointer v0.22.4 // indirect
+	github.com/go-openapi/jsonreference v0.21.4 // indirect
+	github.com/go-openapi/loads v0.23.2 // indirect
+	github.com/go-openapi/runtime v0.29.2 // indirect
+	github.com/go-openapi/spec v0.22.2 // indirect
+	github.com/go-openapi/strfmt v0.25.0 // indirect
+	github.com/go-openapi/swag v0.25.4 // indirect
+	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
+	github.com/go-openapi/swag/conv v0.25.4 // indirect
+	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
+	github.com/go-openapi/swag/loading v0.25.4 // indirect
+	github.com/go-openapi/swag/mangling v0.25.4 // indirect
+	github.com/go-openapi/swag/netutils v0.25.4 // indirect
+	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
+	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
+	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/go-openapi/validate v0.25.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.3 // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-metrics v0.5.4 // indirect
+	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/go-version v1.8.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jaswdr/faker/v2 v2.8.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.43.2 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/maximhq/bifrost/plugins/compat v0.1.27 // indirect
+	github.com/maximhq/bifrost/plugins/maxim v1.6.28 // indirect
+	github.com/maximhq/bifrost/plugins/mocker v1.5.28 // indirect
+	github.com/maximhq/bifrost/plugins/modelcatalogresolver v1.0.9 // indirect
+	github.com/maximhq/bifrost/plugins/otel v1.4.0 // indirect
+	github.com/maximhq/bifrost/plugins/telemetry v1.5.28 // indirect
+	github.com/maximhq/maxim-go v0.2.1 // indirect
+	github.com/mholt/archives v0.1.2 // indirect
+	github.com/miekg/dns v1.1.68 // indirect
+	github.com/minio/minlz v1.0.0 // indirect
+	github.com/minio/simdjson-go v0.4.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/moby/api v1.54.1 // indirect
+	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/moby/patternmatcher v0.6.1 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode/v2 v2.2.2 // indirect
+	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/onsi/ginkgo/v2 v2.25.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/outcaste-io/ristretto v0.2.3 // indirect
+	github.com/paulmach/orb v0.11.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pinecone-io/go-pinecone/v5 v5.3.0 // indirect
+	github.com/pion/datachannel v1.6.0 // indirect
+	github.com/pion/dtls/v3 v3.1.2 // indirect
+	github.com/pion/ice/v4 v4.2.1 // indirect
+	github.com/pion/interceptor v0.1.44 // indirect
+	github.com/pion/logging v0.2.4 // indirect
+	github.com/pion/mdns/v2 v2.1.0 // indirect
+	github.com/pion/randutil v0.1.0 // indirect
+	github.com/pion/rtcp v1.2.16 // indirect
+	github.com/pion/rtp v1.10.1 // indirect
+	github.com/pion/sctp v1.9.2 // indirect
+	github.com/pion/sdp/v3 v3.0.18 // indirect
+	github.com/pion/srtp/v3 v3.0.10 // indirect
+	github.com/pion/stun/v3 v3.1.1 // indirect
+	github.com/pion/transport/v4 v4.0.1 // indirect
+	github.com/pion/turn/v4 v4.1.4 // indirect
+	github.com/pion/webrtc/v4 v4.2.9 // indirect
+	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
+	github.com/qdrant/go-client v1.16.2 // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sergi/go-diff v1.4.0 // indirect
+	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/viper v1.19.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/theckman/httpforwarded v0.4.0 // indirect
+	github.com/therootcompany/xz v1.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.16 // indirect
+	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/wasilibs/go-re2 v1.9.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/weaviate/weaviate v1.36.5 // indirect
+	github.com/weaviate/weaviate-go-client/v5 v5.7.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.0.2 // indirect
+	go.einride.tech/aip v0.83.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.6.6 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.6.6 // indirect
+	go.mongodb.org/mongo-driver v1.17.7 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/component v1.39.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.39.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.133.0 // indirect
+	go.opentelemetry.io/collector/pdata v1.39.0 // indirect
+	go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
+	golang.org/x/arch v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
+	golang.org/x/term v0.43.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/clickhouse v0.7.0 // indirect
+	gorm.io/driver/postgres v1.6.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
+)
+```
+
+</Update>

--- a/docs/changelogs/v1.6.4.mdx
+++ b/docs/changelogs/v1.6.4.mdx
@@ -106,7 +106,7 @@ description: "v1.6.4 changelog - 2026-07-14"
 - [#5113](https://github.com/maximhq/bifrost/issues/5113) - Gemini/Vertex streaming stops emitting web_search_call items after first grounded request
 
 </Update>
-<Update label="Core" description="1.6.4">
+<Update label="Core" description="1.7.1">
 - feat: add Sarvam AI provider with chat, text-to-speech, and speech-to-text support (thanks [@Purvi09](https://github.com/Purvi09)!)
 - feat: add ElevenLabs sound effects (text-to-sound) support (thanks [@SecretSun](https://github.com/SecretSun)!)
 - feat: add `ProjectID` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex
@@ -149,7 +149,7 @@ description: "v1.6.4 changelog - 2026-07-14"
 - chore: upgrade ClickHouse client library
 
 </Update>
-<Update label="Framework" description="1.4.4">
+<Update label="Framework" description="1.5.1">
 - feat: add durable background-job `sidekiq` table, store methods, and runner with recovery and reaper
 - feat: pass created-by user ID and runner ID through sidekiq job lifecycle, add `GetInFlightSidekiqJobByKind` to config store interface
 - feat: show canonical model names in dashboard model rankings (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)
@@ -168,58 +168,58 @@ description: "v1.6.4 changelog - 2026-07-14"
 - chore: upgrade ClickHouse client library
 
 </Update>
-<Update label="compat" description="0.1.26">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="compat" description="0.1.27">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="governance" description="1.6.4">
+<Update label="governance" description="1.6.5">
 - fix: parallelize resting-budget flows only when absolutely required to reduce lock contention
 - fix: add guards against invalid rate-limit reset timeouts
 - fix: calendar-based alignment qualifier for budget periods
 - fix: attribute passthrough virtual keys sent via Azure api-key header (thanks [@eyeveil](https://github.com/eyeveil)!)
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="jsonparser" description="1.5.27">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="jsonparser" description="1.5.28">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="logging" description="1.5.27">
+<Update label="logging" description="1.6.1">
 - feat: migrate cost recalculation to durable background sidekiq job with resume and dedup
 - feat: redact trace content before connector export
 - fix: match model filter on canonical_model_name and restore routing info for cost recalculation
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="maxim" description="1.6.27">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="maxim" description="1.6.28">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="mocker" description="1.5.27">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="mocker" description="1.5.28">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="modelcatalogresolver" description="1.0.8">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="modelcatalogresolver" description="1.0.9">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="otel" description="1.3.4">
+<Update label="otel" description="1.4.0">
 - fix: send status code on OTEL metrics
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="prompts" description="1.0.27">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="prompts" description="1.0.28">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="semanticcache" description="1.5.27">
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+<Update label="semanticcache" description="1.5.28">
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>
-<Update label="telemetry" description="1.5.27">
+<Update label="telemetry" description="1.5.28">
 - feat: add missing connector attributes
 - fix: reduce metrics cardinality explosion risk
 - fix: forward request id and trace id through telemetry
-- chore: upgraded core to v1.6.4 and framework to v1.4.4
+- chore: upgraded core to v1.7.1 and framework to v1.5.1
 
 </Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -910,6 +910,7 @@
             "icon": "building",
             "pages": [
               "changelogs/ent-v2.0.0-prerelease1",
+              "changelogs/ent-v1.5.4",
               "changelogs/ent-v1.5.3",
               "changelogs/ent-v1.5.2",
               "changelogs/ent-v1.5.1",


### PR DESCRIPTION
## Summary

Adds the Enterprise v1.5.4 changelog and updates the OSS v1.6.4 changelog to reflect bumped plugin and module versions across the ecosystem. The Enterprise release ships on `transports/v1.6.4` and introduces a guardrails redaction engine, a new alerting system, major SCIM/OIDC provisioning improvements, and picks up OSS additions including the Sarvam AI provider and durable background jobs.

## Changes

- Added `docs/changelogs/ent-v1.5.4.mdx` documenting the full Enterprise v1.5.4 release, including:
  - Guardrails redaction pipeline (PII via Presidio/Azure Language, secrets detection, custom regex) with logs-only and reversible modes, RBAC-gated reveal, and streaming output redaction
  - New alerting system with declarative channels, CEL-based rules, alert history, and a management UI
  - SCIM/OIDC overhaul: SailPoint support, wildcard/glob role mappings, Entra parallelized fetches, Keycloak group/role propagation, transactional team/BU mapping ownership transfers, and SCIM config hot-reload via cluster gossip
  - WebSocket-based propagation progress, optional Google Workspace admin email, leader-gated OAuth2 sweep worker, and connector attribution attributes
- Updated `docs/changelogs/v1.6.4.mdx` to reflect version bumps across all OSS plugins and modules: Core (`1.7.1`), Framework (`1.5.1`), compat (`0.1.27`), governance (`1.6.5`), logging (`1.6.1`), otel (`1.4.0`), telemetry (`1.5.28`), and all other plugins incremented accordingly.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the new changelog page renders correctly in the docs site and that all version labels in `v1.6.4.mdx` match the updated plugin versions.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Covers OSS issues: #2347, #3455, #4318, #4353, #4367, #4402, #4477, #4679, #4689, #4712, #4780, #4834, #4846, #4851, #4870, #4940, #4963, #5002, #5013, #5027, #5036, #5037, #5051, #5061, #5093, #5097, #5100, #5101, #5108, #5113.

## Security considerations

The Enterprise changelog documents RBAC-gated reveal of redacted PII/secrets content, phase-scoped redaction, and OAuth2 hardening (private-use redirect URI allowlist, sweep worker gating). No new security surface is introduced by the documentation change itself.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable