### PR TITLE
chore: release Bifrost Helm chart v2.1.29

### DIFF
--- a/docs/changelogs/helm-v2.1.29.mdx
+++ b/docs/changelogs/helm-v2.1.29.mdx
@@ -7,9 +7,8 @@ description: "Helm v2.1.29 changelog - 2026-07-15"
 
 ## Changelog
 
-- SCIM provisioning can now be enabled declaratively (Helm/`config.json`) for Okta, Entra, SailPoint, and generic OIDC via `bifrost.scim.config.provisioningToken` and `claimScimAttributes` — no dashboard step required.
-- OTEL plugin now supports `request_headers` to capture request headers as span attributes.
-- Added generic OIDC SCIM/SSO provider support (`bifrost.scim.provider: generic`) for any standards-compliant OIDC IdP. Configure via `bifrost.scim.config` (`issuerUrl` and `clientId` required; optional `clientSecret`, `audience`, endpoint overrides, `teamIdsField`, `rolesField`, `scopes`, and attribute/claim mappings). Endpoints are resolved via OIDC discovery unless overridden. Renders into `scim_config.config`.
+- Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to the Okta, Entra, SailPoint, and generic OIDC SCIM providers, so inbound SCIM provisioning can be seeded declaratively instead of via the dashboard. Both render into `scim_config.config`. Generate a token with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` (supports `env.` prefix).
+- Added `request_headers` to the OTEL plugin config (`bifrost.plugins.otel.config.request_headers` and `profiles[*].request_headers`) to capture request headers as span attributes. Renders into `request_headers`.
 - Added `bifrost.client.dualCredentialConflictBehavior` to control what happens when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"` (reject with 400), `"prefer_vk"` (drop IDP token, use VK), or `"prefer_idp"` (default, IDP token wins). Renders into `client.dual_credential_conflict_behavior`.
 
 </Update>

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.28
+version: 2.1.29
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,7 +4,7 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.28
+**Latest Version:** 2.1.29
 
 ## Changelog
 

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -621,7 +621,7 @@ bifrost:
         headers: {}
         # TLS configuration
         tls_ca_cert: "" # Path to TLS CA certificate file
-        insecure: false # Skip TLS verification (ignored if tls_ca_cert is set)
+        # insecure: false # Skip TLS verification (ignored if tls_ca_cert is set)
         # Drop message content (input/output messages, embeddings, tool defs/args/results) from exported spans
         disable_content_logging: false
         # Group requests sharing the same x-bf-session-id header into one trace (an inbound W3C traceparent takes precedence)

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.12
+    created: "2026-07-15T15:43:16.611595+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 624ec3120c38f482ef3a760a49d4b9a2281db57ffc18faaf514cb5a617fe6f35
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://github.com/maximhq/bifrost/releases/download/helm-chart-v2.1.29/bifrost-2.1.29.tgz
+    version: 2.1.29
+  - apiVersion: v2
+    appVersion: 1.5.12
     created: "2026-07-14T15:06:42.147711+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -1180,4 +1204,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-07-14T15:06:42.143799+05:30"
+generated: "2026-07-15T15:43:16.600848+05:30"


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart to v2.1.29 and documents three new configuration additions: declarative SCIM provisioning token support, request header capture in the OTEL plugin, and dual-credential conflict behavior control.

## Changes

- Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to Okta, Entra, SailPoint, and generic OIDC SCIM providers, enabling inbound SCIM provisioning to be seeded declaratively without a dashboard step. Tokens can be generated with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` and support the `env.` prefix. Both fields render into `scim_config.config`.
- Added `request_headers` to the OTEL plugin config (`bifrost.plugins.otel.config.request_headers` and `profiles[*].request_headers`) to capture request headers as span attributes, rendering into `request_headers`.
- Added `bifrost.client.dualCredentialConflictBehavior` to control behavior when an inference request presents both an IDP access token and a virtual key (`x-bf-vk`). Accepts `"error"`, `"prefer_vk"`, or `"prefer_idp"` (default). Renders into `client.dual_credential_conflict_behavior`.
- Bumped chart version from 2.1.28 to 2.1.29.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the updated Helm chart and verify the new fields render correctly into the resulting config:

```sh
helm upgrade --install bifrost ./helm-charts/bifrost -f your-values.yaml

# Verify SCIM provisioning token is present in scim_config.config
# Verify OTEL plugin request_headers appear in the rendered plugin config
# Verify dual_credential_conflict_behavior is set correctly in client config
```

**New config fields:**

| Field | Values | Renders Into |
|---|---|---|
| `bifrost.scim.config.provisioningToken` | string / `env.<VAR>` | `scim_config.config` |
| `bifrost.scim.config.claimScimAttributes` | bool | `scim_config.config` |
| `bifrost.plugins.otel.config.request_headers` | list of header names | `request_headers` |
| `bifrost.client.dualCredentialConflictBehavior` | `error`, `prefer_vk`, `prefer_idp` | `client.dual_credential_conflict_behavior` |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

`bifrost.scim.config.provisioningToken` is a sensitive credential. Use the `env.` prefix to source it from an environment variable rather than embedding it in plaintext in `values.yaml`. Token generation should use `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` to produce a URL-safe base64 value.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable