### PR TITLE
feat: add `archiveInterval`, `archiveGracePeriod`, and `archiveMaxObjectBytes` audit log archival config options

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1570,6 +1570,15 @@ false
 {{- if .Values.bifrost.auditLogs.hmacKey }}
 {{- $_ := set $auditLogs "hmac_key" .Values.bifrost.auditLogs.hmacKey }}
 {{- end }}
+{{- if .Values.bifrost.auditLogs.archiveInterval }}
+{{- $_ := set $auditLogs "archive_interval" .Values.bifrost.auditLogs.archiveInterval }}
+{{- end }}
+{{- if .Values.bifrost.auditLogs.archiveGracePeriod }}
+{{- $_ := set $auditLogs "archive_grace_period" .Values.bifrost.auditLogs.archiveGracePeriod }}
+{{- end }}
+{{- if .Values.bifrost.auditLogs.archiveMaxObjectBytes }}
+{{- $_ := set $auditLogs "archive_max_object_bytes" (int64 .Values.bifrost.auditLogs.archiveMaxObjectBytes) }}
+{{- end }}
 {{- if .Values.bifrost.auditLogs.objectStorage }}
 {{- $aos := .Values.bifrost.auditLogs.objectStorage }}
 {{- $aosConfig := dict "type" $aos.type "bucket" $aos.bucket }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3516,9 +3516,28 @@
             "hmacKey": {
               "type": "string"
             },
+            "archiveInterval": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
+              "description": "Archival window size and job period, as a Go duration string (e.g. '24h'). The supported range is 5m and above; anything shorter is raised to 5m at runtime rather than failing startup. Only used when objectStorage is set. Default: 24h",
+              "default": "24h"
+            },
+            "archiveGracePeriod": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
+              "description": "How long to hold a window open past its end before archiving it, absorbing clock skew and late inserts. Must be shorter than archiveInterval, otherwise no window would ever close; the runtime substitutes a safe default if it is not. Only used when objectStorage is set. Default: 15m",
+              "default": "15m"
+            },
+            "archiveMaxObjectBytes": {
+              "type": "integer",
+              "minimum": 1048576,
+              "maximum": 4294967296,
+              "description": "Roll a new part object once the current part reaches this many uncompressed bytes. Peak node memory is roughly 2x this when compress is true, so size pod memory limits accordingly. The minimum and maximum above are strict validation limits: helm install/template rejects a value outside [1MiB, 4GiB] rather than adjusting it. Only used when objectStorage is set. Default: 134217728 (128MiB)",
+              "default": 134217728
+            },
             "objectStorage": {
               "type": "object",
-              "description": "Optional object storage for archiving audit events to S3/GCS. Each flushed batch is written as a gzipped JSONL object at {prefix}/audit-logs/YYYY/MM/DD/HH/{id}.jsonl[.gz], in addition to the database.",
+              "description": "Optional object storage for archiving audit events to S3/GCS. A background job periodically copies audit events from the database, one closed time window at a time, writing each window as JSONL part objects plus a manifest at {prefix}/audit-logs/YYYY/MM/DD/{start}-{end}/. The database remains the source of truth; archival never deletes rows (retentionDays handles that independently).",
               "properties": {
                 "type": {
                   "type": "string",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1137,10 +1137,29 @@ bifrost:
   auditLogs:
     disabled: false
     hmacKey: ""
-    # Object storage archival for audit events (optional)
-    # When configured, each flushed batch of audit events is written as a JSONL object at
-    # {prefix}/audit-logs/YYYY/MM/DD/HH/{id}.jsonl in addition to the DB.
-    # Set compress: true to gzip the objects ({id}.jsonl.gz).
+    # Object storage archival for audit events (optional).
+    #
+    # When configured, a background job periodically copies audit events from the
+    # database to object storage, one closed time window at a time. Each window is
+    # written as one or more JSONL part objects plus a manifest that lists them:
+    #   {prefix}/audit-logs/YYYY/MM/DD/<start>-<end>/part-00000.jsonl[.gz]
+    #   {prefix}/audit-logs/YYYY/MM/DD/<start>-<end>/manifest.json[.gz]
+    # Read the manifest to enumerate a window; ignore any object it does not list.
+    #
+    # The database remains the source of truth. Archival never deletes rows —
+    # retentionDays handles that independently. In a cluster, only the leader
+    # archives. Events written before archival is first enabled are not backfilled.
+    #
+    # Window size and job period. Default 24h, minimum 5m.
+    # archiveInterval: "24h"
+    # A window only closes once (now - grace) has passed its end, which absorbs
+    # clock skew and late inserts. Must be less than archiveInterval. Default 15m.
+    # archiveGracePeriod: "15m"
+    # Roll a new part object once the current part reaches this many uncompressed
+    # bytes. Default 134217728 (128MiB). Raising it produces fewer, larger objects;
+    # note peak memory on the archiving node is roughly 2x this when compress: true,
+    # so size pod memory limits accordingly.
+    # archiveMaxObjectBytes: 134217728
     # objectStorage:
     #   type: s3        # Options: s3, gcs
     #   bucket: ""      # Bucket name

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5920,9 +5920,28 @@
           "minimum": 0,
           "description": "Number of days to retain audit logs (0 means no retention limit)"
         },
+        "archive_interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
+          "description": "Archival window size and job period, as a Go duration string (e.g. '24h', '1h', '30m'). Each window is archived as one set of objects. The supported range is 5m and above: this schema accepts any valid duration, and the runtime raises anything shorter to 5m rather than failing startup. Only used when object_storage is set. Default: 24h",
+          "default": "24h"
+        },
+        "archive_grace_period": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))*$",
+          "description": "How long to hold a window open past its end before archiving it, as a Go duration string. Absorbs clock skew and late inserts. Must be shorter than archive_interval, otherwise no window would ever close and archival would silently do nothing; the runtime substitutes a safe default if it is not. Only used when object_storage is set. Default: 15m",
+          "default": "15m"
+        },
+        "archive_max_object_bytes": {
+          "type": "integer",
+          "minimum": 1048576,
+          "maximum": 4294967296,
+          "description": "Roll a new part object once the current part reaches this many uncompressed bytes. Bounds memory on the archiving node: peak usage is roughly 2x this value when compress is true, since gzip allocates a second full buffer. The minimum and maximum above are strict validation limits — a config outside [1MiB, 4GiB] is rejected as invalid rather than accepted and adjusted. (The runtime additionally clamps to the same range, as a safety net for configs that never pass through schema validation.) Only used when object_storage is set. Default: 134217728 (128MiB)",
+          "default": 134217728
+        },
         "object_storage": {
           "type": "object",
-          "description": "Optional object storage for archiving audit events to S3/GCS. When configured, each flushed batch of audit events is written as a gzipped JSONL object at {prefix}/audit-logs/YYYY/MM/DD/HH/{id}.jsonl[.gz], in addition to the database (which remains the source of truth). Archival is going-forward only; existing rows are not backfilled.",
+          "description": "Optional object storage for archiving audit events to S3/GCS. Setting this enables archival; there is no separate on/off flag. A background job periodically copies audit events from the database, one closed time window at a time, writing each window as one or more JSONL part objects plus a manifest listing them: {prefix}/audit-logs/YYYY/MM/DD/{start}-{end}/part-00000.jsonl[.gz] and .../manifest.json[.gz]. Read the manifest to enumerate a window and ignore any object it does not list. The database remains the source of truth and archival never deletes rows (retention_days handles that independently). In a cluster only one node archives a given window. Archival is going-forward only; existing rows are not backfilled. See archive_interval, archive_grace_period and archive_max_object_bytes to tune it.",
           "properties": {
             "type": {
               "type": "string",


### PR DESCRIPTION
## Summary

Adds three new tunable parameters for audit log archival to object storage: `archive_interval`, `archive_grace_period`, and `archive_max_object_bytes`. These allow operators to control the archival window size, how long a window stays open past its end to absorb late inserts, and the maximum uncompressed size of each part object before rolling to a new one.

## Changes

- Added `archive_interval` (default `24h`, minimum `5m`) to control the archival window size and background job period. Each closed window is written as a set of objects to object storage.
- Added `archive_grace_period` (default `15m`) to hold a window open past its end before archiving, absorbing clock skew and late inserts. Must be less than `archive_interval`.
- Added `archive_max_object_bytes` (default `128MiB`, range `1MiB–4GiB`) to roll a new part object once the current part reaches the specified uncompressed byte threshold. Peak memory on the archiving node is roughly 2x this value when compression is enabled.
- Updated the object storage description to reflect the new windowed archival model: a background job writes each closed window as one or more JSONL part objects plus a manifest at `{prefix}/audit-logs/YYYY/MM/DD/{start}-{end}/`. The manifest is the authoritative index for a window; any object not listed in it should be ignored.
- Updated `values.yaml` comments to document the new parameters and clarify archival behavior (no backfill, no row deletion, leader-only in a cluster).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy bifrost with `objectStorage` configured and set non-default values for the new parameters:

```yaml
bifrost:
  auditLogs:
    archiveInterval: "1h"
    archiveGracePeriod: "5m"
    archiveMaxObjectBytes: 10485760  # 10MiB
    objectStorage:
      type: s3
      bucket: my-bucket
```

Verify that:
- Audit events are archived into windowed paths (`YYYY/MM/DD/{start}-{end}/part-00000.jsonl[.gz]`) rather than the old per-batch path.
- A `manifest.json[.gz]` is written alongside each set of part objects.
- Windows only close after `archiveGracePeriod` has elapsed past the window end.
- Part objects roll over once they reach `archiveMaxObjectBytes` uncompressed bytes.

```sh
go test ./...
```

**New config parameters:**

| Parameter | Default | Description |
|---|---|---|
| `archive_interval` / `archiveInterval` | `24h` | Archival window size and job period (minimum `5m`) |
| `archive_grace_period` / `archiveGracePeriod` | `15m` | Grace period past window end before archiving; must be less than `archive_interval` |
| `archive_max_object_bytes` / `archiveMaxObjectBytes` | `134217728` (128MiB) | Max uncompressed bytes per part object before rolling; clamped to `[1MiB, 4GiB]` |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`archive_max_object_bytes` directly influences peak memory consumption on the archiving node (roughly 2x the value when compression is enabled). Operators should size pod memory limits accordingly to avoid OOM conditions when tuning this value upward.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable