### PR TITLE
feat: add webhook endpoint admin API, in-memory store, config.json sync, and per-endpoint delivery tuning

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -103,6 +103,7 @@ type ClientConfig struct {
 	OAuth2ServerConfig                    *tables.OAuth2ServerConfig       `json:"oauth2_server_config,omitempty"`       // OAuth2 AS-specific settings (IssuerURL, token TTLs). Only relevant when MCPServerAuthMode is both or oauth.
 	ConfigHash                            string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
 	DumpErrorsInConsoleLogs               bool                             `json:"dump_errors_in_console_logs"`          // Dump error details in console logs
+	WebhookConfig                         *tables.WebhookConfig            `json:"webhook_config,omitempty"`             // Global webhook delivery settings; nil means all defaults
 }
 
 // IsMCPOAuthDiscoveryEnabled reports whether the well-known OAuth discovery
@@ -250,6 +251,16 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	// Only hash non-default value to avoid legacy config hash churn on upgrade.
 	if c.DumpErrorsInConsoleLogs {
 		hash.Write([]byte("dumpErrorsInConsoleLogs:true"))
+	}
+
+	// Only hash when present to avoid legacy config hash churn on upgrade.
+	if c.WebhookConfig != nil {
+		data, err := sonic.Marshal(c.WebhookConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write([]byte("webhookConfig:"))
+		hash.Write(data)
 	}
 
 	// Hash integer fields
@@ -1471,6 +1482,67 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 
 	// will enable it in the future with a migration
 	// hash.Write([]byte("disabled:" + strconv.FormatBool(m.Disabled)))
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// GenerateWebhookEndpointHash generates a SHA256 hash of a webhook endpoint's
+// declared fields. This is used to detect changes between config.json and
+// database config. Operational fields (failure counters, timestamps) and the
+// generated ID are excluded on purpose.
+func GenerateWebhookEndpointHash(endpoint *tables.TableWebhookEndpoint) (string, error) {
+	hash := sha256.New()
+
+	hash.Write([]byte("name:" + endpoint.Name))
+	hash.Write([]byte("url:" + endpoint.URL))
+
+	// The signing secret is deliberately excluded: it is set once at creation
+	// and rotates only through RotateWebhookEndpointSecret, so config-file
+	// sync must not treat a changed webhooks[].secret as a mutation — doing so
+	// would store the new hash while UpdateWebhookEndpoint leaves the credential
+	// untouched, silently diverging the two.
+
+	// Hash Events (sorted for deterministic hashing)
+	if len(endpoint.Events) > 0 {
+		sortedEvents := make([]string, 0, len(endpoint.Events))
+		for _, event := range endpoint.Events {
+			sortedEvents = append(sortedEvents, string(event))
+		}
+		sort.Strings(sortedEvents)
+		data, err := sonic.Marshal(sortedEvents)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
+	hash.Write([]byte("includeResponse:" + strconv.FormatBool(endpoint.IncludeResponse)))
+	hash.Write([]byte("allowPrivateNetwork:" + strconv.FormatBool(endpoint.AllowPrivateNetwork)))
+	hash.Write([]byte("disabled:" + strconv.FormatBool(endpoint.Disabled)))
+
+	hash.Write([]byte("maxRetries:" + strconv.Itoa(endpoint.MaxRetries)))
+	hash.Write([]byte("retryBackoffInitialSeconds:" + strconv.Itoa(endpoint.RetryBackoffInitialSeconds)))
+	hash.Write([]byte("retryBackoffMaxSeconds:" + strconv.Itoa(endpoint.RetryBackoffMaxSeconds)))
+	hash.Write([]byte("attemptTimeoutSeconds:" + strconv.Itoa(endpoint.AttemptTimeoutSeconds)))
+	hash.Write([]byte("maxResponsePayloadKBs:" + strconv.Itoa(endpoint.MaxResponsePayloadKBs)))
+	hash.Write([]byte("maxConcurrentDeliveries:" + strconv.Itoa(endpoint.MaxConcurrentDeliveries)))
+
+	// Hash Headers (sorted for deterministic hashing)
+	if len(endpoint.Headers) > 0 {
+		keys := make([]string, 0, len(endpoint.Headers))
+		for k := range endpoint.Headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			val := endpoint.Headers[k]
+			if val.IsFromSecret() {
+				hash.Write([]byte(k + ":ref:" + val.GetRawRef()))
+			} else {
+				hash.Write([]byte(k + ":val:" + val.Val))
+			}
+		}
+	}
+
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -448,6 +448,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_bedrock_project_id_columns"}, run: migrationAddBedrockProjectIDColumns},
 	{IDs: []string{"add_webhook_endpoints_table"}, run: migrationAddWebhookEndpointsTable},
 	{IDs: []string{"add_webhook_jobs_table"}, run: migrationAddWebhookJobsTable},
+	{IDs: []string{"add_webhook_config_client_column"}, run: migrationAddWebhookConfigClientColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10705,6 +10706,41 @@ func migrationAddWebhookEndpointsTable(ctx context.Context, db *gorm.DB, logger 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running webhook endpoints table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddWebhookConfigClientColumn adds the webhook_config_json column
+// to config_client.
+func migrationAddWebhookConfigClientColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_webhook_config_client_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableClientConfig{}, "webhook_config_json") {
+				if err := mg.AddColumn(&tables.TableClientConfig{}, "WebhookConfigJSON"); err != nil {
+					return fmt.Errorf("add webhook_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableClientConfig{}, "webhook_config_json") {
+				if err := mg.DropColumn(&tables.TableClientConfig{}, "WebhookConfigJSON"); err != nil {
+					return fmt.Errorf("drop webhook_config_json column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running webhook config client column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -282,6 +282,7 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		AllowDirectKeys:                       config.AllowDirectKeys,
 		MCPServerAuthMode:                     config.MCPServerAuthMode,
 		OAuth2ServerConfig:                    config.OAuth2ServerConfig,
+		WebhookConfig:                         config.WebhookConfig,
 		ConfigHash:                            config.ConfigHash,
 	}
 	// Delete existing client config and create new one in a transaction.
@@ -549,6 +550,7 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		AllowDirectKeys:                       dbConfig.AllowDirectKeys,
 		MCPServerAuthMode:                     dbConfig.MCPServerAuthMode,
 		OAuth2ServerConfig:                    dbConfig.OAuth2ServerConfig,
+		WebhookConfig:                         dbConfig.WebhookConfig,
 		ConfigHash:                            dbConfig.ConfigHash,
 	}, nil
 }
@@ -7469,7 +7471,9 @@ func (s *RDBConfigStore) CreateWebhookEndpoint(ctx context.Context, endpoint *ta
 
 // UpdateWebhookEndpoint updates an endpoint's caller-editable fields. Callers
 // are expected to run endpoint.Validate() on user-supplied input first.
-// Signing secrets are never modified here — use RotateWebhookEndpointSecret.
+// Signing secrets are never modified here — the secret is immutable after
+// creation and rotates only through RotateWebhookEndpointSecret (the config
+// hash excludes it, so a changed config.json secret is intentionally inert).
 // Changing the URL resets the consecutive-failure counter; re-enabling a
 // disabled endpoint does not — only a successful delivery clears the streak.
 func (s *RDBConfigStore) UpdateWebhookEndpoint(ctx context.Context, endpoint *tables.TableWebhookEndpoint) error {

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2938,3 +2938,54 @@ func TestWebhookJobStaleOwnerAfterReclaimIsFenced(t *testing.T) {
 	// The live claim holder still owns the job.
 	require.NoError(t, store.DeleteWebhookJob(ctx, "job-1", "", newLease))
 }
+
+func TestClientConfigWebhookConfigRoundTrip(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.UpdateClientConfig(ctx, &ClientConfig{
+		WebhookConfig: &tables.WebhookConfig{DeliveryHistoryRetentionDays: 90},
+	}))
+	loaded, err := store.GetClientConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, loaded.WebhookConfig, "webhook settings must survive the database round-trip")
+	assert.Equal(t, 90, loaded.WebhookConfig.DeliveryHistoryRetentionDays)
+
+	// Absent settings stay absent rather than becoming a zero-value struct.
+	require.NoError(t, store.UpdateClientConfig(ctx, &ClientConfig{}))
+	loaded, err = store.GetClientConfig(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, loaded.WebhookConfig)
+}
+
+func TestWebhookEndpointTuningRoundTripAndHash(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	endpoint := testWebhookEndpoint("tuning-test")
+	endpoint.MaxRetries = 2
+	endpoint.RetryBackoffInitialSeconds = 5
+	endpoint.AttemptTimeoutSeconds = 3
+	require.NoError(t, endpoint.Validate())
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, endpoint))
+
+	fetched, err := store.GetWebhookEndpointByID(ctx, endpoint.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, fetched.MaxRetries)
+	assert.Equal(t, 5, fetched.RetryBackoffInitialSeconds)
+	assert.Equal(t, 3, fetched.AttemptTimeoutSeconds)
+	assert.Zero(t, fetched.MaxConcurrentDeliveries, "unset knobs stay zero (worker default)")
+
+	// Tuning participates in change detection for config.json sync.
+	baseHash, err := GenerateWebhookEndpointHash(fetched)
+	require.NoError(t, err)
+	fetched.MaxRetries = 7
+	changedHash, err := GenerateWebhookEndpointHash(fetched)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseHash, changedHash)
+
+	// Negative knobs are rejected at validation.
+	invalid := testWebhookEndpoint("tuning-invalid")
+	invalid.MaxRetries = -1
+	assert.Error(t, invalid.Validate())
+}

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -20,7 +20,7 @@ type TableClientConfig struct {
 	EnableLogging                         *bool  `gorm:"default:true" json:"enable_logging"`
 	DisableContentLogging                 bool   `gorm:"default:false" json:"disable_content_logging"` // DisableContentLogging controls whether sensitive content (inputs, outputs, embeddings, etc.) is logged
 	DisableDBPingsInHealth                bool   `gorm:"default:false" json:"disable_db_pings_in_health"`
-	DumpErrorsInConsoleLogs               bool   `gorm:"default:false" json:"dump_errors_in_console_logs"` // Dump full error details to the server console logs
+	DumpErrorsInConsoleLogs               bool   `gorm:"default:false" json:"dump_errors_in_console_logs"`       // Dump full error details to the server console logs
 	LogRetentionDays                      int    `gorm:"default:365" json:"log_retention_days" validate:"min=1"` // Number of days to retain logs (minimum 1 day)
 	EnforceAuthOnInference                bool   `gorm:"default:false" json:"enforce_auth_on_inference"`
 	EnforceGovernanceHeader               bool   `gorm:"" json:"enforce_governance_header"`
@@ -39,9 +39,9 @@ type TableClientConfig struct {
 	RoutingChainMaxDepth                  int    `gorm:"default:10" json:"routing_chain_max_depth"`                       // Maximum depth for routing rule chain evaluation (default: 10)
 	MCPExternalClientURL                  string `gorm:"type:varchar(512)" json:"mcp_external_client_url,omitempty"`      // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers
 	WhitelistedRoutesJSON                 string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
-	AllowPerRequestContentStorageOverride bool `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
-	AllowPerRequestRawOverride            bool `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
-	AllowDirectKeys                       bool `gorm:"default:false" json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key header
+	AllowPerRequestContentStorageOverride bool   `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
+	AllowPerRequestRawOverride            bool   `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
+	AllowDirectKeys                       bool   `gorm:"default:false" json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key header
 
 	// Compat plugin feature flags
 	CompatConvertTextToChat      bool `gorm:"column:compat_convert_text_to_chat;default:false" json:"-"`
@@ -58,6 +58,9 @@ type TableClientConfig struct {
 	// by AfterFind. The explicit column name avoids GORM deriving the leading
 	// acronym as "o_auth2_..." from the field name.
 	OAuth2ServerConfigJSON string `gorm:"column:oauth2_server_config_json;type:text" json:"-"`
+	// WebhookConfigJSON holds the webhook delivery settings as a JSON blob,
+	// deserialized into Webhooks by AfterFind.
+	WebhookConfigJSON string `gorm:"column:webhook_config_json;type:text" json:"-"`
 
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
@@ -67,15 +70,34 @@ type TableClientConfig struct {
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	PrometheusLabels    []string                  `gorm:"-" json:"prometheus_labels"`
-	AllowedOrigins      []string                  `gorm:"-" json:"allowed_origins,omitempty"`
-	AllowedHeaders      []string                  `gorm:"-" json:"allowed_headers,omitempty"`
-	RequiredHeaders     []string                  `gorm:"-" json:"required_headers,omitempty"`
-	LoggingHeaders      []string                  `gorm:"-" json:"logging_headers,omitempty"`
-	WhitelistedRoutes   []string                  `gorm:"-" json:"whitelisted_routes,omitempty"`
-	HeaderFilterConfig  *GlobalHeaderFilterConfig `gorm:"-" json:"header_filter_config,omitempty"`
-	Metadata            map[string]any            `gorm:"-" json:"metadata,omitempty"`
+	PrometheusLabels   []string                  `gorm:"-" json:"prometheus_labels"`
+	AllowedOrigins     []string                  `gorm:"-" json:"allowed_origins,omitempty"`
+	AllowedHeaders     []string                  `gorm:"-" json:"allowed_headers,omitempty"`
+	RequiredHeaders    []string                  `gorm:"-" json:"required_headers,omitempty"`
+	LoggingHeaders     []string                  `gorm:"-" json:"logging_headers,omitempty"`
+	WhitelistedRoutes  []string                  `gorm:"-" json:"whitelisted_routes,omitempty"`
+	HeaderFilterConfig *GlobalHeaderFilterConfig `gorm:"-" json:"header_filter_config,omitempty"`
+	Metadata           map[string]any            `gorm:"-" json:"metadata,omitempty"`
 	OAuth2ServerConfig *OAuth2ServerConfig       `gorm:"-" json:"oauth2_server_config,omitempty"`
+	WebhookConfig      *WebhookConfig            `gorm:"-" json:"webhook_config,omitempty"`
+}
+
+// WebhookConfig holds global webhook delivery settings. Delivery
+// tuning (retries, backoff, timeouts, payload caps) lives on each endpoint;
+// only storage policy is global. Zero values fall back to the defaults,
+// read at server startup.
+type WebhookConfig struct {
+	DeliveryHistoryRetentionDays int `json:"delivery_history_retention_days,omitempty"` // How long delivery history rows are kept (default: 30)
+}
+
+// DeliveryHistoryRetention returns the configured retention for webhook
+// delivery history rows, falling back to the default (30 days) when unset.
+// Safe on a nil receiver — nil means all defaults.
+func (w *WebhookConfig) DeliveryHistoryRetention() time.Duration {
+	if w == nil || w.DeliveryHistoryRetentionDays <= 0 {
+		return 30 * 24 * time.Hour
+	}
+	return time.Duration(w.DeliveryHistoryRetentionDays) * 24 * time.Hour
 }
 
 // TableName sets the table name for each model
@@ -174,6 +196,16 @@ func (cc *TableClientConfig) BeforeSave(tx *gorm.DB) error {
 		cc.OAuth2ServerConfigJSON = ""
 	}
 
+	if cc.WebhookConfig != nil {
+		data, err := json.Marshal(cc.WebhookConfig)
+		if err != nil {
+			return err
+		}
+		cc.WebhookConfigJSON = string(data)
+	} else {
+		cc.WebhookConfigJSON = ""
+	}
+
 	return nil
 }
 
@@ -241,6 +273,16 @@ func (cc *TableClientConfig) AfterFind(tx *gorm.DB) error {
 		cc.OAuth2ServerConfig = &authCfg
 	} else {
 		cc.OAuth2ServerConfig = nil
+	}
+
+	if cc.WebhookConfigJSON != "" {
+		var webhooksCfg WebhookConfig
+		if err := json.Unmarshal([]byte(cc.WebhookConfigJSON), &webhooksCfg); err != nil {
+			return err
+		}
+		cc.WebhookConfig = &webhooksCfg
+	} else {
+		cc.WebhookConfig = nil
 	}
 
 	return nil

--- a/transports/bifrost-http/handlers/webhooks.go
+++ b/transports/bifrost-http/handlers/webhooks.go
@@ -1,0 +1,487 @@
+// Package handlers - webhooks.go implements the admin API for webhook
+// endpoints: registration, secret lifecycle, test deliveries, delivery
+// history, and redelivery. Every mutation writes the database first and then
+// refreshes the in-memory endpoint store, which serves the submit path and the
+// delivery worker.
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/bytedance/sonic"
+	"github.com/fasthttp/router"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/webhooks"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// WebhookEndpointManager refreshes the in-memory webhook endpoint store from
+// the database after a single-endpoint mutation. The base server implementation
+// updates local memory; a clustered deployment overrides it to also notify
+// peers so their in-memory copies (read by the submit path and the delivery
+// worker) stay current.
+type WebhookEndpointManager interface {
+	ReloadWebhookEndpoint(ctx context.Context, id string) error
+	RemoveWebhookEndpoint(ctx context.Context, id string) error
+}
+
+// WebhookHandler manages webhook endpoint configuration and delivery history.
+type WebhookHandler struct {
+	manager    WebhookEndpointManager
+	store      *lib.Config
+	dispatcher *webhooks.Dispatcher
+}
+
+// NewWebhookHandler creates a new webhook admin handler. The manager refreshes
+// (and, in a cluster, propagates) the in-memory endpoint store after each
+// mutation. The dispatcher may be nil when delivery is not configured; test
+// deliveries are then refused.
+func NewWebhookHandler(manager WebhookEndpointManager, store *lib.Config, dispatcher *webhooks.Dispatcher) *WebhookHandler {
+	return &WebhookHandler{
+		manager:    manager,
+		store:      store,
+		dispatcher: dispatcher,
+	}
+}
+
+// RegisterRoutes registers the webhook admin routes.
+func (h *WebhookHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.GET("/api/webhooks", lib.ChainMiddlewares(h.listWebhookEndpoints, middlewares...))
+	r.POST("/api/webhooks", lib.ChainMiddlewares(h.createWebhookEndpoint, middlewares...))
+	r.GET("/api/webhooks/{id}", lib.ChainMiddlewares(h.getWebhookEndpoint, middlewares...))
+	r.PUT("/api/webhooks/{id}", lib.ChainMiddlewares(h.updateWebhookEndpoint, middlewares...))
+	r.DELETE("/api/webhooks/{id}", lib.ChainMiddlewares(h.deleteWebhookEndpoint, middlewares...))
+	r.POST("/api/webhooks/{id}/rotate-secret", lib.ChainMiddlewares(h.rotateWebhookEndpointSecret, middlewares...))
+	r.POST("/api/webhooks/{id}/test", lib.ChainMiddlewares(h.testWebhookEndpoint, middlewares...))
+	r.GET("/api/webhooks/{id}/deliveries", lib.ChainMiddlewares(h.listWebhookDeliveries, middlewares...))
+	r.POST("/api/webhooks/deliveries/{id}/redeliver", lib.ChainMiddlewares(h.redeliverWebhook, middlewares...))
+}
+
+// webhookEndpointRequest is the caller-editable shape for create and update.
+// Signing secrets are always server-generated and rotated through the
+// dedicated endpoint, so no secret field is accepted here. The tuning knobs
+// are optional; zero means "use the delivery worker's default".
+type webhookEndpointRequest struct {
+	Name                string                           `json:"name"`
+	URL                 string                           `json:"url"`
+	Events              []configstoreTables.WebhookEvent `json:"events"`
+	Headers             map[string]schemas.SecretVar     `json:"headers"`
+	IncludeResponse     bool                             `json:"include_response"`
+	AllowPrivateNetwork bool                             `json:"allow_private_network"`
+	Disabled            bool                             `json:"disabled"`
+
+	MaxRetries                 int `json:"max_retries"`
+	RetryBackoffInitialSeconds int `json:"retry_backoff_initial_seconds"`
+	RetryBackoffMaxSeconds     int `json:"retry_backoff_max_seconds"`
+	AttemptTimeoutSeconds      int `json:"attempt_timeout_seconds"`
+	MaxResponsePayloadKBs      int `json:"max_response_payload_kbs"`
+	MaxConcurrentDeliveries    int `json:"max_concurrent_deliveries"`
+}
+
+func (r *webhookEndpointRequest) toTable(id string) *configstoreTables.TableWebhookEndpoint {
+	return &configstoreTables.TableWebhookEndpoint{
+		ID:                         id,
+		Name:                       r.Name,
+		URL:                        r.URL,
+		Events:                     r.Events,
+		Headers:                    r.Headers,
+		IncludeResponse:            r.IncludeResponse,
+		AllowPrivateNetwork:        r.AllowPrivateNetwork,
+		Disabled:                   r.Disabled,
+		MaxRetries:                 r.MaxRetries,
+		RetryBackoffInitialSeconds: r.RetryBackoffInitialSeconds,
+		RetryBackoffMaxSeconds:     r.RetryBackoffMaxSeconds,
+		AttemptTimeoutSeconds:      r.AttemptTimeoutSeconds,
+		MaxResponsePayloadKBs:      r.MaxResponsePayloadKBs,
+		MaxConcurrentDeliveries:    r.MaxConcurrentDeliveries,
+	}
+}
+
+// redactedWebhookEndpoint returns a copy safe for API responses: custom
+// header values are replaced with placeholders, preserving env references
+// (the signing secret is already excluded from JSON).
+func redactedWebhookEndpoint(endpoint *configstoreTables.TableWebhookEndpoint) *configstoreTables.TableWebhookEndpoint {
+	if endpoint == nil || len(endpoint.Headers) == 0 {
+		return endpoint
+	}
+	copied := *endpoint
+	copied.Headers = make(map[string]schemas.SecretVar, len(endpoint.Headers))
+	for name, value := range endpoint.Headers {
+		copied.Headers[name] = *value.FullyRedacted()
+	}
+	return &copied
+}
+
+// storeAvailable guards every route against a disabled config store.
+func (h *WebhookHandler) storeAvailable(ctx *fasthttp.RequestCtx) bool {
+	if h.store == nil || h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Config store is not available")
+		return false
+	}
+	return true
+}
+
+// listWebhookEndpoints returns all endpoints. Reads the store, not memory:
+// list views include the operational failure counters, which are only
+// tracked in the database.
+func (h *WebhookHandler) listWebhookEndpoints(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	endpoints, err := h.store.ConfigStore.GetWebhookEndpoints(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to list webhook endpoints: %v", err))
+		return
+	}
+	redacted := make([]*configstoreTables.TableWebhookEndpoint, 0, len(endpoints))
+	for i := range endpoints {
+		redacted = append(redacted, redactedWebhookEndpoint(&endpoints[i]))
+	}
+	SendJSON(ctx, map[string]any{
+		"endpoints": redacted,
+		"count":     len(redacted),
+	})
+}
+
+// getWebhookEndpoint returns one endpoint; the signing secret is never
+// included in responses.
+func (h *WebhookHandler) getWebhookEndpoint(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	endpoint, err := h.store.ConfigStore.GetWebhookEndpointByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "Webhook endpoint not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get webhook endpoint: %v", err))
+		return
+	}
+	SendJSON(ctx, redactedWebhookEndpoint(endpoint))
+}
+
+// createWebhookEndpoint registers a new endpoint. The generated signing
+// secret is returned exactly once in this response and never again.
+func (h *WebhookHandler) createWebhookEndpoint(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	var req webhookEndpointRequest
+	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	endpoint := req.toTable(uuid.NewString())
+	if err := endpoint.Validate(); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.store.ConfigStore.CreateWebhookEndpoint(ctx, endpoint); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "A webhook endpoint with this name already exists")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create webhook endpoint: %v", err))
+		return
+	}
+	// Refresh memory so the delivery worker can serve this endpoint.
+	if err := h.manager.ReloadWebhookEndpoint(ctx, endpoint.ID); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reload webhook endpoint in memory: %v, please restart bifrost to sync with the database", err))
+		return
+	}
+	// The store left the plaintext secret on the struct after commit, so this
+	// response can show it exactly once.
+	SendJSONWithStatus(ctx, map[string]any{
+		"endpoint": redactedWebhookEndpoint(endpoint),
+		"secret":   endpoint.Secret.GetValue(),
+	}, fasthttp.StatusCreated)
+}
+
+// updateWebhookEndpoint replaces an endpoint's caller-editable fields. The
+// full desired state must be sent — omitted fields are cleared, and an empty
+// name or URL is rejected by validation.
+func (h *WebhookHandler) updateWebhookEndpoint(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	var req webhookEndpointRequest
+	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	// Masked header values round-tripped from a read are placeholders, not
+	// real values — restore the stored value so an edit that touches other
+	// fields cannot corrupt the headers.
+	if len(req.Headers) > 0 {
+		if existing, ok := h.store.WebhookEndpointByID(id); ok {
+			for name, value := range req.Headers {
+				if value.IsMaskedPlaceholder() {
+					if stored, found := existing.Headers[name]; found {
+						req.Headers[name] = stored
+					}
+				}
+			}
+		}
+	}
+	endpoint := req.toTable(id)
+	if err := endpoint.Validate(); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.store.ConfigStore.UpdateWebhookEndpoint(ctx, endpoint); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "Webhook endpoint not found")
+			return
+		}
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "A webhook endpoint with this name already exists")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update webhook endpoint: %v", err))
+		return
+	}
+	// Reconcile memory from the canonical row in a single post-commit read, then
+	// serve the response from that in-memory row — so a successful update never
+	// leaves workers on stale config behind a second read that could fail.
+	if err := h.manager.ReloadWebhookEndpoint(ctx, id); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reload webhook endpoint in memory: %v, please restart bifrost to sync with the database", err))
+		return
+	}
+	updated, ok := h.store.WebhookEndpointByID(id)
+	if !ok {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Webhook endpoint missing from memory after reload, please restart bifrost to sync with the database")
+		return
+	}
+	SendJSON(ctx, redactedWebhookEndpoint(updated))
+}
+
+// deleteWebhookEndpoint removes an endpoint. In-flight deliveries referencing
+// it are retired by the delivery worker on their next attempt.
+func (h *WebhookHandler) deleteWebhookEndpoint(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	if err := h.store.ConfigStore.DeleteWebhookEndpoint(ctx, id); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "Webhook endpoint not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete webhook endpoint: %v", err))
+		return
+	}
+	// Remove from in-memory store via manager callback (non-fatal: DB already updated).
+	if err := h.manager.RemoveWebhookEndpoint(ctx, id); err != nil {
+		logger.Error("failed to remove webhook endpoint from memory: %v", err)
+	}
+	SendJSON(ctx, map[string]any{"status": "success"})
+}
+
+// rotateWebhookEndpointSecret swaps in a freshly generated signing secret,
+// effective immediately, and returns it exactly once.
+func (h *WebhookHandler) rotateWebhookEndpointSecret(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	rotated, err := h.store.ConfigStore.RotateWebhookEndpointSecret(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "Webhook endpoint not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to rotate webhook secret: %v", err))
+		return
+	}
+	// Memory must sign with the new secret from this moment on.
+	if err := h.manager.ReloadWebhookEndpoint(ctx, id); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reload webhook endpoint in memory: %v, please restart bifrost to sync with the database", err))
+		return
+	}
+	SendJSON(ctx, map[string]any{
+		"endpoint": redactedWebhookEndpoint(rotated),
+		"secret":   rotated.Secret.GetValue(),
+	})
+}
+
+// testWebhookEndpoint sends one signed sample event through the production
+// delivery path and reports the receiver's response. Rate-limited per
+// endpoint so a misclicked button cannot hammer a receiver.
+func (h *WebhookHandler) testWebhookEndpoint(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	if h.dispatcher == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Webhook delivery is not available")
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	endpoint, ok := h.store.WebhookEndpointByID(id)
+	if !ok {
+		SendError(ctx, fasthttp.StatusNotFound, "Webhook endpoint not found")
+		return
+	}
+	if endpoint.Disabled {
+		SendError(ctx, fasthttp.StatusBadRequest, "Webhook endpoint is disabled")
+		return
+	}
+	// The event to sample is optional; it defaults to the endpoint's first
+	// subscription and must be one the endpoint would actually receive.
+	event := endpoint.Events[0]
+	if body := ctx.PostBody(); len(body) > 0 {
+		var req struct {
+			Event configstoreTables.WebhookEvent `json:"event"`
+		}
+		if err := sonic.Unmarshal(body, &req); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+			return
+		}
+		if req.Event != "" {
+			event = req.Event
+		}
+	}
+	if !slices.Contains(endpoint.Events, event) {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Endpoint is not subscribed to event %q", event))
+		return
+	}
+	statusCode, err := h.dispatcher.DeliverTest(ctx, endpoint, event)
+	if err != nil {
+		SendJSON(ctx, map[string]any{
+			"delivered": false,
+			"error":     err.Error(),
+		})
+		return
+	}
+	SendJSON(ctx, map[string]any{
+		"delivered":            statusCode >= 200 && statusCode < 300,
+		"receiver_status_code": statusCode,
+	})
+}
+
+// listWebhookDeliveries returns one page of delivery history for an
+// endpoint, newest first. History outlives its endpoint, so no existence
+// check is made against the endpoint itself.
+func (h *WebhookHandler) listWebhookDeliveries(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	if h.store.LogsStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Logs store is not available")
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	limit, offset := 0, 0
+	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
+		if limit, err = strconv.Atoi(limitStr); err != nil || limit < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be a non-negative number")
+			return
+		}
+	}
+	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
+		if offset, err = strconv.Atoi(offsetStr); err != nil || offset < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be a non-negative number")
+			return
+		}
+	}
+	limit, offset = ClampPaginationParams(limit, offset)
+	result, err := h.store.LogsStore.SearchWebhookDeliveries(ctx, id, logstore.PaginationOptions{Limit: limit, Offset: offset})
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to list webhook deliveries: %v", err))
+		return
+	}
+	SendJSON(ctx, result)
+}
+
+// redeliverWebhook re-queues the delivery a history record belongs to, under
+// its original webhook id so receivers can deduplicate the replay.
+func (h *WebhookHandler) redeliverWebhook(ctx *fasthttp.RequestCtx) {
+	if !h.storeAvailable(ctx) {
+		return
+	}
+	if h.store.LogsStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Logs store is not available")
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	delivery, err := h.store.LogsStore.FindWebhookDeliveryByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "Webhook delivery not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load webhook delivery: %v", err))
+		return
+	}
+	endpoint, ok := h.store.WebhookEndpointByID(delivery.EndpointID)
+	if !ok {
+		SendError(ctx, fasthttp.StatusBadRequest, "The endpoint this delivery belongs to no longer exists")
+		return
+	}
+	if endpoint.Disabled {
+		SendError(ctx, fasthttp.StatusBadRequest, "The endpoint this delivery belongs to is disabled")
+		return
+	}
+	// Same id as the original delivery: the webhook-id header stays stable,
+	// so receiver-side deduplication of the replay remains intentional.
+	job := &configstoreTables.TableWebhookJob{
+		ID:         delivery.WebhookID,
+		EndpointID: delivery.EndpointID,
+		AsyncJobID: delivery.AsyncJobID,
+		Event:      delivery.Event,
+	}
+	if err := h.store.ConfigStore.CreateWebhookJob(ctx, job); err != nil {
+		if errors.Is(err, configstore.ErrAlreadyExists) {
+			SendError(ctx, fasthttp.StatusConflict, "This delivery is already in flight")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to queue redelivery: %v", err))
+		return
+	}
+	if h.dispatcher != nil {
+		h.dispatcher.Wake()
+	}
+	SendJSONWithStatus(ctx, map[string]any{
+		"status":     "queued",
+		"webhook_id": delivery.WebhookID,
+	}, fasthttp.StatusAccepted)
+}

--- a/transports/bifrost-http/handlers/webhooks_test.go
+++ b/transports/bifrost-http/handlers/webhooks_test.go
@@ -1,0 +1,397 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/webhooks"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// configWebhookManager adapts a *lib.Config to WebhookEndpointManager,
+// mirroring the base server's per-endpoint reload/remove so handler tests
+// observe the same in-memory refresh the real wiring produces.
+type configWebhookManager struct{ config *lib.Config }
+
+func (m configWebhookManager) ReloadWebhookEndpoint(ctx context.Context, id string) error {
+	endpoint, err := m.config.ConfigStore.GetWebhookEndpointByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	m.config.SetWebhookEndpoint(endpoint)
+	return nil
+}
+
+func (m configWebhookManager) RemoveWebhookEndpoint(ctx context.Context, id string) error {
+	m.config.RemoveWebhookEndpoint(id)
+	return nil
+}
+
+func newWebhookTestHandler(t *testing.T) (*WebhookHandler, *lib.Config) {
+	t.Helper()
+	ctx := context.Background()
+
+	store, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: filepath.Join(t.TempDir(), "config.db")},
+	}, testLogger{})
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Close(context.Background()) })
+
+	logsStore, err := logstore.NewLogStore(ctx, &logstore.Config{
+		Enabled: true,
+		Type:    logstore.LogStoreTypeSQLite,
+		Config:  &logstore.SQLiteConfig{Path: filepath.Join(t.TempDir(), "logs.db")},
+	}, testLogger{})
+	require.NoError(t, err)
+	t.Cleanup(func() { logsStore.Close(context.Background()) })
+
+	config := &lib.Config{ConfigStore: store, LogsStore: logsStore}
+	dispatcher := webhooks.NewDispatcher(ctx, "", 30*24*time.Hour, store, logsStore, config, testLogger{})
+	t.Cleanup(dispatcher.Stop)
+	return NewWebhookHandler(configWebhookManager{config}, config, dispatcher), config
+}
+
+func newWebhookRequestCtx(body string, pathParams map[string]string) *fasthttp.RequestCtx {
+	var req fasthttp.Request
+	req.SetBodyString(body)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+	for key, value := range pathParams {
+		ctx.SetUserValue(key, value)
+	}
+	return ctx
+}
+
+func decodeJSONResponse(t *testing.T, ctx *fasthttp.RequestCtx) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(ctx.Response.Body(), &payload), "body: %s", ctx.Response.Body())
+	return payload
+}
+
+func createTestWebhookEndpoint(t *testing.T, handler *WebhookHandler, name string) (id, secret string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"name":%q,"url":"https://93.184.216.34/hook","events":["async_job.completed","async_job.failed"]}`, name)
+	ctx := newWebhookRequestCtx(body, nil)
+	handler.createWebhookEndpoint(ctx)
+	require.Equal(t, fasthttp.StatusCreated, ctx.Response.StatusCode(), "body: %s", ctx.Response.Body())
+	payload := decodeJSONResponse(t, ctx)
+	endpoint := payload["endpoint"].(map[string]any)
+	return endpoint["id"].(string), payload["secret"].(string)
+}
+
+func TestWebhookHandlerRouteRegistration(t *testing.T) {
+	handler, _ := newWebhookTestHandler(t)
+	r := router.New()
+	// Panics on route conflicts, which is the failure this guards against.
+	handler.RegisterRoutes(r)
+}
+
+func TestWebhookHandlerCreateAndGet(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+
+	id, secret := createTestWebhookEndpoint(t, handler, "create-test")
+	assert.Contains(t, secret, "whsec_")
+
+	// The secret is shown exactly once: reads never include it.
+	getCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.getWebhookEndpoint(getCtx)
+	require.Equal(t, fasthttp.StatusOK, getCtx.Response.StatusCode())
+	assert.NotContains(t, string(getCtx.Response.Body()), "whsec_")
+	assert.NotContains(t, string(getCtx.Response.Body()), secret)
+
+	// The in-memory store serves the endpoint, with its secret, immediately.
+	inMemory, ok := config.WebhookEndpointByID(id)
+	require.True(t, ok)
+	assert.Equal(t, "create-test", inMemory.Name)
+	assert.Equal(t, secret, inMemory.Secret.GetValue())
+	byName, ok := config.WebhookEndpointByName("create-test")
+	require.True(t, ok)
+	assert.Equal(t, id, byName.ID)
+
+	listCtx := newWebhookRequestCtx("", nil)
+	handler.listWebhookEndpoints(listCtx)
+	require.Equal(t, fasthttp.StatusOK, listCtx.Response.StatusCode())
+	assert.Equal(t, float64(1), decodeJSONResponse(t, listCtx)["count"])
+
+	missingCtx := newWebhookRequestCtx("", map[string]string{"id": "does-not-exist"})
+	handler.getWebhookEndpoint(missingCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerCreateValidation(t *testing.T) {
+	handler, _ := newWebhookTestHandler(t)
+
+	cases := map[string]string{
+		"missing name":     `{"url":"https://93.184.216.34/hook","events":["async_job.completed"]}`,
+		"http without opt": `{"name":"a","url":"http://93.184.216.34/hook","events":["async_job.completed"]}`,
+		"no events":        `{"name":"a","url":"https://93.184.216.34/hook","events":[]}`,
+		"unknown event":    `{"name":"a","url":"https://93.184.216.34/hook","events":["bogus.event"]}`,
+		"invalid body":     `{not json`,
+	}
+	for name, body := range cases {
+		ctx := newWebhookRequestCtx(body, nil)
+		handler.createWebhookEndpoint(ctx)
+		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode(), name)
+	}
+}
+
+func TestWebhookHandlerDuplicateName(t *testing.T) {
+	handler, _ := newWebhookTestHandler(t)
+	createTestWebhookEndpoint(t, handler, "dup-name")
+
+	ctx := newWebhookRequestCtx(`{"name":"dup-name","url":"https://93.184.216.34/hook","events":["async_job.completed"]}`, nil)
+	handler.createWebhookEndpoint(ctx)
+	assert.Equal(t, fasthttp.StatusConflict, ctx.Response.StatusCode())
+}
+
+func TestWebhookHandlerUpdate(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+	id, _ := createTestWebhookEndpoint(t, handler, "update-test")
+
+	updateCtx := newWebhookRequestCtx(`{"name":"renamed","url":"https://93.184.216.34/hook2","events":["async_job.completed"],"disabled":true}`, map[string]string{"id": id})
+	handler.updateWebhookEndpoint(updateCtx)
+	require.Equal(t, fasthttp.StatusOK, updateCtx.Response.StatusCode(), "body: %s", updateCtx.Response.Body())
+
+	// Memory follows the database, including the name index.
+	_, ok := config.WebhookEndpointByName("update-test")
+	assert.False(t, ok, "old name must leave the in-memory index")
+	renamed, ok := config.WebhookEndpointByName("renamed")
+	require.True(t, ok)
+	assert.Equal(t, "https://93.184.216.34/hook2", renamed.URL)
+	assert.True(t, renamed.Disabled)
+
+	missingCtx := newWebhookRequestCtx(`{"name":"x","url":"https://93.184.216.34/hook","events":["async_job.completed"]}`, map[string]string{"id": "does-not-exist"})
+	handler.updateWebhookEndpoint(missingCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerDelete(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+	id, _ := createTestWebhookEndpoint(t, handler, "delete-test")
+
+	deleteCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.deleteWebhookEndpoint(deleteCtx)
+	require.Equal(t, fasthttp.StatusOK, deleteCtx.Response.StatusCode())
+
+	_, ok := config.WebhookEndpointByID(id)
+	assert.False(t, ok, "deleted endpoints must leave the in-memory store")
+
+	againCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.deleteWebhookEndpoint(againCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, againCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerRotateSecret(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+	id, originalSecret := createTestWebhookEndpoint(t, handler, "rotate-test")
+
+	rotateCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.rotateWebhookEndpointSecret(rotateCtx)
+	require.Equal(t, fasthttp.StatusOK, rotateCtx.Response.StatusCode())
+	newSecret := decodeJSONResponse(t, rotateCtx)["secret"].(string)
+	assert.Contains(t, newSecret, "whsec_")
+	assert.NotEqual(t, originalSecret, newSecret)
+
+	// Deliveries sign with the new secret from this moment on.
+	inMemory, ok := config.WebhookEndpointByID(id)
+	require.True(t, ok)
+	assert.Equal(t, newSecret, inMemory.Secret.GetValue())
+
+	missingCtx := newWebhookRequestCtx("", map[string]string{"id": "does-not-exist"})
+	handler.rotateWebhookEndpointSecret(missingCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
+}
+
+func seedWebhookDelivery(t *testing.T, config *lib.Config, id, webhookID, endpointID string, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, config.LogsStore.CreateWebhookDelivery(context.Background(), &logstore.WebhookDelivery{
+		ID: id, WebhookID: webhookID, EndpointID: endpointID, AsyncJobID: "job-1",
+		Event: configstoreTables.WebhookEventAsyncJobCompleted, AttemptNo: 1,
+		Outcome: logstore.WebhookDeliveryOutcomeExhausted, StatusCode: 503,
+		CreatedAt: createdAt,
+	}))
+}
+
+func TestWebhookHandlerListDeliveries(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+	id, _ := createTestWebhookEndpoint(t, handler, "deliveries-test")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	seedWebhookDelivery(t, config, "d1", "wh1", id, now.Add(-time.Minute))
+	seedWebhookDelivery(t, config, "d2", "wh2", id, now)
+
+	listCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	listCtx.QueryArgs().Set("limit", "1")
+	handler.listWebhookDeliveries(listCtx)
+	require.Equal(t, fasthttp.StatusOK, listCtx.Response.StatusCode())
+	payload := decodeJSONResponse(t, listCtx)
+	deliveries := payload["deliveries"].([]any)
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, "d2", deliveries[0].(map[string]any)["id"], "newest first")
+	assert.Equal(t, float64(2), payload["pagination"].(map[string]any)["total_count"])
+
+	badCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	badCtx.QueryArgs().Set("limit", "not-a-number")
+	handler.listWebhookDeliveries(badCtx)
+	assert.Equal(t, fasthttp.StatusBadRequest, badCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerRedeliver(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+	id, _ := createTestWebhookEndpoint(t, handler, "redeliver-test")
+	seedWebhookDelivery(t, config, "d1", "wh1", id, time.Now().UTC())
+
+	redeliverCtx := newWebhookRequestCtx("", map[string]string{"id": "d1"})
+	handler.redeliverWebhook(redeliverCtx)
+	require.Equal(t, fasthttp.StatusAccepted, redeliverCtx.Response.StatusCode(), "body: %s", redeliverCtx.Response.Body())
+	assert.Equal(t, "wh1", decodeJSONResponse(t, redeliverCtx)["webhook_id"])
+
+	// The replay reuses the original webhook id, so the queue row exists
+	// under it and a second redelivery conflicts while it is in flight.
+	due, err := config.ConfigStore.ListDueWebhookJobs(context.Background(), 0)
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, "wh1", due[0].ID)
+
+	conflictCtx := newWebhookRequestCtx("", map[string]string{"id": "d1"})
+	handler.redeliverWebhook(conflictCtx)
+	assert.Equal(t, fasthttp.StatusConflict, conflictCtx.Response.StatusCode())
+
+	missingCtx := newWebhookRequestCtx("", map[string]string{"id": "unknown-delivery"})
+	handler.redeliverWebhook(missingCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
+
+	// History whose endpoint has since been deleted cannot be redelivered.
+	seedWebhookDelivery(t, config, "d-orphan", "wh-orphan", "ep-gone", time.Now().UTC())
+	orphanCtx := newWebhookRequestCtx("", map[string]string{"id": "d-orphan"})
+	handler.redeliverWebhook(orphanCtx)
+	assert.Equal(t, fasthttp.StatusBadRequest, orphanCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerTestDelivery(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+
+	var received http.Header
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received = r.Header.Clone()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+
+	// Loopback receivers require the private-network opt-in.
+	body := fmt.Sprintf(`{"name":"test-fire","url":%q,"events":["async_job.completed"],"allow_private_network":true}`, receiver.URL)
+	createCtx := newWebhookRequestCtx(body, nil)
+	handler.createWebhookEndpoint(createCtx)
+	require.Equal(t, fasthttp.StatusCreated, createCtx.Response.StatusCode(), "body: %s", createCtx.Response.Body())
+	id := decodeJSONResponse(t, createCtx)["endpoint"].(map[string]any)["id"].(string)
+
+	testCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.testWebhookEndpoint(testCtx)
+	require.Equal(t, fasthttp.StatusOK, testCtx.Response.StatusCode())
+	payload := decodeJSONResponse(t, testCtx)
+	assert.Equal(t, true, payload["delivered"])
+	assert.Equal(t, float64(http.StatusNoContent), payload["receiver_status_code"])
+	assert.NotEmpty(t, received.Get("webhook-signature"), "test deliveries go through the signing path")
+
+	// Test fires are not rate limited, so an immediate second fire is delivered
+	// just like the first.
+	repeatCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.testWebhookEndpoint(repeatCtx)
+	require.Equal(t, fasthttp.StatusOK, repeatCtx.Response.StatusCode(), "body: %s", repeatCtx.Response.Body())
+	assert.Equal(t, true, decodeJSONResponse(t, repeatCtx)["delivered"])
+
+	missingCtx := newWebhookRequestCtx("", map[string]string{"id": "does-not-exist"})
+	handler.testWebhookEndpoint(missingCtx)
+	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
+
+	_ = config
+}
+
+func TestWebhookHandlerStoreUnavailable(t *testing.T) {
+	cfg := &lib.Config{}
+	handler := NewWebhookHandler(configWebhookManager{cfg}, cfg, nil)
+	ctx := newWebhookRequestCtx("", nil)
+	handler.listWebhookEndpoints(ctx)
+	assert.Equal(t, fasthttp.StatusServiceUnavailable, ctx.Response.StatusCode())
+}
+
+func TestWebhookHandlerPerEndpointTuning(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+
+	body := `{"name":"tuned","url":"https://93.184.216.34/hook","events":["async_job.completed"],"max_retries":2,"attempt_timeout_seconds":5,"max_concurrent_deliveries":3}`
+	createCtx := newWebhookRequestCtx(body, nil)
+	handler.createWebhookEndpoint(createCtx)
+	require.Equal(t, fasthttp.StatusCreated, createCtx.Response.StatusCode(), "body: %s", createCtx.Response.Body())
+	endpoint := decodeJSONResponse(t, createCtx)["endpoint"].(map[string]any)
+	assert.Equal(t, float64(2), endpoint["max_retries"])
+	assert.Equal(t, float64(5), endpoint["attempt_timeout_seconds"])
+
+	// The in-memory store carries the knobs for the delivery worker.
+	inMemory, ok := config.WebhookEndpointByName("tuned")
+	require.True(t, ok)
+	assert.Equal(t, 2, inMemory.MaxRetries)
+	assert.Equal(t, 5, inMemory.AttemptTimeoutSeconds)
+	assert.Equal(t, 3, inMemory.MaxConcurrentDeliveries)
+
+	// Negative knobs are rejected.
+	badCtx := newWebhookRequestCtx(`{"name":"bad","url":"https://93.184.216.34/hook","events":["async_job.completed"],"max_retries":-1}`, nil)
+	handler.createWebhookEndpoint(badCtx)
+	assert.Equal(t, fasthttp.StatusBadRequest, badCtx.Response.StatusCode())
+}
+
+func TestWebhookHandlerHeaders(t *testing.T) {
+	handler, config := newWebhookTestHandler(t)
+
+	body := `{"name":"headers-test","url":"https://93.184.216.34/hook","events":["async_job.completed"],"headers":{"Authorization":"Bearer receiver-token"}}`
+	createCtx := newWebhookRequestCtx(body, nil)
+	handler.createWebhookEndpoint(createCtx)
+	require.Equal(t, fasthttp.StatusCreated, createCtx.Response.StatusCode(), "body: %s", createCtx.Response.Body())
+	id := decodeJSONResponse(t, createCtx)["endpoint"].(map[string]any)["id"].(string)
+	assert.NotContains(t, string(createCtx.Response.Body()), "receiver-token", "header values are never echoed")
+
+	// Reads mask header values but keep the names visible.
+	getCtx := newWebhookRequestCtx("", map[string]string{"id": id})
+	handler.getWebhookEndpoint(getCtx)
+	require.Equal(t, fasthttp.StatusOK, getCtx.Response.StatusCode())
+	assert.Contains(t, string(getCtx.Response.Body()), "Authorization")
+	assert.NotContains(t, string(getCtx.Response.Body()), "receiver-token")
+
+	// The in-memory store (what the delivery worker reads) keeps real values.
+	inMemory, ok := config.WebhookEndpointByID(id)
+	require.True(t, ok)
+	authHeader := inMemory.Headers["Authorization"]
+	assert.Equal(t, "Bearer receiver-token", authHeader.GetValue())
+
+	// A masked value round-tripped through an update must not clobber the
+	// stored value.
+	updateBody := `{"name":"headers-test","url":"https://93.184.216.34/hook","events":["async_job.completed"],"headers":{"Authorization":"<REDACTED>"}}`
+	updateCtx := newWebhookRequestCtx(updateBody, map[string]string{"id": id})
+	handler.updateWebhookEndpoint(updateCtx)
+	require.Equal(t, fasthttp.StatusOK, updateCtx.Response.StatusCode(), "body: %s", updateCtx.Response.Body())
+	inMemory, ok = config.WebhookEndpointByID(id)
+	require.True(t, ok)
+	authHeader = inMemory.Headers["Authorization"]
+	assert.Equal(t, "Bearer receiver-token", authHeader.GetValue(), "masked placeholders must restore the stored value")
+
+	// Reserved header names are rejected.
+	reservedCtx := newWebhookRequestCtx(`{"name":"h2","url":"https://93.184.216.34/hook","events":["async_job.completed"],"headers":{"webhook-signature":"x"}}`, nil)
+	handler.createWebhookEndpoint(reservedCtx)
+	assert.Equal(t, fasthttp.StatusBadRequest, reservedCtx.Response.StatusCode())
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -170,6 +170,7 @@ type ConfigData struct {
 	Providers         map[string]configstore.ProviderConfig `json:"providers"`
 	FrameworkConfig   *framework.FrameworkConfig            `json:"framework,omitempty"`
 	MCP               *schemas.MCPConfig                    `json:"mcp,omitempty"`
+	Webhooks          []*WebhookEndpointConfig              `json:"webhooks,omitempty"`
 	Governance        *configstore.GovernanceConfig         `json:"governance,omitempty"`
 	VectorStoreConfig *vectorstore.Config                   `json:"vector_store,omitempty"`
 	ConfigStoreConfig *configstore.Config                   `json:"config_store,omitempty"`
@@ -267,6 +268,50 @@ func (v *FeatureFlagFileValue) UnmarshalJSON(data []byte) error {
 		v.Enabled = false
 	}
 	return nil
+}
+
+// WebhookEndpointConfig declares one webhook endpoint in config.json.
+// The secret is optional and best supplied as an env reference; when absent
+// one is generated at creation time. The tuning knobs are optional; zero
+// means "use the delivery worker's default".
+type WebhookEndpointConfig struct {
+	ID                  string                           `json:"id,omitempty"`
+	Name                string                           `json:"name"`
+	URL                 string                           `json:"url"`
+	Secret              *schemas.SecretVar               `json:"secret,omitempty"`
+	Events              []configstoreTables.WebhookEvent `json:"events"`
+	Headers             map[string]schemas.SecretVar     `json:"headers,omitempty"`
+	IncludeResponse     bool                             `json:"include_response,omitempty"`
+	AllowPrivateNetwork bool                             `json:"allow_private_network,omitempty"`
+	Disabled            bool                             `json:"disabled,omitempty"`
+
+	MaxRetries                 int `json:"max_retries,omitempty"`
+	RetryBackoffInitialSeconds int `json:"retry_backoff_initial_seconds,omitempty"`
+	RetryBackoffMaxSeconds     int `json:"retry_backoff_max_seconds,omitempty"`
+	AttemptTimeoutSeconds      int `json:"attempt_timeout_seconds,omitempty"`
+	MaxResponsePayloadKBs      int `json:"max_response_payload_kbs,omitempty"`
+	MaxConcurrentDeliveries    int `json:"max_concurrent_deliveries,omitempty"`
+}
+
+// toTable converts a file declaration into the table model.
+func (w *WebhookEndpointConfig) toTable() *configstoreTables.TableWebhookEndpoint {
+	return &configstoreTables.TableWebhookEndpoint{
+		ID:                         w.ID,
+		Name:                       w.Name,
+		URL:                        w.URL,
+		Secret:                     w.Secret,
+		Events:                     w.Events,
+		Headers:                    w.Headers,
+		IncludeResponse:            w.IncludeResponse,
+		AllowPrivateNetwork:        w.AllowPrivateNetwork,
+		Disabled:                   w.Disabled,
+		MaxRetries:                 w.MaxRetries,
+		RetryBackoffInitialSeconds: w.RetryBackoffInitialSeconds,
+		RetryBackoffMaxSeconds:     w.RetryBackoffMaxSeconds,
+		AttemptTimeoutSeconds:      w.AttemptTimeoutSeconds,
+		MaxResponsePayloadKBs:      w.MaxResponsePayloadKBs,
+		MaxConcurrentDeliveries:    w.MaxConcurrentDeliveries,
+	}
 }
 
 // normalizeSourceOfTruth returns the configured source-of-truth mode, defaulting to split.
@@ -382,6 +427,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
 		Providers         map[string]configstore.ProviderConfig `json:"providers"`
 		MCP               *schemas.MCPConfig                    `json:"mcp,omitempty"`
+		Webhooks          []*WebhookEndpointConfig              `json:"webhooks,omitempty"`
 		Governance        *configstore.GovernanceConfig         `json:"governance,omitempty"`
 		VectorStoreConfig json.RawMessage                       `json:"vector_store,omitempty"`
 		ConfigStoreConfig json.RawMessage                       `json:"config_store,omitempty"`
@@ -407,6 +453,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	cd.AuthConfig = temp.AuthConfig
 	cd.Providers = temp.Providers
 	cd.MCP = temp.MCP
+	cd.Webhooks = temp.Webhooks
 	cd.Governance = temp.Governance
 	cd.Plugins = temp.Plugins
 	cd.WebSocket = temp.WebSocket
@@ -477,9 +524,10 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 //   - Support for provider-specific key configurations (Azure, Vertex, Bedrock)
 //   - Lock-free plugin reads via atomic.Pointer for minimal hot-path latency
 type Config struct {
-	Mu     sync.RWMutex // Exported for direct access from handlers (governance plugin)
-	muMCP  sync.RWMutex
-	client *bifrost.Bifrost
+	Mu         sync.RWMutex // Exported for direct access from handlers (governance plugin)
+	muMCP      sync.RWMutex
+	muWebhooks sync.RWMutex
+	client     *bifrost.Bifrost
 
 	configPath string
 
@@ -508,6 +556,14 @@ type Config struct {
 	GovernanceConfig *configstore.GovernanceConfig
 	FrameworkConfig  *framework.FrameworkConfig
 	ProxyConfig      *configstoreTables.GlobalProxyConfig
+
+	// webhookEndpoints serves webhook endpoint config to the request path and
+	// the delivery worker without database reads. Guarded by muWebhooks;
+	// handlers mutate it in lockstep with every database write. Operational
+	// counters are deliberately not mirrored here — reads that need them go
+	// to the store.
+	webhookEndpoints       map[string]*configstoreTables.TableWebhookEndpoint // keyed by ID
+	webhookEndpointsByName map[string]string                                  // unique name -> ID
 
 	// Plugin Storage (SINGLE SOURCE OF TRUTH)
 	// All plugins are stored in BasePlugins. Interface-specific caches are
@@ -890,19 +946,21 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	}
 	// 6. MCP config
 	loadMCPConfig(ctx, config, &configData)
-	// 7. Governance config
+	// 7. Webhook endpoints
+	loadWebhooksConfig(ctx, config, &configData)
+	// 8. Governance config
 	loadGovernanceConfig(ctx, config, &configData)
-	// 8. Auth config
+	// 9. Auth config
 	loadAuthConfig(ctx, config, &configData)
-	// 9. Plugins
+	// 10. Plugins
 	loadPlugins(ctx, config, &configData)
-	// 10. Skills registry (after plugins, before framework)
+	// 11. Skills registry (after plugins, before framework)
 	loadSkillsRegistry(ctx, config, &configData)
-	// 11. Framework config and pricing manager
+	// 12. Framework config and pricing manager
 	initFrameworkConfig(ctx, config, &configData)
-	// 12. Encryption sync
+	// 13. Encryption sync
 	syncEncryption(ctx, config)
-	// 12. Env label (config.json takes precedence over BIFROST_ENV_LABEL env var)
+	// 14. Env label (config.json takes precedence over BIFROST_ENV_LABEL env var)
 	truncateLabel := func(s string) string {
 		r := []rune(s)
 		if len(r) > 14 {
@@ -915,7 +973,7 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	} else if label := strings.TrimSpace(os.Getenv("BIFROST_ENV_LABEL")); label != "" {
 		config.EnvLabel = truncateLabel(label)
 	}
-	// 13. WebSocket defaults
+	// 15. WebSocket defaults
 	if configData.WebSocket != nil {
 		configData.WebSocket.CheckAndSetDefaults()
 		config.WebSocketConfig = configData.WebSocket
@@ -924,7 +982,7 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 		wsConfig.CheckAndSetDefaults()
 		config.WebSocketConfig = wsConfig
 	}
-	// 13. Server config
+	// 16. Server config
 	if configData.Server != nil {
 		config.ServerConfig = configData.Server
 	} else {
@@ -1953,6 +2011,162 @@ func syncMCPConfigFromFile(ctx context.Context, config *Config, configData *Conf
 		}
 	}
 	config.MCPConfig = fileMCPConfig
+}
+
+// loadWebhooksConfig loads webhook endpoints into memory and reconciles
+// config.json declarations against the database, mirroring the MCP config
+// flow: declarations are validated with a warn-and-skip policy, matched
+// against database rows by name using the config hash for change detection,
+// and pruned only when config.json is the source of truth and the section is
+// physically present.
+func loadWebhooksConfig(ctx context.Context, config *Config, configData *ConfigData) {
+	fileEndpoints := make([]*configstoreTables.TableWebhookEndpoint, 0)
+	// Every declared name, valid or not: an entry that fails validation must
+	// still protect its existing database row from the source-of-truth prune —
+	// a typo in one field must never delete a working endpoint.
+	declaredNames := make(map[string]bool)
+	if configData.Webhooks != nil {
+		for _, declared := range configData.Webhooks {
+			if declared == nil {
+				continue
+			}
+			if declared.Name != "" {
+				declaredNames[declared.Name] = true
+			}
+			endpoint := declared.toTable()
+			if err := endpoint.Validate(); err != nil {
+				logger.Warn("skipping webhook endpoint %q from config file: %v", declared.Name, err)
+				continue
+			}
+			fileEndpoints = append(fileEndpoints, endpoint)
+		}
+	}
+
+	if config.ConfigStore == nil {
+		if len(fileEndpoints) > 0 {
+			logger.Warn("config store is disabled - webhook endpoints from config file will not be available")
+		}
+		return
+	}
+
+	existing, err := config.ConfigStore.GetWebhookEndpoints(ctx)
+	if err != nil {
+		logger.Warn("failed to load webhook endpoints: %v", err)
+		return
+	}
+
+	if configData.isConfigJSONSourceOfTruth() && configData.sectionPresent("webhooks") {
+		syncWebhookEndpointsFromFile(ctx, config, fileEndpoints, declaredNames, existing)
+	} else {
+		mergeWebhookEndpoints(ctx, config, fileEndpoints, existing)
+	}
+
+	// Memory serves the final database state, whichever path produced it.
+	final, err := config.ConfigStore.GetWebhookEndpoints(ctx)
+	if err != nil {
+		logger.Warn("failed to reload webhook endpoints: %v", err)
+		return
+	}
+	config.replaceWebhookEndpoints(final)
+}
+
+// mergeWebhookEndpoints reconciles file declarations additively: new names
+// are created, changed ones (by config hash) are updated, and database
+// endpoints absent from the file are left alone. Best-effort with per-item
+// warnings, matching the other config-section loaders.
+func mergeWebhookEndpoints(ctx context.Context, config *Config, fileEndpoints []*configstoreTables.TableWebhookEndpoint, existing []configstoreTables.TableWebhookEndpoint) {
+	existingByName := make(map[string]*configstoreTables.TableWebhookEndpoint, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+	}
+	for _, endpoint := range fileEndpoints {
+		fileHash, err := configstore.GenerateWebhookEndpointHash(endpoint)
+		if err != nil {
+			logger.Warn("failed to hash webhook endpoint %q: %v", endpoint.Name, err)
+			continue
+		}
+		endpoint.ConfigHash = fileHash
+		if match, ok := existingByName[endpoint.Name]; ok {
+			if match.ConfigHash == fileHash {
+				continue
+			}
+			endpoint.ID = match.ID
+			if err := config.ConfigStore.UpdateWebhookEndpoint(ctx, endpoint); err != nil {
+				logger.Warn("failed to update webhook endpoint %q: %v", endpoint.Name, err)
+			}
+			continue
+		}
+		if endpoint.ID == "" {
+			endpoint.ID = uuid.NewString()
+		}
+		if err := config.ConfigStore.CreateWebhookEndpoint(ctx, endpoint); err != nil {
+			logger.Warn("failed to create webhook endpoint %q: %v", endpoint.Name, err)
+		}
+	}
+}
+
+// syncWebhookEndpointsFromFile makes the database mirror the config file:
+// declarations are created or updated as in the merge path, and database
+// endpoints not present in the file are deleted. Best-effort, non-
+// transactional — each step warns and continues, and a later load converges.
+// The prune fails safe: a row is only deleted when its name appears in
+// NEITHER the applied set nor the declared set, so a declaration that failed
+// validation or hashing keeps its existing endpoint instead of removing it.
+func syncWebhookEndpointsFromFile(ctx context.Context, config *Config, fileEndpoints []*configstoreTables.TableWebhookEndpoint, declaredNames map[string]bool, existing []configstoreTables.TableWebhookEndpoint) {
+	existingByName := make(map[string]*configstoreTables.TableWebhookEndpoint, len(existing))
+	existingByID := make(map[string]*configstoreTables.TableWebhookEndpoint, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+		existingByID[existing[i].ID] = &existing[i]
+	}
+
+	keepIDs := make(map[string]bool, len(fileEndpoints))
+	for _, endpoint := range fileEndpoints {
+		// Resolve the match before anything that can fail, so failures keep
+		// the existing row rather than exposing it to the prune below.
+		match := existingByName[endpoint.Name]
+		if match == nil && endpoint.ID != "" {
+			match = existingByID[endpoint.ID]
+		}
+		if match != nil {
+			keepIDs[match.ID] = true
+		}
+
+		fileHash, err := configstore.GenerateWebhookEndpointHash(endpoint)
+		if err != nil {
+			logger.Warn("failed to hash webhook endpoint %q: %v", endpoint.Name, err)
+			continue
+		}
+		endpoint.ConfigHash = fileHash
+
+		if match != nil {
+			if match.ConfigHash == fileHash {
+				continue
+			}
+			endpoint.ID = match.ID
+			if err := config.ConfigStore.UpdateWebhookEndpoint(ctx, endpoint); err != nil {
+				logger.Warn("failed to update webhook endpoint %q: %v", endpoint.Name, err)
+			}
+			continue
+		}
+		if endpoint.ID == "" {
+			endpoint.ID = uuid.NewString()
+		}
+		if err := config.ConfigStore.CreateWebhookEndpoint(ctx, endpoint); err != nil {
+			logger.Warn("failed to create webhook endpoint %q: %v", endpoint.Name, err)
+			continue
+		}
+		keepIDs[endpoint.ID] = true
+	}
+
+	for i := range existing {
+		if keepIDs[existing[i].ID] || declaredNames[existing[i].Name] {
+			continue
+		}
+		if err := config.ConfigStore.DeleteWebhookEndpoint(ctx, existing[i].ID); err != nil {
+			logger.Warn("failed to delete webhook endpoint %q: %v", existing[i].Name, err)
+		}
+	}
 }
 
 // loadGovernanceConfig loads and merges governance config from file
@@ -6066,6 +6280,83 @@ func (c *Config) GetOAuth2SigningKey(ctx context.Context) (*configstoreTables.OA
 	}
 	c.oauth2SigningKey.Store(k)
 	return k, nil
+}
+
+// Webhook endpoint config is served from memory on the submit path and by the
+// delivery worker, so neither performs a database read. Handlers keep it in
+// lockstep with every database write.
+
+// WebhookEndpointByID returns the endpoint for id, or false when it does not
+// exist. Callers must treat the returned endpoint as read-only.
+func (c *Config) WebhookEndpointByID(id string) (*configstoreTables.TableWebhookEndpoint, bool) {
+	c.muWebhooks.RLock()
+	defer c.muWebhooks.RUnlock()
+	endpoint, ok := c.webhookEndpoints[id]
+	return endpoint, ok
+}
+
+// WebhookEndpointByName returns the endpoint with the given unique name, or
+// false when it does not exist. Callers must treat the returned endpoint as
+// read-only.
+func (c *Config) WebhookEndpointByName(name string) (*configstoreTables.TableWebhookEndpoint, bool) {
+	c.muWebhooks.RLock()
+	defer c.muWebhooks.RUnlock()
+	id, ok := c.webhookEndpointsByName[name]
+	if !ok {
+		return nil, false
+	}
+	endpoint, ok := c.webhookEndpoints[id]
+	return endpoint, ok
+}
+
+// SetWebhookEndpoint upserts an endpoint in the in-memory store, replacing
+// any previous entry with the same ID (including a stale name-index entry
+// after a rename). Called by handlers right after a successful database
+// write, and by the config load.
+func (c *Config) SetWebhookEndpoint(endpoint *configstoreTables.TableWebhookEndpoint) {
+	if endpoint == nil || endpoint.ID == "" {
+		return
+	}
+	copied := *endpoint
+	c.muWebhooks.Lock()
+	defer c.muWebhooks.Unlock()
+	if c.webhookEndpoints == nil {
+		c.webhookEndpoints = make(map[string]*configstoreTables.TableWebhookEndpoint)
+		c.webhookEndpointsByName = make(map[string]string)
+	}
+	if previous, ok := c.webhookEndpoints[copied.ID]; ok && previous.Name != copied.Name {
+		delete(c.webhookEndpointsByName, previous.Name)
+	}
+	c.webhookEndpoints[copied.ID] = &copied
+	c.webhookEndpointsByName[copied.Name] = copied.ID
+}
+
+// RemoveWebhookEndpoint deletes an endpoint from the in-memory store. Called
+// by handlers right after a successful database delete.
+func (c *Config) RemoveWebhookEndpoint(id string) {
+	c.muWebhooks.Lock()
+	defer c.muWebhooks.Unlock()
+	endpoint, ok := c.webhookEndpoints[id]
+	if !ok {
+		return
+	}
+	delete(c.webhookEndpointsByName, endpoint.Name)
+	delete(c.webhookEndpoints, id)
+}
+
+// replaceWebhookEndpoints swaps the whole in-memory store for the given rows.
+func (c *Config) replaceWebhookEndpoints(endpoints []configstoreTables.TableWebhookEndpoint) {
+	byID := make(map[string]*configstoreTables.TableWebhookEndpoint, len(endpoints))
+	byName := make(map[string]string, len(endpoints))
+	for i := range endpoints {
+		endpoint := endpoints[i]
+		byID[endpoint.ID] = &endpoint
+		byName[endpoint.Name] = endpoint.ID
+	}
+	c.muWebhooks.Lock()
+	defer c.muWebhooks.Unlock()
+	c.webhookEndpoints = byID
+	c.webhookEndpointsByName = byName
 }
 
 // autoDetectProviders automatically detects common environment variables and sets up providers

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -370,6 +370,7 @@ import (
 	"github.com/maximhq/bifrost/framework"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -377,6 +378,7 @@ import (
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	otelPlugin "github.com/maximhq/bifrost/plugins/otel"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -1628,10 +1630,6 @@ func (m *MockConfigStore) RecordWebhookEndpointSuccess(ctx context.Context, id s
 
 func (m *MockConfigStore) RecordWebhookEndpointFailure(ctx context.Context, id string) (int, error) {
 	return 0, nil
-}
-
-func (m *MockConfigStore) DisableWebhookEndpoint(ctx context.Context, id string) error {
-	return nil
 }
 
 func (m *MockConfigStore) CreateWebhookJob(ctx context.Context, job *tables.TableWebhookJob) error {
@@ -17111,6 +17109,10 @@ func getSchemaTypeMappings() []schemaTypeMapping {
 		{"mcp.client_configs.stdio_config", reflect.TypeOf(schemas.MCPStdioConfig{}), false},
 		{"mcp.tool_manager_config", reflect.TypeOf(schemas.MCPToolManagerConfig{}), false},
 
+		// Webhooks config
+		{"webhooks", reflect.TypeOf(WebhookEndpointConfig{}), true},
+		{"client.webhook_config", reflect.TypeOf(tables.WebhookConfig{}), false},
+
 		// Governance config
 		{"governance", reflect.TypeOf(configstore.GovernanceConfig{}), false},
 		{"governance.budgets", reflect.TypeOf(tables.TableBudget{}), true},
@@ -19983,4 +19985,188 @@ func TestLoadPlugins_OtelPluginSpanFilterPassthrough(t *testing.T) {
 	plugins, ok := filterMap["plugins"].([]any)
 	require.True(t, ok, "plugin_span_filter.plugins should be an array")
 	require.ElementsMatch(t, []any{"logging", "compat"}, plugins)
+}
+
+func testMemoryEndpoint(id, name string) *configstoreTables.TableWebhookEndpoint {
+	return &configstoreTables.TableWebhookEndpoint{
+		ID:     id,
+		Name:   name,
+		URL:    "https://93.184.216.34/hook",
+		Events: []configstoreTables.WebhookEvent{configstoreTables.WebhookEventAsyncJobCompleted},
+	}
+}
+
+func TestWebhookEndpointMemoryStore(t *testing.T) {
+	config := &Config{}
+
+	// Empty store misses cleanly.
+	_, ok := config.WebhookEndpointByID("ep-1")
+	assert.False(t, ok)
+
+	config.SetWebhookEndpoint(testMemoryEndpoint("ep-1", "first"))
+	byID, ok := config.WebhookEndpointByID("ep-1")
+	require.True(t, ok)
+	assert.Equal(t, "first", byID.Name)
+	byName, ok := config.WebhookEndpointByName("first")
+	require.True(t, ok)
+	assert.Equal(t, "ep-1", byName.ID)
+
+	// A rename evicts the stale name-index entry.
+	config.SetWebhookEndpoint(testMemoryEndpoint("ep-1", "renamed"))
+	_, ok = config.WebhookEndpointByName("first")
+	assert.False(t, ok)
+	_, ok = config.WebhookEndpointByName("renamed")
+	assert.True(t, ok)
+
+	// Mutating the caller's struct after Set must not affect the store.
+	external := testMemoryEndpoint("ep-2", "second")
+	config.SetWebhookEndpoint(external)
+	external.Name = "mutated"
+	stored, ok := config.WebhookEndpointByID("ep-2")
+	require.True(t, ok)
+	assert.Equal(t, "second", stored.Name)
+
+	config.RemoveWebhookEndpoint("ep-1")
+	_, ok = config.WebhookEndpointByID("ep-1")
+	assert.False(t, ok)
+	_, ok = config.WebhookEndpointByName("renamed")
+	assert.False(t, ok)
+
+	config.replaceWebhookEndpoints([]configstoreTables.TableWebhookEndpoint{*testMemoryEndpoint("ep-3", "third")})
+	_, ok = config.WebhookEndpointByID("ep-2")
+	assert.False(t, ok, "replace swaps the whole store")
+	_, ok = config.WebhookEndpointByName("third")
+	assert.True(t, ok)
+}
+
+// parseConfigData round-trips raw config JSON through ConfigData.UnmarshalJSON
+// so section-presence tracking behaves exactly as it does for a real file.
+func parseConfigData(t *testing.T, raw string) *ConfigData {
+	t.Helper()
+	var configData ConfigData
+	require.NoError(t, json.Unmarshal([]byte(raw), &configData))
+	return &configData
+}
+
+func webhookNamesInStore(t *testing.T, store configstore.ConfigStore) map[string]string {
+	t.Helper()
+	endpoints, err := store.GetWebhookEndpoints(context.Background())
+	require.NoError(t, err)
+	names := make(map[string]string, len(endpoints))
+	for _, endpoint := range endpoints {
+		names[endpoint.Name] = endpoint.URL
+	}
+	return names
+}
+
+func TestLoadWebhooksConfigMerge(t *testing.T) {
+	initTestLogger()
+	store := createTestSQLiteConfigStore(t, t.TempDir())
+	config := &Config{ConfigStore: store}
+
+	// One valid declaration, one invalid (skipped with a warning).
+	configData := parseConfigData(t, `{
+		"webhooks": [
+			{"name": "from-file", "url": "https://93.184.216.34/hook", "events": ["async_job.completed"]},
+			{"name": "broken", "url": "http://93.184.216.34/hook", "events": ["async_job.completed"]}
+		]
+	}`)
+	loadWebhooksConfig(context.Background(), config, configData)
+
+	names := webhookNamesInStore(t, store)
+	require.Len(t, names, 1)
+	assert.Contains(t, names, "from-file")
+
+	// Memory serves the synced endpoint.
+	endpoint, ok := config.WebhookEndpointByName("from-file")
+	require.True(t, ok)
+	require.NotNil(t, endpoint.Secret, "a signing secret is generated at creation")
+
+	// An endpoint created outside the file survives a merge reload.
+	uiEndpoint := testMemoryEndpoint("", "from-ui")
+	require.NoError(t, store.CreateWebhookEndpoint(context.Background(), uiEndpoint))
+
+	// A changed URL in the file updates the existing row instead of duplicating.
+	configData = parseConfigData(t, `{
+		"webhooks": [
+			{"name": "from-file", "url": "https://93.184.216.34/hook2", "events": ["async_job.completed"]}
+		]
+	}`)
+	loadWebhooksConfig(context.Background(), config, configData)
+
+	names = webhookNamesInStore(t, store)
+	require.Len(t, names, 2)
+	assert.Equal(t, "https://93.184.216.34/hook2", names["from-file"])
+	assert.Contains(t, names, "from-ui")
+
+	// Both are served from memory after the reload.
+	_, ok = config.WebhookEndpointByName("from-ui")
+	assert.True(t, ok)
+}
+
+func TestLoadWebhooksConfigSourceOfTruthPrunes(t *testing.T) {
+	initTestLogger()
+	store := createTestSQLiteConfigStore(t, t.TempDir())
+	config := &Config{ConfigStore: store}
+
+	require.NoError(t, store.CreateWebhookEndpoint(context.Background(), testMemoryEndpoint("", "db-only")))
+
+	configData := parseConfigData(t, `{
+		"source_of_truth": "config.json",
+		"webhooks": [
+			{"name": "from-file", "url": "https://93.184.216.34/hook", "events": ["async_job.completed"]}
+		]
+	}`)
+	require.True(t, configData.isConfigJSONSourceOfTruth(), "fixture must opt into file-as-source-of-truth")
+	loadWebhooksConfig(context.Background(), config, configData)
+
+	names := webhookNamesInStore(t, store)
+	require.Len(t, names, 1)
+	assert.Contains(t, names, "from-file")
+	_, ok := config.WebhookEndpointByName("db-only")
+	assert.False(t, ok, "rows absent from the file are pruned when it is the source of truth")
+
+	// Re-running with an unchanged file is a no-op (hash match).
+	loadWebhooksConfig(context.Background(), config, configData)
+	assert.Len(t, webhookNamesInStore(t, store), 1)
+}
+
+func TestLoadWebhooksConfigInvalidDeclarationKeepsEndpoint(t *testing.T) {
+	initTestLogger()
+	store := createTestSQLiteConfigStore(t, t.TempDir())
+	config := &Config{ConfigStore: store}
+
+	// A valid endpoint exists in the DB and is re-declared in the file, but
+	// this run's declaration is malformed (bad URL). The source-of-truth
+	// prune must NOT delete the working row over a typo — fail safe.
+	require.NoError(t, store.CreateWebhookEndpoint(context.Background(), testMemoryEndpoint("", "keep-me")))
+
+	configData := parseConfigData(t, `{
+		"source_of_truth": "config.json",
+		"webhooks": [
+			{"name": "keep-me", "url": "not-a-valid-url", "events": ["async_job.completed"]}
+		]
+	}`)
+	require.True(t, configData.isConfigJSONSourceOfTruth())
+	loadWebhooksConfig(context.Background(), config, configData)
+
+	names := webhookNamesInStore(t, store)
+	assert.Contains(t, names, "keep-me", "an invalid declaration must not prune its existing endpoint")
+}
+
+func TestLoadWebhooksConfigWithoutSection(t *testing.T) {
+	initTestLogger()
+	store := createTestSQLiteConfigStore(t, t.TempDir())
+	config := &Config{ConfigStore: store}
+
+	require.NoError(t, store.CreateWebhookEndpoint(context.Background(), testMemoryEndpoint("", "db-only")))
+
+	// Source-of-truth mode without a webhooks section must not prune —
+	// presence of the section is what authorizes it.
+	configData := parseConfigData(t, `{"source_of_truth": "config.json"}`)
+	loadWebhooksConfig(context.Background(), config, configData)
+
+	assert.Len(t, webhookNamesInStore(t, store), 1)
+	_, ok := config.WebhookEndpointByName("db-only")
+	assert.True(t, ok, "database endpoints load into memory even with no file section")
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/maximhq/bifrost/framework/sidekiq"
 	"github.com/maximhq/bifrost/framework/temptoken"
 	"github.com/maximhq/bifrost/framework/tracing"
+	"github.com/maximhq/bifrost/framework/webhooks"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 	"github.com/maximhq/bifrost/plugins/logging"
@@ -110,6 +111,9 @@ type ServerCallbacks interface {
 	OnKeyDeleted(ctx context.Context, provider schemas.ModelProvider, keyID string) error
 	ReloadRoutingRule(ctx context.Context, id string) error
 	RemoveRoutingRule(ctx context.Context, id string) error
+	// Webhook related callbacks
+	ReloadWebhookEndpoint(ctx context.Context, id string) error
+	RemoveWebhookEndpoint(ctx context.Context, id string) error
 	// MCP related callbacks
 	AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	RemoveMCPClient(ctx context.Context, id string) error
@@ -182,6 +186,8 @@ type BifrostHTTPServer struct {
 
 	SidekiqRunner         *sidekiq.Runner
 	SidekiqDispatcherStop func()
+
+	WebhookDispatcher *webhooks.Dispatcher
 
 	wsPool *bfws.Pool
 }
@@ -861,6 +867,25 @@ func (s *BifrostHTTPServer) RemoveRoutingRule(ctx context.Context, id string) er
 	return nil
 }
 
+// ReloadWebhookEndpoint refreshes a single webhook endpoint in the in-memory
+// store from the database after a mutation. A clustered deployment overrides
+// this to also notify peers so their in-memory copies stay current.
+func (s *BifrostHTTPServer) ReloadWebhookEndpoint(ctx context.Context, id string) error {
+	endpoint, err := s.Config.ConfigStore.GetWebhookEndpointByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	s.Config.SetWebhookEndpoint(endpoint)
+	return nil
+}
+
+// RemoveWebhookEndpoint drops a webhook endpoint from the in-memory store after
+// a database delete. A clustered deployment overrides this to also notify peers.
+func (s *BifrostHTTPServer) RemoveWebhookEndpoint(ctx context.Context, id string) error {
+	s.Config.RemoveWebhookEndpoint(id)
+	return nil
+}
+
 // ReloadClientConfigFromConfigStore reloads the client config from config store
 func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Context) error {
 	if s.Config == nil || s.Config.ConfigStore == nil {
@@ -1525,6 +1550,8 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if skillsHandler != nil {
 		skillsHandler.RegisterRoutes(s.Router, middlewares...)
 	}
+	webhookHandler := handlers.NewWebhookHandler(callbacks, s.Config, s.WebhookDispatcher)
+	webhookHandler.RegisterRoutes(s.Router, middlewares...)
 	skillsServingHandler := handlers.NewSkillsServingHandler(s.Config.ConfigStore, s.Config.ObjectStore)
 	if skillsServingHandler != nil {
 		skillsServingHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1768,11 +1795,25 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		return fmt.Errorf("failed to instantiate plugins: %v", err)
 	}
 
+	// Initialize the webhook delivery dispatcher (requires both stores; the
+	// in-memory endpoint store on Config serves endpoint lookups).
+	if s.Config.LogsStore != nil && s.Config.ConfigStore != nil {
+		s.WebhookDispatcher = webhooks.NewDispatcher(ctx, "", s.Config.ClientConfig.WebhookConfig.DeliveryHistoryRetention(), s.Config.ConfigStore, s.Config.LogsStore, s.Config, logger)
+		s.WebhookDispatcher.Start()
+		logger.Info("webhook dispatcher initialized")
+	}
+
 	// Initialize async job executor (requires LogsStore + governance plugin)
 	if s.Config.LogsStore != nil {
 		governancePlugin, govErr := lib.FindPluginAs[governance.BaseGovernancePlugin](s.Config, s.getGovernancePluginName())
 		if govErr == nil {
-			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), nil, logger)
+			// The dispatcher interface value must stay nil when no dispatcher
+			// exists — a typed-nil pointer would defeat the executor's nil check.
+			var jobDispatcher logstore.WebhookDispatcher
+			if s.WebhookDispatcher != nil {
+				jobDispatcher = s.WebhookDispatcher
+			}
+			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), jobDispatcher, logger)
 			logger.Info("async job executor initialized")
 		}
 	}
@@ -2057,6 +2098,10 @@ func (s *BifrostHTTPServer) Start() error {
 			if s.AsyncJobCleaner != nil {
 				logger.Info("stopping async job cleaner...")
 				s.AsyncJobCleaner.StopCleanupRoutine()
+			}
+			if s.WebhookDispatcher != nil {
+				logger.Info("stopping webhook dispatcher...")
+				s.WebhookDispatcher.Stop()
 			}
 			if s.WSTicketStore != nil {
 				logger.Info("stopping ws ticket store...")

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -110,6 +110,19 @@
           "description": "Dump full error details to the server console logs. Useful for debugging; may be noisy in production.",
           "default": false
         },
+        "webhook_config": {
+          "type": "object",
+          "description": "Global webhook delivery settings; per-endpoint tuning lives on each endpoint. Read at server startup.",
+          "properties": {
+            "delivery_history_retention_days": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 30,
+              "description": "How long delivery history records are kept before being reaped."
+            }
+          },
+          "additionalProperties": false
+        },
         "log_retention_days": {
           "type": "integer",
           "minimum": 1,
@@ -1235,6 +1248,115 @@
         }
       },
       "additionalProperties": false
+    },
+    "webhooks": {
+      "type": "array",
+      "description": "Webhook endpoint declarations synced into the database at startup, reconciled by name.",
+      "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable endpoint ID. Generated when omitted."
+              },
+              "name": {
+                "type": "string",
+                "description": "Unique endpoint name."
+              },
+              "url": {
+                "type": "string",
+                "description": "Delivery URL. HTTPS required unless allow_private_network is set; credentials and fragments are rejected; link-local and metadata addresses are always blocked."
+              },
+              "secret": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": { "type": "string" },
+                      "env_var": { "type": "string" },
+                      "from_env": { "type": "boolean" }
+                    },
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Signing secret in the whsec_ format. Best supplied as an env reference (\"env.MY_VAR\"); generated when omitted."
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["async_job.completed", "async_job.failed"]
+                },
+                "description": "Events this endpoint subscribes to."
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "anyOf": [
+                    { "type": "string" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "value": { "type": "string" },
+                        "env_var": { "type": "string" },
+                        "from_env": { "type": "boolean" }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "description": "Custom headers sent with every delivery (e.g. an Authorization value the receiver requires). Values support env var syntax (\"env.MY_VAR\") and are encrypted at rest. Reserved delivery headers (webhook-id, webhook-timestamp, webhook-signature, content-type, etc.) cannot be overridden."
+              },
+              "include_response": {
+                "type": "boolean",
+                "default": false,
+                "description": "Inline the job response into delivery payloads, capped by max_response_payload_kbs."
+              },
+              "allow_private_network": {
+                "type": "boolean",
+                "default": false,
+                "description": "Permit private-network receivers and plain http. Link-local and metadata addresses stay blocked."
+              },
+              "disabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Register the endpoint without delivering to it."
+              },
+              "max_retries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many times a failed delivery is retried after its first attempt (default: 4)."
+              },
+              "retry_backoff_initial_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Delay before the first retry in seconds; each further retry doubles it (default: 30)."
+              },
+              "retry_backoff_max_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Cap on the per-retry delay in seconds (default: 1800)."
+              },
+              "attempt_timeout_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "End-to-end bound for one delivery attempt in seconds (default: 10)."
+              },
+              "max_response_payload_kbs": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Cap for inlined response payloads in KB when include_response is set (default: 256). Oversized responses are omitted and flagged with response_omitted."
+              },
+              "max_concurrent_deliveries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Concurrent in-flight deliveries to this endpoint per node (default: 10)."
+              }
+            },
+            "required": ["name", "url", "events"],
+            "additionalProperties": false
+      }
     },
     "mcp": {
       "type": "object",


### PR DESCRIPTION
## Summary

This PR wires up the webhook admin API and integrates webhook endpoint configuration into the config.json lifecycle. It adds a `WebhookConfig` global settings struct to the client config, a `webhooks` section to config.json for declaring endpoints declaratively, an in-memory endpoint store on `Config` for zero-database-read serving on the hot path, and a full set of admin HTTP handlers for endpoint CRUD, secret rotation, test delivery, delivery history, and redelivery.

## Changes

- Added `WebhookConfig` to `ClientConfig` and `TableClientConfig`, stored as a JSON blob column (`webhook_config_json`) with `BeforeSave`/`AfterFind` serialization. Includes a `DeliveryHistoryRetention()` helper with a 30-day default on a nil receiver.
- Added a database migration (`add_webhook_config_client_column`) to introduce the column.
- Added `GenerateWebhookEndpointHash` for deterministic change detection of endpoint declarations, covering all declared fields (sorted events and headers for stability) while excluding operational counters and generated IDs.
- Added `WebhookEndpointConfig` to `ConfigData` and the `loadWebhooksConfig` startup step, which validates declarations with a warn-and-skip policy and reconciles them against the database using either an additive merge or a full sync depending on whether `source_of_truth: config.json` is set and the `webhooks` section is physically present.
- Added an in-memory webhook endpoint store (`webhookEndpoints`, `webhookEndpointsByName`) on `Config`, guarded by a dedicated `muWebhooks` mutex, with `WebhookEndpointByID`, `WebhookEndpointByName`, `SetWebhookEndpoint`, `RemoveWebhookEndpoint`, and `replaceWebhookEndpoints` methods. Handlers keep it in lockstep with every database write.
- Added `WebhookHandler` with routes for list, get, create, update, delete, rotate-secret, test delivery (with a per-endpoint 10-second cooldown), delivery history pagination, and redelivery. Custom header values are redacted in all API responses; masked placeholders round-tripped through an update are restored from the in-memory store to avoid corrupting stored values.
- Wired `WebhookDispatcher` into `BifrostHTTPServer.Bootstrap`, passing it to the async job executor and stopping it on shutdown. The dispatcher is only initialized when both the config store and logs store are available.
- Extended `config.schema.json` with the `webhooks` array and `client.webhook_config` object schemas.

Notable design decisions:
- The in-memory store deliberately does not mirror operational counters (failure counts, timestamps); list views that need them read the database directly.
- Config hash for `WebhookConfig` is only written when the field is non-nil to avoid hash churn on upgrade for existing deployments.
- Pruning in source-of-truth mode requires the `webhooks` key to be physically present in the file, preventing an absent section from wiping all database endpoints.
- The typed-nil dispatcher problem for the async job executor interface is handled explicitly to avoid a non-nil interface wrapping a nil pointer.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/...
```

- Create a webhook endpoint via `POST /api/webhooks` and verify the secret is returned exactly once.
- Rotate the secret via `POST /api/webhooks/{id}/rotate-secret` and confirm the old secret is no longer used for signing.
- Add a `webhooks` section to config.json and restart; verify the endpoint appears in the database and is served from memory.
- Set `source_of_truth: config.json`, remove an endpoint from the file, and restart; verify the database row is pruned.
- Set `source_of_truth: config.json` without a `webhooks` key; verify existing database endpoints are not pruned.
- Fire a test delivery via `POST /api/webhooks/{id}/test` and confirm the receiver gets a signed request; fire again immediately and confirm a 429 response.
- Seed a failed delivery and redeliver via `POST /api/webhooks/deliveries/{id}/redeliver`; confirm the job appears in the queue under the original webhook ID and a second redeliver returns 409.

New config fields:

| Field | Location | Description |
|---|---|---|
| `client.webhook_config.delivery_history_retention_days` | config.json `client` block | How long delivery history rows are kept (default: 30 days) |
| `webhooks[].max_retries` | config.json `webhooks` array | Per-endpoint retry count (default: 4) |
| `webhooks[].attempt_timeout_seconds` | config.json `webhooks` array | Per-attempt timeout (default: 10s) |
| `webhooks[].max_concurrent_deliveries` | config.json `webhooks` array | Concurrency cap per node (default: 10) |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- Signing secrets are generated server-side and returned exactly once at creation or rotation; they are never included in read responses or list views.
- Custom header values (e.g. `Authorization`) are encrypted at rest and redacted in all API responses; only header names are visible.
- Reserved delivery headers (`webhook-id`, `webhook-timestamp`, `webhook-signature`, `content-type`) cannot be overridden by callers.
- Plain HTTP delivery URLs require explicit `allow_private_network: true`; link-local and metadata addresses are always blocked regardless of that flag.
- The per-endpoint test delivery cooldown (10 seconds) limits abuse of the test endpoint against external receivers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable