### PR TITLE
feat: validate routing CEL expressions at write time in create/update handlers

### DIFF
--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/cel-go/common/types"
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/routing"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
 
@@ -595,6 +596,43 @@ func extractMapKeysFromCEL(expr, mapName string) []string {
 		}
 	}
 	return keys
+}
+
+var (
+	routingValidationEnv     *cel.Env
+	routingValidationEnvErr  error
+	routingValidationEnvOnce sync.Once
+)
+
+// ValidateRoutingCELExpression compiles a routing CEL expression against the routing
+// environment and returns an error describing any syntax or type problem. An empty (or
+// whitespace-only) expression is treated as match-all ("true") and is considered valid.
+//
+// This mirrors the compilation performed lazily in GetRoutingProgram so that HTTP handlers
+// can reject a malformed expression at write time instead of it silently failing at first
+// evaluation. The environment is built once and reused across calls.
+func ValidateRoutingCELExpression(expr string) error {
+	if strings.TrimSpace(expr) == "" {
+		return nil
+	}
+
+	routingValidationEnvOnce.Do(func() {
+		routingValidationEnv, routingValidationEnvErr = createCELEnvironment()
+	})
+	if routingValidationEnvErr != nil {
+		return fmt.Errorf("failed to initialize CEL environment: %w", routingValidationEnvErr)
+	}
+
+	// Match the normalization and format check applied at evaluation time.
+	normalized := routing.NormalizeMapKeysInCEL(expr)
+	if err := routing.ValidateCELExpression(normalized); err != nil {
+		return err
+	}
+
+	if _, issues := routingValidationEnv.Compile(normalized); issues != nil && issues.Err() != nil {
+		return fmt.Errorf("CEL compile error: %s", issues.Err().Error())
+	}
+	return nil
 }
 
 // createCELEnvironment creates a new CEL environment for routing rules

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -1420,6 +1420,38 @@ func TestCreateCELEnvironment(t *testing.T) {
 	require.NotNil(t, env)
 }
 
+// TestValidateRoutingCELExpression covers the write-time CEL validation used by the
+// routing-rule create/update handlers.
+func TestValidateRoutingCELExpression(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{name: "empty is match-all and valid", expr: "", wantErr: false},
+		{name: "whitespace only is valid", expr: "   ", wantErr: false},
+		{name: "simple equality", expr: `model == "claude-sonnet-4-6"`, wantErr: false},
+		{name: "contains", expr: `model.contains("fable")`, wantErr: false},
+		{name: "header lookup", expr: `headers["x-tier"] == "premium"`, wantErr: false},
+		{name: "conjunction", expr: `model == "gpt-4o" && provider == "openai"`, wantErr: false},
+		{name: "unknown identifier", expr: `nonexistent_field == "x"`, wantErr: true},
+		{name: "syntax error unbalanced paren", expr: `model == "gpt-4o" && (provider == "openai"`, wantErr: true},
+		{name: "type mismatch string vs number", expr: `model == 5`, wantErr: true},
+		{name: "dangling operator", expr: `model ==`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRoutingCELExpression(tt.expr)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestExtractRoutingVariables_BasicContext tests extracting variables from basic context
 func TestExtractRoutingVariables_BasicContext(t *testing.T) {
 	ctx := &RoutingContext{

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -4004,6 +4004,11 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, err.Error())
 		return
 	}
+	// Reject malformed CEL at write time instead of it silently failing at first evaluation.
+	if err := governance.ValidateRoutingCELExpression(req.CelExpression); err != nil {
+		SendError(ctx, 400, fmt.Sprintf("invalid CEL expression: %s", err.Error()))
+		return
+	}
 
 	// Set defaults and normalize scope/scope_id
 	scope := req.Scope
@@ -4116,6 +4121,12 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 		rule.ChainRule = *req.ChainRule
 	}
 	if req.CelExpression != nil {
+		// Validate only when the field is supplied, so unrelated updates (e.g. toggling
+		// enabled) never start failing on a pre-existing malformed expression.
+		if err := governance.ValidateRoutingCELExpression(*req.CelExpression); err != nil {
+			SendError(ctx, 400, fmt.Sprintf("invalid CEL expression: %s", err.Error()))
+			return
+		}
 		rule.CelExpression = *req.CelExpression
 	}
 	if req.Targets != nil {


### PR DESCRIPTION
## Summary

Routing rule CEL expressions were previously only compiled and validated at first evaluation, meaning a malformed expression could be persisted successfully and fail silently at runtime. This PR adds write-time validation so that invalid CEL expressions are rejected with a `400` error when a routing rule is created or updated.

## Changes

- Added `ValidateRoutingCELExpression` in `plugins/governance/routing.go` that builds the CEL environment once (via `sync.Once`) and compiles the normalized expression, returning a descriptive error on any syntax or type problem. Empty/whitespace-only expressions are treated as match-all and pass validation.
- Wired `ValidateRoutingCELExpression` into the `createRoutingRule` and `updateRoutingRule` HTTP handlers so invalid expressions are rejected at write time. The update handler only validates when `CelExpression` is explicitly supplied, so unrelated updates (e.g. toggling `enabled`) are unaffected.
- Added `TestValidateRoutingCELExpression` covering valid expressions (empty, whitespace, equality, `contains`, header lookup, conjunction) and invalid ones (unknown identifiers, syntax errors, type mismatches, dangling operators).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/...
```

To validate manually, attempt to create or update a routing rule with an invalid CEL expression (e.g. `model ==`) and confirm a `400` response is returned with a descriptive error message. A valid expression (e.g. `model == "gpt-4o"`) should be accepted as before.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

CEL expressions are now compiled before persistence, reducing the risk of storing expressions that could cause unexpected runtime behaviour or panics during evaluation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable