### PR TITLE
fix changelog for audit log s3 storage

### DIFF
--- a/docs/changelogs/ent-v1.5.4.mdx
+++ b/docs/changelogs/ent-v1.5.4.mdx
@@ -35,7 +35,6 @@ Release on `transports/v1.6.4`. Ships a full guardrails redaction engine (PII, s
 - **Bedrock Project Scoping** - Optional `project_id` in Bedrock and Bedrock Mantle key configs, with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex, plus UI support.
 - **Trace Redaction** - Phase-scoped redaction and revealing, a transient redaction data field for guardrails, and trace content redaction before connector export.
 - **Durable Background Jobs** - New `sidekiq` background-job table, store methods, and runner with recovery; cost recalculation migrated to a durable, resumable job with polling instead of SSE.
-- **Audit Log Object Storage** - S3/GCS object storage config schema for audit log archival.
 - **Alerting Configuration Schema** - Alerting schema in `config.schema.json` with declarative channels and CEL-based rules, plus Helm chart support.
 - **Model Catalog Pricing** - Pricing data added to the model catalog.
 - **Canonical Model Names** - Dashboard model rankings show canonical model names instead of inference-profile IDs.

--- a/docs/changelogs/v1.6.4.mdx
+++ b/docs/changelogs/v1.6.4.mdx
@@ -24,7 +24,6 @@ description: "v1.6.4 changelog - 2026-07-14"
 - **Bedrock Project Scoping** - Added optional `project_id` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex, plus UI support
 - **Trace Redaction** - Phase-scoped redaction and revealing, transient redaction data field for guardrails, and trace content redaction before connector export
 - **Durable Background Jobs** - New `sidekiq` background-job table, store methods, and runner with recovery and reaper; cost recalculation migrated to a durable, resumable job with polling instead of SSE
-- **Audit Log Object Storage** - S3/GCS object storage config schema for audit log archival
 - **Alerting Configuration** - Alerting schema in `config.schema.json` with declarative channels and CEL-based rules, Helm chart support, and enterprise fallback pages
 - **Model Catalog Pricing** - Added pricing data to the model catalog (thanks [@johnbrett](https://github.com/johnbrett)!)
 - **Canonical Model Names** - Dashboard model rankings now show canonical model names instead of inference-profile IDs (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -5,7 +5,6 @@
 - **Bedrock Project Scoping** - Added optional `project_id` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex, plus UI support
 - **Trace Redaction** - Phase-scoped redaction and revealing, transient redaction data field for guardrails, and trace content redaction before connector export
 - **Durable Background Jobs** - New `sidekiq` background-job table, store methods, and runner with recovery and reaper; cost recalculation migrated to a durable, resumable job with polling instead of SSE
-- **Audit Log Object Storage** - S3/GCS object storage config schema for audit log archival
 - **Alerting Configuration** - Alerting schema in `config.schema.json` with declarative channels and CEL-based rules, Helm chart support, and enterprise fallback pages
 - **Model Catalog Pricing** - Added pricing data to the model catalog (thanks [@johnbrett](https://github.com/johnbrett)!)
 - **Canonical Model Names** - Dashboard model rankings now show canonical model names instead of inference-profile IDs (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)


### PR DESCRIPTION
## Summary

Removes the **Audit Log Object Storage** entry from the v1.6.4 and ent-v1.5.4 changelogs, as well as the transports changelog, indicating this feature is being pulled from the release.

## Changes

- Removed the "Audit Log Object Storage" bullet (S3/GCS object storage config schema for audit log archival) from all three changelog files.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the changelog pages for v1.6.4 and ent-v1.5.4 no longer list the Audit Log Object Storage feature.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable