### PR TITLE
feat: send HTTP/2 PING keepalives on the Bedrock provider

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -9,3 +9,4 @@
 - fix: bedrock invoke flow now retains image/tool_use/tool_return content blocks that were previously dropped by the decoder (#5814)
 - fix: inject placeholder text block for document-only messages on Bedrock, which otherwise rejected the request (#5817)
 - fix: retain tool `cache_control` markers through Bedrock Converse invoke requests so prompt caching applies to system blocks and tools (#5811)
+- feat: opt-in HTTP/2 PING keepalives on the Bedrock provider via a configurable interval (0 = off) [@jeremym-tanium](https://github.com/jeremym-tanium)

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -10,3 +10,4 @@
 - fix: inject placeholder text block for document-only messages on Bedrock, which otherwise rejected the request (#5817)
 - fix: retain tool `cache_control` markers through Bedrock Converse invoke requests so prompt caching applies to system blocks and tools (#5811)
 - feat: opt-in HTTP/2 PING keepalives on the Bedrock provider via a configurable interval (0 = off) [@jeremym-tanium](https://github.com/jeremym-tanium)
+- fix: clamp http2_ping_interval_in_seconds to avoid int64 overflow on conversion to time.Duration [@jeremym-tanium](https://github.com/jeremym-tanium)

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -122,6 +122,14 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		transport.TLSClientConfig = tlsConfig
 	}
 
+	// When HTTP/2 is enforced, send client-initiated PING keepalives so an idle
+	// streaming connection isn't closed by an intermediary (surfaces as "unexpected EOF").
+	if config.NetworkConfig.EnforceHTTP2 {
+		transport.HTTP2 = &http.HTTP2Config{
+			SendPingTimeout: time.Duration(config.NetworkConfig.HTTP2PingIntervalInSeconds) * time.Second,
+		}
+	}
+
 	client := &http.Client{Transport: transport, Timeout: requestTimeout}
 	streamingClient := providerUtils.BuildStreamingHTTPClient(client)
 

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -122,9 +122,10 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		transport.TLSClientConfig = tlsConfig
 	}
 
-	// When HTTP/2 is enforced, send client-initiated PING keepalives so an idle
-	// streaming connection isn't closed by an intermediary (surfaces as "unexpected EOF").
-	if config.NetworkConfig.EnforceHTTP2 {
+	// When HTTP/2 is enforced and a ping interval is configured, send client-initiated
+	// PING keepalives so an idle streaming connection isn't closed by an intermediary
+	// (surfaces as "unexpected EOF"). Left off by default; opt in via the interval.
+	if config.NetworkConfig.EnforceHTTP2 && config.NetworkConfig.HTTP2PingIntervalInSeconds > 0 {
 		transport.HTTP2 = &http.HTTP2Config{
 			SendPingTimeout: time.Duration(config.NetworkConfig.HTTP2PingIntervalInSeconds) * time.Second,
 		}

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -579,6 +579,44 @@ func TestBedrockTransportHTTP2Config(t *testing.T) {
 	assert.Equal(t, schemas.DefaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
 	assert.Equal(t, schemas.DefaultMaxIdleConnsPerHost, transport.MaxIdleConns)
 	assert.True(t, transport.ForceAttemptHTTP2)
+	assert.Nil(t, transport.HTTP2, "ping keepalive must stay off when the interval is unset")
+}
+
+func TestBedrockTransportHTTP2PingKeepalive(t *testing.T) {
+	newTransport := func(t *testing.T, enforceHTTP2 bool, pingIntervalSeconds int) *http.Transport {
+		t.Helper()
+		config := &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 300,
+				EnforceHTTP2:                   enforceHTTP2,
+				HTTP2PingIntervalInSeconds:     pingIntervalSeconds,
+			},
+		}
+		config.CheckAndSetDefaults()
+
+		provider, err := NewBedrockProvider(config, noopLogger{})
+		require.NoError(t, err)
+
+		transport, ok := provider.client.Transport.(*http.Transport)
+		require.True(t, ok, "transport should be *http.Transport")
+		return transport
+	}
+
+	t.Run("enforced with a positive interval configures the PING keepalive", func(t *testing.T) {
+		transport := newTransport(t, true, 45)
+		require.NotNil(t, transport.HTTP2, "enforce_http2 + positive interval must set transport.HTTP2")
+		assert.Equal(t, 45*time.Second, transport.HTTP2.SendPingTimeout)
+	})
+
+	t.Run("enforced with a zero interval leaves the keepalive off", func(t *testing.T) {
+		transport := newTransport(t, true, 0)
+		assert.Nil(t, transport.HTTP2, "enforce_http2 alone must not imply pinging")
+	})
+
+	t.Run("non-enforced with a positive interval leaves the keepalive off", func(t *testing.T) {
+		transport := newTransport(t, false, 45)
+		assert.Nil(t, transport.HTTP2, "a ping interval without enforce_http2 must be a no-op")
+	})
 }
 
 func TestBedrockTransportCustomMaxConns(t *testing.T) {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -21,7 +21,6 @@ const (
 	DefaultStreamIdleTimeoutInSeconds = 120 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
 	DefaultKeepAliveTimeoutInSeconds  = 30  // Idle keep-alive for pooled connections — how long an idle connection is kept for reuse before being closed
 	DefaultMaxConnsPerHost            = 5000
-	DefaultHTTP2PingIntervalInSeconds = 30 // Seconds of stream idle before an HTTP/2 keepalive PING
 	MaxConnsPerHostUpperBound         = 10000
 	DefaultMaxIdleConnsPerHost        = 40
 )
@@ -66,7 +65,7 @@ type NetworkConfig struct {
 	KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`  // Idle keep-alive for pooled connections; set below the upstream server's keep-alive to avoid reusing connections it has already closed. Default: 30s
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
-	HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"` // Seconds of stream idle before an HTTP/2 keepalive PING (0 = default 30s; only when enforce_http2)
+	HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"` // Seconds of stream idle before an HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)
 	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
 	AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`          // Allow connections to RFC 1918 private IPs (for k8s pods, LAN deployments). Link-local (169.254.x.x) is always blocked.
 }
@@ -571,10 +570,6 @@ func (config *ProviderConfig) CheckAndSetDefaults() {
 
 	if config.NetworkConfig.DefaultRequestTimeoutInSeconds <= 0 {
 		config.NetworkConfig.DefaultRequestTimeoutInSeconds = DefaultRequestTimeoutInSeconds
-	}
-
-	if config.NetworkConfig.EnforceHTTP2 && config.NetworkConfig.HTTP2PingIntervalInSeconds <= 0 {
-		config.NetworkConfig.HTTP2PingIntervalInSeconds = DefaultHTTP2PingIntervalInSeconds
 	}
 
 	if config.NetworkConfig.MaxRetries == 0 {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -23,10 +23,12 @@ const (
 	DefaultMaxConnsPerHost            = 5000
 	MaxConnsPerHostUpperBound         = 10000
 	DefaultMaxIdleConnsPerHost        = 40
-	// HTTP2PingIntervalUpperBoundSeconds is the largest value that survives
-	// conversion to time.Duration (int64 nanoseconds) without overflow:
-	// math.MaxInt64 / time.Second, floored.
-	HTTP2PingIntervalUpperBoundSeconds = 9223372036
+	// HTTP2PingIntervalUpperBoundSeconds matches the sibling *_in_seconds fields
+	// on NetworkConfig (StreamIdleTimeoutInSeconds, KeepAliveTimeoutInSeconds),
+	// which cap at 3600 in config.schema.json — a sensible range for this field
+	// and, incidentally, nowhere near where the * time.Second conversion in the
+	// Bedrock transport could overflow int64 (math.MaxInt64 / time.Second).
+	HTTP2PingIntervalUpperBoundSeconds = 3600
 )
 
 // Pre-defined errors for provider operations

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -21,6 +21,7 @@ const (
 	DefaultStreamIdleTimeoutInSeconds = 120 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
 	DefaultKeepAliveTimeoutInSeconds  = 30  // Idle keep-alive for pooled connections — how long an idle connection is kept for reuse before being closed
 	DefaultMaxConnsPerHost            = 5000
+	DefaultHTTP2PingIntervalInSeconds = 30 // Seconds of stream idle before an HTTP/2 keepalive PING
 	MaxConnsPerHostUpperBound         = 10000
 	DefaultMaxIdleConnsPerHost        = 40
 )
@@ -65,6 +66,7 @@ type NetworkConfig struct {
 	KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`  // Idle keep-alive for pooled connections; set below the upstream server's keep-alive to avoid reusing connections it has already closed. Default: 30s
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
+	HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"` // Seconds of stream idle before an HTTP/2 keepalive PING (0 = default 30s; only when enforce_http2)
 	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
 	AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`          // Allow connections to RFC 1918 private IPs (for k8s pods, LAN deployments). Link-local (169.254.x.x) is always blocked.
 }
@@ -90,6 +92,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
+		HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
 		AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`
 	}
@@ -110,6 +113,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.KeepAliveTimeoutInSeconds = alias.KeepAliveTimeoutInSeconds
 	nc.MaxConnsPerHost = alias.MaxConnsPerHost
 	nc.EnforceHTTP2 = alias.EnforceHTTP2
+	nc.HTTP2PingIntervalInSeconds = alias.HTTP2PingIntervalInSeconds
 	nc.BetaHeaderOverrides = alias.BetaHeaderOverrides
 	nc.AllowPrivateNetwork = alias.AllowPrivateNetwork
 
@@ -183,6 +187,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		KeepAliveTimeoutInSeconds      int               `json:"keep_alive_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
+		HTTP2PingIntervalInSeconds     int               `json:"http2_ping_interval_in_seconds,omitempty"`
 		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
 		AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`
 	}
@@ -200,6 +205,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		KeepAliveTimeoutInSeconds:  nc.KeepAliveTimeoutInSeconds,
 		MaxConnsPerHost:            nc.MaxConnsPerHost,
 		EnforceHTTP2:               nc.EnforceHTTP2,
+		HTTP2PingIntervalInSeconds: nc.HTTP2PingIntervalInSeconds,
 		BetaHeaderOverrides:        nc.BetaHeaderOverrides,
 		AllowPrivateNetwork:        nc.AllowPrivateNetwork,
 	}
@@ -565,6 +571,10 @@ func (config *ProviderConfig) CheckAndSetDefaults() {
 
 	if config.NetworkConfig.DefaultRequestTimeoutInSeconds <= 0 {
 		config.NetworkConfig.DefaultRequestTimeoutInSeconds = DefaultRequestTimeoutInSeconds
+	}
+
+	if config.NetworkConfig.EnforceHTTP2 && config.NetworkConfig.HTTP2PingIntervalInSeconds <= 0 {
+		config.NetworkConfig.HTTP2PingIntervalInSeconds = DefaultHTTP2PingIntervalInSeconds
 	}
 
 	if config.NetworkConfig.MaxRetries == 0 {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -23,6 +23,10 @@ const (
 	DefaultMaxConnsPerHost            = 5000
 	MaxConnsPerHostUpperBound         = 10000
 	DefaultMaxIdleConnsPerHost        = 40
+	// HTTP2PingIntervalUpperBoundSeconds is the largest value that survives
+	// conversion to time.Duration (int64 nanoseconds) without overflow:
+	// math.MaxInt64 / time.Second, floored.
+	HTTP2PingIntervalUpperBoundSeconds = 9223372036
 )
 
 // Pre-defined errors for provider operations
@@ -596,6 +600,12 @@ func (config *ProviderConfig) CheckAndSetDefaults() {
 		config.NetworkConfig.MaxConnsPerHost = DefaultMaxConnsPerHost
 	} else if config.NetworkConfig.MaxConnsPerHost > MaxConnsPerHostUpperBound {
 		config.NetworkConfig.MaxConnsPerHost = MaxConnsPerHostUpperBound
+	}
+
+	// Clamp before the seconds-to-time.Duration conversion in the Bedrock
+	// transport (* time.Second) can silently overflow int64.
+	if config.NetworkConfig.HTTP2PingIntervalInSeconds > HTTP2PingIntervalUpperBoundSeconds {
+		config.NetworkConfig.HTTP2PingIntervalInSeconds = HTTP2PingIntervalUpperBoundSeconds
 	}
 
 	// Create a defensive copy of ExtraHeaders to prevent data races

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1159,10 +1159,10 @@ func TestNetworkConfig_HTTP2PingInterval(t *testing.T) {
 	assert.Equal(t, 45, decoded.HTTP2PingIntervalInSeconds, "http2_ping_interval_in_seconds should round-trip")
 	assert.Contains(t, string(data), `"http2_ping_interval_in_seconds":45`)
 
-	// enforce_http2 set + interval unset -> filled with the default
+	// enforce_http2 set + interval unset -> left at zero (pings are opt-in, off by default)
 	cfgDefault := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true}}
 	cfgDefault.CheckAndSetDefaults()
-	assert.Equal(t, DefaultHTTP2PingIntervalInSeconds, cfgDefault.NetworkConfig.HTTP2PingIntervalInSeconds)
+	assert.Equal(t, 0, cfgDefault.NetworkConfig.HTTP2PingIntervalInSeconds)
 
 	// explicit interval is preserved
 	cfgExplicit := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: 5}}

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1150,6 +1150,31 @@ func TestNetworkConfig_StreamIdleTimeoutRoundTrip(t *testing.T) {
 	assert.Contains(t, string(data), `"stream_idle_timeout_in_seconds":120`)
 }
 
+func TestNetworkConfig_HTTP2PingInterval(t *testing.T) {
+	nc := NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: 45}
+	data, err := json.Marshal(nc)
+	require.NoError(t, err)
+	var decoded NetworkConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, 45, decoded.HTTP2PingIntervalInSeconds, "http2_ping_interval_in_seconds should round-trip")
+	assert.Contains(t, string(data), `"http2_ping_interval_in_seconds":45`)
+
+	// enforce_http2 set + interval unset -> filled with the default
+	cfgDefault := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true}}
+	cfgDefault.CheckAndSetDefaults()
+	assert.Equal(t, DefaultHTTP2PingIntervalInSeconds, cfgDefault.NetworkConfig.HTTP2PingIntervalInSeconds)
+
+	// explicit interval is preserved
+	cfgExplicit := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: 5}}
+	cfgExplicit.CheckAndSetDefaults()
+	assert.Equal(t, 5, cfgExplicit.NetworkConfig.HTTP2PingIntervalInSeconds)
+
+	// enforce_http2 off -> left at zero (no ping keepalive)
+	cfgOff := &ProviderConfig{}
+	cfgOff.CheckAndSetDefaults()
+	assert.Equal(t, 0, cfgOff.NetworkConfig.HTTP2PingIntervalInSeconds)
+}
+
 // TestNormalizeResponsesToolType verifies that versioned/provider-specific tool type
 // strings are normalized to their canonical ResponsesToolType values.
 func TestNormalizeResponsesToolType(t *testing.T) {

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1173,6 +1173,12 @@ func TestNetworkConfig_HTTP2PingInterval(t *testing.T) {
 	cfgOff := &ProviderConfig{}
 	cfgOff.CheckAndSetDefaults()
 	assert.Equal(t, 0, cfgOff.NetworkConfig.HTTP2PingIntervalInSeconds)
+
+	// a value above the int64-nanosecond ceiling is clamped rather than left to
+	// overflow silently when the Bedrock transport multiplies it by time.Second
+	cfgOverflow := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: HTTP2PingIntervalUpperBoundSeconds + 1}}
+	cfgOverflow.CheckAndSetDefaults()
+	assert.Equal(t, HTTP2PingIntervalUpperBoundSeconds, cfgOverflow.NetworkConfig.HTTP2PingIntervalInSeconds)
 }
 
 // TestNormalizeResponsesToolType verifies that versioned/provider-specific tool type

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5740,6 +5740,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 9223372036,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "beta_header_overrides": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5740,7 +5740,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "beta_header_overrides": {
           "type": "object",

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5740,7 +5740,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 9223372036,
+          "maximum": 3600,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "beta_header_overrides": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5737,6 +5737,11 @@
           "type": "boolean",
           "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
+        "http2_ping_interval_in_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
+        },
         "beta_header_overrides": {
           "type": "object",
           "additionalProperties": {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3724,7 +3724,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 9223372036,
+          "maximum": 3600,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {
@@ -3805,7 +3805,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 9223372036,
+          "maximum": 3600,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3721,6 +3721,11 @@
           "type": "boolean",
           "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
+        "http2_ping_interval_in_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
+        },
         "insecure_skip_verify": {
           "type": "boolean",
           "description": "Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments."
@@ -3795,6 +3800,11 @@
         "enforce_http2": {
           "type": "boolean",
           "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
+        },
+        "http2_ping_interval_in_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
         },
         "insecure_skip_verify": {
           "type": "boolean",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3724,6 +3724,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 9223372036,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {
@@ -3804,6 +3805,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
+          "maximum": 9223372036,
           "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3724,7 +3724,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -3804,7 +3804,7 @@
         "http2_ping_interval_in_seconds": {
           "type": "integer",
           "minimum": 0,
-          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = default 30; only when enforce_http2)."
+          "description": "Seconds of stream idle before a client-initiated HTTP/2 keepalive PING (0 = disabled; only when enforce_http2)."
         },
         "insecure_skip_verify": {
           "type": "boolean",

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -43,7 +43,7 @@ const NetworkConfigSchema = z
 		keep_alive_timeout_in_seconds: z.number().int().min(1).max(3600).optional(),
 		max_conns_per_host: z.number().int().min(1).max(10000).optional(),
 		enforce_http2: z.boolean().optional(),
-		http2_ping_interval_in_seconds: z.number().int().min(0).optional(),
+		http2_ping_interval_in_seconds: z.number().int().min(0).max(3600).optional(),
 	})
 	.refine((v) => v.retry_backoff_initial <= v.retry_backoff_max, {
 		message: "Initial backoff must be <= max backoff",

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -43,6 +43,7 @@ const NetworkConfigSchema = z
 		keep_alive_timeout_in_seconds: z.number().int().min(1).max(3600).optional(),
 		max_conns_per_host: z.number().int().min(1).max(10000).optional(),
 		enforce_http2: z.boolean().optional(),
+		http2_ping_interval_in_seconds: z.number().int().min(0).optional(),
 	})
 	.refine((v) => v.retry_backoff_initial <= v.retry_backoff_max, {
 		message: "Initial backoff must be <= max backoff",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -262,6 +262,7 @@ export interface NetworkConfig {
 	keep_alive_timeout_in_seconds?: number;
 	max_conns_per_host?: number;
 	enforce_http2?: boolean;
+	http2_ping_interval_in_seconds?: number;
 	beta_header_overrides?: Record<string, boolean>;
 	allow_private_network?: boolean;
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -430,6 +430,12 @@ export const networkConfigSchema = z
 			.max(10000, "Max connections must be at most 10000")
 			.optional(),
 		enforce_http2: z.boolean().optional(),
+		http2_ping_interval_in_seconds: z
+			.number()
+			.int("HTTP/2 ping interval must be a whole number of seconds")
+			.min(0, "HTTP/2 ping interval must be at least 0 seconds")
+			.max(3600, "HTTP/2 ping interval must be at most 3600 seconds i.e. 60 minutes")
+			.optional(),
 		allow_private_network: z.boolean().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
@@ -489,6 +495,12 @@ export const networkFormConfigSchema = z
 			.max(10000, "Max connections must be at most 10000")
 			.optional(),
 		enforce_http2: z.boolean().optional(),
+		http2_ping_interval_in_seconds: z.coerce
+			.number("HTTP/2 ping interval must be a number")
+			.int("HTTP/2 ping interval must be a whole number of seconds")
+			.min(0, "HTTP/2 ping interval must be at least 0 seconds")
+			.max(3600, "HTTP/2 ping interval must be at most 3600 seconds i.e. 60 minutes")
+			.optional(),
 		allow_private_network: z.boolean().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {


### PR DESCRIPTION
## Summary
When a Bedrock stream goes silent for tens of seconds (model "thinking"), an intermediary (reverse proxy / load balancer / service mesh) with an idle timeout shorter than the gap can sever the connection, surfacing as `io.ErrUnexpectedEOF`. This adds client-initiated HTTP/2 PING keepalives on the Bedrock provider transport so a quiet stream stays warm.

## Changes
- `core/providers/bedrock/bedrock.go`: when `network_config.enforce_http2` is set and a positive `http2_ping_interval_in_seconds` is configured, set the transport's `http.HTTP2Config{SendPingTimeout}` (Go 1.24+ stdlib) to send a PING after that idle interval. Off by default (no ping) to keep `enforce_http2` orthogonal to keepalive.
- `core/schemas/provider.go`: add `http2_ping_interval_in_seconds` to `NetworkConfig` (opt-in; `0` = disabled, matching net/http's own `SendPingTimeout` semantics; mirrored in the Marshal/Unmarshal aliases).
- `core/schemas/serialization_test.go`: unit test for the field round-trip + opt-in (0 = off) behavior.

## Type of change
- [x] New feature (non-breaking)

## How to test
`cd core && go test ./schemas/ -run TestNetworkConfig_HTTP2PingInterval -count=1`. Also validated end-to-end against real Bedrock behind an intermediary with a short idle timeout: HTTP/2 negotiated, PING frames emitted at the interval, stream survives a long thinking gap.

## Affected areas
core / providers / bedrock; core / schemas

## Breaking changes
None — gated on the existing `enforce_http2` flag; default off.

## Related issues
Closes #5211

## Security considerations
None.

