### PR TITLE
docs: update audit log archival to document windowed, manifest-based archival with tuning fields

### DIFF
--- a/docs/enterprise/audit-logs.mdx
+++ b/docs/enterprise/audit-logs.mdx
@@ -23,7 +23,7 @@ Audit log entries can be signed with an HMAC key, retained for a configurable nu
 | **Filtering**        | Filter by search text, action, outcome, and date range.                                       |
 | **Export**           | Export matching entries as JSON, JSON Lines, or Syslog when the user has download permission. |
 | **Retention**        | Configure how long audit log entries are kept.                                                |
-| **Object storage archival** | Continuously archive audit events to S3/GCS for long-term, off-box, compliance-grade retention. |
+| **Object storage archival** | Periodically archive audit events to S3/GCS in time-windowed, size-bounded JSONL objects for long-term, off-box, compliance-grade retention. |
 
 ---
 
@@ -46,7 +46,22 @@ Audit log entries can be signed with an HMAC key, retained for a configurable nu
 | `disabled`       | boolean | When `true`, audit logging is turned off. Default: `false`.                                                                                |
 | `hmac_key`       | string  | HMAC secret key used to sign audit events. Minimum 32 bytes. Supports `env.` prefix for environment variables (e.g. `env.AUDIT_HMAC_KEY`). |
 | `retention_days` | integer | Days to retain audit log entries **in the database**. `0` disables retention-based cleanup. Does not affect archived objects (see [Archiving to Object Storage](#archiving-to-object-storage)). |
-| `object_storage` | object  | Optional. When set, archives audit events to S3/GCS in addition to the database. See [Archiving to Object Storage](#archiving-to-object-storage). |
+| `object_storage` | object  | Optional. When set, archives audit events to S3/GCS in addition to the database. Setting it is what enables archival — there is no separate on/off flag. See [Archiving to Object Storage](#archiving-to-object-storage). |
+| `archive_interval` | string | Archival window size, as a Go duration string (e.g. `"6h"`). Also the nominal period of the archival job. Default: `"24h"`. Minimum: `"5m"` (lower values are clamped up). |
+| `archive_grace_period` | string | How long a window is held open past its end before it may be archived, absorbing clock skew and late inserts. Must be **strictly less than** `archive_interval`. Default: `"15m"`. |
+| `archive_max_object_bytes` | integer | Uncompressed JSONL size at which a new part object is started. Default: `134217728` (128 MiB). Minimum 1 MiB, maximum 4 GiB. |
+
+<Note>
+The three `archive_*` fields only take effect when `object_storage` is configured.
+
+`config.schema.json` constrains these fields, so an editor wired to it (via `$schema`) will flag a malformed duration like `"6 hours"` or an out-of-range `archive_max_object_bytes` as you type. The gateway itself does **not** reject such values at startup: each field is normalized independently at runtime, so a value that gets past the schema **falls back to its default or is clamped into range rather than failing startup**. A typo like `"6 hours"` silently yields the 24h default, and `archive_interval: "10s"` is quietly raised to the 5m floor.
+
+Because a bad value fails quietly rather than loudly, confirm what actually took effect from the startup log line, which reports all three:
+
+```
+audit log archive routine started (interval: 24h0m0s, grace: 15m0s, max part size: 134217728 bytes)
+```
+</Note>
 
 ## Viewing Audit Logs
 
@@ -83,7 +98,7 @@ Supported export formats:
 
 By default, audit events live only in the database, which is the source of truth for everything you see in the dashboard (viewing, filtering, HMAC verification, and export). Databases, however, are not ideal for multi-year compliance retention or off-box durability.
 
-When you configure `object_storage`, Bifrost **additionally** writes every audit event to an S3-compatible bucket (S3, GCS, MinIO, R2) as it is recorded. This is a dual-write, not an offload: the full event goes to **both** the database and object storage, so each store holds a complete, independent copy.
+When you configure `object_storage`, a background job **additionally** copies every audit event to an S3-compatible bucket (S3, GCS, MinIO, R2), one time window at a time. This is a copy, not an offload: the full event ends up in **both** the database and object storage, so each store holds a complete, independent copy.
 
 <Note>
 This differs from [Log Exports](/enterprise/log-exports), where object storage *offloads* the heavy request/response payload out of the database. For audit logs, object storage is a complete **mirror** — the database is never trimmed of data by enabling it.
@@ -97,35 +112,90 @@ This differs from [Log Exports](/enterprise/log-exports), where object storage *
 | Used by dashboard / API / export / HMAC verify | Yes | No |
 | Contents | Full event | Full event (identical copy) |
 | Retention | Governed by `retention_days` | Governed by your bucket's lifecycle rules |
-| When populated | Always | Only when `object_storage` is configured, **going forward** (no backfill of existing rows) |
+| When populated | Immediately (buffered, sub-second) | Only when `object_storage` is configured, **going forward** (no backfill), and only once a window closes — so the archive trails the database by at least `archive_interval + archive_grace_period` |
 
 Because the two are decoupled, the archive can outlive the database: once `retention_days` deletes an old row, its object in the bucket is left untouched. Use S3 Object Lock / WORM and bucket lifecycle rules to govern how long the archive is kept.
 
+<Warning>
+Retention and archival are **independent** loops — the cleaner deletes by age and does not wait for a window to be archived. Keep `retention_days` comfortably larger than `archive_interval + archive_grace_period`, or rows may be deleted from the database before they are ever copied to the bucket. With the defaults (24h window, 15m grace) the shortest safe setting is `retention_days: 2`; `retention_days: 1` races the archiver.
+</Warning>
+
 ### How Archival Works
 
-Audit events are written in small batches (buffered and flushed together). Each flushed batch becomes **one gzipped JSON Lines object**, written **after** the database write succeeds. The object key is time-partitioned:
+Archival runs as a **periodic background job**, not as part of the request path. Time is divided into fixed windows of `archive_interval`, and each closed window is archived as a unit, in order:
+
+1. **A window closes.** The window `[start, end)` becomes eligible only once `end` is further in the past than `archive_grace_period`. The grace period absorbs clock skew and rows that land slightly late, so a window is not archived while events may still be arriving for it.
+2. **A job is enqueued.** One job archives one window. Job IDs derive from the window bounds, so in a multi-node cluster every node can tick while exactly one job row is created and exactly one node runs it — no leader election or lock is involved.
+3. **Rows are streamed into part objects.** Committed rows in the window are streamed from the database and encoded as JSON Lines. A new part is rolled each time the accumulated uncompressed JSONL crosses `archive_max_object_bytes`; a part boundary never splits a JSON line.
+4. **A manifest commits the window.** After every part has been durably stored, a `manifest.json` listing exactly those parts is written. The manifest is the **commit point** — only once it lands does the archival watermark advance to `end`, making the next window eligible.
+
+Objects for a window live under a single window prefix:
 
 ```
-{prefix}/audit-logs/{YYYY}/{MM}/{DD}/{HH}/{batchID}.jsonl.gz
+{prefix}/audit-logs/{YYYY}/{MM}/{DD}/{start}-{end}/part-00000.jsonl[.gz]
+{prefix}/audit-logs/{YYYY}/{MM}/{DD}/{start}-{end}/manifest.json[.gz]
 ```
 
-For example, with `"prefix": "acme-prod"` and `"compress": true`:
+For example, with `"prefix": "acme-prod"`, `"compress": true`, and a 24h interval:
 
 ```
-acme-prod/audit-logs/2026/07/07/14/9f3a1c2b-6d4e-4a1b-8c2f-1e2d3c4b5a6f.jsonl.gz
+acme-prod/audit-logs/2026/07/14/20260714T000000Z-20260715T000000Z/part-00000.jsonl.gz
+acme-prod/audit-logs/2026/07/14/20260714T000000Z-20260715T000000Z/part-00001.jsonl.gz
+acme-prod/audit-logs/2026/07/14/20260714T000000Z-20260715T000000Z/manifest.json.gz
 ```
 
 | Key segment | Meaning |
 | ----------- | ------- |
 | `{prefix}` | The configurable base path from `object_storage.prefix` (default `bifrost`). |
 | `audit-logs` | Fixed segment so audit objects never collide with request logs (`logs/`, `mcp-logs/`). |
-| `{YYYY}/{MM}/{DD}/{HH}` | UTC hour of the batch's first event — enables lifecycle rules and prefix-scoped queries (Athena, SIEM ingestion). |
-| `{batchID}` | UUID of the first event in the batch; unique, so objects never overwrite each other. |
-| `.jsonl.gz` | JSON Lines (one event per line). The `.gz` suffix is present only when `compress` is enabled. |
+| `{YYYY}/{MM}/{DD}` | UTC date of the window's **start** — enables lifecycle rules and prefix-scoped queries (Athena, SIEM ingestion). |
+| `{start}-{end}` | The window's UTC bounds in compact ISO-8601 (`20060102T150405Z`), so windows sort chronologically in a bucket listing. |
+| `part-00000` | Zero-padded part index, ordered. A window has as many parts as `archive_max_object_bytes` requires. |
+| `manifest.json` | The window's commit record. Written last; see below. |
+| `.gz` | Present only when `compress` is enabled. |
+
+Every object also carries tags (`type`, `window_start`, `window_end`, `count`, and `part`/`parts`) so lifecycle rules and consumers can select objects without listing and pattern-matching keys. Manifests are tagged `type=audit-logs-manifest`, parts `type=audit-logs`.
+
+#### Reading the Archive
+
+**Always read a window through its manifest, and ignore any object the manifest does not list.** A retried window can leave behind an orphaned part from an earlier attempt; the manifest lists exactly the parts that belong to the window, which is what makes it authoritative.
+
+```json
+{
+  "version": 1,
+  "window_start": "2026-07-14T00:00:00Z",
+  "window_end": "2026-07-15T00:00:00Z",
+  "event_count": 128402,
+  "compressed": true,
+  "completed_at": "2026-07-15T00:15:04Z",
+  "parts": [
+    { "key": "acme-prod/audit-logs/2026/07/14/.../part-00000.jsonl.gz", "event_count": 96311, "bytes": 134217508 },
+    { "key": "acme-prod/audit-logs/2026/07/14/.../part-00001.jsonl.gz", "event_count": 32091, "bytes": 44821904 }
+  ]
+}
+```
+
+A window that contained no events still gets a manifest, with an empty `parts` array — a positive record that the window was examined and held nothing. The absence of a manifest means the window is **not** yet committed, not that it was empty.
+
+#### Delivery Guarantees
+
+| Property | Behavior |
+| -------- | -------- |
+| **Archive-only** | The job never deletes database rows. Retention stays governed by `retention_days`. |
+| **At-least-once** | A window commits only after its manifest is durably written, so a crash re-runs the window. Object uploads are retried (3 attempts, exponential backoff), and a window that fails outright is retried on the next pass with the watermark left untouched — archival does not skip ahead past a failure. |
+| **Contiguous** | Exactly one window is in flight at a time, so committed windows never skip a gap. |
+| **First complete write wins** | Once a window has a manifest, a retry keeps the committed archive as-is. Fields enriched *after* a window was committed are deliberately not re-archived. |
+| **No backfill** | On first run a marker records the starting watermark. Audit events written **before** you enabled `object_storage` are never copied to the bucket. |
 
 <Info>
-Archival is **best-effort, not guaranteed**. The upload happens synchronously within the flush and audit batches are never dropped under back-pressure. If an upload fails, the error is logged but the flush still succeeds — the **database** already holds the record and remains the source of truth, but that batch will be **missing from the bucket**, and nothing blocks request handling. Treat object storage as a complete compliance mirror only if you monitor upload failures and replay any missed batches; the database, not the archive, is authoritative.
+Unlike the earlier per-flush implementation, archival is **no longer best-effort** — a failed upload is retried rather than logged and dropped, and the watermark will not advance past a window that did not commit. The database nevertheless remains the source of truth: it is what the dashboard, API, export, and HMAC verification read, and it is written independently of whether the bucket is reachable. Object-storage problems delay the archive; they never block audit logging or request handling.
 </Info>
+
+#### Tuning
+
+- **`archive_interval`** trades archive freshness against object count. Longer windows mean fewer, larger objects and a longer lag before events reach the bucket; shorter windows mean fresher data and more objects. The job wakes at least hourly regardless, so a window that closes shortly after a tick is not left waiting a full 24h.
+- **`archive_max_object_bytes`** bounds peak memory: a part is buffered in memory before upload, so expect roughly **2× this value** per archiving node when `compress` is enabled (compression allocates a second buffer). The 128 MiB default implies a ~256 MiB peak. Raise it for fewer, larger objects on nodes with headroom; lower it on memory-constrained nodes.
+- **`archive_grace_period`** rarely needs changing. Raise it if you run with meaningful clock skew across nodes.
 
 ### Configuration
 
@@ -137,6 +207,9 @@ Archival is **best-effort, not guaranteed**. The upload happens synchronously wi
   "audit_logs": {
     "hmac_key": "env.AUDIT_HMAC_KEY",
     "retention_days": 365,
+    "archive_interval": "24h",
+    "archive_grace_period": "15m",
+    "archive_max_object_bytes": 134217728,
     "object_storage": {
       "type": "s3",
       "bucket": "acme-audit-archive",
@@ -158,6 +231,9 @@ Archival is **best-effort, not guaranteed**. The upload happens synchronously wi
   "audit_logs": {
     "hmac_key": "env.AUDIT_HMAC_KEY",
     "retention_days": 365,
+    "archive_interval": "24h",
+    "archive_grace_period": "15m",
+    "archive_max_object_bytes": 134217728,
     "object_storage": {
       "type": "gcs",
       "bucket": "acme-audit-archive",
@@ -195,6 +271,12 @@ You can point audit archival at its own dedicated (ideally write-once/locked) bu
 </Note>
 
 If the object store cannot be reached at startup, Bifrost logs the error and continues **without** archival — audit logging to the database is never blocked by object-storage problems.
+
+The watermark is persisted, not held in memory, so archival **resumes where it left off** after a restart or an outage: windows that closed while the archiver was down are archived on subsequent passes until it catches up. Nothing is skipped — provided the rows are still in the database, which is what the `retention_days` guidance above protects.
+
+Catch-up is paced, though: each pass enqueues **one** window, and passes run every `archive_interval` (capped at hourly). After a long outage, expect a backlog of *N* windows to take roughly *N* passes to drain — so a multi-day outage with a 24h interval clears at about one window per hour, not all at once.
+
+On shutdown the archiver stops before the object store is released, and an in-flight window is allowed to finish rather than being cancelled, so parts are never left behind without a manifest.
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

Updates the audit log archival documentation to reflect a redesigned background-job-based archival system, replacing the previous per-flush, best-effort write model with a windowed, manifest-committed approach that provides stronger delivery guarantees.

## Changes

- Clarified that archival is now a **periodic background job** operating on fixed time windows rather than a synchronous per-flush upload, and updated all descriptions accordingly.
- Documented three new configuration fields: `archive_interval`, `archive_grace_period`, and `archive_max_object_bytes`, including their defaults, validation behavior, and silent fallback-to-default on invalid values.
- Updated the object key schema from per-batch UUIDs under an hourly prefix to a windowed `{start}-{end}/part-NNNNN.jsonl[.gz]` layout with a `manifest.json` commit record.
- Added a full explanation of the archival lifecycle: window eligibility via grace period, job deduplication across multi-node clusters, part rolling by size, and manifest-as-commit-point semantics.
- Added a manifest JSON example and guidance that consumers must read windows through their manifests to avoid orphaned parts from retried runs.
- Replaced the "best-effort" warning with a delivery guarantees table covering at-least-once, contiguous, and first-complete-write-wins semantics.
- Added a warning that `retention_days` and archival are independent loops, with explicit guidance that `retention_days: 1` races the archiver under default settings.
- Documented catch-up behavior after outages, watermark persistence across restarts, and graceful shutdown behavior.
- Added a tuning section covering the memory implications of `archive_max_object_bytes` and when to adjust `archive_grace_period`.
- Added `archive_interval`, `archive_grace_period`, and `archive_max_object_bytes` to both the S3 and GCS configuration examples.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation for accuracy against the archival implementation. Confirm:

- The object key examples match what the archiver actually writes.
- The manifest JSON schema matches the struct the archiver serializes.
- Default values for `archive_interval` (`24h`), `archive_grace_period` (`15m`), and `archive_max_object_bytes` (`134217728`) match the implementation.
- The `retention_days: 2` minimum safe value holds given the default window and grace period.

## Breaking changes

- [x] Yes
- [ ] No

The object key layout has changed from `{prefix}/audit-logs/{YYYY}/{MM}/{DD}/{HH}/{batchID}.jsonl.gz` to `{prefix}/audit-logs/{YYYY}/{MM}/{DD}/{start}-{end}/part-NNNNN.jsonl[.gz]`. Any existing tooling, lifecycle rules, or SIEM ingestion pipelines keyed on the old path structure will need to be updated. Objects written under the old scheme are not affected retroactively, but new archives will not appear at the old paths.

## Related issues

N/A

## Security considerations

No new secrets or PII handling introduced. The `archive_grace_period` and watermark persistence are relevant to compliance posture — operators should confirm `retention_days` is set high enough to avoid rows being deleted before they are archived.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable