### PR TITLE
updates go mods

### DIFF
--- a/plugins/logging/go.mod
+++ b/plugins/logging/go.mod
@@ -4,6 +4,7 @@ go 1.26.4
 
 require (
 	github.com/bytedance/sonic v1.15.1
+	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.7.1
 	github.com/maximhq/bifrost/framework v1.5.1
 	github.com/stretchr/testify v1.11.1

--- a/tests/cmd/e2eseed/go.mod
+++ b/tests/cmd/e2eseed/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/maximhq/bifrost/core v1.7.0 // indirect
+	github.com/maximhq/bifrost/core v1.7.1 // indirect
 	github.com/maximhq/bifrost/framework v1.3.16 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect

--- a/tests/cmd/seed/go.mod
+++ b/tests/cmd/seed/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/maximhq/bifrost/core v1.7.0
+	github.com/maximhq/bifrost/core v1.7.1
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/tests/cmd/seedvks/go.mod
+++ b/tests/cmd/seedvks/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.7.0
+	github.com/maximhq/bifrost/core v1.7.1
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1


### PR DESCRIPTION
## Summary

Bumps `github.com/maximhq/bifrost/core` from `v1.7.0` to `v1.7.1` across test seed commands and adds `github.com/google/uuid v1.6.0` as a dependency to the logging plugin.

## Changes

- Updated `bifrost/core` to `v1.7.1` in `tests/cmd/seed`, `tests/cmd/seedvks`, and `tests/cmd/e2eseed`
- Added `github.com/google/uuid v1.6.0` to the logging plugin's dependencies

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable