### PR TITLE
fix tag fetches

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 #   VERSIONS_TO_TEST  - Number of previous versions to test (default: 3)
 
 # Pull all the tags available
-#git fetch --tags
+git fetch --tags
 
 # Get the absolute path of the script directory
 if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Re-enables the `git fetch --tags` command in the migration test script that was previously commented out, ensuring that all available tags are pulled before running migration tests.

## Changes

- Uncommented `git fetch --tags` in `run-migration-tests.sh` so that version tags are fetched from the remote before the migration test logic runs. Without this, the script may not have access to the tags needed to determine which previous versions to test against.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the migration test workflow and confirm that previous version tags are correctly resolved and tested against.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable