### PR TITLE
feat: add `prompt_tokens` and `completion_tokens` to search stats

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -936,11 +936,13 @@ func (s *RDBLogStore) getCountFromMatView(ctx context.Context, filters SearchFil
 // Latency is a weighted average across hourly buckets.
 func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFilters) (*SearchStats, error) {
 	var result struct {
-		TotalCount   int64   `gorm:"column:total_count"`
-		SuccessCount int64   `gorm:"column:success_count"`
-		AvgLatency   float64 `gorm:"column:avg_latency"`
-		TotalTokens  int64   `gorm:"column:total_tokens"`
-		TotalCost    float64 `gorm:"column:total_cost"`
+		TotalCount       int64   `gorm:"column:total_count"`
+		SuccessCount     int64   `gorm:"column:success_count"`
+		AvgLatency       float64 `gorm:"column:avg_latency"`
+		TotalTokens      int64   `gorm:"column:total_tokens"`
+		PromptTokens     int64   `gorm:"column:prompt_tokens"`
+		CompletionTokens int64   `gorm:"column:completion_tokens"`
+		TotalCost        float64 `gorm:"column:total_cost"`
 	}
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
@@ -949,6 +951,8 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 		COALESCE(SUM(success_count), 0) AS success_count,
 		CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_latency,
 		COALESCE(SUM(total_tokens), 0) AS total_tokens,
+		COALESCE(SUM(total_prompt_tokens), 0) AS prompt_tokens,
+		COALESCE(SUM(total_completion_tokens), 0) AS completion_tokens,
 		COALESCE(SUM(total_cost), 0) AS total_cost
 	`).Scan(&result).Error; err != nil {
 		return nil, err
@@ -972,6 +976,8 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 		UserFacingTotalRequests:   result.TotalCount, // matview approximation; no per-chain data available
 		AverageLatency:            result.AvgLatency,
 		TotalTokens:               result.TotalTokens,
+		PromptTokens:              result.PromptTokens,
+		CompletionTokens:          result.CompletionTokens,
 		TotalCost:                 result.TotalCost,
 		CacheHitRateTotalRequests: &cacheHitRateTotalRequests,
 	}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1019,11 +1019,13 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	if totalCount > 0 {
 		// Single query for all terminal-request stats: counts, latency, tokens, cost
 		var result struct {
-			CompletedCount sql.NullInt64   `gorm:"column:completed_count"`
-			SuccessCount   sql.NullInt64   `gorm:"column:success_count"`
-			AvgLatency     sql.NullFloat64 `gorm:"column:avg_latency"`
-			TotalTokens    sql.NullInt64   `gorm:"column:total_tokens"`
-			TotalCost      sql.NullFloat64 `gorm:"column:total_cost"`
+			CompletedCount   sql.NullInt64   `gorm:"column:completed_count"`
+			SuccessCount     sql.NullInt64   `gorm:"column:success_count"`
+			AvgLatency       sql.NullFloat64 `gorm:"column:avg_latency"`
+			TotalTokens      sql.NullInt64   `gorm:"column:total_tokens"`
+			PromptTokens     sql.NullInt64   `gorm:"column:prompt_tokens"`
+			CompletionTokens sql.NullInt64   `gorm:"column:completion_tokens"`
+			TotalCost        sql.NullFloat64 `gorm:"column:total_cost"`
 		}
 
 		statsQuery := s.ScopedDB(ctx).Model(&Log{})
@@ -1035,6 +1037,8 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success_count,
 			AVG(latency) as avg_latency,
 			SUM(total_tokens) as total_tokens,
+			SUM(prompt_tokens) as prompt_tokens,
+			SUM(completion_tokens) as completion_tokens,
 			SUM(cost) as total_cost
 		`).Scan(&result).Error; err != nil {
 			return nil, err
@@ -1049,6 +1053,12 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			}
 			if result.TotalTokens.Valid {
 				stats.TotalTokens = result.TotalTokens.Int64
+			}
+			if result.PromptTokens.Valid {
+				stats.PromptTokens = result.PromptTokens.Int64
+			}
+			if result.CompletionTokens.Valid {
+				stats.CompletionTokens = result.CompletionTokens.Int64
 			}
 			if result.TotalCost.Valid {
 				stats.TotalCost = result.TotalCost.Float64

--- a/framework/logstore/rdb_stats_test.go
+++ b/framework/logstore/rdb_stats_test.go
@@ -1,0 +1,58 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// GetStats reports input/output tokens alongside the total so the logs stats
+// card can show the split. Only terminal requests contribute, matching the
+// total/cost aggregates computed in the same query.
+func TestGetStatsTokenSplit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Log{}))
+
+	s := &RDBLogStore{db: db, logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}
+	ctx := context.Background()
+	now := time.Now()
+
+	seed := []struct {
+		id                        string
+		prompt, completion, total int
+		status                    string
+	}{
+		{"a", 100, 10, 110, "success"},
+		{"b", 200, 20, 220, "success"},
+		{"c", 400, 40, 440, "error"},       // terminal, must count
+		{"d", 999, 99, 1098, "processing"}, // non-terminal, must NOT count
+	}
+	for _, sd := range seed {
+		require.NoError(t, db.Create(&Log{
+			ID:               sd.id,
+			Timestamp:        now,
+			Status:           sd.status,
+			PromptTokens:     sd.prompt,
+			CompletionTokens: sd.completion,
+			TotalTokens:      sd.total,
+		}).Error)
+	}
+
+	stats, err := s.GetStats(ctx, SearchFilters{})
+	require.NoError(t, err)
+
+	require.Equal(t, int64(770), stats.TotalTokens, "total excludes non-terminal")
+	require.Equal(t, int64(700), stats.PromptTokens, "prompt = 100+200+400")
+	require.Equal(t, int64(70), stats.CompletionTokens, "completion = 10+20+40")
+	require.Equal(t, stats.TotalTokens, stats.PromptTokens+stats.CompletionTokens, "split sums to total")
+}

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -116,6 +116,8 @@ type SearchStats struct {
 	UserFacingTotalRequests   int64   `json:"user_facing_total_requests"`              // Count of root requests (fallback_index = 0) used as denominator for UserFacingSuccessRate
 	AverageLatency            float64 `json:"average_latency"`                         // Average latency in milliseconds
 	TotalTokens               int64   `json:"total_tokens"`                            // Total tokens used
+	PromptTokens              int64   `json:"prompt_tokens"`                           // Input tokens used
+	CompletionTokens          int64   `json:"completion_tokens"`                       // Output tokens used
 	TotalCost                 float64 `json:"total_cost"`                              // Total cost in dollars
 	CacheHitRateTotalRequests *int64  `json:"cache_hit_rate_total_requests,omitempty"` // Completed requests used as local-cache hit-rate denominator
 	DirectCacheHits           *int64  `json:"direct_cache_hits,omitempty"`             // Number of direct (exact) semantic cache hits


### PR DESCRIPTION
## Summary

Exposes prompt (input) and completion (output) token counts as distinct fields in the `SearchStats` response, allowing consumers to see the token split rather than only the aggregate total.

## Changes

- Added `PromptTokens` and `CompletionTokens` fields to the `SearchStats` struct in `tables.go`, surfaced as `prompt_tokens` and `completion_tokens` in JSON.
- Extended the raw SQL query in `GetStats` (`rdb.go`) to aggregate `SUM(prompt_tokens)` and `SUM(completion_tokens)` alongside the existing `total_tokens`, and maps the nullable results into the new struct fields.
- Extended the materialized-view query in `getStatsFromMatView` (`matviews.go`) to aggregate `total_prompt_tokens` and `total_completion_tokens` from `mv_logs_hourly`, mapping them into the same struct fields.
- Added `rdb_stats_test.go` with a focused unit test (`TestGetStatsTokenSplit`) that seeds an in-memory SQLite database with terminal and non-terminal log rows and asserts that prompt/completion tokens are summed correctly, non-terminal rows are excluded, and the split sums to the total.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestGetStatsTokenSplit -v
```

Expected output: all three assertions pass — prompt tokens equal 700, completion tokens equal 70, and their sum equals the total of 770. Non-terminal (`processing`) rows must not contribute to any of the counts.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing implications. The new fields are additive to an existing read-only stats response.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable