### PR TITLE
fix: reasoning item streaming in mux

### DIFF
--- a/core/providers/anthropic/reasoningstream_test.go
+++ b/core/providers/anthropic/reasoningstream_test.go
@@ -1,0 +1,174 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// reasoningStreamChunk builds a single Chat streaming chunk.
+func reasoningStreamChunk(id string, delta *schemas.ChatStreamResponseChoiceDelta, finishReason *string) *schemas.BifrostChatResponse {
+	return &schemas.BifrostChatResponse{
+		ID:    id,
+		Model: "deepseek-reasoner",
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				Index:                    0,
+				FinishReason:             finishReason,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{Delta: delta},
+			},
+		},
+	}
+}
+
+// TestReasoningStream_NoOrphanThinkingBlock drives the full Chat -> Responses ->
+// Anthropic SSE pipeline for a reasoning model (reasoning_content first, then
+// content) and asserts the emitted Anthropic stream is well-formed: every
+// content_block_delta references a block a prior content_block_start opened, and
+// every opened block is stopped. Before the fix, the thinking delta landed on an
+// index no content_block_start opened, which Claude Code rejects with
+// "Content block not found", aborts the stream, and reports a client disconnect.
+func TestReasoningStream_NoOrphanThinkingBlock(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	p := func(s string) *string { return &s }
+	chunks := []*schemas.BifrostChatResponse{
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Role: p("assistant"), Reasoning: p("")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Reasoning: p("The")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Reasoning: p(" user asked")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Content: p("Run ")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Content: p("make test")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{}, p("stop")),
+	}
+
+	openBlocks := map[int]bool{} // set of currently-open block indices
+	var sawThinkingStart, sawThinkingDelta bool
+
+	for _, c := range chunks {
+		for _, r := range c.ToBifrostResponsesStreamResponse(state) {
+			for _, e := range ToAnthropicResponsesStreamResponse(ctx, r) {
+				switch e.Type {
+				case AnthropicStreamEventTypeContentBlockStart:
+					if e.Index == nil {
+						t.Fatal("content_block_start with nil index")
+					}
+					if _, dup := openBlocks[*e.Index]; dup {
+						t.Fatalf("content_block_start opened index %d twice", *e.Index)
+					}
+					openBlocks[*e.Index] = true
+					if e.ContentBlock != nil && e.ContentBlock.Type == AnthropicContentBlockTypeThinking {
+						sawThinkingStart = true
+					}
+				case AnthropicStreamEventTypeContentBlockDelta:
+					if e.Index == nil {
+						t.Fatal("content_block_delta with nil index")
+					}
+					if _, open := openBlocks[*e.Index]; !open {
+						t.Fatalf("content_block_delta for index %d that no content_block_start opened (orphan block)", *e.Index)
+					}
+					if e.Delta != nil && e.Delta.Type == AnthropicStreamDeltaTypeThinking {
+						sawThinkingDelta = true
+					}
+				case AnthropicStreamEventTypeContentBlockStop:
+					if e.Index == nil {
+						t.Fatal("content_block_stop with nil index")
+					}
+					if _, open := openBlocks[*e.Index]; !open {
+						t.Fatalf("content_block_stop for unopened index %d", *e.Index)
+					}
+					delete(openBlocks, *e.Index)
+				}
+			}
+		}
+	}
+
+	if !sawThinkingStart {
+		t.Fatal("no content_block_start type=thinking emitted for reasoning content")
+	}
+	if !sawThinkingDelta {
+		t.Fatal("no thinking_delta emitted")
+	}
+	if len(openBlocks) != 0 {
+		t.Fatalf("blocks left open (never stopped): %v", openBlocks)
+	}
+	if misses := getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexMisses; len(misses) != 0 {
+		t.Fatalf("block index misses (delta/stop for an unregistered block): %v", misses)
+	}
+}
+
+// TestConvertBifrostReasoning_SignaturePresent asserts converted (non-Anthropic)
+// reasoning yields a thinking block with a non-nil signature. The Agent SDK's
+// non-streaming parser requires the field; omitting it fails with
+// "Missing required field in assistant message: 'signature'".
+func TestConvertBifrostReasoning_SignaturePresent(t *testing.T) {
+	reasoning := "The user asked how to run core tests."
+	msg := &schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				{Type: schemas.ResponsesOutputMessageContentTypeReasoning, Text: &reasoning}, // no Signature
+			},
+		},
+	}
+
+	blocks := convertBifrostReasoningToAnthropicThinking(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 thinking block, got %d", len(blocks))
+	}
+	if blocks[0].Type != AnthropicContentBlockTypeThinking {
+		t.Fatalf("expected thinking block, got %q", blocks[0].Type)
+	}
+	if blocks[0].Signature == nil {
+		t.Fatal("thinking block signature is nil; Agent SDK parse would fail on the missing field")
+	}
+}
+
+// TestReasoningStream_ResumedReasoningNotEmittedPastStop guards the
+// reasoning -> text -> reasoning ordering: once text closes the thinking block,
+// a resumed reasoning chunk must not emit a thinking delta past its
+// content_block_stop. The late reasoning is dropped; the stream stays well-formed.
+func TestReasoningStream_ResumedReasoningNotEmittedPastStop(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	p := func(s string) *string { return &s }
+	chunks := []*schemas.BifrostChatResponse{
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Role: p("assistant"), Reasoning: p("think")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Content: p("answer")}, nil),
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{Reasoning: p(" more think")}, nil), // resumes after text
+		reasoningStreamChunk("c1", &schemas.ChatStreamResponseChoiceDelta{}, p("stop")),
+	}
+
+	openBlocks := map[int]bool{}
+	for _, c := range chunks {
+		for _, r := range c.ToBifrostResponsesStreamResponse(state) {
+			for _, e := range ToAnthropicResponsesStreamResponse(ctx, r) {
+				switch e.Type {
+				case AnthropicStreamEventTypeContentBlockStart:
+					openBlocks[*e.Index] = true
+				case AnthropicStreamEventTypeContentBlockDelta:
+					if !openBlocks[*e.Index] {
+						t.Fatalf("content_block_delta for index %d with no open block (delta past stop / orphan)", *e.Index)
+					}
+				case AnthropicStreamEventTypeContentBlockStop:
+					delete(openBlocks, *e.Index)
+				}
+			}
+		}
+	}
+	if len(openBlocks) != 0 {
+		t.Fatalf("blocks left open: %v", openBlocks)
+	}
+	if misses := getOrCreateAnthropicToResponsesStreamState(ctx).blockIndexMisses; len(misses) != 0 {
+		t.Fatalf("block index misses: %v", misses)
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5690,10 +5690,16 @@ func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage) [
 	if msg.Content != nil && msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {
 			if block.Type == schemas.ResponsesOutputMessageContentTypeReasoning && block.Text != nil {
+				// signature is required by the Agent SDK; converted (non-Anthropic) reasoning
+				// has none, so default to empty rather than omitting the field.
+				signature := block.Signature
+				if signature == nil {
+					signature = schemas.Ptr("")
+				}
 				thinkingBlock := AnthropicContentBlock{
 					Type:      AnthropicContentBlockTypeThinking,
 					Thinking:  block.Text,
-					Signature: block.Signature,
+					Signature: signature,
 				}
 				thinkingBlocks = append(thinkingBlocks, thinkingBlock)
 			}
@@ -5707,8 +5713,9 @@ func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage) [
 		if len(msg.ResponsesReasoning.Summary) > 0 {
 			for _, reasoningContent := range msg.ResponsesReasoning.Summary {
 				thinkingBlock := AnthropicContentBlock{
-					Type:     AnthropicContentBlockTypeThinking,
-					Thinking: &reasoningContent.Text,
+					Type:      AnthropicContentBlockTypeThinking,
+					Thinking:  &reasoningContent.Text,
+					Signature: schemas.Ptr(""), // required by the Agent SDK; converted reasoning has no signature
 				}
 				thinkingBlocks = append(thinkingBlocks, thinkingBlock)
 			}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1524,6 +1524,11 @@ type ChatToResponsesStreamState struct {
 	TextItemClosed        bool              // Whether text item has been closed
 	TextItemHasContent    bool              // Whether text item has received any content deltas
 	TextBuffer            strings.Builder   // Accumulated text deltas for output_text.done/content_part.done
+	TextOutputIndex       int               // Output index assigned to the text/message item
+	ReasoningItemAdded    bool              // Whether the reasoning item has been opened
+	ReasoningItemClosed   bool              // Whether the reasoning item has been closed
+	ReasoningOutputIndex  int               // Output index assigned to the reasoning item
+	ReasoningBuffer       strings.Builder   // Accumulated reasoning deltas for reasoning output_item.done
 	CurrentOutputIndex    int               // Current output index counter
 	ToolCallOutputIndices map[string]int    // Maps tool call ID to output index
 	SequenceNumber        int               // Monotonic sequence number across all chunks
@@ -1592,6 +1597,11 @@ func AcquireChatToResponsesStreamState() *ChatToResponsesStreamState {
 	state.TextItemClosed = false
 	state.TextItemHasContent = false
 	state.TextBuffer = strings.Builder{}
+	state.TextOutputIndex = 0
+	state.ReasoningItemAdded = false
+	state.ReasoningItemClosed = false
+	state.ReasoningOutputIndex = 0
+	state.ReasoningBuffer = strings.Builder{}
 	state.SequenceNumber = 0
 	return state
 }
@@ -1626,6 +1636,11 @@ func ReleaseChatToResponsesStreamState(state *ChatToResponsesStreamState) {
 		state.TextItemClosed = false
 		state.TextItemHasContent = false
 		state.TextBuffer = strings.Builder{}
+		state.TextOutputIndex = 0
+		state.ReasoningItemAdded = false
+		state.ReasoningItemClosed = false
+		state.ReasoningOutputIndex = 0
+		state.ReasoningBuffer = strings.Builder{}
 		state.SequenceNumber = 0
 		chatToResponsesStreamStatePool.Put(state)
 	}
@@ -1697,12 +1712,103 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 	hasContent := delta.Content != nil && *delta.Content != ""
 	hasReasoning := delta.Reasoning != nil && *delta.Reasoning != ""
 
-	// Create output items if we have content OR reasoning (for reasoning-only models)
-	if hasContent || (hasReasoning && !state.TextItemAdded) {
-		// Text content delta (or reasoning-only response)
+	// closeReasoningItem brackets the reasoning block with an output_item.done so the
+	// reverse converters emit a content_block_stop. Called before the text/tool blocks
+	// open and at finish, so reasoning is fully closed before any other block starts —
+	// a delta for an unclosed/overlapping block makes strict clients drop the stream.
+	closeReasoningItem := func() {
+		if !state.ReasoningItemAdded || state.ReasoningItemClosed {
+			return
+		}
+		itemID := state.ItemIDs["reasoning"]
+		reasoningText := state.ReasoningBuffer.String()
+		reasoningType := ResponsesMessageTypeReasoning
+		role := ResponsesInputMessageRoleAssistant
+		doneItem := &ResponsesMessage{
+			Type: &reasoningType,
+			Role: &role,
+			Content: &ResponsesMessageContent{
+				ContentBlocks: []ResponsesMessageContentBlock{
+					{Type: ResponsesOutputMessageContentTypeReasoning, Text: &reasoningText},
+				},
+			},
+		}
+		if itemID != "" {
+			doneItem.ID = &itemID
+		}
+		responses = append(responses, &BifrostResponsesStreamResponse{
+			Type:           ResponsesStreamResponseTypeOutputItemDone,
+			SequenceNumber: state.SequenceNumber,
+			OutputIndex:    Ptr(state.ReasoningOutputIndex),
+			Item:           doneItem,
+			ExtraFields:    cr.ExtraFields,
+		})
+		state.SequenceNumber++
+		state.ReasoningItemClosed = true
+	}
+
+	// Reasoning streams before any text. Open a dedicated reasoning item so a proper
+	// content_block_start (type=thinking) precedes every thinking delta; a bare delta
+	// at an index no start opened makes strict clients (Claude Code) drop the stream.
+	// Skip once closed: a reasoning chunk resuming after text/tool would emit a delta past its stop.
+	if hasReasoning && !state.ReasoningItemClosed {
+		if !state.ReasoningItemAdded {
+			outputIndex := state.CurrentOutputIndex
+			state.CurrentOutputIndex++
+			var itemID string
+			if state.MessageID == nil {
+				itemID = fmt.Sprintf("item_%d_reasoning", outputIndex)
+			} else {
+				itemID = fmt.Sprintf("msg_%s_reasoning", *state.MessageID)
+			}
+			state.ItemIDs["reasoning"] = itemID
+			state.ReasoningOutputIndex = outputIndex
+
+			reasoningType := ResponsesMessageTypeReasoning
+			role := ResponsesInputMessageRoleAssistant
+			item := &ResponsesMessage{
+				ID:   &itemID,
+				Type: &reasoningType,
+				Role: &role,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{},
+				},
+			}
+			responses = append(responses, &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeOutputItemAdded,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				Item:           item,
+				ExtraFields:    cr.ExtraFields,
+			})
+			state.SequenceNumber++
+			state.ReasoningItemAdded = true
+		}
+
+		state.ReasoningBuffer.WriteString(*delta.Reasoning)
+		itemID := state.ItemIDs["reasoning"]
+		reasoningDelta := &BifrostResponsesStreamResponse{
+			Type:           ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+			SequenceNumber: state.SequenceNumber,
+			OutputIndex:    Ptr(state.ReasoningOutputIndex),
+			Delta:          delta.Reasoning,
+			ExtraFields:    cr.ExtraFields,
+		}
+		if itemID != "" {
+			reasoningDelta.ItemID = &itemID
+		}
+		responses = append(responses, reasoningDelta)
+		state.SequenceNumber++
+	}
+
+	// Text content delta. Reasoning (if any) is closed first so blocks never overlap.
+	if hasContent {
+		closeReasoningItem()
+
 		if !state.TextItemAdded {
-			// Add text item if not already added
-			outputIndex := 0
+			outputIndex := state.CurrentOutputIndex
+			state.CurrentOutputIndex++
+			state.TextOutputIndex = outputIndex
 			// Generate stable ID for text item
 			var itemID string
 			if state.MessageID == nil {
@@ -1757,36 +1863,25 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			state.SequenceNumber++
 		}
 
-		// Emit text delta - at least one is required for lifecycle validation
-		// Even for reasoning-only responses, we emit an empty delta on the first chunk
-		if hasContent || (!state.TextItemHasContent && (hasReasoning || hasContent)) {
-			itemID := state.ItemIDs["text"]
+		itemID := state.ItemIDs["text"]
+		contentDelta := *delta.Content
+		state.TextBuffer.WriteString(contentDelta)
 
-			var contentDelta string
-			if hasContent {
-				contentDelta = *delta.Content
-				state.TextBuffer.WriteString(contentDelta)
-			} else {
-				// For reasoning-only responses, emit empty delta on first chunk
-				contentDelta = ""
-			}
-
-			response := &BifrostResponsesStreamResponse{
-				Type:           ResponsesStreamResponseTypeOutputTextDelta,
-				SequenceNumber: state.SequenceNumber,
-				OutputIndex:    Ptr(0),
-				ContentIndex:   Ptr(0),
-				Delta:          &contentDelta,
-				LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
-				ExtraFields:    cr.ExtraFields,
-			}
-			if itemID != "" {
-				response.ItemID = &itemID
-			}
-			responses = append(responses, response)
-			state.SequenceNumber++
-			state.TextItemHasContent = true
+		response := &BifrostResponsesStreamResponse{
+			Type:           ResponsesStreamResponseTypeOutputTextDelta,
+			SequenceNumber: state.SequenceNumber,
+			OutputIndex:    Ptr(state.TextOutputIndex),
+			ContentIndex:   Ptr(0),
+			Delta:          &contentDelta,
+			LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
+			ExtraFields:    cr.ExtraFields,
 		}
+		if itemID != "" {
+			response.ItemID = &itemID
+		}
+		responses = append(responses, response)
+		state.SequenceNumber++
+		state.TextItemHasContent = true
 	}
 
 	if len(delta.ToolCalls) > 0 {
@@ -1812,9 +1907,11 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		// Check if this is a new tool call (only when ID is present)
 		if toolCall.ID != nil && *toolCall.ID != "" {
 			if _, exists := state.ToolCallOutputIndices[toolCallID]; !exists {
+				// Close reasoning item so its thinking block is bracketed before the tool block.
+				closeReasoningItem()
 				// Close text item if still open and has content
 				if state.TextItemAdded && !state.TextItemClosed && state.TextItemHasContent {
-					outputIndex := 0
+					outputIndex := state.TextOutputIndex
 					itemID := state.ItemIDs["text"]
 
 					finalText := state.TextBuffer.String()
@@ -1953,19 +2050,6 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		}
 	}
 
-	if delta.Reasoning != nil && *delta.Reasoning != "" {
-		// Reasoning/thought content delta (for models that support reasoning)
-		response := &BifrostResponsesStreamResponse{
-			Type:           ResponsesStreamResponseTypeReasoningSummaryTextDelta,
-			SequenceNumber: state.SequenceNumber,
-			OutputIndex:    Ptr(0),
-			Delta:          delta.Reasoning,
-			ExtraFields:    cr.ExtraFields,
-		}
-		responses = append(responses, response)
-		state.SequenceNumber++
-	}
-
 	if delta.Refusal != nil && *delta.Refusal != "" {
 		// Refusal delta
 		response := &BifrostResponsesStreamResponse{
@@ -1983,9 +2067,13 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 	if choice.FinishReason != nil {
 		terminalEventType, terminalStatus, terminalIncompleteDetails := responsesTerminalFromChatFinishReason(choice.FinishReason)
 
+		// Close reasoning item if the stream ends while it is still open (reasoning-only
+		// or reasoning cut short), so the thinking block is bracketed by a content_block_stop.
+		closeReasoningItem()
+
 		// Close text item if still open (regardless of whether it has content, to support reasoning-only responses)
 		if state.TextItemAdded && !state.TextItemClosed {
-			outputIndex := 0
+			outputIndex := state.TextOutputIndex
 			itemID := state.ItemIDs["text"]
 
 			finalText := state.TextBuffer.String()
@@ -2134,6 +2222,27 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			response.Model = *state.Model
 		}
 		var allOutput []ResponsesMessage
+
+		// Reasoning first (output index 0), mirroring the non-streaming converter's ordering.
+		if state.ReasoningItemAdded {
+			reasoningType := ResponsesMessageTypeReasoning
+			role := ResponsesInputMessageRoleAssistant
+			reasoningText := state.ReasoningBuffer.String()
+			itemID := state.ItemIDs["reasoning"]
+			rMsg := ResponsesMessage{
+				Type: &reasoningType,
+				Role: &role,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{Type: ResponsesOutputMessageContentTypeReasoning, Text: &reasoningText},
+					},
+				},
+			}
+			if itemID != "" {
+				rMsg.ID = &itemID
+			}
+			allOutput = append(allOutput, rMsg)
+		}
 
 		if state.TextItemAdded {
 			statusFinal := terminalStatus

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1205,3 +1205,113 @@ func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
 		t.Fatalf("expected schema.type=object, got %v", schemaMap["type"])
 	}
 }
+
+// streamChunk builds a single Chat streaming chunk for the reasoning/text ordering tests.
+func streamChunk(id string, delta *ChatStreamResponseChoiceDelta, finishReason *string) *BifrostChatResponse {
+	return &BifrostChatResponse{
+		ID:    id,
+		Model: "deepseek-reasoner",
+		Choices: []BifrostResponseChoice{
+			{
+				Index:                    0,
+				FinishReason:             finishReason,
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{Delta: delta},
+			},
+		},
+	}
+}
+
+// TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock reproduces the
+// Claude Code "Content block not found" disconnect: a Chat-Completions reasoning
+// model (reasoning_content first, then content) must yield a proper reasoning output
+// item (added -> deltas carrying its ItemID -> done) BEFORE the text item, so the
+// Anthropic reverse converter emits content_block_start type=thinking before any
+// thinking delta. Previously reasoning only opened a text item and the reasoning
+// delta had no ItemID, producing an orphan thinking block.
+func TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	chunks := []*BifrostChatResponse{
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{Role: Ptr("assistant"), Reasoning: Ptr("")}, nil),
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{Reasoning: Ptr("The")}, nil),
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{Reasoning: Ptr(" user")}, nil),
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{Content: Ptr("Run ")}, nil),
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{Content: Ptr("tests")}, nil),
+		streamChunk("c1", &ChatStreamResponseChoiceDelta{}, Ptr("stop")),
+	}
+
+	var events []*BifrostResponsesStreamResponse
+	for _, c := range chunks {
+		events = append(events, c.ToBifrostResponsesStreamResponse(state)...)
+	}
+
+	var reasoningItemID string
+	var reasoningOutputIndex, textOutputIndex = -1, -1
+	reasoningAddedIdx, reasoningDoneIdx, textAddedIdx := -1, -1, -1
+	firstReasoningDeltaIdx := -1
+
+	for i, e := range events {
+		switch e.Type {
+		case ResponsesStreamResponseTypeOutputItemAdded:
+			if e.Item != nil && e.Item.Type != nil && *e.Item.Type == ResponsesMessageTypeReasoning {
+				if reasoningAddedIdx == -1 {
+					reasoningAddedIdx = i
+				}
+				if e.Item.ID != nil {
+					reasoningItemID = *e.Item.ID
+				}
+				if e.OutputIndex != nil {
+					reasoningOutputIndex = *e.OutputIndex
+				}
+			}
+			if e.Item != nil && e.Item.Type != nil && *e.Item.Type == ResponsesMessageTypeMessage {
+				if textAddedIdx == -1 {
+					textAddedIdx = i
+				}
+				if e.OutputIndex != nil {
+					textOutputIndex = *e.OutputIndex
+				}
+			}
+		case ResponsesStreamResponseTypeReasoningSummaryTextDelta:
+			if firstReasoningDeltaIdx == -1 {
+				firstReasoningDeltaIdx = i
+			}
+			if e.ItemID == nil || *e.ItemID == "" {
+				t.Fatalf("reasoning delta at event %d has no ItemID (orphan thinking block)", i)
+			}
+			if e.ItemID != nil && *e.ItemID != reasoningItemID {
+				t.Fatalf("reasoning delta ItemID %q != reasoning item ID %q", *e.ItemID, reasoningItemID)
+			}
+		case ResponsesStreamResponseTypeOutputItemDone:
+			if e.Item != nil && e.Item.Type != nil && *e.Item.Type == ResponsesMessageTypeReasoning && reasoningDoneIdx == -1 {
+				reasoningDoneIdx = i
+			}
+		}
+	}
+
+	if reasoningAddedIdx == -1 {
+		t.Fatal("no reasoning output_item.added emitted")
+	}
+	if firstReasoningDeltaIdx == -1 {
+		t.Fatal("no reasoning delta emitted")
+	}
+	if reasoningAddedIdx >= firstReasoningDeltaIdx {
+		t.Fatalf("reasoning output_item.added (%d) must precede first reasoning delta (%d)", reasoningAddedIdx, firstReasoningDeltaIdx)
+	}
+	if reasoningDoneIdx == -1 {
+		t.Fatal("no reasoning output_item.done emitted (thinking block never closed)")
+	}
+	if textAddedIdx == -1 {
+		t.Fatal("no text output_item.added emitted")
+	}
+	if reasoningDoneIdx >= textAddedIdx {
+		t.Fatalf("reasoning output_item.done (%d) must precede text output_item.added (%d)", reasoningDoneIdx, textAddedIdx)
+	}
+	if reasoningOutputIndex != 0 {
+		t.Fatalf("reasoning output index = %d, want 0 (reasoning first)", reasoningOutputIndex)
+	}
+	if textOutputIndex <= reasoningOutputIndex {
+		t.Fatalf("text output index %d must be greater than reasoning output index %d", textOutputIndex, reasoningOutputIndex)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where reasoning models (e.g. DeepSeek Reasoner) streaming through the Chat → Responses → Anthropic SSE pipeline produced orphan thinking blocks — `content_block_delta` events referencing an index that no prior `content_block_start` had opened. Strict clients like Claude Code reject this with "Content block not found", abort the stream, and report a client disconnect. Additionally, fixes the Agent SDK's non-streaming parser failing with "Missing required field in assistant message: 'signature'" when converted (non-Anthropic) reasoning blocks omit the `signature` field.

## Changes

- **Reasoning item lifecycle**: Reasoning content now opens a dedicated `output_item.added` (type=reasoning) before emitting any reasoning deltas, and closes it with `output_item.done` before the text or tool-call item opens. This ensures `content_block_start type=thinking` always precedes any `thinking_delta` in the Anthropic SSE layer, and blocks never overlap.
- **Output index ordering**: Reasoning is assigned output index 0, with the text item receiving a higher index. Previously both reasoning and text deltas were hardcoded to index 0, causing collisions.
- **Reasoning item state tracking**: Added `ReasoningItemAdded`, `ReasoningItemClosed`, `ReasoningOutputIndex`, `ReasoningBuffer`, and `TextOutputIndex` fields to `ChatToResponsesStreamState` so the reasoning block's lifecycle is tracked independently from the text block.
- **Signature defaulting**: `convertBifrostReasoningToAnthropicThinking` now defaults `Signature` to an empty string pointer instead of `nil` for converted (non-Anthropic) reasoning blocks, satisfying the Agent SDK's required-field check.
- **Removed empty delta workaround**: The previous workaround that emitted an empty text delta for reasoning-only responses is removed; reasoning models now emit proper reasoning items instead.
- **Tests**: Added `TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock` (schema layer) and `TestReasoningStream_NoOrphanThinkingBlock` / `TestConvertBifrostReasoning_SignaturePresent` (Anthropic provider layer) to assert correct block ordering, ItemID propagation, and signature presence.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock -v
go test ./core/providers/anthropic/... -run TestReasoningStream_NoOrphanThinkingBlock -v
go test ./core/providers/anthropic/... -run TestConvertBifrostReasoning_SignaturePresent -v
go test ./...
```

Expected: all three new tests pass, and no existing tests regress. When streaming a reasoning model (e.g. DeepSeek Reasoner) through the Anthropic SSE endpoint, Claude Code no longer disconnects with "Content block not found".

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are limited to stream event ordering and field defaulting in the reasoning/thinking block conversion path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable