### PR TITLE
feat: propagate inference `request_id` through async jobs and webhook deliveries for LLM log reconciliation

### DIFF
--- a/core/schemas/async.go
+++ b/core/schemas/async.go
@@ -33,6 +33,7 @@ const (
 // AsyncJobResponse is the JSON response returned when creating or polling an async job
 type AsyncJobResponse struct {
 	ID          string         `json:"id"`
+	RequestID   string         `json:"request_id,omitempty"`
 	Status      AsyncJobStatus `json:"status"`
 	ExpiresAt   *time.Time     `json:"expires_at,omitempty"`
 	CreatedAt   time.Time      `json:"created_at"`

--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -120,9 +120,17 @@ func (e *AsyncJobExecutor) SubmitJob(bifrostCtx *schemas.BifrostContext, resultT
 		return nil, fmt.Errorf("failed to resolve webhook endpoint: %w", err)
 	}
 
+	// The background execution inherits the submit call's request id, so its
+	// LLM log row is keyed by it — store it for reconciliation.
+	requestID := ""
+	if bifrostCtx != nil {
+		requestID = bifrost.GetStringFromContext(bifrostCtx, schemas.BifrostContextKeyRequestID)
+	}
+
 	now := time.Now().UTC()
 	job := &AsyncJob{
 		ID:           uuid.New().String(),
+		RequestID:    requestID,
 		Status:       schemas.AsyncJobStatusPending,
 		RequestType:  operationType,
 		VirtualKeyID: virtualKeyID,

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -112,6 +112,24 @@ func TestSubmitJob_PropagatesContextValues(t *testing.T) {
 	assert.Equal(t, true, capturedCtx.Value(schemas.BifrostIsAsyncRequest))
 }
 
+func TestSubmitJob_StoresRequestID(t *testing.T) {
+	// File-backed store: the test polls the job row across goroutines, and a
+	// :memory: DSN gives each pooled connection its own database.
+	executor := newWebhookTestExecutor(t, nil)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-123")
+
+	job, err := executor.SubmitJob(ctx, 3600, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+		return map[string]string{"status": "ok"}, nil
+	}, schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	assert.Equal(t, "req-123", job.RequestID, "the submit call's request id keys the job's LLM log entry")
+
+	stored := waitForJobStatus(t, executor.logstore, job.ID)
+	assert.Equal(t, "req-123", stored.RequestID)
+}
+
 func TestSubmitJob_NilContextValues(t *testing.T) {
 	executor := newTestAsyncExecutor(t)
 

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -276,6 +276,8 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_redaction_mapping_column"}, run: migrationAddRedactionMappingColumn},
 	{IDs: []string{"webhook_deliveries_init"}, run: migrationCreateWebhookDeliveriesTable},
 	{IDs: []string{"async_jobs_add_webhook_endpoint_id_column"}, run: migrationAddWebhookEndpointIDColumn},
+	{IDs: []string{"async_jobs_add_request_id_column"}, run: migrationAddAsyncJobRequestIDColumn},
+	{IDs: []string{"webhook_deliveries_add_request_id_column"}, run: migrationAddWebhookDeliveryRequestIDColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -1630,6 +1632,60 @@ func migrationAddWebhookEndpointIDColumn(ctx context.Context, db *gorm.DB, logge
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding webhook_endpoint_id column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddAsyncJobRequestIDColumn adds the request_id column to the
+// async_jobs table: the inference request id the background execution runs
+// under, which is also the id its LLM log row is keyed by.
+func migrationAddAsyncJobRequestIDColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "async_jobs_add_request_id_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &AsyncJob{}, "request_id")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &AsyncJob{}, "request_id")
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding request_id column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddWebhookDeliveryRequestIDColumn adds the request_id column to
+// the webhook_deliveries table for databases created before the column
+// existed; fresh databases get it from the table-create migration.
+func migrationAddWebhookDeliveryRequestIDColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "webhook_deliveries_add_request_id_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &WebhookDelivery{}, "request_id")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &WebhookDelivery{}, "request_id")
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding request_id column to webhook_deliveries: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1070,6 +1070,7 @@ func (l *MCPToolLog) DeserializeFields() error {
 type AsyncJob struct {
 	ID           string                 `gorm:"primaryKey;type:varchar(255)" json:"id"`
 	Status       schemas.AsyncJobStatus `gorm:"type:varchar(50);index:idx_async_jobs_status;not null" json:"status"`
+	RequestID    string                 `gorm:"type:varchar(255)" json:"request_id,omitempty"`
 	RequestType  schemas.RequestType    `gorm:"type:varchar(50);index:idx_async_jobs_request_type;not null" json:"request_type"`
 	Response     string                 `gorm:"type:text" json:"response"`
 	StatusCode   int                    `gorm:"default:0" json:"status_code,omitempty"`
@@ -1093,6 +1094,7 @@ func (AsyncJob) TableName() string {
 func (j *AsyncJob) ToResponse() *schemas.AsyncJobResponse {
 	resp := &schemas.AsyncJobResponse{
 		ID:          j.ID,
+		RequestID:   j.RequestID,
 		Status:      j.Status,
 		ExpiresAt:   j.ExpiresAt,
 		CreatedAt:   j.CreatedAt,
@@ -1199,10 +1201,14 @@ const (
 // response bodies. WebhookID is the delivery's `webhook-id` wire header,
 // shared by every attempt of the same delivery.
 type WebhookDelivery struct {
-	ID         string                 `gorm:"primaryKey;type:varchar(36)" json:"id"`
-	WebhookID  string                 `gorm:"type:varchar(36);index:idx_webhook_deliveries_webhook_id;not null" json:"webhook_id"`
-	EndpointID string                 `gorm:"type:varchar(36);index:idx_webhook_deliveries_endpoint_id;not null" json:"endpoint_id"`
-	AsyncJobID string                 `gorm:"type:varchar(255);not null" json:"async_job_id"`
+	ID         string `gorm:"primaryKey;type:varchar(36)" json:"id"`
+	WebhookID  string `gorm:"type:varchar(36);index:idx_webhook_deliveries_webhook_id;not null" json:"webhook_id"`
+	EndpointID string `gorm:"type:varchar(36);index:idx_webhook_deliveries_endpoint_id;not null" json:"endpoint_id"`
+	AsyncJobID string `gorm:"type:varchar(255);not null" json:"async_job_id"`
+	// RequestID is the async job's inference request id — the same id the
+	// LLM logs record — copied here at attempt time. Empty when the job row
+	// expired before the attempt.
+	RequestID  string                 `gorm:"type:varchar(255)" json:"request_id,omitempty"`
 	Event      tables.WebhookEvent    `gorm:"type:varchar(255);not null" json:"event"`
 	AttemptNo  int                    `gorm:"not null;default:0" json:"attempt_no"`
 	Outcome    WebhookDeliveryOutcome `gorm:"type:varchar(50);not null" json:"outcome"`

--- a/framework/webhooks/dispatcher.go
+++ b/framework/webhooks/dispatcher.go
@@ -369,18 +369,35 @@ func (d *Dispatcher) attempt(job tables.TableWebhookJob, endpoint *tables.TableW
 	attemptNo := job.AttemptCount + 1
 
 	if endpoint == nil || endpoint.Disabled {
-		// Nothing to deliver to anymore; retire the job with a terminal
-		// history record. No counter updates: there was no receiver attempt,
-		// and the endpoint is already gone or disabled.
-		d.finalize(job, attemptNo, attemptResult{errText: "webhook endpoint deleted or disabled"}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
+		// Nothing to deliver to anymore; retire the job with a terminal history
+		// record. No counter updates: there was no receiver attempt, and the
+		// endpoint is already gone or disabled. Carry the async job's request id
+		// so the history row still reconciles with its LLM log.
+		var requestID string
+		asyncJob, findErr := d.logStore.FindAsyncJobByID(d.baseCtx, job.AsyncJobID)
+		switch {
+		case findErr == nil:
+			requestID = asyncJob.RequestID
+		case errors.Is(findErr, logstore.ErrNotFound):
+			// The job's result TTL lapsed; retire without a request id.
+		default:
+			// Transient storage error — leave the row claimed so a retry after
+			// the lease expiry can retire it with correlation intact, matching
+			// the delivery path below.
+			d.logger.Warn("webhooks: reading async job %s failed: %v", job.AsyncJobID, findErr)
+			return
+		}
+		d.finalize(job, attemptNo, requestID, attemptResult{errText: "webhook endpoint deleted or disabled"}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
 		return
 	}
 
 	var body []byte
 	var err error
+	var requestID string
 	asyncJob, findErr := d.logStore.FindAsyncJobByID(d.baseCtx, job.AsyncJobID)
 	switch {
 	case findErr == nil:
+		requestID = asyncJob.RequestID
 		body, err = renderPayload(asyncJob, job.Event, endpoint.IncludeResponse, tuning.maxResponsePayloadBytes, now)
 	case errors.Is(findErr, logstore.ErrNotFound):
 		// The job row must have existed for this delivery to be queued, so
@@ -399,7 +416,7 @@ func (d *Dispatcher) attempt(job tables.TableWebhookJob, endpoint *tables.TableW
 		// every lease expiry, forever and without history. Retire it as a
 		// recorded permanent failure instead (no receiver was attempted, so
 		// the endpoint counters must not move).
-		d.finalize(job, attemptNo, attemptResult{errText: fmt.Sprintf("rendering payload failed: %v", err)}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
+		d.finalize(job, attemptNo, requestID, attemptResult{errText: fmt.Sprintf("rendering payload failed: %v", err)}, logstore.WebhookDeliveryOutcomePermanentFailure, now, false, tuning, leaseUntil)
 		return
 	}
 
@@ -411,7 +428,7 @@ func (d *Dispatcher) attempt(job tables.TableWebhookJob, endpoint *tables.TableW
 	if outcome == logstore.WebhookDeliveryOutcomeRetryableFailure && attemptNo > tuning.maxRetries {
 		outcome = logstore.WebhookDeliveryOutcomeExhausted
 	}
-	d.finalize(job, attemptNo, result, outcome, now, true, tuning, leaseUntil)
+	d.finalize(job, attemptNo, requestID, result, outcome, now, true, tuning, leaseUntil)
 }
 
 // finalize persists an attempt: history first, then the queue row, then the
@@ -420,13 +437,14 @@ func (d *Dispatcher) attempt(job tables.TableWebhookJob, endpoint *tables.TableW
 // receiver's webhook-id dedupe absorbs the duplicate. touchCounters is false
 // when no receiver was attempted (endpoint gone), which must not move the
 // failure streak.
-func (d *Dispatcher) finalize(job tables.TableWebhookJob, attemptNo int, result attemptResult, outcome logstore.WebhookDeliveryOutcome, now time.Time, touchCounters bool, tuning endpointTuning, leaseUntil time.Time) {
+func (d *Dispatcher) finalize(job tables.TableWebhookJob, attemptNo int, requestID string, result attemptResult, outcome logstore.WebhookDeliveryOutcome, now time.Time, touchCounters bool, tuning endpointTuning, leaseUntil time.Time) {
 	expiresAt := now.Add(d.historyRetention)
 	history := &logstore.WebhookDelivery{
 		ID:         uuid.NewString(),
 		WebhookID:  job.ID,
 		EndpointID: job.EndpointID,
 		AsyncJobID: job.AsyncJobID,
+		RequestID:  requestID,
 		Event:      job.Event,
 		AttemptNo:  attemptNo,
 		Outcome:    outcome,

--- a/framework/webhooks/dispatcher_test.go
+++ b/framework/webhooks/dispatcher_test.go
@@ -174,6 +174,7 @@ type fakeLogStore struct {
 	mu         sync.Mutex
 	asyncJobs  map[string]*logstore.AsyncJob
 	deliveries []logstore.WebhookDelivery
+	findErr    error // when set, FindAsyncJobByID returns it (simulates a DB outage)
 }
 
 func newFakeLogStore() *fakeLogStore {
@@ -183,6 +184,9 @@ func newFakeLogStore() *fakeLogStore {
 func (f *fakeLogStore) FindAsyncJobByID(ctx context.Context, id string) (*logstore.AsyncJob, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
 	job, ok := f.asyncJobs[id]
 	if !ok {
 		return nil, logstore.ErrNotFound
@@ -609,6 +613,42 @@ func TestEndpointGoneRetiresJobWithoutCounters(t *testing.T) {
 	assert.Contains(t, deliveries[0].Error, "deleted or disabled")
 	assert.Nil(t, f.configStore.job("wh-1"))
 	assert.Zero(t, f.configStore.failures["ep-gone"], "no receiver attempt happened, the streak must not move")
+}
+
+func TestDisabledEndpointRetiresJobKeepingRequestID(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "http://127.0.0.1:0")
+	endpoint.Disabled = true
+	f := newFixture(t, endpoint)
+	asyncJob := testAsyncJob()
+	asyncJob.RequestID = "req-abc"
+	f.logStore.asyncJobs["job-1"] = asyncJob
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	deliveries := f.logStore.deliveryList()
+	require.Len(t, deliveries, 1)
+	assert.Equal(t, logstore.WebhookDeliveryOutcomePermanentFailure, deliveries[0].Outcome)
+	assert.Contains(t, deliveries[0].Error, "deleted or disabled")
+	assert.Equal(t, "req-abc", deliveries[0].RequestID,
+		"the request id must survive so the terminal history row reconciles with its LLM log")
+	assert.Nil(t, f.configStore.job("wh-1"))
+}
+
+func TestDisabledEndpointDefersRetireOnTransientLookupError(t *testing.T) {
+	endpoint := testEndpoint("ep-1", "http://127.0.0.1:0")
+	endpoint.Disabled = true
+	f := newFixture(t, endpoint)
+	// A transient storage error (not ErrNotFound) must not permanently retire
+	// the job: leaving it claimed lets a later attempt correlate the request id
+	// once the database recovers.
+	f.logStore.findErr = fmt.Errorf("database temporarily unavailable")
+	require.NoError(t, f.configStore.CreateWebhookJob(context.Background(), dueWebhookJob("wh-1", "ep-1", "job-1")))
+
+	f.dispatcher.processDue(*f.configStore.job("wh-1"))
+
+	assert.Empty(t, f.logStore.deliveryList(), "no terminal history row on a transient lookup failure")
+	assert.NotNil(t, f.configStore.job("wh-1"), "the job stays claimed for a retry after the lease expires")
 }
 
 func TestClaimLosersDoNothing(t *testing.T) {

--- a/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
@@ -383,20 +383,22 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 												</TableCell>
 												<TableCell className="whitespace-nowrap">{relativeTime(latest.created_at)}</TableCell>
 												<TableCell>
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<button
-																type="button"
-																className="cursor-pointer font-mono text-xs"
-																onClick={() => copy(latest.async_job_id)}
-																aria-label="Copy request ID"
-																data-testid={`webhook-delivery-request-id-${run.key}`}
-															>
-																{latest.async_job_id.slice(0, 8)}…
-															</button>
-														</TooltipTrigger>
-														<TooltipContent className="font-mono">{latest.async_job_id}</TooltipContent>
-													</Tooltip>
+													{latest.request_id ? (
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<code
+																	className="cursor-pointer font-mono text-xs"
+																	onClick={() => copy(latest.request_id ?? "")}
+																	data-testid={`webhook-delivery-request-id-${webhookId}`}
+																>
+																	{latest.request_id.slice(0, 8)}…
+																</code>
+															</TooltipTrigger>
+															<TooltipContent className="font-mono">{latest.request_id}</TooltipContent>
+														</Tooltip>
+													) : (
+														"-"
+													)}
 												</TableCell>
 												<TableCell className="whitespace-nowrap">
 													<Badge variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[latest.event]}`}>

--- a/ui/lib/types/webhooks.ts
+++ b/ui/lib/types/webhooks.ts
@@ -76,6 +76,7 @@ export interface WebhookDelivery {
 	webhook_id: string;
 	endpoint_id: string;
 	async_job_id: string;
+	request_id?: string;
 	event: WebhookEvent;
 	attempt_no: number;
 	outcome: WebhookDeliveryOutcome;


### PR DESCRIPTION
## Summary

Async jobs and webhook deliveries now carry the originating inference request ID, making it possible to correlate a webhook delivery history record directly with its LLM log entry without having to join through the async job.

## Changes

- Added `request_id` field to `AsyncJobResponse`, `AsyncJob` (DB table), and `WebhookDelivery` (DB table).
- When a job is submitted, the request ID is read from the `BifrostContext` and stored on the `AsyncJob` row.
- When the webhook dispatcher attempts a delivery, it copies `request_id` from the resolved async job onto the `WebhookDelivery` history record. If the job row has already expired, the field is left empty.
- Two new database migrations add the `request_id` column to `async_jobs` and `webhook_deliveries` for existing databases.
- The webhook details UI now displays `request_id` (truncated, copyable) instead of `async_job_id` in the delivery history table. A `-` placeholder is shown when the field is absent (e.g. deliveries recorded before the migration).
- The `WebhookDelivery` TypeScript type gains an optional `request_id` field.
- A new test (`TestSubmitJob_StoresRequestID`) verifies that the request ID is persisted on both the in-memory job struct and the stored row.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Submit an async request with a traceable request ID, then open the webhook details sheet for the corresponding endpoint. The delivery history row should display the truncated request ID (matching the LLM log entry) rather than the async job ID. For deliveries recorded before the migration, a `-` should appear.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`request_id` values are internal correlation identifiers and do not contain secrets or PII. They are already surfaced in LLM log rows; exposing them in async job and webhook delivery records does not introduce new information disclosure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable