### PR TITLE
fix: handle line by line errors in streaming

### DIFF
--- a/core/providers/gemini/errors.go
+++ b/core/providers/gemini/errors.go
@@ -1,6 +1,8 @@
 package gemini
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -8,6 +10,41 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
+
+// GeminiStreamAPIError is an error payload Gemini delivers inside an HTTP 200
+// stream body (e.g. mid-stream 429 RESOURCE_EXHAUSTED quota aborts). It keeps
+// the upstream code/status/message so they can be preserved on the wire.
+type GeminiStreamAPIError struct {
+	Err *GeminiGenerationErrorStruct
+}
+
+func (e *GeminiStreamAPIError) Error() string {
+	return fmt.Sprintf("gemini api error: %d %s - %s", e.Err.Code, e.Err.Status, e.Err.Message)
+}
+
+// toGeminiStreamBifrostError builds the BifrostError for an error payload
+// detected in a stream chunk, preserving the upstream code/status/message
+// (e.g. mid-stream 429s) when the payload parsed as a typed API error.
+func toGeminiStreamBifrostError(err error) *schemas.BifrostError {
+	bifrostErr := &schemas.BifrostError{
+		Type:           schemas.Ptr("gemini_api_error"),
+		IsBifrostError: false,
+		Error: &schemas.ErrorField{
+			Message: err.Error(),
+			Error:   err,
+		},
+	}
+	var apiErr *GeminiStreamAPIError
+	if errors.As(err, &apiErr) {
+		bifrostErr.StatusCode = schemas.Ptr(apiErr.Err.Code)
+		bifrostErr.Error.Code = schemas.Ptr(strconv.Itoa(apiErr.Err.Code))
+		bifrostErr.Error.Message = apiErr.Err.Message
+		if apiErr.Err.Status != "" {
+			bifrostErr.Error.Type = schemas.Ptr(apiErr.Err.Status)
+		}
+	}
+	return bifrostErr
+}
 
 // ToGeminiError derives a GeminiGenerationError from a BifrostError
 func ToGeminiError(bifrostErr *schemas.BifrostError) *GeminiGenerationError {

--- a/core/providers/gemini/errors_test.go
+++ b/core/providers/gemini/errors_test.go
@@ -60,3 +60,35 @@ func TestParseGeminiError_RoundTripToGeminiError(t *testing.T) {
 		t.Fatalf("expected status RESOURCE_EXHAUSTED to survive round trip, got %q", geminiErr.Error.Status)
 	}
 }
+
+// TestProcessGeminiStreamChunk_MidStreamError verifies that an error payload
+// delivered inside an HTTP 200 stream body (e.g. Vertex aborting with a
+// pretty-printed 429 on quota exhaustion) is surfaced as a typed error that
+// preserves the upstream code, status, and message.
+func TestProcessGeminiStreamChunk_MidStreamError(t *testing.T) {
+	chunk := "{\n" +
+		"  \"error\": {\n" +
+		"    \"code\": 429,\n" +
+		"    \"message\": \"Resource exhausted. Please try again later.\",\n" +
+		"    \"status\": \"RESOURCE_EXHAUSTED\"\n" +
+		"  }\n" +
+		"}"
+
+	resp, err := processGeminiStreamChunk([]byte(chunk))
+	if resp != nil {
+		t.Fatal("expected nil response for error chunk")
+	}
+	apiErr, ok := err.(*GeminiStreamAPIError)
+	if !ok {
+		t.Fatalf("expected *GeminiStreamAPIError, got %T: %v", err, err)
+	}
+	if apiErr.Err.Code != 429 {
+		t.Errorf("expected code 429, got %d", apiErr.Err.Code)
+	}
+	if apiErr.Err.Status != "RESOURCE_EXHAUSTED" {
+		t.Errorf("expected status RESOURCE_EXHAUSTED, got %q", apiErr.Err.Status)
+	}
+	if apiErr.Err.Message != "Resource exhausted. Please try again later." {
+		t.Errorf("unexpected message: %q", apiErr.Err.Message)
+	}
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -560,14 +560,7 @@ func HandleGeminiChatCompletionStream(
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
 					// Handle API error
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr("gemini_api_error"),
-						IsBifrostError: false,
-						Error: &schemas.ErrorField{
-							Message: err.Error(),
-							Error:   err,
-						},
-					}
+					bifrostErr := toGeminiStreamBifrostError(err)
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
 					return
@@ -1080,14 +1073,7 @@ func HandleGeminiResponsesStream(
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
 					// Handle API error
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr("gemini_api_error"),
-						IsBifrostError: false,
-						Error: &schemas.ErrorField{
-							Message: err.Error(),
-							Error:   err,
-						},
-					}
+					bifrostErr := toGeminiStreamBifrostError(err)
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, sendBackRawRequest, sendBackRawResponse), responseChan, logger, postHookSpanFinalizer)
 					return
@@ -1545,14 +1531,7 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
 					// Handle API error
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr("gemini_api_error"),
-						IsBifrostError: false,
-						Error: &schemas.ErrorField{
-							Message: err.Error(),
-							Error:   err,
-						},
-					}
+					bifrostErr := toGeminiStreamBifrostError(err)
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
 					return
@@ -1839,14 +1818,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 			geminiResponse, err := processGeminiStreamChunk(jsonData)
 			if err != nil {
 				if strings.Contains(err.Error(), "gemini api error") {
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr("gemini_api_error"),
-						IsBifrostError: false,
-						Error: &schemas.ErrorField{
-							Message: err.Error(),
-							Error:   err,
-						},
-					}
+					bifrostErr := toGeminiStreamBifrostError(err)
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
 					return
@@ -3128,6 +3100,10 @@ func (provider *GeminiProvider) BatchDelete(ctx *schemas.BifrostContext, keys []
 func processGeminiStreamChunk(jsonData []byte) (*GenerateContentResponse, error) {
 	// Error chunks are rare; avoid a second decode in the common path.
 	if bytes.Contains(jsonData, []byte(`"error"`)) {
+		var errorResp GeminiGenerationError
+		if err := sonic.Unmarshal(jsonData, &errorResp); err == nil && errorResp.Error != nil {
+			return nil, &GeminiStreamAPIError{Err: errorResp.Error}
+		}
 		var errorCheck map[string]interface{}
 		if err := sonic.Unmarshal(jsonData, &errorCheck); err == nil {
 			if errValue, hasError := errorCheck["error"]; hasError {

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -73,6 +74,7 @@ var (
 // Handles Format A SSE streams (data-only: OpenAI, Gemini, Cohere, etc.).
 type defaultSSEDataReader struct {
 	scanner *bufio.Scanner
+	pending []byte // line carried over from an aborted multi-line JSON accumulation
 }
 
 func newDefaultSSEDataReader(reader io.Reader) *defaultSSEDataReader {
@@ -82,8 +84,11 @@ func newDefaultSSEDataReader(reader io.Reader) *defaultSSEDataReader {
 }
 
 func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
-	for r.scanner.Scan() {
-		line := r.scanner.Bytes()
+	for {
+		line, ok := r.nextLine()
+		if !ok {
+			break
+		}
 		// Skip empty lines and comments
 		if len(line) == 0 || line[0] == ':' {
 			continue
@@ -112,13 +117,62 @@ func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
 			continue
 		}
 
-		// Non-SSE line: return as-is (raw JSON error fallback, e.g. OpenAI)
+		// Non-SSE line: raw JSON error fallback (e.g. OpenAI). Google pretty-prints
+		// stream-abort error bodies (e.g. mid-stream 429s) across multiple lines;
+		// reassemble those so chunk parsers see one complete payload.
+		trimmed := bytes.TrimLeft(line, " \t\r")
+		if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') && !sonic.Valid(trimmed) {
+			return r.readMultilineJSON(line), nil
+		}
 		return append([]byte(nil), line...), nil
 	}
 	if err := r.scanner.Err(); err != nil {
 		return nil, err
 	}
 	return nil, io.EOF
+}
+
+// nextLine returns the line carried over from an aborted multi-line JSON
+// accumulation, or advances the scanner. The returned slice is only valid
+// until the next call.
+func (r *defaultSSEDataReader) nextLine() ([]byte, bool) {
+	if r.pending != nil {
+		line := r.pending
+		r.pending = nil
+		return line, true
+	}
+	if r.scanner.Scan() {
+		return r.scanner.Bytes(), true
+	}
+	return nil, false
+}
+
+// readMultilineJSON accumulates raw lines starting at open until they form
+// complete JSON, the stream ends, or the buffer hits sseMaxBufSize. An SSE
+// "data:" line aborts accumulation (carried over to the next ReadDataLine)
+// so a live stream can never be swallowed. The validity check only runs once
+// the buffer can close a JSON value (last byte '}' or ']'); a partial buffer
+// at stream end is returned as-is for the caller to surface.
+func (r *defaultSSEDataReader) readMultilineJSON(open []byte) []byte {
+	buf := append([]byte(nil), open...)
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+		if bytes.HasPrefix(line, sseDataPrefix) {
+			r.pending = append([]byte(nil), line...)
+			return buf
+		}
+		buf = append(buf, '\n')
+		buf = append(buf, line...)
+		if trimmed := bytes.TrimRight(buf, " \t\r\n"); len(trimmed) > 0 &&
+			(trimmed[len(trimmed)-1] == '}' || trimmed[len(trimmed)-1] == ']') &&
+			sonic.Valid(buf) {
+			return buf
+		}
+		if len(buf) >= sseMaxBufSize {
+			return buf
+		}
+	}
+	return buf
 }
 
 // defaultSSEEventReader implements SSEEventReader using bufio.NewScanner.

--- a/core/providers/utils/sse_test.go
+++ b/core/providers/utils/sse_test.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+// drainSSEDataReader reads payloads until EOF, failing the test on any other error.
+func drainSSEDataReader(t *testing.T, r SSEDataReader) []string {
+	t.Helper()
+	var payloads []string
+	for {
+		data, err := r.ReadDataLine()
+		if err == io.EOF {
+			return payloads
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		payloads = append(payloads, string(data))
+	}
+}
+
+func TestSSEDataReader_DataLinesAndDone(t *testing.T) {
+	stream := "data: {\"a\":1}\n" +
+		": comment\n" +
+		"\n" +
+		"data: {\"b\":2}\n" +
+		"data: [DONE]\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	if len(payloads) != 2 || payloads[0] != `{"a":1}` || payloads[1] != `{"b":2}` {
+		t.Errorf("unexpected payloads: %#v", payloads)
+	}
+}
+
+func TestSSEDataReader_SingleLineRawJSONFallback(t *testing.T) {
+	stream := `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}` + "\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	if len(payloads) != 1 || payloads[0] != `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}` {
+		t.Errorf("unexpected payloads: %#v", payloads)
+	}
+}
+
+// Vertex aborts streams (e.g. mid-stream 429s) with a pretty-printed error
+// body outside SSE framing; the reader must reassemble it into one payload.
+func TestSSEDataReader_MultilineErrorReassembly(t *testing.T) {
+	stream := "data: {\"candidates\":[{}]}\n" +
+		"{\n" +
+		"  \"error\": {\n" +
+		"    \"code\": 429,\n" +
+		"    \"message\": \"Resource exhausted. Please try again later.\",\n" +
+		"    \"status\": \"RESOURCE_EXHAUSTED\"\n" +
+		"  }\n" +
+		"}\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	if len(payloads) != 2 {
+		t.Fatalf("expected 2 payloads, got %d: %#v", len(payloads), payloads)
+	}
+	if payloads[0] != `{"candidates":[{}]}` {
+		t.Errorf("unexpected data payload: %q", payloads[0])
+	}
+	want := "{\n  \"error\": {\n    \"code\": 429,\n    \"message\": \"Resource exhausted. Please try again later.\",\n    \"status\": \"RESOURCE_EXHAUSTED\"\n  }\n}"
+	if payloads[1] != want {
+		t.Errorf("unexpected reassembled payload: %q", payloads[1])
+	}
+}
+
+// A data: line arriving mid-accumulation aborts reassembly and is delivered
+// on the next read, so a live stream can never be swallowed.
+func TestSSEDataReader_AccumulationAbortedByDataLine(t *testing.T) {
+	stream := "{\n" +
+		"data: {\"b\":2}\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	if len(payloads) != 2 || payloads[0] != "{" || payloads[1] != `{"b":2}` {
+		t.Errorf("unexpected payloads: %#v", payloads)
+	}
+}
+
+// An opening line indented with whitespace must still enter reassembly.
+func TestSSEDataReader_MultilineReassemblyWithLeadingWhitespace(t *testing.T) {
+	stream := "  {\n" +
+		"    \"error\": {\"code\": 429}\n" +
+		"  }\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	want := "  {\n    \"error\": {\"code\": 429}\n  }"
+	if len(payloads) != 1 || payloads[0] != want {
+		t.Errorf("unexpected payloads: %#v", payloads)
+	}
+}
+
+// A stream ending mid-object returns the partial buffer as-is for the caller
+// to surface (warn + skip), matching the previous per-line behavior.
+func TestSSEDataReader_PartialObjectAtEOF(t *testing.T) {
+	stream := "{\n" +
+		"  \"error\": {\n"
+	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))
+	if len(payloads) != 1 || payloads[0] != "{\n  \"error\": {" {
+		t.Errorf("unexpected payloads: %#v", payloads)
+	}
+}


### PR DESCRIPTION
## Summary

Gemini (and Vertex AI) can abort a streaming response mid-flight by injecting a pretty-printed JSON error payload directly into the HTTP 200 stream body, outside of SSE framing. Previously, these payloads were either silently dropped or surfaced as opaque string errors, losing the upstream HTTP status code, error status, and message. This PR fixes both the SSE reader and the Gemini error handling path so that mid-stream errors (e.g. 429 `RESOURCE_EXHAUSTED` quota aborts) are fully preserved and propagated.

## Changes

- **SSE reader (`sse.go`):** Added multi-line JSON reassembly to `defaultSSEDataReader`. When a raw line starts with `{` or `[` but is not valid JSON on its own, the reader now accumulates subsequent lines until a complete JSON value is formed, the stream ends, or the buffer limit is hit. A `data:` line encountered mid-accumulation aborts reassembly and is carried over to the next `ReadDataLine` call via a `pending` field, ensuring live stream chunks are never swallowed.

- **Typed stream error (`errors.go`):** Introduced `GeminiStreamAPIError`, a dedicated error type that wraps `GeminiGenerationErrorStruct` and preserves the upstream `code`, `status`, and `message` from mid-stream error payloads.

- **Stream error conversion (`errors.go`):** Added `toGeminiStreamBifrostError`, which builds a `BifrostError` from a stream chunk error. When the error is a `*GeminiStreamAPIError`, it populates `StatusCode`, `Error.Code`, and `Error.Type` from the upstream payload rather than falling back to a generic string.

- **Stream chunk parsing (`gemini.go`):** `processGeminiStreamChunk` now attempts to unmarshal error chunks into `GeminiGenerationError` first, returning a typed `*GeminiStreamAPIError` instead of a generic map-based error. All four streaming handlers (`HandleGeminiChatCompletionStream`, `HandleGeminiResponsesStream`, `SpeechStream`, `TranscriptionStream`) now call `toGeminiStreamBifrostError` instead of constructing a bare `BifrostError` inline.

- **Tests:** Added `TestProcessGeminiStreamChunk_MidStreamError` to verify typed error extraction from a stream chunk, and a full suite of `defaultSSEDataReader` tests covering normal SSE data lines, single-line raw JSON fallback, multi-line error reassembly, mid-accumulation abort by a `data:` line, and partial objects at EOF.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/gemini/...
go test ./core/providers/utils/...
```

To validate end-to-end, send a Gemini or Vertex AI streaming request that triggers a mid-stream quota abort (e.g. a request that exhausts a per-minute token quota). The resulting `BifrostError` should carry `StatusCode: 429`, `Error.Type: "RESOURCE_EXHAUSTED"`, and the upstream message rather than a generic error string.

## Breaking changes

- [x] No

## Security considerations

No auth, secrets, or PII are involved. The change only affects how error payloads already present in the stream body are parsed and forwarded.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable