### PR TITLE
feat: add webhooks management UI with endpoint CRUD, delivery history, secret reveal, and sidebar entry

### DIFF
--- a/ui/app/workspace/webhooks/dialogs/webhookSecretDialog.tsx
+++ b/ui/app/workspace/webhooks/dialogs/webhookSecretDialog.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { ArrowUpRight, Check, Copy } from "lucide-react";
+
+const WEBHOOKS_VERIFICATION_DOCS_URL = "https://docs.getbifrost.ai/features/webhooks?utm_source=bfd#verifying-deliveries";
+
+export interface WebhookSecretReveal {
+	endpointName: string;
+	secret: string;
+}
+
+interface WebhookSecretDialogProps {
+	reveal: WebhookSecretReveal | null;
+	onClose: () => void;
+}
+
+// The signing secret is returned exactly once by create and rotate-secret;
+// the API never exposes it again, so this dialog is the only chance to copy it.
+export function WebhookSecretDialog({ reveal, onClose }: WebhookSecretDialogProps) {
+	const { copy, copied } = useCopyToClipboard();
+
+	return (
+		<Dialog open={!!reveal} onOpenChange={(open) => !open && onClose()}>
+			<DialogContent data-testid="webhook-secret-dialog">
+				<DialogHeader>
+					<DialogTitle>Signing secret for {reveal?.endpointName}</DialogTitle>
+					<DialogDescription>
+						Use this secret to verify the <code>webhook-signature</code> header on deliveries. It is shown only once - copy it now and store
+						it securely. If you lose it, rotate the endpoint to get a new one.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="flex items-center gap-2 rounded-sm border p-3">
+					<code className="min-w-0 flex-1 font-mono text-sm break-all" data-testid="webhook-secret-value">
+						{reveal?.secret}
+					</code>
+					<Button
+						variant="ghost"
+						size="sm"
+						aria-label="Copy signing secret"
+						onClick={() => reveal && copy(reveal.secret)}
+						data-testid="webhook-secret-copy-btn"
+					>
+						{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+					</Button>
+					<span className="sr-only" aria-live="polite">
+						{copied ? "Signing secret copied" : ""}
+					</span>
+				</div>
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => {
+							window.open(WEBHOOKS_VERIFICATION_DOCS_URL, "_blank", "noopener,noreferrer");
+						}}
+					>
+						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+					</Button>
+					<Button onClick={onClose} data-testid="webhook-secret-done-btn">
+						I&apos;ve stored the secret
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/ui/app/workspace/webhooks/layout.tsx
+++ b/ui/app/workspace/webhooks/layout.tsx
@@ -1,0 +1,16 @@
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { createFileRoute } from "@tanstack/react-router";
+import WebhooksPage from "./page";
+
+function RouteComponent() {
+	const hasWebhooksAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+	if (!hasWebhooksAccess) {
+		return <NoPermissionView entity="webhooks" />;
+	}
+	return <WebhooksPage />;
+}
+
+export const Route = createFileRoute("/workspace/webhooks")({
+	component: RouteComponent,
+});

--- a/ui/app/workspace/webhooks/page.tsx
+++ b/ui/app/workspace/webhooks/page.tsx
@@ -1,0 +1,9 @@
+import WebhooksView from "./views/webhooksView";
+
+export default function WebhooksPage() {
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<WebhooksView />
+		</div>
+	);
+}

--- a/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
@@ -1,0 +1,505 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { getErrorMessage, useGetWebhookDeliveriesQuery, useRedeliverWebhookDeliveryMutation } from "@/lib/store";
+import {
+	WEBHOOK_EVENT_COLORS,
+	WEBHOOK_TUNING_DEFAULTS,
+	WebhookDelivery,
+	WebhookDeliveryOutcome,
+	WebhookEndpoint,
+	WebhookEvent,
+} from "@/lib/types/webhooks";
+import { format, formatDistanceToNow } from "date-fns";
+import { ChevronDown, ChevronLeft, ChevronRight, Info, Loader2, RefreshCcw, Send } from "lucide-react";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+const PAGE_SIZE = 25;
+
+const OUTCOME_COLORS: Record<WebhookDeliveryOutcome, string> = {
+	delivered: "bg-green-100 text-green-800",
+	retryable_failure: "bg-yellow-100 text-yellow-800",
+	permanent_failure: "bg-red-100 text-red-800",
+	exhausted: "bg-red-100 text-red-800",
+};
+
+const OUTCOME_LABELS: Record<WebhookDeliveryOutcome, string> = {
+	delivered: "delivered",
+	retryable_failure: "retrying",
+	permanent_failure: "failed",
+	exhausted: "retries exhausted",
+};
+
+const DetailEntry = ({ label, value }: { label: string; value: React.ReactNode }) => (
+	<div>
+		<div className="text-muted-foreground text-xs">{label}</div>
+		<div className="text-sm font-medium break-all">{value}</div>
+	</div>
+);
+
+const relativeTime = (timestamp?: string) => (timestamp ? formatDistanceToNow(new Date(timestamp), { addSuffix: true }) : "never");
+
+// Wraps a badge with the attempt's error text as a tooltip when present.
+const withErrorTooltip = (badge: React.ReactNode, error?: string) => {
+	if (!error) {
+		return badge;
+	}
+	return (
+		<Tooltip>
+			<TooltipTrigger>{badge}</TooltipTrigger>
+			{/* text-wrap overrides the component's text-balance, which leaves a
+			    right-side gap by shortening lines inside a full-width box. */}
+			<TooltipContent className="max-w-[400px] text-wrap break-words">{error}</TooltipContent>
+		</Tooltip>
+	);
+};
+
+// Run-level outcome: where the delivery as a whole stands.
+const outcomeBadge = (attempt: WebhookDelivery) =>
+	withErrorTooltip(
+		<Badge variant="outline" className={OUTCOME_COLORS[attempt.outcome]}>
+			{OUTCOME_LABELS[attempt.outcome]}
+		</Badge>,
+		attempt.error,
+	);
+
+// Colour a response status code by band: 2xx delivered, 429/5xx retryable,
+// other 4xx permanent.
+const statusCodeClass = (code: number | undefined): string => {
+	if (code && code >= 200 && code < 300) return "bg-green-100 text-green-800";
+	if (code === 429 || (code && code >= 500)) return "bg-yellow-100 text-yellow-800";
+	return "bg-red-100 text-red-800";
+};
+
+// A send's attempts, oldest first, as a "503 → 503 → 200" sequence of
+// status-code chips. Failed attempts surface their error on hover. A response
+// that never arrived (network error) has a zero status code, shown as a dash.
+const attemptSequence = (attemptsNewestFirst: WebhookDelivery[]) => (
+	<div className="flex items-center gap-1">
+		{[...attemptsNewestFirst].reverse().map((attempt, index) => (
+			<Fragment key={attempt.id}>
+				{index > 0 && <span className="text-muted-foreground text-xs">→</span>}
+				{withErrorTooltip(
+					<Badge variant="outline" className={`font-mono text-xs ${statusCodeClass(attempt.status_code)}`}>
+						{attempt.status_code || "-"}
+					</Badge>,
+					attempt.error,
+				)}
+			</Fragment>
+		))}
+	</div>
+);
+
+interface WebhookDetailsSheetProps {
+	endpoint: WebhookEndpoint | null;
+	// Test fires are owned by the parent so the in-flight state stays shared
+	// with the table's actions menu.
+	isTesting: boolean;
+	// Gates the mutating controls (test fire, redeliver) so a view-only user
+	// sees the history without the ability to trigger deliveries.
+	canManage: boolean;
+	onTest: (endpoint: WebhookEndpoint, event: WebhookEvent) => void;
+	onClose: () => void;
+}
+
+export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, onClose }: WebhookDetailsSheetProps) {
+	const open = !!endpoint;
+	const [offset, setOffset] = useState(0);
+	const [redeliverWebhookDelivery] = useRedeliverWebhookDeliveryMutation();
+	const [redeliveringIds, setRedeliveringIds] = useState<Set<string>>(new Set());
+	const { copy } = useCopyToClipboard();
+
+	useEffect(() => {
+		setOffset(0);
+	}, [endpoint?.id]);
+
+	const { data, isLoading, isError } = useGetWebhookDeliveriesQuery(
+		{ endpointId: endpoint?.id ?? "", limit: PAGE_SIZE, offset },
+		{ skip: !open, pollingInterval: 5000 },
+	);
+	const totalCount = data?.pagination.total_count ?? 0;
+
+	// The history groups into two levels. Level 1 is one row per delivery
+	// (webhook_id): the notification owed to the endpoint for a job event.
+	// Level 2 is its sends: the original plus each manual redelivery, which
+	// reuse the webhook_id and restart attempt numbering, so a send boundary is
+	// where attempt_no stops decreasing. Attempts within a send stay inline as a
+	// status-code sequence. Rows arrive newest-first, so the delivery order and
+	// the newest attempt of each send both come for free.
+	const deliveries = useMemo(() => {
+		const rows = data?.deliveries ?? [];
+		const order: string[] = [];
+		const byWebhookId = new Map<string, WebhookDelivery[]>();
+		for (const row of rows) {
+			const existing = byWebhookId.get(row.webhook_id);
+			if (existing) {
+				existing.push(row);
+			} else {
+				byWebhookId.set(row.webhook_id, [row]);
+				order.push(row.webhook_id);
+			}
+		}
+		return order.map((webhookId) => {
+			const attempts = byWebhookId.get(webhookId) ?? [];
+			// Split the newest-first attempts into sends at each attempt-number restart.
+			const sendsNewestFirst: WebhookDelivery[][] = [];
+			for (const attempt of attempts) {
+				const current = sendsNewestFirst[sendsNewestFirst.length - 1];
+				if (current && attempt.attempt_no < current[current.length - 1].attempt_no) {
+					current.push(attempt);
+				} else {
+					sendsNewestFirst.push([attempt]);
+				}
+			}
+			// The oldest send is the original; label the rest as redeliveries in order.
+			const sends = [...sendsNewestFirst].reverse().map((sendAttempts, index) => ({
+				key: `${webhookId}:${index}`,
+				label: index === 0 ? "Original" : `Redelivery ${index}`,
+				attempts: sendAttempts,
+			}));
+			return { webhookId, latest: attempts[0], latestSend: sends[sends.length - 1], sends };
+		});
+	}, [data]);
+
+	const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+	const toggleExpanded = (webhookId: string) => {
+		setExpandedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(webhookId)) {
+				next.delete(webhookId);
+			} else {
+				next.add(webhookId);
+			}
+			return next;
+		});
+	};
+
+	const handleRedeliver = async (deliveryId: string) => {
+		setRedeliveringIds((prev) => new Set(prev).add(deliveryId));
+		try {
+			await redeliverWebhookDelivery(deliveryId).unwrap();
+			toast.success("Redelivery queued under the original webhook id");
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		} finally {
+			setRedeliveringIds((prev) => {
+				const next = new Set(prev);
+				next.delete(deliveryId);
+				return next;
+			});
+		}
+	};
+
+	// Effective knob value with its unit; unset knobs show the worker default.
+	const tuning = (key: keyof typeof WEBHOOK_TUNING_DEFAULTS, unit = "") => {
+		const value = endpoint?.[key] || WEBHOOK_TUNING_DEFAULTS[key];
+		return `${value}${unit}`;
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
+			<SheetContent className="flex w-full flex-col gap-0 overflow-x-hidden p-8 sm:max-w-[60%]">
+				<SheetHeader className="flex flex-col items-start px-0">
+					<SheetTitle className="flex w-fit items-center gap-2 font-medium">
+						<p className="text-md max-w-full truncate">{endpoint?.name}</p>
+						{endpoint?.disabled ? (
+							<Badge variant="outline" className="bg-gray-100 text-gray-800">
+								disabled
+							</Badge>
+						) : (
+							<Badge variant="outline" className="bg-green-100 text-green-800">
+								enabled
+							</Badge>
+						)}
+					</SheetTitle>
+					<SheetDescription className="break-all">{endpoint?.url}</SheetDescription>
+				</SheetHeader>
+
+				<div className="space-y-4 rounded-sm border p-4">
+					<div className="grid grid-cols-3 gap-4">
+						<DetailEntry
+							label="Events"
+							value={
+								<div className="flex flex-wrap gap-1">
+									{endpoint?.events.map((event) => (
+										<Badge key={event} variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[event]}`}>
+											{event}
+										</Badge>
+									))}
+								</div>
+							}
+						/>
+						<DetailEntry label="Include response" value={endpoint?.include_response ? "yes" : "no"} />
+						<DetailEntry label="Private network" value={endpoint?.allow_private_network ? "allowed" : "blocked"} />
+						<DetailEntry label="Last success" value={relativeTime(endpoint?.last_success_at)} />
+						<DetailEntry label="Last failure" value={relativeTime(endpoint?.last_failure_at)} />
+						<DetailEntry label="Consecutive failures" value={endpoint?.consecutive_failures ?? 0} />
+						<DetailEntry label="Max retries" value={tuning("max_retries")} />
+						<DetailEntry
+							label="Retry backoff"
+							value={`${tuning("retry_backoff_initial_seconds", "s")} → ${tuning("retry_backoff_max_seconds", "s")}`}
+						/>
+						<DetailEntry label="Attempt timeout" value={tuning("attempt_timeout_seconds", "s")} />
+					</div>
+				</div>
+
+				<div className="mt-4 flex items-center justify-between">
+					<h3 className="font-semibold">Delivery History</h3>
+					{canManage && (
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="outline"
+									size="sm"
+									className="min-w-[10rem] justify-between"
+									disabled={isTesting || endpoint?.disabled}
+									data-testid="webhook-test-fire-btn"
+								>
+									{isTesting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+									<span className="flex-1 text-center">Send Test Event</span>
+									<ChevronDown className="h-3 w-3" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent align="end">
+								{endpoint?.events.map((event) => (
+									<DropdownMenuItem
+										key={event}
+										className="cursor-pointer"
+										data-testid={`webhook-test-fire-${event}`}
+										onSelect={() => onTest(endpoint, event)}
+									>
+										{event}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuContent>
+						</DropdownMenu>
+					)}
+				</div>
+
+				<div className="mt-4 min-h-0 flex-1 overflow-auto rounded-sm border [scrollbar-gutter:stable]">
+					<Table>
+						<TableHeader className="bg-muted sticky top-0 z-10">
+							<TableRow>
+								<TableHead className="w-8 px-2"></TableHead>
+								<TableHead>Time</TableHead>
+								<TableHead>Request ID</TableHead>
+								<TableHead>Event</TableHead>
+								<TableHead>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="inline-flex cursor-help items-center gap-1.5">
+												Status
+												<Info className="text-muted-foreground size-3" />
+											</span>
+										</TooltipTrigger>
+										<TooltipContent className="max-w-xs">
+											<div className="space-y-1">
+												<p>
+													<span className="font-medium">delivered</span>: receiver returned a 2xx.
+												</p>
+												<p>
+													<span className="font-medium">retrying</span>: transient failure (network error, timeout, 429, or 5xx); another
+													attempt is scheduled.
+												</p>
+												<p>
+													<span className="font-medium">failed</span>: permanent error (a non-retryable 4xx such as 401/404); not retried
+													automatically.
+												</p>
+												<p>
+													<span className="font-medium">retries exhausted</span>: kept failing until the retry budget ran out.
+												</p>
+											</div>
+										</TooltipContent>
+									</Tooltip>
+								</TableHead>
+								<TableHead>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="inline-flex cursor-help items-center gap-1.5">
+												Responses
+												<Info className="text-muted-foreground size-3" />
+											</span>
+										</TooltipTrigger>
+										<TooltipContent className="max-w-xs">
+											One chip per delivery attempt, oldest to newest: the receiver's response code, or a dash when no response arrived.
+											Hover a failed code for its error.
+										</TooltipContent>
+									</Tooltip>
+								</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell colSpan={7} className="h-24 text-center">
+										<Loader2 className="mx-auto h-4 w-4 animate-spin" />
+									</TableCell>
+								</TableRow>
+							) : isError ? (
+								<TableRow>
+									<TableCell colSpan={7} className="text-destructive h-24 text-center" data-testid="webhook-delivery-history-error">
+										Failed to load delivery history. Retrying…
+									</TableCell>
+								</TableRow>
+							) : deliveries.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
+										No deliveries yet.
+									</TableCell>
+								</TableRow>
+							) : (
+								deliveries.map(({ webhookId, latest, latestSend, sends }) => {
+									const hasResends = sends.length > 1;
+									const expanded = expandedIds.has(webhookId);
+									// The delivery counts as delivered if any send reached the receiver,
+									// even when a later manual redelivery failed. Headline the newest
+									// successful send; otherwise fall back to the latest send's state.
+									const deliveredSend = [...sends].reverse().find((send) => send.attempts[0].outcome === "delivered");
+									const headlineSend = deliveredSend ?? latestSend;
+									const headline = headlineSend.attempts[0];
+									return (
+										<Fragment key={webhookId}>
+											<TableRow data-testid={`webhook-delivery-row-${webhookId}`}>
+												<TableCell className="px-2">
+													{hasResends && (
+														<Button
+															variant="ghost"
+															size="icon"
+															className="size-8"
+															onClick={() => toggleExpanded(webhookId)}
+															aria-expanded={expanded}
+															aria-label={expanded ? "Collapse redeliveries" : "Expand redeliveries"}
+															data-testid={`webhook-delivery-expand-${webhookId}`}
+														>
+															{expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+														</Button>
+													)}
+												</TableCell>
+												<TableCell className="whitespace-nowrap">{relativeTime(latest.created_at)}</TableCell>
+												<TableCell>
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<button
+																type="button"
+																className="cursor-pointer font-mono text-xs"
+																onClick={() => copy(latest.async_job_id)}
+																aria-label="Copy request ID"
+																data-testid={`webhook-delivery-request-id-${run.key}`}
+															>
+																{latest.async_job_id.slice(0, 8)}…
+															</button>
+														</TooltipTrigger>
+														<TooltipContent className="font-mono">{latest.async_job_id}</TooltipContent>
+													</Tooltip>
+												</TableCell>
+												<TableCell className="whitespace-nowrap">
+													<Badge variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[latest.event]}`}>
+														{latest.event}
+													</Badge>
+												</TableCell>
+												<TableCell>
+													<div className="flex items-center gap-2">
+														{outcomeBadge(headline)}
+														{hasResends && (
+															<Badge variant="outline" className="text-muted-foreground text-xs">
+																{sends.length} sends
+															</Badge>
+														)}
+													</div>
+												</TableCell>
+												<TableCell>{attemptSequence(headlineSend.attempts)}</TableCell>
+												<TableCell className="text-right">
+													{canManage && (
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() => handleRedeliver(latest.id)}
+															disabled={redeliveringIds.has(latest.id) || latest.outcome === "retryable_failure" || endpoint?.disabled}
+															data-testid={`webhook-redeliver-btn-${webhookId}`}
+															aria-label="Redeliver"
+														>
+															{redeliveringIds.has(latest.id) ? (
+																<Loader2 className="h-4 w-4 animate-spin" />
+															) : (
+																<RefreshCcw className="h-4 w-4" />
+															)}
+														</Button>
+													)}
+												</TableCell>
+											</TableRow>
+											{hasResends &&
+												expanded &&
+												sends.map((send) => {
+													const sendLatest = send.attempts[0];
+													return (
+														<TableRow key={send.key} className="bg-muted/30" data-testid={`webhook-delivery-send-${send.key}`}>
+															<TableCell className="px-2"></TableCell>
+															<TableCell colSpan={3}>
+																<div className="flex items-center gap-2">
+																	<span
+																		className="border-border ml-1 inline-block size-2.5 rounded-bl-[3px] border-b border-l"
+																		aria-hidden="true"
+																	/>
+																	<span className="text-sm font-medium">{send.label}</span>
+																	<span className="text-muted-foreground text-xs tabular-nums">
+																		{format(new Date(sendLatest.created_at), "MMM d, yyyy hh:mm:ss aa")}
+																	</span>
+																</div>
+															</TableCell>
+															<TableCell>{outcomeBadge(sendLatest)}</TableCell>
+															<TableCell>{attemptSequence(send.attempts)}</TableCell>
+															<TableCell></TableCell>
+														</TableRow>
+													);
+												})}
+										</Fragment>
+									);
+								})
+							)}
+						</TableBody>
+					</Table>
+				</div>
+
+				{totalCount > 0 && (
+					<div className="flex shrink-0 items-center justify-between text-xs" data-testid="webhook-delivery-pagination">
+						<div className="text-muted-foreground flex items-center gap-2">
+							{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
+							deliveries
+						</div>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+								disabled={offset === 0}
+								aria-label="Previous page"
+							>
+								<ChevronLeft className="size-3" />
+							</Button>
+							<div className="flex items-center gap-1">
+								<span>Page</span>
+								<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+								<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
+							</div>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => setOffset(offset + PAGE_SIZE)}
+								disabled={offset + PAGE_SIZE >= totalCount}
+								aria-label="Next page"
+							>
+								<ChevronRight className="size-3" />
+							</Button>
+						</div>
+					</div>
+				)}
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/webhooks/views/webhookSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookSheet.tsx
@@ -1,0 +1,360 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { HeadersTable } from "@/components/ui/headersTable";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import { getErrorMessage, useCreateWebhookEndpointMutation, useUpdateWebhookEndpointMutation } from "@/lib/store";
+import { SecretVar } from "@/lib/types/schemas";
+import { WEBHOOK_EVENTS, WEBHOOK_TUNING_DEFAULTS, WebhookEndpoint, WebhookEndpointRequest, WebhookEvent } from "@/lib/types/webhooks";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { WebhookSecretReveal } from "../dialogs/webhookSecretDialog";
+
+const webhookFormSchema = z
+	.object({
+		name: z.string().trim().min(1, "Name is required"),
+		url: z
+			.string()
+			.trim()
+			.min(1, "URL is required")
+			.refine((value) => {
+				try {
+					const parsed = new URL(value);
+					return ["http:", "https:"].includes(parsed.protocol) && Boolean(parsed.hostname);
+				} catch {
+					return false;
+				}
+			}, "Enter a valid HTTP(S) URL"),
+		events: z.array(z.enum(["async_job.completed", "async_job.failed"])).min(1, "Subscribe to at least one event"),
+		include_response: z.boolean(),
+		allow_private_network: z.boolean(),
+		max_retries: z.number().int().min(0).optional(),
+		retry_backoff_initial_seconds: z.number().int().min(0).optional(),
+		retry_backoff_max_seconds: z.number().int().min(0).optional(),
+		attempt_timeout_seconds: z.number().int().min(0).optional(),
+		max_response_payload_kbs: z.number().int().min(0).optional(),
+		max_concurrent_deliveries: z.number().int().min(0).optional(),
+	})
+	.refine((data) => data.allow_private_network || !data.url.startsWith("http://"), {
+		message: 'http:// URLs require "Allow private network" to be enabled',
+		path: ["url"],
+	});
+
+type WebhookFormData = z.infer<typeof webhookFormSchema>;
+
+const TUNING_FIELDS: {
+	key: keyof typeof WEBHOOK_TUNING_DEFAULTS;
+	label: string;
+	description: string;
+}[] = [
+	{ key: "max_retries", label: "Max retries", description: "Retries after the first delivery attempt." },
+	{
+		key: "retry_backoff_initial_seconds",
+		label: "Initial retry backoff (seconds)",
+		description: "Delay before the first retry; doubles per retry.",
+	},
+	{ key: "retry_backoff_max_seconds", label: "Max retry backoff (seconds)", description: "Cap on the per-retry delay." },
+	{ key: "attempt_timeout_seconds", label: "Attempt timeout (seconds)", description: "End-to-end bound for one delivery attempt." },
+	{
+		key: "max_response_payload_kbs",
+		label: "Max response payload (KB)",
+		description: "Responses above this size are omitted from the payload.",
+	},
+	{
+		key: "max_concurrent_deliveries",
+		label: "Max concurrent deliveries",
+		description: "Concurrent in-flight deliveries to this endpoint per node.",
+	},
+];
+
+const formDefaults = (endpoint: WebhookEndpoint | null): WebhookFormData => ({
+	name: endpoint?.name ?? "",
+	url: endpoint?.url ?? "",
+	events: endpoint?.events ?? ["async_job.completed", "async_job.failed"],
+	include_response: endpoint?.include_response ?? false,
+	allow_private_network: endpoint?.allow_private_network ?? false,
+	max_retries: endpoint?.max_retries || undefined,
+	retry_backoff_initial_seconds: endpoint?.retry_backoff_initial_seconds || undefined,
+	retry_backoff_max_seconds: endpoint?.retry_backoff_max_seconds || undefined,
+	attempt_timeout_seconds: endpoint?.attempt_timeout_seconds || undefined,
+	max_response_payload_kbs: endpoint?.max_response_payload_kbs || undefined,
+	max_concurrent_deliveries: endpoint?.max_concurrent_deliveries || undefined,
+});
+
+interface WebhookSheetProps {
+	open: boolean;
+	// null creates a new endpoint; otherwise edits the given one.
+	endpoint: WebhookEndpoint | null;
+	onClose: () => void;
+	// Create returns the signing secret exactly once; the parent shows it.
+	onSecret: (reveal: WebhookSecretReveal) => void;
+}
+
+export function WebhookSheet({ open, endpoint, onClose, onSecret }: WebhookSheetProps) {
+	const isEditing = !!endpoint;
+	const [createWebhookEndpoint, { isLoading: isCreating }] = useCreateWebhookEndpointMutation();
+	const [updateWebhookEndpoint, { isLoading: isUpdating }] = useUpdateWebhookEndpointMutation();
+	const isSaving = isCreating || isUpdating;
+
+	// Header values are SecretVars managed outside the form (HeadersTable is
+	// not a form control). Stored values arrive fully redacted; untouched
+	// placeholders round-trip as-is and the server restores the real value.
+	const [headers, setHeaders] = useState<Record<string, SecretVar>>({});
+	// HeadersTable edits bypass react-hook-form, so header changes carry
+	// their own dirty flag for the submit gate.
+	const [headersDirty, setHeadersDirty] = useState(false);
+	// Header validation runs on submit (HeadersTable is not a form control);
+	// the message persists beside the table and clears when headers change.
+	const [headersError, setHeadersError] = useState<string | null>(null);
+
+	const {
+		register,
+		handleSubmit,
+		setValue,
+		watch,
+		reset,
+		formState: { errors, isDirty },
+	} = useForm<WebhookFormData>({
+		resolver: zodResolver(webhookFormSchema),
+		defaultValues: formDefaults(null),
+	});
+
+	const events = watch("events");
+	const includeResponse = watch("include_response");
+	const allowPrivateNetwork = watch("allow_private_network");
+	const hasChanges = isDirty || headersDirty;
+
+	useEffect(() => {
+		if (!open) return;
+		reset(formDefaults(endpoint));
+		setHeaders(endpoint?.headers ?? {});
+		setHeadersDirty(false);
+		setHeadersError(null);
+	}, [open, endpoint, reset]);
+
+	const handleHeadersChange = (next: Record<string, SecretVar>) => {
+		setHeaders(next);
+		setHeadersDirty(true);
+		setHeadersError(null);
+	};
+
+	const toggleEvent = (event: WebhookEvent, checked: boolean) => {
+		const next = checked ? [...events, event] : events.filter((e) => e !== event);
+		setValue("events", next, { shouldValidate: true, shouldDirty: true });
+	};
+
+	const onSubmit = async (data: WebhookFormData) => {
+		const cleanedHeaders: Record<string, SecretVar> = {};
+		for (const [name, value] of Object.entries(headers)) {
+			if (!name.trim()) continue;
+			if (!value?.value?.trim() && !value?.ref?.trim()) {
+				setHeadersError(`Header "${name}" must have a value`);
+				return;
+			}
+			cleanedHeaders[name.trim()] = value;
+		}
+
+		const request: WebhookEndpointRequest = {
+			name: data.name,
+			url: data.url,
+			events: data.events,
+			headers: cleanedHeaders,
+			include_response: data.include_response,
+			allow_private_network: data.allow_private_network,
+			disabled: endpoint?.disabled ?? false,
+			max_retries: data.max_retries ?? 0,
+			retry_backoff_initial_seconds: data.retry_backoff_initial_seconds ?? 0,
+			retry_backoff_max_seconds: data.retry_backoff_max_seconds ?? 0,
+			attempt_timeout_seconds: data.attempt_timeout_seconds ?? 0,
+			max_response_payload_kbs: data.max_response_payload_kbs ?? 0,
+			max_concurrent_deliveries: data.max_concurrent_deliveries ?? 0,
+		};
+
+		try {
+			if (isEditing) {
+				await updateWebhookEndpoint({ id: endpoint.id, data: request }).unwrap();
+				toast.success("Webhook endpoint updated successfully");
+				onClose();
+			} else {
+				const response = await createWebhookEndpoint(request).unwrap();
+				toast.success("Webhook endpoint created successfully");
+				onClose();
+				onSecret({ endpointName: response.endpoint.name, secret: response.secret });
+			}
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	};
+
+	return (
+		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
+			<SheetContent className="flex w-full flex-col overflow-x-hidden px-0" data-testid="webhook-sheet-content">
+				<SheetHeader className="flex flex-col items-start px-7 pt-8">
+					<SheetTitle>{isEditing ? endpoint.name : "Add Webhook Endpoint"}</SheetTitle>
+					<SheetDescription>
+						{isEditing
+							? "Update the endpoint's URL, subscriptions, and delivery behavior."
+							: "Register an HTTPS endpoint to receive signed notifications when async jobs finish."}
+					</SheetDescription>
+				</SheetHeader>
+
+				<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+					<div className="flex-1 space-y-4 overflow-y-auto px-8">
+						<div className="space-y-2">
+							<Label htmlFor="webhook-name">Name</Label>
+							<Input
+								id="webhook-name"
+								placeholder="e.g., billing-service"
+								data-testid="webhook-name-input"
+								{...register("name")}
+								className={errors.name ? "border-destructive" : ""}
+							/>
+							{errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="webhook-url">URL</Label>
+							<Input
+								id="webhook-url"
+								placeholder="https://example.com/hooks/bifrost"
+								data-testid="webhook-url-input"
+								{...register("url")}
+								className={errors.url ? "border-destructive" : ""}
+							/>
+							{errors.url && <p className="text-destructive text-sm">{errors.url.message}</p>}
+						</div>
+
+						<div className="space-y-2">
+							<Label>Events</Label>
+							<div className="space-y-2 rounded-sm border p-4">
+								{WEBHOOK_EVENTS.map((event) => (
+									<div key={event.value}>
+										<label className="flex cursor-pointer items-center gap-2 text-sm" htmlFor={`webhook-event-${event.value}`}>
+											<Checkbox
+												id={`webhook-event-${event.value}`}
+												checked={events.includes(event.value)}
+												onCheckedChange={(checked) => toggleEvent(event.value, checked === true)}
+												data-testid={`webhook-event-${event.value}-checkbox`}
+											/>
+											{event.label}
+										</label>
+										<p className="text-muted-foreground pl-6 text-xs">{event.description}</p>
+									</div>
+								))}
+							</div>
+							{errors.events && <p className="text-destructive text-sm">{errors.events.message}</p>}
+						</div>
+
+						<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+							<div className="space-y-0.5">
+								<Label htmlFor="webhook-include-response" className="text-sm font-normal">
+									Include response payload
+								</Label>
+								<p className="text-muted-foreground text-xs">
+									Inline the job's result in the notification. Oversized or already-expired results are delivered as a thin payload instead.
+								</p>
+							</div>
+							<Switch
+								id="webhook-include-response"
+								checked={includeResponse}
+								onCheckedChange={(checked) => setValue("include_response", checked, { shouldDirty: true })}
+								data-testid="webhook-include-response-switch"
+							/>
+						</div>
+
+						<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+							<div className="space-y-0.5">
+								<Label htmlFor="webhook-private-network" className="text-sm font-normal">
+									Allow private network
+								</Label>
+								<p className="text-muted-foreground text-xs">
+									Permit deliveries to private IP ranges. Only enable this for receivers inside your own network.
+								</p>
+							</div>
+							<Switch
+								id="webhook-private-network"
+								checked={allowPrivateNetwork}
+								onCheckedChange={(checked) => setValue("allow_private_network", checked, { shouldDirty: true, shouldValidate: true })}
+								data-testid="webhook-private-network-switch"
+							/>
+						</div>
+
+						<div className="space-y-2">
+							<HeadersTable<SecretVar>
+								value={headers}
+								onChange={handleHeadersChange}
+								useSecretVarInput
+								label="Custom Headers"
+								keyPlaceholder="e.g., Authorization"
+								valuePlaceholder="Value or env.VARIABLE"
+							/>
+							{headersError && (
+								<p className="text-destructive text-xs" data-testid="webhook-headers-error">
+									{headersError}
+								</p>
+							)}
+							<p className="text-muted-foreground text-xs">
+								Sent with every delivery. Signing and content headers are reserved and cannot be overridden.
+							</p>
+						</div>
+
+						<div className="space-y-4">
+							<h3 className="text-sm leading-none font-medium" data-testid="webhook-tuning-heading">
+								Delivery Tuning
+							</h3>
+							{TUNING_FIELDS.map((field) => {
+								const fieldValue = watch(field.key);
+								const isUsingDefault = fieldValue === undefined || fieldValue === 0;
+								return (
+									<div key={field.key} className="flex items-center justify-between gap-4 rounded-lg border px-4 py-2">
+										<div className="flex flex-col items-start gap-0.5">
+											<Label htmlFor={`webhook-${field.key}`} className="text-sm font-normal">
+												{field.label}
+											</Label>
+											<p className="text-muted-foreground text-xs">{field.description}</p>
+											{isUsingDefault && <p className="text-muted-foreground text-xs">Using delivery worker default</p>}
+										</div>
+										<Input
+											id={`webhook-${field.key}`}
+											type="number"
+											min="0"
+											className={`w-24 ${isUsingDefault ? "text-muted-foreground" : ""}`}
+											placeholder={String(WEBHOOK_TUNING_DEFAULTS[field.key])}
+											data-testid={`webhook-${field.key}-input`}
+											value={fieldValue ?? ""}
+											onChange={(e) =>
+												setValue(field.key, e.target.value === "" ? undefined : Number(e.target.value), {
+													shouldValidate: true,
+													shouldDirty: true,
+												})
+											}
+										/>
+									</div>
+								);
+							})}
+							<p className="text-muted-foreground pb-2 text-xs">
+								If retries extend past the job's result TTL, later deliveries carry a thin payload marked <code>result_expired</code>.
+							</p>
+						</div>
+					</div>
+
+					<div className="dark:bg-card border-border border-t bg-white px-8 py-4">
+						<div className="flex justify-end gap-2">
+							<Button type="button" variant="outline" onClick={onClose} disabled={isSaving} data-testid="webhook-cancel-btn">
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isSaving || !hasChanges} data-testid="webhook-save-btn">
+								{isSaving ? "Saving..." : isEditing ? "Update Endpoint" : "Create Endpoint"}
+							</Button>
+						</div>
+					</div>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/webhooks/views/webhooksEmptyState.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksEmptyState.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/components/ui/button";
+import { ArrowUpRight, Webhook } from "lucide-react";
+
+const WEBHOOKS_DOCS_URL = "https://docs.getbifrost.ai/features/webhooks";
+
+interface WebhooksEmptyStateProps {
+	onAddClick: () => void;
+	canCreate: boolean;
+}
+
+export function WebhooksEmptyState({ onAddClick, canCreate }: WebhooksEmptyStateProps) {
+	return (
+		<div
+			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
+			data-testid="webhooks-empty-state"
+		>
+			<div className="text-muted-foreground">
+				<Webhook className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
+			</div>
+			<div className="flex flex-col gap-1">
+				<h1 className="text-muted-foreground text-xl font-medium">Get notified when async jobs finish</h1>
+				<div className="text-muted-foreground mx-auto mt-2 max-w-[600px] text-sm font-normal">
+					Register webhook endpoints and Bifrost will send a signed notification whenever an async inference job completes or fails, so you
+					don't have to poll for results.
+				</div>
+				<div className="mx-auto mt-6 flex flex-row flex-wrap items-center justify-center gap-2">
+					<Button
+						variant="outline"
+						onClick={() => {
+							window.open(`${WEBHOOKS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
+						}}
+					>
+						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
+					</Button>
+					<Button onClick={onAddClick} disabled={!canCreate} data-testid="create-webhook-btn">
+						Add Webhook Endpoint
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/app/workspace/webhooks/views/webhooksView.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksView.tsx
@@ -1,0 +1,449 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+	getErrorMessage,
+	useDeleteWebhookEndpointMutation,
+	useGetWebhookEndpointsQuery,
+	useRotateWebhookEndpointSecretMutation,
+	useTestWebhookEndpointMutation,
+	useUpdateWebhookEndpointMutation,
+} from "@/lib/store";
+import {
+	WEBHOOK_EVENT_COLORS,
+	WEBHOOK_TEST_COOLDOWN_SECONDS,
+	WebhookEndpoint,
+	WebhookEndpointRequest,
+	WebhookEvent,
+} from "@/lib/types/webhooks";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { MoreHorizontal, PencilIcon, Plus, RotateCcw, Search, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { WebhookSecretDialog, WebhookSecretReveal } from "../dialogs/webhookSecretDialog";
+import { WebhookDetailsSheet } from "./webhookDetailsSheet";
+import { WebhookSheet } from "./webhookSheet";
+import { WebhooksEmptyState } from "./webhooksEmptyState";
+
+const POLLING_INTERVAL = 5000;
+
+// PUT replaces the endpoint's full editable state, so toggles resend the row
+// as-is. Redacted header values round-trip untouched and the server keeps the
+// stored credentials.
+const toRequest = (endpoint: WebhookEndpoint, overrides: Partial<WebhookEndpointRequest>): WebhookEndpointRequest => ({
+	name: endpoint.name,
+	url: endpoint.url,
+	events: endpoint.events,
+	headers: endpoint.headers ?? {},
+	include_response: endpoint.include_response,
+	allow_private_network: endpoint.allow_private_network,
+	disabled: endpoint.disabled,
+	max_retries: endpoint.max_retries ?? 0,
+	retry_backoff_initial_seconds: endpoint.retry_backoff_initial_seconds ?? 0,
+	retry_backoff_max_seconds: endpoint.retry_backoff_max_seconds ?? 0,
+	attempt_timeout_seconds: endpoint.attempt_timeout_seconds ?? 0,
+	max_response_payload_kbs: endpoint.max_response_payload_kbs ?? 0,
+	max_concurrent_deliveries: endpoint.max_concurrent_deliveries ?? 0,
+	...overrides,
+});
+
+function WebhookActionsMenu({
+	endpoint,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onRotate,
+	onDelete,
+}: {
+	endpoint: WebhookEndpoint;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (endpoint: WebhookEndpoint) => void;
+	onRotate: (endpoint: WebhookEndpoint) => void;
+	onDelete: (endpoint: WebhookEndpoint) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label="Webhook actions"
+					data-testid={`webhook-actions-btn-${endpoint.name}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="end"
+				onCloseAutoFocus={(e) => {
+					// Edit opens a Sheet; letting the dropdown restore focus to its
+					// trigger fights the Sheet's autofocus, so hand focus off instead.
+					e.preventDefault();
+				}}
+			>
+				{hasUpdateAccess && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						data-testid={`webhook-edit-btn-${endpoint.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							setIsOpen(false);
+							onEdit(endpoint);
+						}}
+					>
+						<PencilIcon className="h-4 w-4" /> Edit
+					</DropdownMenuItem>
+				)}
+				{hasUpdateAccess && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						data-testid={`webhook-rotate-btn-${endpoint.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							setIsOpen(false);
+							onRotate(endpoint);
+						}}
+					>
+						<RotateCcw className="h-4 w-4" /> Rotate secret
+					</DropdownMenuItem>
+				)}
+				{hasDeleteAccess && (
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						data-testid={`webhook-delete-btn-${endpoint.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							setIsOpen(false);
+							onDelete(endpoint);
+						}}
+					>
+						<Trash2 className="h-4 w-4" /> Delete
+					</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export default function WebhooksView() {
+	const hasCreateAccess = useRbac(RbacResource.Governance, RbacOperation.Create);
+	const hasUpdateAccess = useRbac(RbacResource.Governance, RbacOperation.Update);
+	const hasDeleteAccess = useRbac(RbacResource.Governance, RbacOperation.Delete);
+
+	const { data, isLoading, isError, error, refetch } = useGetWebhookEndpointsQuery(undefined, { pollingInterval: POLLING_INTERVAL });
+	const [updateWebhookEndpoint] = useUpdateWebhookEndpointMutation();
+	const [deleteWebhookEndpoint, { isLoading: isDeleting }] = useDeleteWebhookEndpointMutation();
+	const [rotateWebhookEndpointSecret, { isLoading: isRotating }] = useRotateWebhookEndpointSecretMutation();
+	const [testWebhookEndpoint] = useTestWebhookEndpointMutation();
+
+	const [search, setSearch] = useState("");
+	const [sheetOpen, setSheetOpen] = useState(false);
+	const [editingEndpoint, setEditingEndpoint] = useState<WebhookEndpoint | null>(null);
+	const [detailsEndpoint, setDetailsEndpoint] = useState<WebhookEndpoint | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<WebhookEndpoint | null>(null);
+	const [rotateTarget, setRotateTarget] = useState<WebhookEndpoint | null>(null);
+	const [secretReveal, setSecretReveal] = useState<WebhookSecretReveal | null>(null);
+	const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
+	const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
+
+	const endpoints = useMemo(() => data?.endpoints ?? [], [data]);
+	const filteredEndpoints = useMemo(() => {
+		const query = search.trim().toLowerCase();
+		if (!query) return endpoints;
+		return endpoints.filter((e) => e.name.toLowerCase().includes(query) || e.url.toLowerCase().includes(query));
+	}, [endpoints, search]);
+
+	// Row data refreshes every poll; keep the open details sheet in sync.
+	const liveDetailsEndpoint = useMemo(
+		() => (detailsEndpoint ? (endpoints.find((e) => e.id === detailsEndpoint.id) ?? detailsEndpoint) : null),
+		[detailsEndpoint, endpoints],
+	);
+
+	const handleAdd = () => {
+		setEditingEndpoint(null);
+		setSheetOpen(true);
+	};
+
+	const handleEdit = (endpoint: WebhookEndpoint) => {
+		setEditingEndpoint(endpoint);
+		setSheetOpen(true);
+	};
+
+	const handleToggle = async (endpoint: WebhookEndpoint, enabled: boolean) => {
+		setTogglingIds((prev) => new Set(prev).add(endpoint.id));
+		try {
+			await updateWebhookEndpoint({ id: endpoint.id, data: toRequest(endpoint, { disabled: !enabled }) }).unwrap();
+			toast.success(`Endpoint ${enabled ? "enabled" : "disabled"} successfully`);
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		} finally {
+			setTogglingIds((prev) => {
+				const next = new Set(prev);
+				next.delete(endpoint.id);
+				return next;
+			});
+		}
+	};
+
+	const handleTest = async (endpoint: WebhookEndpoint, event: WebhookEvent) => {
+		setTestingIds((prev) => new Set(prev).add(endpoint.id));
+		try {
+			const result = await testWebhookEndpoint({ id: endpoint.id, event }).unwrap();
+			if (result.delivered) {
+				toast.success(`Test delivered, receiver answered ${result.receiver_status_code}`);
+			} else if (result.error) {
+				toast.error(`Test failed: ${result.error}`);
+			} else {
+				toast.error(`Test rejected, receiver answered ${result.receiver_status_code}`);
+			}
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		} finally {
+			setTestingIds((prev) => {
+				const next = new Set(prev);
+				next.delete(endpoint.id);
+				return next;
+			});
+		}
+	};
+
+	const handleDelete = async () => {
+		if (!deleteTarget) return;
+		try {
+			await deleteWebhookEndpoint(deleteTarget.id).unwrap();
+			toast.success("Webhook endpoint deleted successfully");
+			if (detailsEndpoint?.id === deleteTarget.id) setDetailsEndpoint(null);
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		} finally {
+			setDeleteTarget(null);
+		}
+	};
+
+	const handleRotate = async () => {
+		if (!rotateTarget) return;
+		try {
+			const response = await rotateWebhookEndpointSecret(rotateTarget.id).unwrap();
+			toast.success("Signing secret rotated successfully");
+			setSecretReveal({ endpointName: response.endpoint.name, secret: response.secret });
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		} finally {
+			setRotateTarget(null);
+		}
+	};
+
+	if (isLoading) {
+		return <FullPageLoader />;
+	}
+
+	// A failed load must not masquerade as an empty workspace; the empty state
+	// invites creating an endpoint, so a hidden fetch error could prompt a
+	// duplicate. Only fatal when there is no data to fall back on; a transient
+	// poll failure over cached rows keeps rendering the list.
+	if (isError && !data) {
+		return (
+			<div className="flex flex-col items-center justify-center gap-3 py-16 text-center" data-testid="webhooks-load-error">
+				<p className="text-sm font-medium">Failed to load webhook endpoints.</p>
+				<p className="text-muted-foreground max-w-md text-sm">{getErrorMessage(error)}</p>
+				<Button variant="outline" size="sm" onClick={() => void refetch()}>
+					Retry
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="w-full space-y-4">
+			{endpoints.length === 0 ? (
+				<WebhooksEmptyState onAddClick={handleAdd} canCreate={hasCreateAccess} />
+			) : (
+				<>
+					<div className="flex items-center justify-between">
+						<div>
+							<h2 className="text-lg font-semibold tracking-tight">Webhooks</h2>
+							<p className="text-muted-foreground text-sm">
+								Register endpoints to receive signed notifications when async inference jobs complete or fail. Pass the endpoint's name in
+								the <code>x-bf-async-webhook</code> header when submitting a job.
+							</p>
+						</div>
+						<Button onClick={handleAdd} disabled={!hasCreateAccess} data-testid="create-webhook-btn">
+							<Plus className="h-4 w-4" />
+							Add Endpoint
+						</Button>
+					</div>
+
+					<div className="relative max-w-sm">
+						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+						<Input
+							placeholder="Search by name or URL"
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							className="pr-8 pl-9"
+							data-testid="webhook-search-input"
+						/>
+						{search && (
+							<Button
+								variant="ghost"
+								size="icon"
+								className="absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2"
+								onClick={() => setSearch("")}
+								aria-label="Clear search"
+							>
+								<X className="h-3 w-3" />
+							</Button>
+						)}
+					</div>
+
+					<div className="overflow-auto rounded-sm border">
+						<Table data-testid="webhooks-table">
+							<TableHeader className="bg-muted sticky top-0 z-10">
+								<TableRow>
+									<TableHead>Name</TableHead>
+									<TableHead>URL</TableHead>
+									<TableHead>Events</TableHead>
+									<TableHead>Enabled</TableHead>
+									<TableHead className={`bg-muted/50 sticky right-0 z-10 w-14 text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{filteredEndpoints.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={5} className="text-muted-foreground h-24 text-center">
+											No matching webhook endpoints found.
+										</TableCell>
+									</TableRow>
+								) : (
+									filteredEndpoints.map((endpoint) => (
+										<TableRow
+											key={endpoint.id}
+											className="group cursor-pointer"
+											onClick={() => setDetailsEndpoint(endpoint)}
+											data-testid={`webhook-row-${endpoint.name}`}
+										>
+											<TableCell className="font-medium">{endpoint.name}</TableCell>
+											<TableCell>
+												<code className="block max-w-[320px] truncate font-mono text-xs">{endpoint.url}</code>
+											</TableCell>
+											<TableCell>
+												<div className="flex flex-wrap gap-1">
+													{endpoint.events.map((event) => (
+														<Badge key={event} variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[event]}`}>
+															{event}
+														</Badge>
+													))}
+												</div>
+											</TableCell>
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												<Switch
+													checked={!endpoint.disabled}
+													disabled={!hasUpdateAccess || togglingIds.has(endpoint.id)}
+													onCheckedChange={(checked) => void handleToggle(endpoint, checked)}
+													data-testid={`webhook-enabled-switch-${endpoint.name}`}
+												/>
+											</TableCell>
+											<TableCell
+												className={`bg-card group-hover:bg-muted/50 sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
+												onClick={(e) => e.stopPropagation()}
+											>
+												<WebhookActionsMenu
+													endpoint={endpoint}
+													hasUpdateAccess={hasUpdateAccess}
+													hasDeleteAccess={hasDeleteAccess}
+													onEdit={handleEdit}
+													onRotate={setRotateTarget}
+													onDelete={setDeleteTarget}
+												/>
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+				</>
+			)}
+
+			<WebhookSheet
+				open={sheetOpen}
+				endpoint={editingEndpoint}
+				onClose={() => {
+					setSheetOpen(false);
+					setEditingEndpoint(null);
+				}}
+				onSecret={setSecretReveal}
+			/>
+
+			<WebhookDetailsSheet
+				endpoint={liveDetailsEndpoint}
+				isTesting={liveDetailsEndpoint ? testingIds.has(liveDetailsEndpoint.id) : false}
+				canManage={hasUpdateAccess}
+				onTest={(e, event) => void handleTest(e, event)}
+				onClose={() => setDetailsEndpoint(null)}
+			/>
+
+			<WebhookSecretDialog reveal={secretReveal} onClose={() => setSecretReveal(null)} />
+
+			<AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete webhook endpoint</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete <b>{deleteTarget?.name}</b>? Pending deliveries to it will be dropped and jobs referencing it
+							will be rejected. This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid="webhook-delete-cancel-btn">Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							className="bg-destructive hover:bg-destructive/90"
+							onClick={() => void handleDelete()}
+							disabled={isDeleting}
+							data-testid="webhook-delete-confirm-btn"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog open={!!rotateTarget} onOpenChange={(open) => !open && setRotateTarget(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Rotate signing secret</AlertDialogTitle>
+						<AlertDialogDescription>
+							The current secret for <b>{rotateTarget?.name}</b> stops working immediately and deliveries are signed with the new one from
+							now on. Update your receiver right after rotating.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid="webhook-rotate-cancel-btn">Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={() => void handleRotate()} disabled={isRotating} data-testid="webhook-rotate-confirm-btn">
+							Rotate
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -46,6 +46,7 @@ import {
 	Users,
 	Wallet,
 	WalletCards,
+	Webhook,
 	CircuitBoard,
 	GitCompareArrows,
 } from "lucide-react";
@@ -897,6 +898,13 @@ export default function AppSidebar() {
 						hasAccess: hasGuardrailsProvidersAccess,
 					},
 				],
+			},
+			{
+				title: "Webhooks",
+				url: "/workspace/webhooks",
+				icon: Webhook,
+				description: "Async job webhook endpoints",
+				hasAccess: hasGovernanceLegacyAccess,
 			},
 			{
 				title: "Cluster Config",

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -197,6 +197,8 @@ export const baseApi = createApi({
 		"AlertChannels",
 		"AlertRules",
 		"AlertHistory",
+		"WebhookEndpoints",
+		"WebhookDeliveries",
 	],
 	endpoints: () => ({}),
 });

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -18,3 +18,4 @@ export * from "./providersApi";
 export * from "./promptsApi";
 export * from "./sessionApi";
 export * from "./skillsApi";
+export * from "./webhooksApi";

--- a/ui/lib/store/apis/webhooksApi.ts
+++ b/ui/lib/store/apis/webhooksApi.ts
@@ -1,0 +1,93 @@
+import {
+	GetWebhookDeliveriesParams,
+	GetWebhookDeliveriesResponse,
+	GetWebhookEndpointsResponse,
+	RedeliverWebhookResponse,
+	TestWebhookEndpointResponse,
+	WebhookEndpoint,
+	WebhookEndpointRequest,
+	WebhookEvent,
+	WebhookSecretResponse,
+} from "@/lib/types/webhooks";
+import { baseApi } from "./baseApi";
+
+export const webhooksApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getWebhookEndpoints: builder.query<GetWebhookEndpointsResponse, void>({
+			query: () => ({ url: "/webhooks" }),
+			providesTags: ["WebhookEndpoints"],
+		}),
+
+		createWebhookEndpoint: builder.mutation<WebhookSecretResponse, WebhookEndpointRequest>({
+			query: (data) => ({
+				url: "/webhooks",
+				method: "POST",
+				body: data,
+			}),
+			invalidatesTags: ["WebhookEndpoints"],
+		}),
+
+		updateWebhookEndpoint: builder.mutation<WebhookEndpoint, { id: string; data: WebhookEndpointRequest }>({
+			query: ({ id, data }) => ({
+				url: `/webhooks/${id}`,
+				method: "PUT",
+				body: data,
+			}),
+			invalidatesTags: ["WebhookEndpoints"],
+		}),
+
+		deleteWebhookEndpoint: builder.mutation<{ status: string }, string>({
+			query: (id) => ({
+				url: `/webhooks/${id}`,
+				method: "DELETE",
+			}),
+			invalidatesTags: ["WebhookEndpoints"],
+		}),
+
+		rotateWebhookEndpointSecret: builder.mutation<WebhookSecretResponse, string>({
+			query: (id) => ({
+				url: `/webhooks/${id}/rotate-secret`,
+				method: "POST",
+			}),
+			invalidatesTags: ["WebhookEndpoints"],
+		}),
+
+		testWebhookEndpoint: builder.mutation<TestWebhookEndpointResponse, { id: string; event: WebhookEvent }>({
+			query: ({ id, event }) => ({
+				url: `/webhooks/${id}/test`,
+				method: "POST",
+				body: { event },
+			}),
+		}),
+
+		getWebhookDeliveries: builder.query<GetWebhookDeliveriesResponse, GetWebhookDeliveriesParams>({
+			query: ({ endpointId, limit, offset }) => ({
+				url: `/webhooks/${endpointId}/deliveries`,
+				params: {
+					...(limit !== undefined && { limit }),
+					...(offset !== undefined && { offset }),
+				},
+			}),
+			providesTags: ["WebhookDeliveries"],
+		}),
+
+		redeliverWebhookDelivery: builder.mutation<RedeliverWebhookResponse, string>({
+			query: (deliveryId) => ({
+				url: `/webhooks/deliveries/${deliveryId}/redeliver`,
+				method: "POST",
+			}),
+			invalidatesTags: ["WebhookDeliveries"],
+		}),
+	}),
+});
+
+export const {
+	useGetWebhookEndpointsQuery,
+	useCreateWebhookEndpointMutation,
+	useUpdateWebhookEndpointMutation,
+	useDeleteWebhookEndpointMutation,
+	useRotateWebhookEndpointSecretMutation,
+	useTestWebhookEndpointMutation,
+	useGetWebhookDeliveriesQuery,
+	useRedeliverWebhookDeliveryMutation,
+} = webhooksApi;

--- a/ui/lib/types/webhooks.ts
+++ b/ui/lib/types/webhooks.ts
@@ -1,0 +1,123 @@
+import { SecretVar } from "./schemas";
+
+// Wire shapes for the /api/webhooks admin API.
+
+export type WebhookEvent = "async_job.completed" | "async_job.failed";
+
+export const WEBHOOK_EVENTS: { value: WebhookEvent; label: string; description: string }[] = [
+	{ value: "async_job.completed", label: "Async job completed", description: "An async inference job finished successfully." },
+	{ value: "async_job.failed", label: "Async job failed", description: "An async inference job reached a terminal failure." },
+];
+
+export interface WebhookEndpoint {
+	id: string;
+	name: string;
+	url: string;
+	events: WebhookEvent[];
+	headers?: Record<string, SecretVar>;
+	include_response: boolean;
+	allow_private_network: boolean;
+	disabled: boolean;
+	// Delivery tuning knobs; 0 or absent means the delivery worker default
+	// (see WEBHOOK_TUNING_DEFAULTS).
+	max_retries?: number;
+	retry_backoff_initial_seconds?: number;
+	retry_backoff_max_seconds?: number;
+	attempt_timeout_seconds?: number;
+	max_response_payload_kbs?: number;
+	max_concurrent_deliveries?: number;
+	consecutive_failures: number;
+	last_success_at?: string;
+	last_failure_at?: string;
+	created_at: string;
+	updated_at: string;
+}
+
+// PUT replaces the endpoint's full caller-editable state — omitted fields are
+// cleared server-side, so every field is required here.
+export interface WebhookEndpointRequest {
+	name: string;
+	url: string;
+	events: WebhookEvent[];
+	headers: Record<string, SecretVar>;
+	include_response: boolean;
+	allow_private_network: boolean;
+	disabled: boolean;
+	max_retries: number;
+	retry_backoff_initial_seconds: number;
+	retry_backoff_max_seconds: number;
+	attempt_timeout_seconds: number;
+	max_response_payload_kbs: number;
+	max_concurrent_deliveries: number;
+}
+
+export interface GetWebhookEndpointsResponse {
+	endpoints: WebhookEndpoint[];
+	count: number;
+}
+
+// Returned by create and rotate-secret; the signing secret appears exactly
+// once in these responses and can never be read back afterwards.
+export interface WebhookSecretResponse {
+	endpoint: WebhookEndpoint;
+	secret: string;
+}
+
+export interface TestWebhookEndpointResponse {
+	delivered: boolean;
+	receiver_status_code?: number;
+	error?: string;
+}
+
+export type WebhookDeliveryOutcome = "delivered" | "retryable_failure" | "permanent_failure" | "exhausted";
+
+export interface WebhookDelivery {
+	id: string;
+	webhook_id: string;
+	endpoint_id: string;
+	async_job_id: string;
+	event: WebhookEvent;
+	attempt_no: number;
+	outcome: WebhookDeliveryOutcome;
+	status_code?: number;
+	error?: string;
+	created_at: string;
+	expires_at?: string;
+}
+
+export interface GetWebhookDeliveriesParams {
+	endpointId: string;
+	limit?: number;
+	offset?: number;
+}
+
+export interface GetWebhookDeliveriesResponse {
+	deliveries: WebhookDelivery[];
+	pagination: {
+		limit: number;
+		offset: number;
+		total_count: number;
+	};
+}
+
+export interface RedeliverWebhookResponse {
+	status: string;
+	webhook_id: string;
+}
+
+// Soft tints for event badges, matching the delivery-outcome color language
+// (green = completed/delivered, red = failed).
+export const WEBHOOK_EVENT_COLORS: Record<WebhookEvent, string> = {
+	"async_job.completed": "bg-green-100 text-green-800",
+	"async_job.failed": "bg-red-100 text-red-800",
+};
+
+// Delivery worker defaults, shown as placeholders for unset (0) knobs.
+export const WEBHOOK_TUNING_DEFAULTS = {
+	max_retries: 4,
+	retry_backoff_initial_seconds: 30,
+	retry_backoff_max_seconds: 1800,
+	attempt_timeout_seconds: 10,
+	max_response_payload_kbs: 256,
+	max_concurrent_deliveries: 10,
+} as const;


### PR DESCRIPTION
## Summary

Adds a full webhook endpoint management UI to the workspace, allowing users to register, configure, and monitor HTTPS endpoints that receive signed notifications when async inference jobs complete or fail.

## Changes

- Added a new `/workspace/webhooks` route with RBAC gating via `RbacResource.Governance` — users without view access see a `NoPermissionView`
- Built `WebhooksView` as the main table listing all endpoints with name, URL, subscribed events, and an enable/disable toggle; supports search by name or URL
- Built `WebhookSheet` (create/edit slide-over) with fields for name, URL, event subscriptions, include-response toggle, private-network toggle, custom headers (via `HeadersTable` with `SecretVar` support), and an expandable delivery tuning accordion covering retries, backoff, timeout, payload size cap, and concurrency
- Built `WebhookDetailsSheet` showing endpoint metadata and a paginated delivery history table; deliveries are grouped into runs (original send + redeliveries) with per-run attempt expansion, outcome/status badges with error tooltips, and per-row redeliver actions; polling refreshes the list every 5 seconds
- Built `WebhookSecretDialog` to display the signing secret exactly once after create or rotate-secret, with a copy button and a link to the verification docs; the secret is never retrievable again after this dialog is dismissed
- Added a `WebhooksEmptyState` shown when no endpoints exist yet
- Added `WebhookActionsMenu` with edit, rotate-secret, and delete actions; delete and rotate are confirmed via `AlertDialog`s
- Implemented per-endpoint test-fire with a 30-second cooldown tracked in the UI; a 429 from the server resumes the countdown from the server-reported `retry_after_seconds`
- Added `webhooksApi` RTK Query endpoints: `getWebhookEndpoints`, `createWebhookEndpoint`, `updateWebhookEndpoint`, `deleteWebhookEndpoint`, `rotateWebhookEndpointSecret`, `testWebhookEndpoint`, `getWebhookDeliveries`, and `redeliverWebhookDelivery`; registered `WebhookEndpoints` and `WebhookDeliveries` cache tags in `baseApi`
- Added `webhooks.ts` type definitions covering `WebhookEndpoint`, `WebhookEndpointRequest`, `WebhookDelivery`, `WebhookDeliveryOutcome`, response shapes, event color maps, tuning defaults, and the test cooldown constant
- Added a "Webhooks" entry to the sidebar under the Governance section

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to **Workspace → Webhooks** with a user that has Governance view access.
2. Click **Add Webhook Endpoint**, fill in a name and an HTTPS URL, select at least one event, and save — the signing secret dialog should appear exactly once.
3. From the endpoint row's actions menu, click **Rotate secret** and confirm — the new secret dialog should appear.
4. Click a row to open the details sheet; submit an async job referencing the endpoint and verify deliveries appear with correct outcome badges.
5. Use **Send Test Event** from the details sheet and confirm the 30-second cooldown activates on both the sheet button and the table row.
6. Expand a delivery run with multiple attempts and verify per-attempt rows show attempt number, outcome, and status code.
7. Click the redeliver button on a delivery and confirm a new run appears.
8. Delete an endpoint and confirm pending deliveries are dropped and the row is removed.
9. Log in as a user without Governance access and confirm the route renders `NoPermissionView`.

## Screenshots/Recordings

_Add before/after screenshots or clips of the webhooks table, create sheet, secret dialog, and details sheet._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

- The signing secret is returned by the API exactly once (on create and rotate) and is never stored or re-exposed by the UI after the dialog is dismissed.
- Custom header values are stored as `SecretVar` and arrive fully redacted from the server; the UI round-trips placeholders as-is so the server restores the real credentials without them transiting the browser.
- The `allow_private_network` toggle is required to be enabled before an `http://` URL is accepted, preventing accidental SSRF to private ranges.
- Test fires are rate-limited server-side with a 30-second cooldown; the UI enforces the same limit locally and resumes from the server-reported `retry_after_seconds` on a 429.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable