### PR TITLE
feat: adds MCP metrics to OTEL

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2805,6 +2805,20 @@ func ensureMCPRawStorageContext(ctx *schemas.BifrostContext) {
 	ctx.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
 }
 
+// ensureMCPTracerContext installs the tracer on a request-scoped context for MCP tool
+// executions that skip the chat/responses flow (chiefly the inbound MCP-server path). A
+// trace must already exist (created by the HTTP TracingMiddleware) for StartSpan to emit a
+// span. Existing value never overwritten; nil ctx/tracer no-op.
+func ensureMCPTracerContext(ctx *schemas.BifrostContext, tracer schemas.Tracer) {
+	if ctx == nil || tracer == nil {
+		return
+	}
+	if _, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok {
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
+}
+
 // ExecuteChatMCPTool executes an MCP tool call and returns the result as a chat message.
 // This is the main public API for manual MCP tool execution in Chat format. All the
 // real work — request pooling, plugin gate (PreMCPHook / PostMCPHook), short-circuit
@@ -2814,6 +2828,7 @@ func (bifrost *Bifrost) ExecuteChatMCPTool(ctx *schemas.BifrostContext, toolCall
 		ctx = bifrost.ctx
 	} else {
 		ensureMCPRawStorageContext(ctx)
+		ensureMCPTracerContext(ctx, bifrost.getTracer())
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{
@@ -2832,6 +2847,7 @@ func (bifrost *Bifrost) ExecuteResponsesMCPTool(ctx *schemas.BifrostContext, too
 		ctx = bifrost.ctx
 	} else {
 		ensureMCPRawStorageContext(ctx)
+		ensureMCPTracerContext(ctx, bifrost.getTracer())
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{

--- a/core/mcp/error_classify_test.go
+++ b/core/mcp/error_classify_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestMCPErrorTypeClassification asserts that mcpErrorType maps failed MCP ops onto the
+// low-cardinality error.type values used by the mcp.client.operation.duration metric,
+// including the sentinel-wrapped wire errors and the _OTHER catch-all.
+func TestMCPErrorTypeClassification(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *schemas.BifrostError
+		want string
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: "_OTHER",
+		},
+		{
+			name: "auth required takes precedence",
+			err: &schemas.BifrostError{
+				Error:       &schemas.ErrorField{Message: "auth", Error: ErrMCPToolTimeout},
+				ExtraFields: schemas.BifrostErrorExtraFields{MCPAuthRequired: &schemas.MCPAuthRequiredError{}},
+			},
+			want: "auth_required",
+		},
+		{
+			name: "timeout sentinel through fmt wrap",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Message: "MCP tool call timed out after 30s: search",
+					Error:   fmt.Errorf("MCP tool call timed out after 30s: search: %w", ErrMCPToolTimeout),
+				},
+			},
+			want: "timeout",
+		},
+		{
+			name: "tool_error sentinel through fmt wrap",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Message: "MCP tool call failed for search: boom",
+					Error:   fmt.Errorf("MCP tool call failed for search: boom: %w", ErrMCPToolCallFailed),
+				},
+			},
+			want: "tool_error",
+		},
+		{
+			name: "unclassified error falls back to _OTHER",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{Message: "tool execution returned nil result", Error: fmt.Errorf("nil result")},
+			},
+			want: "_OTHER",
+		},
+		{
+			name: "error present but no wrapped chain",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{Message: "plugin denied"},
+			},
+			want: "_OTHER",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mcpErrorType(tt.err); got != tt.want {
+				t.Errorf("mcpErrorType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/mcp/pluginpipeline.go
+++ b/core/mcp/pluginpipeline.go
@@ -2,12 +2,20 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Sentinels wrapped (%w) into wire-op errors so mcpErrorType classifies error.type via
+// errors.Is, not message text. toolmanager.go wraps them at the CallTool site.
+var (
+	ErrMCPToolTimeout    = errors.New("mcp tool call timed out")
+	ErrMCPToolCallFailed = errors.New("mcp tool call failed")
 )
 
 // MCPOpFunc is the closure each call site provides to RunWithPluginPipeline. It receives the
@@ -49,80 +57,111 @@ func (m *MCPManager) RunWithPluginPipeline(
 		}
 	}
 
-	// Wrap the whole gate (PreHook + op + PostHook) in an outer span so traces show one
-	// row per MCP op alongside the per-plugin spans the pipeline emits internally.
+	// Span layout mirrors the LLM path: /mcp HTTP span is the parent, PreHook spans chain
+	// under it, the op span nests under the last PreHook, and PostHook spans nest under the
+	// op span. A PreHook short-circuit produces no op span (like a short-circuited llm.call).
 	tracer, _ := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
-	var spanHandle schemas.SpanHandle
-	if tracer != nil {
-		spanName := fmt.Sprintf("mcp.%s", req.RequestType)
-		if req.ClientName != "" {
-			spanName = fmt.Sprintf("%s.%s", spanName, req.ClientName)
-		}
-		_, spanHandle = tracer.StartSpan(ctx, spanName, schemas.SpanKindMCPClient)
-		// Emit OTel GenAI tool-execution attributes on execute-tool spans so downstream
-		// backends can correlate tool calls with their requesting llm.call.
-		if req != nil && req.RequestType.IsExecuteTool() {
-			tracer.SetAttribute(spanHandle, schemas.AttrOperationName, schemas.OTelOperationNameExecuteTool)
-			tracer.SetAttribute(spanHandle, schemas.AttrToolType, "function")
-			if name := req.GetToolName(); name != "" {
-				tracer.SetAttribute(spanHandle, schemas.AttrToolName, name)
-			}
-			// GetToolArguments returns interface{}; the Responses branch boxes a
-			// *string, so a nil pointer survives the != nil guard. Unwrap and skip
-			// it explicitly, and deref non-nil so the attribute is the JSON string.
-			if args := req.GetToolArguments(); args != nil {
-				if p, ok := args.(*string); ok {
-					if p != nil {
-						tracer.SetAttribute(spanHandle, schemas.AttrToolCallArguments, *p)
-					}
-				} else {
-					tracer.SetAttribute(spanHandle, schemas.AttrToolCallArguments, args)
-				}
-			}
-			if req.ChatAssistantMessageToolCall != nil && req.ChatAssistantMessageToolCall.ID != nil {
-				tracer.SetAttribute(spanHandle, schemas.AttrToolCallID, *req.ChatAssistantMessageToolCall.ID)
-			} else if req.ResponsesToolMessage != nil && req.ResponsesToolMessage.CallID != nil {
-				tracer.SetAttribute(spanHandle, schemas.AttrToolCallID, *req.ResponsesToolMessage.CallID)
-			}
-		}
-	}
-	defer func() {
-		if tracer == nil {
-			return
-		}
-		// Tool-call result captured via named returns — set just before EndSpan so the
-		// attribute lands on the open span before it's frozen.
-		if finalResponse != nil && req != nil && req.RequestType.IsExecuteTool() {
-			if data, err := schemas.MarshalString(finalResponse); err == nil {
-				tracer.SetAttribute(spanHandle, schemas.AttrToolCallResult, data)
-			}
-		}
-		if finalError != nil {
-			msg := ""
-			if finalError.Error != nil {
-				msg = finalError.Error.Message
-			}
-			tracer.EndSpan(spanHandle, schemas.SpanStatusError, msg)
-		} else {
-			tracer.EndSpan(spanHandle, schemas.SpanStatusOk, "")
-		}
-	}()
 
-	// MCP request type stamped on every wrapped BifrostError so downstream gates
-	// (governance, logging) can discriminate execute-tool calls from ping/list_tools.
+	// Stamped on every wrapped BifrostError so downstream gates discriminate execute-tool
+	// from ping/list_tools.
 	mcpReqType := schemas.MCPRequestType("")
 	if req != nil {
 		mcpReqType = req.RequestType
 	}
 
-	// No pipeline configured → run the op directly, no hooks (but span still recorded).
+	// Set by startOpSpan only when the wire op runs (nil for short-circuits → deferred end
+	// is a no-op). startOpSpan threads the new span id onto ctx (no restore) so the op and
+	// PostHook spans nest under it.
+	var opSpanHandle schemas.SpanHandle
+	startOpSpan := func(r *schemas.BifrostMCPRequest) {
+		if tracer == nil {
+			return
+		}
+		spanName := fmt.Sprintf("mcp.%s", mcpReqType)
+		if r != nil && r.ClientName != "" {
+			spanName = fmt.Sprintf("%s.%s", spanName, r.ClientName)
+		}
+		spanKind := schemas.SpanKindMCPClient
+		if mcpReqType.IsExecuteTool() {
+			spanKind = schemas.SpanKindMCPTool
+		}
+		spanCtx, handle := tracer.StartSpan(ctx, spanName, spanKind)
+		opSpanHandle = handle
+		if spanCtx != nil {
+			if id, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok && id != "" {
+				ctx.SetValue(schemas.BifrostContextKeySpanID, id)
+			}
+		}
+		if r == nil {
+			return
+		}
+		tracer.SetAttribute(handle, schemas.AttrMCPMethodName, r.RequestType.OTelMethodName())
+		if transport := m.connectionTypeForClientName(r.ClientName).OTelNetworkTransport(); transport != "" {
+			tracer.SetAttribute(handle, schemas.AttrNetworkTransport, transport)
+		}
+		// Emit OTel GenAI tool-execution attributes on execute-tool spans so downstream
+		// backends can correlate tool calls with their requesting llm.call.
+		if r.RequestType.IsExecuteTool() {
+			tracer.SetAttribute(handle, schemas.AttrOperationName, schemas.OTelOperationNameExecuteTool)
+			tracer.SetAttribute(handle, schemas.AttrToolType, "function")
+			if name := r.GetToolName(); name != "" {
+				tracer.SetAttribute(handle, schemas.AttrToolName, name)
+			}
+			// GetToolArguments returns interface{}; the Responses branch boxes a *string, so
+			// a nil pointer survives the != nil guard. Deref non-nil so the attr is the JSON string.
+			if args := r.GetToolArguments(); args != nil {
+				if p, ok := args.(*string); ok {
+					if p != nil {
+						tracer.SetAttribute(handle, schemas.AttrToolCallArguments, *p)
+					}
+				} else {
+					tracer.SetAttribute(handle, schemas.AttrToolCallArguments, args)
+				}
+			}
+			if r.ChatAssistantMessageToolCall != nil && r.ChatAssistantMessageToolCall.ID != nil {
+				tracer.SetAttribute(handle, schemas.AttrToolCallID, *r.ChatAssistantMessageToolCall.ID)
+			} else if r.ResponsesToolMessage != nil && r.ResponsesToolMessage.CallID != nil {
+				tracer.SetAttribute(handle, schemas.AttrToolCallID, *r.ResponsesToolMessage.CallID)
+			}
+		}
+	}
+	defer func() {
+		if tracer == nil || opSpanHandle == nil {
+			return
+		}
+		if finalResponse != nil {
+			// Tool-execution (CallTool) latency, so the metric measures it, not span wall-time.
+			if finalResponse.ExtraFields.Latency > 0 {
+				tracer.SetAttribute(opSpanHandle, schemas.AttrBifrostMCPToolDurationMs, finalResponse.ExtraFields.Latency)
+			}
+			if req != nil && req.RequestType.IsExecuteTool() {
+				if data, err := schemas.MarshalString(finalResponse); err == nil {
+					tracer.SetAttribute(opSpanHandle, schemas.AttrToolCallResult, data)
+				}
+			}
+		}
+		setMCPGovernanceSpanAttrs(tracer, opSpanHandle, ctx)
+		if finalError != nil {
+			msg := ""
+			if finalError.Error != nil {
+				msg = finalError.Error.Message
+			}
+			tracer.SetAttribute(opSpanHandle, schemas.AttrErrorTypeSpec, mcpErrorType(finalError))
+			tracer.EndSpan(opSpanHandle, schemas.SpanStatusError, msg)
+		} else {
+			tracer.EndSpan(opSpanHandle, schemas.SpanStatusOk, "")
+		}
+	}()
+
+	// No pipeline configured → run the op directly under its own span, no hooks.
 	pipeline := m.GetPluginPipeline()
 	if pipeline == nil {
+		startOpSpan(req)
 		resp, opErr := op(req)
 		if opErr != nil {
 			return resp, &schemas.BifrostError{
 				IsBifrostError: false,
-				Error:          &schemas.ErrorField{Message: opErr.Error()},
+				Error:          &schemas.ErrorField{Message: opErr.Error(), Error: opErr},
 				ExtraFields:    schemas.BifrostErrorExtraFields{MCPRequestType: mcpReqType},
 			}
 		}
@@ -130,7 +169,8 @@ func (m *MCPManager) RunWithPluginPipeline(
 	}
 	defer m.ReleasePluginPipeline(pipeline)
 
-	// PreHooks. preReq is the (possibly mutated) request that must flow to the op.
+	// PreHooks. preReq is the (possibly mutated) request for the op. Their spans chain under
+	// the /mcp HTTP span — no op span exists yet.
 	preReq, shortCircuit, preCount := pipeline.RunMCPPreHooks(ctx, req)
 
 	// Pull attribution from the request so short-circuit responses still carry
@@ -146,7 +186,7 @@ func (m *MCPManager) RunWithPluginPipeline(
 	}
 
 	if shortCircuit != nil {
-		// Short-circuit with response — still run PostHooks for plugins that ran.
+		// Short-circuit: the wire op never runs, so no op span is created. PostHooks still run.
 		if shortCircuit.Response != nil {
 			shortCircuit.Response.PopulateExtraFields(mcpReqType, clientName, toolName)
 			finalResp, finalErr := pipeline.RunMCPPostHooks(ctx, shortCircuit.Response, nil, preCount)
@@ -182,18 +222,23 @@ func (m *MCPManager) RunWithPluginPipeline(
 		}
 	}
 
+	// Op span created after the PreHooks so it nests under the last PreHook; PostHooks nest
+	// under it.
+	startOpSpan(preReq)
+
 	// Run the actual wire op with the mutated request.
 	resp, opErr := op(preReq)
 	if resp != nil {
 		resp.PopulateExtraFields(mcpReqType, clientName, toolName)
 	}
 
-	// Wrap opErr as BifrostError so PostHooks see a typed error.
+	// Wrap opErr so PostHooks see a typed error. Keep the original on ErrorField.Error
+	// (json:"-") so mcpErrorType classifies it via errors.Is.
 	var bErr *schemas.BifrostError
 	if opErr != nil {
 		bErr = &schemas.BifrostError{
 			IsBifrostError: false,
-			Error:          &schemas.ErrorField{Message: opErr.Error()},
+			Error:          &schemas.ErrorField{Message: opErr.Error(), Error: opErr},
 			ExtraFields:    schemas.BifrostErrorExtraFields{MCPRequestType: mcpReqType},
 		}
 	}
@@ -236,25 +281,59 @@ func (m *MCPManager) runConnectWithPluginPipeline(
 		clientName = req.ClientName
 	}
 
-	// Outer span so traces show one row per Connect op.
+	// Span layout mirrors RunWithPluginPipeline: connect span created after the PreConnection
+	// hooks, nesting under the last one; PostConnection hooks nest under it. Connect is the
+	// MCP "initialize" method.
 	tracer, _ := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
-	var spanHandle schemas.SpanHandle
-	if tracer != nil {
-		spanName := "mcp.connect"
-		if clientName != "" {
-			spanName = fmt.Sprintf("%s.%s", spanName, clientName)
+
+	var connSpanHandle schemas.SpanHandle
+	startConnectSpan := func(r *schemas.BifrostMCPConnectRequest) {
+		if tracer == nil {
+			return
 		}
-		_, spanHandle = tracer.StartSpan(ctx, spanName, schemas.SpanKindMCPClient)
+		name := clientName
+		if r != nil && r.ClientName != "" {
+			name = r.ClientName
+		}
+		spanName := "mcp.connect"
+		if name != "" {
+			spanName = fmt.Sprintf("%s.%s", spanName, name)
+		}
+		spanCtx, handle := tracer.StartSpan(ctx, spanName, schemas.SpanKindMCPClient)
+		connSpanHandle = handle
+		if spanCtx != nil {
+			if id, ok := spanCtx.Value(schemas.BifrostContextKeySpanID).(string); ok && id != "" {
+				ctx.SetValue(schemas.BifrostContextKeySpanID, id)
+			}
+		}
+		tracer.SetAttribute(handle, schemas.AttrMCPMethodName, "initialize")
+		if r != nil {
+			if transport := r.ConnectionType.OTelNetworkTransport(); transport != "" {
+				tracer.SetAttribute(handle, schemas.AttrNetworkTransport, transport)
+			}
+		}
 	}
 	defer func() {
-		if tracer != nil {
-			tracer.EndSpan(spanHandle, schemas.SpanStatusOk, "")
+		if tracer == nil || connSpanHandle == nil {
+			return
+		}
+		setMCPGovernanceSpanAttrs(tracer, connSpanHandle, ctx)
+		if finalError != nil {
+			msg := ""
+			if finalError.Error != nil {
+				msg = finalError.Error.Message
+			}
+			tracer.SetAttribute(connSpanHandle, schemas.AttrErrorTypeSpec, mcpErrorType(finalError))
+			tracer.EndSpan(connSpanHandle, schemas.SpanStatusError, msg)
+		} else {
+			tracer.EndSpan(connSpanHandle, schemas.SpanStatusOk, "")
 		}
 	}()
 
-	// No pipeline configured → run the op directly.
+	// No pipeline configured → run the op directly under its own span.
 	pipeline := m.GetPluginPipeline()
 	if pipeline == nil {
+		startConnectSpan(req)
 		resp, opErr := op(req)
 		if opErr != nil {
 			return resp, &schemas.BifrostError{
@@ -301,6 +380,9 @@ func (m *MCPManager) runConnectWithPluginPipeline(
 			Error:          &schemas.ErrorField{Message: "Connect request after plugin hooks cannot be nil"},
 		}
 	}
+
+	// Connect span created after the PreConnection hooks so they nest under it.
+	startConnectSpan(preReq)
 
 	resp, opErr := op(preReq)
 	if resp != nil {
@@ -425,4 +507,63 @@ func (chm *ClientHealthMonitor) runPingWithHooks(ctx context.Context, conn *clie
 		return fmt.Errorf("ping failed: %s", bErr.GetErrorString())
 	}
 	return nil
+}
+
+// connectionTypeForClientName resolves a client's transport by name. Returns "" when no
+// live client matches (per-user/ephemeral connections), so callers omit the attribute.
+func (m *MCPManager) connectionTypeForClientName(name string) schemas.MCPConnectionType {
+	if name == "" {
+		return ""
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, state := range m.clientMap {
+		// Match on ExecutionConfig.Name, as GetClientByName does.
+		if state != nil && state.ExecutionConfig != nil && state.ExecutionConfig.Name == name {
+			return state.ExecutionConfig.ConnectionType
+		}
+	}
+	return ""
+}
+
+// mcpErrorType classifies a failed MCP op into a low-cardinality error.type for the
+// metric (_OTHER is the OTel catch-all). Best-effort: an error swapped by a PostHook
+// degrades to _OTHER.
+func mcpErrorType(bErr *schemas.BifrostError) string {
+	if bErr == nil {
+		return "_OTHER"
+	}
+	if bErr.ExtraFields.MCPAuthRequired != nil {
+		return "auth_required"
+	}
+	if bErr.Error != nil && bErr.Error.Error != nil {
+		switch {
+		case errors.Is(bErr.Error.Error, ErrMCPToolTimeout):
+			return "timeout"
+		case errors.Is(bErr.Error.Error, ErrMCPToolCallFailed):
+			return "tool_error"
+		}
+	}
+	return "_OTHER"
+}
+
+// setMCPGovernanceSpanAttrs copies the metric-safe bifrost.* governance identity from
+// context onto an MCP span for per-tenant metric breakdowns. Absent dims are skipped.
+func setMCPGovernanceSpanAttrs(tracer schemas.Tracer, handle schemas.SpanHandle, ctx *schemas.BifrostContext) {
+	if tracer == nil || ctx == nil {
+		return
+	}
+	setIfPresent := func(ctxKey schemas.BifrostContextKey, attrKey string) {
+		if v, ok := ctx.Value(ctxKey).(string); ok && v != "" {
+			tracer.SetAttribute(handle, attrKey, v)
+		}
+	}
+	setIfPresent(schemas.BifrostContextKeyGovernanceVirtualKeyID, schemas.AttrBifrostVirtualKeyID)
+	setIfPresent(schemas.BifrostContextKeyGovernanceVirtualKeyName, schemas.AttrBifrostVirtualKeyName)
+	setIfPresent(schemas.BifrostContextKeyGovernanceTeamID, schemas.AttrBifrostTeamID)
+	setIfPresent(schemas.BifrostContextKeyGovernanceTeamName, schemas.AttrBifrostTeamName)
+	setIfPresent(schemas.BifrostContextKeyGovernanceCustomerID, schemas.AttrBifrostCustomerID)
+	setIfPresent(schemas.BifrostContextKeyGovernanceCustomerName, schemas.AttrBifrostCustomerName)
+	setIfPresent(schemas.BifrostContextKeyGovernanceBusinessUnitID, schemas.AttrBifrostBusinessUnitID)
+	setIfPresent(schemas.BifrostContextKeyGovernanceBusinessUnitName, schemas.AttrBifrostBusinessUnitName)
 }

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -710,12 +710,12 @@ func (m *ToolsManager) executeToolInternal(
 
 	toolResponse, callErr := clientConn.CallTool(toolCtx, callRequest)
 	if callErr != nil {
-		// Check if it was a timeout error
+		// Sentinel-wrapped so the gate can classify error.type (timeout vs tool_error).
 		if toolCtx.Err() == context.DeadlineExceeded {
-			return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
+			return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s: %w", toolExecutionTimeout, toolName, ErrMCPToolTimeout)
 		}
 		m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, executionConfig.Name, callErr)
-		return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
+		return nil, "", "", fmt.Errorf("MCP tool call failed for %s: %v: %w", toolName, callErr, ErrMCPToolCallFailed)
 	}
 
 	// Extract text from MCP response

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -935,6 +935,21 @@ func (t MCPRequestType) IsExecuteTool() bool {
 	return false
 }
 
+// OTelMethodName returns the OTel semconv mcp.method.name for this request type
+// (tools/call, tools/list, ping). Unknown types fall back to the raw string.
+func (t MCPRequestType) OTelMethodName() string {
+	switch {
+	case t.IsExecuteTool():
+		return "tools/call"
+	case t == MCPRequestTypeListTools:
+		return "tools/list"
+	case t == MCPRequestTypePing:
+		return "ping"
+	default:
+		return string(t)
+	}
+}
+
 // BifrostMCPRequest is the envelope for MCP requests that flow through the generic
 // PreMCPHook/PostMCPHook pipeline (Ping, ListTools, ExecuteTool variants). Connect
 // requests do NOT use this envelope — they are dispatched via the typed

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -531,6 +531,19 @@ const (
 	MCPConnectionTypeInProcess MCPConnectionType = "inprocess" // In-process (in-memory) connection
 )
 
+// OTelNetworkTransport returns the OTel semconv network.transport value: stdio→"pipe",
+// http/sse→"tcp". InProcess has none, so it returns "" and callers omit the attribute.
+func (c MCPConnectionType) OTelNetworkTransport() string {
+	switch c {
+	case MCPConnectionTypeSTDIO:
+		return "pipe"
+	case MCPConnectionTypeHTTP, MCPConnectionTypeSSE:
+		return "tcp"
+	default:
+		return ""
+	}
+}
+
 // MCPStdioConfig defines how to launch a STDIO-based MCP server.
 type MCPStdioConfig struct {
 	Command string   `json:"command"` // Executable command to run

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -688,6 +688,15 @@ const (
 	AttrToolCallResult    = "gen_ai.tool.call.result"
 	AttrToolType          = "gen_ai.tool.type"
 
+	// OTel MCP semconv attributes on mcp.client spans, read by the duration metric.
+	AttrMCPMethodName    = "mcp.method.name"   // e.g. tools/call, tools/list, ping
+	AttrNetworkTransport = "network.transport" // pipe (stdio) | tcp (http/sse)
+
+	// Tool-execution latency (ms) — the raw CallTool round-trip — so the duration metric
+	// measures it, not span wall-time (which covers the PostHooks). Bifrost-namespaced; not
+	// OTel MCP semconv.
+	AttrBifrostMCPToolDurationMs = "bifrost.mcp.tool.duration_ms"
+
 	// =====================================================================
 	// Bifrost-namespaced attributes (bifrost.*)
 	//

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -676,6 +676,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 			}
 			if t.metricsExporter != nil {
 				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
+				p.recordMCPMetricsFromTrace(ctx, t.metricsExporter, trace)
 			}
 		}(t)
 	}
@@ -792,6 +793,76 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID),
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName),
 	)
+}
+
+// buildMCPSpanAttrs builds the duration-metric dimensions: semconv attrs + governance
+// identity. error.type is appended by the caller on failure. Empty optionals skipped.
+func buildMCPSpanAttrs(span *schemas.Span) []attribute.KeyValue {
+	attrs := span.Attributes
+	out := []attribute.KeyValue{
+		attribute.String(schemas.AttrMCPMethodName, getStringAttr(attrs, schemas.AttrMCPMethodName)),
+	}
+	if tool := getStringAttr(attrs, schemas.AttrToolName); tool != "" {
+		out = append(out, attribute.String(schemas.AttrToolName, tool))
+	}
+	if transport := getStringAttr(attrs, schemas.AttrNetworkTransport); transport != "" {
+		out = append(out, attribute.String(schemas.AttrNetworkTransport, transport))
+	}
+	// Governance identity: bifrost.* span attrs → flat metric label names.
+	for spanKey, labelKey := range mcpGovernanceLabelMap {
+		if v := getStringAttr(attrs, spanKey); v != "" {
+			out = append(out, attribute.String(labelKey, v))
+		}
+	}
+	return out
+}
+
+// mcpGovernanceLabelMap maps bifrost.* span attr keys to the flat metric label names.
+var mcpGovernanceLabelMap = map[string]string{
+	schemas.AttrBifrostVirtualKeyID:     "virtual_key_id",
+	schemas.AttrBifrostVirtualKeyName:   "virtual_key_name",
+	schemas.AttrBifrostTeamID:           "team_id",
+	schemas.AttrBifrostTeamName:         "team_name",
+	schemas.AttrBifrostCustomerID:       "customer_id",
+	schemas.AttrBifrostCustomerName:     "customer_name",
+	schemas.AttrBifrostBusinessUnitID:   "business_unit_id",
+	schemas.AttrBifrostBusinessUnitName: "business_unit_name",
+}
+
+// recordMCPMetricsFromTrace records the duration metric once per MCP client span. Called
+// from Inject alongside recordMetricsFromTrace.
+func (p *OtelPlugin) recordMCPMetricsFromTrace(ctx context.Context, exporter *MetricsExporter, trace *schemas.Trace) {
+	if trace == nil || exporter == nil {
+		return
+	}
+	for _, span := range trace.Spans {
+		// Both MCP kinds are client operations for mcp.client.operation.duration:
+		// SpanKindMCPTool (tool calls) and SpanKindMCPClient (ping/list_tools/connect).
+		if span == nil || (span.Kind != schemas.SpanKindMCPClient && span.Kind != schemas.SpanKindMCPTool) {
+			continue
+		}
+		// Skip un-enriched spans so we never emit an empty mcp.method.name dimension.
+		if getStringAttr(span.Attributes, schemas.AttrMCPMethodName) == "" {
+			continue
+		}
+		mcpAttrs := buildMCPSpanAttrs(span)
+		if span.Status == schemas.SpanStatusError {
+			errorType := getStringAttr(span.Attributes, schemas.AttrErrorTypeSpec)
+			if errorType == "" {
+				errorType = "_OTHER"
+			}
+			mcpAttrs = append(mcpAttrs, attribute.String(schemas.AttrErrorTypeSpec, errorType))
+		}
+		// Prefer tool-execution (CallTool) latency over span wall-time (which covers PostHooks).
+		// Fall back to wall-time when it's absent (e.g. the op failed before returning one).
+		var durationSeconds float64
+		if toolMs := getIntAttr(span.Attributes, schemas.AttrBifrostMCPToolDurationMs); toolMs > 0 {
+			durationSeconds = float64(toolMs) / 1000.0
+		} else if !span.StartTime.IsZero() && !span.EndTime.IsZero() {
+			durationSeconds = span.EndTime.Sub(span.StartTime).Seconds()
+		}
+		exporter.RecordMCPOperationDuration(ctx, durationSeconds, mcpAttrs...)
+	}
 }
 
 // recordMetricsFromTrace extracts metrics data from a completed trace and records them

--- a/plugins/otel/mcp_metrics_test.go
+++ b/plugins/otel/mcp_metrics_test.go
@@ -1,0 +1,202 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// attrMap collapses a []attribute.KeyValue into a lookup for assertions.
+func attrMap(kvs []attribute.KeyValue) map[string]string {
+	out := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		out[string(kv.Key)] = kv.Value.AsString()
+	}
+	return out
+}
+
+// TestBuildMCPSpanAttrsSemconvAndGovernance asserts the MCP metric attribute set carries
+// the OTel semconv dimensions plus the flat-named governance labels, and that absent
+// optional dimensions are omitted (no empty-value label churn).
+func TestBuildMCPSpanAttrsSemconvAndGovernance(t *testing.T) {
+	span := &schemas.Span{
+		Kind: schemas.SpanKindMCPTool, // a tools/call is a tool invocation
+		Attributes: map[string]any{
+			schemas.AttrMCPMethodName:       "tools/call",
+			schemas.AttrToolName:            "search",
+			schemas.AttrNetworkTransport:    "pipe",
+			schemas.AttrBifrostVirtualKeyID: "vk_123",
+			schemas.AttrBifrostTeamName:     "platform",
+			// business unit / customer intentionally absent
+		},
+	}
+
+	got := attrMap(buildMCPSpanAttrs(span))
+
+	want := map[string]string{
+		schemas.AttrMCPMethodName:    "tools/call",
+		schemas.AttrToolName:         "search",
+		schemas.AttrNetworkTransport: "pipe",
+		"virtual_key_id":             "vk_123",
+		"team_name":                  "platform",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("attr %q = %q, want %q", k, got[k], v)
+		}
+	}
+	// error.type is added by the recorder only on failure, never by buildMCPSpanAttrs.
+	if _, ok := got[schemas.AttrErrorTypeSpec]; ok {
+		t.Error("error.type must not be present on a non-error span's attrs")
+	}
+	// Absent optional governance dims must not appear as empty labels.
+	for _, absent := range []string{"customer_id", "business_unit_id", "team_id"} {
+		if _, ok := got[absent]; ok {
+			t.Errorf("absent dimension %q should be omitted, got %q", absent, got[absent])
+		}
+	}
+}
+
+// TestRecordMCPMetricsFromTraceRecordsBothKinds asserts the recorder emits one
+// mcp.client.operation.duration sample per MCP span — for BOTH SpanKindMCPTool (tool
+// calls) and SpanKindMCPClient (lifecycle) — preferring the wire latency over wall-time,
+// tagging error.type on failures, and skipping un-enriched and non-MCP spans.
+func TestRecordMCPMetricsFromTraceRecordsBothKinds(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := &MetricsExporter{provider: provider, meter: provider.Meter("test")}
+	m.initMetrics()
+
+	now := time.Now()
+	trace := &schemas.Trace{
+		Spans: []*schemas.Span{
+			{ // tool call → MCPTool; duration from the 2000ms wire latency, not 5s wall-time
+				Kind:      schemas.SpanKindMCPTool,
+				StartTime: now, EndTime: now.Add(5 * time.Second),
+				Status: schemas.SpanStatusOk,
+				Attributes: map[string]any{
+					schemas.AttrMCPMethodName:            "tools/call",
+					schemas.AttrToolName:                 "search",
+					schemas.AttrBifrostMCPToolDurationMs: int64(2000),
+				},
+			},
+			{ // lifecycle → MCPClient; wall-time fallback (1s) + error.type
+				Kind:      schemas.SpanKindMCPClient,
+				StartTime: now, EndTime: now.Add(1 * time.Second),
+				Status: schemas.SpanStatusError,
+				Attributes: map[string]any{
+					schemas.AttrMCPMethodName: "tools/list",
+					schemas.AttrErrorTypeSpec: "timeout",
+				},
+			},
+			{ // un-enriched MCP span (no mcp.method.name) → skipped
+				Kind:       schemas.SpanKindMCPClient,
+				Attributes: map[string]any{},
+			},
+			{ // non-MCP span → ignored even with an mcp attr present
+				Kind:       schemas.SpanKindLLMCall,
+				Attributes: map[string]any{schemas.AttrMCPMethodName: "tools/call"},
+			},
+		},
+	}
+
+	(&OtelPlugin{}).recordMCPMetricsFromTrace(context.Background(), m, trace)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	hist := findMCPHistogram(t, &rm)
+	if len(hist.DataPoints) != 2 {
+		t.Fatalf("data points = %d, want 2 (MCPTool + MCPClient; un-enriched + LLM skipped)", len(hist.DataPoints))
+	}
+
+	sawToolCall, sawListTools := false, false
+	for _, dp := range hist.DataPoints {
+		method, _ := dp.Attributes.Value(attribute.Key(schemas.AttrMCPMethodName))
+		switch method.AsString() {
+		case "tools/call":
+			sawToolCall = true
+			if dp.Count != 1 || dp.Sum != 2.0 {
+				t.Errorf("tools/call: count=%d sum=%v, want 1 and 2.0 (wire latency)", dp.Count, dp.Sum)
+			}
+			if _, ok := dp.Attributes.Value(attribute.Key(schemas.AttrErrorTypeSpec)); ok {
+				t.Error("tools/call: error.type must be absent on success")
+			}
+		case "tools/list":
+			sawListTools = true
+			if dp.Count != 1 || dp.Sum != 1.0 {
+				t.Errorf("tools/list: count=%d sum=%v, want 1 and 1.0 (wall-time)", dp.Count, dp.Sum)
+			}
+			et, ok := dp.Attributes.Value(attribute.Key(schemas.AttrErrorTypeSpec))
+			if !ok || et.AsString() != "timeout" {
+				t.Errorf("tools/list: error.type = %q (present=%v), want timeout", et.AsString(), ok)
+			}
+		default:
+			t.Errorf("unexpected mcp.method.name %q", method.AsString())
+		}
+	}
+	if !sawToolCall || !sawListTools {
+		t.Fatalf("missing data points: tools/call=%v tools/list=%v", sawToolCall, sawListTools)
+	}
+}
+
+// findMCPHistogram returns the mcp.client.operation.duration histogram from collected metrics.
+func findMCPHistogram(t *testing.T, rm *metricdata.ResourceMetrics) metricdata.Histogram[float64] {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, mtr := range sm.Metrics {
+			if mtr.Name != "mcp.client.operation.duration" {
+				continue
+			}
+			hist, ok := mtr.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric %q is %T, want Histogram[float64]", mtr.Name, mtr.Data)
+			}
+			return hist
+		}
+	}
+	t.Fatal("mcp.client.operation.duration metric not found")
+	return metricdata.Histogram[float64]{}
+}
+
+// TestMCPRequestTypeOTelMethodName pins the semconv method-name mapping used to stamp
+// mcp.method.name onto the span.
+func TestMCPRequestTypeOTelMethodName(t *testing.T) {
+	cases := map[schemas.MCPRequestType]string{
+		schemas.MCPRequestTypeExecuteTool:       "tools/call",
+		schemas.MCPRequestTypeChatToolCall:      "tools/call",
+		schemas.MCPRequestTypeResponsesToolCall: "tools/call",
+		schemas.MCPRequestTypeListTools:         "tools/list",
+		schemas.MCPRequestTypePing:              "ping",
+	}
+	for in, want := range cases {
+		if got := in.OTelMethodName(); got != want {
+			t.Errorf("OTelMethodName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// Unknown types fall back to the raw string rather than being dropped.
+	if got := schemas.MCPRequestType("custom").OTelMethodName(); got != "custom" {
+		t.Errorf("unknown fallback = %q, want %q", got, "custom")
+	}
+}
+
+// TestMCPConnectionTypeOTelNetworkTransport pins the transport mapping.
+func TestMCPConnectionTypeOTelNetworkTransport(t *testing.T) {
+	cases := map[schemas.MCPConnectionType]string{
+		schemas.MCPConnectionTypeSTDIO:     "pipe",
+		schemas.MCPConnectionTypeHTTP:      "tcp",
+		schemas.MCPConnectionTypeSSE:       "tcp",
+		schemas.MCPConnectionTypeInProcess: "", // no network transport
+	}
+	for in, want := range cases {
+		if got := in.OTelNetworkTransport(); got != want {
+			t.Errorf("OTelNetworkTransport(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -59,6 +59,10 @@ type MetricsExporter struct {
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
 
+	// OTel MCP semconv duration histogram. _count gives call volume and error.type gives
+	// the error rate, so no separate MCP counters are needed.
+	mcpClientOperationDuration *syncFloat64Histogram
+
 	// HTTP metrics
 	httpRequestsTotal     *syncInt64Counter
 	httpRequestDuration   *syncFloat64Histogram
@@ -150,6 +154,11 @@ var (
 	// payload over 10KB into +Inf.
 	httpBodySizeBuckets = []float64{
 		100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000,
+	}
+
+	// mcpOperationDurationBuckets: boundaries recommended by the MCP semconv.
+	mcpOperationDurationBuckets = []float64{
+		0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300,
 	}
 )
 
@@ -407,6 +416,15 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: []float64{0, 1, 2, 3, 5, 10},
 	}
 
+	// Dotted name is intentional: the exact semconv metric name, not a bifrost_* metric.
+	m.mcpClientOperationDuration = &syncFloat64Histogram{
+		name:       "mcp.client.operation.duration",
+		desc:       "Duration of an MCP request as observed by the client (Bifrost) from send until the response is received",
+		unit:       "s",
+		meter:      m.meter,
+		boundaries: mcpOperationDurationBuckets,
+	}
+
 	// HTTP metrics
 	m.httpRequestsTotal = &syncInt64Counter{
 		name:  "http_requests_total",
@@ -522,6 +540,11 @@ func (m *MetricsExporter) RecordStreamInterTokenLatency(ctx context.Context, lat
 // Recorded once per request (off the final span), not once per attempt.
 func (m *MetricsExporter) RecordRequestRetries(ctx context.Context, retries float64, attrs ...attribute.KeyValue) {
 	m.requestRetries.Record(ctx, retries, metric.WithAttributes(attrs...))
+}
+
+// RecordMCPOperationDuration records the mcp.client.operation.duration metric for one op.
+func (m *MetricsExporter) RecordMCPOperationDuration(ctx context.Context, durationSeconds float64, attrs ...attribute.KeyValue) {
+	m.mcpClientOperationDuration.Record(ctx, durationSeconds, metric.WithAttributes(attrs...))
 }
 
 // RecordHTTPRequest records an HTTP request metric


### PR DESCRIPTION
## Summary

MCP operations were missing OTel tracing spans and the `mcp.client.operation.duration` metric because the tracer was never stamped onto request-scoped contexts for standalone MCP tool executions, and the plugin pipeline emitted a single flat span rather than following the nested span layout used by the LLM path.

## Changes

- Added `ensureMCPTracerContext` to stamp the tracer onto the `BifrostContext` for `ExecuteChatMCPTool` and `ExecuteResponsesMCPTool` calls, which bypass the chat/responses flow that normally sets it.
- Restructured span creation in `RunWithPluginPipeline` and `runConnectWithPluginPipeline` to match the LLM path: PreHook spans chain under the inbound HTTP span, the op span is created after PreHooks complete (nesting under the last one), and PostHook spans nest under the op span. Short-circuited requests produce no op span.
- Added `SpanKindMCPTool` for `tools/call` spans, distinct from `SpanKindMCPClient` used for lifecycle ops (ping, list_tools, connect).
- Added `mcp.method.name` (`tools/call`, `tools/list`, `ping`) and `network.transport` (`pipe` for stdio, `tcp` for HTTP/SSE) OTel semconv attributes on MCP spans.
- Added `bifrost.mcp.tool.duration_ms` to carry the raw `CallTool` wire latency so the duration metric measures the wire round-trip rather than span wall-time (which includes PostHooks).
- Added `error.type` classification on failed MCP spans via sentinel errors (`ErrMCPToolTimeout`, `ErrMCPToolCallFailed`) wrapped with `%w` at the `CallTool` site, classified by `mcpErrorType` via `errors.Is`.
- Added `setMCPGovernanceSpanAttrs` to copy governance identity (`bifrost.virtual_key_id`, `team_id`, etc.) from context onto MCP spans for per-tenant metric breakdowns.
- Added `mcp.client.operation.duration` histogram in the OTel metrics exporter with semconv-recommended bucket boundaries. `recordMCPMetricsFromTrace` emits one sample per MCP span, preferring wire latency over wall-time and appending `error.type` on failures.
- Preserved the original `error` value on `ErrorField.Error` (json:`"-"`) when wrapping `opErr` as `BifrostError` so `errors.Is` chains work through PostHook boundaries.
- Added `OTelMethodName()` on `MCPRequestType` and `OTelNetworkTransport()` on `MCPConnectionType` for semconv mapping.
- Added `connectionTypeForClientName` to resolve a client's transport by name for the `network.transport` attribute.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/... ./plugins/otel/...
```

`TestMCPErrorTypeClassification` validates sentinel-based `error.type` classification including `auth_required`, `timeout`, `tool_error`, and the `_OTHER` catch-all.

`TestRecordMCPMetricsFromTraceRecordsBothKinds` validates that `mcp.client.operation.duration` emits one data point per enriched MCP span (`SpanKindMCPTool` and `SpanKindMCPClient`), uses wire latency over wall-time when available, tags `error.type` on failures, and skips un-enriched and non-MCP spans.

`TestBuildMCPSpanAttrsSemconvAndGovernance` validates that semconv dimensions and flat-named governance labels are present and that absent optional dimensions are omitted.

`TestMCPRequestTypeOTelMethodName` and `TestMCPConnectionTypeOTelNetworkTransport` pin the semconv mapping tables.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Governance identity values copied to span attributes are already present in the request context and are not new data exposures.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable