### PR TITLE
refactor: resolve async webhook endpoint by name at submit time via `WebhookManager` instead of pre-normalizing to ID in context

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -223,7 +223,6 @@ const (
 	BifrostContextKeyAPIKeyName        BifrostContextKey = "x-bf-api-key"          // string (explicit key name selection)
 	BifrostContextKeyAPIKeyID          BifrostContextKey = "x-bf-api-key-id"       // string (explicit key ID selection, takes priority over name)
 	BifrostContextKeyDirectKey         BifrostContextKey = "x-bf-direct-key"       // schemas.Key (raw key supplied via x-bf-direct-key: true header; bypasses registered key pool)
-	BifrostContextKeyAsyncWebhook      BifrostContextKey = "x-bf-async-webhook"    // string (webhook endpoint to notify when an async job finishes; the submit path validates the caller's id-or-name reference and normalizes this value to the endpoint ID before the job is created)
 	BifrostContextKeyRequestID         BifrostContextKey = "request-id"            // string
 	BifrostContextKeyFallbackRequestID BifrostContextKey = "fallback-request-id"   // string
 
@@ -379,6 +378,7 @@ const (
 	BifrostContextKeyConnectionClosed                    BifrostContextKey = "connection_closed"
 	BifrostContextKeyTempTokenScope                      BifrostContextKey = "bifrost-temp-token-scope"       // string (set by auth middleware when a temp token authorized the request - names the scope from the temptoken registry)
 	BifrostContextKeyTempTokenResourceID                 BifrostContextKey = "bifrost-temp-token-resource-id" // string (set by auth middleware alongside the scope - the resource_id the token is bound to, e.g. an OAuth flow ID for mcp_auth)
+	BifrostContextKeyAsyncWebhookEndpoint                BifrostContextKey = "bifrost-async-webhook-endpoint" // string (webhook endpoint name to notify when an async job finishes - carried as-is from the x-bf-async-webhook header; the submit path resolves and validates it before the job is created)
 )
 
 const (

--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -43,21 +43,30 @@ type WebhookDispatcher interface {
 	EnqueueJobEvent(ctx context.Context, job *AsyncJob)
 }
 
+// WebhookManager resolves registered webhook endpoints so submit-time
+// references can be validated before a job is accepted.
+type WebhookManager interface {
+	WebhookEndpointByName(endpointName string) (*configstoreTables.TableWebhookEndpoint, bool)
+}
+
 // AsyncJobExecutor manages async job creation and background execution.
 type AsyncJobExecutor struct {
 	logstore          LogStore
 	governanceStore   GovernanceStore
-	logger            schemas.Logger
 	webhookDispatcher WebhookDispatcher
+	webhookManager    WebhookManager
+	logger            schemas.Logger
 }
 
 // NewAsyncJobExecutor creates a new AsyncJobExecutor. A nil webhookDispatcher
-// leaves webhook notification disabled.
-func NewAsyncJobExecutor(logstore LogStore, governanceStore GovernanceStore, webhookDispatcher WebhookDispatcher, logger schemas.Logger) *AsyncJobExecutor {
+// leaves webhook notification disabled; a nil webhookManager rejects any
+// submit that references a webhook endpoint.
+func NewAsyncJobExecutor(logstore LogStore, governanceStore GovernanceStore, webhookDispatcher WebhookDispatcher, webhookManager WebhookManager, logger schemas.Logger) *AsyncJobExecutor {
 	return &AsyncJobExecutor{
 		logstore:          logstore,
 		governanceStore:   governanceStore,
 		webhookDispatcher: webhookDispatcher,
+		webhookManager:    webhookManager,
 		logger:            logger,
 	}
 }
@@ -106,15 +115,23 @@ func (e *AsyncJobExecutor) SubmitJob(bifrostCtx *schemas.BifrostContext, resultT
 		virtualKeyID = &vk.ID
 	}
 
+	endpoint, err := e.getWebhookEndpointIfPresent(bifrostCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve webhook endpoint: %w", err)
+	}
+
 	now := time.Now().UTC()
 	job := &AsyncJob{
-		ID:                uuid.New().String(),
-		Status:            schemas.AsyncJobStatusPending,
-		RequestType:       operationType,
-		VirtualKeyID:      virtualKeyID,
-		WebhookEndpointID: getWebhookEndpointIDFromContext(bifrostCtx),
-		ResultTTL:         resultTTL,
-		CreatedAt:         now,
+		ID:           uuid.New().String(),
+		Status:       schemas.AsyncJobStatusPending,
+		RequestType:  operationType,
+		VirtualKeyID: virtualKeyID,
+		ResultTTL:    resultTTL,
+		CreatedAt:    now,
+	}
+
+	if endpoint != nil {
+		job.WebhookEndpointID = &endpoint.ID
 	}
 
 	ctx := context.Background()
@@ -252,6 +269,37 @@ func (e *AsyncJobExecutor) notifyWebhook(ctx context.Context, job *AsyncJob, sta
 	e.webhookDispatcher.EnqueueJobEvent(ctx, &notified)
 }
 
+// getWebhookEndpointIfPresent resolves the webhook endpoint name the caller
+// attached to the request context, if any. A reference that does not resolve
+// to an existing, enabled endpoint is an error: accepting the job anyway
+// would silently drop the notification the caller asked for.
+func (e *AsyncJobExecutor) getWebhookEndpointIfPresent(ctx *schemas.BifrostContext) (*configstoreTables.TableWebhookEndpoint, error) {
+	if ctx == nil {
+		return nil, nil
+	}
+	webhookEndpointName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyAsyncWebhookEndpoint)
+	if webhookEndpointName == "" {
+		return nil, nil
+	}
+	if e.webhookManager == nil {
+		return nil, fmt.Errorf("webhook manager is not available")
+	}
+	// Fail fast when delivery is not wired: without a dispatcher the job would
+	// persist an endpoint reference that notifyWebhook can never act on,
+	// silently dropping the notification the caller asked for.
+	if e.webhookDispatcher == nil {
+		return nil, fmt.Errorf("webhook dispatcher is not available")
+	}
+	endpoint, ok := e.webhookManager.WebhookEndpointByName(webhookEndpointName)
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown webhook endpoint with name %q", ErrInvalidWebhookReference, webhookEndpointName)
+	}
+	if endpoint.Disabled {
+		return nil, fmt.Errorf("%w: webhook endpoint %q is disabled", ErrInvalidWebhookReference, endpoint.Name)
+	}
+	return endpoint, nil
+}
+
 // --- Cleaner ---
 
 // AsyncJobCleaner manages the cleanup of expired async jobs.
@@ -360,19 +408,4 @@ func getVirtualKeyFromContext(ctx *schemas.BifrostContext) *string {
 		return nil
 	}
 	return &vkValue
-}
-
-// getWebhookEndpointIDFromContext extracts the webhook endpoint to notify
-// when this job reaches a terminal state. Submit entry points validate the
-// caller's endpoint reference and normalize the context value to the
-// endpoint ID before submitting; nil means no webhook was requested.
-func getWebhookEndpointIDFromContext(ctx *schemas.BifrostContext) *string {
-	if ctx == nil {
-		return nil
-	}
-	endpointID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyAsyncWebhook)
-	if endpointID == "" {
-		return nil
-	}
-	return &endpointID
 }

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -51,7 +51,7 @@ func newTestAsyncExecutor(t *testing.T) *AsyncJobExecutor {
 		},
 	}
 
-	return NewAsyncJobExecutor(store, govStore, nil, asyncTestLogger{})
+	return NewAsyncJobExecutor(store, govStore, nil, nil, asyncTestLogger{})
 }
 
 // waitForJobCompletion polls until the operation callback has been invoked.
@@ -260,13 +260,27 @@ func newWebhookTestExecutor(t *testing.T, dispatcher WebhookDispatcher) *AsyncJo
 	}, asyncTestLogger{})
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close(ctx) })
-	return NewAsyncJobExecutor(store, &testGovernanceStore{}, dispatcher, asyncTestLogger{})
+	return NewAsyncJobExecutor(store, &testGovernanceStore{}, dispatcher, testWebhookManager{}, asyncTestLogger{})
+}
+
+// testWebhookManager resolves the single endpoint used by webhook tests.
+type testWebhookManager struct{}
+
+func (testWebhookManager) WebhookEndpointByName(name string) (*configstoreTables.TableWebhookEndpoint, bool) {
+	switch name {
+	case "receiver":
+		return &configstoreTables.TableWebhookEndpoint{ID: "ep-1", Name: "receiver"}, true
+	case "off":
+		return &configstoreTables.TableWebhookEndpoint{ID: "ep-2", Name: "off", Disabled: true}, true
+	default:
+		return nil, false
+	}
 }
 
 func submitWebhookTestJob(t *testing.T, executor *AsyncJobExecutor, operation AsyncOperation) *AsyncJob {
 	t.Helper()
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(schemas.BifrostContextKeyAsyncWebhook, "ep-1")
+	ctx.SetValue(schemas.BifrostContextKeyAsyncWebhookEndpoint, "receiver")
 	job, err := executor.SubmitJob(ctx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
@@ -274,7 +288,9 @@ func submitWebhookTestJob(t *testing.T, executor *AsyncJobExecutor, operation As
 }
 
 func TestSubmitJob_StampsWebhookEndpointID(t *testing.T) {
-	executor := newWebhookTestExecutor(t, nil)
+	// A non-nil dispatcher is required to reach endpoint-name resolution: the
+	// submit path fails fast when delivery is unwired, before stamping.
+	executor := newWebhookTestExecutor(t, &recordingWebhookDispatcher{})
 
 	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
 		return map[string]string{"status": "ok"}, nil
@@ -285,6 +301,26 @@ func TestSubmitJob_StampsWebhookEndpointID(t *testing.T) {
 	stored := waitForJobStatus(t, executor.logstore, job.ID)
 	require.NotNil(t, stored.WebhookEndpointID, "the endpoint reference must be persisted on the job row")
 	assert.Equal(t, "ep-1", *stored.WebhookEndpointID)
+}
+
+func TestSubmitJob_RejectsUnusableWebhookReference(t *testing.T) {
+	// A non-nil dispatcher lets the submit path reach WebhookEndpointByName so
+	// the unknown/disabled reference branches are exercised rather than short-
+	// circuiting on the fail-fast "dispatcher not available" guard.
+	executor := newWebhookTestExecutor(t, &recordingWebhookDispatcher{})
+
+	operation := func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	}
+	for name, reference := range map[string]string{"unknown": "no-such-endpoint", "disabled": "off"} {
+		t.Run(name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyAsyncWebhookEndpoint, reference)
+			job, err := executor.SubmitJob(ctx, 3600, operation, schemas.ChatCompletionRequest)
+			require.Error(t, err)
+			assert.Nil(t, job)
+		})
+	}
 }
 
 func TestSubmitJob_NoWebhookWithoutContextValue(t *testing.T) {

--- a/framework/logstore/errors.go
+++ b/framework/logstore/errors.go
@@ -5,4 +5,7 @@ import "fmt"
 var (
 	ErrNotFound    = fmt.Errorf("log not found")
 	ErrJobInternal = fmt.Errorf("internal job store error")
+	// ErrInvalidWebhookReference marks a submit whose webhook endpoint
+	// reference is unusable — a caller mistake, not a server failure.
+	ErrInvalidWebhookReference = fmt.Errorf("invalid webhook endpoint reference")
 )

--- a/transports/bifrost-http/handlers/asyncinference.go
+++ b/transports/bifrost-http/handlers/asyncinference.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -129,7 +130,7 @@ func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
 		schemas.TextCompletionRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -166,7 +167,7 @@ func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
 		schemas.ChatCompletionRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -203,7 +204,7 @@ func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
 		schemas.ResponsesRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Failed to create async job: %v", err))
+		sendSubmitJobError(ctx, err)
 		return
 	}
 
@@ -236,7 +237,7 @@ func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
 		schemas.EmbeddingRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -273,7 +274,7 @@ func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
 		schemas.SpeechRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -310,7 +311,7 @@ func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
 		schemas.TranscriptionRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -347,7 +348,7 @@ func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
 		schemas.ImageGenerationRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -384,7 +385,7 @@ func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
 		schemas.ImageEditRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -416,7 +417,7 @@ func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
 		schemas.ImageVariationRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -448,7 +449,7 @@ func (h *AsyncHandler) asyncRerank(ctx *fasthttp.RequestCtx) {
 		schemas.RerankRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -480,7 +481,7 @@ func (h *AsyncHandler) asyncOCR(ctx *fasthttp.RequestCtx) {
 		schemas.OCRRequest,
 	)
 	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		sendSubmitJobError(ctx, err)
 		return
 	}
 	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
@@ -545,4 +546,14 @@ func getResultTTLFromHeaderWithDefault(ctx *fasthttp.RequestCtx, defaultTTL int)
 		return defaultTTL
 	}
 	return resultTTLInt
+}
+
+// sendSubmitJobError maps a submit failure to HTTP: an unusable webhook
+// reference is the caller's mistake, everything else is server-side.
+func sendSubmitJobError(ctx *fasthttp.RequestCtx, err error) {
+	if errors.Is(err, logstore.ErrInvalidWebhookReference) {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+	SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create async job: %v", err))
 }

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -1682,6 +1682,13 @@ func (g *GenericRouter) handleAsyncCreate(
 
 	job, err := executor.SubmitJob(bifrostCtx, resultTTL, operation, operationType)
 	if err != nil {
+		// An unusable webhook reference is the caller's mistake, not a
+		// server failure.
+		if errors.Is(err, logstore.ErrInvalidWebhookReference) {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter,
+				newBifrostErrorWithCode(err, "failed to create async job", fasthttp.StatusBadRequest))
+			return
+		}
 		g.sendError(ctx, bifrostCtx, config.ErrorConverter,
 			newBifrostError(err, "failed to create async job"))
 		return

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -488,6 +488,18 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 			extraHeaders[labelName] = append(extraHeaders[labelName], string(value))
 			return true
 		}
+		// Async webhook header: names the webhook endpoint to notify when the
+		// async job finishes. Carried as-is; the submit path validates it.
+		// Handled before direct forwarding: an allowlist that matches this
+		// reserved header would otherwise forward-and-return below, dropping the
+		// endpoint name so the job runs with no notification.
+		if keyStr == "x-bf-async-webhook" {
+			valueStr := strings.TrimSpace(string(value))
+			if valueStr != "" {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyAsyncWebhookEndpoint, valueStr)
+			}
+			return true
+		}
 		// Direct header forwarding: when allowlist is configured, any header explicitly
 		// in the allowlist can be forwarded directly without the x-bf-eh- prefix.
 		// This enables forwarding arbitrary headers like "anthropic-beta" directly.
@@ -565,7 +577,6 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 			}
 			return true
 		}
-
 		// Compat header: per-request override of compat plugin settings.
 		// Accepts: "true" (enable all), JSON array of feature names, or ["*"] (enable all).
 		// An empty array [] or absent header means no overrides.

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -171,6 +171,31 @@ func TestConvertToBifrostContext_StarAllowlistDirectForwardingSecurityBlocked(t 
 	}
 }
 
+// TestConvertToBifrostContext_AsyncWebhookHeaderSurvivesStarAllowlist verifies
+// that the reserved x-bf-async-webhook header is captured into the context even
+// when a "*" allowlist would otherwise forward-and-return it as a direct header,
+// which would drop the endpoint name and run the async job without notifying.
+func TestConvertToBifrostContext_AsyncWebhookHeaderSurvivesStarAllowlist(t *testing.T) {
+	matcher := NewHeaderMatcher(&configstoreTables.GlobalHeaderFilterConfig{
+		Allowlist: []string{"*"},
+	})
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-async-webhook", "receiver")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
+	defer cancel()
+
+	if got, ok := bifrostCtx.Value(schemas.BifrostContextKeyAsyncWebhookEndpoint).(string); !ok || got != "receiver" {
+		t.Errorf("expected async webhook endpoint %q to be captured under a * allowlist, got %q (present=%v)", "receiver", got, ok)
+	}
+	// The reserved header must not also leak into forwarded extra headers.
+	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if _, ok := extraHeaders["x-bf-async-webhook"]; ok {
+		t.Error("expected reserved x-bf-async-webhook to be consumed, not forwarded as an extra header")
+	}
+}
+
 // TestConvertToBifrostContext_PrefixWildcardDirectForwarding verifies that
 // prefix wildcard patterns like "anthropic-*" work for direct header forwarding
 // (without x-bf-eh- prefix).
@@ -605,5 +630,35 @@ func TestConvertToBifrostContext_APIKeyHeaderNonVirtualKeyIgnored(t *testing.T) 
 
 	if got := bifrostCtx.Value(schemas.BifrostContextKeyVirtualKey); got != nil {
 		t.Fatalf("virtual key should not be set from a non-VK api-key value, got %#v", got)
+	}
+}
+
+func TestConvertToBifrostContext_AsyncWebhookHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{name: "value carried as-is", header: "billing", want: "billing"},
+		{name: "value trimmed", header: "  billing  ", want: "billing"},
+		{name: "blank header ignored", header: "   ", want: ""},
+		{name: "absent header ignored", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			if tc.header != "" {
+				ctx.Request.Header.Set("x-bf-async-webhook", tc.header)
+			}
+			bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
+			if bifrostCtx == nil {
+				t.Fatal("expected a bifrost context")
+			}
+			defer cancel()
+			got, _ := bifrostCtx.Value(schemas.BifrostContextKeyAsyncWebhookEndpoint).(string)
+			if got != tc.want {
+				t.Fatalf("context webhook endpoint = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1813,7 +1813,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 			if s.WebhookDispatcher != nil {
 				jobDispatcher = s.WebhookDispatcher
 			}
-			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), jobDispatcher, logger)
+			s.Config.AsyncJobExecutor = logstore.NewAsyncJobExecutor(s.Config.LogsStore, governancePlugin.GetGovernanceStore(), jobDispatcher, s.Config, logger)
 			logger.Info("async job executor initialized")
 		}
 	}


### PR DESCRIPTION
## Summary

Webhook endpoint references in async job submissions are now resolved and validated at submit time rather than being pre-normalized to an endpoint ID before the job is created. This ensures that a job referencing an unknown or disabled webhook endpoint is rejected immediately, preventing silent notification loss.

## Changes

- Replaced `BifrostContextKeyAsyncWebhook` (which previously expected a pre-resolved endpoint ID) with `BifrostContextKeyAsyncWebhookEndpoint` (which carries the raw endpoint name from the `x-bf-async-webhook` header).
- Introduced a `WebhookManager` interface on `AsyncJobExecutor` with a `WebhookEndpointByName` method, used to resolve and validate the endpoint name at submit time.
- `SubmitJob` now calls `getWebhookEndpointIfPresent`, which looks up the named endpoint via `WebhookManager`, rejects unknown endpoints, and rejects disabled endpoints — returning an error rather than silently accepting the job.
- `NewAsyncJobExecutor` accepts a `WebhookManager` parameter; a nil manager causes any submit that references a webhook endpoint to fail.
- The HTTP transport's `ConvertToBifrostContext` now explicitly handles the `x-bf-async-webhook` header, trimming whitespace and storing the value under the new context key. Previously this relied on implicit pass-through and pre-resolution elsewhere.
- Removed the now-unnecessary `getWebhookEndpointIDFromContext` helper.
- Added tests covering rejection of unknown and disabled endpoint references, and header parsing behavior in the HTTP transport.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... ./transports/bifrost-http/lib/...
```

- Submit an async job with `x-bf-async-webhook: <valid-endpoint-name>` — the job should be accepted and the endpoint ID stamped on the job record.
- Submit with an unknown endpoint name — expect an error response and no job created.
- Submit with a disabled endpoint name — expect an error response and no job created.
- Submit without the header — job should be accepted with no webhook endpoint attached.

## Breaking changes

- [x] Yes
- [ ] No

`NewAsyncJobExecutor` now requires a `WebhookManager` argument. Any caller constructing an `AsyncJobExecutor` directly must be updated to pass a `WebhookManager` implementation (or `nil` to disable webhook support). The context key used to carry the webhook reference has changed from `BifrostContextKeyAsyncWebhook` to `BifrostContextKeyAsyncWebhookEndpoint`; any code setting the old key will no longer have effect.

## Related issues

## Security considerations

Endpoint resolution is now enforced at job submission, preventing a caller from referencing an arbitrary or disabled webhook endpoint. A nil `WebhookManager` causes any webhook-referencing submit to fail explicitly rather than silently dropping the notification.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable