### PR TITLE
feat: add mcp metrics to telemetry plugin

### DIFF
--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -31,6 +31,7 @@ const (
 const (
 	startTimeKey         schemas.BifrostContextKey = "bf-prom-start-time"
 	activeRequestTypeKey schemas.BifrostContextKey = "bf-prom-active-req-type"
+	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -173,10 +174,12 @@ type PrometheusPlugin struct {
 	KeyRotationEventsTotal         *prometheus.CounterVec
 	ActiveRequests                 *prometheus.GaugeVec
 	ProviderKeyUp                  *prometheus.GaugeVec
+	MCPToolDuration                *prometheus.HistogramVec
 	customLabels                   []string
 
 	defaultHTTPLabels    []string
 	defaultBifrostLabels []string
+	defaultMCPLabels     []string
 
 	// Push gateway fields
 	pushConfig *PushGatewayConfig
@@ -226,6 +229,13 @@ var (
 	}
 )
 
+// Compile-time checks that PrometheusPlugin implements the hook interfaces it
+// registers metrics for (MCP hooks are auto-discovered by rebuildInterfaceCaches).
+var (
+	_ schemas.LLMPlugin = (*PrometheusPlugin)(nil)
+	_ schemas.MCPPlugin = (*PrometheusPlugin)(nil)
+)
+
 // Init creates a new PrometheusPlugin with initialized metrics.
 // defaultBifrostLabelNames is the canonical set of Prometheus labels attached to
 // bifrost.* metrics. It is a package var (not an Init local) so the connector-
@@ -251,6 +261,28 @@ var defaultBifrostLabelNames = []string{
 	"business_unit_id",
 	"business_unit_name",
 }
+
+// defaultMCPLabelNames is the label set for bifrost_mcp_* metrics: the MCP semconv
+// dimensions available in the hook plus the governance identity. No network_transport
+// (core stamps it on the span, not context) and no provider/model.
+var defaultMCPLabelNames = []string{
+	"mcp_client",
+	"mcp_tool_name",
+	"mcp_method",
+	"error_type",
+	"virtual_key_id",
+	"virtual_key_name",
+	"team_id",
+	"team_name",
+	"customer_id",
+	"customer_name",
+	"business_unit_id",
+	"business_unit_name",
+}
+
+// mcpOperationDurationBuckets: the OTel MCP semconv boundaries, matching plugins/otel
+// so both exporters report the same quantiles for the same operation.
+var mcpOperationDurationBuckets = []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300}
 
 func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger schemas.Logger) (*PrometheusPlugin, error) {
 	if config == nil {
@@ -491,6 +523,18 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		[]string{"provider", "key_id", "key_name"},
 	)
 
+	// Mirrors the OTel semconv metric mcp.client.operation.duration. _count gives
+	// tool-call volume and error_type the error rate, so no separate MCP counters.
+	defaultMCPLabels := append([]string(nil), defaultMCPLabelNames...)
+	bifrostMCPToolDuration := factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bifrost_mcp_client_operation_duration_seconds",
+			Help:    "Duration of an MCP tool call as observed by Bifrost (the MCP client).",
+			Buckets: mcpOperationDurationBuckets,
+		},
+		append(defaultMCPLabels, filteredCustomLabels...),
+	)
+
 	plugin := &PrometheusPlugin{
 		logger:                         logger,
 		pricingManager:                 pricingManager,
@@ -520,9 +564,11 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		KeyRotationEventsTotal:         bifrostKeyRotationEventsTotal,
 		ActiveRequests:                 bifrostActiveRequests,
 		ProviderKeyUp:                  bifrostProviderKeyUp,
+		MCPToolDuration:                bifrostMCPToolDuration,
 		customLabels:                   filteredCustomLabels,
 		defaultHTTPLabels:              defaultHTTPLabels,
 		defaultBifrostLabels:           defaultBifrostLabels,
+		defaultMCPLabels:               defaultMCPLabels,
 	}
 
 	// Default /metrics scraping to on when the config omits the field — preserves
@@ -635,6 +681,116 @@ func (p *PrometheusPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.
 	return req, nil, nil
 }
 
+// applyCustomLabels resolves each configured custom label into labelValues.
+// Resolution order (first match wins):
+//  1. x-bf-dim-* headers (canonical; BifrostContextKeyDimensions)
+//  2. x-bf-prom-* headers (deprecated; kept for backward compatibility)
+//  3. Direct BifrostContextKey lookup (Go SDK usage — documented API)
+func (p *PrometheusPlugin) applyCustomLabels(ctx *schemas.BifrostContext, labelValues map[string]string) {
+	dims, _ := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
+	requestHeaders, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	for _, key := range p.customLabels {
+		if dims != nil {
+			if v, ok := dims[key]; ok {
+				labelValues[key] = v
+				continue
+			}
+		}
+		if requestHeaders != nil {
+			if v, ok := requestHeaders["x-bf-prom-"+key]; ok {
+				labelValues[key] = v
+				continue
+			}
+		}
+		if value := ctx.Value(schemas.BifrostContextKey(key)); value != nil {
+			if strValue, ok := value.(string); ok {
+				labelValues[key] = strValue
+			}
+		}
+	}
+}
+
+// PreMCPHook stashes the tool-call start time so PostMCPHook has a wall-time
+// fallback on the error path (where the response — and its latency — is absent).
+func (p *PrometheusPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) (*schemas.BifrostMCPRequest, *schemas.MCPPluginShortCircuit, error) {
+	if ctx != nil && req != nil && req.RequestType.IsExecuteTool() {
+		ctx.SetValue(mcpStartTimeKey, time.Now())
+		// Stash identity so the error path (resp == nil) still has tool/client
+		// for codemode filtering and metric labels.
+		ctx.SetValue(mcpClientNameKey, req.ClientName)
+		ctx.SetValue(mcpToolNameKey, req.GetToolName())
+	}
+	return req, nil, nil
+}
+
+// PostMCPHook records the MCP tool-call duration. Only execute-tool calls are
+// recorded (codemode tools skipped); ping/list_tools are lifecycle, not tool calls.
+// The gate stamps MCPRequestType on both the success response and the error.
+func (p *PrometheusPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.BifrostMCPResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostMCPResponse, *schemas.BifrostError, error) {
+	if ctx == nil {
+		return resp, bifrostErr, nil
+	}
+	mcpReqType := schemas.MCPRequestType("")
+	toolName, clientName := "", ""
+	if resp != nil {
+		mcpReqType = resp.ExtraFields.MCPRequestType
+		toolName = resp.ExtraFields.ToolName
+		clientName = resp.ExtraFields.ClientName
+	} else if bifrostErr != nil {
+		mcpReqType = bifrostErr.ExtraFields.MCPRequestType
+		// No response on the error path — recover identity stashed in PreMCPHook.
+		clientName = bifrost.GetStringFromContext(ctx, mcpClientNameKey)
+		toolName = bifrost.GetStringFromContext(ctx, mcpToolNameKey)
+	}
+	if !mcpReqType.IsExecuteTool() || bifrost.IsCodemodeTool(toolName) {
+		return resp, bifrostErr, nil
+	}
+
+	// Prefer the wire tool-call latency; fall back to wall-time on the error path.
+	var durationSeconds float64
+	if resp != nil && resp.ExtraFields.Latency > 0 {
+		durationSeconds = float64(resp.ExtraFields.Latency) / 1000.0
+	} else if start, ok := ctx.Value(mcpStartTimeKey).(time.Time); ok {
+		durationSeconds = time.Since(start).Seconds()
+	}
+
+	errorType := ""
+	if bifrostErr != nil {
+		errorType = mcpErrorType(bifrostErr)
+	}
+
+	labelValues := map[string]string{
+		"mcp_client":         clientName,
+		"mcp_tool_name":      toolName,
+		"mcp_method":         mcpReqType.OTelMethodName(),
+		"error_type":         errorType,
+		"virtual_key_id":     bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID),
+		"virtual_key_name":   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName),
+		"team_id":            bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID),
+		"team_name":          bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName),
+		"customer_id":        bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID),
+		"customer_name":      bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName),
+		"business_unit_id":   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID),
+		"business_unit_name": bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName),
+	}
+	p.applyCustomLabels(ctx, labelValues)
+
+	promLabelValues := getPrometheusLabelValues(append(p.defaultMCPLabels, p.customLabels...), labelValues)
+	p.MCPToolDuration.WithLabelValues(promLabelValues...).Observe(durationSeconds)
+
+	return resp, bifrostErr, nil
+}
+
+// mcpErrorType classifies an MCP tool-call failure into a low-cardinality error_type.
+// Coarse by design: timeout/tool_error granularity (which the OTel/Datadog span path
+// derives from error.type) would require core's error sentinels here.
+func mcpErrorType(bifrostErr *schemas.BifrostError) string {
+	if bifrostErr != nil && bifrostErr.ExtraFields.MCPAuthRequired != nil {
+		return "auth_required"
+	}
+	return "_OTHER"
+}
+
 // extractProviderCacheTokens returns provider-side prompt-cache token counts from a
 // response's usage: cache-read (cached) input tokens, cache-write (creation) input tokens,
 // and the Anthropic-only 5m/1h TTL breakdown of the write total. Chat/text-completion carry
@@ -741,33 +897,7 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	}
 
 	// Get all custom prometheus labels from context BEFORE the goroutine.
-	// Resolution order (first match wins):
-	//   1. x-bf-dim-* headers (canonical; set by HTTP transport as BifrostContextKeyDimensions)
-	//   2. x-bf-prom-* headers (deprecated; kept for backward compatibility)
-	//   3. Direct BifrostContextKey lookup (Go SDK usage — documented API)
-	dims, _ := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
-	requestHeaders, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
-	for _, key := range p.customLabels {
-		if dims != nil {
-			if v, ok := dims[key]; ok {
-				labelValues[key] = v
-				continue
-			}
-		}
-		// support for to be deprecated x-bf-prom-* headers
-		if requestHeaders != nil {
-			if v, ok := requestHeaders["x-bf-prom-"+key]; ok {
-				labelValues[key] = v
-				continue
-			}
-		}
-		// fallback: direct context key (Go SDK usage, documented API)
-		if value := ctx.Value(schemas.BifrostContextKey(key)); value != nil {
-			if strValue, ok := value.(string); ok {
-				labelValues[key] = strValue
-			}
-		}
-	}
+	p.applyCustomLabels(ctx, labelValues)
 
 	// Get label values in the correct order (cache_type will be handled separately for cache hits)
 	promLabelValues := getPrometheusLabelValues(append(p.defaultBifrostLabels, p.customLabels...), labelValues)

--- a/plugins/telemetry/mcp_metrics_test.go
+++ b/plugins/telemetry/mcp_metrics_test.go
@@ -1,0 +1,223 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestInitFiltersCustomLabelsCollidingWithMCP is a regression for the P1 panic: a custom
+// label matching an MCP metric label was appended twice to the MCP HistogramVec, so promauto
+// panicked at Init. Colliding labels must be dropped; non-colliding ones kept.
+func TestInitFiltersCustomLabelsCollidingWithMCP(t *testing.T) {
+	p, err := Init(&Config{CustomLabels: []string{"mcp_client", "error_type", "keep_me"}}, nil, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if containsLabel(p.customLabels, "mcp_client") || containsLabel(p.customLabels, "error_type") {
+		t.Fatalf("MCP-colliding custom labels not filtered: %v", p.customLabels)
+	}
+	if !containsLabel(p.customLabels, "keep_me") {
+		t.Fatalf("non-colliding custom label was dropped: %v", p.customLabels)
+	}
+}
+
+// mcpSample is one gathered series of the MCP duration histogram.
+type mcpSample struct {
+	count  uint64
+	sum    float64
+	labels map[string]string
+}
+
+// gatherMCP returns every series of bifrost_mcp_client_operation_duration_seconds.
+func gatherMCP(t *testing.T, reg *prometheus.Registry) []mcpSample {
+	t.Helper()
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	var out []mcpSample
+	for _, mf := range fams {
+		if mf.GetName() != "bifrost_mcp_client_operation_duration_seconds" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			out = append(out, mcpSample{m.GetHistogram().GetSampleCount(), m.GetHistogram().GetSampleSum(), labels})
+		}
+	}
+	return out
+}
+
+func mcpHookContext() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyID, "vk-1")
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamID, "team-9")
+	return ctx
+}
+
+// TestPostMCPHookRecordsToolDuration verifies a successful execute-tool call records one
+// histogram sample using the wire latency (ms→s) with the semconv + governance labels.
+func TestPostMCPHookRecordsToolDuration(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := mcpHookContext()
+
+	req := &schemas.BifrostMCPRequest{RequestType: schemas.MCPRequestTypeChatToolCall}
+	if _, _, err := p.PreMCPHook(ctx, req); err != nil {
+		t.Fatalf("PreMCPHook: %v", err)
+	}
+	resp := &schemas.BifrostMCPResponse{
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			MCPRequestType: schemas.MCPRequestTypeChatToolCall,
+			ClientName:     "ctx7",
+			ToolName:       "query-docs",
+			Latency:        2574,
+		},
+	}
+	if _, _, err := p.PostMCPHook(ctx, resp, nil); err != nil {
+		t.Fatalf("PostMCPHook: %v", err)
+	}
+
+	samples := gatherMCP(t, p.registry)
+	if len(samples) != 1 {
+		t.Fatalf("want 1 mcp series, got %d", len(samples))
+	}
+	s := samples[0]
+	if s.count != 1 {
+		t.Fatalf("sample count = %d, want 1", s.count)
+	}
+	if s.sum < 2.573 || s.sum > 2.575 {
+		t.Fatalf("duration sum = %v, want ~2.574 (from Latency ms)", s.sum)
+	}
+	for k, want := range map[string]string{
+		"mcp_client":     "ctx7",
+		"mcp_tool_name":  "query-docs",
+		"mcp_method":     "tools/call",
+		"error_type":     "",
+		"virtual_key_id": "vk-1",
+		"team_id":        "team-9",
+	} {
+		if s.labels[k] != want {
+			t.Fatalf("label %s = %q, want %q", k, s.labels[k], want)
+		}
+	}
+}
+
+// TestPostMCPHookSkipsNonToolAndCodemode verifies lifecycle ops (list_tools) and codemode
+// tools are not recorded.
+func TestPostMCPHookSkipsNonToolAndCodemode(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := mcpHookContext()
+
+	// list_tools is a lifecycle op, not a tool call.
+	listResp := &schemas.BifrostMCPResponse{
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			MCPRequestType: schemas.MCPRequestTypeListTools,
+			ClientName:     "ctx7",
+			Latency:        10,
+		},
+	}
+	if _, _, err := p.PostMCPHook(ctx, listResp, nil); err != nil {
+		t.Fatalf("PostMCPHook(list_tools): %v", err)
+	}
+	// A codemode tool call must be skipped.
+	codemodeResp := &schemas.BifrostMCPResponse{
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			MCPRequestType: schemas.MCPRequestTypeChatToolCall,
+			ClientName:     "codemode",
+			ToolName:       "executeToolCode",
+			Latency:        20,
+		},
+	}
+	if _, _, err := p.PostMCPHook(ctx, codemodeResp, nil); err != nil {
+		t.Fatalf("PostMCPHook(codemode): %v", err)
+	}
+
+	if samples := gatherMCP(t, p.registry); len(samples) != 0 {
+		t.Fatalf("want 0 mcp series (both skipped), got %d", len(samples))
+	}
+}
+
+// TestPostMCPHookErrorTypeAndWallTimeFallback verifies the error path tags error_type and
+// falls back to wall-time latency when no response latency exists.
+func TestPostMCPHookErrorTypeAndWallTimeFallback(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := mcpHookContext()
+
+	req := mcpToolReq("ctx7", "query-docs")
+	if _, _, err := p.PreMCPHook(ctx, req); err != nil {
+		t.Fatalf("PreMCPHook: %v", err)
+	}
+	// Seed a known past start time so the wall-time fallback is a detectable ~1s.
+	ctx.SetValue(mcpStartTimeKey, time.Now().Add(-time.Second))
+
+	// No response — latency comes from the wall-time stash; identity from PreMCPHook.
+	bifrostErr := &schemas.BifrostError{
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			MCPRequestType:  schemas.MCPRequestTypeChatToolCall,
+			MCPAuthRequired: &schemas.MCPAuthRequiredError{},
+		},
+	}
+	if _, _, err := p.PostMCPHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostMCPHook: %v", err)
+	}
+
+	samples := gatherMCP(t, p.registry)
+	if len(samples) != 1 {
+		t.Fatalf("want 1 mcp series, got %d", len(samples))
+	}
+	s := samples[0]
+	if s.count != 1 {
+		t.Fatalf("sample count = %d, want 1", s.count)
+	}
+	if s.labels["error_type"] != "auth_required" {
+		t.Fatalf("error_type = %q, want auth_required", s.labels["error_type"])
+	}
+	if s.sum < 1 || s.sum > 2 {
+		t.Fatalf("wall-time duration = %v, want ~1s (fallback active)", s.sum)
+	}
+	// Identity must be recovered on the error path (no response present).
+	if s.labels["mcp_client"] != "ctx7" || s.labels["mcp_tool_name"] != "query-docs" {
+		t.Fatalf("recovered identity = (%q, %q), want (ctx7, query-docs)", s.labels["mcp_client"], s.labels["mcp_tool_name"])
+	}
+}
+
+// TestPostMCPHookErrorPathSkipsCodemode verifies a failed codemode tool call is skipped:
+// the tool name recovered from PreMCPHook drives the codemode filter even with no response.
+func TestPostMCPHookErrorPathSkipsCodemode(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := mcpHookContext()
+
+	req := mcpToolReq("codemode", "executeToolCode")
+	if _, _, err := p.PreMCPHook(ctx, req); err != nil {
+		t.Fatalf("PreMCPHook: %v", err)
+	}
+	bifrostErr := &schemas.BifrostError{
+		ExtraFields: schemas.BifrostErrorExtraFields{MCPRequestType: schemas.MCPRequestTypeChatToolCall},
+	}
+	if _, _, err := p.PostMCPHook(ctx, nil, bifrostErr); err != nil {
+		t.Fatalf("PostMCPHook: %v", err)
+	}
+	if samples := gatherMCP(t, p.registry); len(samples) != 0 {
+		t.Fatalf("want 0 mcp series (failed codemode call must be skipped), got %d", len(samples))
+	}
+}
+
+// mcpToolReq builds an execute-tool MCP request with a client name and tool name.
+func mcpToolReq(client, tool string) *schemas.BifrostMCPRequest {
+	name := tool
+	return &schemas.BifrostMCPRequest{
+		RequestType: schemas.MCPRequestTypeChatToolCall,
+		ClientName:  client,
+		ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{
+			Function: schemas.ChatAssistantMessageToolCallFunction{Name: &name},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `bifrost_mcp_client_operation_duration_seconds` Prometheus histogram to the telemetry plugin, mirroring the OTel semconv metric `mcp.client.operation.duration`. This gives operators MCP tool-call latency, volume (via `_count`), and error rate (via `error_type`) out of the box without requiring separate counters.

## Changes

- Introduces `PreMCPHook` and `PostMCPHook` on `PrometheusPlugin`, implementing the `schemas.MCPPlugin` interface. `PreMCPHook` stashes a wall-clock start time so `PostMCPHook` has a latency fallback on the error path when no wire latency is available.
- Adds `MCPToolDuration` (`*prometheus.HistogramVec`) with buckets aligned to the OTel MCP semconv boundaries (`0.01s … 300s`) so both Prometheus and OTel exporters report the same quantiles.
- Defines `defaultMCPLabelNames` covering MCP semconv dimensions (`mcp_client`, `mcp_tool_name`, `mcp_method`, `error_type`) plus the full governance identity label set (`virtual_key_id`, `virtual_key_name`, `team_id`, `team_name`, `customer_id`, `customer_name`, `business_unit_id`, `business_unit_name`).
- Skips recording for lifecycle operations (`list_tools`) and codemode tools, keeping the metric focused on user-facing tool calls.
- Classifies errors into a low-cardinality `error_type` label (`auth_required` / `_OTHER`).
- Extracts the inline custom-label resolution logic from `PostLLMHook` into a shared `applyCustomLabels` method, used by both LLM and MCP hooks.
- Adds compile-time interface assertions confirming `PrometheusPlugin` satisfies both `schemas.LLMPlugin` and `schemas.MCPPlugin`.
- Adds `mcp_metrics_test.go` covering: successful tool-call duration recording with wire latency, skipping of lifecycle and codemode calls, and error-path `error_type` tagging with wall-time fallback.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/telemetry/...
```

The three new test cases validate:
1. A successful `execute-tool` call records one histogram sample with wire latency converted from ms to seconds and correct semconv + governance labels.
2. `list_tools` responses and codemode tool calls produce zero histogram samples.
3. An error response with `MCPAuthRequired` tags `error_type=auth_required` and falls back to wall-time latency when no wire latency is present.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced. The `error_type` label is intentionally low-cardinality and does not surface sensitive error details.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable