### PR TITLE
feat(helm+docs): add `stream_replay_duration_ms` to guardrail rules for block-capable streaming output replay control 

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -1146,6 +1146,7 @@ bifrost:
         apply_to: "input"
         sampling_rate: 100
         timeout: 1000
+        stream_replay_event_interval_ms: 25
         provider_config_ids:
           - 1
     providers:
@@ -1167,6 +1168,7 @@ assert_field_value 'guardrails rule[0].enabled' '.guardrails_config.guardrail_ru
 assert_field_value 'guardrails rule[0].apply_to' '.guardrails_config.guardrail_rules.[0].apply_to' '"input"'
 assert_field_value 'guardrails rule[0].sampling_rate' '.guardrails_config.guardrail_rules.[0].sampling_rate' '100'
 assert_field_value 'guardrails rule[0].timeout' '.guardrails_config.guardrail_rules.[0].timeout' '1000'
+assert_field_value 'guardrails rule[0].stream_replay_event_interval_ms' '.guardrails_config.guardrail_rules.[0].stream_replay_event_interval_ms' '25'
 assert_field 'guardrails rule[0].provider_config_ids' '.guardrails_config.guardrail_rules.[0].provider_config_ids'
 
 assert_field 'guardrails_config.guardrail_providers' '.guardrails_config.guardrail_providers'

--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -572,6 +572,8 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 
 Rules are CEL expressions that fire when their condition matches. Available CEL variables:
 
+For block-capable streaming output rules, `stream_replay_event_interval_ms` sets the delay between consecutive buffered events after the response is allowed. It defaults to `0`, which sends all buffered events immediately; the dashboard initializes it to `25` when pacing is enabled. When multiple matched block-capable rules specify different positive values, Bifrost uses the largest interval.
+
 | Variable | Type | Description |
 |----------|------|-------------|
 | `model` | `string` | Model name from the request |
@@ -605,6 +607,7 @@ Rules are CEL expressions that fire when their condition matches. Available CEL 
         "apply_to": "output",
         "sampling_rate": 100,
         "timeout": 15,
+        "stream_replay_event_interval_ms": 25,
         "provider_config_ids": [3]
       },
       {

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -510,6 +510,7 @@ Rule fields:
 | `apply_to` | Yes | `"input"`, `"output"`, or `"both"` |
 | `sampling_rate` | No | `0`–`100`; percentage of requests to check (default: 100) |
 | `timeout` | No | Rule timeout in seconds |
+| `stream_replay_event_interval_ms` | No | Delay between buffered events after block-capable output guardrails allow a streaming response. Defaults to `0` (immediate delivery); the dashboard uses `25` when pacing is enabled. |
 | `provider_config_ids` | No | Provider `id`s to invoke when this rule matches |
 
 ```yaml
@@ -534,6 +535,7 @@ bifrost:
         apply_to: "output"
         sampling_rate: 100
         timeout: 15
+        stream_replay_event_interval_ms: 25
         provider_config_ids: [3]
 
       - id: 103

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -159,11 +159,15 @@ flowchart TB
 
 ## Streaming Output Guardrails
 
-When an output guardrail is used with a streaming response, Bifrost accumulates the response until the model is done generating it, then checks the full response. If the response passes, Bifrost sends it to the client. If a guardrail blocks or changes the response, Bifrost applies that result instead.
+Streaming delivery depends on what the matched output guardrails can do:
 
-This adds time before the client receives output: Bifrost waits for response generation and guardrail evaluation to finish. The added wait depends on the model's generation time and the configured guardrail profiles.
+- Detect-only and logs-only rules observe the stream without delaying client delivery.
+- Runtime redaction checks buffered text segments and releases the resulting safe text as the response is generated.
+- If any matched rule can block, Bifrost holds the complete stream until generation and guardrail evaluation finish. If `stream_replay_event_interval_ms` is positive, an allowed stream is replayed with that delay between buffered events; otherwise, it is delivered immediately. A blocked stream returns the guardrail intervention instead.
 
-Input guardrails check the request before Bifrost sends it to the LLM provider.
+Replay pacing is disabled by default. The dashboard initializes the event interval to `25` milliseconds when pacing is enabled, while `0` sends all buffered events immediately. If multiple matched block-capable rules configure different intervals, Bifrost uses the largest value. This behavior applies to streaming Chat Completions, Text Completions, and Responses API requests.
+
+Input guardrails still check the request before Bifrost sends it to the LLM provider.
 
 <Note>
   Gray Swan is a tool-call-specific exception. Text-only streams are delivered directly to the client and are not sent to Cygnal. See [Gray Swan Cygnal](/integrations/guardrails/grayswan#streaming-output-and-tool-calls) for the full behavior.
@@ -353,26 +357,28 @@ curl -X DELETE http://localhost:8080/api/guardrails/rules/1
 <Tab title="Helm">
 
 ```yaml
-guardrails_config:
-  guardrail_rules:
-    - id: 1
-      name: "Block PII in Prompts"
-      description: "Prevent PII from being sent to LLM providers"
-      enabled: true
-      cel_expression: "request.messages.exists(m, m.role == 'user')"
-      apply_to: "input"
-      sampling_rate: 100
-      timeout: 5000
-      provider_config_ids: [1, 2]
-    - id: 2
-      name: "Content Filter for Responses"
-      description: "Filter harmful content from LLM responses"
-      enabled: true
-      cel_expression: "true"
-      apply_to: "output"
-      sampling_rate: 100
-      timeout: 3000
-      provider_config_ids: [2]
+bifrost:
+  guardrails:
+    rules:
+      - id: 1
+        name: "Block PII in Prompts"
+        description: "Prevent PII from being sent to LLM providers"
+        enabled: true
+        cel_expression: "request.messages.exists(m, m.role == 'user')"
+        apply_to: "input"
+        sampling_rate: 100
+        timeout: 5000
+        provider_config_ids: [1, 2]
+      - id: 2
+        name: "Content Filter for Responses"
+        description: "Filter harmful content from LLM responses"
+        enabled: true
+        cel_expression: "true"
+        apply_to: "output"
+        sampling_rate: 100
+        timeout: 3000
+        stream_replay_event_interval_ms: 25
+        provider_config_ids: [2]
 ```
 
 </Tab>
@@ -664,96 +670,97 @@ curl -X DELETE http://localhost:8080/api/guardrails/bedrock \
 <Tab title="Helm">
 
 ```yaml
-guardrails_config:
-  guardrail_providers:
-    - id: 1
-      provider_name: "secrets"
-      policy_name: "Block Leaked Credentials"
-      enabled: true
-      config:
-        ignored_secret_keywords:
-          - "example"
-          - "dummy"
-    - id: 2
-      provider_name: "regex"
-      policy_name: "PII Detection"
-      enabled: true
-      config:
-        patterns:
-          - pattern: "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b"
-            description: "Email address"
-            flags: "i"
-          - pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
-            description: "US Social Security Number"
-    - id: 3
-      provider_name: "bedrock"
-      policy_name: "PII Detection Profile"
-      enabled: true
-      config:
-        guardrail_arn: "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123"
-        guardrail_version: "1"
-        region: "us-east-1"
-        # AWS Authentication (choose one method):
-        # Option 1: Explicit credentials
-        access_key: "env.AWS_ACCESS_KEY_ID"
-        secret_key: "env.AWS_SECRET_ACCESS_KEY"
-        # Option 2: IAM Role - omit access_key and secret_key
-        # (Bifrost will use IAM credentials from the environment)
-    - id: 4
-      provider_name: "azure"
-      policy_name: "Content Safety Profile"
-      enabled: true
-      config:
-        endpoint: "https://your-resource.cognitiveservices.azure.com/"
-        api_key: "env.AZURE_CONTENT_SAFETY_API_KEY"
-        analyze_enabled: true
-        analyze_severity_threshold: "medium"
-        jailbreak_shield_enabled: true
-    - id: 5
-      provider_name: "model-armor"
-      policy_name: "Google Model Armor Production"
-      enabled: true
-      timeout: 30
-      config:
-        auth_type: "default_credential"
-        project_id: "env.GCP_PROJECT_ID"
-        location: "env.GCP_LOCATION"
-        template_id: "env.GMA_TEMPLATE_ID"
-    - id: 6
-      provider_name: "crowdstrike-aidr"
-      policy_name: "CrowdStrike AIDR Production"
-      enabled: true
-      timeout: 30
-      config:
-        api_key: "env.CS_AIDR_TOKEN"
-        base_url: "env.CS_AIDR_BASE_URL"
-        app_id: "bifrost-production"
-        collector_instance_id: "prod-us-east-1"
-    - id: 7
-      provider_name: "grayswan"
-      policy_name: "Custom Safety Rules"
-      enabled: true
-      config:
-        api_key: "env.GRAYSWAN_API_KEY"
-        violation_threshold: 0.5
-        reasoning_mode: "hybrid"
-        rules:
-          no_pii: "Do not allow personally identifiable information"
-          professional_tone: "Ensure responses maintain a professional tone"
-    - id: 8
-      provider_name: "patronus-ai"
-      policy_name: "Patronus Quality Checks"
-      enabled: true
-      config:
-        api_key: "env.PATRONUS_API_KEY"
-        base_url: "https://api.patronus.ai"
-        evaluators:
-          - evaluator: "pii"
-            explain_strategy: "on-fail"
-          - evaluator: "judge"
-            criteria: "patronus:is-concise"
-            explain_strategy: "on-fail"
-        capture: "none"
+bifrost:
+  guardrails:
+    providers:
+      - id: 1
+        provider_name: "secrets"
+        policy_name: "Block Leaked Credentials"
+        enabled: true
+        config:
+          ignored_secret_keywords:
+            - "example"
+            - "dummy"
+      - id: 2
+        provider_name: "regex"
+        policy_name: "PII Detection"
+        enabled: true
+        config:
+          patterns:
+            - pattern: "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b"
+              description: "Email address"
+              flags: "i"
+            - pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+              description: "US Social Security Number"
+      - id: 3
+        provider_name: "bedrock"
+        policy_name: "PII Detection Profile"
+        enabled: true
+        config:
+          guardrail_arn: "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123"
+          guardrail_version: "1"
+          region: "us-east-1"
+          # AWS Authentication (choose one method):
+          # Option 1: Explicit credentials
+          access_key: "env.AWS_ACCESS_KEY_ID"
+          secret_key: "env.AWS_SECRET_ACCESS_KEY"
+          # Option 2: IAM Role - omit access_key and secret_key
+          # (Bifrost will use IAM credentials from the environment)
+      - id: 4
+        provider_name: "azure"
+        policy_name: "Content Safety Profile"
+        enabled: true
+        config:
+          endpoint: "https://your-resource.cognitiveservices.azure.com/"
+          api_key: "env.AZURE_CONTENT_SAFETY_API_KEY"
+          analyze_enabled: true
+          analyze_severity_threshold: "medium"
+          jailbreak_shield_enabled: true
+      - id: 5
+        provider_name: "model-armor"
+        policy_name: "Google Model Armor Production"
+        enabled: true
+        timeout: 30
+        config:
+          auth_type: "default_credential"
+          project_id: "env.GCP_PROJECT_ID"
+          location: "env.GCP_LOCATION"
+          template_id: "env.GMA_TEMPLATE_ID"
+      - id: 6
+        provider_name: "crowdstrike-aidr"
+        policy_name: "CrowdStrike AIDR Production"
+        enabled: true
+        timeout: 30
+        config:
+          api_key: "env.CS_AIDR_TOKEN"
+          base_url: "env.CS_AIDR_BASE_URL"
+          app_id: "bifrost-production"
+          collector_instance_id: "prod-us-east-1"
+      - id: 7
+        provider_name: "grayswan"
+        policy_name: "Custom Safety Rules"
+        enabled: true
+        config:
+          api_key: "env.GRAYSWAN_API_KEY"
+          violation_threshold: 0.5
+          reasoning_mode: "hybrid"
+          rules:
+            no_pii: "Do not allow personally identifiable information"
+            professional_tone: "Ensure responses maintain a professional tone"
+      - id: 8
+        provider_name: "patronus-ai"
+        policy_name: "Patronus Quality Checks"
+        enabled: true
+        config:
+          api_key: "env.PATRONUS_API_KEY"
+          base_url: "https://api.patronus.ai"
+          evaluators:
+            - evaluator: "pii"
+              explain_strategy: "on-fail"
+            - evaluator: "judge"
+              criteria: "patronus:is-concise"
+              explain_strategy: "on-fail"
+          capture: "none"
 ```
 
 </Tab>

--- a/docs/enterprise/guardrails/custom-regex.mdx
+++ b/docs/enterprise/guardrails/custom-regex.mdx
@@ -25,7 +25,7 @@ Custom Regex runs in-process and uses Go's RE2-compatible regexp engine. It does
 Custom Regex currently evaluates text content. It does not inspect image pixels or binary file contents.
 
 <Note>
-  **Streaming output:** When this profile is used in an `output` or `both` rule, Bifrost accumulates the stream until the model response is complete, then checks the full response. It does not check individual stream chunks. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
+  **Streaming output:** Delivery depends on whether the matched patterns detect, redact, or can block. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
 </Note>
 
 ## Pattern Fields

--- a/docs/enterprise/guardrails/redaction.mdx
+++ b/docs/enterprise/guardrails/redaction.mdx
@@ -70,6 +70,8 @@ Redaction mode decides where Bifrost applies the rewrite.
 | Logs only | `logs_only` | Left raw | Redacted with reversible placeholders | Placeholderized content | Yes, for Bifrost logs only |
 | Runtime + reversible logs | `runtime_reversible` | Redacted with reversible placeholders | Redacted with reversible placeholders | Placeholderized content | Yes, for Bifrost logs only |
 
+For streaming output, runtime redaction checks buffered text segments before releasing their redacted content. Logs-only redaction does not delay client delivery. If the same matched rule set can also block, Bifrost holds the complete stream until the final guardrail decision; see [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails).
+
 ### Runtime (`runtime`)
 
 Use `runtime` when sensitive text should not reach the model provider or the caller. Bifrost rewrites detected text in the live request or response and stores the already-redacted value in Bifrost logs.

--- a/docs/enterprise/guardrails/secrets-detection.mdx
+++ b/docs/enterprise/guardrails/secrets-detection.mdx
@@ -52,7 +52,7 @@ For the full behavior matrix, including reveal permissions and connector export 
 | `redaction_mode` | No | `runtime` | `runtime`, `logs_only`, or `runtime_reversible`. Used when `action` is `redact`. |
 
 <Note>
-  **Streaming output:** When this profile is used in an `output` or `both` rule, Bifrost accumulates the stream until the model response is complete, then checks the full response. It does not check individual stream chunks. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
+  **Streaming output:** Delivery depends on whether the profile detects, redacts, or can block. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
 </Note>
 
 ## Supported Secret Types

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -12,6 +12,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 - Added `bifrost.client.retainContentInObjectStorage` (default off, commented out) to keep full request/response content in object storage when content logging is disabled — via the global `disableContentLogging` setting or the `x-bf-disable-content-logging` header — instead of dropping it. The content is hidden: the database row stays metadata-only and the UI/API never fetch the payload back, so it is only readable with direct access to the bucket. Requires `storage.logsStore.objectStorage.enabled: true`; without it the content is dropped as before. Renders into `client.retain_content_in_object_storage`.
 
+- Added `bifrost.guardrails.rules[].stream_replay_event_interval_ms` to configure the delay between buffered events after block-capable output guardrails allow a streaming response; `0` keeps immediate delivery.
+
 ### 2.1.29
 
 - Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to the Okta, Entra, SailPoint, and generic OIDC SCIM providers, so inbound SCIM provisioning can be seeded declaratively instead of via the dashboard. Both render into `scim_config.config`. Generate a token with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` (supports `env.` prefix).

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -735,6 +735,7 @@ false
 {{- if .timeout }}{{- $_ := set $rule "timeout" .timeout }}{{- end }}
 {{- if hasKey . "max_turns_to_send" }}{{- $_ := set $rule "max_turns_to_send" .max_turns_to_send }}{{- end }}
 {{- if .evaluation_mode }}{{- $_ := set $rule "evaluation_mode" .evaluation_mode }}{{- end }}
+{{- if hasKey . "stream_replay_event_interval_ms" }}{{- $_ := set $rule "stream_replay_event_interval_ms" .stream_replay_event_interval_ms }}{{- end }}
 {{- if .provider_config_ids }}{{- $_ := set $rule "provider_config_ids" .provider_config_ids }}{{- end }}
 {{- $rules = append $rules $rule }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2929,6 +2929,13 @@
                     "default": "bundled",
                     "description": "How the rule's turns are sent to its guardrail providers. 'bundled' (default) concatenates all turns into one guardrail call. 'per_turn' sends each turn in its own call, evaluated in isolation, to avoid context-sensitive classifiers (e.g. Bedrock prompt-attack) combining unrelated turns into a false-positive block; this scans every turn but uses more provider calls."
                   },
+                  "stream_replay_event_interval_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "default": 0,
+                    "description": "Delay in milliseconds between consecutive buffered events after block-capable streaming output guardrails allow the response. 0 sends the buffered events immediately."
+                  },
                   "provider_config_ids": {
                     "type": "array",
                     "items": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1079,6 +1079,7 @@ bifrost:
       #   timeout: 60        # Timeout in seconds for rule execution (default: 60)
       #   max_turns_to_send: 0
       #   evaluation_mode: "bundled"   # "bundled" (default) | "per_turn" (each turn scanned in isolation; avoids cross-turn false positives, more provider calls)
+      #   stream_replay_event_interval_ms: 25  # Delay between buffered events after an allowed response; 0 sends them immediately
     providers: []
       # - id: 1
       #   provider_name: "bedrock"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6139,6 +6139,13 @@
                 "default": "bundled",
                 "description": "How the rule's turns are sent to its guardrail providers. 'bundled' (default) concatenates all turns into one guardrail call. 'per_turn' sends each turn in its own call, evaluated in isolation, to avoid context-sensitive classifiers (e.g. Bedrock prompt-attack) combining unrelated turns into a false-positive block; this scans every turn but uses more provider calls."
               },
+              "stream_replay_event_interval_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 1000,
+                "default": 0,
+                "description": "Delay in milliseconds between consecutive buffered events after block-capable streaming output guardrails allow the response. 0 sends the buffered events immediately."
+              },
               "provider_config_ids": {
                 "type": "array",
                 "items": {


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


