### PR TITLE
feat: add webhook delivery dispatcher with SSRF-safe HTTP client, Standard Webhooks signing, and per-endpoint retry/concurrency tuning

### DIFF
--- a/framework/webhooks/client.go
+++ b/framework/webhooks/client.go
@@ -1,0 +1,181 @@
+package webhooks
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/maximhq/bifrost/core/network"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// maxErrorBodyBytes caps how much of a failing receiver's response body is
+// read for the delivery history's error text.
+const maxErrorBodyBytes = 4 * 1024
+
+// deliveryClient performs one signed POST per delivery attempt. It holds one
+// HTTP client per security policy: the strict client re-resolves and
+// re-validates every IP at dial time (rebinding-safe), while the private
+// client — used only for endpoints registered with allow_private_network —
+// skips only the public-IP requirement. Both refuse redirects and require
+// TLS >= 1.2. The clients carry no timeout state at all — every phase (DNS,
+// dial, TLS, body) is bounded by the per-attempt context, which carries the
+// endpoint's own attempt timeout — so endpoints sharing a policy can share
+// connection pools safely.
+type deliveryClient struct {
+	strict  *http.Client
+	private *http.Client
+}
+
+func newDeliveryClient() *deliveryClient {
+	build := func(dial func(ctx context.Context, netw, addr string) (net.Conn, error)) *http.Client {
+		return &http.Client{
+			Transport: &http.Transport{
+				DialContext:     dial,
+				TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+			},
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	return &deliveryClient{
+		// A zero dial timeout defers entirely to the per-attempt context.
+		strict:  build(network.SSRFSafeDialContext(0)),
+		private: build(newPrivateDialContext()),
+	}
+}
+
+// newPrivateDialContext returns the dialer for allow_private_network
+// endpoints. Loopback, RFC1918, and public receivers are the point of the
+// flag, but unspecified and link-local (cloud metadata) addresses stay
+// blocked at dial time — the same gate the provider clients apply — so a
+// DNS record that flips to 169.254.169.254 after registration still cannot
+// be reached. Dial time is bounded by the caller's context.
+func newPrivateDialContext() func(ctx context.Context, netw, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{}
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, err
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no addresses found for %s", host)
+		}
+		for _, ip := range ips {
+			if ip.IsUnspecified() {
+				return nil, fmt.Errorf("connection to unspecified IP %s is not allowed", ip)
+			}
+			if network.IsLinkLocal(ip) {
+				return nil, fmt.Errorf("connection to link-local IP %s is not allowed", ip)
+			}
+		}
+		return dialer.DialContext(ctx, netw, net.JoinHostPort(ips[0].String(), port))
+	}
+}
+
+// attemptResult captures the observable outcome of one delivery attempt.
+type attemptResult struct {
+	// statusCode is the receiver's HTTP status, or 0 when no response was
+	// obtained (network error, signing failure, invalid URL).
+	statusCode int
+	// errText is a truncated human-readable failure reason for the delivery
+	// history; empty on success.
+	errText string
+}
+
+// deliver signs body for the given delivery id and POSTs it to the endpoint.
+func (c *deliveryClient) deliver(ctx context.Context, endpoint *tables.TableWebhookEndpoint, event tables.WebhookEvent, webhookID string, body []byte, timestamp time.Time) attemptResult {
+	parsed, err := url.Parse(endpoint.URL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return attemptResult{errText: "invalid webhook URL scheme"}
+	}
+	// Endpoint validation already ties plaintext HTTP to the private-network
+	// opt-in; re-check here so a row that bypassed it (older data, direct
+	// writes) can never send signed payloads and custom headers in cleartext.
+	if parsed.Scheme == "http" && !endpoint.AllowPrivateNetwork {
+		return attemptResult{errText: "https is required unless allow_private_network is set"}
+	}
+	secret := ""
+	if endpoint.Secret != nil {
+		secret = endpoint.Secret.GetValue()
+	}
+	signature, err := Sign(secret, webhookID, timestamp, body)
+	if err != nil {
+		return attemptResult{errText: fmt.Sprintf("cannot sign delivery: %v", err)}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.URL, bytes.NewReader(body))
+	if err != nil {
+		return attemptResult{errText: err.Error()}
+	}
+	// Custom endpoint headers go first; the reserved delivery headers are set
+	// after them, so they always win even if validation was bypassed.
+	for name, value := range endpoint.Headers {
+		if tables.IsProtectedWebhookHeader(name) {
+			continue
+		}
+		req.Header.Set(name, value.GetValue())
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "Bifrost-Webhooks/1.0")
+	req.Header.Set("webhook-id", webhookID)
+	req.Header.Set("webhook-timestamp", strconv.FormatInt(timestamp.Unix(), 10))
+	req.Header.Set("webhook-signature", signature)
+	req.Header.Set("X-Bifrost-Event", string(event))
+
+	client := c.strict
+	if endpoint.AllowPrivateNetwork {
+		client = c.private
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return attemptResult{errText: err.Error()}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		// Drain (bounded) so the keep-alive connection can be reused for the
+		// next delivery; closing an unread body discards the connection.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return attemptResult{statusCode: resp.StatusCode}
+	}
+	snippet, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+	if readErr != nil && len(snippet) == 0 {
+		snippet = []byte(fmt.Sprintf("(failed to read response body: %v)", readErr))
+	}
+	return attemptResult{
+		statusCode: resp.StatusCode,
+		errText:    fmt.Sprintf("receiver responded %d: %s", resp.StatusCode, snippet),
+	}
+}
+
+// classify maps an attempt result to its delivery outcome, before the
+// attempt-budget check promotes retryable failures to exhausted. Any 2xx is
+// success; 408, 429, 5xx, and transport-level failures are worth retrying;
+// everything else — including 3xx, since redirects are never followed — is a
+// permanent receiver-side rejection.
+func classify(result attemptResult) logstore.WebhookDeliveryOutcome {
+	switch {
+	case result.statusCode >= 200 && result.statusCode < 300:
+		return logstore.WebhookDeliveryOutcomeDelivered
+	case result.statusCode == 0,
+		result.statusCode == http.StatusRequestTimeout,
+		result.statusCode == http.StatusTooManyRequests,
+		result.statusCode >= 500:
+		return logstore.WebhookDeliveryOutcomeRetryableFailure
+	default:
+		return logstore.WebhookDeliveryOutcomePermanentFailure
+	}
+}

--- a/framework/webhooks/dispatcher.go
+++ b/framework/webhooks/dispatcher.go
@@ -1,0 +1,491 @@
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// ConfigStore is the subset of the configstore the dispatcher needs: the
+// webhook job queue plus the endpoint operational counters.
+type ConfigStore interface {
+	CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error
+	ListDueWebhookJobs(ctx context.Context, limit int) ([]tables.TableWebhookJob, error)
+	ClaimWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) (bool, error)
+	RescheduleWebhookJob(ctx context.Context, id, runnerID string, leaseUntil, nextAttemptAt time.Time) error
+	DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error
+	RecordWebhookEndpointSuccess(ctx context.Context, id string) error
+	RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error)
+}
+
+// LogStore is the subset of the logstore the dispatcher needs: reading the
+// async job at send time and appending per-attempt delivery history.
+type LogStore interface {
+	FindAsyncJobByID(ctx context.Context, id string) (*logstore.AsyncJob, error)
+	CreateWebhookDelivery(ctx context.Context, delivery *logstore.WebhookDelivery) error
+}
+
+// EndpointResolver serves webhook endpoint configuration from memory. It is
+// consulted on every enqueue and every delivery attempt, so changes to an
+// endpoint (disable, delete, secret rotation) take effect on the next
+// attempt without a database read.
+type EndpointResolver interface {
+	WebhookEndpointByID(id string) (*tables.TableWebhookEndpoint, bool)
+}
+
+// Default delivery tuning, applied when an endpoint does not set its own
+// knobs. Retry defaults mirror the provider retry convention (max retries
+// plus exponential backoff between an initial and a max step) and are
+// deliberately tighter than classic event-bus webhook schedules: the payload
+// announces a TTL-bounded inference result, so the default window
+// (30s + 1m + 2m + 4m ≈ 7.5m) sits well inside the default 1h result TTL.
+// Longer receiver outages are the caller's poll-reconciliation territory.
+const (
+	defaultMaxRetries              = 4
+	defaultRetryBackoffInitial     = 30 * time.Second
+	defaultRetryBackoffMax         = 30 * time.Minute
+	defaultAttemptTimeout          = 10 * time.Second
+	defaultMaxResponsePayloadKBs   = 256
+	defaultMaxConcurrentDeliveries = 10
+)
+
+// enqueueAttempts bounds the inline insert retries when queueing a delivery
+// for a finished job; exhausting them loses the notification (accepted crash
+// window) and is surfaced with a Warn log.
+const enqueueAttempts = 3
+
+// scanBatchSize bounds how many due jobs one queue scan loads and offers for
+// claiming, so a large backlog drains across scans instead of being read
+// into memory at once.
+const scanBatchSize = 64
+
+// pollInterval is the queue scan fallback cadence; the in-process signal
+// channel usually wakes the worker sooner.
+const pollInterval = 5 * time.Second
+
+// Dispatcher drains the webhook job queue: it claims due jobs, performs one
+// signed delivery attempt per claim, records history, and reschedules or
+// retires the job. One Dispatcher runs per node; the atomic claim decides a
+// single owner per attempt, so running it everywhere needs no coordination.
+type Dispatcher struct {
+	runnerID         string
+	historyRetention time.Duration
+	configStore      ConfigStore
+	logStore         LogStore
+	resolver         EndpointResolver
+	client           *deliveryClient
+	logger           schemas.Logger
+
+	signal   chan struct{}
+	baseCtx  context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+
+	mu          sync.Mutex
+	perEndpoint map[string]int
+}
+
+// NewDispatcher builds a stopped dispatcher; call Start to launch its worker.
+// The dispatcher's lifetime is bounded by ctx as well as by Stop. runnerID
+// fences queue claims — the node id in a cluster, empty on a single node.
+// historyRetention sets expires_at on delivery history rows and must be
+// positive. Delivery tuning (retries, backoff, timeouts, payload caps,
+// concurrency) is per endpoint.
+func NewDispatcher(ctx context.Context, runnerID string, historyRetention time.Duration, configStore ConfigStore, logStore LogStore, resolver EndpointResolver, logger schemas.Logger) *Dispatcher {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Dispatcher{
+		runnerID:         runnerID,
+		historyRetention: historyRetention,
+		configStore:      configStore,
+		logStore:         logStore,
+		resolver:         resolver,
+		client:           newDeliveryClient(),
+		logger:           logger,
+		signal:           make(chan struct{}, 1),
+		baseCtx:          ctx,
+		cancel:           cancel,
+		perEndpoint:      make(map[string]int),
+	}
+}
+
+// Start launches the queue worker. The first scan runs immediately, which is
+// also what recovers deliveries left claimed or due by a previous process.
+func (d *Dispatcher) Start() {
+	d.wg.Add(1)
+	go d.run()
+}
+
+// Stop cancels the worker and waits for in-flight deliveries to finish.
+func (d *Dispatcher) Stop() {
+	d.stopOnce.Do(func() {
+		d.cancel()
+		d.wg.Wait()
+	})
+}
+
+// EnqueueJobEvent queues the webhook delivery for a job that just reached a
+// terminal state. Callers invoke it right after the terminal job update; it
+// performs no receiver I/O — just the queue insert plus a worker wake-up.
+func (d *Dispatcher) EnqueueJobEvent(ctx context.Context, job *logstore.AsyncJob) {
+	if job == nil || job.WebhookEndpointID == nil {
+		return
+	}
+	event, ok := EventForJobStatus(job.Status)
+	if !ok {
+		return
+	}
+	endpointID := *job.WebhookEndpointID
+	endpoint, ok := d.resolver.WebhookEndpointByID(endpointID)
+	if !ok || endpoint.Disabled || !subscribesTo(endpoint, event) {
+		d.logger.Debug("webhooks: skipping enqueue for job %s: endpoint %s is gone, disabled, or unsubscribed", job.ID, endpointID)
+		return
+	}
+	webhookJob := &tables.TableWebhookJob{
+		ID:         uuid.NewString(),
+		EndpointID: endpoint.ID,
+		AsyncJobID: job.ID,
+		Event:      event,
+	}
+	var err error
+	for attempt := range enqueueAttempts {
+		if err = d.configStore.CreateWebhookJob(ctx, webhookJob); err == nil {
+			break
+		}
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			err = nil
+			break
+		}
+		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+	}
+	if err != nil {
+		// The notification is lost; make that operator-visible. This is a
+		// rare storage-failure path, not request-path noise.
+		d.logger.Warn("webhooks: dropping notification for job %s to endpoint %s: enqueue failed after %d attempts: %v", job.ID, endpointID, enqueueAttempts, err)
+		return
+	}
+	d.Wake()
+}
+
+// DeliverTest sends one signed sample of the given event through the exact
+// production delivery path — same rendering, signing, client, and
+// redirect/TLS policy — without touching the queue, history, or failure
+// counters. It returns the receiver's status code.
+func (d *Dispatcher) DeliverTest(ctx context.Context, endpoint *tables.TableWebhookEndpoint, event tables.WebhookEvent) (int, error) {
+	now := time.Now().UTC()
+	sample := &logstore.AsyncJob{
+		ID:          "test-" + uuid.NewString(),
+		Status:      statusForEvent(event),
+		RequestType: schemas.ChatCompletionRequest,
+		StatusCode:  200,
+		CreatedAt:   now,
+		CompletedAt: &now,
+	}
+	if event == tables.WebhookEventAsyncJobFailed {
+		sample.StatusCode = 500
+	}
+	tuning := tuningFor(endpoint)
+	body, err := renderPayload(sample, event, false, tuning.maxResponsePayloadBytes, now)
+	if err != nil {
+		return 0, err
+	}
+	ctx, cancelAttempt := context.WithTimeout(ctx, tuning.attemptTimeout)
+	defer cancelAttempt()
+	result := d.client.deliver(ctx, endpoint, event, uuid.NewString(), body, now)
+	if result.statusCode == 0 {
+		return 0, errors.New(result.errText)
+	}
+	return result.statusCode, nil
+}
+
+// Wake nudges the worker to scan the queue now instead of waiting for the
+// next poll tick — non-blocking; a full signal buffer means a scan is already
+// pending. Callers use it after inserting queue rows outside EnqueueJobEvent
+// (e.g. redelivery).
+func (d *Dispatcher) Wake() {
+	select {
+	case d.signal <- struct{}{}:
+	default:
+	}
+}
+
+func (d *Dispatcher) run() {
+	defer d.wg.Done()
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	d.dispatchOnce()
+	for {
+		select {
+		case <-d.baseCtx.Done():
+			return
+		case <-d.signal:
+			d.dispatchOnce()
+		case <-ticker.C:
+			d.dispatchOnce()
+		}
+	}
+}
+
+// dispatchOnce scans for due jobs and hands each to a delivery goroutine,
+// bounded by the per-endpoint cap. Jobs skipped by the cap stay due and are
+// picked up by a later scan.
+func (d *Dispatcher) dispatchOnce() {
+	jobs, err := d.configStore.ListDueWebhookJobs(d.baseCtx, scanBatchSize)
+	if err != nil {
+		d.logger.Warn("webhooks: listing due jobs failed: %v", err)
+		return
+	}
+	for _, job := range jobs {
+		if !d.reserveEndpointSlot(job.EndpointID, d.concurrencyLimitFor(job.EndpointID)) {
+			continue
+		}
+		d.wg.Add(1)
+		go func(job tables.TableWebhookJob) {
+			defer d.wg.Done()
+			defer d.releaseEndpointSlot(job.EndpointID)
+			d.processDue(job)
+		}(job)
+	}
+}
+
+// concurrencyLimitFor resolves an endpoint's concurrent-delivery cap; a
+// missing endpoint takes the default (its jobs get retired on attempt).
+func (d *Dispatcher) concurrencyLimitFor(endpointID string) int {
+	endpoint, _ := d.resolver.WebhookEndpointByID(endpointID)
+	return tuningFor(endpoint).maxConcurrentDeliveries
+}
+
+func (d *Dispatcher) reserveEndpointSlot(endpointID string, limit int) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.perEndpoint[endpointID] >= limit {
+		return false
+	}
+	d.perEndpoint[endpointID]++
+	return true
+}
+
+func (d *Dispatcher) releaseEndpointSlot(endpointID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.perEndpoint[endpointID] <= 1 {
+		delete(d.perEndpoint, endpointID)
+	} else {
+		d.perEndpoint[endpointID]--
+	}
+}
+
+// endpointTuning holds the effective delivery knobs for one attempt:
+// per-endpoint values where the endpoint sets them, dispatcher defaults
+// otherwise.
+type endpointTuning struct {
+	maxRetries              int
+	retryBackoffInitial     time.Duration
+	retryBackoffMax         time.Duration
+	attemptTimeout          time.Duration
+	maxResponsePayloadBytes int
+	maxConcurrentDeliveries int
+}
+
+// tuningFor resolves the effective knobs for an endpoint; a nil endpoint
+// yields the defaults.
+func tuningFor(endpoint *tables.TableWebhookEndpoint) endpointTuning {
+	tuning := endpointTuning{
+		maxRetries:              defaultMaxRetries,
+		retryBackoffInitial:     defaultRetryBackoffInitial,
+		retryBackoffMax:         defaultRetryBackoffMax,
+		attemptTimeout:          defaultAttemptTimeout,
+		maxResponsePayloadBytes: defaultMaxResponsePayloadKBs * 1024,
+		maxConcurrentDeliveries: defaultMaxConcurrentDeliveries,
+	}
+	if endpoint == nil {
+		return tuning
+	}
+	if endpoint.MaxRetries > 0 {
+		tuning.maxRetries = endpoint.MaxRetries
+	}
+	if endpoint.RetryBackoffInitialSeconds > 0 {
+		tuning.retryBackoffInitial = time.Duration(endpoint.RetryBackoffInitialSeconds) * time.Second
+	}
+	if endpoint.RetryBackoffMaxSeconds > 0 {
+		tuning.retryBackoffMax = time.Duration(endpoint.RetryBackoffMaxSeconds) * time.Second
+	}
+	if endpoint.AttemptTimeoutSeconds > 0 {
+		tuning.attemptTimeout = time.Duration(endpoint.AttemptTimeoutSeconds) * time.Second
+	}
+	if endpoint.MaxResponsePayloadKBs > 0 {
+		tuning.maxResponsePayloadBytes = endpoint.MaxResponsePayloadKBs * 1024
+	}
+	if endpoint.MaxConcurrentDeliveries > 0 {
+		tuning.maxConcurrentDeliveries = endpoint.MaxConcurrentDeliveries
+	}
+	return tuning
+}
+
+// processDue claims one due job and, if this node wins, performs a single
+// delivery attempt.
+func (d *Dispatcher) processDue(job tables.TableWebhookJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			d.logger.Warn("webhooks: delivery attempt for job %s panicked: %v", job.ID, r)
+		}
+	}()
+	// Resolve once; the same endpoint state sizes the lease and drives the
+	// attempt. A missing endpoint still claims, so the job can be retired.
+	endpoint, ok := d.resolver.WebhookEndpointByID(job.EndpointID)
+	if !ok {
+		endpoint = nil
+	}
+	tuning := tuningFor(endpoint)
+	lease := max(2*tuning.attemptTimeout, 30*time.Second)
+	// The lease expiry doubles as this claim's fencing token: terminal queue
+	// mutations must present it, so an attempt that outlived its lease cannot
+	// clobber the state of whoever reclaimed the job.
+	leaseUntil := time.Now().UTC().Add(lease)
+	won, err := d.configStore.ClaimWebhookJob(d.baseCtx, job.ID, d.runnerID, leaseUntil)
+	if err != nil {
+		d.logger.Warn("webhooks: claiming job %s failed: %v", job.ID, err)
+		return
+	}
+	if !won {
+		return
+	}
+	d.attempt(job, endpoint, tuning, leaseUntil)
+}
+
+// attempt runs one claimed delivery attempt end to end.
+func (d *Dispatcher) attempt(job tables.TableWebhookJob, endpoint *tables.TableWebhookEndpoint, tuning endpointTuning, leaseUntil time.Time) {
+	now := time.Now().UTC()
+	attemptNo := job.AttemptCount + 1
+
+	if endpoint == nil || endpoint.Disabled {
+		// Nothing to deliver to anymore; retire the job with a terminal
+		// history record. No counter updates: there was no receiver attempt,
+		// and the endpoint is already gone or disabled.
+		d.finalize(job, attemptNo, attemptResult{errText: "webhook endpoint deleted or disabled"}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
+		return
+	}
+
+	var body []byte
+	var err error
+	asyncJob, findErr := d.logStore.FindAsyncJobByID(d.baseCtx, job.AsyncJobID)
+	switch {
+	case findErr == nil:
+		body, err = renderPayload(asyncJob, job.Event, endpoint.IncludeResponse, tuning.maxResponsePayloadBytes, now)
+	case errors.Is(findErr, logstore.ErrNotFound):
+		// The job row must have existed for this delivery to be queued, so
+		// not-found can only mean its result TTL lapsed: deliver the
+		// degraded body that says so instead of dropping the notification.
+		body, err = renderExpiredPayload(&job, now)
+	default:
+		// Storage hiccup — not an attempt. Leave the row claimed; the lease
+		// expiry re-offers it to any node.
+		d.logger.Warn("webhooks: reading async job %s failed: %v", job.AsyncJobID, findErr)
+		return
+	}
+	if err != nil {
+		// Rendering is deterministic on stored state, so retrying cannot
+		// succeed — leaving the job claimed would rerun the same failure on
+		// every lease expiry, forever and without history. Retire it as a
+		// recorded permanent failure instead (no receiver was attempted, so
+		// the endpoint counters must not move).
+		d.finalize(job, attemptNo, attemptResult{errText: fmt.Sprintf("rendering payload failed: %v", err)}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
+		return
+	}
+
+	attemptCtx, cancelAttempt := context.WithTimeout(d.baseCtx, tuning.attemptTimeout)
+	result := d.client.deliver(attemptCtx, endpoint, job.Event, job.ID, body, now)
+	cancelAttempt()
+
+	outcome := classify(result)
+	if outcome == logstore.WebhookDeliveryOutcomeRetryableFailure && attemptNo > tuning.maxRetries {
+		outcome = logstore.WebhookDeliveryOutcomeExhausted
+	}
+	d.finalize(job, attemptNo, result, outcome, now, true, tuning, leaseUntil)
+}
+
+// finalize persists an attempt: history first, then the queue row, then the
+// endpoint counters. If the history insert fails the queue row is left
+// claimed on purpose — the lease expires, the attempt reruns, and the
+// receiver's webhook-id dedupe absorbs the duplicate. touchCounters is false
+// when no receiver was attempted (endpoint gone), which must not move the
+// failure streak.
+func (d *Dispatcher) finalize(job tables.TableWebhookJob, attemptNo int, result attemptResult, outcome logstore.WebhookDeliveryOutcome, now time.Time, touchCounters bool, tuning endpointTuning, leaseUntil time.Time) {
+	expiresAt := now.Add(d.historyRetention)
+	history := &logstore.WebhookDelivery{
+		ID:         uuid.NewString(),
+		WebhookID:  job.ID,
+		EndpointID: job.EndpointID,
+		AsyncJobID: job.AsyncJobID,
+		Event:      job.Event,
+		AttemptNo:  attemptNo,
+		Outcome:    outcome,
+		StatusCode: result.statusCode,
+		Error:      result.errText,
+		CreatedAt:  now,
+		ExpiresAt:  &expiresAt,
+	}
+	if err := d.logStore.CreateWebhookDelivery(d.baseCtx, history); err != nil {
+		d.logger.Warn("webhooks: recording delivery history for job %s failed, attempt will rerun after lease expiry: %v", job.ID, err)
+		return
+	}
+
+	if outcome == logstore.WebhookDeliveryOutcomeRetryableFailure {
+		next := now.Add(retryBackoff(attemptNo, tuning))
+		if err := d.configStore.RescheduleWebhookJob(d.baseCtx, job.ID, d.runnerID, leaseUntil, next); err != nil {
+			d.logger.Warn("webhooks: rescheduling job %s failed: %v", job.ID, err)
+		}
+	} else {
+		if err := d.configStore.DeleteWebhookJob(d.baseCtx, job.ID, d.runnerID, leaseUntil); err != nil {
+			d.logger.Warn("webhooks: retiring job %s failed: %v", job.ID, err)
+		}
+	}
+
+	if !touchCounters {
+		return
+	}
+	if outcome == logstore.WebhookDeliveryOutcomeDelivered {
+		if err := d.configStore.RecordWebhookEndpointSuccess(d.baseCtx, job.EndpointID); err != nil {
+			d.logger.Warn("webhooks: recording success for endpoint %s failed: %v", job.EndpointID, err)
+		}
+		return
+	}
+	if _, err := d.configStore.RecordWebhookEndpointFailure(d.baseCtx, job.EndpointID); err != nil {
+		d.logger.Warn("webhooks: recording failure for endpoint %s failed: %v", job.EndpointID, err)
+	}
+}
+
+// retryBackoff returns the delay before retry number retryNo (1-based, so
+// the retry after the first failed attempt is retry 1): exponential
+// initial * 2^(retryNo-1) capped at the effective max, with ±20% jitter —
+// the same shape the core request path uses for provider retries.
+func retryBackoff(retryNo int, tuning endpointTuning) time.Duration {
+	// Double stepwise instead of shifting: initial<<n overflows int64 around
+	// n=30 for second-scale initials, which would turn the backoff negative
+	// (a hot retry loop) once an endpoint allows enough retries.
+	backoff := tuning.retryBackoffInitial
+	for i := 1; i < retryNo && backoff < tuning.retryBackoffMax; i++ {
+		if backoff > tuning.retryBackoffMax/2 {
+			backoff = tuning.retryBackoffMax
+			break
+		}
+		backoff *= 2
+	}
+	backoff = min(backoff, tuning.retryBackoffMax)
+	jitter := float64(backoff) * (0.8 + 0.4*rand.Float64())
+	return min(time.Duration(jitter), tuning.retryBackoffMax)
+}
+
+func subscribesTo(endpoint *tables.TableWebhookEndpoint, event tables.WebhookEvent) bool {
+	return slices.Contains(endpoint.Events, event)
+}

--- a/framework/webhooks/dispatcher_test.go
+++ b/framework/webhooks/dispatcher_test.go
@@ -1,0 +1,840 @@
+package webhooks
+
+import (
+	"context"
+	"crypto/hmac"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+
+// --- fakes -----------------------------------------------------------------
+
+type recordingLogger struct {
+	mu    sync.Mutex
+	warns []string
+}
+
+func (l *recordingLogger) Debug(string, ...any) {}
+func (l *recordingLogger) Info(string, ...any)  {}
+func (l *recordingLogger) Warn(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(msg, args...))
+}
+func (l *recordingLogger) Error(string, ...any)                   {}
+func (l *recordingLogger) Fatal(string, ...any)                   {}
+func (l *recordingLogger) SetLevel(schemas.LogLevel)              {}
+func (l *recordingLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (l *recordingLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func (l *recordingLogger) warnCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.warns)
+}
+
+// fakeConfigStore mirrors the real queue semantics — due predicate on claim,
+// claimed_by + live-lease fencing on reschedule/delete — over an in-memory map.
+type fakeConfigStore struct {
+	mu             sync.Mutex
+	jobs           map[string]*tables.TableWebhookJob
+	failures       map[string]int
+	successes      map[string]int
+	createFailures int // fail this many CreateWebhookJob calls before succeeding
+}
+
+func newFakeConfigStore() *fakeConfigStore {
+	return &fakeConfigStore{
+		jobs:      make(map[string]*tables.TableWebhookJob),
+		failures:  make(map[string]int),
+		successes: make(map[string]int),
+	}
+}
+
+func (f *fakeConfigStore) CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.createFailures > 0 {
+		f.createFailures--
+		return fmt.Errorf("simulated storage failure")
+	}
+	if job.NextAttemptAt.IsZero() {
+		job.NextAttemptAt = time.Now()
+	}
+	job.CreatedAt = time.Now()
+	copied := *job
+	f.jobs[job.ID] = &copied
+	return nil
+}
+
+func (f *fakeConfigStore) ListDueWebhookJobs(ctx context.Context, limit int) ([]tables.TableWebhookJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	now := time.Now()
+	var due []tables.TableWebhookJob
+	for _, job := range f.jobs {
+		if job.NextAttemptAt.After(now) {
+			continue
+		}
+		if job.ClaimedUntil != nil && job.ClaimedUntil.After(now) {
+			continue
+		}
+		due = append(due, *job)
+	}
+	return due, nil
+}
+
+func (f *fakeConfigStore) ClaimWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	job, ok := f.jobs[id]
+	now := time.Now()
+	if !ok || job.NextAttemptAt.After(now) || (job.ClaimedUntil != nil && job.ClaimedUntil.After(now)) {
+		return false, nil
+	}
+	job.ClaimedBy = runnerID
+	job.ClaimedUntil = &leaseUntil
+	return true, nil
+}
+
+func (f *fakeConfigStore) RescheduleWebhookJob(ctx context.Context, id, runnerID string, leaseUntil, nextAttemptAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	job, ok := f.jobs[id]
+	if !ok || job.ClaimedBy != runnerID || job.ClaimedUntil == nil || !job.ClaimedUntil.Equal(leaseUntil) {
+		return fmt.Errorf("webhook job not found or no longer owned by caller")
+	}
+	job.AttemptCount++
+	job.NextAttemptAt = nextAttemptAt
+	job.ClaimedBy = ""
+	job.ClaimedUntil = nil
+	return nil
+}
+
+func (f *fakeConfigStore) DeleteWebhookJob(ctx context.Context, id, runnerID string, leaseUntil time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	job, ok := f.jobs[id]
+	if !ok || job.ClaimedBy != runnerID || job.ClaimedUntil == nil || !job.ClaimedUntil.Equal(leaseUntil) {
+		return fmt.Errorf("webhook job not found or no longer owned by caller")
+	}
+	delete(f.jobs, id)
+	return nil
+}
+
+func (f *fakeConfigStore) RecordWebhookEndpointSuccess(ctx context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.successes[id]++
+	f.failures[id] = 0
+	return nil
+}
+
+func (f *fakeConfigStore) RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.failures[id]++
+	return f.failures[id], nil
+}
+
+func (f *fakeConfigStore) job(id string) *tables.TableWebhookJob {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	job, ok := f.jobs[id]
+	if !ok {
+		return nil
+	}
+	copied := *job
+	return &copied
+}
+
+func (f *fakeConfigStore) jobCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.jobs)
+}
+
+type fakeLogStore struct {
+	mu         sync.Mutex
+	asyncJobs  map[string]*logstore.AsyncJob
+	deliveries []logstore.WebhookDelivery
+}
+
+func newFakeLogStore() *fakeLogStore {
+	return &fakeLogStore{asyncJobs: make(map[string]*logstore.AsyncJob)}
+}
+
+func (f *fakeLogStore) FindAsyncJobByID(ctx context.Context, id string) (*logstore.AsyncJob, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	job, ok := f.asyncJobs[id]
+	if !ok {
+		return nil, logstore.ErrNotFound
+	}
+	return job, nil
+}
+
+func (f *fakeLogStore) CreateWebhookDelivery(ctx context.Context, delivery *logstore.WebhookDelivery) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deliveries = append(f.deliveries, *delivery)
+	return nil
+}
+
+func (f *fakeLogStore) deliveryList() []logstore.WebhookDelivery {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]logstore.WebhookDelivery(nil), f.deliveries...)
+}
+
+type fakeResolver struct {
+	mu        sync.Mutex
+	endpoints map[string]*tables.TableWebhookEndpoint
+}
+
+func newFakeResolver(endpoints ...*tables.TableWebhookEndpoint) *fakeResolver {
+	r := &fakeResolver{endpoints: make(map[string]*tables.TableWebhookEndpoint)}
+	for _, endpoint := range endpoints {
+		r.endpoints[endpoint.ID] = endpoint
+	}
+	return r
+}
+
+func (r *fakeResolver) WebhookEndpointByID(id string) (*tables.TableWebhookEndpoint, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	endpoint, ok := r.endpoints[id]
+	return endpoint, ok
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func testEndpoint(id, url string) *tables.TableWebhookEndpoint {
+	return &tables.TableWebhookEndpoint{
+		ID:                  id,
+		Name:                id,
+		URL:                 url,
+		Secret:              &schemas.SecretVar{Val: testSecret},
+		AllowPrivateNetwork: true, // test receivers listen on loopback
+		Events:              []tables.WebhookEvent{tables.WebhookEventAsyncJobCompleted, tables.WebhookEventAsyncJobFailed},
+	}
+}
+
+func dueWebhookJob(id, endpointID, asyncJobID string) *tables.TableWebhookJob {
+	return &tables.TableWebhookJob{
+		ID:            id,
+		EndpointID:    endpointID,
+		AsyncJobID:    asyncJobID,
+		Event:         tables.WebhookEventAsyncJobCompleted,
+		NextAttemptAt: time.Now().Add(-time.Second),
+	}
+}
+
+type dispatcherFixture struct {
+	dispatcher  *Dispatcher
+	configStore *fakeConfigStore
+	logStore    *fakeLogStore
+	resolver    *fakeResolver
+	logger      *recordingLogger
+}
+
+func newFixture(t *testing.T, endpoints ...*tables.TableWebhookEndpoint) *dispatcherFixture {
+	t.Helper()
+	f := &dispatcherFixture{
+		configStore: newFakeConfigStore(),
+		logStore:    newFakeLogStore(),
+		resolver:    newFakeResolver(endpoints...),
+		logger:      &recordingLogger{},
+	}
+	f.dispatcher = NewDispatcher(context.Background(), "", 30*24*time.Hour, f.configStore, f.logStore, f.resolver, f.logger)
+	t.Cleanup(f.dispatcher.Stop)
+	return f
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestEnqueueJobEvent(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	f := newFixture(t, endpoint)
+	endpointID := endpoint.ID
+
+	job := &logstore.AsyncJob{ID: "job-1", Status: schemas.AsyncJobStatusCompleted, WebhookEndpointID: &endpointID}
+	f.dispatcher.EnqueueJobEvent(context.Background(), job)
+
+	require.Equal(t, 1, f.configStore.jobCount())
+	var queued *tables.TableWebhookJob
+	for id := range f.configStore.jobs {
+		queued = f.configStore.job(id)
+	}
+	assert.Equal(t, "ep-1", queued.EndpointID)
+	assert.Equal(t, "job-1", queued.AsyncJobID)
+	assert.Equal(t, tables.WebhookEventAsyncJobCompleted, queued.Event)
+
+	select {
+	case <-f.dispatcher.signal:
+	default:
+		t.Fatal("enqueue must wake the worker")
+	}
+}
+
+func TestEnqueueJobEventSkips(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	f := newFixture(t, endpoint)
+	endpointID := endpoint.ID
+	missingID := "ep-missing"
+
+	// No endpoint requested on the job.
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "j1", Status: schemas.AsyncJobStatusCompleted})
+	// Non-terminal status.
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "j2", Status: schemas.AsyncJobStatusProcessing, WebhookEndpointID: &endpointID})
+	// Endpoint vanished after submit.
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "j3", Status: schemas.AsyncJobStatusCompleted, WebhookEndpointID: &missingID})
+	// Endpoint disabled after submit.
+	endpoint.Disabled = true
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "j4", Status: schemas.AsyncJobStatusCompleted, WebhookEndpointID: &endpointID})
+	// Endpoint unsubscribed from the failure event.
+	endpoint.Disabled = false
+	endpoint.Events = []tables.WebhookEvent{tables.WebhookEventAsyncJobCompleted}
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "j5", Status: schemas.AsyncJobStatusFailed, WebhookEndpointID: &endpointID})
+
+	assert.Zero(t, f.configStore.jobCount())
+}
+
+func TestEnqueueJobEventWarnsWhenRetriesExhausted(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	f := newFixture(t, endpoint)
+	f.configStore.createFailures = enqueueAttempts
+	endpointID := endpoint.ID
+
+	f.dispatcher.EnqueueJobEvent(context.Background(), &logstore.AsyncJob{ID: "job-1", Status: schemas.AsyncJobStatusCompleted, WebhookEndpointID: &endpointID})
+
+	assert.Zero(t, f.configStore.jobCount())
+	assert.Equal(t, 1, f.logger.warnCount(), "a lost notification must be operator-visible")
+}
+
+func TestDeliverySuccessFlow(t *testing.T) {
+	var received struct {
+		mu      sync.Mutex
+		body    []byte
+		headers http.Header
+	}
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.mu.Lock()
+		defer received.mu.Unlock()
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		received.body = requestBody
+		received.headers = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	// History first: one delivered attempt.
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeDelivered, deliveries[0].Outcome)
+	assert.Equal(t, "wh-1", deliveries[0].WebhookID)
+	assert.Equal(t, 1, deliveries[0].AttemptNo)
+	assert.Equal(t, http.StatusOK, deliveries[0].StatusCode)
+	assert.Empty(t, deliveries[0].Error)
+	require.NotNil(t, deliveries[0].ExpiresAt)
+
+	// Terminal outcome retires the queue row and resets the failure streak.
+	assert.Nil(t, f.configStore.job("wh-1"))
+	assert.Equal(t, 1, f.configStore.successes["ep-1"])
+
+	// The wire request is a verifiable Standard Webhooks delivery.
+	received.mu.Lock()
+	defer received.mu.Unlock()
+	assert.Equal(t, "wh-1", received.headers.Get("webhook-id"))
+	assert.Equal(t, "async_job.completed", received.headers.Get("X-Bifrost-Event"))
+	assert.Equal(t, "application/json", received.headers.Get("Content-Type"))
+	require.NotEmpty(t, received.headers.Get("webhook-timestamp"))
+	var ts int64
+	_, err := fmt.Sscanf(received.headers.Get("webhook-timestamp"), "%d", &ts)
+	require.NoError(t, err)
+	expected, err := Sign(testSecret, "wh-1", time.Unix(ts, 0), received.body)
+	require.NoError(t, err)
+	assert.True(t, hmac.Equal([]byte(expected), []byte(received.headers.Get("webhook-signature"))))
+}
+
+func TestDeliveryRetryableFailureReschedules(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	before := time.Now()
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeRetryableFailure, deliveries[0].Outcome)
+	assert.Equal(t, http.StatusInternalServerError, deliveries[0].StatusCode)
+	assert.Contains(t, deliveries[0].Error, "receiver responded 500")
+
+	job := f.configStore.job("wh-1")
+	require.NotNil(t, job, "retryable failures keep the job queued")
+	assert.Equal(t, 1, job.AttemptCount)
+	assert.Empty(t, job.ClaimedBy)
+	assert.Nil(t, job.ClaimedUntil)
+	// First backoff step is 30s ±20%.
+	delay := job.NextAttemptAt.Sub(before)
+	assert.GreaterOrEqual(t, delay, 24*time.Second)
+	assert.LessOrEqual(t, delay, 37*time.Second)
+	assert.Equal(t, 1, f.configStore.failures["ep-1"])
+}
+
+func TestDeliveryExhaustsAttemptBudget(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "still broken", http.StatusServiceUnavailable)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	job := dueWebhookJob("wh-1", "ep-1", "job-1")
+	job.AttemptCount = 4 // the next attempt is the fifth and final one (default: 4 retries + the original attempt)
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), job))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeExhausted, deliveries[0].Outcome)
+	assert.Equal(t, 5, deliveries[0].AttemptNo)
+	assert.Nil(t, f.configStore.job("wh-1"), "an exhausted delivery is retired")
+}
+
+func TestDeliveryPermanentFailure(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomePermanentFailure, deliveries[0].Outcome)
+	assert.Nil(t, f.configStore.job("wh-1"))
+	assert.Equal(t, 1, f.configStore.failures["ep-1"])
+}
+
+func TestRedirectsAreNotFollowed(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("redirect target must never be called")
+	}))
+	defer target.Close()
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomePermanentFailure, deliveries[0].Outcome, "3xx is terminal because redirects are refused")
+	assert.Equal(t, http.StatusFound, deliveries[0].StatusCode)
+}
+
+func TestPrivateDialerStillBlocksLinkLocal(t *testing.T) {
+	dial := newPrivateDialContext()
+	_, err := dial(context.Background(), "tcp", "169.254.169.254:80")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "link-local")
+
+	_, err = dial(context.Background(), "tcp", "0.0.0.0:80")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unspecified")
+}
+
+func TestStrictClientBlocksPrivateReceivers(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("loopback receiver must not be reachable without allow_private_network")
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	endpoint.AllowPrivateNetwork = false
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeRetryableFailure, deliveries[0].Outcome)
+	assert.Zero(t, deliveries[0].StatusCode)
+}
+
+func TestExpiredAsyncJobDeliversDegradedPayload(t *testing.T) {
+	var body []byte
+	var mu sync.Mutex
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		body = requestBody
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	endpoint.IncludeResponse = true // even opted-in endpoints get the thin expired body
+	f := newFixture(t, endpoint)
+	// No async job seeded: the row expired before this attempt.
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeDelivered, deliveries[0].Outcome)
+
+	mu.Lock()
+	defer mu.Unlock()
+	data := decodeEnvelope(t, body)["data"].(map[string]any)
+	assert.Equal(t, true, data["result_expired"])
+	assert.Equal(t, "job-1", data["job_id"])
+	assert.NotContains(t, data, "response")
+}
+
+func TestRetryBackoffHighRetryNumbersStayPositive(t *testing.T) {
+	// initial<<retryNo used to overflow int64 around retry 30 for second-scale
+	// initials, producing a NEGATIVE backoff (an immediate-retry hot loop) on
+	// endpoints tuned with a large retry budget.
+	tuning := tuningFor(nil) // defaults: initial 30s, max 30m
+	for _, retryNo := range []int{30, 40, 1000} {
+		delay := retryBackoff(retryNo, tuning)
+		assert.Greater(t, delay, time.Duration(0), "retry %d", retryNo)
+		assert.LessOrEqual(t, delay, defaultRetryBackoffMax, "retry %d", retryNo)
+		assert.GreaterOrEqual(t, delay, time.Duration(float64(defaultRetryBackoffMax)*0.8), "retry %d sits at the jittered cap", retryNo)
+	}
+}
+
+func TestRenderFailureRetiresJobAsPermanent(t *testing.T) {
+	// A stored response that cannot re-serialize makes rendering fail
+	// deterministically; the job must be retired with a recorded permanent
+	// failure instead of looping on lease expiry forever.
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	endpoint.IncludeResponse = true
+	f := newFixture(t, endpoint)
+	invalid := testAsyncJob()
+	invalid.Response = `{"broken`
+	f.logStore.asyncJobs["job-1"] = invalid
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomePermanentFailure, deliveries[0].Outcome)
+	assert.Contains(t, deliveries[0].Error, "rendering payload failed")
+	assert.Nil(t, f.configStore.job("wh-1"), "the job must be retired, not left claimed")
+	assert.Zero(t, f.configStore.failures["ep-1"], "no receiver attempt happened, the streak must not move")
+}
+
+func TestDeliverRefusesPlaintextHTTPWithoutOptIn(t *testing.T) {
+	// Validation ties http to allow_private_network at write time; the client
+	// re-checks so a row that bypassed validation never sends signed payloads
+	// and custom headers in cleartext.
+	endpoint := testEndpoint("ep-1", "http://receiver.example/hook")
+	endpoint.AllowPrivateNetwork = false
+	c := newDeliveryClient()
+	result := c.deliver(context.Background(), endpoint, tables.WebhookEventAsyncJobCompleted, "wh-1", []byte("{}"), time.Now().UTC())
+	assert.Zero(t, result.statusCode)
+	assert.Contains(t, result.errText, "https is required")
+}
+
+func TestEndpointGoneRetiresJobWithoutCounters(t *testing.T) {
+	f := newFixture(t) // resolver knows no endpoints
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-gone", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomePermanentFailure, deliveries[0].Outcome)
+	assert.Contains(t, deliveries[0].Error, "deleted or disabled")
+	assert.Nil(t, f.configStore.job("wh-1"))
+	assert.Zero(t, f.configStore.failures["ep-gone"], "no receiver attempt happened, the streak must not move")
+}
+
+func TestClaimLosersDoNothing(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	f := newFixture(t, endpoint)
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	// Another node holds a live lease on the job.
+	lease := time.Now().Add(time.Minute)
+	won, err := f.configStore.ClaimWebhookJob(context.Background(), "wh-1", "other-node", lease)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	assert.Empty(t, f.logStore.deliveryList(), "a lost claim must not attempt delivery")
+	job := f.configStore.job("wh-1")
+	assert.Equal(t, "other-node", job.ClaimedBy)
+}
+
+func TestRestartRecoveryClaimsExpiredLease(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+
+	// A previous process died mid-attempt: the job is claimed but the lease
+	// has already lapsed.
+	job := dueWebhookJob("wh-1", "ep-1", "job-1")
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), job))
+	expiredLease := time.Now().Add(-time.Second)
+	won, err := f.configStore.ClaimWebhookJob(context.Background(), "wh-1", "dead-node", expiredLease)
+	require.NoError(t, err)
+	require.True(t, won)
+
+	f.dispatcher.Start()
+	assert.Eventually(t, func() bool {
+		return f.configStore.job("wh-1") == nil && len(f.logStore.deliveryList()) == 1
+	}, 2*time.Second, 10*time.Millisecond, "the worker must reclaim and deliver the orphaned job")
+	f.dispatcher.Stop()
+
+	deliveries := f.logStore.deliveryList()
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeDelivered, deliveries[0].Outcome)
+}
+
+func TestDeliverTest(t *testing.T) {
+	var headers http.Header
+	var mu sync.Mutex
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		headers = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	f := newFixture(t, endpoint)
+
+	status, err := f.dispatcher.DeliverTest(context.Background(), endpoint, tables.WebhookEventAsyncJobCompleted)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, status)
+
+	// The test delivery must not touch the queue, history, or counters.
+	assert.Zero(t, f.configStore.jobCount())
+	assert.Empty(t, f.logStore.deliveryList())
+	assert.Zero(t, f.configStore.successes["ep-1"])
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.NotEmpty(t, headers.Get("webhook-signature"), "test deliveries go through the production signing path")
+}
+
+func TestRetryBackoffBounds(t *testing.T) {
+	tuning := tuningFor(nil) // defaults: initial 30s, max 30m
+	expected := []time.Duration{
+		30 * time.Second, // retry 1
+		time.Minute,      // retry 2
+		2 * time.Minute,  // retry 3
+		4 * time.Minute,  // retry 4
+		8 * time.Minute,  // retry 5
+		16 * time.Minute, // retry 6
+		30 * time.Minute, // retry 7: 32m capped at the max
+		30 * time.Minute, // retry 8: stays at the cap
+	}
+	for i, base := range expected {
+		retryNo := i + 1
+		upper := time.Duration(float64(base) * 1.2)
+		if upper > defaultRetryBackoffMax {
+			upper = defaultRetryBackoffMax
+		}
+		for range 50 {
+			delay := retryBackoff(retryNo, tuning)
+			assert.GreaterOrEqual(t, delay, time.Duration(float64(base)*0.8), "retry %d", retryNo)
+			assert.LessOrEqual(t, delay, upper, "retry %d", retryNo)
+		}
+	}
+}
+
+func TestPerEndpointTuningOverrides(t *testing.T) {
+	// Defaults apply when the endpoint sets nothing.
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	tuning := tuningFor(endpoint)
+	assert.Equal(t, defaultMaxRetries, tuning.maxRetries)
+	assert.Equal(t, defaultRetryBackoffInitial, tuning.retryBackoffInitial)
+	assert.Equal(t, defaultRetryBackoffMax, tuning.retryBackoffMax)
+	assert.Equal(t, 10*time.Second, tuning.attemptTimeout)
+	assert.Equal(t, 256*1024, tuning.maxResponsePayloadBytes)
+	assert.Equal(t, defaultMaxConcurrentDeliveries, tuning.maxConcurrentDeliveries)
+
+	// Endpoint-set knobs win over the defaults.
+	endpoint.MaxRetries = 1
+	endpoint.RetryBackoffInitialSeconds = 5
+	endpoint.RetryBackoffMaxSeconds = 60
+	endpoint.AttemptTimeoutSeconds = 3
+	endpoint.MaxResponsePayloadKBs = 1
+	endpoint.MaxConcurrentDeliveries = 4
+	tuning = tuningFor(endpoint)
+	assert.Equal(t, 1, tuning.maxRetries)
+	assert.Equal(t, 5*time.Second, tuning.retryBackoffInitial)
+	assert.Equal(t, time.Minute, tuning.retryBackoffMax)
+	assert.Equal(t, 3*time.Second, tuning.attemptTimeout)
+	assert.Equal(t, 1024, tuning.maxResponsePayloadBytes)
+	assert.Equal(t, 4, tuning.maxConcurrentDeliveries)
+}
+
+func TestPerEndpointMaxRetriesExhaustsEarlier(t *testing.T) {
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusServiceUnavailable)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	endpoint.MaxRetries = 1 // two attempts total for this endpoint
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	job := dueWebhookJob("wh-1", "ep-1", "job-1")
+	job.AttemptCount = 1 // the next attempt is the second and final one
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), job))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomeExhausted, deliveries[0].Outcome)
+	assert.Nil(t, f.configStore.job("wh-1"))
+}
+
+func TestPerEndpointPayloadCap(t *testing.T) {
+	var body []byte
+	var mu sync.Mutex
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		requestBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		body = requestBody
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	endpoint.IncludeResponse = true
+	endpoint.MaxResponsePayloadKBs = 1
+	f := newFixture(t, endpoint)
+	job := testAsyncJob()
+	job.Response = `{"padding":"` + strings.Repeat("x", 2048) + `"}`
+	f.logStore.asyncJobs["job-1"] = job
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	data := decodeEnvelope(t, body)["data"].(map[string]any)
+	assert.NotContains(t, data, "response", "the endpoint's own cap applies")
+	assert.Equal(t, true, data["response_omitted"])
+}
+
+func TestPerEndpointConcurrencyLimit(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "https://receiver.example/hook")
+	endpoint.MaxConcurrentDeliveries = 1
+	f := newFixture(t, endpoint)
+
+	require.Equal(t, 1, f.dispatcher.concurrencyLimitFor("ep-1"), "the endpoint's own cap applies")
+	assert.Equal(t, defaultMaxConcurrentDeliveries, f.dispatcher.concurrencyLimitFor("ep-unknown"))
+
+	require.True(t, f.dispatcher.reserveEndpointSlot("ep-1", 1))
+	assert.False(t, f.dispatcher.reserveEndpointSlot("ep-1", 1), "no second slot below the cap")
+	f.dispatcher.releaseEndpointSlot("ep-1")
+	assert.True(t, f.dispatcher.reserveEndpointSlot("ep-1", 1), "released slots become available again")
+}
+
+func TestDeliverySendsCustomHeaders(t *testing.T) {
+	var received http.Header
+	var mu sync.Mutex
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer receiver.Close()
+
+	endpoint := testEndpoint("ep-1", receiver.URL)
+	endpoint.Headers = map[string]schemas.SecretVar{
+		"Authorization": {Val: "Bearer receiver-token"},
+		// A reserved name that slipped past validation must not reach the wire.
+		"webhook-signature": {Val: "forged"},
+	}
+	f := newFixture(t, endpoint)
+	f.logStore.asyncJobs["job-1"] = testAsyncJob()
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "Bearer receiver-token", received.Get("Authorization"))
+	assert.NotEqual(t, "forged", received.Get("webhook-signature"), "reserved headers always come from the delivery client")
+}

--- a/framework/webhooks/payload.go
+++ b/framework/webhooks/payload.go
@@ -1,0 +1,130 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// eventEnvelope is the JSON body of every delivery request.
+type eventEnvelope struct {
+	Event     tables.WebhookEvent `json:"event"`
+	CreatedAt time.Time           `json:"created_at"`
+	Data      eventData           `json:"data"`
+}
+
+// eventData describes the async job the event refers to. All fields beyond
+// JobID and Status are best-effort: they are omitted when the job row is no
+// longer available at send time (see renderExpiredPayload).
+type eventData struct {
+	JobID           string                 `json:"job_id"`
+	RequestType     schemas.RequestType    `json:"request_type,omitempty"`
+	Status          schemas.AsyncJobStatus `json:"status"`
+	StatusCode      int                    `json:"status_code,omitempty"`
+	CreatedAt       *time.Time             `json:"created_at,omitempty"`
+	CompletedAt     *time.Time             `json:"completed_at,omitempty"`
+	ResultURL       string                 `json:"result_url,omitempty"`
+	ResultExpiresAt *time.Time             `json:"result_expires_at,omitempty"`
+	Response        json.RawMessage        `json:"response,omitempty"`
+	ResponseOmitted bool                   `json:"response_omitted,omitempty"`
+	ResultExpired   bool                   `json:"result_expired,omitempty"`
+}
+
+// asyncResultPathByType maps each async-capable request type to its
+// result-fetch route. This is the canonical reverse of the submit-route
+// mapping in the HTTP layer: result routes are typed
+// (/v1/async/<type>/{job_id}); there is no generic job route.
+var asyncResultPathByType = map[schemas.RequestType]string{
+	schemas.TextCompletionRequest:  "/v1/async/completions",
+	schemas.ChatCompletionRequest:  "/v1/async/chat/completions",
+	schemas.ResponsesRequest:       "/v1/async/responses",
+	schemas.EmbeddingRequest:       "/v1/async/embeddings",
+	schemas.SpeechRequest:          "/v1/async/audio/speech",
+	schemas.TranscriptionRequest:   "/v1/async/audio/transcriptions",
+	schemas.ImageGenerationRequest: "/v1/async/images/generations",
+	schemas.ImageEditRequest:       "/v1/async/images/edits",
+	schemas.ImageVariationRequest:  "/v1/async/images/variations",
+	schemas.RerankRequest:          "/v1/async/rerank",
+	schemas.OCRRequest:             "/v1/async/ocr",
+}
+
+// AsyncResultPath returns the relative URL a caller can GET to fetch the
+// result of the given job, or false when the request type has no async
+// result route.
+func AsyncResultPath(requestType schemas.RequestType, jobID string) (string, bool) {
+	base, ok := asyncResultPathByType[requestType]
+	if !ok {
+		return "", false
+	}
+	return base + "/" + jobID, true
+}
+
+// EventForJobStatus maps a terminal async job status to the webhook event it
+// fires; non-terminal statuses return false.
+func EventForJobStatus(status schemas.AsyncJobStatus) (tables.WebhookEvent, bool) {
+	switch status {
+	case schemas.AsyncJobStatusCompleted:
+		return tables.WebhookEventAsyncJobCompleted, true
+	case schemas.AsyncJobStatusFailed:
+		return tables.WebhookEventAsyncJobFailed, true
+	default:
+		return "", false
+	}
+}
+
+// statusForEvent is the reverse of EventForJobStatus, used when the job row
+// itself is gone and the status must be derived from the queued event.
+func statusForEvent(event tables.WebhookEvent) schemas.AsyncJobStatus {
+	if event == tables.WebhookEventAsyncJobFailed {
+		return schemas.AsyncJobStatusFailed
+	}
+	return schemas.AsyncJobStatusCompleted
+}
+
+// renderPayload builds the delivery body for a live async job row. The
+// response is inlined only when the endpoint opted in and the stored response
+// fits within maxResponseBytes; an oversized response is dropped and flagged
+// with response_omitted so the receiver knows to fetch it instead.
+func renderPayload(job *logstore.AsyncJob, event tables.WebhookEvent, includeResponse bool, maxResponseBytes int, now time.Time) ([]byte, error) {
+	data := eventData{
+		JobID:           job.ID,
+		RequestType:     job.RequestType,
+		Status:          job.Status,
+		StatusCode:      job.StatusCode,
+		CreatedAt:       &job.CreatedAt,
+		CompletedAt:     job.CompletedAt,
+		ResultExpiresAt: job.ExpiresAt,
+	}
+	if url, ok := AsyncResultPath(job.RequestType, job.ID); ok {
+		data.ResultURL = url
+	}
+	if includeResponse && job.Response != "" {
+		if len(job.Response) <= maxResponseBytes {
+			data.Response = json.RawMessage(job.Response)
+		} else {
+			data.ResponseOmitted = true
+		}
+	}
+	return json.Marshal(eventEnvelope{Event: event, CreatedAt: now, Data: data})
+}
+
+// renderExpiredPayload builds the degraded delivery body used when the async
+// job row expired before this attempt fired. Only fields carried by the
+// queue row survive; result_expired tells the receiver the outcome is known
+// but the result — and any fetch-back — is gone. A result URL is not
+// included: it cannot be built without the request type and would be dead
+// anyway.
+func renderExpiredPayload(job *tables.TableWebhookJob, now time.Time) ([]byte, error) {
+	return json.Marshal(eventEnvelope{
+		Event:     job.Event,
+		CreatedAt: now,
+		Data: eventData{
+			JobID:         job.AsyncJobID,
+			Status:        statusForEvent(job.Event),
+			ResultExpired: true,
+		},
+	})
+}

--- a/framework/webhooks/payload_test.go
+++ b/framework/webhooks/payload_test.go
@@ -1,0 +1,129 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testAsyncJob() *logstore.AsyncJob {
+	created := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	completed := created.Add(time.Minute)
+	expires := completed.Add(time.Hour)
+	return &logstore.AsyncJob{
+		ID:          "job-1",
+		Status:      schemas.AsyncJobStatusCompleted,
+		RequestType: schemas.ChatCompletionRequest,
+		Response:    `{"choices":[{"index":0}]}`,
+		StatusCode:  200,
+		CreatedAt:   created,
+		CompletedAt: &completed,
+		ExpiresAt:   &expires,
+	}
+}
+
+func decodeEnvelope(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	return envelope
+}
+
+func TestRenderPayloadThin(t *testing.T) {
+	now := time.Now().UTC()
+	body, err := renderPayload(testAsyncJob(), tables.WebhookEventAsyncJobCompleted, false, 256*1024, now)
+	require.NoError(t, err)
+
+	envelope := decodeEnvelope(t, body)
+	assert.Equal(t, "async_job.completed", envelope["event"])
+	data := envelope["data"].(map[string]any)
+	assert.Equal(t, "job-1", data["job_id"])
+	assert.Equal(t, "chat_completion", data["request_type"])
+	assert.Equal(t, "completed", data["status"])
+	assert.Equal(t, float64(200), data["status_code"])
+	assert.Equal(t, "/v1/async/chat/completions/job-1", data["result_url"])
+	assert.Contains(t, data, "result_expires_at")
+	assert.NotContains(t, data, "response")
+	assert.NotContains(t, data, "response_omitted")
+	assert.NotContains(t, data, "result_expired")
+}
+
+func TestRenderPayloadIncludeResponse(t *testing.T) {
+	now := time.Now().UTC()
+	job := testAsyncJob()
+
+	body, err := renderPayload(job, tables.WebhookEventAsyncJobCompleted, true, 256*1024, now)
+	require.NoError(t, err)
+	data := decodeEnvelope(t, body)["data"].(map[string]any)
+	require.Contains(t, data, "response")
+	assert.NotContains(t, data, "response_omitted")
+
+	// An oversized response is dropped and flagged instead of inlined.
+	job.Response = `{"padding":"` + strings.Repeat("x", 2048) + `"}`
+	body, err = renderPayload(job, tables.WebhookEventAsyncJobCompleted, true, 1024, now)
+	require.NoError(t, err)
+	data = decodeEnvelope(t, body)["data"].(map[string]any)
+	assert.NotContains(t, data, "response")
+	assert.Equal(t, true, data["response_omitted"])
+}
+
+func TestRenderExpiredPayload(t *testing.T) {
+	now := time.Now().UTC()
+	body, err := renderExpiredPayload(&tables.TableWebhookJob{
+		ID:         "wh-1",
+		EndpointID: "ep-1",
+		AsyncJobID: "job-1",
+		Event:      tables.WebhookEventAsyncJobFailed,
+	}, now)
+	require.NoError(t, err)
+
+	envelope := decodeEnvelope(t, body)
+	assert.Equal(t, "async_job.failed", envelope["event"])
+	data := envelope["data"].(map[string]any)
+	assert.Equal(t, "job-1", data["job_id"])
+	assert.Equal(t, "failed", data["status"], "status derives from the queued event")
+	assert.Equal(t, true, data["result_expired"])
+	// Nothing that lived only on the async row survives — including the
+	// result URL, which needs the request type and is dead anyway.
+	assert.NotContains(t, data, "result_url")
+	assert.NotContains(t, data, "request_type")
+	assert.NotContains(t, data, "status_code")
+	assert.NotContains(t, data, "result_expires_at")
+}
+
+func TestAsyncResultPath(t *testing.T) {
+	url, ok := AsyncResultPath(schemas.ChatCompletionRequest, "job-9")
+	require.True(t, ok)
+	assert.Equal(t, "/v1/async/chat/completions/job-9", url)
+
+	_, ok = AsyncResultPath(schemas.CountTokensRequest, "job-9")
+	assert.False(t, ok, "request types without an async result route must return false")
+
+	for requestType, base := range asyncResultPathByType {
+		url, ok := AsyncResultPath(requestType, "id")
+		require.True(t, ok, requestType)
+		assert.Equal(t, base+"/id", url)
+	}
+}
+
+func TestEventForJobStatus(t *testing.T) {
+	event, ok := EventForJobStatus(schemas.AsyncJobStatusCompleted)
+	require.True(t, ok)
+	assert.Equal(t, tables.WebhookEventAsyncJobCompleted, event)
+
+	event, ok = EventForJobStatus(schemas.AsyncJobStatusFailed)
+	require.True(t, ok)
+	assert.Equal(t, tables.WebhookEventAsyncJobFailed, event)
+
+	_, ok = EventForJobStatus(schemas.AsyncJobStatusProcessing)
+	assert.False(t, ok)
+	_, ok = EventForJobStatus(schemas.AsyncJobStatusPending)
+	assert.False(t, ok)
+}

--- a/framework/webhooks/signer.go
+++ b/framework/webhooks/signer.go
@@ -1,0 +1,61 @@
+// Package webhooks delivers signed event notifications to registered webhook
+// endpoints. It renders payloads, signs them in the Standard Webhooks format,
+// and runs the delivery worker that drains the webhook job queue with
+// at-least-once semantics.
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// secretPrefix is the Standard Webhooks signing-secret prefix; the remainder
+// of the secret is the base64-encoded HMAC key.
+const secretPrefix = "whsec_"
+
+// Sign computes the Standard Webhooks signature for one delivery attempt:
+// HMAC-SHA256 over "{webhookID}.{unix timestamp}.{body}" keyed with the
+// base64-decoded endpoint secret, returned in the "v1,<base64>" wire form
+// carried by the webhook-signature header.
+func Sign(secret, webhookID string, timestamp time.Time, body []byte) (string, error) {
+	key, err := decodeSecret(secret)
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(signedContent(webhookID, timestamp, body))
+	return "v1," + base64.StdEncoding.EncodeToString(mac.Sum(nil)), nil
+}
+
+// signedContent builds the exact byte sequence covered by the signature.
+func signedContent(webhookID string, timestamp time.Time, body []byte) []byte {
+	prefix := webhookID + "." + strconv.FormatInt(timestamp.Unix(), 10) + "."
+	content := make([]byte, 0, len(prefix)+len(body))
+	content = append(content, prefix...)
+	return append(content, body...)
+}
+
+// decodeSecret strips the whsec_ prefix and base64-decodes the remainder into
+// the raw HMAC key.
+func decodeSecret(secret string) ([]byte, error) {
+	if secret == "" {
+		return nil, fmt.Errorf("webhook signing secret is empty")
+	}
+	encoded := strings.TrimPrefix(secret, secretPrefix)
+	key, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook signing secret: %w", err)
+	}
+	// Standard Webhooks requires the decoded HMAC key to be 24–64 bytes, so a
+	// bare "whsec_" (empty key) or an out-of-range secret is rejected rather
+	// than used to sign or verify.
+	if len(key) < 24 || len(key) > 64 {
+		return nil, fmt.Errorf("webhook signing secret must decode to 24-64 bytes, got %d", len(key))
+	}
+	return key, nil
+}

--- a/framework/webhooks/signer_test.go
+++ b/framework/webhooks/signer_test.go
@@ -1,0 +1,71 @@
+package webhooks
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignReferenceVector pins the canonical example from the Standard
+// Webhooks specification, so any drift from the reference implementation
+// fails loudly.
+func TestSignReferenceVector(t *testing.T) {
+	signature, err := Sign(
+		"whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
+		"msg_p5jXN8AQM9LWM0D4loKWxJek",
+		time.Unix(1614265330, 0),
+		[]byte(`{"test": 2432232314}`),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE=", signature)
+}
+
+func TestSignSecretHandling(t *testing.T) {
+	body := []byte(`{}`)
+	ts := time.Unix(1700000000, 0)
+
+	_, err := Sign("", "wh-1", ts, body)
+	assert.Error(t, err, "empty secret must be rejected")
+
+	_, err = Sign("whsec_not-base64!!!", "wh-1", ts, body)
+	assert.Error(t, err, "non-base64 secret must be rejected")
+
+	// The decoded key must be 24–64 bytes per the Standard Webhooks spec.
+	_, err = Sign("whsec_", "wh-1", ts, body)
+	assert.Error(t, err, "bare whsec_ (empty key) must be rejected")
+	_, err = Sign("whsec_"+base64.StdEncoding.EncodeToString(make([]byte, 23)), "wh-1", ts, body)
+	assert.Error(t, err, "sub-24-byte key must be rejected")
+	_, err = Sign("whsec_"+base64.StdEncoding.EncodeToString(make([]byte, 65)), "wh-1", ts, body)
+	assert.Error(t, err, "over-64-byte key must be rejected")
+	_, err = Sign("whsec_"+base64.StdEncoding.EncodeToString(make([]byte, 24)), "wh-1", ts, body)
+	assert.NoError(t, err, "24-byte key is the minimum valid length")
+
+	// The prefix is optional on input; the same key must produce the same
+	// signature either way.
+	withPrefix, err := Sign("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-1", ts, body)
+	require.NoError(t, err)
+	withoutPrefix, err := Sign("MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-1", ts, body)
+	require.NoError(t, err)
+	assert.Equal(t, withPrefix, withoutPrefix)
+}
+
+func TestSignVariesWithInputs(t *testing.T) {
+	ts := time.Unix(1700000000, 0)
+	base, err := Sign("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-1", ts, []byte(`{"a":1}`))
+	require.NoError(t, err)
+
+	differentID, err := Sign("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-2", ts, []byte(`{"a":1}`))
+	require.NoError(t, err)
+	assert.NotEqual(t, base, differentID)
+
+	differentBody, err := Sign("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-1", ts, []byte(`{"a":2}`))
+	require.NoError(t, err)
+	assert.NotEqual(t, base, differentBody)
+
+	differentTime, err := Sign("whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw", "wh-1", ts.Add(time.Second), []byte(`{"a":1}`))
+	require.NoError(t, err)
+	assert.NotEqual(t, base, differentTime)
+}


### PR DESCRIPTION
## Summary

This PR introduces the webhook delivery subsystem for Bifrost. It implements the full pipeline for signing, dispatching, and recording webhook notifications when async jobs reach a terminal state, using at-least-once delivery semantics backed by a persistent job queue.

## Changes

- **`signer.go`**: Implements Standard Webhooks-compliant HMAC-SHA256 signing (`v1,<base64>` wire format). The signed content covers `{webhookID}.{unix timestamp}.{body}`, matching the reference specification vector.
- **`client.go`**: Introduces `deliveryClient`, which maintains two HTTP clients — a strict SSRF-safe client that blocks private/link-local IPs, and a private client for endpoints registered with `allow_private_network` that still blocks unspecified and link-local (e.g. cloud metadata) addresses. Both clients refuse redirects and require TLS ≥ 1.2. Timeouts are fully delegated to the per-attempt context rather than held on the client, allowing safe connection pool sharing.
- **`payload.go`**: Renders the JSON delivery envelope (`eventEnvelope`) for live async job rows, with optional response inlining bounded by a per-endpoint payload cap. Provides a degraded `renderExpiredPayload` path for when the async job row has TTL-lapsed before the delivery fires, delivering a `result_expired: true` body instead of dropping the notification.
- **`dispatcher.go`**: Implements `Dispatcher`, the queue worker that scans for due jobs, atomically claims them with a lease, performs one delivery attempt per claim, records history, and either reschedules (retryable failures) or retires (success, permanent failure, exhausted budget) the job. Retry backoff is exponential with ±20% jitter, capped at a configurable max. Per-endpoint concurrency is bounded by an in-process slot counter. `EnqueueJobEvent` inserts queue rows at job completion and wakes the worker. `DeliverTest` sends a signed sample event through the full production path without touching the queue or counters.
- **Tests**: Full coverage across signing (including the Standard Webhooks reference vector), payload rendering (thin, include-response, oversized, expired), and dispatcher behavior (success, retryable failure, exhausted budget, permanent failure, redirect refusal, SSRF blocking, expired job degraded payload, endpoint-gone retirement without counter movement, claim fencing, lease recovery, test delivery, custom headers, per-endpoint tuning overrides).

Notable design decisions:
- The claim-and-lease pattern means the dispatcher can run on every node with no coordination; the atomic claim decides a single owner per attempt.
- History insert failure intentionally leaves the job claimed so the lease expiry re-offers it, and the receiver's `webhook-id` deduplication absorbs any resulting duplicate delivery.
- Reserved delivery headers (`webhook-id`, `webhook-timestamp`, `webhook-signature`, `Content-Type`, `User-Agent`, `X-Bifrost-Event`) always win over endpoint-configured custom headers, even if validation was bypassed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/webhooks/...
```

The test suite spins up local `httptest` servers and in-memory fakes for the config store, log store, and endpoint resolver. Key scenarios covered:

- A successful delivery retires the queue row and increments the endpoint success counter.
- A 5xx response reschedules the job with exponential backoff and increments the failure counter.
- After the attempt budget is exhausted, the job is retired with outcome `exhausted`.
- A 3xx response is treated as a permanent failure (redirects are never followed).
- A loopback receiver is unreachable without `allow_private_network`; link-local addresses are blocked even with it.
- An expired async job row results in a degraded `result_expired` payload being delivered rather than the notification being dropped.
- A job with an expired lease from a dead node is reclaimed and delivered on restart.
- Custom endpoint headers are forwarded; reserved header names are silently dropped.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- The strict delivery client uses SSRF-safe dial logic that re-resolves and re-validates IPs at dial time, preventing DNS rebinding attacks where a hostname resolves to a public IP at registration but flips to a private one at delivery.
- The private-network client still blocks unspecified (`0.0.0.0`) and link-local (`169.254.x.x`) addresses, preventing access to cloud metadata endpoints even for endpoints explicitly granted private network access.
- Signing secrets are base64-decoded at sign time; an empty or malformed secret is rejected before any I/O occurs.
- Reserved delivery headers (`webhook-signature`, etc.) are always set by the delivery client and cannot be overridden by endpoint-configured custom headers.
- Both clients require TLS ≥ 1.2 and do not follow redirects.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable