### PR TITLE
fix: drops unsupported reasoning summary values for azure model router

### DIFF
--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1656,6 +1656,11 @@ func isOpenAIReasoningModel(model string) bool {
 	return len(name) == 2 || name[2] == '-'
 }
 
+// IsAzureModelRouter reports whether model is Azure's model-router model.
+func IsAzureModelRouter(model string) bool {
+	return strings.Contains(model, "model-router")
+}
+
 // IsElevenlabsSoundModel checks if the model targets ElevenLabs' text-to-sound
 // effects API (POST /v1/sound-generation, e.g. "eleven_text_to_sound_v2")
 // rather than text-to-speech. These models are not tied to a voice.

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -158,9 +158,16 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 			params.PromptCacheKey = nil
 			dropped = append(dropped, "prompt_cache_key")
 		}
-		if params.Reasoning != nil && !isSupported["reasoning"] {
-			params.Reasoning = nil
-			dropped = append(dropped, "reasoning")
+		if params.Reasoning != nil {
+			if !isSupported["reasoning"] {
+				params.Reasoning = nil
+				dropped = append(dropped, "reasoning")
+			} else if params.Reasoning.Summary != nil && *params.Reasoning.Summary != "auto" &&
+				schemas.IsAzureModelRouter(req.ResponsesRequest.Model) {
+				// model-router only supports "auto" summary
+				params.Reasoning.Summary = nil
+				dropped = append(dropped, "reasoning.summary")
+			}
 		}
 		if params.ServiceTier != nil && !isSupported["service_tier"] {
 			params.ServiceTier = nil


### PR DESCRIPTION
## Summary

Azure's `model-router` model only supports `"auto"` as a value for the `reasoning.summary` parameter. When a different value is provided, the request would fail. This PR adds handling to strip the unsupported `reasoning.summary` value when routing through `model-router`, ensuring compatibility without breaking the broader reasoning parameter support.

## Changes

- Added `IsModelRouter` helper in `core/schemas/utils.go` to detect Azure's `model-router` model by name.
- Updated the `dropUnsupportedParams` logic in `plugins/compat/dropparams.go` so that when `reasoning` is supported but `reasoning.summary` is set to a non-`"auto"` value and the model is `model-router`, the summary field is cleared and logged as dropped.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request targeting Azure's `model-router` model with a `reasoning.summary` value other than `"auto"` (e.g., `"detailed"`) and verify that the parameter is stripped before the request is forwarded and that the request succeeds.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable