### PR TITLE
feat: add `bifrost.client.dualCredentialConflictBehavior` to Helm chart

### DIFF
--- a/docs/changelogs/helm-v2.1.29.mdx
+++ b/docs/changelogs/helm-v2.1.29.mdx
@@ -8,5 +8,6 @@ description: "Helm v2.1.29 changelog - 2026-07-15"
 ## Changelog
 
 - Added generic OIDC SCIM/SSO provider support (`bifrost.scim.provider: generic`) for any standards-compliant OIDC IdP. Configure via `bifrost.scim.config` (`issuerUrl` and `clientId` required; optional `clientSecret`, `audience`, endpoint overrides, `teamIdsField`, `rolesField`, `scopes`, and attribute/claim mappings). Endpoints are resolved via OIDC discovery unless overridden. Renders into `scim_config.config`.
+- Added `bifrost.client.dualCredentialConflictBehavior` to control what happens when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"` (reject with 400), `"prefer_vk"` (drop IDP token, use VK), or `"prefer_idp"` (default, IDP token wins). Renders into `client.dual_credential_conflict_behavior`.
 
 </Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1015,6 +1015,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.29",
               "changelogs/helm-v2.1.28",
               "changelogs/helm-v2.1.27",
               "changelogs/helm-v2.1.26",

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,6 +8,10 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
+### 2.1.29
+
+- Added `bifrost.client.dualCredentialConflictBehavior` to control what happens when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"` (reject with 400), `"prefer_vk"` (drop IDP token, use VK), or `"prefer_idp"` (default, IDP token wins). Renders into `client.dual_credential_conflict_behavior`.
+
 ### 2.1.28
 
 - Restored `runAsUser: 1000` defaults in `podSecurityContext` and `securityContext` (dropped in 2.1.27). Images before v1.6.4 use a non-numeric `USER appuser`, so kubelet could not verify `runAsNonRoot: true` and pods failed with CreateContainerConfigError. OpenShift (restricted-v2) users unset the pins with explicit nulls: `podSecurityContext.runAsUser: null`, `podSecurityContext.fsGroup: null`, `securityContext.runAsUser: null`.

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -228,6 +228,9 @@ false
 {{- if hasKey .Values.bifrost.client "enforceAuthOnInference" }}
 {{- $_ := set $client "enforce_auth_on_inference" .Values.bifrost.client.enforceAuthOnInference }}
 {{- end }}
+{{- if .Values.bifrost.client.dualCredentialConflictBehavior }}
+{{- $_ := set $client "dual_credential_conflict_behavior" .Values.bifrost.client.dualCredentialConflictBehavior }}
+{{- end }}
 {{- if hasKey .Values.bifrost.client "enforceGovernanceHeader" }}
 {{- $_ := set $client "enforce_governance_header" .Values.bifrost.client.enforceGovernanceHeader }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -463,6 +463,11 @@
               "type": "boolean",
               "description": "Require auth (VK, API key, or user token) on inference endpoints"
             },
+            "dualCredentialConflictBehavior": {
+              "type": "string",
+              "enum": ["error", "prefer_vk", "prefer_idp"],
+              "description": "Behavior when an inference request presents both an IDP access token and a virtual key (x-bf-vk). 'error' rejects with 400; 'prefer_vk' drops the IDP token and uses the VK; 'prefer_idp' (default) uses the IDP token for identity."
+            },
             "enforceSCIMAuth": {
               "type": "boolean",
               "description": "Deprecated: use enforceAuthOnInference"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -288,6 +288,10 @@ bifrost:
     # Require auth (VK, API key, or user token) on inference endpoints.
     # Open by default in the raw binary; this chart enables enforcement for production.
     enforceAuthOnInference: true
+    # dualCredentialConflictBehavior -- Behavior when an inference request presents both an IDP
+    # access token and a virtual key (x-bf-vk). Options: "error" (reject with 400),
+    # "prefer_vk" (drop IDP token, use VK), "prefer_idp" (default, IDP token wins for identity).
+    # dualCredentialConflictBehavior: "prefer_idp"
     maxRequestBodySizeMb: 100
     compat:
       convertTextToChat: false


### PR DESCRIPTION
## Summary

Adds a new `bifrost.client.dualCredentialConflictBehavior` Helm value to control how Bifrost handles inference requests that present both an IDP access token and a virtual key (`x-bf-vk`) simultaneously. Previously, this conflict scenario had no configurable resolution path; this change exposes the underlying `client.dual_credential_conflict_behavior` config field through the Helm chart.

## Changes

- Added `bifrost.client.dualCredentialConflictBehavior` to `values.yaml` (commented out by default, implying `prefer_idp` behavior) with three accepted values:
  - `"error"` — rejects the request with a 400
  - `"prefer_vk"` — drops the IDP token and uses the virtual key
  - `"prefer_idp"` — IDP token wins for identity (default behavior)
- Added the corresponding rendering logic in `_helpers.tpl` to map the Helm value to `dual_credential_conflict_behavior` in the generated config
- Added a JSON schema entry with an `enum` constraint to validate the field at install/upgrade time
- Bumped the chart version from `2.1.28` to `2.1.29` and added the changelog entry

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Render the chart with the new value and confirm the config key appears
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.client.dualCredentialConflictBehavior=prefer_vk \
  | grep dual_credential_conflict_behavior

# Validate schema enforcement — this should fail
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.client.dualCredentialConflictBehavior=invalid_value

# Confirm default render (value commented out) produces no key
helm template bifrost ./helm-charts/bifrost \
  | grep -c dual_credential_conflict_behavior  # expect 0
```

New config field:

| Helm Value | Config Key | Options | Default |
|---|---|---|---|
| `bifrost.client.dualCredentialConflictBehavior` | `client.dual_credential_conflict_behavior` | `error`, `prefer_vk`, `prefer_idp` | `prefer_idp` (omitted) |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This field directly affects authentication resolution when a request carries dual credentials. The default (`prefer_idp`) preserves existing behavior. Operators choosing `prefer_vk` should be aware that IDP-based identity will be silently dropped, which may affect audit logging or policy enforcement tied to user identity.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable