### PR TITLE
feat: add webhook jobs work-queue and delivery history tables with store methods and tests

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -447,6 +447,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"repair_bare_wildcard_allowed_models"}, run: migrationRepairBareWildcardAllowedModels},
 	{IDs: []string{"add_bedrock_project_id_columns"}, run: migrationAddBedrockProjectIDColumns},
 	{IDs: []string{"add_webhook_endpoints_table"}, run: migrationAddWebhookEndpointsTable},
+	{IDs: []string{"add_webhook_jobs_table"}, run: migrationAddWebhookJobsTable},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10704,6 +10705,34 @@ func migrationAddWebhookEndpointsTable(ctx context.Context, db *gorm.DB, logger 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running webhook endpoints table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddWebhookJobsTable creates the webhook_jobs work-queue table.
+func migrationAddWebhookJobsTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_webhook_jobs_table"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasTable(&tables.TableWebhookJob{}) {
+				if err := mg.CreateTable(&tables.TableWebhookJob{}); err != nil {
+					return fmt.Errorf("create webhook_jobs table: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Migrator().DropTable(&tables.TableWebhookJob{})
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running webhook jobs table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7543,3 +7543,196 @@ func (s *RDBConfigStore) RotateWebhookEndpointSecret(ctx context.Context, id str
 	rotated.Secret = &schemas.SecretVar{Val: newSecret}
 	return &rotated, nil
 }
+
+// RecordWebhookEndpointSuccess resets the endpoint's consecutive-failure
+// streak after a successful delivery. Operational counters are written with
+// atomic column updates — delivery workers on several nodes may record
+// results for the same endpoint concurrently — and bypass the save hooks so
+// they never touch the endpoint's config fields or updated_at.
+func (s *RDBConfigStore) RecordWebhookEndpointSuccess(ctx context.Context, id string) error {
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableWebhookEndpoint{}).
+		Where("id = ?", id).
+		UpdateColumns(map[string]any{
+			"consecutive_failures": 0,
+			"last_success_at":      time.Now(),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// RecordWebhookEndpointFailure increments the endpoint's consecutive-failure
+// streak and returns the post-increment value so the caller can apply its
+// auto-disable threshold. The increment is a single SQL expression — never a
+// read-modify-write — so concurrent recorders cannot lose updates; the
+// read-back inside the transaction observes this recorder's own increment.
+func (s *RDBConfigStore) RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error) {
+	var failures int
+	err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		res := tx.Model(&tables.TableWebhookEndpoint{}).
+			Where("id = ?", id).
+			UpdateColumns(map[string]any{
+				"consecutive_failures": gorm.Expr("consecutive_failures + 1"),
+				"last_failure_at":      time.Now(),
+			})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		var row struct{ ConsecutiveFailures int }
+		if err := tx.Model(&tables.TableWebhookEndpoint{}).
+			Select("consecutive_failures").
+			Where("id = ?", id).
+			Scan(&row).Error; err != nil {
+			return err
+		}
+		failures = row.ConsecutiveFailures
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return failures, nil
+}
+
+// CreateWebhookJob inserts a new delivery job into the webhook work queue.
+// The caller supplies the id: it doubles as the delivery's `webhook-id`
+// header and must stay stable across attempts and redeliveries, so receivers
+// can deduplicate. A zero NextAttemptAt means due immediately.
+func (s *RDBConfigStore) CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error {
+	if job == nil {
+		return fmt.Errorf("webhook job cannot be nil")
+	}
+	if job.ID == "" {
+		return fmt.Errorf("webhook job id is required")
+	}
+	if job.EndpointID == "" {
+		return fmt.Errorf("webhook job endpoint id is required")
+	}
+	if job.AsyncJobID == "" {
+		return fmt.Errorf("webhook job async job id is required")
+	}
+	if !job.Event.IsValid() {
+		return fmt.Errorf("unknown webhook event %q", job.Event)
+	}
+	// A new job must enter the queue in the initial, unclaimed state: a nonzero
+	// attempt count or a pre-set claim would let it start already hidden behind
+	// a lease, invisible to every worker until the phantom lease expired.
+	if job.AttemptCount != 0 || job.ClaimedBy != "" || job.ClaimedUntil != nil {
+		return fmt.Errorf("new webhook job must be unattempted and unclaimed")
+	}
+	// Queue timestamps are normalized to UTC: SQLite compares datetimes as
+	// strings, so mixed offsets break the due and lease predicates.
+	now := time.Now().UTC()
+	if job.NextAttemptAt.IsZero() {
+		job.NextAttemptAt = now
+	} else {
+		job.NextAttemptAt = job.NextAttemptAt.UTC()
+	}
+	job.CreatedAt = now
+	return s.parseGormError(s.DB().WithContext(ctx).Create(job).Error)
+}
+
+// ListDueWebhookJobs returns up to limit jobs that are due for a delivery
+// attempt: next_attempt_at has passed and no live claim lease is held.
+// Ordered oldest-due-first; limit <= 0 means no limit. Every node lists and
+// races to claim; the atomic ClaimWebhookJob decides the single winner per
+// job, so listing needs no cross-node coordination.
+func (s *RDBConfigStore) ListDueWebhookJobs(ctx context.Context, limit int) ([]tables.TableWebhookJob, error) {
+	now := time.Now().UTC()
+	query := s.DB().WithContext(ctx).
+		Where("next_attempt_at <= ? AND (claimed_until IS NULL OR claimed_until < ?)", now, now).
+		Order("next_attempt_at ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	var jobs []tables.TableWebhookJob
+	if err := query.Find(&jobs).Error; err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+// ClaimWebhookJob atomically claims a due job for runnerID until leaseUntil.
+// The conditional UPDATE re-checks the due predicate, so at most one
+// concurrent claimer wins (RowsAffected == 1). A lease that expired without
+// being released — its owner died mid-attempt — makes the row claimable
+// again, which is also how delivery work is recovered after a restart.
+func (s *RDBConfigStore) ClaimWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) (bool, error) {
+	now := time.Now().UTC()
+	// The lease must expire strictly in the future: a past or present expiry
+	// would win the claim yet leave the row immediately reclaimable, so a
+	// second worker could seize a job this caller still believes it owns.
+	leaseUntil = normalizeLeaseTime(leaseUntil)
+	if !leaseUntil.After(now) {
+		return false, fmt.Errorf("webhook job lease must expire in the future")
+	}
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableWebhookJob{}).
+		Where("id = ? AND next_attempt_at <= ? AND (claimed_until IS NULL OR claimed_until < ?)", id, now, now).
+		Updates(map[string]any{
+			"claimed_by":    runnerID,
+			"claimed_until": leaseUntil,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// normalizeLeaseTime is applied to claimed_until on every write and fence
+// comparison: UTC (mixed offsets break SQLite's string datetime compares) and
+// microsecond precision (Postgres truncates to microseconds, so an exact
+// equality fence must not carry nanoseconds).
+func normalizeLeaseTime(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Microsecond)
+}
+
+// RescheduleWebhookJob records a retryable failed attempt on a claimed job:
+// it increments the attempt counter, sets the next due time, and releases
+// the claim lease. Fenced on claimed_by plus the exact lease issued to this
+// claim — runner identity alone cannot distinguish successive claims by the
+// same runner (the single-node runner id is empty), while a reclaim always
+// carries a later lease expiry, so a stale owner's mutation matches nothing.
+func (s *RDBConfigStore) RescheduleWebhookJob(ctx context.Context, id, runnerID string, leaseUntil, nextAttemptAt time.Time) error {
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableWebhookJob{}).
+		Where("id = ? AND claimed_by = ? AND claimed_until = ?", id, runnerID, normalizeLeaseTime(leaseUntil)).
+		Updates(map[string]any{
+			"attempt_count":   gorm.Expr("attempt_count + 1"),
+			"next_attempt_at": nextAttemptAt.UTC(),
+			"claimed_by":      "",
+			"claimed_until":   nil,
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("webhook job not found or no longer owned by caller")
+	}
+	return nil
+}
+
+// DeleteWebhookJob removes a job whose delivery reached a terminal outcome —
+// queue rows only exist while a delivery is in flight. Fenced on claimed_by
+// plus the exact lease issued to this claim (see RescheduleWebhookJob), so
+// only the current claim holder can retire the job.
+func (s *RDBConfigStore) DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error {
+	res := s.DB().WithContext(ctx).
+		Where("id = ? AND claimed_by = ? AND claimed_until = ?", id, runnerID, normalizeLeaseTime(leaseUntil)).
+		Delete(&tables.TableWebhookJob{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("webhook job not found or no longer owned by caller")
+	}
+	return nil
+}

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,6 +59,7 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TableMCPPerUserHeaderFlow{},
 		&tables.TableOAuth2RefreshToken{},
 		&tables.TableWebhookEndpoint{},
+		&tables.TableWebhookJob{},
 	)
 	require.NoError(t, err, "Failed to migrate test database")
 
@@ -2560,4 +2562,379 @@ func TestWebhookEndpointUpdatePersistsTuningAndHeaders(t *testing.T) {
 	require.Len(t, fetched.Headers, 1)
 	auth := fetched.Headers["Authorization"]
 	assert.Equal(t, "Bearer tok", auth.GetValue())
+}
+
+func TestWebhookEndpointRecordFailureAndSuccess(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	endpoint := testWebhookEndpoint("counter-test")
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, endpoint))
+
+	failures, err := store.RecordWebhookEndpointFailure(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, failures)
+	failures, err = store.RecordWebhookEndpointFailure(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, failures)
+
+	fetched, err := store.GetWebhookEndpointByID(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, fetched.ConsecutiveFailures)
+	assert.NotNil(t, fetched.LastFailureAt)
+	assert.Nil(t, fetched.LastSuccessAt)
+
+	require.NoError(t, store.RecordWebhookEndpointSuccess(ctx, endpoint.ID))
+	fetched, err = store.GetWebhookEndpointByID(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, fetched.ConsecutiveFailures)
+	assert.NotNil(t, fetched.LastSuccessAt)
+
+	_, err = store.RecordWebhookEndpointFailure(ctx, "does-not-exist")
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.ErrorIs(t, store.RecordWebhookEndpointSuccess(ctx, "does-not-exist"), ErrNotFound)
+}
+
+func TestWebhookEndpointCounterUpdatesLeaveConfigUntouched(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	endpoint := testWebhookEndpoint("counter-config-test")
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, endpoint))
+	secret := endpoint.Secret.GetValue()
+
+	before, err := store.GetWebhookEndpointByID(ctx, endpoint.ID)
+	require.NoError(t, err)
+
+	_, err = store.RecordWebhookEndpointFailure(ctx, endpoint.ID)
+	require.NoError(t, err)
+	require.NoError(t, store.RecordWebhookEndpointSuccess(ctx, endpoint.ID))
+
+	after, err := store.GetWebhookEndpointByID(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, before.UpdatedAt.UnixNano(), after.UpdatedAt.UnixNano(),
+		"operational counters must not touch updated_at")
+	assert.Equal(t, before.URL, after.URL)
+	assert.Equal(t, before.Events, after.Events)
+	assert.Equal(t, secret, after.Secret.GetValue(),
+		"operational counters must not touch the stored secret")
+}
+
+func testWebhookJob(id, endpointID string) *tables.TableWebhookJob {
+	return &tables.TableWebhookJob{
+		ID:         id,
+		EndpointID: endpointID,
+		AsyncJobID: "async-job-1",
+		Event:      tables.WebhookEventAsyncJobCompleted,
+	}
+}
+
+// getWebhookJob reads a queue row directly; the store deliberately exposes no
+// single-row getter, since workers only ever list-and-claim.
+func getWebhookJob(t *testing.T, store *RDBConfigStore, id string) *tables.TableWebhookJob {
+	t.Helper()
+	var job tables.TableWebhookJob
+	require.NoError(t, store.DB().Where("id = ?", id).First(&job).Error)
+	return &job
+}
+
+// setWebhookJobClaimedUntil forces a job's lease expiry to a fixed time so
+// lease expiry can be exercised deterministically without sleeping.
+func setWebhookJobClaimedUntil(t *testing.T, store *RDBConfigStore, id string, ts time.Time) {
+	t.Helper()
+	require.NoError(t, store.DB().Model(&tables.TableWebhookJob{}).
+		Where("id = ?", id).UpdateColumn("claimed_until", ts.UTC()).Error)
+}
+
+func TestWebhookJobCreateValidation(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	assert.Error(t, store.CreateWebhookJob(ctx, nil))
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{EndpointID: "ep", AsyncJobID: "job", Event: tables.WebhookEventAsyncJobCompleted}))
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{ID: "id", AsyncJobID: "job", Event: tables.WebhookEventAsyncJobCompleted}))
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{ID: "id", EndpointID: "ep", Event: tables.WebhookEventAsyncJobCompleted}))
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{ID: "id", EndpointID: "ep", AsyncJobID: "job", Event: "bogus.event"}))
+	// A new job must enter unattempted and unclaimed.
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{ID: "id", EndpointID: "ep", AsyncJobID: "job", Event: tables.WebhookEventAsyncJobCompleted, AttemptCount: 1}))
+	assert.Error(t, store.CreateWebhookJob(ctx, &tables.TableWebhookJob{ID: "id", EndpointID: "ep", AsyncJobID: "job", Event: tables.WebhookEventAsyncJobCompleted, ClaimedBy: "node-a"}))
+}
+
+func TestWebhookJobCreateDefaultsAndDuplicate(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	job := testWebhookJob("job-1", "ep-1")
+	require.NoError(t, store.CreateWebhookJob(ctx, job))
+	assert.False(t, job.NextAttemptAt.IsZero(), "zero NextAttemptAt defaults to now (due immediately)")
+	assert.False(t, job.CreatedAt.IsZero())
+
+	stored := getWebhookJob(t, store, "job-1")
+	assert.Equal(t, 0, stored.AttemptCount)
+	assert.Empty(t, stored.ClaimedBy)
+	assert.Nil(t, stored.ClaimedUntil)
+
+	// The id doubles as the delivery's wire identifier and must stay unique
+	// while a delivery is in flight.
+	assert.ErrorIs(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")), ErrAlreadyExists)
+}
+
+func TestWebhookJobClaimRace(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	// Pin the pool to a single connection so both racers hit the same
+	// in-memory database; SQLite serializes writes on that connection, which
+	// is precisely the atomicity the conditional UPDATE relies on.
+	sqlDB, err := store.DB().DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+
+	// Two nodes claim the same job simultaneously: both block on the barrier,
+	// then fire together. Exactly one conditional UPDATE may match the still-due
+	// row, so exactly one claimer must win.
+	nodes := []string{"node-a", "node-b"}
+	results := make([]bool, len(nodes))
+	errs := make([]error, len(nodes))
+	var start sync.WaitGroup
+	start.Add(1)
+	var done sync.WaitGroup
+	for i, node := range nodes {
+		done.Add(1)
+		go func(i int, node string) {
+			defer done.Done()
+			start.Wait()
+			results[i], errs[i] = store.ClaimWebhookJob(ctx, "job-1", node, time.Now().Add(time.Minute))
+		}(i, node)
+	}
+	start.Done()
+	done.Wait()
+
+	for i, node := range nodes {
+		require.NoErrorf(t, errs[i], "claim by %s errored", node)
+	}
+	wins := 0
+	for _, won := range results {
+		if won {
+			wins++
+		}
+	}
+	assert.Equal(t, 1, wins, "exactly one concurrent claimer must win")
+
+	stored := getWebhookJob(t, store, "job-1")
+	assert.Contains(t, nodes, stored.ClaimedBy, "the stored claim must belong to a racer")
+	require.NotNil(t, stored.ClaimedUntil)
+}
+
+func TestWebhookJobClaimLeaseExpiryReclaim(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "node-a", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, won)
+
+	// The owner dies mid-attempt: its lease lapses and another node reclaims.
+	setWebhookJobClaimedUntil(t, store, "job-1", time.Now().Add(-time.Second))
+	won, err = store.ClaimWebhookJob(ctx, "job-1", "node-b", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.True(t, won)
+	assert.Equal(t, "node-b", getWebhookJob(t, store, "job-1").ClaimedBy)
+}
+
+func TestWebhookJobClaimNotDueRejected(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	job := testWebhookJob("job-1", "ep-1")
+	job.NextAttemptAt = time.Now().Add(time.Hour)
+	require.NoError(t, store.CreateWebhookJob(ctx, job))
+
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "node-a", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, won)
+
+	won, err = store.ClaimWebhookJob(ctx, "missing-job", "node-a", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, won)
+
+	// A non-future lease is rejected outright: winning with an already-expired
+	// lease would leave the job instantly reclaimable by another worker.
+	won, err = store.ClaimWebhookJob(ctx, "job-1", "node-a", time.Now().Add(-time.Second))
+	assert.Error(t, err)
+	assert.False(t, won)
+}
+
+func TestWebhookJobListDue(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	// Oldest due job, listed first.
+	oldest := testWebhookJob("due-oldest", "ep-1")
+	oldest.NextAttemptAt = time.Now().Add(-2 * time.Minute)
+	require.NoError(t, store.CreateWebhookJob(ctx, oldest))
+
+	newer := testWebhookJob("due-newer", "ep-1")
+	newer.NextAttemptAt = time.Now().Add(-time.Minute)
+	require.NoError(t, store.CreateWebhookJob(ctx, newer))
+
+	future := testWebhookJob("future", "ep-1")
+	future.NextAttemptAt = time.Now().Add(time.Hour)
+	require.NoError(t, store.CreateWebhookJob(ctx, future))
+
+	claimed := testWebhookJob("claimed-live", "ep-1")
+	claimed.NextAttemptAt = time.Now().Add(-time.Minute)
+	require.NoError(t, store.CreateWebhookJob(ctx, claimed))
+	won, err := store.ClaimWebhookJob(ctx, "claimed-live", "node-a", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, won)
+
+	expired := testWebhookJob("claimed-expired", "ep-1")
+	expired.NextAttemptAt = time.Now().Add(-3 * time.Minute)
+	require.NoError(t, store.CreateWebhookJob(ctx, expired))
+	won, err = store.ClaimWebhookJob(ctx, "claimed-expired", "node-a", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.True(t, won)
+	setWebhookJobClaimedUntil(t, store, "claimed-expired", time.Now().Add(-time.Second))
+
+	due, err := store.ListDueWebhookJobs(ctx, 0)
+	require.NoError(t, err)
+	ids := make([]string, 0, len(due))
+	for _, j := range due {
+		ids = append(ids, j.ID)
+	}
+	assert.Equal(t, []string{"claimed-expired", "due-oldest", "due-newer"}, ids)
+
+	due, err = store.ListDueWebhookJobs(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, "claimed-expired", due[0].ID)
+}
+
+// TestWebhookJobUTCDueComparison guards the queue's time handling with the
+// UTC timestamps the dispatcher actually writes: SQLite compares datetimes
+// as strings, so a due check made with a local-zone now sees a future UTC
+// next_attempt_at as already due on any machine east of UTC — which made
+// retries fire on the next poll tick instead of after their backoff.
+func TestWebhookJobUTCDueComparison(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	future := testWebhookJob("utc-future", "ep-1")
+	future.NextAttemptAt = time.Now().UTC().Add(time.Hour)
+	require.NoError(t, store.CreateWebhookJob(ctx, future))
+
+	due, err := store.ListDueWebhookJobs(ctx, 0)
+	require.NoError(t, err)
+	assert.Empty(t, due, "a job due an hour from now must not be listed")
+
+	won, err := store.ClaimWebhookJob(ctx, "utc-future", "node-a", time.Now().UTC().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, won, "a job due an hour from now must not be claimable")
+}
+
+func TestWebhookJobReschedule(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+	lease := time.Now().Add(time.Minute)
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "node-a", lease)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	// A non-owner cannot reschedule someone else's claim.
+	assert.Error(t, store.RescheduleWebhookJob(ctx, "job-1", "node-b", lease, time.Now().Add(5*time.Minute)))
+
+	next := time.Now().Add(5 * time.Minute)
+	require.NoError(t, store.RescheduleWebhookJob(ctx, "job-1", "node-a", lease, next))
+
+	stored := getWebhookJob(t, store, "job-1")
+	assert.Equal(t, 1, stored.AttemptCount)
+	assert.Empty(t, stored.ClaimedBy)
+	assert.Nil(t, stored.ClaimedUntil)
+	assert.WithinDuration(t, next, stored.NextAttemptAt, time.Second)
+
+	// The claim was released, so a second reschedule has nothing to fence on.
+	assert.Error(t, store.RescheduleWebhookJob(ctx, "job-1", "node-a", lease, next))
+}
+
+func TestWebhookJobDelete(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+
+	// Only the current claim holder can retire a job.
+	assert.Error(t, store.DeleteWebhookJob(ctx, "job-1", "node-a", time.Now().Add(time.Minute)))
+
+	lease := time.Now().Add(time.Minute)
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "node-a", lease)
+	require.NoError(t, err)
+	require.True(t, won)
+	assert.Error(t, store.DeleteWebhookJob(ctx, "job-1", "node-b", lease))
+	require.NoError(t, store.DeleteWebhookJob(ctx, "job-1", "node-a", lease))
+
+	var count int64
+	require.NoError(t, store.DB().Model(&tables.TableWebhookJob{}).Where("id = ?", "job-1").Count(&count).Error)
+	assert.Zero(t, count)
+}
+
+func TestWebhookJobClaimCycleWithEmptyRunnerID(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	// Single-node mode claims with an empty runner id; the lease alone
+	// fences, and fenced writes still match the empty claimed_by.
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+	lease := time.Now().Add(time.Minute)
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "", lease)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	won, err = store.ClaimWebhookJob(ctx, "job-1", "", time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	assert.False(t, won, "live lease must fence even without runner ids")
+
+	require.NoError(t, store.RescheduleWebhookJob(ctx, "job-1", "", lease, time.Now().Add(time.Minute)))
+	assert.Equal(t, 1, getWebhookJob(t, store, "job-1").AttemptCount)
+}
+
+func TestWebhookJobStaleOwnerAfterReclaimIsFenced(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	// Same runner reclaims a job after its first lease expired — the stale
+	// attempt still holds the OLD lease value, and runner identity alone
+	// cannot tell the two claims apart (the single-node runner id is empty).
+	require.NoError(t, store.CreateWebhookJob(ctx, testWebhookJob("job-1", "ep-1")))
+	staleLease := time.Now().Add(time.Minute)
+	won, err := store.ClaimWebhookJob(ctx, "job-1", "", staleLease)
+	require.NoError(t, err)
+	require.True(t, won)
+	setWebhookJobClaimedUntil(t, store, "job-1", time.Now().Add(-time.Second))
+
+	// The expired-lease value in the DB, exactly as the reclaim will see it.
+	expiredLease := *getWebhookJob(t, store, "job-1").ClaimedUntil
+
+	newLease := time.Now().Add(time.Minute)
+	won, err = store.ClaimWebhookJob(ctx, "job-1", "", newLease)
+	require.NoError(t, err)
+	require.True(t, won, "expired lease must be reclaimable")
+
+	// The stale owner's terminal mutations must match nothing.
+	assert.Error(t, store.RescheduleWebhookJob(ctx, "job-1", "", staleLease, time.Now().Add(time.Minute)))
+	assert.Error(t, store.RescheduleWebhookJob(ctx, "job-1", "", expiredLease, time.Now().Add(time.Minute)))
+	assert.Error(t, store.DeleteWebhookJob(ctx, "job-1", "", staleLease))
+	assert.Error(t, store.DeleteWebhookJob(ctx, "job-1", "", expiredLease))
+
+	stored := getWebhookJob(t, store, "job-1")
+	assert.Zero(t, stored.AttemptCount, "stale reschedule must not move the attempt counter")
+	require.NotNil(t, stored.ClaimedUntil, "stale delete must not release the live claim")
+
+	// The live claim holder still owns the job.
+	require.NoError(t, store.DeleteWebhookJob(ctx, "job-1", "", newLease))
 }

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -683,6 +683,15 @@ type ConfigStore interface {
 	UpdateWebhookEndpoint(ctx context.Context, endpoint *tables.TableWebhookEndpoint) error
 	DeleteWebhookEndpoint(ctx context.Context, id string) error
 	RotateWebhookEndpointSecret(ctx context.Context, id string) (*tables.TableWebhookEndpoint, error)
+	RecordWebhookEndpointSuccess(ctx context.Context, id string) error
+	RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error)
+
+	// Webhook Jobs - in-flight webhook delivery work queue
+	CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error
+	ListDueWebhookJobs(ctx context.Context, limit int) ([]tables.TableWebhookJob, error)
+	ClaimWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) (bool, error)
+	RescheduleWebhookJob(ctx context.Context, id, runnerID string, leaseUntil, nextAttemptAt time.Time) error
+	DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error
 
 	// DB returns the underlying database connection.
 	DB() *gorm.DB

--- a/framework/configstore/tables/webhooks.go
+++ b/framework/configstore/tables/webhooks.go
@@ -284,3 +284,32 @@ func (w *TableWebhookEndpoint) AfterFind(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// TableWebhookJob is one in-flight webhook delivery in the work queue. A row
+// exists only while its delivery is pending or retrying: it is created when a
+// subscribed event fires, claimed for each attempt, and deleted once the
+// delivery reaches a terminal outcome — so the table's steady-state size is
+// the number of concurrent in-flight deliveries. The row id doubles as the
+// delivery's stable `webhook-id` header value across attempts and redeliveries.
+type TableWebhookJob struct {
+	ID         string       `gorm:"type:varchar(36);primaryKey" json:"id"`
+	EndpointID string       `gorm:"type:varchar(36);not null;index" json:"endpoint_id"`
+	AsyncJobID string       `gorm:"type:varchar(255);not null" json:"async_job_id"`
+	Event      WebhookEvent `gorm:"type:varchar(255);not null" json:"event"`
+
+	AttemptCount  int       `gorm:"not null;default:0" json:"attempt_count"`
+	NextAttemptAt time.Time `gorm:"not null;index" json:"next_attempt_at"`
+
+	// ClaimedBy and ClaimedUntil form the delivery lease: a row with a live
+	// lease is owned by exactly one worker; once the lease expires the row is
+	// reclaimable (its owner is presumed dead mid-attempt). ClaimedBy holds
+	// the claiming runner's id and is empty in single-node mode, where the
+	// lease alone provides the fencing.
+	ClaimedBy    string     `gorm:"type:varchar(255);not null;default:''" json:"claimed_by,omitempty"`
+	ClaimedUntil *time.Time `json:"claimed_until,omitempty"`
+
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}
+
+// TableName sets the table name for the webhook job model
+func (TableWebhookJob) TableName() string { return "webhook_jobs" }

--- a/framework/logstore/clickhousemigrate.go
+++ b/framework/logstore/clickhousemigrate.go
@@ -267,12 +267,30 @@ func migrationClickHouseAsyncJobsTable(ctx context.Context, db *gorm.DB, cluster
 	return clickhouseReconcileColumns(ctx, db, &AsyncJob{}, "async_jobs", cluster, logger)
 }
 
+// migrationClickHouseWebhookDeliveriesTable creates the webhook_deliveries
+// table and reconciles it with the WebhookDelivery struct. Delivery history
+// is insert-only metadata, so it follows the logs retention setting for its
+// TTL backstop; DeleteExpiredWebhookDeliveries handles normal expiry from
+// each row's expires_at.
+func migrationClickHouseWebhookDeliveriesTable(ctx context.Context, db *gorm.DB, cluster string, retentionDays int, logger schemas.Logger) error {
+	logger.Info("[logstore] clickhouse: creating table webhook_deliveries")
+	if err := clickhouseCreateTable(ctx, db, &WebhookDelivery{}, chTableOpts{
+		table:   "webhook_deliveries",
+		orderBy: "id",
+		ttl:     chLogsTTL(retentionDays),
+	}, cluster); err != nil {
+		return fmt.Errorf("clickhouse: create webhook_deliveries table: %w", err)
+	}
+	return clickhouseReconcileColumns(ctx, db, &WebhookDelivery{}, "webhook_deliveries", cluster, logger)
+}
+
 // clickhouseMigrationSteps lists the per-table migrations in execution order,
 // mirroring logstoreMigrationSteps for the SQL stores.
 var clickhouseMigrationSteps = []clickhouseMigrationStep{
 	migrationClickHouseLogsTable,
 	migrationClickHouseMCPToolLogsTable,
 	migrationClickHouseAsyncJobsTable,
+	migrationClickHouseWebhookDeliveriesTable,
 }
 
 // triggerClickHouseMigrations runs all registered ClickHouse table migrations

--- a/framework/logstore/clickhousestore.go
+++ b/framework/logstore/clickhousestore.go
@@ -499,6 +499,34 @@ func (s *ClickHouseLogStore) DeleteStaleAsyncJobs(ctx context.Context, staleSinc
 	}
 }
 
+// DeleteExpiredWebhookDeliveries deletes webhook delivery history whose
+// expiry has passed. Overridden for the same reason as DeleteLogsBatch:
+// mutation deletes report 0 rows affected, so ids are selected first and
+// their count returned.
+func (s *ClickHouseLogStore) DeleteExpiredWebhookDeliveries(ctx context.Context) (int64, error) {
+	now := time.Now().UTC()
+	const batchLimit = 100
+	var total int64
+	for {
+		var ids []string
+		if err := s.db.WithContext(ctx).Model(&WebhookDelivery{}).Select("id").
+			Where("expires_at IS NOT NULL AND expires_at < ?", now).
+			Limit(batchLimit).Pluck("id", &ids).Error; err != nil {
+			return total, err
+		}
+		if len(ids) == 0 {
+			return total, nil
+		}
+		if err := s.db.WithContext(ctx).Where("id IN ?", ids).Delete(&WebhookDelivery{}).Error; err != nil {
+			return total, err
+		}
+		total += int64(len(ids))
+		if len(ids) < batchLimit {
+			return total, nil
+		}
+	}
+}
+
 // UpdateAsyncJob applies a column->value map to an async job row via
 // read-modify-write.
 func (s *ClickHouseLogStore) UpdateAsyncJob(ctx context.Context, id string, updates map[string]interface{}) error {

--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -49,7 +49,7 @@ func trySetupClickHouseStore(t *testing.T) *ClickHouseLogStore {
 		t.Skipf("ClickHouse not available, skipping test: %v", err)
 	}
 	ch := store.(*ClickHouseLogStore)
-	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs"} {
+	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs", "webhook_deliveries"} {
 		require.NoError(t, ch.db.Exec("TRUNCATE TABLE "+table).Error)
 	}
 	t.Cleanup(func() { _ = ch.Close(context.Background()) })

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -1238,3 +1238,26 @@ func (h *HybridLogStore) DeleteExpiredAsyncJobs(ctx context.Context) (int64, err
 func (h *HybridLogStore) DeleteStaleAsyncJobs(ctx context.Context, staleSince time.Time) (int64, error) {
 	return h.inner.DeleteStaleAsyncJobs(ctx, staleSince)
 }
+
+// Webhook Delivery methods — delegated directly; delivery history rows are
+// metadata-only and never carry offloadable payloads.
+
+// CreateWebhookDelivery appends one webhook delivery attempt record.
+func (h *HybridLogStore) CreateWebhookDelivery(ctx context.Context, delivery *WebhookDelivery) error {
+	return h.inner.CreateWebhookDelivery(ctx, delivery)
+}
+
+// FindWebhookDeliveryByID retrieves a webhook delivery attempt by its ID.
+func (h *HybridLogStore) FindWebhookDeliveryByID(ctx context.Context, id string) (*WebhookDelivery, error) {
+	return h.inner.FindWebhookDeliveryByID(ctx, id)
+}
+
+// SearchWebhookDeliveries returns one page of delivery history for an endpoint.
+func (h *HybridLogStore) SearchWebhookDeliveries(ctx context.Context, endpointID string, pagination PaginationOptions) (*WebhookDeliverySearchResult, error) {
+	return h.inner.SearchWebhookDeliveries(ctx, endpointID, pagination)
+}
+
+// DeleteExpiredWebhookDeliveries deletes delivery history whose expiry has passed.
+func (h *HybridLogStore) DeleteExpiredWebhookDeliveries(ctx context.Context) (int64, error) {
+	return h.inner.DeleteExpiredWebhookDeliveries(ctx)
+}

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -4,8 +4,9 @@ package logstore
 // Postgres (raw path, no matviews), and ClickHouse, runs every LogStore
 // interface method on all three, and asserts that the non-reference backends
 // return results equal to Postgres (the reference). This is the executable
-// form of "every backend is 100% compatible": all 60 interface methods are
-// exercised - reads, writes, mutations, async jobs, and deletes - including
+// form of "every backend is 100% compatible": every interface method is
+// exercised - reads, writes, mutations, async jobs, webhook deliveries, and
+// deletes - including
 // every dialect branch in rdb.go (metadata JSON, cache-hit extraction,
 // histogram bucket math, routing-engine matching, distinct queries) and the
 // DAC queryscope path.
@@ -36,6 +37,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/queryscope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +64,7 @@ func parityBackends(t *testing.T) map[string]LogStore {
 	dropAllManagedMatViews(db)
 	require.NoError(t, db.Exec("DROP TABLE IF EXISTS mcp_tool_logs CASCADE").Error)
 	require.NoError(t, db.Exec("DROP TABLE IF EXISTS async_jobs CASCADE").Error)
+	require.NoError(t, db.Exec("DROP TABLE IF EXISTS webhook_deliveries CASCADE").Error)
 	require.NoError(t, db.Exec("DROP TABLE IF EXISTS logs CASCADE").Error)
 	require.NoError(t, db.Exec("CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)").Error)
 	require.NoError(t, db.Exec("DELETE FROM migrations").Error)
@@ -425,6 +428,27 @@ func asyncJobProjection(j *AsyncJob) map[string]any {
 		out["expires_ms"] = j.ExpiresAt.UnixMilli()
 	}
 	return out
+}
+
+func webhookDeliveryProjection(d *WebhookDelivery) map[string]any {
+	out := map[string]any{
+		"id": d.ID, "webhook_id": d.WebhookID, "endpoint_id": d.EndpointID,
+		"async_job_id": d.AsyncJobID, "event": d.Event, "attempt_no": d.AttemptNo,
+		"outcome": d.Outcome, "status_code": d.StatusCode, "error": d.Error,
+		"created_ms": d.CreatedAt.UnixMilli(),
+	}
+	if d.ExpiresAt != nil {
+		out["expires_ms"] = d.ExpiresAt.UnixMilli()
+	}
+	return out
+}
+
+func webhookDeliverySearchProjection(r *WebhookDeliverySearchResult) any {
+	deliveries := make([]map[string]any, 0, len(r.Deliveries))
+	for _, d := range r.Deliveries {
+		deliveries = append(deliveries, webhookDeliveryProjection(&d))
+	}
+	return map[string]any{"total": r.Pagination.TotalCount, "deliveries": deliveries}
 }
 
 // remainingLogIDs lists surviving log ids - the post-state assertion used
@@ -1030,6 +1054,70 @@ func TestLogStoreParity(t *testing.T) {
 		// Expired cleanup removes j2 with the same count everywhere.
 		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
 			return s.DeleteExpiredAsyncJobs(ctx)
+		})
+	})
+
+	// --- Phase: webhook deliveries ---
+
+	t.Run("WebhookDeliveries", func(t *testing.T) {
+		mkDelivery := func(id, webhookID, endpointID string, attemptNo int, outcome WebhookDeliveryOutcome, statusCode int, errMsg string, createdOffset time.Duration, expires *time.Time) *WebhookDelivery {
+			return &WebhookDelivery{
+				ID: id, WebhookID: webhookID, EndpointID: endpointID, AsyncJobID: "j1",
+				Event: tables.WebhookEventAsyncJobCompleted, AttemptNo: attemptNo,
+				Outcome: outcome, StatusCode: statusCode, Error: errMsg,
+				CreatedAt: base.Add(createdOffset), ExpiresAt: expires,
+			}
+		}
+		runOnAll(t, stores, func(ctx context.Context, s LogStore) error {
+			// wd1/wd2 are two attempts of the same delivery on one endpoint;
+			// wd3 belongs to another endpoint and expired ten minutes ago.
+			if err := s.CreateWebhookDelivery(ctx, mkDelivery("wd1", "wh1", "wh-ep-1", 1, WebhookDeliveryOutcomeRetryableFailure, 503, "upstream unavailable", -2*time.Minute, nil)); err != nil {
+				return err
+			}
+			if err := s.CreateWebhookDelivery(ctx, mkDelivery("wd2", "wh1", "wh-ep-1", 2, WebhookDeliveryOutcomeDelivered, 200, "", -time.Minute, nil)); err != nil {
+				return err
+			}
+			return s.CreateWebhookDelivery(ctx, mkDelivery("wd3", "wh2", "wh-ep-2", 1, WebhookDeliveryOutcomeExhausted, 500, "gave up", -time.Hour, timePtrP(base.Add(-10*time.Minute))))
+		})
+
+		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+			d, err := s.FindWebhookDeliveryByID(ctx, "wd1")
+			if err != nil {
+				return nil, err
+			}
+			return webhookDeliveryProjection(d), nil
+		})
+		for name, s := range stores {
+			_, err := s.FindWebhookDeliveryByID(ctx, "missing-delivery")
+			assert.ErrorIs(t, err, ErrNotFound, name)
+		}
+
+		// Endpoint-scoped history pages newest-first on every backend.
+		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+			res, err := s.SearchWebhookDeliveries(ctx, "wh-ep-1", PaginationOptions{Limit: 10})
+			if err != nil {
+				return nil, err
+			}
+			return webhookDeliverySearchProjection(res), nil
+		})
+		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+			res, err := s.SearchWebhookDeliveries(ctx, "wh-ep-1", PaginationOptions{Limit: 1, Offset: 1})
+			if err != nil {
+				return nil, err
+			}
+			return webhookDeliverySearchProjection(res), nil
+		})
+
+		// Expired cleanup removes wd3 with the same count everywhere.
+		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+			return s.DeleteExpiredWebhookDeliveries(ctx)
+		})
+		assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+			res, err := s.SearchWebhookDeliveries(ctx, "wh-ep-2", PaginationOptions{Limit: 10})
+			if err != nil {
+				return nil, err
+			}
+			return webhookDeliverySearchProjection(res), nil
 		})
 	})
 

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -274,6 +274,8 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_recreate_filter_customers_matview_multivalue"}, run: migrationRecreateFilterCustomersMatView},
 	{IDs: []string{"logs_add_canonical_model_columns_v2"}, run: migrationAddCanonicalModelColumns},
 	{IDs: []string{"logs_add_redaction_mapping_column"}, run: migrationAddRedactionMappingColumn},
+	{IDs: []string{"webhook_deliveries_init"}, run: migrationCreateWebhookDeliveriesTable},
+	{IDs: []string{"async_jobs_add_webhook_endpoint_id_column"}, run: migrationAddWebhookEndpointIDColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -1553,6 +1555,81 @@ func migrationCreateAsyncJobsTable(ctx context.Context, db *gorm.DB, logger sche
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while creating async_jobs table: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationCreateWebhookDeliveriesTable creates the webhook_deliveries table
+// and its indexes if missing.
+func migrationCreateWebhookDeliveriesTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "webhook_deliveries_init"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			dbMigrator := tx.Migrator()
+			if !dbMigrator.HasTable(&WebhookDelivery{}) {
+				logger.Info("[logstore] %s: creating table WebhookDelivery", migrationName)
+				if err := dbMigrator.CreateTable(&WebhookDelivery{}); err != nil {
+					return err
+				}
+			}
+
+			// Explicitly create indexes as declared in struct tags
+			for _, index := range []string{
+				"idx_webhook_deliveries_webhook_id",
+				"idx_webhook_deliveries_endpoint_id",
+				"idx_webhook_deliveries_created_at",
+				"idx_webhook_deliveries_expires_at",
+			} {
+				if !dbMigrator.HasIndex(&WebhookDelivery{}, index) {
+					logger.Info("[logstore] %s: creating index %s on WebhookDelivery", migrationName, index)
+					if err := dbMigrator.CreateIndex(&WebhookDelivery{}, index); err != nil {
+						return fmt.Errorf("failed to create index %s: %w", index, err)
+					}
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			logger.Info("[logstore] %s: dropping table WebhookDelivery", migrationName)
+			return tx.Migrator().DropTable(&WebhookDelivery{})
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while creating webhook_deliveries table: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddWebhookEndpointIDColumn adds the webhook_endpoint_id column to
+// the async_jobs table. It references the webhook endpoint to notify when a
+// job reaches a terminal state.
+func migrationAddWebhookEndpointIDColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "async_jobs_add_webhook_endpoint_id_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &AsyncJob{}, "webhook_endpoint_id")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &AsyncJob{}, "webhook_endpoint_id")
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding webhook_endpoint_id column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -4194,3 +4194,100 @@ func (s *RDBLogStore) DeleteStaleAsyncJobs(ctx context.Context, staleSince time.
 		Delete(&AsyncJob{})
 	return result.RowsAffected, result.Error
 }
+
+// CreateWebhookDelivery appends one webhook delivery attempt record. The
+// history table is insert-only: rows are never updated after creation.
+func (s *RDBLogStore) CreateWebhookDelivery(ctx context.Context, delivery *WebhookDelivery) error {
+	return s.db.WithContext(ctx).Create(delivery).Error
+}
+
+// FindWebhookDeliveryByID retrieves a webhook delivery attempt by its ID.
+func (s *RDBLogStore) FindWebhookDeliveryByID(ctx context.Context, id string) (*WebhookDelivery, error) {
+	var delivery WebhookDelivery
+	result := s.db.WithContext(ctx).Where("id = ?", id).First(&delivery)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, result.Error
+	}
+	return &delivery, nil
+}
+
+// SearchWebhookDeliveries returns one page of delivery history for an
+// endpoint. Pagination is by delivery group (webhook_id), not by individual
+// attempt: a page holds every attempt of the webhook_ids it covers, so a
+// delivery run never straddles a page boundary and the caller can group
+// attempts into runs without losing any. Groups are ordered by their most
+// recent attempt, and attempts within the page are returned newest first.
+func (s *RDBLogStore) SearchWebhookDeliveries(ctx context.Context, endpointID string, pagination PaginationOptions) (*WebhookDeliverySearchResult, error) {
+	limit := pagination.Limit
+	if limit <= 0 || limit > defaultMaxSearchLimit {
+		limit = defaultMaxSearchLimit
+	}
+	// Total counts delivery groups, so the pager reflects the rows the caller
+	// renders rather than raw attempts.
+	var total int64
+	if err := s.db.WithContext(ctx).Model(&WebhookDelivery{}).
+		Where("endpoint_id = ?", endpointID).
+		Distinct("webhook_id").
+		Count(&total).Error; err != nil {
+		return nil, err
+	}
+	// Select the page of webhook_ids, most-recently-active first.
+	webhookIDs := []string{}
+	pageQuery := s.db.WithContext(ctx).
+		Model(&WebhookDelivery{}).
+		Where("endpoint_id = ?", endpointID).
+		Group("webhook_id").
+		Order("MAX(created_at) DESC, webhook_id DESC").
+		Limit(limit)
+	if pagination.Offset > 0 {
+		pageQuery = pageQuery.Offset(pagination.Offset)
+	}
+	if err := pageQuery.Pluck("webhook_id", &webhookIDs).Error; err != nil {
+		return nil, err
+	}
+	// Fetch every attempt of the selected groups so no run is split.
+	deliveries := []WebhookDelivery{}
+	if len(webhookIDs) > 0 {
+		if err := s.db.WithContext(ctx).
+			Where("endpoint_id = ? AND webhook_id IN ?", endpointID, webhookIDs).
+			Order("created_at DESC, id DESC").
+			Find(&deliveries).Error; err != nil {
+			return nil, err
+		}
+	}
+	result := &WebhookDeliverySearchResult{
+		Deliveries: deliveries,
+		Pagination: pagination,
+	}
+	result.Pagination.Limit = limit
+	result.Pagination.TotalCount = total
+	return result, nil
+}
+
+// DeleteExpiredWebhookDeliveries deletes delivery history whose expires_at has passed.
+// Rows with a null expires_at are kept.
+// Deletes in batches to avoid long-running transactions that hold row locks.
+func (s *RDBLogStore) DeleteExpiredWebhookDeliveries(ctx context.Context) (int64, error) {
+	now := time.Now().UTC()
+	const batchLimit = 100
+	var totalDeleted int64
+	for {
+		result := s.db.WithContext(ctx).
+			Where("id IN (?)",
+				s.db.Model(&WebhookDelivery{}).Select("id").
+					Where("expires_at IS NOT NULL AND expires_at < ?", now).
+					Limit(batchLimit),
+			).Delete(&WebhookDelivery{})
+		if result.Error != nil {
+			return totalDeleted, result.Error
+		}
+		totalDeleted += result.RowsAffected
+		if result.RowsAffected < batchLimit {
+			break
+		}
+	}
+	return totalDeleted, nil
+}

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -97,6 +97,12 @@ type LogStore interface {
 	UpdateAsyncJob(ctx context.Context, id string, updates map[string]interface{}) error
 	DeleteExpiredAsyncJobs(ctx context.Context) (int64, error)
 	DeleteStaleAsyncJobs(ctx context.Context, staleSince time.Time) (int64, error)
+
+	// Webhook Delivery methods
+	CreateWebhookDelivery(ctx context.Context, delivery *WebhookDelivery) error
+	FindWebhookDeliveryByID(ctx context.Context, id string) (*WebhookDelivery, error)
+	SearchWebhookDeliveries(ctx context.Context, endpointID string, pagination PaginationOptions) (*WebhookDeliverySearchResult, error)
+	DeleteExpiredWebhookDeliveries(ctx context.Context) (int64, error)
 }
 
 // NewLogStore creates a new log store based on the configuration.

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1075,10 +1075,13 @@ type AsyncJob struct {
 	StatusCode   int                    `gorm:"default:0" json:"status_code,omitempty"`
 	Error        string                 `gorm:"type:text" json:"error,omitempty"`
 	VirtualKeyID *string                `gorm:"type:varchar(255);index:idx_async_jobs_vk_id" json:"virtual_key_id,omitempty"`
-	ResultTTL    int                    `gorm:"default:3600" json:"-"` // TTL in seconds, used to calculate ExpiresAt on completion
-	ExpiresAt    *time.Time             `gorm:"index:idx_async_jobs_expires_at" json:"expires_at,omitempty"`
-	CreatedAt    time.Time              `gorm:"index;not null" json:"created_at"`
-	CompletedAt  *time.Time             `json:"completed_at,omitempty"`
+	// WebhookEndpointID references the webhook endpoint to notify when this
+	// job reaches a terminal state, when one was requested at submit time.
+	WebhookEndpointID *string    `gorm:"type:varchar(36)" json:"webhook_endpoint_id,omitempty"`
+	ResultTTL         int        `gorm:"default:3600" json:"-"` // TTL in seconds, used to calculate ExpiresAt on completion
+	ExpiresAt         *time.Time `gorm:"index:idx_async_jobs_expires_at" json:"expires_at,omitempty"`
+	CreatedAt         time.Time  `gorm:"index;not null" json:"created_at"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
 }
 
 // TableName sets the table name for GORM
@@ -1172,6 +1175,52 @@ func (j *AsyncJob) ToResponse() *schemas.AsyncJobResponse {
 	}
 
 	return resp
+}
+
+// WebhookDeliveryOutcome classifies the result of one webhook delivery attempt.
+type WebhookDeliveryOutcome string
+
+const (
+	// WebhookDeliveryOutcomeDelivered means the receiver acknowledged with a 2xx.
+	WebhookDeliveryOutcomeDelivered WebhookDeliveryOutcome = "delivered"
+	// WebhookDeliveryOutcomeRetryableFailure means the attempt failed but the
+	// delivery has retries left.
+	WebhookDeliveryOutcomeRetryableFailure WebhookDeliveryOutcome = "retryable_failure"
+	// WebhookDeliveryOutcomePermanentFailure means the receiver rejected the
+	// delivery with a non-retryable status; no further attempts are made.
+	WebhookDeliveryOutcomePermanentFailure WebhookDeliveryOutcome = "permanent_failure"
+	// WebhookDeliveryOutcomeExhausted means the final allowed attempt failed.
+	WebhookDeliveryOutcomeExhausted WebhookDeliveryOutcome = "exhausted"
+)
+
+// WebhookDelivery records one webhook delivery attempt. Rows are insert-only
+// — every attempt appends a new record and existing rows are never updated —
+// and carry delivery metadata only, never event payloads or receiver
+// response bodies. WebhookID is the delivery's `webhook-id` wire header,
+// shared by every attempt of the same delivery.
+type WebhookDelivery struct {
+	ID         string                 `gorm:"primaryKey;type:varchar(36)" json:"id"`
+	WebhookID  string                 `gorm:"type:varchar(36);index:idx_webhook_deliveries_webhook_id;not null" json:"webhook_id"`
+	EndpointID string                 `gorm:"type:varchar(36);index:idx_webhook_deliveries_endpoint_id;not null" json:"endpoint_id"`
+	AsyncJobID string                 `gorm:"type:varchar(255);not null" json:"async_job_id"`
+	Event      tables.WebhookEvent    `gorm:"type:varchar(255);not null" json:"event"`
+	AttemptNo  int                    `gorm:"not null;default:0" json:"attempt_no"`
+	Outcome    WebhookDeliveryOutcome `gorm:"type:varchar(50);not null" json:"outcome"`
+	StatusCode int                    `gorm:"default:0" json:"status_code,omitempty"`
+	Error      string                 `gorm:"type:text" json:"error,omitempty"`
+	CreatedAt  time.Time              `gorm:"index:idx_webhook_deliveries_created_at;not null" json:"created_at"`
+	ExpiresAt  *time.Time             `gorm:"index:idx_webhook_deliveries_expires_at" json:"expires_at,omitempty"`
+}
+
+// TableName sets the table name for GORM
+func (WebhookDelivery) TableName() string {
+	return "webhook_deliveries"
+}
+
+// WebhookDeliverySearchResult represents one page of webhook delivery history.
+type WebhookDeliverySearchResult struct {
+	Deliveries []WebhookDelivery `json:"deliveries"`
+	Pagination PaginationOptions `json:"pagination"`
 }
 
 // MCPToolLogSearchFilters represents the available filters for MCP tool log searches

--- a/framework/logstore/webhookdelivery_test.go
+++ b/framework/logstore/webhookdelivery_test.go
@@ -1,0 +1,173 @@
+package logstore
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupWebhookDeliveryTestStore builds a SQLite-backed store; migrations run
+// inside newSqliteLogStore, so this also exercises the webhook_deliveries
+// table migration.
+func setupWebhookDeliveryTestStore(t *testing.T) LogStore {
+	t.Helper()
+	store, err := newSqliteLogStore(context.Background(), &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "webhookdeliveries.db"),
+	}, testLogger{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(context.Background()) })
+	return store
+}
+
+func testWebhookDelivery(id, endpointID string, createdAt time.Time) *WebhookDelivery {
+	return &WebhookDelivery{
+		ID:         id,
+		WebhookID:  "wh-" + id,
+		EndpointID: endpointID,
+		AsyncJobID: "job-1",
+		Event:      tables.WebhookEventAsyncJobCompleted,
+		AttemptNo:  1,
+		Outcome:    WebhookDeliveryOutcomeDelivered,
+		StatusCode: 200,
+		CreatedAt:  createdAt,
+	}
+}
+
+func TestWebhookDeliveryCreateAndFind(t *testing.T) {
+	store := setupWebhookDeliveryTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	delivery := testWebhookDelivery("d1", "ep1", now)
+	delivery.Outcome = WebhookDeliveryOutcomeRetryableFailure
+	delivery.StatusCode = 503
+	delivery.Error = "upstream unavailable"
+	require.NoError(t, store.CreateWebhookDelivery(ctx, delivery))
+
+	fetched, err := store.FindWebhookDeliveryByID(ctx, "d1")
+	require.NoError(t, err)
+	assert.Equal(t, "wh-d1", fetched.WebhookID)
+	assert.Equal(t, "ep1", fetched.EndpointID)
+	assert.Equal(t, "job-1", fetched.AsyncJobID)
+	assert.Equal(t, tables.WebhookEventAsyncJobCompleted, fetched.Event)
+	assert.Equal(t, 1, fetched.AttemptNo)
+	assert.Equal(t, WebhookDeliveryOutcomeRetryableFailure, fetched.Outcome)
+	assert.Equal(t, 503, fetched.StatusCode)
+	assert.Equal(t, "upstream unavailable", fetched.Error)
+	assert.Nil(t, fetched.ExpiresAt)
+
+	_, err = store.FindWebhookDeliveryByID(ctx, "missing")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestWebhookDeliverySearchPagination(t *testing.T) {
+	store := setupWebhookDeliveryTestStore(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+
+	// Three attempts on ep1 at distinct times plus one row on another
+	// endpoint that must never appear in ep1 pages.
+	for i, id := range []string{"d1", "d2", "d3"} {
+		require.NoError(t, store.CreateWebhookDelivery(ctx,
+			testWebhookDelivery(id, "ep1", base.Add(time.Duration(i)*time.Second))))
+	}
+	require.NoError(t, store.CreateWebhookDelivery(ctx, testWebhookDelivery("other", "ep2", base)))
+
+	page, err := store.SearchWebhookDeliveries(ctx, "ep1", PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), page.Pagination.TotalCount)
+	require.Len(t, page.Deliveries, 3)
+	// Newest first.
+	assert.Equal(t, "d3", page.Deliveries[0].ID)
+	assert.Equal(t, "d2", page.Deliveries[1].ID)
+	assert.Equal(t, "d1", page.Deliveries[2].ID)
+
+	page, err = store.SearchWebhookDeliveries(ctx, "ep1", PaginationOptions{Limit: 1, Offset: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), page.Pagination.TotalCount)
+	require.Len(t, page.Deliveries, 1)
+	assert.Equal(t, "d2", page.Deliveries[0].ID)
+
+	page, err = store.SearchWebhookDeliveries(ctx, "unknown-endpoint", PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), page.Pagination.TotalCount)
+	assert.Empty(t, page.Deliveries)
+}
+
+// TestWebhookDeliverySearchKeepsRunsWholeAcrossPages verifies that pagination is
+// by delivery group (webhook_id), so a multi-attempt run is returned whole on a
+// single page and never split across a page boundary.
+func TestWebhookDeliverySearchKeepsRunsWholeAcrossPages(t *testing.T) {
+	store := setupWebhookDeliveryTestStore(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Second)
+
+	mk := func(id, webhookID string, attemptNo int, offset time.Duration) *WebhookDelivery {
+		return &WebhookDelivery{
+			ID: id, WebhookID: webhookID, EndpointID: "ep1", AsyncJobID: "job-1",
+			Event: tables.WebhookEventAsyncJobCompleted, AttemptNo: attemptNo,
+			Outcome: WebhookDeliveryOutcomeDelivered, StatusCode: 200,
+			CreatedAt: base.Add(offset),
+		}
+	}
+	// Three groups; whB has two attempts that must page together.
+	require.NoError(t, store.CreateWebhookDelivery(ctx, mk("a1", "whA", 1, 0)))
+	require.NoError(t, store.CreateWebhookDelivery(ctx, mk("a2", "whA", 2, time.Second)))
+	require.NoError(t, store.CreateWebhookDelivery(ctx, mk("b1", "whB", 1, 2*time.Second)))
+	require.NoError(t, store.CreateWebhookDelivery(ctx, mk("b2", "whB", 2, 3*time.Second)))
+	require.NoError(t, store.CreateWebhookDelivery(ctx, mk("c1", "whC", 1, 4*time.Second)))
+
+	// Total counts groups (3), not raw attempts (5); the first group is the
+	// most recently active.
+	first, err := store.SearchWebhookDeliveries(ctx, "ep1", PaginationOptions{Limit: 1, Offset: 0})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), first.Pagination.TotalCount)
+	require.Len(t, first.Deliveries, 1)
+	assert.Equal(t, "c1", first.Deliveries[0].ID)
+
+	// A one-row page still returns whB's entire run — both attempts, newest
+	// first — rather than a boundary-split partial run.
+	second, err := store.SearchWebhookDeliveries(ctx, "ep1", PaginationOptions{Limit: 1, Offset: 1})
+	require.NoError(t, err)
+	require.Len(t, second.Deliveries, 2)
+	assert.Equal(t, "b2", second.Deliveries[0].ID)
+	assert.Equal(t, "b1", second.Deliveries[1].ID)
+	for _, d := range second.Deliveries {
+		assert.Equal(t, "whB", d.WebhookID)
+	}
+}
+
+func TestWebhookDeliveryDeleteExpired(t *testing.T) {
+	store := setupWebhookDeliveryTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	expired := testWebhookDelivery("expired", "ep1", now.Add(-2*time.Hour))
+	expiredAt := now.Add(-time.Hour)
+	expired.ExpiresAt = &expiredAt
+	require.NoError(t, store.CreateWebhookDelivery(ctx, expired))
+
+	future := testWebhookDelivery("future", "ep1", now)
+	futureAt := now.Add(time.Hour)
+	future.ExpiresAt = &futureAt
+	require.NoError(t, store.CreateWebhookDelivery(ctx, future))
+
+	// A row with no expiry set is never reaped.
+	require.NoError(t, store.CreateWebhookDelivery(ctx, testWebhookDelivery("no-expiry", "ep1", now)))
+
+	deleted, err := store.DeleteExpiredWebhookDeliveries(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	_, err = store.FindWebhookDeliveryByID(ctx, "expired")
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = store.FindWebhookDeliveryByID(ctx, "future")
+	require.NoError(t, err)
+	_, err = store.FindWebhookDeliveryByID(ctx, "no-expiry")
+	require.NoError(t, err)
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1622,6 +1622,38 @@ func (m *MockConfigStore) RotateWebhookEndpointSecret(ctx context.Context, id st
 	return nil, configstore.ErrNotFound
 }
 
+func (m *MockConfigStore) RecordWebhookEndpointSuccess(ctx context.Context, id string) error {
+	return nil
+}
+
+func (m *MockConfigStore) RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error) {
+	return 0, nil
+}
+
+func (m *MockConfigStore) DisableWebhookEndpoint(ctx context.Context, id string) error {
+	return nil
+}
+
+func (m *MockConfigStore) CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error {
+	return nil
+}
+
+func (m *MockConfigStore) ListDueWebhookJobs(ctx context.Context, limit int) ([]tables.TableWebhookJob, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) ClaimWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) (bool, error) {
+	return false, nil
+}
+
+func (m *MockConfigStore) RescheduleWebhookJob(ctx context.Context, id, runnerID string, leaseUntil, nextAttemptAt time.Time) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error {
+	return nil
+}
+
 func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 	initTestLogger()
 


### PR DESCRIPTION
## Summary

Adds the persistence layer for webhook delivery: a `webhook_jobs` work-queue table for in-flight deliveries and a `webhook_deliveries` history table for delivery attempt records, along with the store methods needed to drive the delivery worker loop.

## Changes

- **`webhook_jobs` table** (`configstore`): New `TableWebhookJob` model and `add_webhook_jobs_table` migration. Rows exist only while a delivery is pending or retrying and are deleted on terminal outcome. The row ID doubles as the stable `webhook-id` wire header across attempts.
- **Webhook job store methods** (`configstore`): `CreateWebhookJob`, `ListDueWebhookJobs`, `ClaimWebhookJob`, `RescheduleWebhookJob`, and `DeleteWebhookJob`. Claiming uses a conditional UPDATE so at most one concurrent worker wins per job; expired leases make rows reclaimable for crash recovery.
- **Endpoint delivery counters** (`configstore`): `RecordWebhookEndpointSuccess` and `RecordWebhookEndpointFailure` update `consecutive_failures` and the last-success/failure timestamps via atomic column expressions, bypassing save hooks so config fields and `updated_at` are never touched.
- **`webhook_deliveries` table** (`logstore`): New `WebhookDelivery` model, `webhook_deliveries_init` migration, and ClickHouse table creation. Rows are insert-only delivery attempt metadata (no payloads). Expiry is handled by `DeleteExpiredWebhookDeliveries` with batched deletes.
- **`async_jobs` schema** (`logstore`): `async_jobs_add_webhook_endpoint_id_column` migration adds `webhook_endpoint_id` to reference the endpoint to notify on job completion.
- **`LogStore` and `ConfigStore` interfaces** extended with all new methods; `HybridLogStore` delegates to its inner store.
- **`MockConfigStore`** in the HTTP transport test suite updated to satisfy the expanded `ConfigStore` interface.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/logstore/...
```

Key test coverage added:
- `TestWebhookEndpointRecordFailureAndSuccess` — counter increment/reset and not-found errors
- `TestWebhookEndpointCounterUpdatesLeaveConfigUntouched` — verifies `updated_at` and config fields are not modified
- `TestWebhookJobCreateValidation`, `TestWebhookJobCreateDefaultsAndDuplicate` — input validation and duplicate detection
- `TestWebhookJobClaimRace`, `TestWebhookJobClaimLeaseExpiryReclaim`, `TestWebhookJobClaimNotDueRejected` — claim fencing and lease expiry recovery
- `TestWebhookJobListDue` — ordering, future-job exclusion, live-lease exclusion, expired-lease inclusion
- `TestWebhookJobReschedule`, `TestWebhookJobDelete` — ownership fencing on reschedule and delete
- `TestWebhookJobClaimCycleWithEmptyRunnerID` — single-node mode with empty runner ID
- `TestWebhookDeliveryCreateAndFind`, `TestWebhookDeliverySearchPagination`, `TestWebhookDeliveryDeleteExpired` — delivery history CRUD
- `TestLogStoreParity` extended with a `WebhookDeliveries` phase covering all three backends

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Webhook secrets are not stored in or exposed by any of the new tables. Delivery counter updates bypass GORM save hooks to prevent accidental secret re-encryption or field clobbering during high-frequency operational writes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable