### PR TITLE
initial implementation of extra data toggle

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6349,7 +6349,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if cfg := config.CustomProviderConfig; cfg != nil && cfg.BaseProviderType != "" {
 			baseProvider = cfg.BaseProviderType
 		}
-		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
+		resolvePassthroughExtraParams(req.Context, config, baseProvider, req.RequestType)
 
 		// Disable Anthropic raw-body passthrough when this attempt's provider isn't Anthropic-native (e.g. Bedrock).
 		clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider)

--- a/core/providers/deepseek/deepseek.go
+++ b/core/providers/deepseek/deepseek.go
@@ -84,7 +84,7 @@ func (provider *DeepSeekProvider) ListModels(ctx *schemas.BifrostContext, keys [
 // It formats the request, sends it to DeepSeek, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *DeepSeekProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
@@ -105,7 +105,7 @@ func (provider *DeepSeekProvider) TextCompletion(ctx *schemas.BifrostContext, ke
 // It formats the request, sends it to DeepSeek, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *DeepSeekProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
@@ -128,7 +128,7 @@ func (provider *DeepSeekProvider) TextCompletionStream(ctx *schemas.BifrostConte
 
 // ChatCompletion performs a chat completion request to the DeepSeek API.
 func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
@@ -151,7 +151,7 @@ func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 // Uses DeepSeek's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostStreamChunk objects representing the stream or an error if the request fails.
 func (provider *DeepSeekProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -112,8 +112,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		openaiReq.ChatParameters.Prediction = prediction
 		return openaiReq
 	default:
-		// Check if provider is a custom provider
-		if isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool); ok && isCustomProvider {
+		if passthroughExtraParams, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); passthroughExtraParams {
 			return openaiReq
 		}
 		openaiReq.filterOpenAISpecificParameters(capModel)

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -106,6 +106,40 @@ func TestToOpenAIChatRequest_PreservesN(t *testing.T) {
 	}
 }
 
+func TestToOpenAIChatRequest_CustomProviderUsesEffectivePassthroughPolicy(t *testing.T) {
+	cacheKey := "provider-cache-key"
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.ModelProvider("custom-openai-compatible"),
+		Model:    "custom-model",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+		Params:   &schemas.ChatParameters{PromptCacheKey: &cacheKey},
+	}
+
+	for _, tt := range []struct {
+		name string
+		pass bool
+	}{
+		{name: "false filters provider-specific fields", pass: false},
+		{name: "true preserves provider-specific fields", pass: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, tt.pass)
+
+			result := ToOpenAIChatRequest(ctx, request)
+			if result == nil {
+				t.Fatal("expected request")
+			}
+			if tt.pass && (result.PromptCacheKey == nil || *result.PromptCacheKey != cacheKey) {
+				t.Fatalf("prompt_cache_key = %#v, want %q", result.PromptCacheKey, cacheKey)
+			}
+			if !tt.pass && result.PromptCacheKey != nil {
+				t.Fatalf("prompt_cache_key should be filtered, got %#v", result.PromptCacheKey)
+			}
+		})
+	}
+}
+
 func TestToOpenAIChatRequest_NormalizesReasoningEffort(t *testing.T) {
 	// DeepSeek is configured as a custom OpenAI-compatible provider, which registers
 	// itself so ParseModelString can strip its prefix from "deepseek/deepseek-v4-pro".

--- a/core/providers/sgl/chat_test.go
+++ b/core/providers/sgl/chat_test.go
@@ -86,8 +86,7 @@ func TestChatCompletion_ExtraParamsForwardedAutomatically(t *testing.T) {
 		},
 	}
 
-	// Intentionally do NOT set BifrostContextKeyPassthroughExtraParams — the provider
-	// should set it automatically.
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	hello := "Hello"

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -126,7 +126,7 @@ func (provider *SGLProvider) ListModels(ctx *schemas.BifrostContext, keys []sche
 
 // TextCompletion performs a text completion request to the SGL API.
 func (provider *SGLProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -151,7 +151,7 @@ func (provider *SGLProvider) TextCompletion(ctx *schemas.BifrostContext, key sch
 // It formats the request, sends it to SGL, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *SGLProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -178,7 +178,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx *schemas.BifrostContext, p
 
 // ChatCompletion performs a chat completion request to the SGL API.
 func (provider *SGLProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -205,7 +205,7 @@ func (provider *SGLProvider) ChatCompletion(ctx *schemas.BifrostContext, key sch
 // Uses SGL's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *SGLProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/vllm/chat_test.go
+++ b/core/providers/vllm/chat_test.go
@@ -55,8 +55,7 @@ func TestChatCompletion_ExtraParamsForwardedAutomatically(t *testing.T) {
 		},
 	}
 
-	// Intentionally do NOT set BifrostContextKeyPassthroughExtraParams — the provider
-	// should set it automatically.
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	hello := "Hello"

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -119,7 +119,7 @@ func (provider *VLLMProvider) ListModels(ctx *schemas.BifrostContext, keys []sch
 
 // TextCompletion performs a text completion request to vLLM's API.
 func (provider *VLLMProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -142,7 +142,7 @@ func (provider *VLLMProvider) TextCompletion(ctx *schemas.BifrostContext, key sc
 
 // TextCompletionStream performs a streaming text completion request to vLLM's API.
 func (provider *VLLMProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -169,7 +169,7 @@ func (provider *VLLMProvider) TextCompletionStream(ctx *schemas.BifrostContext, 
 
 // ChatCompletion performs a chat completion request to vLLM's API.
 func (provider *VLLMProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -193,7 +193,7 @@ func (provider *VLLMProvider) ChatCompletion(ctx *schemas.BifrostContext, key sc
 
 // ChatCompletionStream performs a streaming chat completion request to vLLM's API.
 func (provider *VLLMProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -304,7 +304,7 @@ const (
 	BifrostContextKeyDropRawResponseFromClient           BifrostContextKey = "bifrost-drop-raw-response-from-client"            // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw response should be stripped from the client-facing response
 	BifrostContextKeyShouldStoreRawInLogs                BifrostContextKey = "bifrost-should-store-raw-in-logs"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request/response should be persisted in log records
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
-	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyPassthroughExtraParamsOverride      BifrostContextKey = "bifrost-passthrough-extra-params-override"        // bool (set by HTTP transport from a valid request header)
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyHTTPRoute                           BifrostContextKey = "bifrost-http-route"                               // string (set by bifrost - DO NOT SET THIS MANUALLY — matched route template, set by HTTP transport; used as the low-cardinality metrics `path` label)
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -533,10 +533,11 @@ type ProviderConfig struct {
 	ConcurrencyAndBufferSize ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
 	Logger                  Logger                `json:"-"`
-	ProxyConfig             *ProxyConfig          `json:"proxy_config,omitempty"`     // Proxy configuration
-	SendBackRawRequest      bool                  `json:"send_back_raw_request"`      // Send raw request back in the bifrost response (default: false)
-	SendBackRawResponse     bool                  `json:"send_back_raw_response"`     // Send raw response back in the bifrost response (default: false)
-	StoreRawRequestResponse bool                  `json:"store_raw_request_response"` // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
+	ProxyConfig             *ProxyConfig          `json:"proxy_config,omitempty"`             // Proxy configuration
+	SendBackRawRequest      bool                  `json:"send_back_raw_request"`              // Send raw request back in the bifrost response (default: false)
+	SendBackRawResponse     bool                  `json:"send_back_raw_response"`             // Send raw response back in the bifrost response (default: false)
+	StoreRawRequestResponse bool                  `json:"store_raw_request_response"`         // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
+	PassthroughExtraParams  *bool                 `json:"passthrough_extra_params,omitempty"` // Whether extra request parameters are forwarded to the provider (nil uses provider default)
 	CustomProviderConfig    *CustomProviderConfig `json:"custom_provider_config,omitempty"`
 	OpenAIConfig            *OpenAIConfig         `json:"openai_config,omitempty"`
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -377,6 +377,8 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyLargeResponseMode)
 	ctx.ClearValue(schemas.BifrostContextKeyExtraHeaders)
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
+	ctx.ClearValue(schemas.BifrostContextKeyPassthroughExtraParamsOverride)
+	ctx.ClearValue(schemas.BifrostContextKeyPassthroughExtraParams)
 }
 
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {
@@ -406,6 +408,36 @@ var standardProvidersSet = func() map[schemas.ModelProvider]struct{} {
 func IsStandardProvider(providerKey schemas.ModelProvider) bool {
 	_, ok := standardProvidersSet[providerKey]
 	return ok
+}
+
+// resolvePassthroughExtraParams resolves and records the converter policy for one
+// provider attempt. Request overrides are intentionally stored separately from the
+// effective value so each fallback can recompute its own policy.
+func resolvePassthroughExtraParams(ctx *schemas.BifrostContext, config *schemas.ProviderConfig, baseProvider schemas.ModelProvider, requestType schemas.RequestType) bool {
+	if ctx != nil {
+		if override, ok := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParamsOverride).(bool); ok {
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, override)
+			return override
+		}
+	}
+
+	if config != nil && config.PassthroughExtraParams != nil {
+		effective := *config.PassthroughExtraParams
+		if ctx != nil {
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, effective)
+		}
+		return effective
+	}
+
+	effective := baseProvider == schemas.VLLM ||
+		baseProvider == schemas.SGL ||
+		baseProvider == schemas.DeepSeek ||
+		requestType == schemas.ImageGenerationRequest ||
+		requestType == schemas.ImageGenerationStreamRequest
+	if ctx != nil {
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, effective)
+	}
+	return effective
 }
 
 // IsStreamRequestType returns true if the given request type is a stream request.

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -273,3 +273,54 @@ func TestIsPrivateIP(t *testing.T) {
 	}
 }
 
+func TestResolvePassthroughExtraParams(t *testing.T) {
+	trueValue, falseValue := true, false
+	tests := []struct {
+		name        string
+		override    *bool
+		config      *bool
+		provider    schemas.ModelProvider
+		requestType schemas.RequestType
+		want        bool
+	}{
+		{name: "generic default", provider: schemas.OpenAI, requestType: schemas.ChatCompletionRequest, want: false},
+		{name: "vllm default", provider: schemas.VLLM, requestType: schemas.ChatCompletionRequest, want: true},
+		{name: "sgl default", provider: schemas.SGL, requestType: schemas.ChatCompletionRequest, want: true},
+		{name: "deepseek default", provider: schemas.DeepSeek, requestType: schemas.ChatCompletionRequest, want: true},
+		{name: "image generation default", provider: schemas.OpenAI, requestType: schemas.ImageGenerationRequest, want: true},
+		{name: "explicit false beats provider default", config: &falseValue, provider: schemas.DeepSeek, requestType: schemas.ChatCompletionRequest, want: false},
+		{name: "explicit true enables generic provider", config: &trueValue, provider: schemas.OpenAI, requestType: schemas.ChatCompletionRequest, want: true},
+		{name: "header false beats explicit true", override: &falseValue, config: &trueValue, provider: schemas.VLLM, requestType: schemas.ChatCompletionRequest, want: false},
+		{name: "header true beats explicit false", override: &trueValue, config: &falseValue, provider: schemas.OpenAI, requestType: schemas.ChatCompletionRequest, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			if tt.override != nil {
+				ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParamsOverride, *tt.override)
+			}
+
+			got := resolvePassthroughExtraParams(ctx, &schemas.ProviderConfig{PassthroughExtraParams: tt.config}, tt.provider, tt.requestType)
+			if got != tt.want {
+				t.Fatalf("resolved policy = %t, want %t", got, tt.want)
+			}
+			if effective, ok := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); !ok || effective != tt.want {
+				t.Fatalf("effective context policy = (%t, %t), want (%t, true)", effective, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePassthroughExtraParams_OverwritesPriorAttempt(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	resolvePassthroughExtraParams(ctx, &schemas.ProviderConfig{}, schemas.DeepSeek, schemas.ChatCompletionRequest)
+	if got, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); !got {
+		t.Fatal("DeepSeek default should enable passthrough")
+	}
+
+	resolvePassthroughExtraParams(ctx, &schemas.ProviderConfig{}, schemas.OpenAI, schemas.ChatCompletionRequest)
+	if got, ok := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); !ok || got {
+		t.Fatalf("effective policy after fallback = (%t, %t), want (false, true)", got, ok)
+	}
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -445,6 +445,7 @@ type ProviderConfig struct {
 	SendBackRawRequest       bool                              `json:"send_back_raw_request"`                 // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
 	StoreRawRequestResponse  bool                              `json:"store_raw_request_response"`            // Capture raw request/response for internal logging only; strip from API responses returned to clients
+	PassthroughExtraParams   *bool                             `json:"passthrough_extra_params,omitempty"`    // Whether extra request parameters are forwarded to the provider (nil uses provider default)
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
 	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`               // OpenAI-specific configuration
 	ConfigHash               string                            `json:"config_hash,omitempty"`                 // Hash of config.json version, used for change detection
@@ -459,12 +460,18 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 	if p.NetworkConfig != nil {
 		redactedNetworkConfig = p.NetworkConfig.Redacted()
 	}
+	var passthroughExtraParams *bool
+	if p.PassthroughExtraParams != nil {
+		value := *p.PassthroughExtraParams
+		passthroughExtraParams = &value
+	}
 	redactedConfig := ProviderConfig{
 		NetworkConfig:            redactedNetworkConfig,
 		ConcurrencyAndBufferSize: p.ConcurrencyAndBufferSize,
 		SendBackRawRequest:       p.SendBackRawRequest,
 		SendBackRawResponse:      p.SendBackRawResponse,
 		StoreRawRequestResponse:  p.StoreRawRequestResponse,
+		PassthroughExtraParams:   passthroughExtraParams,
 		CustomProviderConfig:     p.CustomProviderConfig,
 		OpenAIConfig:             p.OpenAIConfig,
 		ConfigHash:               p.ConfigHash,
@@ -706,6 +713,11 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 	// Hash StoreRawRequestResponse
 	if p.StoreRawRequestResponse {
 		hash.Write([]byte("storeRawRequestResponse"))
+	}
+	// Hash PassthroughExtraParams, preserving nil/false/true as distinct configurations.
+	if p.PassthroughExtraParams != nil {
+		hash.Write([]byte("passthroughExtraParams"))
+		hash.Write([]byte(strconv.FormatBool(*p.PassthroughExtraParams)))
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -228,3 +228,27 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 			"env var reference %q missing from redacted JSON output", ref)
 	}
 }
+
+func TestProviderConfigRedactedPreservesPassthroughExtraParams(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value *bool
+	}{
+		{name: "nil"},
+		{name: "false", value: schemas.Ptr(false)},
+		{name: "true", value: schemas.Ptr(true)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := ProviderConfig{PassthroughExtraParams: tt.value}
+			redacted := config.Redacted()
+
+			if tt.value == nil {
+				assert.Nil(t, redacted.PassthroughExtraParams)
+				return
+			}
+			require.NotNil(t, redacted.PassthroughExtraParams)
+			assert.Equal(t, *tt.value, *redacted.PassthroughExtraParams)
+			assert.NotSame(t, config.PassthroughExtraParams, redacted.PassthroughExtraParams)
+		})
+	}
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -446,6 +446,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_inference_geo_multiplier_column"}, run: migrationAddInferenceGeoMultiplierColumn},
 	{IDs: []string{"repair_bare_wildcard_allowed_models"}, run: migrationRepairBareWildcardAllowedModels},
 	{IDs: []string{"add_bedrock_project_id_columns"}, run: migrationAddBedrockProjectIDColumns},
+	{IDs: []string{"add_passthrough_extra_params_column"}, run: migrationAddPassthroughExtraParamsColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10677,4 +10678,21 @@ func migrationAddSidekiqKindStatusCreatedIndex(ctx context.Context, db *gorm.DB,
 		return fmt.Errorf("error running %s migration: %w", migrationName, err)
 	}
 	return nil
+}
+
+// migrationAddPassthroughExtraParamsColumn adds the nullable passthrough_extra_params column to providers without changing existing rows.
+func migrationAddPassthroughExtraParamsColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_passthrough_extra_params_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+
+	return RunSingleMigration(ctx, migrator.DefaultOptions, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &tables.TableProvider{}, "passthrough_extra_params")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return dropColumnIfExists(tx.WithContext(ctx), logger, &tables.TableProvider{}, "passthrough_extra_params")
+		},
+	})
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2767,3 +2767,34 @@ func TestFullMigration_UpgradeFromPreDumpErrorsSchema(t *testing.T) {
 	assert.NotEmpty(t, gotHash)
 	assert.NotEqual(t, "stale-hash", gotHash, "config_hash should have been recomputed by the chain")
 }
+
+func TestMigrationAddPassthroughExtraParamsColumnIsNullableAndIdempotent(t *testing.T) {
+	for _, ndb := range forEachProviderMigrationDB(t, "passthrough_extra_params") {
+		t.Run(ndb.name, func(t *testing.T) {
+			db := ndb.db
+			ctx := context.Background()
+			now := time.Now()
+			require.NoError(t, db.Exec(`
+				INSERT INTO config_providers (name, config_hash, created_at, updated_at, encryption_status)
+				VALUES (?, ?, ?, ?, ?)
+			`, "existing-provider", "existing-hash", now, now, "plain_text").Error)
+
+			require.False(t, db.Migrator().HasColumn(&tables.TableProvider{}, "passthrough_extra_params"))
+			require.NoError(t, migrationAddPassthroughExtraParamsColumn(ctx, db, testMigrationLogger))
+			require.True(t, db.Migrator().HasColumn(&tables.TableProvider{}, "passthrough_extra_params"))
+
+			var existing tables.TableProvider
+			require.NoError(t, db.Where("name = ?", "existing-provider").First(&existing).Error)
+			assert.Nil(t, existing.PassthroughExtraParams, "migration must not backfill a provider default")
+
+			require.NoError(t, migrationAddPassthroughExtraParamsColumn(ctx, db, testMigrationLogger))
+
+			require.NoError(t, db.Model(&tables.TableProvider{}).
+				Where("name = ?", "existing-provider").
+				Update("passthrough_extra_params", false).Error)
+			require.NoError(t, db.Where("name = ?", "existing-provider").First(&existing).Error)
+			require.NotNil(t, existing.PassthroughExtraParams)
+			assert.False(t, *existing.PassthroughExtraParams)
+		})
+	}
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -662,6 +662,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			SendBackRawRequest:       providerConfig.SendBackRawRequest,
 			SendBackRawResponse:      providerConfig.SendBackRawResponse,
 			StoreRawRequestResponse:  providerConfig.StoreRawRequestResponse,
+			PassthroughExtraParams:   providerConfig.PassthroughExtraParams,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
 			OpenAIConfig:             providerConfig.OpenAIConfig,
 			ConfigHash:               providerConfig.ConfigHash,
@@ -891,6 +892,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.SendBackRawRequest = configCopy.SendBackRawRequest
 	dbProvider.SendBackRawResponse = configCopy.SendBackRawResponse
 	dbProvider.StoreRawRequestResponse = configCopy.StoreRawRequestResponse
+	dbProvider.PassthroughExtraParams = configCopy.PassthroughExtraParams
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
 	dbProvider.OpenAIConfig = configCopy.OpenAIConfig
 	dbProvider.ConfigHash = configCopy.ConfigHash
@@ -1062,6 +1064,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		SendBackRawRequest:       configCopy.SendBackRawRequest,
 		SendBackRawResponse:      configCopy.SendBackRawResponse,
 		StoreRawRequestResponse:  configCopy.StoreRawRequestResponse,
+		PassthroughExtraParams:   configCopy.PassthroughExtraParams,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
 		OpenAIConfig:             configCopy.OpenAIConfig,
 		ConfigHash:               configCopy.ConfigHash,
@@ -1221,6 +1224,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			SendBackRawRequest:       dbProvider.SendBackRawRequest,
 			SendBackRawResponse:      dbProvider.SendBackRawResponse,
 			StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
+			PassthroughExtraParams:   dbProvider.PassthroughExtraParams,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
 			OpenAIConfig:             dbProvider.OpenAIConfig,
 			ConfigHash:               dbProvider.ConfigHash,
@@ -1254,6 +1258,7 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 		SendBackRawRequest:       dbProvider.SendBackRawRequest,
 		SendBackRawResponse:      dbProvider.SendBackRawResponse,
 		StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
+		PassthroughExtraParams:   dbProvider.PassthroughExtraParams,
 		CustomProviderConfig:     dbProvider.CustomProviderConfig,
 		OpenAIConfig:             dbProvider.OpenAIConfig,
 		ConfigHash:               dbProvider.ConfigHash,

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2313,3 +2313,43 @@ func TestUpsertModelParametersBatch_SQLite(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, got, 3)
 }
+
+func TestRDBConfigStore_ProviderPassthroughExtraParamsRoundTrip(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		value *bool
+	}{
+		{name: "omitted"},
+		{name: "disabled", value: schemas.Ptr(false)},
+		{name: "enabled", value: schemas.Ptr(true)},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := schemas.ModelProvider(tt.name)
+			require.NoError(t, store.AddProvider(ctx, provider, ProviderConfig{
+				PassthroughExtraParams: tt.value,
+			}))
+
+			got, err := store.GetProviderConfig(ctx, provider)
+			require.NoError(t, err)
+			if tt.value == nil {
+				assert.Nil(t, got.PassthroughExtraParams)
+				return
+			}
+			require.NotNil(t, got.PassthroughExtraParams)
+			assert.Equal(t, *tt.value, *got.PassthroughExtraParams)
+
+			got.SendBackRawRequest = true
+			require.NoError(t, store.UpdateProvider(ctx, provider, *got))
+
+			updated, err := store.GetProviderConfig(ctx, provider)
+			require.NoError(t, err)
+			require.NotNil(t, updated.PassthroughExtraParams)
+			assert.Equal(t, *tt.value, *updated.PassthroughExtraParams)
+		})
+	}
+}

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -25,6 +25,7 @@ type TableProvider struct {
 	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
 	StoreRawRequestResponse  bool      `json:"store_raw_request_response"`
+	PassthroughExtraParams   *bool     `gorm:"type:boolean" json:"passthrough_extra_params,omitempty"`
 	CreatedAt                time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt                time.Time `gorm:"index;not null" json:"updated_at"`
 

--- a/tests/e2e/features/providers/pages/providers.page.ts
+++ b/tests/e2e/features/providers/pages/providers.page.ts
@@ -493,6 +493,13 @@ export class ProvidersPage extends BasePage {
   }
 
   /**
+   * Get the Network-tab switch that controls forwarding unmodeled parameters.
+   */
+  getPassthroughExtraParamsSwitch(): Locator {
+    return this.page.getByTestId('network-config-passthrough-extra-params')
+  }
+
+  /**
    * Save debugging configuration and wait for success toast
    */
   async saveDebuggingConfig(): Promise<void> {

--- a/tests/e2e/features/providers/providers.spec.ts
+++ b/tests/e2e/features/providers/providers.spec.ts
@@ -696,6 +696,31 @@ test.describe("Network Configuration", () => {
     await expect(providersPage.page.getByLabel(/Max Backoff/i)).toBeVisible();
   });
 
+  test("should save and reopen the passthrough extra parameters switch", async ({
+    providersPage,
+  }) => {
+    await providersPage.selectConfigTab("network");
+
+    const passthroughSwitch = providersPage.getPassthroughExtraParamsSwitch();
+    const originalValue =
+      (await passthroughSwitch.getAttribute("data-state")) === "checked";
+
+    await passthroughSwitch.click();
+    await providersPage.saveNetworkConfig();
+
+    await providersPage.goto();
+    await providersPage.selectProvider("openai");
+    await providersPage.selectConfigTab("network");
+
+    const reopenedSwitch = providersPage.getPassthroughExtraParamsSwitch();
+    expect((await reopenedSwitch.getAttribute("data-state")) === "checked").toBe(
+      !originalValue,
+    );
+
+    await reopenedSwitch.click();
+    await providersPage.saveNetworkConfig();
+  });
+
   test("should update timeout value", async ({ providersPage }) => {
     await providersPage.selectConfigTab("network");
 

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -79,6 +79,7 @@ type ProviderResponse struct {
 	SendBackRawRequest       bool                             `json:"send_back_raw_request"`            // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                             `json:"send_back_raw_response"`           // Include raw response in BifrostResponse
 	StoreRawRequestResponse  bool                             `json:"store_raw_request_response"`       // Capture raw request/response for internal logging only
+	PassthroughExtraParams   *bool                            `json:"passthrough_extra_params"`         // Whether extra request parameters are forwarded to the provider
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"`          // OpenAI-specific configuration
 	ProviderStatus           ProviderStatus                   `json:"provider_status"`                  // Health/initialization status of the provider
@@ -107,6 +108,7 @@ type providerCreatePayload struct {
 	SendBackRawRequest       *bool                             `json:"send_back_raw_request,omitempty"`
 	SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"`
 	StoreRawRequestResponse  *bool                             `json:"store_raw_request_response,omitempty"`
+	PassthroughExtraParams   *bool                             `json:"passthrough_extra_params,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"` // OpenAI-specific configuration
 }
@@ -118,6 +120,7 @@ type providerUpdatePayload struct {
 	SendBackRawRequest       *bool                            `json:"send_back_raw_request,omitempty"`
 	SendBackRawResponse      *bool                            `json:"send_back_raw_response,omitempty"`
 	StoreRawRequestResponse  *bool                            `json:"store_raw_request_response,omitempty"`
+	PassthroughExtraParams   *bool                            `json:"passthrough_extra_params,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"` // OpenAI-specific configuration
 }
@@ -310,6 +313,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawRequest:       payload.SendBackRawRequest != nil && *payload.SendBackRawRequest,
 		SendBackRawResponse:      payload.SendBackRawResponse != nil && *payload.SendBackRawResponse,
 		StoreRawRequestResponse:  payload.StoreRawRequestResponse != nil && *payload.StoreRawRequestResponse,
+		PassthroughExtraParams:   payload.PassthroughExtraParams,
 		CustomProviderConfig:     payload.CustomProviderConfig,
 		OpenAIConfig:             payload.OpenAIConfig,
 	}
@@ -353,6 +357,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			StoreRawRequestResponse:  config.StoreRawRequestResponse,
+			PassthroughExtraParams:   config.PassthroughExtraParams,
 			CustomProviderConfig:     config.CustomProviderConfig,
 			Status:                   config.Status,
 			Description:              config.Description,
@@ -440,6 +445,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		CustomProviderConfig:     oldConfigRaw.CustomProviderConfig,
 		OpenAIConfig:             oldConfigRaw.OpenAIConfig,
 		StoreRawRequestResponse:  oldConfigRaw.StoreRawRequestResponse,
+		PassthroughExtraParams:   oldConfigRaw.PassthroughExtraParams,
 		Status:                   oldConfigRaw.Status,
 		Description:              oldConfigRaw.Description,
 	}
@@ -516,6 +522,9 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	if payload.StoreRawRequestResponse != nil {
 		config.StoreRawRequestResponse = *payload.StoreRawRequestResponse
 	}
+	if payload.PassthroughExtraParams != nil {
+		config.PassthroughExtraParams = payload.PassthroughExtraParams
+	}
 
 	// Add provider to store if it doesn't exist (upsert behavior)
 	if _, err := h.inMemoryStore.GetProviderConfigRaw(provider); err != nil {
@@ -571,6 +580,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			StoreRawRequestResponse:  config.StoreRawRequestResponse,
+			PassthroughExtraParams:   config.PassthroughExtraParams,
 			CustomProviderConfig:     config.CustomProviderConfig,
 			Status:                   config.Status,
 			Description:              config.Description,
@@ -1219,6 +1229,7 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		SendBackRawRequest:       config.SendBackRawRequest,
 		SendBackRawResponse:      config.SendBackRawResponse,
 		StoreRawRequestResponse:  config.StoreRawRequestResponse,
+		PassthroughExtraParams:   config.PassthroughExtraParams,
 		CustomProviderConfig:     config.CustomProviderConfig,
 		OpenAIConfig:             config.OpenAIConfig,
 		ProviderStatus:           status,

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -102,7 +102,8 @@ func TestAddProvider_ReloadsRuntimeEvenWhenModelDiscoveryIsSkipped(t *testing.T)
 	}
 
 	body, err := sonic.Marshal(providerCreatePayload{
-		Provider: "mock-openai",
+		Provider:               "mock-openai",
+		PassthroughExtraParams: schemas.Ptr(true),
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			BaseProviderType: schemas.OpenAI,
 			IsKeyLess:        true,
@@ -125,8 +126,12 @@ func TestAddProvider_ReloadsRuntimeEvenWhenModelDiscoveryIsSkipped(t *testing.T)
 	if len(modelsManager.reloadCalls) != 1 || modelsManager.reloadCalls[0] != "mock-openai" {
 		t.Fatalf("expected provider reload for mock-openai, got %#v", modelsManager.reloadCalls)
 	}
-	if _, exists := h.inMemoryStore.Providers["mock-openai"]; !exists {
+	stored, exists := h.inMemoryStore.Providers["mock-openai"]
+	if !exists {
 		t.Fatalf("expected provider to be added to in-memory store")
+	}
+	if stored.PassthroughExtraParams == nil || !*stored.PassthroughExtraParams {
+		t.Fatalf("expected provider POST to preserve passthrough_extra_params=true, got %#v", stored.PassthroughExtraParams)
 	}
 }
 
@@ -1342,5 +1347,33 @@ func TestListModels_KeyBlacklistIsCaseInsensitive(t *testing.T) {
 		if strings.EqualFold(m.Name, "gpt-3.5-turbo") {
 			t.Fatalf("gpt-3.5-turbo should be blocked by blacklist, got %v", resp.Models)
 		}
+	}
+}
+
+func TestProviderResponsePreservesPassthroughExtraParams(t *testing.T) {
+	handler := &ProviderHandler{}
+	for _, tt := range []struct {
+		name  string
+		value *bool
+	}{
+		{name: "nil"},
+		{name: "false", value: schemas.Ptr(false)},
+		{name: "true", value: schemas.Ptr(true)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			response := handler.getProviderResponseFromConfig(schemas.OpenAI, configstore.ProviderConfig{
+				PassthroughExtraParams: tt.value,
+			}, ProviderStatusActive)
+
+			if tt.value == nil {
+				if response.PassthroughExtraParams != nil {
+					t.Fatalf("expected nil passthrough_extra_params, got %v", *response.PassthroughExtraParams)
+				}
+				return
+			}
+			if response.PassthroughExtraParams == nil || *response.PassthroughExtraParams != *tt.value {
+				t.Fatalf("expected passthrough_extra_params=%v, got %#v", *tt.value, response.PassthroughExtraParams)
+			}
+		})
 	}
 }

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -89,6 +89,22 @@ type RequestWithSettableExtraParams interface {
 	SetExtraParams(params map[string]interface{})
 }
 
+// retainExtraParamsFromRawBody preserves provider-specific fields until the
+// selected provider resolves whether they may be merged into its request.
+func retainExtraParamsFromRawBody(req interface{}, rawBody []byte) {
+	rws, ok := req.(RequestWithSettableExtraParams)
+	if !ok || len(rawBody) == 0 {
+		return
+	}
+
+	var wrapper struct {
+		ExtraParams map[string]interface{} `json:"extra_params"`
+	}
+	if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+		rws.SetExtraParams(wrapper.ExtraParams)
+	}
+}
+
 // BatchRequest wraps a Bifrost batch request with its type information.
 type BatchRequest struct {
 	Type            schemas.RequestType
@@ -730,25 +746,13 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				}
 			}
 
-			// Extract the "extra_params" JSON key when passthrough is
-			// explicitly enabled via x-bf-passthrough-extra-params: true.
-			// Provider-specific fields (e.g. Bedrock guardrailConfig)
-			// must be nested under "extra_params" in the request body.
-			// Runs after both RequestParser and default JSON paths.
-			if !isLargePayload && bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
-				if rws, ok := req.(RequestWithSettableExtraParams); ok {
-					if rawBody == nil {
-						rawBody = ctx.Request.Body()
-					}
-					if len(rawBody) > 0 {
-						var wrapper struct {
-							ExtraParams map[string]interface{} `json:"extra_params"`
-						}
-						if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
-							rws.SetExtraParams(wrapper.ExtraParams)
-						}
-					}
+			// Retain "extra_params" for every eligible parsed request. Provider selection
+			// resolves whether converters may merge the retained values later.
+			if !isLargePayload {
+				if rawBody == nil {
+					rawBody = ctx.Request.Body()
 				}
+				retainExtraParamsFromRawBody(req, rawBody)
 			}
 		}
 

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -111,7 +111,7 @@ func TestRequestWithSettableExtraParams_AllOpenAIRequestTypes(t *testing.T) {
 	}
 }
 
-func TestExtraParamsRequiresPassthroughHeader(t *testing.T) {
+func TestExtraParamsExtractedIndependentOfPolicy(t *testing.T) {
 	handlerStore := &mockHandlerStore{}
 	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
 
@@ -136,61 +136,19 @@ func TestExtraParamsRequiresPassthroughHeader(t *testing.T) {
 		}
 	}`)
 
-	t.Run("extra_params NOT extracted without passthrough header", func(t *testing.T) {
+	for _, passthrough := range []bool{false, true} {
 		req := chatRoute.GetRequestTypeInstance(context.Background())
-		err := sonic.Unmarshal(rawBody, req)
-		require.NoError(t, err)
+		require.NoError(t, sonic.Unmarshal(rawBody, req))
 
 		bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
-		// Header not set -- simulate router logic
-		if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
-			if rws, ok := req.(RequestWithSettableExtraParams); ok {
-				var wrapper struct {
-					ExtraParams map[string]interface{} `json:"extra_params"`
-				}
-				if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
-					rws.SetExtraParams(wrapper.ExtraParams)
-				}
-				_ = rws
-			}
-		}
-
-		openaiReq, ok := req.(*openai.OpenAIChatRequest)
-		require.True(t, ok)
-		assert.Empty(t, openaiReq.ChatParameters.ExtraParams,
-			"ExtraParams should be empty when passthrough header is not set")
-	})
-
-	t.Run("extra_params extracted with passthrough header", func(t *testing.T) {
-		req := chatRoute.GetRequestTypeInstance(context.Background())
-		err := sonic.Unmarshal(rawBody, req)
-		require.NoError(t, err)
-
-		bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
-		bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
-
-		if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
-			if rws, ok := req.(RequestWithSettableExtraParams); ok {
-				var wrapper struct {
-					ExtraParams map[string]interface{} `json:"extra_params"`
-				}
-				if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
-					rws.SetExtraParams(wrapper.ExtraParams)
-				}
-			}
-		}
+		bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, passthrough)
+		retainExtraParamsFromRawBody(req, rawBody)
 
 		openaiReq, ok := req.(*openai.OpenAIChatRequest)
 		require.True(t, ok)
 		require.Contains(t, openaiReq.ChatParameters.ExtraParams, "guardrailConfig",
-			"guardrailConfig should be in ExtraParams when passthrough header is set")
-
-		gc, ok := openaiReq.ChatParameters.ExtraParams["guardrailConfig"].(map[string]interface{})
-		require.True(t, ok)
-		assert.Equal(t, "my-guardrail", gc["guardrailIdentifier"])
-		assert.Equal(t, "1", gc["guardrailVersion"])
-		assert.Equal(t, "disabled", gc["trace"])
-	})
+			"extra_params must be retained before the provider policy is resolved")
+	}
 }
 
 func TestExtraParamsPassthrough_NestedStructures(t *testing.T) {

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -95,6 +95,10 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 	providerConfig.SendBackRawRequest = config.SendBackRawRequest
 	providerConfig.SendBackRawResponse = config.SendBackRawResponse
 	providerConfig.StoreRawRequestResponse = config.StoreRawRequestResponse
+	if config.PassthroughExtraParams != nil {
+		value := *config.PassthroughExtraParams
+		providerConfig.PassthroughExtraParams = &value
+	}
 	if config.CustomProviderConfig != nil {
 		providerConfig.CustomProviderConfig = config.CustomProviderConfig
 	}

--- a/transports/bifrost-http/lib/account_test.go
+++ b/transports/bifrost-http/lib/account_test.go
@@ -1,0 +1,38 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaseAccountGetConfigForProviderPreservesPassthroughExtraParams(t *testing.T) {
+	account := NewBaseAccount(&Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+		"omitted":  {},
+		"disabled": {PassthroughExtraParams: schemas.Ptr(false)},
+		"enabled":  {PassthroughExtraParams: schemas.Ptr(true)},
+	}})
+
+	for _, tt := range []struct {
+		provider schemas.ModelProvider
+		want     *bool
+	}{
+		{provider: "omitted"},
+		{provider: "disabled", want: schemas.Ptr(false)},
+		{provider: "enabled", want: schemas.Ptr(true)},
+	} {
+		t.Run(string(tt.provider), func(t *testing.T) {
+			config, err := account.GetConfigForProvider(tt.provider)
+			require.NoError(t, err)
+			if tt.want == nil {
+				assert.Nil(t, config.PassthroughExtraParams)
+				return
+			}
+			require.NotNil(t, config.PassthroughExtraParams)
+			assert.Equal(t, *tt.want, *config.PassthroughExtraParams)
+		})
+	}
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -19924,3 +19924,25 @@ func TestLoadPlugins_OtelPluginSpanFilterPassthrough(t *testing.T) {
 	require.True(t, ok, "plugin_span_filter.plugins should be an array")
 	require.ElementsMatch(t, []any{"logging", "compat"}, plugins)
 }
+
+func TestGenerateProviderConfigHashDistinguishesPassthroughExtraParamsStates(t *testing.T) {
+	hashes := make(map[string]string)
+	for _, tt := range []struct {
+		name  string
+		value *bool
+	}{
+		{name: "nil"},
+		{name: "false", value: schemas.Ptr(false)},
+		{name: "true", value: schemas.Ptr(true)},
+	} {
+		hash, err := (&configstore.ProviderConfig{
+			PassthroughExtraParams: tt.value,
+		}).GenerateConfigHash("openai")
+		require.NoError(t, err)
+		hashes[tt.name] = hash
+	}
+
+	if hashes["nil"] == hashes["false"] || hashes["nil"] == hashes["true"] || hashes["false"] == hashes["true"] {
+		t.Fatalf("expected nil, false, and true passthrough values to hash differently: %#v", hashes)
+	}
+}

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -552,10 +552,11 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 			}
 			return true
 		}
-		// Add passthrough extra params header support
+		// Passthrough extra params supports an optional per-request boolean override.
+		// Invalid values deliberately leave the policy unresolved for provider selection.
 		if keyStr == "x-bf-passthrough-extra-params" {
-			if valueStr := string(value); valueStr == "true" {
-				bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParamsOverride, b)
 			}
 			return true
 		}

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -98,6 +98,35 @@ func TestConvertToBifrostContext_SecondCallReturnsSameSharedContext(t *testing.T
 	}
 }
 
+func TestConvertToBifrostContext_PassthroughExtraParamsOverride(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		header    string
+		want      bool
+		wantValue bool
+	}{
+		{name: "true", header: "true", want: true, wantValue: true},
+		{name: "false", header: "false", want: false, wantValue: true},
+		{name: "invalid", header: "not-a-bool", wantValue: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.Set("x-bf-passthrough-extra-params", tt.header)
+
+			bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
+			defer cancel()
+
+			got, ok := bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParamsOverride).(bool)
+			if ok != tt.wantValue || (ok && got != tt.want) {
+				t.Fatalf("override = (%t, %t), want (%t, %t)", got, ok, tt.want, tt.wantValue)
+			}
+			if effective := bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams); effective != nil {
+				t.Fatalf("effective policy must remain unresolved in HTTP context, got %#v", effective)
+			}
+		})
+	}
+}
+
 // TestConvertToBifrostContext_StarAllowlistSecurityHeadersBlocked verifies that
 // even with a "*" allowlist (allow all), the hardcoded security denylist in
 // ConvertToBifrostContext still blocks security-sensitive headers.

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1595,3 +1595,29 @@ func TestValidateConfigSchema_BedrockKeyConfig_MissingRegion(t *testing.T) {
 // Guardrails tests are skipped for the public schema as guardrails_config
 // is an enterprise feature with a different schema structure.
 // Enterprise-specific tests should be added to the enterprise test suite.
+
+func TestValidateConfigSchema_PassthroughExtraParamsNullable(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "omitted", value: ""},
+		{name: "null", value: `"passthrough_extra_params": null,`},
+		{name: "false", value: `"passthrough_extra_params": false,`},
+		{name: "true", value: `"passthrough_extra_params": true,`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			config := `{
+				"providers": {
+					"openai": {
+						` + tt.value + `
+						"keys": [{"name": "default", "value": "sk-test", "weight": 1, "models": ["gpt-4"]}]
+					}
+				}
+			}`
+			if err := ValidateConfigSchema([]byte(config), loadLocalSchema(t)); err != nil {
+				t.Fatalf("expected %s passthrough_extra_params to validate: %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4057,6 +4057,10 @@
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         }
@@ -4095,6 +4099,10 @@
         "store_raw_request_response": {
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
@@ -4135,6 +4143,10 @@
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         }
@@ -4173,6 +4185,10 @@
         "store_raw_request_response": {
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
@@ -4213,6 +4229,10 @@
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         }
@@ -4251,6 +4271,10 @@
         "store_raw_request_response": {
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
@@ -4291,6 +4315,10 @@
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         }
@@ -4330,6 +4358,10 @@
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         }
@@ -4367,6 +4399,10 @@
         "store_raw_request_response": {
           "type": "boolean",
           "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "passthrough_extra_params": {
+          "type": ["boolean", "null"],
+          "description": "Whether extra request parameters are forwarded to the provider (null uses the provider default)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -17,7 +17,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
-import { buildProviderUpdatePayload } from "../views/utils";
+import { buildProviderUpdatePayload, resolvePassthroughExtraParams } from "../views/utils";
 
 interface NetworkFormFragmentProps {
 	provider: ModelProvider;
@@ -89,6 +89,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				allow_private_network: provider.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
+			passthrough_extra_params: resolvePassthroughExtraParams(provider),
 		},
 	});
 
@@ -125,6 +126,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				allow_private_network: data.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
+			passthrough_extra_params: data.passthrough_extra_params,
 		});
 		updateProvider(updatedProvider)
 			.unwrap()
@@ -158,8 +160,9 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 				allow_private_network: provider.network_config?.allow_private_network ?? DefaultNetworkConfig.allow_private_network,
 			},
+			passthrough_extra_params: resolvePassthroughExtraParams(provider),
 		});
-	}, [form, provider.name, provider.network_config]);
+	}, [form, provider.name, provider.network_config, provider.passthrough_extra_params]);
 
 	const baseURLRequired = isCustomProvider;
 	const hideBaseURL = provider.name === "vllm" || provider.name === "ollama" || provider.name === "sgl";
@@ -405,6 +408,26 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											onCheckedChange={field.onChange}
 											disabled={!hasUpdateProviderAccess}
 											data-testid="network-config-enforce-http2"
+										/>
+									</FormControl>
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="passthrough_extra_params"
+							render={({ field }) => (
+								<FormItem className="flex flex-row items-center justify-between">
+									<div className="space-y-0.5">
+										<FormLabel>Passthrough Extra Parameters</FormLabel>
+										<FormDescription>Forward request parameters that Bifrost does not explicitly model to this provider.</FormDescription>
+									</div>
+									<FormControl>
+										<Switch
+											checked={field.value}
+											onCheckedChange={field.onChange}
+											disabled={!hasUpdateProviderAccess}
+											data-testid="network-config-passthrough-extra-params"
 										/>
 									</FormControl>
 								</FormItem>

--- a/ui/app/workspace/providers/views/utils.test.ts
+++ b/ui/app/workspace/providers/views/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { ModelProvider } from "@/lib/types/config";
+
+import { buildProviderUpdatePayload, resolvePassthroughExtraParams } from "./utils";
+
+const provider = (name: string, passthroughExtraParams?: boolean): ModelProvider =>
+	({
+		name,
+		provider_status: "active",
+		passthrough_extra_params: passthroughExtraParams,
+	}) as ModelProvider;
+
+describe("resolvePassthroughExtraParams", () => {
+	it("uses the provider default only when the API response is nil", () => {
+		expect(resolvePassthroughExtraParams(provider("deepseek"))).toBe(true);
+		expect(resolvePassthroughExtraParams(provider("vllm"))).toBe(true);
+		expect(resolvePassthroughExtraParams(provider("sgl"))).toBe(true);
+		expect(resolvePassthroughExtraParams(provider("openai"))).toBe(false);
+	});
+
+	it("keeps an explicit false instead of applying a provider default", () => {
+		expect(resolvePassthroughExtraParams(provider("deepseek", false))).toBe(false);
+	});
+});
+
+describe("buildProviderUpdatePayload", () => {
+	it("preserves the field across unrelated full-PUT saves", () => {
+		const payload = buildProviderUpdatePayload(provider("openai", true), {});
+
+		expect(payload.passthrough_extra_params).toBe(true);
+	});
+
+	it("sends an explicit false from the Network form", () => {
+		const payload = buildProviderUpdatePayload(provider("deepseek", true), {
+			passthrough_extra_params: false,
+		});
+
+		expect(payload.passthrough_extra_params).toBe(false);
+	});
+});

--- a/ui/app/workspace/providers/views/utils.ts
+++ b/ui/app/workspace/providers/views/utils.ts
@@ -1,6 +1,16 @@
 import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
 import { ModelProvider, UpdateProviderRequest } from "@/lib/types/config";
 
+const PROVIDERS_WITH_PASSTHROUGH_EXTRA_PARAMS_DEFAULT: Record<string, true> = { vllm: true, sgl: true, deepseek: true };
+
+/**
+ * The Network tab knows the provider but not the request type, so it can only
+ * resolve named provider defaults. Request-specific defaults (such as image
+ * generation) remain a runtime concern.
+ */
+export const resolvePassthroughExtraParams = (provider: Pick<ModelProvider, "name" | "passthrough_extra_params">): boolean =>
+	provider.passthrough_extra_params ?? PROVIDERS_WITH_PASSTHROUGH_EXTRA_PARAMS_DEFAULT[provider.name.toLowerCase()] === true;
+
 export const buildProviderUpdatePayload = (provider: ModelProvider, updates: Partial<UpdateProviderRequest>) => {
 	const { name } = provider;
 
@@ -14,5 +24,6 @@ export const buildProviderUpdatePayload = (provider: ModelProvider, updates: Par
 		store_raw_request_response: updates.store_raw_request_response ?? provider.store_raw_request_response,
 		custom_provider_config: updates.custom_provider_config ?? provider.custom_provider_config,
 		openai_config: updates.openai_config ?? provider.openai_config,
+		passthrough_extra_params: updates.passthrough_extra_params ?? provider.passthrough_extra_params,
 	};
 };

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -397,6 +397,7 @@ export interface ModelProviderConfig {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	passthrough_extra_params?: boolean;
 	status?: "unknown" | "success" | "list_models_failed";
 	description?: string;
 }
@@ -425,6 +426,7 @@ export interface AddProviderRequest {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	passthrough_extra_params?: boolean;
 }
 
 // UpdateProviderRequest matching Go's UpdateProviderRequest
@@ -437,6 +439,7 @@ export interface UpdateProviderRequest {
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	openai_config?: OpenAIConfig;
+	passthrough_extra_params?: boolean;
 }
 
 export interface CreateProviderKeyRequest extends ModelProviderKey {}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -800,6 +800,7 @@ export const proxyOnlyFormSchema = z.object({
 
 // Network-only form schema for the NetworkFormFragment
 export const networkOnlyFormSchema = z.object({
+	passthrough_extra_params: z.boolean(),
 	network_config: networkFormConfigSchema.optional(),
 });
 


### PR DESCRIPTION
## Summary

Adds toggle to allow extra parameters passthrough
DeepSeek, VLLM and SG have it enabled by default.
This is replacement to https://github.com/maximhq/bifrost/pull/4364 - since it's completely different approach and old codebase in that PR diverged too much from current master.

## Changes

Adds additional parameter and toggle to preserve extra parameters when passing requests to upstream providers.
Keeps logic intact (vllm, sg, deepseek preserve it's current behavior)
Header should still override logic set in ui/config.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

<img width="769" height="210" alt="Screenshot 2026-07-15 at 02 30 20" src="https://github.com/user-attachments/assets/8c46c4a9-3147-44a9-bca9-ca95e5c9998a" />

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

https://github.com/maximhq/bifrost/issues/4272 https://github.com/maximhq/bifrost/issues/3181

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


