### PR TITLE
feat: add `WebhookDispatcher` interface and wire async job terminal-state webhook notifications via `BifrostContextKeyAsyncWebhook`

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -223,6 +223,7 @@ const (
 	BifrostContextKeyAPIKeyName        BifrostContextKey = "x-bf-api-key"          // string (explicit key name selection)
 	BifrostContextKeyAPIKeyID          BifrostContextKey = "x-bf-api-key-id"       // string (explicit key ID selection, takes priority over name)
 	BifrostContextKeyDirectKey         BifrostContextKey = "x-bf-direct-key"       // schemas.Key (raw key supplied via x-bf-direct-key: true header; bypasses registered key pool)
+	BifrostContextKeyAsyncWebhook      BifrostContextKey = "x-bf-async-webhook"    // string (webhook endpoint to notify when an async job finishes; the submit path validates the caller's id-or-name reference and normalizes this value to the endpoint ID before the job is created)
 	BifrostContextKeyRequestID         BifrostContextKey = "request-id"            // string
 	BifrostContextKeyFallbackRequestID BifrostContextKey = "fallback-request-id"   // string
 

--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -37,19 +37,28 @@ type GovernanceStore interface {
 	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
 }
 
-// AsyncJobExecutor manages async job creation and background execution.
-type AsyncJobExecutor struct {
-	logstore        LogStore
-	governanceStore GovernanceStore
-	logger          schemas.Logger
+// WebhookDispatcher queues a webhook notification for a job that reached a
+// terminal state. Implementations must not block on receiver I/O.
+type WebhookDispatcher interface {
+	EnqueueJobEvent(ctx context.Context, job *AsyncJob)
 }
 
-// NewAsyncJobExecutor creates a new AsyncJobExecutor.
-func NewAsyncJobExecutor(logstore LogStore, governanceStore GovernanceStore, logger schemas.Logger) *AsyncJobExecutor {
+// AsyncJobExecutor manages async job creation and background execution.
+type AsyncJobExecutor struct {
+	logstore          LogStore
+	governanceStore   GovernanceStore
+	logger            schemas.Logger
+	webhookDispatcher WebhookDispatcher
+}
+
+// NewAsyncJobExecutor creates a new AsyncJobExecutor. A nil webhookDispatcher
+// leaves webhook notification disabled.
+func NewAsyncJobExecutor(logstore LogStore, governanceStore GovernanceStore, webhookDispatcher WebhookDispatcher, logger schemas.Logger) *AsyncJobExecutor {
 	return &AsyncJobExecutor{
-		logstore:        logstore,
-		governanceStore: governanceStore,
-		logger:          logger,
+		logstore:          logstore,
+		governanceStore:   governanceStore,
+		webhookDispatcher: webhookDispatcher,
+		logger:            logger,
 	}
 }
 
@@ -99,12 +108,13 @@ func (e *AsyncJobExecutor) SubmitJob(bifrostCtx *schemas.BifrostContext, resultT
 
 	now := time.Now().UTC()
 	job := &AsyncJob{
-		ID:           uuid.New().String(),
-		Status:       schemas.AsyncJobStatusPending,
-		RequestType:  operationType,
-		VirtualKeyID: virtualKeyID,
-		ResultTTL:    resultTTL,
-		CreatedAt:    now,
+		ID:                uuid.New().String(),
+		Status:            schemas.AsyncJobStatusPending,
+		RequestType:       operationType,
+		VirtualKeyID:      virtualKeyID,
+		WebhookEndpointID: getWebhookEndpointIDFromContext(bifrostCtx),
+		ResultTTL:         resultTTL,
+		CreatedAt:         now,
 	}
 
 	ctx := context.Background()
@@ -116,13 +126,13 @@ func (e *AsyncJobExecutor) SubmitJob(bifrostCtx *schemas.BifrostContext, resultT
 	if bifrostCtx != nil {
 		contextValues = bifrostCtx.GetUserValues()
 	}
-	go e.executeJob(job.ID, job.ResultTTL, operation, contextValues)
+	go e.executeJob(job, operation, contextValues)
 
 	return job, nil
 }
 
 // executeJob runs the operation in the background and updates the job record.
-func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation AsyncOperation, contextValues map[any]any) {
+func (e *AsyncJobExecutor) executeJob(job *AsyncJob, operation AsyncOperation, contextValues map[any]any) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// Restore original request context values (virtual key, tracing headers, etc.)
@@ -137,9 +147,9 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 
 	markFailed := func(msg string) {
 		now := time.Now().UTC()
-		expiresAt := now.Add(time.Duration(resultTTL) * time.Second)
+		expiresAt := now.Add(time.Duration(job.ResultTTL) * time.Second)
 		errJSON, _ := sonic.Marshal(&schemas.BifrostError{Error: &schemas.ErrorField{Message: msg}})
-		if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]any{
+		if err := e.logstore.UpdateAsyncJob(ctx, job.ID, map[string]any{
 			"status":       schemas.AsyncJobStatusFailed,
 			"status_code":  fasthttp.StatusInternalServerError,
 			"error":        string(errJSON),
@@ -147,7 +157,9 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 			"expires_at":   expiresAt,
 		}); err != nil {
 			e.logger.Warn("failed to update async job to failed: %v", err)
+			return
 		}
+		e.notifyWebhook(ctx, job, schemas.AsyncJobStatusFailed)
 	}
 
 	// The bifrost execution flow is very stable and panics are not expected.
@@ -155,13 +167,13 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 	// state rather than being stuck in "processing" if an unexpected panic occurs.
 	defer func() {
 		if r := recover(); r != nil {
-			e.logger.Warn("async job %s panicked: %v", jobID, r)
+			e.logger.Warn("async job %s panicked: %v", job.ID, r)
 			markFailed(fmt.Sprintf("internal error: %v", r))
 		}
 	}()
 
 	// Mark as processing
-	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]any{
+	if err := e.logstore.UpdateAsyncJob(ctx, job.ID, map[string]any{
 		"status": schemas.AsyncJobStatusProcessing,
 	}); err != nil {
 		e.logger.Warn("failed to update async job: %v", err)
@@ -173,7 +185,7 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 	resp, bifrostErr := operation(ctx)
 
 	now := time.Now().UTC()
-	expiresAt := now.Add(time.Duration(resultTTL) * time.Second)
+	expiresAt := now.Add(time.Duration(job.ResultTTL) * time.Second)
 
 	if bifrostErr != nil {
 		errJSON, err := sonic.Marshal(bifrostErr)
@@ -186,7 +198,7 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 		if bifrostErr.StatusCode != nil {
 			statusCode = *bifrostErr.StatusCode
 		}
-		if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+		if err := e.logstore.UpdateAsyncJob(ctx, job.ID, map[string]interface{}{
 			"status":       schemas.AsyncJobStatusFailed,
 			"status_code":  statusCode,
 			"error":        string(errJSON),
@@ -194,7 +206,9 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 			"expires_at":   expiresAt,
 		}); err != nil {
 			e.logger.Warn("failed to update async job: %v", err)
+			return
 		}
+		e.notifyWebhook(ctx, job, schemas.AsyncJobStatusFailed)
 		return
 	}
 
@@ -204,7 +218,7 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 		markFailed(fmt.Sprintf("failed to serialize result: %v", err))
 		return
 	}
-	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+	if err := e.logstore.UpdateAsyncJob(ctx, job.ID, map[string]interface{}{
 		"status":       schemas.AsyncJobStatusCompleted,
 		"status_code":  fasthttp.StatusOK,
 		"response":     string(respJSON),
@@ -212,7 +226,30 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 		"expires_at":   expiresAt,
 	}); err != nil {
 		e.logger.Warn("failed to update async job: %v", err)
+		return
 	}
+	e.notifyWebhook(ctx, job, schemas.AsyncJobStatusCompleted)
+}
+
+// notifyWebhook hands a job that just reached a terminal state to the
+// webhook dispatcher. It only fires after the terminal update committed: a
+// job whose terminal write failed still reads as processing, so notifying
+// for it would contradict what polling callers see.
+func (e *AsyncJobExecutor) notifyWebhook(ctx context.Context, job *AsyncJob, status schemas.AsyncJobStatus) {
+	if e.webhookDispatcher == nil || job.WebhookEndpointID == nil {
+		return
+	}
+	// The job's terminal state is already committed; a dispatcher panic must
+	// not reach executeJob's recovery, which would overwrite a completed job
+	// as failed.
+	defer func() {
+		if r := recover(); r != nil {
+			e.logger.Warn("async job %s webhook enqueue panicked: %v", job.ID, r)
+		}
+	}()
+	notified := *job
+	notified.Status = status
+	e.webhookDispatcher.EnqueueJobEvent(ctx, &notified)
 }
 
 // --- Cleaner ---
@@ -300,6 +337,14 @@ func (c *AsyncJobCleaner) cleanupExpiredJobs(ctx context.Context) {
 	} else if staleDeleted > 0 {
 		c.logger.Warn("async job cleanup: deleted %d stale processing jobs (stuck > %dh)", staleDeleted, asyncJobStaleProcessingHours)
 	}
+
+	// Reap webhook delivery history whose retention window has passed.
+	deliveriesDeleted, err := c.store.DeleteExpiredWebhookDeliveries(ctx)
+	if err != nil {
+		c.logger.Warn("failed to delete expired webhook deliveries: %v", err)
+	} else if deliveriesDeleted > 0 {
+		c.logger.Debug("webhook delivery cleanup completed: deleted %d expired records", deliveriesDeleted)
+	}
 }
 
 // getVirtualKeyFromContext extracts the virtual key value from context.
@@ -315,4 +360,19 @@ func getVirtualKeyFromContext(ctx *schemas.BifrostContext) *string {
 		return nil
 	}
 	return &vkValue
+}
+
+// getWebhookEndpointIDFromContext extracts the webhook endpoint to notify
+// when this job reaches a terminal state. Submit entry points validate the
+// caller's endpoint reference and normalize the context value to the
+// endpoint ID before submitting; nil means no webhook was requested.
+func getWebhookEndpointIDFromContext(ctx *schemas.BifrostContext) *string {
+	if ctx == nil {
+		return nil
+	}
+	endpointID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyAsyncWebhook)
+	if endpointID == "" {
+		return nil
+	}
+	return &endpointID
 }

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -2,6 +2,8 @@ package logstore
 
 import (
 	"context"
+	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -49,7 +51,7 @@ func newTestAsyncExecutor(t *testing.T) *AsyncJobExecutor {
 		},
 	}
 
-	return NewAsyncJobExecutor(store, govStore, asyncTestLogger{})
+	return NewAsyncJobExecutor(store, govStore, nil, asyncTestLogger{})
 }
 
 // waitForJobCompletion polls until the operation callback has been invoked.
@@ -210,4 +212,178 @@ func TestSubmitJob_OperationFailure_PreservesContext(t *testing.T) {
 	// Verify job was marked as failed — poll until DB update completes
 	retrievedJob := waitForJobStatus(t, executor.logstore, job.ID)
 	assert.Equal(t, schemas.AsyncJobStatusFailed, retrievedJob.Status)
+}
+
+// recordingWebhookDispatcher captures every terminal-state notification.
+type recordingWebhookDispatcher struct {
+	mu   sync.Mutex
+	jobs []AsyncJob
+}
+
+func (r *recordingWebhookDispatcher) EnqueueJobEvent(_ context.Context, job *AsyncJob) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.jobs = append(r.jobs, *job)
+}
+
+func (r *recordingWebhookDispatcher) enqueued() []AsyncJob {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]AsyncJob(nil), r.jobs...)
+}
+
+// waitForWebhookEnqueue polls until the dispatcher has received n
+// notifications; the enqueue happens right after the terminal DB update, so
+// terminal job status alone does not guarantee it already fired.
+func waitForWebhookEnqueue(t *testing.T, dispatcher *recordingWebhookDispatcher, n int) []AsyncJob {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if jobs := dispatcher.enqueued(); len(jobs) >= n {
+			return jobs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for webhook enqueue")
+	return nil
+}
+
+// newWebhookTestExecutor builds an executor over a file-backed SQLite store:
+// tests below poll job rows from the test goroutine while executeJob writes
+// from another, and a :memory: DSN gives each pooled connection its own
+// database.
+func newWebhookTestExecutor(t *testing.T, dispatcher WebhookDispatcher) *AsyncJobExecutor {
+	t.Helper()
+	ctx := context.Background()
+	store, err := newSqliteLogStore(ctx, &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "asyncwebhooks.db"),
+	}, asyncTestLogger{})
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close(ctx) })
+	return NewAsyncJobExecutor(store, &testGovernanceStore{}, dispatcher, asyncTestLogger{})
+}
+
+func submitWebhookTestJob(t *testing.T, executor *AsyncJobExecutor, operation AsyncOperation) *AsyncJob {
+	t.Helper()
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyAsyncWebhook, "ep-1")
+	job, err := executor.SubmitJob(ctx, 3600, operation, schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	require.NotNil(t, job)
+	return job
+}
+
+func TestSubmitJob_StampsWebhookEndpointID(t *testing.T) {
+	executor := newWebhookTestExecutor(t, nil)
+
+	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	})
+	require.NotNil(t, job.WebhookEndpointID)
+	assert.Equal(t, "ep-1", *job.WebhookEndpointID)
+
+	stored := waitForJobStatus(t, executor.logstore, job.ID)
+	require.NotNil(t, stored.WebhookEndpointID, "the endpoint reference must be persisted on the job row")
+	assert.Equal(t, "ep-1", *stored.WebhookEndpointID)
+}
+
+func TestSubmitJob_NoWebhookWithoutContextValue(t *testing.T) {
+	dispatcher := &recordingWebhookDispatcher{}
+	executor := newWebhookTestExecutor(t, dispatcher)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	job, err := executor.SubmitJob(ctx, 3600, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	}, schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	assert.Nil(t, job.WebhookEndpointID)
+
+	waitForJobStatus(t, executor.logstore, job.ID)
+	assert.Empty(t, dispatcher.enqueued(), "jobs without a webhook reference must not notify")
+}
+
+func TestExecuteJob_WebhookEnqueuedOnSuccess(t *testing.T) {
+	dispatcher := &recordingWebhookDispatcher{}
+	executor := newWebhookTestExecutor(t, dispatcher)
+
+	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	})
+
+	enqueued := waitForWebhookEnqueue(t, dispatcher, 1)
+	require.Len(t, enqueued, 1)
+	assert.Equal(t, job.ID, enqueued[0].ID)
+	assert.Equal(t, schemas.AsyncJobStatusCompleted, enqueued[0].Status)
+	require.NotNil(t, enqueued[0].WebhookEndpointID)
+	assert.Equal(t, "ep-1", *enqueued[0].WebhookEndpointID)
+}
+
+func TestExecuteJob_WebhookEnqueuedOnFailure(t *testing.T) {
+	dispatcher := &recordingWebhookDispatcher{}
+	executor := newWebhookTestExecutor(t, dispatcher)
+
+	statusCode := fasthttp.StatusBadRequest
+	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return nil, &schemas.BifrostError{StatusCode: &statusCode, Error: &schemas.ErrorField{Message: "test error"}}
+	})
+
+	enqueued := waitForWebhookEnqueue(t, dispatcher, 1)
+	require.Len(t, enqueued, 1)
+	assert.Equal(t, job.ID, enqueued[0].ID)
+	assert.Equal(t, schemas.AsyncJobStatusFailed, enqueued[0].Status)
+}
+
+func TestExecuteJob_WebhookEnqueuedOnPanic(t *testing.T) {
+	dispatcher := &recordingWebhookDispatcher{}
+	executor := newWebhookTestExecutor(t, dispatcher)
+
+	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		panic("boom")
+	})
+
+	enqueued := waitForWebhookEnqueue(t, dispatcher, 1)
+	require.Len(t, enqueued, 1)
+	assert.Equal(t, job.ID, enqueued[0].ID)
+	assert.Equal(t, schemas.AsyncJobStatusFailed, enqueued[0].Status)
+
+	stored := waitForJobStatus(t, executor.logstore, job.ID)
+	assert.Equal(t, schemas.AsyncJobStatusFailed, stored.Status)
+}
+
+func TestExecuteJob_NilDispatcherIsSafe(t *testing.T) {
+	executor := newWebhookTestExecutor(t, nil)
+
+	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	})
+
+	stored := waitForJobStatus(t, executor.logstore, job.ID)
+	assert.Equal(t, schemas.AsyncJobStatusCompleted, stored.Status)
+}
+
+func TestAsyncJobCleaner_ReapsExpiredWebhookDeliveries(t *testing.T) {
+	ctx := context.Background()
+	store, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: ":memory:"}, asyncTestLogger{})
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close(ctx) })
+
+	expiredAt := time.Now().UTC().Add(-time.Hour)
+	require.NoError(t, store.CreateWebhookDelivery(ctx, &WebhookDelivery{
+		ID: "d-expired", WebhookID: "wh-1", EndpointID: "ep-1", AsyncJobID: "job-1",
+		Event: configstoreTables.WebhookEventAsyncJobCompleted, AttemptNo: 1,
+		Outcome: WebhookDeliveryOutcomeDelivered, CreatedAt: expiredAt.Add(-time.Hour), ExpiresAt: &expiredAt,
+	}))
+	require.NoError(t, store.CreateWebhookDelivery(ctx, &WebhookDelivery{
+		ID: "d-live", WebhookID: "wh-2", EndpointID: "ep-1", AsyncJobID: "job-2",
+		Event: configstoreTables.WebhookEventAsyncJobCompleted, AttemptNo: 1,
+		Outcome: WebhookDeliveryOutcomeDelivered, CreatedAt: time.Now().UTC(),
+	}))
+
+	cleaner := NewAsyncJobCleaner(store, asyncTestLogger{})
+	cleaner.cleanupExpiredJobs(ctx)
+
+	_, err = store.FindWebhookDeliveryByID(ctx, "d-expired")
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = store.FindWebhookDeliveryByID(ctx, "d-live")
+	assert.NoError(t, err)
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1772,7 +1772,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if s.Config.LogsStore != nil {
 		governancePlugin, govErr := lib.FindPluginAs[governance.BaseGovernancePlugin](s.Config, s.getGovernancePluginName())
 		if govErr == nil {
-			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), logger)
+			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), nil, logger)
 			logger.Info("async job executor initialized")
 		}
 	}


### PR DESCRIPTION
## Summary

This PR introduces the plumbing for webhook notifications on async job terminal states. A new `WebhookDispatcher` interface is added to the async job executor, allowing implementations to be notified (via `EnqueueJobEvent`) when a job reaches a completed or failed state. The webhook endpoint ID is carried through the request context (`x-bf-async-webhook`) and stamped onto the job record at submission time. Notifications are only dispatched after the terminal DB write succeeds, ensuring polling callers and webhook receivers see a consistent state.

## Changes

- Added `BifrostContextKeyAsyncWebhook` context key to carry the normalized webhook endpoint ID from the submit path into the job executor.
- Introduced the `WebhookDispatcher` interface with a single non-blocking `EnqueueJobEvent` method.
- Extended `AsyncJobExecutor` to accept an optional `WebhookDispatcher`; a `nil` value disables webhook notifications safely.
- `SubmitJob` now reads the webhook endpoint ID from context and stamps it onto the `AsyncJob` record before persisting.
- `executeJob` now calls `notifyWebhook` after every successful terminal DB write (completed, failed, or panic-recovered failed). Notifications are skipped if the terminal write itself fails, preventing contradictory state between polling and webhook consumers.
- `AsyncJobCleaner` now also reaps expired webhook delivery history records as part of its cleanup cycle.
- Updated `NewAsyncJobExecutor` signature to include `WebhookDispatcher`; all call sites updated accordingly (passing `nil` until a concrete dispatcher is wired in).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -v -run TestSubmitJob_StampsWebhookEndpointID
go test ./framework/logstore/... -v -run TestSubmitJob_NoWebhookWithoutContextValue
go test ./framework/logstore/... -v -run TestExecuteJob_WebhookEnqueuedOnSuccess
go test ./framework/logstore/... -v -run TestExecuteJob_WebhookEnqueuedOnFailure
go test ./framework/logstore/... -v -run TestExecuteJob_WebhookEnqueuedOnPanic
go test ./framework/logstore/... -v -run TestExecuteJob_NilDispatcherIsSafe
go test ./framework/logstore/... -v -run TestAsyncJobCleaner_ReapsExpiredWebhookDeliveries
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

`NewAsyncJobExecutor` now requires a `WebhookDispatcher` argument (third positional parameter, before `logger`). Any caller constructing an `AsyncJobExecutor` directly must be updated to pass `nil` or a concrete dispatcher.

## Related issues

## Security considerations

The webhook endpoint ID stored on the job record is expected to be pre-validated and normalized to an internal endpoint ID by the submit path before the context value is set. Raw caller-supplied endpoint references should never reach the executor directly.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable