### PR TITLE
feat: add server-side pagination, search, and filtering to webhook endpoints list

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -7399,6 +7399,46 @@ func (s *RDBConfigStore) GetWebhookEndpoints(ctx context.Context) ([]tables.Tabl
 	return endpoints, nil
 }
 
+// GetWebhookEndpointsPaginated returns one page of webhook endpoints matching
+// the given filters, along with the total match count for pagination.
+func (s *RDBConfigStore) GetWebhookEndpointsPaginated(ctx context.Context, params WebhookEndpointsQueryParams) ([]tables.TableWebhookEndpoint, int64, error) {
+	query := s.DB().WithContext(ctx).Model(&tables.TableWebhookEndpoint{})
+	if params.Search != "" {
+		// Escape LIKE metacharacters so a literal % or _ in the search matches
+		// itself rather than acting as a wildcard.
+		likeEscaper := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+		needle := "%" + likeEscaper.Replace(strings.ToLower(params.Search)) + "%"
+		// Raw OR conditions are parenthesized explicitly so they AND cleanly
+		// with the other filters.
+		query = query.Where(`(LOWER(name) LIKE ? ESCAPE '\' OR LOWER(url) LIKE ? ESCAPE '\')`, needle, needle)
+	}
+	if params.Disabled != nil {
+		query = query.Where("disabled = ?", *params.Disabled)
+	}
+	if len(params.Events) > 0 {
+		// Events are stored as a JSON string array; a quoted-substring match
+		// selects endpoints subscribed to any of the requested events.
+		conditions := make([]string, 0, len(params.Events))
+		args := make([]any, 0, len(params.Events))
+		for _, event := range params.Events {
+			conditions = append(conditions, "events_json LIKE ?")
+			args = append(args, `%"`+event+`"%`)
+		}
+		query = query.Where("("+strings.Join(conditions, " OR ")+")", args...)
+	}
+
+	var totalCount int64
+	if err := query.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var endpoints []tables.TableWebhookEndpoint
+	if err := query.Order("created_at ASC, id ASC").Offset(params.Offset).Limit(params.Limit).Find(&endpoints).Error; err != nil {
+		return nil, 0, err
+	}
+	return endpoints, totalCount, nil
+}
+
 // GetWebhookEndpointByID retrieves a webhook endpoint by its ID.
 func (s *RDBConfigStore) GetWebhookEndpointByID(ctx context.Context, id string) (*tables.TableWebhookEndpoint, error) {
 	var endpoint tables.TableWebhookEndpoint

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2326,6 +2326,99 @@ func testWebhookEndpoint(name string) *tables.TableWebhookEndpoint {
 	}
 }
 
+func TestWebhookEndpointsPaginated(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	billing := testWebhookEndpoint("billing-hook")
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, billing))
+
+	alerts := testWebhookEndpoint("alerts-hook")
+	alerts.URL = "https://93.184.216.34/alerts"
+	alerts.Events = []tables.WebhookEvent{tables.WebhookEventAsyncJobFailed}
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, alerts))
+
+	paused := testWebhookEndpoint("paused-hook")
+	paused.Disabled = true
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, paused))
+
+	names := func(endpoints []tables.TableWebhookEndpoint) []string {
+		out := make([]string, 0, len(endpoints))
+		for _, e := range endpoints {
+			out = append(out, e.Name)
+		}
+		return out
+	}
+
+	// No filters: everything, creation order, full count.
+	all, total, err := store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Equal(t, []string{"billing-hook", "alerts-hook", "paused-hook"}, names(all))
+
+	// Paging: total stays the full match count.
+	page, total, err := store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{Limit: 1, Offset: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Equal(t, []string{"alerts-hook"}, names(page))
+
+	// Search matches name or URL, case-insensitively.
+	found, total, err := store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{Search: "ALERTS", Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"alerts-hook"}, names(found))
+
+	// Disabled filter is tri-state.
+	enabledOnly := false
+	found, total, err = store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{Disabled: &enabledOnly, Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), total)
+	assert.Equal(t, []string{"billing-hook", "alerts-hook"}, names(found))
+
+	// Event filter selects subscribers of any requested event.
+	found, total, err = store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{
+		Events: []string{string(tables.WebhookEventAsyncJobFailed)},
+		Limit:  10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"alerts-hook"}, names(found))
+
+	// Filters compose with AND semantics.
+	found, total, err = store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{
+		Search:   "hook",
+		Disabled: &enabledOnly,
+		Events:   []string{string(tables.WebhookEventAsyncJobCompleted)},
+		Limit:    10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"billing-hook"}, names(found))
+}
+
+func TestWebhookEndpointsSearchEscapesLikeWildcards(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, testWebhookEndpoint("prod-hook")))
+	require.NoError(t, store.CreateWebhookEndpoint(ctx, testWebhookEndpoint("team_hook")))
+
+	names := func(endpoints []tables.TableWebhookEndpoint) []string {
+		out := make([]string, 0, len(endpoints))
+		for _, e := range endpoints {
+			out = append(out, e.Name)
+		}
+		return out
+	}
+
+	// A literal "_" must match only the name that contains one — not act as a
+	// single-character LIKE wildcard, which would also match "prod-hook".
+	found, total, err := store.GetWebhookEndpointsPaginated(ctx, WebhookEndpointsQueryParams{Search: "_", Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, []string{"team_hook"}, names(found))
+}
+
 func TestWebhookEndpointCreate(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -62,6 +62,16 @@ type RoutingRulesQueryParams struct {
 	Search string
 }
 
+// WebhookEndpointsQueryParams holds pagination, filtering, and search
+// parameters for webhook endpoint queries.
+type WebhookEndpointsQueryParams struct {
+	Limit    int
+	Offset   int
+	Search   string   // matches name or url (case-insensitive)
+	Events   []string // endpoints subscribed to any of these events, OR semantics
+	Disabled *bool    // nil = no filter; true/false = filter on disabled
+}
+
 // MCPClientsQueryParams holds pagination, filtering, and search parameters for MCP client queries.
 type MCPClientsQueryParams struct {
 	Limit            int
@@ -677,6 +687,7 @@ type ConfigStore interface {
 
 	// Webhook Endpoints
 	GetWebhookEndpoints(ctx context.Context) ([]tables.TableWebhookEndpoint, error)
+	GetWebhookEndpointsPaginated(ctx context.Context, params WebhookEndpointsQueryParams) ([]tables.TableWebhookEndpoint, int64, error)
 	GetWebhookEndpointByID(ctx context.Context, id string) (*tables.TableWebhookEndpoint, error)
 	GetWebhookEndpointByName(ctx context.Context, name string) (*tables.TableWebhookEndpoint, error)
 	CreateWebhookEndpoint(ctx context.Context, endpoint *tables.TableWebhookEndpoint) error

--- a/transports/bifrost-http/handlers/webhooks.go
+++ b/transports/bifrost-http/handlers/webhooks.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
@@ -130,14 +131,51 @@ func (h *WebhookHandler) storeAvailable(ctx *fasthttp.RequestCtx) bool {
 	return true
 }
 
-// listWebhookEndpoints returns all endpoints. Reads the store, not memory:
-// list views include the operational failure counters, which are only
-// tracked in the database.
+// listWebhookEndpoints returns one page of endpoints matching the query
+// filters. Reads the store, not memory: list views include the operational
+// failure counters, which are only tracked in the database.
 func (h *WebhookHandler) listWebhookEndpoints(ctx *fasthttp.RequestCtx) {
 	if !h.storeAvailable(ctx) {
 		return
 	}
-	endpoints, err := h.store.ConfigStore.GetWebhookEndpoints(ctx)
+	args := ctx.QueryArgs()
+	params := configstore.WebhookEndpointsQueryParams{
+		Search: strings.TrimSpace(string(args.Peek("search"))),
+		Events: parseCommaSeparated(string(args.Peek("event"))),
+	}
+	for _, event := range params.Events {
+		if !configstoreTables.WebhookEvent(event).IsValid() {
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Unknown webhook event %q", event))
+			return
+		}
+	}
+	if disabledStr := string(args.Peek("disabled")); disabledStr != "" {
+		disabled, err := strconv.ParseBool(disabledStr)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid disabled parameter: must be true or false")
+			return
+		}
+		params.Disabled = &disabled
+	}
+	if limitStr := string(args.Peek("limit")); limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil || limit < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid limit parameter: must be a non-negative number")
+			return
+		}
+		params.Limit = limit
+	}
+	if offsetStr := string(args.Peek("offset")); offsetStr != "" {
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil || offset < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Invalid offset parameter: must be a non-negative number")
+			return
+		}
+		params.Offset = offset
+	}
+	params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+
+	endpoints, totalCount, err := h.store.ConfigStore.GetWebhookEndpointsPaginated(ctx, params)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to list webhook endpoints: %v", err))
 		return
@@ -147,8 +185,11 @@ func (h *WebhookHandler) listWebhookEndpoints(ctx *fasthttp.RequestCtx) {
 		redacted = append(redacted, redactedWebhookEndpoint(&endpoints[i]))
 	}
 	SendJSON(ctx, map[string]any{
-		"endpoints": redacted,
-		"count":     len(redacted),
+		"endpoints":   redacted,
+		"count":       len(redacted),
+		"total_count": totalCount,
+		"limit":       params.Limit,
+		"offset":      params.Offset,
 	})
 }
 

--- a/transports/bifrost-http/handlers/webhooks_test.go
+++ b/transports/bifrost-http/handlers/webhooks_test.go
@@ -135,6 +135,66 @@ func TestWebhookHandlerCreateAndGet(t *testing.T) {
 	assert.Equal(t, fasthttp.StatusNotFound, missingCtx.Response.StatusCode())
 }
 
+func TestWebhookHandlerListFilters(t *testing.T) {
+	handler, _ := newWebhookTestHandler(t)
+
+	create := func(body string) {
+		t.Helper()
+		ctx := newWebhookRequestCtx(body, nil)
+		handler.createWebhookEndpoint(ctx)
+		require.Equal(t, fasthttp.StatusCreated, ctx.Response.StatusCode(), "body: %s", ctx.Response.Body())
+	}
+	create(`{"name":"billing","url":"https://93.184.216.34/billing","events":["async_job.completed"]}`)
+	create(`{"name":"alerts","url":"https://93.184.216.34/alerts","events":["async_job.failed"]}`)
+	create(`{"name":"paused","url":"https://93.184.216.34/paused","events":["async_job.completed"],"disabled":true}`)
+
+	list := func(query map[string]string) map[string]any {
+		t.Helper()
+		ctx := newWebhookRequestCtx("", nil)
+		for key, value := range query {
+			ctx.QueryArgs().Set(key, value)
+		}
+		handler.listWebhookEndpoints(ctx)
+		require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode(), "body: %s", ctx.Response.Body())
+		return decodeJSONResponse(t, ctx)
+	}
+
+	// Unfiltered: full count plus the pagination envelope.
+	page := list(nil)
+	assert.Equal(t, float64(3), page["total_count"])
+	assert.Equal(t, float64(3), page["count"])
+	assert.Equal(t, float64(25), page["limit"])
+
+	// Paging keeps the full match count.
+	page = list(map[string]string{"limit": "1", "offset": "1"})
+	assert.Equal(t, float64(3), page["total_count"])
+	assert.Equal(t, float64(1), page["count"])
+
+	page = list(map[string]string{"search": "ALERTS"})
+	assert.Equal(t, float64(1), page["total_count"])
+
+	page = list(map[string]string{"disabled": "true"})
+	assert.Equal(t, float64(1), page["total_count"])
+
+	page = list(map[string]string{"event": "async_job.completed"})
+	assert.Equal(t, float64(2), page["total_count"])
+
+	// Invalid parameters are rejected.
+	for name, query := range map[string]map[string]string{
+		"bad disabled": {"disabled": "maybe"},
+		"bad event":    {"event": "bogus.event"},
+		"bad limit":    {"limit": "not-a-number"},
+		"bad offset":   {"offset": "-1"},
+	} {
+		ctx := newWebhookRequestCtx("", nil)
+		for key, value := range query {
+			ctx.QueryArgs().Set(key, value)
+		}
+		handler.listWebhookEndpoints(ctx)
+		assert.Equal(t, fasthttp.StatusBadRequest, ctx.Response.StatusCode(), name)
+	}
+}
+
 func TestWebhookHandlerCreateValidation(t *testing.T) {
 	handler, _ := newWebhookTestHandler(t)
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1600,6 +1600,10 @@ func (m *MockConfigStore) GetWebhookEndpoints(ctx context.Context) ([]tables.Tab
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetWebhookEndpointsPaginated(ctx context.Context, params configstore.WebhookEndpointsQueryParams) ([]tables.TableWebhookEndpoint, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) GetWebhookEndpointByID(ctx context.Context, id string) (*tables.TableWebhookEndpoint, error) {
 	return nil, configstore.ErrNotFound
 }

--- a/ui/app/workspace/webhooks/views/webhooksFilterBar.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksFilterBar.tsx
@@ -1,0 +1,73 @@
+// Inline filter row above the webhooks table: search input + event and
+// status multi-selects + a clear-filters affordance shown only when
+// something is active.
+
+import { Button } from "@/components/ui/button";
+import { ComboboxSelect } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { WEBHOOK_EVENTS } from "@/lib/types/webhooks";
+import { Search, X } from "lucide-react";
+
+const EVENT_OPTIONS = WEBHOOK_EVENTS.map((event) => ({ label: event.value, value: event.value }));
+
+const STATUS_OPTIONS = [
+	{ label: "Enabled", value: "enabled" },
+	{ label: "Disabled", value: "disabled" },
+];
+
+export interface WebhooksFilterBarProps {
+	search: string;
+	onSearchChange: (value: string) => void;
+	eventFilter: string[];
+	onEventFilterChange: (value: string[]) => void;
+	statusFilter: string[];
+	onStatusFilterChange: (value: string[]) => void;
+	hasActiveFilters: boolean;
+	onClearFilters: () => void;
+}
+
+export default function WebhooksFilterBar(props: WebhooksFilterBarProps) {
+	return (
+		<div className="flex shrink-0 flex-wrap items-center gap-3">
+			<div className="relative max-w-sm min-w-[200px] flex-1">
+				<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+				<Input
+					aria-label="Search webhook endpoints"
+					placeholder="Search by name or URL"
+					value={props.search}
+					onChange={(e) => props.onSearchChange(e.target.value)}
+					className="pl-9"
+					data-testid="webhook-search-input"
+				/>
+			</div>
+			<ComboboxSelect
+				multiple
+				disableSearch
+				compactTrigger
+				data-testid="webhooks-event-filter"
+				options={EVENT_OPTIONS}
+				value={props.eventFilter}
+				onValueChange={props.onEventFilterChange}
+				placeholder="All events"
+				className="h-9 w-[220px]"
+			/>
+			<ComboboxSelect
+				multiple
+				disableSearch
+				compactTrigger
+				data-testid="webhooks-status-filter"
+				options={STATUS_OPTIONS}
+				value={props.statusFilter}
+				onValueChange={props.onStatusFilterChange}
+				placeholder="All statuses"
+				className="h-9 w-[170px]"
+			/>
+			{props.hasActiveFilters && (
+				<Button variant="ghost" size="sm" onClick={props.onClearFilters} data-testid="webhooks-clear-filters-btn" className="h-9">
+					<X className="h-4 w-4" />
+					Clear filters
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/ui/app/workspace/webhooks/views/webhooksView.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksView.tsx
@@ -13,7 +13,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
-import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
@@ -24,23 +23,28 @@ import {
 	useTestWebhookEndpointMutation,
 	useUpdateWebhookEndpointMutation,
 } from "@/lib/store";
-import {
-	WEBHOOK_EVENT_COLORS,
-	WEBHOOK_TEST_COOLDOWN_SECONDS,
-	WebhookEndpoint,
-	WebhookEndpointRequest,
-	WebhookEvent,
-} from "@/lib/types/webhooks";
+import { WEBHOOK_EVENT_COLORS, WEBHOOK_EVENTS, WebhookEndpoint, WebhookEndpointRequest, WebhookEvent } from "@/lib/types/webhooks";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { MoreHorizontal, PencilIcon, Plus, RotateCcw, Search, Trash2, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, MoreHorizontal, PencilIcon, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { WebhookSecretDialog, WebhookSecretReveal } from "../dialogs/webhookSecretDialog";
 import { WebhookDetailsSheet } from "./webhookDetailsSheet";
 import { WebhookSheet } from "./webhookSheet";
 import { WebhooksEmptyState } from "./webhooksEmptyState";
+import WebhooksFilterBar from "./webhooksFilterBar";
 
 const POLLING_INTERVAL = 5000;
+const PAGE_SIZE = 25;
+// Event filter values come from the URL and may be shared or hand-edited; only
+// known events are forwarded so a bogus ?event=... is ignored rather than
+// producing a 400 that hides the whole list.
+const VALID_WEBHOOK_EVENTS = new Set<string>(WEBHOOK_EVENTS.map((e) => e.value));
+// Status filter is likewise URL-driven; an unknown value must be ignored rather
+// than collapsing to "enabled" and silently hiding disabled endpoints.
+const VALID_WEBHOOK_STATUSES = new Set<string>(["enabled", "disabled"]);
 
 // PUT replaces the endpoint's full editable state, so toggles resend the row
 // as-is. Redacted header values round-trip untouched and the server keeps the
@@ -150,13 +154,41 @@ export default function WebhooksView() {
 	const hasUpdateAccess = useRbac(RbacResource.Governance, RbacOperation.Update);
 	const hasDeleteAccess = useRbac(RbacResource.Governance, RbacOperation.Delete);
 
-	const { data, isLoading, isError, error, refetch } = useGetWebhookEndpointsQuery(undefined, { pollingInterval: POLLING_INTERVAL });
+	const [urlState, setUrlState] = useQueryStates({
+		q: parseAsString.withDefault(""),
+		event: parseAsArrayOf(parseAsString).withDefault([]),
+		status: parseAsArrayOf(parseAsString).withDefault([]),
+		// Only paging pushes a history entry; search/filter edits use the default
+		// replace so a back press doesn't walk through every keystroke.
+		offset: parseAsInteger.withDefault(0).withOptions({ history: "push" }),
+	});
+	// The raw q drives the input for responsiveness; the debounced value
+	// drives the server query.
+	const debouncedSearch = useDebouncedValue(urlState.q, 300);
+	// Ignore unrecognized status values, then both-or-neither means no filter.
+	const selectedStatuses = urlState.status.filter((s) => VALID_WEBHOOK_STATUSES.has(s));
+	const disabledFilter = selectedStatuses.length === 1 ? selectedStatuses[0] === "disabled" : undefined;
+	// Drop any unrecognized event value before it reaches the server query.
+	const selectedEvents = useMemo(() => urlState.event.filter((e): e is WebhookEvent => VALID_WEBHOOK_EVENTS.has(e)), [urlState.event]);
+	// URL offset is user-editable; clamp to a non-negative, page-aligned value so
+	// a hand-edited "?offset=-25" never 400s the query and blocks recovery.
+	const offset = Math.max(0, Math.floor(urlState.offset / PAGE_SIZE) * PAGE_SIZE);
+
+	const { data, isLoading, isFetching, isError, error, refetch } = useGetWebhookEndpointsQuery(
+		{
+			search: debouncedSearch.trim() || undefined,
+			events: selectedEvents.length ? selectedEvents : undefined,
+			disabled: disabledFilter,
+			limit: PAGE_SIZE,
+			offset,
+		},
+		{ pollingInterval: POLLING_INTERVAL },
+	);
 	const [updateWebhookEndpoint] = useUpdateWebhookEndpointMutation();
 	const [deleteWebhookEndpoint, { isLoading: isDeleting }] = useDeleteWebhookEndpointMutation();
 	const [rotateWebhookEndpointSecret, { isLoading: isRotating }] = useRotateWebhookEndpointSecretMutation();
 	const [testWebhookEndpoint] = useTestWebhookEndpointMutation();
 
-	const [search, setSearch] = useState("");
 	const [sheetOpen, setSheetOpen] = useState(false);
 	const [editingEndpoint, setEditingEndpoint] = useState<WebhookEndpoint | null>(null);
 	const [detailsEndpoint, setDetailsEndpoint] = useState<WebhookEndpoint | null>(null);
@@ -167,11 +199,24 @@ export default function WebhooksView() {
 	const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
 
 	const endpoints = useMemo(() => data?.endpoints ?? [], [data]);
-	const filteredEndpoints = useMemo(() => {
-		const query = search.trim().toLowerCase();
-		if (!query) return endpoints;
-		return endpoints.filter((e) => e.name.toLowerCase().includes(query) || e.url.toLowerCase().includes(query));
-	}, [endpoints, search]);
+	const totalCount = data?.total_count ?? 0;
+	const hasActiveFilters = urlState.q !== "" || urlState.event.length > 0 || urlState.status.length > 0;
+
+	// Keep the URL offset valid: non-negative, page-aligned, and within the
+	// current match set. Covers a hand-edited offset and a match set that
+	// shrank below the current page (delete, narrowed filter).
+	useEffect(() => {
+		if (isLoading) return;
+		const maxOffset = totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE;
+		const normalized = Math.min(maxOffset, offset);
+		if (normalized !== urlState.offset) {
+			setUrlState({ offset: normalized || null });
+		}
+	}, [isLoading, totalCount, offset, urlState.offset, setUrlState]);
+
+	const handleClearFilters = () => {
+		setUrlState({ q: null, event: null, status: null, offset: null });
+	};
 
 	// Row data refreshes every poll; keep the open details sheet in sync.
 	const liveDetailsEndpoint = useMemo(
@@ -275,7 +320,7 @@ export default function WebhooksView() {
 
 	return (
 		<div className="w-full space-y-4">
-			{endpoints.length === 0 ? (
+			{totalCount === 0 && !hasActiveFilters ? (
 				<WebhooksEmptyState onAddClick={handleAdd} canCreate={hasCreateAccess} />
 			) : (
 				<>
@@ -293,29 +338,18 @@ export default function WebhooksView() {
 						</Button>
 					</div>
 
-					<div className="relative max-w-sm">
-						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-						<Input
-							placeholder="Search by name or URL"
-							value={search}
-							onChange={(e) => setSearch(e.target.value)}
-							className="pr-8 pl-9"
-							data-testid="webhook-search-input"
-						/>
-						{search && (
-							<Button
-								variant="ghost"
-								size="icon"
-								className="absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2"
-								onClick={() => setSearch("")}
-								aria-label="Clear search"
-							>
-								<X className="h-3 w-3" />
-							</Button>
-						)}
-					</div>
+					<WebhooksFilterBar
+						search={urlState.q}
+						onSearchChange={(value) => setUrlState({ q: value || null, offset: 0 })}
+						eventFilter={urlState.event}
+						onEventFilterChange={(value) => setUrlState({ event: value.length ? value : null, offset: 0 })}
+						statusFilter={urlState.status}
+						onStatusFilterChange={(value) => setUrlState({ status: value.length ? value : null, offset: 0 })}
+						hasActiveFilters={hasActiveFilters}
+						onClearFilters={handleClearFilters}
+					/>
 
-					<div className="overflow-auto rounded-sm border">
+					<div className={`overflow-auto rounded-sm border ${isFetching ? "opacity-70" : ""}`}>
 						<Table data-testid="webhooks-table">
 							<TableHeader className="bg-muted sticky top-0 z-10">
 								<TableRow>
@@ -327,14 +361,14 @@ export default function WebhooksView() {
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{filteredEndpoints.length === 0 ? (
+								{endpoints.length === 0 ? (
 									<TableRow>
 										<TableCell colSpan={5} className="text-muted-foreground h-24 text-center">
 											No matching webhook endpoints found.
 										</TableCell>
 									</TableRow>
 								) : (
-									filteredEndpoints.map((endpoint) => (
+									endpoints.map((endpoint) => (
 										<TableRow
 											key={endpoint.id}
 											className="group cursor-pointer"
@@ -381,6 +415,42 @@ export default function WebhooksView() {
 							</TableBody>
 						</Table>
 					</div>
+
+					{totalCount > 0 && (
+						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+							<div className="text-muted-foreground flex items-center gap-2">
+								{(offset + 1).toLocaleString()}-{Math.min(offset + PAGE_SIZE, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
+								entries
+							</div>
+							<div className="flex items-center gap-2">
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => setUrlState({ offset: Math.max(0, offset - PAGE_SIZE) || null })}
+									disabled={offset === 0}
+									data-testid="webhooks-pagination-prev-btn"
+									aria-label="Previous page"
+								>
+									<ChevronLeft className="size-3" />
+								</Button>
+								<div className="flex items-center gap-1">
+									<span>Page</span>
+									<span>{Math.floor(offset / PAGE_SIZE) + 1}</span>
+									<span>of {Math.ceil(totalCount / PAGE_SIZE)}</span>
+								</div>
+								<Button
+									variant="ghost"
+									size="sm"
+									onClick={() => setUrlState({ offset: offset + PAGE_SIZE })}
+									disabled={offset + PAGE_SIZE >= totalCount}
+									data-testid="webhooks-pagination-next-btn"
+									aria-label="Next page"
+								>
+									<ChevronRight className="size-3" />
+								</Button>
+							</div>
+						</div>
+					)}
 				</>
 			)}
 

--- a/ui/lib/store/apis/webhooksApi.ts
+++ b/ui/lib/store/apis/webhooksApi.ts
@@ -1,6 +1,7 @@
 import {
 	GetWebhookDeliveriesParams,
 	GetWebhookDeliveriesResponse,
+	GetWebhookEndpointsParams,
 	GetWebhookEndpointsResponse,
 	RedeliverWebhookResponse,
 	TestWebhookEndpointResponse,
@@ -11,10 +12,24 @@ import {
 } from "@/lib/types/webhooks";
 import { baseApi } from "./baseApi";
 
+// Shapes list params for the wire: empty values are dropped and the events
+// filter is CSV-joined after sorting, so cache keys stay canonical regardless
+// of selection order.
+const buildWebhookEndpointsListParams = (params?: GetWebhookEndpointsParams): Record<string, string | number | boolean> => {
+	const out: Record<string, string | number | boolean> = {};
+	if (!params) return out;
+	if (params.search) out.search = params.search;
+	if (params.events?.length) out.event = [...params.events].sort().join(",");
+	if (params.disabled !== undefined) out.disabled = params.disabled;
+	if (params.limit !== undefined) out.limit = params.limit;
+	if (params.offset !== undefined) out.offset = params.offset;
+	return out;
+};
+
 export const webhooksApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
-		getWebhookEndpoints: builder.query<GetWebhookEndpointsResponse, void>({
-			query: () => ({ url: "/webhooks" }),
+		getWebhookEndpoints: builder.query<GetWebhookEndpointsResponse, GetWebhookEndpointsParams | void>({
+			query: (params) => ({ url: "/webhooks", params: buildWebhookEndpointsListParams(params ?? undefined) }),
 			providesTags: ["WebhookEndpoints"],
 		}),
 

--- a/ui/lib/types/webhooks.ts
+++ b/ui/lib/types/webhooks.ts
@@ -51,9 +51,20 @@ export interface WebhookEndpointRequest {
 	max_concurrent_deliveries: number;
 }
 
+export interface GetWebhookEndpointsParams {
+	search?: string;
+	events?: WebhookEvent[]; // subscribed to any of these, OR semantics
+	disabled?: boolean;
+	limit?: number;
+	offset?: number;
+}
+
 export interface GetWebhookEndpointsResponse {
 	endpoints: WebhookEndpoint[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 // Returned by create and rotate-secret; the signing secret appears exactly


### PR DESCRIPTION
## Summary

The webhook endpoints list API and UI previously fetched all records at once and filtered client-side. This PR moves filtering and pagination to the server, enabling efficient handling of large endpoint sets.

## Changes

- Added `GetWebhookEndpointsPaginated` to the `ConfigStore` interface and its RDB implementation, supporting search (name/URL, case-insensitive), event subscription filtering (OR semantics via JSON substring match), disabled/enabled state filtering, and limit/offset pagination with a total count returned alongside the page.
- Updated `listWebhookEndpoints` in the HTTP handler to parse and validate `search`, `event`, `disabled`, `limit`, and `offset` query parameters, delegating all filtering to the new paginated store method. The response envelope now includes `total_count`, `limit`, and `offset` alongside the existing `count` and `endpoints` fields.
- Replaced the client-side search filter in `WebhooksView` with server-driven query parameters persisted in the URL via `nuqs`. Search input is debounced before triggering a fetch. A `WebhooksFilterBar` component was extracted to house the search input, event multi-select, and status multi-select, with a "Clear filters" button shown when any filter is active.
- Added a pagination footer to the webhooks table with previous/next controls and a "Page X of Y" indicator. The offset auto-corrects to the last valid page when the total count drops below the current position (e.g., after a delete or filter narrowing).
- Added `GetWebhookEndpointsParams` and extended `GetWebhookEndpointsResponse` in the frontend type definitions. The RTK Query endpoint now accepts optional params and serializes them canonically (events sorted and CSV-joined) for stable cache keys.
- Added unit tests for `GetWebhookEndpointsPaginated` covering no-filter, paging, search, disabled, event, and composed filter cases. Added HTTP handler tests covering all filter parameters and invalid input rejection.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

Navigate to the Webhooks page with several endpoints configured. Verify:
- Search by name or URL filters results in real time (after the 300 ms debounce).
- The event and status dropdowns filter independently and compose with search.
- "Clear filters" resets all filters and returns to page 1.
- Pagination controls advance and retreat through pages; the offset resets to 0 when a filter changes.
- Filter state survives a page refresh (URL query params are preserved).
- Invalid `disabled`, `event`, `limit`, and `offset` values return HTTP 400.

## Screenshots/Recordings

_Add before/after screenshots of the webhooks table with the new filter bar and pagination footer._

## Breaking changes

- [x] Yes
- [ ] No

The `GET /webhooks` response envelope now includes `total_count`, `limit`, and `offset` fields. Existing consumers that only read `endpoints` and `count` are unaffected, but consumers expecting the full list in a single unfiltered call should be aware that results are now paginated (default page size 25).

## Related issues

## Security considerations

Event filtering uses parameterized LIKE queries against a JSON string column; no raw user input is interpolated into SQL. The `disabled` parameter is parsed as a strict boolean before use. No secrets or PII are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable