### PR TITLE
fix(bedrock): map ConverseStream stopReason for tool-use turns

### DIFF
--- a/core/providers/bedrock/conversestreamstop_test.go
+++ b/core/providers/bedrock/conversestreamstop_test.go
@@ -164,6 +164,60 @@ func TestConverseStreamToolUseBlockEmitsContentBlockStop(t *testing.T) {
 	}
 }
 
+func TestConverseStreamToolUseSetsToolUseStopReason(t *testing.T) {
+	functionCallType := schemas.ResponsesMessageTypeFunctionCall
+	toolItem := &schemas.ResponsesMessage{
+		Type: &functionCallType,
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: schemas.Ptr("call_1"),
+			Name:   schemas.Ptr("get_weather"),
+		},
+	}
+	chunks := []*schemas.BifrostResponsesStreamResponse{
+		{Type: schemas.ResponsesStreamResponseTypeCreated},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex:  schemas.Ptr(0),
+			ContentIndex: schemas.Ptr(0),
+			Item:         toolItem,
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			ContentIndex: schemas.Ptr(0),
+			Delta:        schemas.Ptr(`{"location":"Paris"}`),
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex:  schemas.Ptr(0),
+			ContentIndex: schemas.Ptr(0),
+			Item:         toolItem,
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				StopReason: schemas.Ptr(string(schemas.BifrostFinishReasonToolCalls)),
+			},
+		},
+	}
+
+	events := encodeConverseStream(t, chunks)
+	for _, event := range events {
+		if event.EventType != "messageStop" {
+			continue
+		}
+		messageStop, ok := event.Payload.(BedrockMessageStopEvent)
+		if !ok {
+			t.Fatalf("messageStop payload has unexpected type %T", event.Payload)
+		}
+		if messageStop.StopReason != "tool_use" {
+			t.Fatalf("messageStop stopReason: want %q, got %q", "tool_use", messageStop.StopReason)
+		}
+		return
+	}
+
+	t.Fatal("messageStop event not found")
+}
+
 // TestConverseStreamReasoningBlockEmitsContentBlockStop covers a reasoning block:
 // reasoning deltas stream as contentBlockDelta(reasoningContent) and the block is
 // closed by the contentBlockStop emitted on the reasoning item's OutputItemDone.

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1791,8 +1791,12 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 	case schemas.ResponsesStreamResponseTypeCompleted:
 		// Message stop - always set stopReason
 		stopReason := "end_turn"
-		if bifrostResp.Response != nil && bifrostResp.Response.IncompleteDetails != nil {
-			stopReason = bifrostResp.Response.IncompleteDetails.Reason
+		if bifrostResp.Response != nil {
+			if bifrostResp.Response.StopReason != nil {
+				stopReason = convertBifrostToBedrockStopReason(*bifrostResp.Response.StopReason)
+			} else if bifrostResp.Response.IncompleteDetails != nil {
+				stopReason = bifrostResp.Response.IncompleteDetails.Reason
+			}
 		}
 		event.StopReason = &stopReason
 


### PR DESCRIPTION
## Summary

On the Bedrock ConverseStream egress, tool-use turns were streaming the toolUse content block correctly but the terminal messageStop event always carried stopReason end_turn. AWS SDK and agent clients that dispatch tools only when stopReason is tool_use never ran tools.

The non-streaming Converse path already maps Bifrost tool_calls to Bedrock tool_use. The streaming Completed handler only looked at IncompleteDetails and ignored Response.StopReason.

## Changes

- In ToBedrockConverseStreamResponse Completed handling, prefer Response.StopReason (via convertBifrostToBedrockStopReason), then IncompleteDetails, then default end_turn.
- Add TestConverseStreamToolUseSetsToolUseStopReason covering a tool-use stream ending with StopReason tool_calls.

Fixes #5206

## Verification

```
cd core && go test ./providers/bedrock/ -count=1 -run 'TestConverseStream' -v
```

All four ConverseStream tests passed locally, including the new stopReason case.

## Backwards compatibility

No API surface change. Only stopReason mapping for completed stream events when StopReason is already present on the Bifrost response.
