### PR TITLE
fix: extend chat↔responses pricing fallback to work bidirectionally

### DIFF
--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -1193,11 +1193,11 @@ func (s *Store) resolvePricing(routingInfo schemas.RoutingInfo, requestType sche
 // getBasePricing looks up catalog pricing for the given model, provider, and request type.
 // It applies a provider-specific fallback chain when an exact match is not found:
 //
-//   - Gemini: retries under the "vertex" provider, then falls back to chat mode for Responses requests.
-//   - Vertex: strips the "provider/model" prefix and retries, then falls back to chat mode for Responses requests.
-//   - Bedrock: prepends the vendor namespace ("anthropic.", "openai.", "google.", "xai.") inferred from the model family, then falls back to chat mode for Responses requests.
+//   - Gemini: retries under the "vertex" provider, then falls back to the counterpart chat/responses mode.
+//   - Vertex: strips the "provider/model" prefix and retries, then falls back to the counterpart chat/responses mode.
+//   - Bedrock: prepends the vendor namespace ("anthropic.", "openai.", "google.", "xai.") inferred from the model family, then falls back to the counterpart chat/responses mode.
 //   - Bedrock Mantle: folded onto the "bedrock" provider up front (datasheet rows for all Bedrock variants are stored there), so it shares every Bedrock fallback.
-//   - All providers: for Responses/ResponsesStream requests, retries the lookup in chat mode.
+//   - All providers: chat and responses requests retry in each other's mode, since a model served over both APIs often has a datasheet row under only one of them.
 //   - All providers: for ImageEdit/ImageVariation requests, retries the lookup in image-generation mode.
 //
 // The method acquires a read lock for the duration of the lookup.
@@ -1215,6 +1215,7 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 	defer s.mu.RUnlock()
 
 	mode := normalizeRequestType(requestType)
+	fallbackMode, hasFallbackMode := chatResponsesFallbackMode(requestType)
 
 	// Datasheet rows for all Bedrock variants are stored under the "bedrock"
 	// provider (normalizeProvider folds bedrock_* onto "bedrock"), so
@@ -1236,10 +1237,10 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 			return &pricing, true
 		}
 
-		// Lookup in chat if responses not found
-		if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest || requestType == schemas.CompactionRequest {
-			s.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
-			pricing, ok = s.pricingData[makeKey(model, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
+		// Lookup in the counterpart chat/responses mode if this model's row is filed under the other one
+		if hasFallbackMode {
+			s.logger.Debug("secondary lookup failed, trying vertex provider for the same model in %s mode", fallbackMode)
+			pricing, ok = s.pricingData[makeKey(model, "vertex", fallbackMode)]
 			if ok {
 				return &pricing, true
 			}
@@ -1256,10 +1257,10 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 				return &pricing, true
 			}
 
-			// Lookup in chat if responses not found
-			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest || requestType == schemas.CompactionRequest {
-				s.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
-				pricing, ok = s.pricingData[makeKey(modelWithoutProvider, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
+			// Lookup in the counterpart chat/responses mode if this model's row is filed under the other one
+			if hasFallbackMode {
+				s.logger.Debug("secondary lookup failed, trying vertex provider for the same model in %s mode", fallbackMode)
+				pricing, ok = s.pricingData[makeKey(modelWithoutProvider, "vertex", fallbackMode)]
 				if ok {
 					return &pricing, true
 				}
@@ -1290,10 +1291,10 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 				return &pricing, true
 			}
 
-			// Lookup in chat if responses not found
-			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest || requestType == schemas.CompactionRequest {
-				s.logger.Debug("secondary lookup failed, trying chat provider for the same model in chat completion")
-				pricing, ok = s.pricingData[makeKey(vendorPrefix+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+			// Lookup in the counterpart chat/responses mode if this model's row is filed under the other one
+			if hasFallbackMode {
+				s.logger.Debug("secondary lookup failed, trying the same prefixed model in %s mode", fallbackMode)
+				pricing, ok = s.pricingData[makeKey(vendorPrefix+model, provider, fallbackMode)]
 				if ok {
 					return &pricing, true
 				}
@@ -1301,10 +1302,10 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 		}
 	}
 
-	// Lookup in chat if responses/compaction not found
-	if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest || requestType == schemas.CompactionRequest {
-		s.logger.Debug("primary lookup failed, trying chat provider for the same model in chat completion")
-		pricing, ok = s.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+	// Lookup in the counterpart chat/responses mode if this model's row is filed under the other one
+	if hasFallbackMode {
+		s.logger.Debug("primary lookup failed, trying the same model in %s mode", fallbackMode)
+		pricing, ok = s.pricingData[makeKey(model, provider, fallbackMode)]
 		if ok {
 			return &pricing, true
 		}

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -2046,6 +2046,72 @@ func TestGetPricing_RealtimeFallsBackToChat(t *testing.T) {
 	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
 }
 
+func TestGetPricing_ChatFallsBackToResponses(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "responses"): chatPricing(0.000005, 0.000015),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "openai"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_ChatStreamFallsBackToResponses(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "responses"): chatPricing(0.000005, 0.000015),
+	})
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionStreamRequest, LookupScopes{Provider: "openai"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.000005, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_BedrockMantleChatStreamFallsBackToBedrockResponses(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-5.5", "bedrock", "responses"): chatPricing(0.0000055, 0.000033),
+	})
+	// The datasheet files openai.gpt-5.5 as responses-only, but bedrock serves it
+	// over chat completions too: bedrock_mantle folds onto bedrock, chat mode
+	// misses, and the responses row is used.
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock_mantle", Model: "openai.gpt-5.5"}, schemas.ChatCompletionStreamRequest, LookupScopes{Provider: "bedrock_mantle"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.0000055, derefF(p.InputCostPerToken))
+	assert.Equal(t, 0.000033, derefF(p.OutputCostPerToken))
+}
+
+func TestGetPricing_BedrockChatAddsOpenAIPrefixThenFallsBackToResponses(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("openai.gpt-5.5", "bedrock", "responses"): chatPricing(0.0000055, 0.000033),
+	})
+	// Bare model name + chat request: the openai. prefix retry fires, then the
+	// prefixed key falls back to responses mode.
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "bedrock", Model: "gpt-5.5"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "bedrock"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.0000055, derefF(p.InputCostPerToken))
+}
+
+func TestGetPricing_ExactModeWinsOverFallback(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"):      chatPricing(0.000005, 0.000015),
+		makeKey("gpt-4o", "openai", "responses"): chatPricing(0.000009, 0.000036),
+	})
+	chat := s.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "openai"})
+	require.NotNil(t, chat)
+	assert.Equal(t, 0.000005, derefF(chat.InputCostPerToken))
+
+	responses := s.resolvePricing(schemas.RoutingInfo{Provider: "openai", Model: "gpt-4o"}, schemas.ResponsesRequest, LookupScopes{Provider: "openai"})
+	require.NotNil(t, responses)
+	assert.Equal(t, 0.000009, derefF(responses.InputCostPerToken))
+}
+
+func TestGetPricing_GeminiChatFallsBackToVertexResponses(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gemini-2.0-flash", "vertex", "responses"): chatPricing(0.0000001, 0.0000004),
+	})
+	// gemini provider + chat request → try vertex + chat → try vertex + responses
+	p := s.resolvePricing(schemas.RoutingInfo{Provider: "gemini", Model: "gemini-2.0-flash"}, schemas.ChatCompletionRequest, LookupScopes{Provider: "gemini"})
+	require.NotNil(t, p)
+	assert.Equal(t, 0.0000001, derefF(p.InputCostPerToken))
+}
+
 func TestGetPricing_GeminiResponsesFallsBackToVertexChat(t *testing.T) {
 	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gemini-2.0-flash", "vertex", "chat"): chatPricing(0.0000001, 0.0000004),

--- a/framework/modelcatalog/datasheet/testdata/pricing.json
+++ b/framework/modelcatalog/datasheet/testdata/pricing.json
@@ -126,6 +126,15 @@
     "provider": "anthropic",
     "base_model": "claude-sonnet-4"
   },
+  "openai.gpt-5.5": {
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "input_cost_per_token": 5.5e-06,
+    "mode": "responses",
+    "output_cost_per_token": 3.3e-05,
+    "provider": "bedrock",
+    "base_model": "openai.gpt-5.5"
+  },
   "text-embedding-3-small": {
     "input_cost_per_token": 2e-08,
     "input_cost_per_token_batches": 1e-08,

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -388,6 +388,22 @@ func normalizeRequestType(reqType schemas.RequestType) string {
 	return "unknown"
 }
 
+// chatResponsesFallbackMode returns the counterpart pricing mode for request
+// types that providers serve over both the chat-completions and the responses
+// API. Many models carry a datasheet row under only one of the two modes (e.g.
+// bedrock's openai.gpt-5.5 ships as responses-only), so a lookup that misses in
+// its own mode retries under the counterpart rather than pricing at zero.
+// Returns false for request types with no such counterpart.
+func chatResponsesFallbackMode(reqType schemas.RequestType) (string, bool) {
+	switch reqType {
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest, schemas.RealtimeRequest, schemas.CompactionRequest:
+		return normalizeRequestType(schemas.ChatCompletionRequest), true
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		return normalizeRequestType(schemas.ResponsesRequest), true
+	}
+	return "", false
+}
+
 // normalizeStreamRequestType maps a stream variant to its non-stream base type.
 // Idempotent — passing a non-stream type returns it unchanged.
 func normalizeStreamRequestType(rt schemas.RequestType) schemas.RequestType {

--- a/plugins/logging/costrecalc_test.go
+++ b/plugins/logging/costrecalc_test.go
@@ -107,6 +107,25 @@ func skipLog(id string, ts time.Time) logstore.Log {
 	}
 }
 
+// bedrockMantleStreamLog mirrors a real bedrock_mantle streaming chat row. The
+// datasheet files openai.gpt-5.5 under responses mode only, so pricing it
+// requires both the bedrock_mantle→bedrock provider fold and the chat→responses
+// mode fallback; without them recalc skips the row as zero-cost.
+func bedrockMantleStreamLog(id string, ts time.Time) logstore.Log {
+	return logstore.Log{
+		ID:        id,
+		Timestamp: ts,
+		Provider:  "bedrock_mantle",
+		Model:     "openai.gpt-5.5",
+		Object:    "chat_completion_stream",
+		TokenUsageParsed: &schemas.BifrostLLMUsage{
+			PromptTokens:     955,
+			CompletionTokens: 3138,
+			TotalTokens:      4093,
+		},
+	}
+}
+
 func newRecalcPlugin(t *testing.T, store *fakeRecalcStore) *LoggerPlugin {
 	t.Helper()
 	return &LoggerPlugin{
@@ -141,6 +160,49 @@ func window(base time.Time) logstore.SearchFilters {
 	start := base.Add(-time.Hour)
 	end := base.Add(time.Hour)
 	return logstore.SearchFilters{StartTime: &start, EndTime: &end}
+}
+
+// TestCalculateCostForLog_BedrockMantleChatStreamUsesResponsesPricing pins the
+// recalc entry point on a stored streaming chat row whose only datasheet entry is
+// filed under responses mode: the cost must come back from the responses rates
+// rather than zero.
+func TestCalculateCostForLog_BedrockMantleChatStreamUsesResponsesPricing(t *testing.T) {
+	p := newRecalcPlugin(t, newFakeRecalcStore(nil))
+	entry := bedrockMantleStreamLog("mantle-1", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	cost, err := p.calculateCostForLog(&entry)
+	if err != nil {
+		t.Fatalf("calculateCostForLog() error = %v", err)
+	}
+	// openai.gpt-5.5 testdata rates (responses mode): input 5.5e-6, output 3.3e-5.
+	want := 955*5.5e-6 + 3138*3.3e-5
+	if diff := cost - want; diff < -1e-9 || diff > 1e-9 {
+		t.Fatalf("cost = %v, want %v (responses-mode rates via the chat→responses fallback)", cost, want)
+	}
+}
+
+// TestRunCostRecalcJob_BackfillsBedrockMantleStreamRow drives the full
+// missing-cost recalc job over an uncosted bedrock_mantle streaming row and
+// proves it is now backfilled instead of counted as skipped.
+func TestRunCostRecalcJob_BackfillsBedrockMantleStreamRow(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := newFakeRecalcStore([]logstore.Log{bedrockMantleStreamLog("mantle-1", base)})
+	p := newRecalcPlugin(t, store)
+
+	final, _, err := runJob(t, p, CostRecalcJobMeta{Filters: window(base), MissingCostOnly: true, Total: 1})
+	if err != nil {
+		t.Fatalf("RunCostRecalcJob() error = %v", err)
+	}
+	if final.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", final.Updated)
+	}
+	if final.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0 (the row must no longer resolve to zero cost)", final.Skipped)
+	}
+	want := 955*5.5e-6 + 3138*3.3e-5
+	if diff := store.cost["mantle-1"] - want; diff < -1e-9 || diff > 1e-9 {
+		t.Errorf("persisted cost = %v, want %v", store.cost["mantle-1"], want)
+	}
 }
 
 // TestRunCostRecalcJob_FullRecalcTiePagination proves the offset cursor walks


### PR DESCRIPTION
## Summary

Pricing lookups previously only fell back from responses-mode requests to chat mode when a datasheet row was missing. Chat and chat-stream requests had no equivalent fallback, so models whose only datasheet entry is filed under `responses` mode (e.g. `openai.gpt-5.5` on Bedrock) would resolve to zero cost when called via the chat completions API.

This PR makes the fallback bidirectional: a chat request that misses its own row retries under responses mode, and a responses request that misses retries under chat mode.

## Changes

- Extracted a `chatResponsesFallbackMode` helper that returns the counterpart pricing mode (`chat` ↔ `responses`) for any request type that participates in the fallback, and `false` for types with no counterpart.
- Replaced four copies of the hardcoded `ResponsesRequest || ResponsesStreamRequest || ...` condition in `getBasePricing` with a single `hasFallbackMode` check that uses the new helper, so both directions are covered uniformly.
- Updated the `getBasePricing` doc comment to reflect that the fallback is now bidirectional.
- Added `openai.gpt-5.5` (responses-only, bedrock) to the test pricing fixture to cover the Bedrock chat→responses path end-to-end.
- Added unit tests covering: chat falling back to responses, chat-stream falling back to responses, Bedrock Mantle chat-stream falling back to Bedrock responses, Bedrock bare model name adding the `openai.` prefix then falling back to responses, exact-mode rows winning over the fallback, and Gemini chat falling back to Vertex responses.
- Added `bedrockMantleStreamLog` test helper and two integration-level recalc tests that prove a `bedrock_mantle` streaming chat row whose only datasheet entry is under responses mode is correctly costed and backfilled by the cost-recalc job rather than skipped as zero-cost.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
go test ./framework/modelcatalog/datasheet/...
go test ./plugins/logging/...
```

The new tests assert that:
- A `ChatCompletionRequest` for `gpt-4o` resolves pricing when only a `responses` row exists.
- A `bedrock_mantle` streaming chat row for `openai.gpt-5.5` is priced at the responses-mode rates (`input 5.5e-6`, `output 3.3e-5`) rather than zero.
- The full recalc job backfills the `bedrock_mantle` row (`Updated=1`, `Skipped=0`).
- When both a `chat` and a `responses` row exist, the exact match wins.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable