### PR TITLE
Correct company name is "Gray Swan", not "GraySwan"

### DIFF
--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -400,7 +400,7 @@ Calls CrowdStrike AIDR's `guard_chat_completions` endpoint for policy-driven AI 
 }
 ```
 
-GraySwan requests automatically include sanitized incoming request headers in GraySwan `metadata.headers`; no extra `config` field is required. Credential-bearing headers such as `authorization`, `x-api-key`, API-key variants, cookies, and `grayswan-api-key` are excluded, while non-sensitive context headers such as `x-request-id`, `traceparent`, `x-tenant-id`, `content-type`, and `content-length` are included when present.
+Gray Swan requests automatically include sanitized incoming request headers in Gray Swan `metadata.headers`; no extra `config` field is required. Credential-bearing headers such as `authorization`, `x-api-key`, API-key variants, cookies, and `grayswan-api-key` are excluded, while non-sensitive context headers such as `x-request-id`, `traceparent`, `x-tenant-id`, `content-type`, and `content-length` are included when present.
 
 </Tab>
 </Tabs>

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -327,7 +327,7 @@ bifrost:
           sampling_rate: 100
 ```
 
-GraySwan requests automatically include sanitized incoming request headers in GraySwan `metadata.headers`; no extra Helm value is required. Credential-bearing headers such as `authorization`, `x-api-key`, API-key variants, cookies, and `grayswan-api-key` are excluded, while non-sensitive context headers such as `x-request-id`, `traceparent`, `x-tenant-id`, `content-type`, and `content-length` are included when present.
+Gray Swan requests automatically include sanitized incoming request headers in Gray Swan `metadata.headers`; no extra Helm value is required. Credential-bearing headers such as `authorization`, `x-api-key`, API-key variants, cookies, and `grayswan-api-key` are excluded, while non-sensitive context headers such as `x-request-id`, `traceparent`, `x-tenant-id`, `content-type`, and `content-length` are included when present.
 
 </Tab>
 </Tabs>

--- a/docs/edge/security.mdx
+++ b/docs/edge/security.mdx
@@ -37,7 +37,7 @@ Your existing guardrail profiles cover Edge traffic with no additional configura
   <Card title="CrowdStrike AIDR" icon="/media/crowdstrike-card.svg" href="/integrations/guardrails/crowdstrike-aidr">
     Inline AI threat detection, policy enforcement, redaction, and AIDR audit visibility.
   </Card>
-  <Card title="GraySwan Cygnal" icon="/media/grayswan-logo-card.svg" href="/integrations/guardrails/grayswan">
+  <Card title="Gray Swan Cygnal" icon="/media/grayswan-logo-card.svg" href="/integrations/guardrails/grayswan">
     AI safety monitoring with natural language rule definitions.
   </Card>
   <Card title="Patronus AI" icon="/media/patronus-logo-card.svg" href="/integrations/guardrails/patronus-ai">

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Enterprise-grade content safety and security validation with native regex, secrets detection, Presidio, Azure AI Language PII, AWS Bedrock Guardrails, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, GraySwan Cygnal, and Patronus AI."
+description: "Enterprise-grade content safety and security validation with native regex, secrets detection, Presidio, Azure AI Language PII, AWS Bedrock Guardrails, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, Gray Swan Cygnal, and Patronus AI."
 icon: "road-barrier"
 ---
 
@@ -39,7 +39,7 @@ icon: "road-barrier"
   <Card title="CrowdStrike AIDR" icon="/media/crowdstrike-card.svg" href="/integrations/guardrails/crowdstrike-aidr">
     Inline AI threat detection, policy enforcement, redaction, and AIDR audit visibility.
   </Card>
-  <Card title="GraySwan Cygnal" icon="/media/grayswan-logo-card.svg" href="/integrations/guardrails/grayswan">
+  <Card title="Gray Swan Cygnal" icon="/media/grayswan-logo-card.svg" href="/integrations/guardrails/grayswan">
     AI safety monitoring with natural language rule definitions.
   </Card>
   <Card title="Patronus AI" icon="/media/patronus-logo-card.svg" href="/integrations/guardrails/patronus-ai">
@@ -54,7 +54,7 @@ Bifrost Guardrails are built around two core concepts that work together to prov
 | Concept | Description |
 |---------|-------------|
 | **Rules** | Custom policies defined using CEL (Common Expression Language) that determine what content to validate and when. Rules can apply to inputs, outputs, or both, and can be linked to one or more profiles for evaluation. |
-| **Profiles** | Configurations for guardrail providers, including Bifrost-native providers (Custom Regex, Secrets Detection) and external providers (Presidio, Azure AI Language PII, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, GraySwan, Patronus AI). Profiles are reusable and can be shared across multiple rules. |
+| **Profiles** | Configurations for guardrail providers, including Bifrost-native providers (Custom Regex, Secrets Detection) and external providers (Presidio, Azure AI Language PII, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, Gray Swan, Patronus AI). Profiles are reusable and can be shared across multiple rules. |
 
 **How They Work Together:**
 - **Profiles** define *how* content is evaluated using native Bifrost checks or external provider capabilities
@@ -66,7 +66,7 @@ Bifrost Guardrails are built around two core concepts that work together to prov
 
 | Feature | Description |
 |---------|-------------|
-| **Multi-Provider Support** | Bifrost-native Custom Regex and Secrets Detection, plus Presidio, Azure AI Language PII, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, GraySwan, and Patronus AI integrations |
+| **Multi-Provider Support** | Bifrost-native Custom Regex and Secrets Detection, plus Presidio, Azure AI Language PII, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, Gray Swan, and Patronus AI integrations |
 | **Dual-Stage Validation** | Guard both inputs (prompts) and outputs (responses) |
 | **Real-Time Processing** | Synchronous and asynchronous validation modes |
 | **CEL-Based Rules** | Define custom policies using Common Expression Language |
@@ -121,7 +121,7 @@ flowchart TB
         Profile1[AWS Bedrock Profile]
         Profile2[Azure Content Safety Profile]
         Profile3[Patronus AI Profile]
-        Profile4[GraySwan Profile]
+        Profile4[Gray Swan Profile]
         Profile5[Secrets Detection Profile]
         Profile6[Custom Regex Profile]
         Profile7[CrowdStrike AIDR Profile]
@@ -166,11 +166,11 @@ This adds time before the client receives output: Bifrost waits for response gen
 Input guardrails check the request before Bifrost sends it to the LLM provider.
 
 <Note>
-  GraySwan is a tool-call-specific exception. Text-only streams are delivered directly to the client and are not sent to Cygnal. See [GraySwan Cygnal](/integrations/guardrails/grayswan#streaming-output-and-tool-calls) for the full behavior.
+  Gray Swan is a tool-call-specific exception. Text-only streams are delivered directly to the client and are not sent to Cygnal. See [Gray Swan Cygnal](/integrations/guardrails/grayswan#streaming-output-and-tool-calls) for the full behavior.
 </Note>
 
 <Note>
-  If the same rule also uses another output guardrail profile, Bifrost waits for that profile to check the completed response. GraySwan's text-only behavior only skips the GraySwan call; it does not bypass the other profile.
+  If the same rule also uses another output guardrail profile, Bifrost waits for that profile to check the completed response. Gray Swan's text-only behavior only skips the Gray Swan call; it does not bypass the other profile.
 </Note>
 
 ---
@@ -423,9 +423,9 @@ Rules can be linked to multiple profiles for comprehensive validation:
 **Best Practices:**
 - Link credential-leakage rules to [Secrets Detection](/enterprise/guardrails/secrets-detection)
 - Link PII detection rules to profiles with PII capabilities (Custom Regex PII template, Presidio, Azure AI Language PII, Bedrock, Patronus)
-- Link content filtering rules to profiles with content safety features (Azure, Bedrock, GraySwan)
-- Use GraySwan for custom natural language rules when you need flexible, readable policies
-- Use multiple profiles for defense-in-depth (e.g., Bedrock + Patronus for PII, Azure + GraySwan for content)
+- Link content filtering rules to profiles with content safety features (Azure, Bedrock, Gray Swan)
+- Use Gray Swan for custom natural language rules when you need flexible, readable policies
+- Use multiple profiles for defense-in-depth (e.g., Bedrock + Patronus for PII, Azure + Gray Swan for content)
 - Set appropriate timeouts when using multiple profiles
 
 ---
@@ -462,7 +462,7 @@ Profiles are reusable configurations for guardrail providers. External providers
 </Frame>
 
 2. **Select Provider Type**
-   - Choose from: Secrets Detection, Custom Regex, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, GraySwan, or Patronus AI
+   - Choose from: Secrets Detection, Custom Regex, AWS Bedrock, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, Gray Swan, or Patronus AI
 
 3. **Configure Provider Settings**
    - Enter credentials and endpoint information for external providers, or local settings for native providers
@@ -763,8 +763,8 @@ guardrails_config:
 
 Third-party guardrail providers offer different capabilities. Bifrost-native providers are documented separately: [Secrets Detection](/enterprise/guardrails/secrets-detection) covers credential leakage, [Custom Regex](/enterprise/guardrails/custom-regex) covers deterministic pattern checks, and [Guardrail Redaction](/enterprise/guardrails/redaction) covers Bifrost-managed redaction modes.
 
-| Capability | AWS Bedrock | Azure Content Safety | Google Model Armor | CrowdStrike AIDR | GraySwan | Patronus AI | Azure AI Language PII | Presidio |
-|------------|-------------|----------------------|--------------------|------------------|----------|-------------|-----------------------|----------|
+| Capability | AWS Bedrock | Azure Content Safety | Google Model Armor | CrowdStrike AIDR | Gray Swan | Patronus AI | Azure AI Language PII | Presidio |
+|------------|-------------|----------------------|--------------------|------------------|-----------|-------------|-----------------------|----------|
 | PII Detection | Yes | No | Yes | Policy-dependent | No | Yes | Yes | Yes |
 | Content Filtering | Yes | Yes | Yes | Policy-dependent | Yes | Yes | No | No |
 | Prompt Injection | Yes | Yes | Yes | Policy-dependent | Yes | Yes | No | No |

--- a/docs/enterprise/overview.mdx
+++ b/docs/enterprise/overview.mdx
@@ -78,7 +78,7 @@ Federate user identity through your existing IdP so accounts, groups, and lifecy
 Apply content guardrails so unsafe input and output are caught before they reach your models or your users.
 
 <Card title="Guardrails" icon="road-barrier" href="/enterprise/guardrails">
-  Content safety, PII detection, secrets detection, and redaction with native checks plus Presidio, Azure AI Language PII, AWS Bedrock Guardrails, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, GraySwan, and Patronus AI.
+  Content safety, PII detection, secrets detection, and redaction with native checks plus Presidio, Azure AI Language PII, AWS Bedrock Guardrails, Azure Content Safety, Google Model Armor, CrowdStrike AIDR, Gray Swan, and Patronus AI.
 </Card>
 
 Out-of-the-box building blocks:

--- a/docs/integrations/guardrails/grayswan.mdx
+++ b/docs/integrations/guardrails/grayswan.mdx
@@ -1,18 +1,18 @@
 ---
-title: "GraySwan Cygnal"
-description: "Integrate GraySwan Cygnal Monitor with Bifrost for AI safety monitoring with natural language rule definitions, violation scoring, and advanced threat detection."
+title: "Gray Swan Cygnal"
+description: "Integrate Gray Swan Cygnal Monitor with Bifrost for AI safety monitoring with natural language rule definitions, violation scoring, and advanced threat detection."
 icon: "/media/grayswan-logo-nav.svg"
 ---
 
-Bifrost integrates with **GraySwan Cygnal Monitor** to provide AI safety monitoring with natural language rule definitions and advanced threat detection capabilities. This page covers the configuration and capabilities of the GraySwan Cygnal guardrail provider.
+Bifrost integrates with **Gray Swan Cygnal Monitor** to provide AI safety monitoring with natural language rule definitions and advanced threat detection capabilities. This page covers the configuration and capabilities of the Gray Swan Cygnal guardrail provider.
 
-![GraySwan configuration form](/media/guardrails/gray-swan-config-on-bifrost.png)
+![Gray Swan configuration form](/media/guardrails/gray-swan-config-on-bifrost.png)
 
 ## Capabilities
 
 - **Violation Scoring**: Continuous 0-1 scale violation detection with configurable thresholds
 - **Custom Natural Language Rules**: Define safety rules in plain English without code
-- **Policy Management**: Use pre-built policies from GraySwan platform or create custom ones
+- **Policy Management**: Use pre-built policies from Gray Swan platform or create custom ones
 - **Indirect Prompt Injection (IPI) Detection**: Identify hidden instructions in user inputs
 - **Mutation Detection**: Detect attempts to manipulate or alter content
 - **Reasoning Modes**: Choose from fast ("off"), balanced ("hybrid"), or thorough ("thinking") analysis
@@ -21,20 +21,20 @@ Bifrost integrates with **GraySwan Cygnal Monitor** to provide AI safety monitor
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `api_key` | string | Yes | - | GraySwan API key |
+| `api_key` | string | Yes | - | Gray Swan API key |
 | `violation_threshold` | number | No | 0.5 | Score threshold (0-1) for triggering intervention. Lower values are more strict. |
 | `reasoning_mode` | enum | No | "off" | Analysis depth: `off` (fastest), `hybrid` (balanced), or `thinking` (most thorough) |
-| `policy_id` | string | No | - | Single custom policy ID from GraySwan platform |
+| `policy_id` | string | No | - | Single custom policy ID from Gray Swan platform |
 | `policy_ids` | array | No | - | Multiple policy IDs for aggregated rule evaluation |
 | `rules` | object | No | - | Custom natural language rules as key-value pairs |
 
 ## Request Header Metadata
 
-For each GraySwan monitor call, Bifrost includes sanitized incoming request headers in GraySwan `metadata.headers`. This gives GraySwan request context for correlation and policy analysis, such as `x-request-id`, `x-correlation-id`, `traceparent`, `x-tenant-id`, `x-org-id`, `content-type`, and `content-length`.
+For each Gray Swan monitor call, Bifrost includes sanitized incoming request headers in Gray Swan `metadata.headers`. This gives Gray Swan request context for correlation and policy analysis, such as `x-request-id`, `x-correlation-id`, `traceparent`, `x-tenant-id`, `x-org-id`, `content-type`, and `content-length`.
 
-Credential-bearing headers are excluded. Bifrost does not send `authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `x-goog-api-key`, `x-bf-vk`, `x-bf-api-key`, `x-bf-api-key-id`, `cookie`, `set-cookie`, or `grayswan-api-key` in GraySwan metadata.
+Credential-bearing headers are excluded. Bifrost does not send `authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `x-goog-api-key`, `x-bf-vk`, `x-bf-api-key`, `x-bf-api-key-id`, `cookie`, `set-cookie`, or `grayswan-api-key` in Gray Swan metadata.
 
-This is metadata only: these values are added to the JSON body sent to GraySwan, not forwarded as outbound HTTP headers, and they cannot override the configured GraySwan API key.
+This is metadata only: these values are added to the JSON body sent to Gray Swan, not forwarded as outbound HTTP headers, and they cannot override the configured Gray Swan API key.
 
 ```json
 {
@@ -58,12 +58,12 @@ If Bifrost detects a supported tool call, it stops forwarding further chunks to 
 Any text sent before Bifrost detects the tool call remains visible to the client. Bifrost recognizes Chat Completions tool calls and Responses API function-call and custom tool-call events.
 
 <Note>
-  If the same rule also uses another output guardrail profile, Bifrost waits for that profile to check the completed response. GraySwan's text-only behavior only skips the GraySwan call; it does not bypass the other profile. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for the shared behavior.
+  If the same rule also uses another output guardrail profile, Bifrost waits for that profile to check the completed response. Gray Swan's text-only behavior only skips the Gray Swan call; it does not bypass the other profile. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for the shared behavior.
 </Note>
 
 ## Custom Rules Example
 
-![GraySwan custom rules](/media/guardrails/gray-swan-custom-rule.png)
+![Gray Swan custom rules](/media/guardrails/gray-swan-custom-rule.png)
 
 Rules are defined as key-value pairs where the key is the rule name and the value is a natural language description:
 

--- a/examples/k8s/enterprise/values-guardrails.yaml
+++ b/examples/k8s/enterprise/values-guardrails.yaml
@@ -28,7 +28,7 @@ bifrost:
         provider_config_ids: [2007]
       - id: 1002
         name: "input-managed-guardrails"
-        description: "Input moderation via Azure + Bedrock + GraySwan"
+        description: "Input moderation via Azure + Bedrock + Gray Swan"
         enabled: true
         cel_expression: "headers[\"test\"] == \"test\""
         query:


### PR DESCRIPTION
## Summary

Gray Swan's official name is "Gray Swan", not "GraySwan"

## Changes

- Updated the docs to reflect the correct name

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [X] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [X] Docs

## Breaking changes

- [ ] Yes
- [X] No

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [X] I updated documentation where needed
- [X] I verified builds succeed (Go and UI)
- [X] I verified the CI pipeline passes locally if applicable

