### PR TITLE
feat: add `provisioningToken` and `claimScimAttributes` to SCIM providers for declarative GitOps provisioning in helm

### DIFF
--- a/docs/changelogs/helm-v2.1.29.mdx
+++ b/docs/changelogs/helm-v2.1.29.mdx
@@ -7,7 +7,8 @@ description: "Helm v2.1.29 changelog - 2026-07-15"
 
 ## Changelog
 
-- Added `request_headers` to the OTEL plugin config, supported on both the single-profile shape (`bifrost.plugins.otel.config.request_headers`) and per-profile entries (`bifrost.plugins.otel.config.profiles[*].request_headers`). Header name patterns (exact or wildcard like `x-custom-*`) are captured and emitted as span attributes; note `*` includes sensitive headers like `Authorization`. Renders into the plugin config `request_headers`. Previously this field was only wired for datadog/bigquery/kafka/pubsub, so OTEL values with `request_headers` failed schema validation and were dropped.
+- SCIM provisioning can now be enabled declaratively (Helm/`config.json`) for Okta, Entra, SailPoint, and generic OIDC via `bifrost.scim.config.provisioningToken` and `claimScimAttributes` — no dashboard step required.
+- OTEL plugin now supports `request_headers` to capture request headers as span attributes.
 - Added generic OIDC SCIM/SSO provider support (`bifrost.scim.provider: generic`) for any standards-compliant OIDC IdP. Configure via `bifrost.scim.config` (`issuerUrl` and `clientId` required; optional `clientSecret`, `audience`, endpoint overrides, `teamIdsField`, `rolesField`, `scopes`, and attribute/claim mappings). Endpoints are resolved via OIDC discovery unless overridden. Renders into `scim_config.config`.
 - Added `bifrost.client.dualCredentialConflictBehavior` to control what happens when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"` (reject with 400), `"prefer_vk"` (drop IDP token, use VK), or `"prefer_idp"` (default, IDP token wins). Renders into `client.dual_credential_conflict_behavior`.
 

--- a/docs/enterprise/setting-up-entra/scim.mdx
+++ b/docs/enterprise/setting-up-entra/scim.mdx
@@ -60,6 +60,56 @@ Copy both values now - you will need them in [Step 2](#step-2-configure-entra-pr
 
 ---
 
+### Alternative: seed the token declaratively (Helm / config.json)
+
+If you manage Bifrost with Helm or a static `config.json` (GitOps), you can seed the **Provisioning Token** yourself instead of generating it in the dashboard.
+
+<Steps>
+
+<Step title="Generate a token">
+
+```bash
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+```
+
+This produces a URL-safe token in the same format Bifrost mints internally.
+
+</Step>
+
+<Step title="Add it to your SCIM config">
+
+Helm `values.yaml`:
+
+```yaml
+bifrost:
+  scim:
+    enabled: true
+    provider: "entra"
+    config:
+      tenantId: "..."
+      clientId: "..."
+      clientSecret: "env.ENTRA_CLIENT_SECRET"
+      provisioningToken: "env.SCIM_PROVISIONING_TOKEN"   # or the literal token
+      claimScimAttributes:                                # per-claim SCIM interpretation
+        groups:
+          attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
+          attributeValue: "displayName"
+```
+
+The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+
+</Step>
+
+</Steps>
+
+<Warning>
+  Keep the token in a Kubernetes Secret and reference it with the `env.` prefix — never commit the literal value. Rotating the token in the dashboard invalidates any value seeded here.
+</Warning>
+
+Then use this token as the **Secret Token** and your deployment's SCIM endpoint as the **Tenant URL** in [Step 2](#step-2-configure-entra-provisioning) below.
+
+---
+
 ## Step 2: Configure Entra provisioning
 
 <Steps>

--- a/docs/enterprise/setting-up-generic-oidc/scim.mdx
+++ b/docs/enterprise/setting-up-generic-oidc/scim.mdx
@@ -58,6 +58,56 @@ After saving, Bifrost shows a **Setup Complete** dialog with:
 
 ---
 
+### Alternative: seed the token declaratively (Helm / config.json)
+
+If you manage Bifrost with Helm or a static `config.json` (GitOps), you can seed the **Provisioning Token** yourself instead of generating it in the dashboard.
+
+<Steps>
+
+<Step title="Generate a token">
+
+```bash
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+```
+
+This produces a URL-safe token in the same format Bifrost mints internally.
+
+</Step>
+
+<Step title="Add it to your SCIM config">
+
+Helm `values.yaml`:
+
+```yaml
+bifrost:
+  scim:
+    enabled: true
+    provider: "generic"
+    config:
+      issuerUrl: "https://idp.company.com"
+      clientId: "..."
+      clientSecret: "env.OIDC_CLIENT_SECRET"
+      provisioningToken: "env.SCIM_PROVISIONING_TOKEN"   # or the literal token
+      claimScimAttributes:                                # per-claim SCIM interpretation
+        groups:
+          attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
+          attributeValue: "displayName"
+```
+
+The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+
+</Step>
+
+</Steps>
+
+<Warning>
+  Keep the token in a Kubernetes Secret and reference it with the `env.` prefix — never commit the literal value. Rotating the token in the dashboard invalidates any value seeded here.
+</Warning>
+
+Then use this token as the **Bearer Token** and your deployment's SCIM endpoint as the **SCIM Base URL** in [Step 2](#step-2-configure-your-idp-to-push-scim-to-bifrost) below.
+
+---
+
 ## Step 2: Configure your IdP to push SCIM to Bifrost
 
 The exact steps vary by provider. Most SCIM-capable IdPs follow this general pattern:

--- a/docs/enterprise/setting-up-okta/scim.mdx
+++ b/docs/enterprise/setting-up-okta/scim.mdx
@@ -60,6 +60,57 @@ Copy both values now — you will need them in [Step 3](#step-3-configure-the-sc
 
 ---
 
+### Alternative: seed the token declaratively (Helm / config.json)
+
+If you manage Bifrost with Helm or a static `config.json` (GitOps), you can seed the **Provisioning Token** yourself instead of generating it in the dashboard.
+
+<Steps>
+
+<Step title="Generate a token">
+
+```bash
+openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
+```
+
+This produces a URL-safe token in the same format Bifrost mints internally.
+
+</Step>
+
+<Step title="Add it to your SCIM config">
+
+Helm `values.yaml`:
+
+```yaml
+bifrost:
+  scim:
+    enabled: true
+    provider: "okta"
+    config:
+      issuerUrl: "https://your-domain.okta.com/oauth2/default"
+      clientId: "..."
+      clientSecret: "env.OKTA_CLIENT_SECRET"
+      apiToken: "env.OKTA_API_TOKEN"
+      provisioningToken: "env.SCIM_PROVISIONING_TOKEN"   # or the literal token
+      claimScimAttributes:                                # per-claim SCIM interpretation
+        groups:
+          attributeType: "group"        # "user" (SCIM User attribute) or "group" (match SCIM Group)
+          attributeValue: "displayName"
+```
+
+The same keys (`provisioningToken`, `claimScimAttributes`) apply directly under `scim_config.config` in a raw `config.json`.
+
+</Step>
+
+</Steps>
+
+<Warning>
+  Keep the token in a Kubernetes Secret and reference it with the `env.` prefix — never commit the literal value. Rotating the token in the dashboard invalidates any value seeded here.
+</Warning>
+
+Then use this token as the **API Token** and your deployment's SCIM endpoint as the **SCIM 2.0 Base URL** in [Step 3](#step-3-configure-the-scim-app) — the rest of the Okta setup is identical.
+
+---
+
 ## Step 2: Create a SCIM App in Okta
 
 <Steps>

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -10,7 +10,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ### 2.1.29
 
-- Added `request_headers` to the OTEL plugin config, on both the single-profile shape (`bifrost.plugins.otel.config.request_headers`) and per-profile entries (`bifrost.plugins.otel.config.profiles[*].request_headers`). Header name patterns (exact or wildcard like `x-custom-*`) are captured and emitted as span attributes; renders into the plugin config `request_headers`. Previously accepted only for datadog/bigquery/kafka/pubsub, so OTEL values with `request_headers` failed schema validation and were dropped from the rendered config.
+- Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to the Okta, Entra, SailPoint, and generic OIDC SCIM providers, so inbound SCIM provisioning can be seeded declaratively instead of via the dashboard. Both render into `scim_config.config`. Generate a token with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` (supports `env.` prefix).
+- Added `request_headers` to the OTEL plugin config (`bifrost.plugins.otel.config.request_headers` and `profiles[*].request_headers`) to capture request headers as span attributes. Renders into `request_headers`.
 - Added `bifrost.client.dualCredentialConflictBehavior` to control what happens when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"` (reject with 400), `"prefer_vk"` (drop IDP token, use VK), or `"prefer_idp"` (default, IDP token wins). Renders into `client.dual_credential_conflict_behavior`.
 
 ### 2.1.28

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2337,7 +2337,8 @@
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+                      "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
                     },
                     "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
                     "additionalProperties": false
@@ -2408,7 +2409,8 @@
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+                      "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
                     },
                     "required": ["tenantId", "clientId"],
                     "additionalProperties": false
@@ -2707,7 +2709,8 @@
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+                      "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
                     },
                     "required": ["product"],
                     "additionalProperties": false
@@ -2777,7 +2780,8 @@
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+                      "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+                      "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
                     },
                     "required": ["issuerUrl", "clientId"],
                     "additionalProperties": false
@@ -6229,6 +6233,10 @@
         "required": ["attributeType", "attributeValue"],
         "additionalProperties": false
       }
+    },
+    "scim_provisioning_token": {
+      "type": "string",
+      "description": "Bearer token that inbound SCIM 2.0 provisioning clients (the IdP's SCIM app) must present in the Authorization header to push users and groups to Bifrost. Normally minted in the dashboard (Governance -> User Provisioning) and shown once, but may be seeded here for declarative/GitOps deployments; supports the env. prefix for environment-variable references. Generate one with: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='"
     }
   }
 }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -945,6 +945,12 @@ bifrost:
       #   - attribute: "department"
       #     value: "platform"
       #     business_unit: "Platform"
+      # # SCIM inbound provisioning (Enterprise): the IdP pushes users/groups to Bifrost's SCIM 2.0 endpoint.
+      # claimScimAttributes:                         # per-claim SCIM interpretation
+      #   groups:
+      #     attributeType: "group"                   # "user" (SCIM User attribute) or "group" (match SCIM Group)
+      #     attributeValue: "displayName"
+      # provisioningToken: "env.SCIM_PROVISIONING_TOKEN"  # bearer token the IdP presents; generate: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
       #
       # Entra (Azure AD) configuration:
       # tenantId: ""
@@ -965,6 +971,12 @@ bifrost:
       #     value: "<group-object-id>"
       #     team: "platform-team"
       # attributeBusinessUnitMappings: []
+      # # SCIM inbound provisioning (Enterprise): the IdP pushes users/groups to Bifrost's SCIM 2.0 endpoint.
+      # claimScimAttributes:                         # per-claim SCIM interpretation
+      #   groups:
+      #     attributeType: "group"                   # "user" (SCIM User attribute) or "group" (match SCIM Group)
+      #     attributeValue: "displayName"
+      # provisioningToken: "env.SCIM_PROVISIONING_TOKEN"  # bearer token the IdP presents; generate: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
       #
       # Keycloak configuration:
       # serverUrl: "https://keycloak.company.com"  # base URL, must NOT include /realms/{realm}
@@ -1025,6 +1037,12 @@ bifrost:
       # attributeRoleMappings: []
       # attributeTeamMappings: []
       # attributeBusinessUnitMappings: []
+      # # SCIM inbound provisioning (Enterprise): the IdP pushes users/groups to Bifrost's SCIM 2.0 endpoint.
+      # claimScimAttributes:                         # per-claim SCIM interpretation
+      #   groups:
+      #     attributeType: "group"                   # "user" (SCIM User attribute) or "group" (match SCIM Group)
+      #     attributeValue: "displayName"
+      # provisioningToken: "env.SCIM_PROVISIONING_TOKEN"  # bearer token the IdP presents; generate: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
 
   # Load balancer configuration for intelligent request routing
   loadBalancer:

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5349,7 +5349,9 @@
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"}
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
       },
       "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
       "additionalProperties": false
@@ -5402,7 +5404,9 @@
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
-        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"}
+        "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
       },
       "required": ["tenantId", "clientId"],
       "additionalProperties": false
@@ -5507,7 +5511,8 @@
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
       },
       "required": ["issuerUrl", "clientId"],
       "additionalProperties": false
@@ -5694,7 +5699,8 @@
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
-        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"}
+        "claimScimAttributes": {"$ref": "#/$defs/scim_claim_attributes"},
+        "provisioningToken": {"$ref": "#/$defs/scim_provisioning_token"}
       },
       "required": ["product"],
       "additionalProperties": false
@@ -5718,6 +5724,10 @@
         "required": ["attributeType", "attributeValue"],
         "additionalProperties": false
       }
+    },
+    "scim_provisioning_token": {
+      "type": "string",
+      "description": "Bearer token that inbound SCIM 2.0 provisioning clients (the IdP's SCIM app) must present in the Authorization header to push users and groups to Bifrost. Normally minted in the dashboard (Governance -> User Provisioning) and shown once, but may be seeded here for declarative/GitOps deployments; supports the env. prefix for environment-variable references. Generate one with: openssl rand -base64 32 | tr '+/' '-_' | tr -d '='"
     },
     "load_balancer_config": {
       "type": "object",


### PR DESCRIPTION
## Summary

Adds declarative (Helm / `config.json`) support for seeding the SCIM provisioning token across all supported IdP providers — Okta, Entra, SailPoint, and generic OIDC — eliminating the requirement to generate the token through the dashboard. Also extends `claimScimAttributes` to the Okta and Entra providers where it was previously missing.

## Changes

- Added `provisioningToken` to the SCIM config schema for Okta, Entra, SailPoint, and generic OIDC providers in both `values.schema.json` and `transports/config.schema.json`. The field accepts a literal token or an `env.` prefixed environment variable reference and renders into `scim_config.config`.
- Added `claimScimAttributes` to the Okta and Entra provider schemas, where it was previously absent.
- Introduced the `scim_provisioning_token` `$defs` entry (shared reference) in both schema files with a description covering generation, security, and GitOps usage.
- Added commented-out `provisioningToken` and `claimScimAttributes` examples to `values.yaml` under the Okta, Entra, and SailPoint provider sections.
- Added "Alternative: seed the token declaratively" sections to the Okta, Entra, and generic OIDC SCIM setup docs, including token generation commands, Helm `values.yaml` examples, and security warnings about storing the token in a Kubernetes Secret.
- Updated the Helm `README.md` and `helm-v2.1.29.mdx` changelog to reflect the new `provisioningToken` / `claimScimAttributes` fields and the OTEL `request_headers` addition.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Deploy Bifrost via Helm with a SCIM provider (e.g., Okta) and set `bifrost.scim.config.provisioningToken` to a token generated with:
   ```sh
   openssl rand -base64 32 | tr '+/' '-_' | tr -d '='
   ```
2. Store the token in a Kubernetes Secret and reference it via the `env.` prefix in `values.yaml`.
3. Configure the IdP's SCIM app to use the token as the Bearer/API token and point it at Bifrost's SCIM endpoint.
4. Verify that user and group provisioning pushes from the IdP succeed without any dashboard-generated token.
5. Confirm that schema validation passes for `provisioningToken` and `claimScimAttributes` on Okta, Entra, SailPoint, and generic OIDC provider configs.

**New config fields:**

| Field | Providers | Description |
|---|---|---|
| `bifrost.scim.config.provisioningToken` | Okta, Entra, SailPoint, generic OIDC | Bearer token the IdP presents to Bifrost's SCIM endpoint. Supports `env.` prefix. |
| `bifrost.scim.config.claimScimAttributes` | Okta, Entra (newly added) | Per-claim SCIM attribute interpretation (e.g., map `groups` claim to SCIM Group `displayName`). |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- The provisioning token grants write access to Bifrost's user/group provisioning endpoint. It must be stored in a Kubernetes Secret and referenced via the `env.` prefix — never committed as a literal value in version-controlled files.
- Rotating the token in the dashboard will invalidate any token seeded declaratively; the two sources are not synchronized.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable