### PR TITLE
fix: send only `disabled` on toggle and convert `tool_sync_interval` units in cache

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -495,20 +495,14 @@ export default function MCPClientsTable({
 													disabled={!hasUpdateMCPClientAccess || togglingClientIds.has(c.config.client_id)}
 													onAsyncCheckedChange={async (checked) => {
 														setTogglingClientIds((prev) => new Set(prev).add(c.config.client_id));
+														// PUT has PATCH semantics: omitted fields keep their stored value.
+														// Send only `disabled` — echoing back fields from the GET response
+														// re-submits them in the response's units, which differ from the
+														// units PUT expects (e.g. tool_sync_interval is ns out, minutes in).
 														await updateMCPClient({
 															id: c.config.client_id,
 															data: {
-																name: c.config.name,
-																is_code_mode_client: c.config.is_code_mode_client,
-																is_ping_available: c.config.is_ping_available,
-																allow_on_all_virtual_keys: c.config.allow_on_all_virtual_keys,
 																disabled: !checked,
-																headers: c.config.headers ?? {},
-																tools_to_execute: c.config.tools_to_execute,
-																tools_to_auto_execute: c.config.tools_to_auto_execute,
-																tool_pricing: c.config.tool_pricing,
-																tool_sync_interval: c.config.tool_sync_interval ?? 0,
-																allowed_extra_headers: c.config.allowed_extra_headers,
 															},
 														})
 															.unwrap()

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -173,7 +173,11 @@ export const mcpApi = baseApi.injectEndpoints({
 										draft.clients[index].config.tools_to_auto_execute = data.tools_to_auto_execute;
 									if (data.is_ping_available !== undefined) draft.clients[index].config.is_ping_available = data.is_ping_available;
 									if (data.tool_pricing !== undefined) draft.clients[index].config.tool_pricing = data.tool_pricing;
-									if (data.tool_sync_interval !== undefined) draft.clients[index].config.tool_sync_interval = data.tool_sync_interval;
+									// The request carries minutes, but the cached config mirrors the GET
+									// response, which carries nanoseconds. Convert so the cache stays in
+									// the server's unit instead of drifting until the next refetch.
+									if (data.tool_sync_interval !== undefined)
+										draft.clients[index].config.tool_sync_interval = data.tool_sync_interval * 6e10;
 									if (data.disabled !== undefined) {
 										draft.clients[index].config.disabled = data.disabled;
 										if (data.disabled) {

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -67,7 +67,10 @@ export interface MCPClientConfig {
 	per_user_header_keys?: string[];
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
-	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
+	// Per-client override (0 = use global, -1 = disabled). API returns NANOSECONDS
+	// (Go time.Duration), while updates send minutes — convert with
+	// toolSyncIntervalToMinutes before showing or resending this value.
+	tool_sync_interval?: number;
 	tool_execution_timeout?: string | number; // Per-client tool execution timeout; API returns string e.g. "30s", UI sends integer seconds (0 = use global)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this


### PR DESCRIPTION
## Summary

Fixes a bug where toggling an MCP client's enabled/disabled state would inadvertently overwrite server-side fields with incorrect values. The root cause was that the PUT endpoint has PATCH semantics (omitted fields retain their stored values), but the UI was echoing back fields from the GET response — including `tool_sync_interval`, which the server returns in nanoseconds but expects to receive in minutes.

## Changes

- The toggle handler in `mcpClientsTable.tsx` now sends only `disabled` in the PUT request body, relying on the server's PATCH semantics to preserve all other fields untouched.
- The optimistic cache update in `mcpApi.ts` now converts `tool_sync_interval` from minutes (request unit) to nanoseconds (cached/GET unit) so the local cache stays consistent with the server representation between refetches.
- The `tool_sync_interval` field in `MCPClientConfig` is documented to clarify the unit mismatch: the API returns nanoseconds (Go `time.Duration`), while updates must send minutes. Callers should use `toolSyncIntervalToMinutes` before displaying or resending the value.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP Registry and find a client with a non-default `tool_sync_interval` configured.
2. Toggle the client's enabled/disabled switch.
3. Verify the client's `tool_sync_interval` is unchanged after the toggle (no unintended reset to 0 or a wrong value).
4. Verify the enabled/disabled state flips correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. This change only affects how fields are serialized in a PUT request and how the local cache is updated.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable