### PR TITLE
feat: show prompt/completion token breakdown in logs stats card

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -441,6 +441,15 @@ export default function LogsPage() {
 				title: "Total Tokens",
 				value: <NumberFlow value={stats?.total_tokens ?? 0} format={COMPACT_NUMBER_FORMAT} />,
 				icon: <Hash className="size-4" />,
+				subValue: (
+					<>
+						<NumberFlow value={stats?.prompt_tokens ?? 0} format={COMPACT_NUMBER_FORMAT} />
+						<span> in / </span>
+						<NumberFlow value={stats?.completion_tokens ?? 0} format={COMPACT_NUMBER_FORMAT} />
+						<span> out</span>
+					</>
+				),
+				description: "Total tokens used, split into input (prompt) and output (completion) tokens.",
 			},
 			{
 				title: "Total Cost",
@@ -667,6 +676,9 @@ export default function LogsPage() {
 												)}
 											</div>
 											<div className="truncate font-mono text-xl font-medium sm:text-2xl">{card.value}</div>
+											{"subValue" in card && card.subValue && (
+												<div className="truncate font-mono text-[10.5px] tabular-nums">{card.subValue}</div>
+											)}
 										</div>
 									</CardContent>
 								</Card>

--- a/ui/app/workspace/model-catalog/views/overviewTab.tsx
+++ b/ui/app/workspace/model-catalog/views/overviewTab.tsx
@@ -96,6 +96,8 @@ export default function OverviewTab({ hasAccess }: OverviewTabProps) {
 									average_latency: 0,
 									user_facing_total_requests: 0,
 									total_tokens: 0,
+									prompt_tokens: 0,
+									completion_tokens: 0,
 									total_cost: 0,
 								},
 							] as const,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -630,6 +630,8 @@ export interface LogStats {
 	user_facing_total_requests: number;
 	average_latency: number;
 	total_tokens: number;
+	prompt_tokens: number;
+	completion_tokens: number;
 	total_cost: number;
 	cache_hit_rate_total_requests?: number | null;
 	direct_cache_hits?: number | null;


### PR DESCRIPTION
## Summary

Adds a breakdown of prompt (input) and completion (output) tokens to the Total Tokens stat card on the Logs page, giving users more granular visibility into how tokens are being consumed.

## Changes

- Added `prompt_tokens` and `completion_tokens` fields to the `LogStats` interface
- Extended the Total Tokens stat card to display a `subValue` showing the input/output token split (e.g. "1.2k in / 800 out")
- Added rendering logic in the stat card component to display the `subValue` when present
- Included a `description` field on the Total Tokens card explaining the breakdown
- Updated the model catalog overview tab's default stats object to include the new token fields

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Logs page and verify the Total Tokens stat card displays a secondary line beneath the main token count showing the prompt and completion token breakdown in the format `X in / Y out`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

The Total Tokens card should now show:
- Primary value: total token count (e.g. `2.1k`)
- Sub-value: `1.2k in / 800 out` in a smaller monospace font beneath

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable