### PR TITLE
feat: add raw CEL mode to routing rule builder with inline error display and round-trip edit support

### DIFF
--- a/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
+++ b/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
@@ -211,6 +211,24 @@ export class RoutingRulesPage extends BasePage {
   }
 
   /**
+   * Open the edit sheet for a rule without making any changes or saving.
+   */
+  async openEditSheet(name: string): Promise<void> {
+    await this.dismissToasts()
+    const row = this.getRuleRow(name)
+    await row.scrollIntoViewIfNeeded()
+
+    const editBtn = row.locator('button').filter({ has: this.page.locator('svg.lucide-pencil') }).or(
+      row.getByRole('button', { name: /Edit/i })
+    )
+    await editBtn.waitFor({ state: 'visible' })
+    await editBtn.click()
+
+    await expect(this.sheet).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+  }
+
+  /**
    * Edit an existing routing rule
    */
   async editRoutingRule(name: string, updates: Partial<RoutingRuleConfig>): Promise<void> {
@@ -496,6 +514,53 @@ export class RoutingRulesPage extends BasePage {
     const celPreview = this.sheet.locator('textarea').last()
     await celPreview.waitFor({ state: 'visible', timeout: 5000 })
     return await celPreview.inputValue()
+  }
+
+  /**
+   * Switch the Conditions editor to raw-CEL mode.
+   */
+  async switchToCelMode(): Promise<void> {
+    const celTab = this.sheet.getByTestId('cel-builder-mode-cel')
+    await celTab.waitFor({ state: 'visible', timeout: 5000 })
+    await celTab.click()
+    await this.celTextarea.waitFor({ state: 'visible', timeout: 5000 })
+  }
+
+  /**
+   * The editable CEL textarea, only present in CEL mode.
+   */
+  get celTextarea(): Locator {
+    return this.sheet.getByTestId('cel-builder-cel-textarea')
+  }
+
+  /**
+   * The inline validation error shown beneath the CEL textarea (e.g. a server-side compile error).
+   */
+  get celError(): Locator {
+    return this.sheet.getByTestId('cel-builder-cel-error')
+  }
+
+  /**
+   * Whether the Conditions editor is currently in raw-CEL mode.
+   */
+  async isCelMode(): Promise<boolean> {
+    return await this.celTextarea.isVisible().catch(() => false)
+  }
+
+  /**
+   * Type a raw CEL expression into the CEL-mode textarea.
+   */
+  async fillCelExpression(expression: string): Promise<void> {
+    await this.celTextarea.waitFor({ state: 'visible', timeout: 5000 })
+    await this.celTextarea.fill(expression)
+  }
+
+  /**
+   * Read the current CEL-mode textarea value.
+   */
+  async getCelTextareaValue(): Promise<string> {
+    await this.celTextarea.waitFor({ state: 'visible', timeout: 5000 })
+    return await this.celTextarea.inputValue()
   }
 
   /**

--- a/tests/e2e/features/routing-rules/routing-rules.spec.ts
+++ b/tests/e2e/features/routing-rules/routing-rules.spec.ts
@@ -341,6 +341,70 @@ test.describe('Routing Rules', () => {
       await routingRulesPage.cancelRule()
     })
 
+    test('should author conditions as raw CEL and round-trip through edit', async ({ routingRulesPage }) => {
+      const ruleName = `CEL Mode Test ${Date.now()}`
+      const celExpression = 'model == "claude-sonnet-4-6"'
+      createdRules.push(ruleName)
+
+      // Create a rule using raw-CEL mode instead of the visual builder
+      await routingRulesPage.createBtn.click()
+      await expect(routingRulesPage.sheet).toBeVisible()
+      await routingRulesPage.waitForSheetAnimation()
+      await routingRulesPage.waitForRuleBuilder()
+
+      await routingRulesPage.nameInput.fill(ruleName)
+      await routingRulesPage.switchToCelMode()
+      await routingRulesPage.fillCelExpression(celExpression)
+
+      await routingRulesPage.saveBtn.click()
+      await routingRulesPage.waitForSuccessToast()
+      await expect(routingRulesPage.sheet).not.toBeVisible({ timeout: 10000 })
+
+      const exists = await routingRulesPage.ruleExists(ruleName)
+      expect(exists).toBe(true)
+
+      // Reopen: a CEL-only rule (no visual query) must open in CEL mode with the
+      // expression intact, not an empty builder that would silently clear it.
+      await routingRulesPage.openEditSheet(ruleName)
+      expect(await routingRulesPage.isCelMode()).toBe(true)
+      expect(await routingRulesPage.getCelTextareaValue()).toBe(celExpression)
+
+      // Saving without touching anything must preserve the CEL expression.
+      await routingRulesPage.saveBtn.click()
+      await routingRulesPage.waitForSuccessToast()
+      await expect(routingRulesPage.sheet).not.toBeVisible({ timeout: 10000 })
+
+      await routingRulesPage.openEditSheet(ruleName)
+      expect(await routingRulesPage.getCelTextareaValue()).toBe(celExpression)
+      await routingRulesPage.cancelRule()
+    })
+
+    test('should reject a malformed CEL expression on save', async ({ routingRulesPage }) => {
+      const ruleName = `CEL Invalid Test ${Date.now()}`
+
+      await routingRulesPage.createBtn.click()
+      await expect(routingRulesPage.sheet).toBeVisible()
+      await routingRulesPage.waitForSheetAnimation()
+      await routingRulesPage.waitForRuleBuilder()
+
+      await routingRulesPage.nameInput.fill(ruleName)
+      await routingRulesPage.switchToCelMode()
+      // Unbalanced parenthesis — rejected by the backend CEL compiler with a 400.
+      await routingRulesPage.fillCelExpression('model == "gpt-4o" && (provider == "openai"')
+
+      await routingRulesPage.saveBtn.click()
+
+      // The sheet stays open on error; the rule must not be created.
+      await expect(routingRulesPage.sheet).toBeVisible()
+      // The compile error is surfaced inline beneath the CEL editor, not in a toast.
+      await expect(routingRulesPage.celError).toBeVisible()
+      await expect(routingRulesPage.celError).toContainText(/cel expression/i)
+      await routingRulesPage.cancelRule()
+
+      const exists = await routingRulesPage.ruleExists(ruleName)
+      expect(exists).toBe(false)
+    })
+
     test('should save rule with conditions successfully', async ({ routingRulesPage }) => {
       const ruleName = `CEL Save Test ${Date.now()}`
       createdRules.push(ruleName)

--- a/ui/app/workspace/routing-rules/components/celBuilder/celRuleBuilder.tsx
+++ b/ui/app/workspace/routing-rules/components/celBuilder/celRuleBuilder.tsx
@@ -3,7 +3,7 @@
  * Thin wrapper around the reusable CELRuleBuilder with routing-specific config
  */
 
-import { CELRuleBuilder as BaseCELRuleBuilder } from "@/components/ui/custom/celBuilder";
+import { CELBuilderMode, CELRuleBuilder as BaseCELRuleBuilder } from "@/components/ui/custom/celBuilder";
 import { getRoutingFields } from "@/lib/config/celFieldsRouting";
 import { celOperatorsRouting } from "@/lib/config/celOperatorsRouting";
 import { convertRuleGroupToCEL, validateRegexPattern } from "@/lib/utils/celConverterRouting";
@@ -17,6 +17,11 @@ interface CELRuleBuilderProps {
 	models?: string[];
 	allowCustomModels?: boolean;
 	isLoading?: boolean;
+	allowCelMode?: boolean;
+	initialMode?: CELBuilderMode;
+	initialCel?: string;
+	onModeChange?: (mode: CELBuilderMode) => void;
+	celError?: string | null;
 }
 
 export function CELRuleBuilder({
@@ -26,6 +31,11 @@ export function CELRuleBuilder({
 	models = [],
 	isLoading = false,
 	allowCustomModels = false,
+	allowCelMode = false,
+	initialMode = "builder",
+	initialCel = "",
+	onModeChange,
+	celError = null,
 }: CELRuleBuilderProps) {
 	const fields = useMemo(() => getRoutingFields(providers, models), [providers, models]);
 
@@ -39,6 +49,11 @@ export function CELRuleBuilder({
 			convertToCEL={convertRuleGroupToCEL}
 			validateRegex={validateRegexPattern}
 			builderContext={{ allowCustomModels }}
+			allowCelMode={allowCelMode}
+			initialMode={initialMode}
+			initialCel={initialCel}
+			onModeChange={onModeChange}
+			celError={celError}
 		/>
 	);
 }

--- a/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
@@ -252,6 +252,9 @@ export function RoutingRuleInfoSheet({ rule, open, onOpenChange, onNavigate, has
 	const targets = rule?.targets ?? [];
 	const fallbacks = rule?.fallbacks ?? [];
 	const hasQuery = rule?.query && (rule.query.rules?.length ?? 0) > 0;
+	// A rule can carry a CEL expression without a visual query (e.g. authored via the API).
+	// Only claim "matches all requests" when neither is present; otherwise the CEL section speaks for itself.
+	const hasCel = !!rule?.cel_expression?.trim();
 	const scopeName = useScopeName(rule?.scope ?? "global", rule?.scope_id);
 
 	const { prev: prevKeys, next: nextKeys } = useSheetNavigation({
@@ -325,7 +328,13 @@ export function RoutingRuleInfoSheet({ rule, open, onOpenChange, onNavigate, has
 							{/* Conditions */}
 							<div className="space-y-3">
 								<h3 className="text-sm font-semibold">Conditions</h3>
-								{hasQuery ? <ConditionGroup group={rule.query!} /> : <p className="text-muted-foreground text-sm">Matches all requests</p>}
+								{hasQuery ? (
+										<ConditionGroup group={rule.query!} />
+									) : hasCel ? (
+										<p className="text-muted-foreground text-sm">Defined as a CEL expression below</p>
+									) : (
+										<p className="text-muted-foreground text-sm">Matches all requests</p>
+									)}
 
 								{/* CEL expression */}
 								<div className="space-y-1.5">

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -28,7 +28,7 @@ import {
 	RoutingTargetFormData,
 } from "@/lib/types/routingRules";
 import { validateRateLimitAndBudgetRules, validateRoutingRules } from "@/lib/utils/celConverterRouting";
-import { normalizeRoutingRuleGroupQuery } from "@/lib/utils/routingRuleGroupQuery";
+import { isValidRuleGroupType, normalizeRoutingRuleGroupQuery } from "@/lib/utils/routingRuleGroupQuery";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Plus, Trash2, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
@@ -47,6 +47,24 @@ const defaultQuery: RuleGroupType = {
 	combinator: "and",
 	rules: [],
 };
+
+type ConditionMode = "builder" | "cel";
+
+/**
+ * Decides which conditions editor a rule opens in. Rules authored outside the visual
+ * builder (e.g. via the API) have a CEL expression but no usable `query`; those open in
+ * CEL mode so the expression stays visible and editable instead of being silently cleared.
+ */
+function initialConditionMode(rule?: RoutingRule | null): ConditionMode {
+	if (!rule) {
+		return "builder";
+	}
+	const hasQuery = isValidRuleGroupType(rule.query) && (rule.query.rules?.length ?? 0) > 0;
+	if (hasQuery) {
+		return "builder";
+	}
+	return rule.cel_expression?.trim() ? "cel" : "builder";
+}
 
 // Lazy-load CEL builder (heavy dependency tree).
 const CELRuleBuilderLazy = lazy(() =>
@@ -74,7 +92,10 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	// State for targets and query (managed outside react-hook-form for complex nested structures)
 	const [targets, setTargets] = useState<RoutingTargetFormData[]>([{ ...DEFAULT_ROUTING_TARGET }]);
 	const [query, setQuery] = useState<RuleGroupType>(defaultQuery);
+	const [conditionMode, setConditionMode] = useState<ConditionMode>("builder");
 	const [builderKey, setBuilderKey] = useState(0);
+	// Server-side CEL compile error, surfaced inline under the CEL editor instead of a toast.
+	const [celError, setCelError] = useState<string | null>(null);
 
 	const {
 		register,
@@ -143,12 +164,16 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 			}
 			// Only react-querybuilder-shaped queries are valid; config may store other JSON under `query`.
 			setQuery(normalizeRoutingRuleGroupQuery(editingRule.query));
+			setConditionMode(initialConditionMode(editingRule));
 			setBuilderKey((prev) => prev + 1);
+			setCelError(null);
 		} else {
 			reset();
 			setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 			setQuery(defaultQuery);
+			setConditionMode("builder");
 			setBuilderKey((prev) => prev + 1);
+			setCelError(null);
 		}
 	}, [editingRule, open, setValue, reset]);
 
@@ -156,9 +181,16 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		(expression: string, newQuery: RuleGroupType) => {
 			setValue("cel_expression", expression);
 			setQuery(newQuery);
+			// Editing the expression clears a stale server-side CEL error.
+			setCelError(null);
 		},
 		[setValue],
 	);
+
+	const handleModeChange = useCallback((mode: ConditionMode) => {
+		setConditionMode(mode);
+		setCelError(null);
+	}, []);
 
 	const addTarget = () => {
 		const remaining = 1 - targets.reduce((sum, t) => sum + (t.weight || 0), 0);
@@ -176,6 +208,8 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	const totalWeight = targets.reduce((sum, t) => sum + (t.weight || 0), 0);
 
 	const onSubmit = (data: RoutingRuleFormData) => {
+		setCelError(null);
+
 		// Validate scope_id is required when scope is not global
 		if (data.scope !== "global" && !data.scope_id?.trim()) {
 			toast.error(`${data.scope === "team" ? "Team" : data.scope === "customer" ? "Customer" : "Virtual Key"} is required`);
@@ -198,18 +232,22 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 			return;
 		}
 
-		// Validate regex patterns in routing rules
-		const regexErrors = validateRoutingRules(query);
-		if (regexErrors.length > 0) {
-			toast.error(`Invalid regex pattern:\n${regexErrors.join("\n")}`);
-			return;
-		}
+		// Builder-only validation: these inspect the visual query, which does not exist in
+		// raw-CEL mode. In CEL mode the expression is validated server-side on save instead.
+		if (conditionMode === "builder") {
+			// Validate regex patterns in routing rules
+			const regexErrors = validateRoutingRules(query);
+			if (regexErrors.length > 0) {
+				toast.error(`Invalid regex pattern:\n${regexErrors.join("\n")}`);
+				return;
+			}
 
-		// Validate rate limit and budget rules
-		const rateLimitErrors = validateRateLimitAndBudgetRules(query);
-		if (rateLimitErrors.length > 0) {
-			toast.error(`Invalid rule configuration:\n${rateLimitErrors.join("\n")}`);
-			return;
+			// Validate rate limit and budget rules
+			const rateLimitErrors = validateRateLimitAndBudgetRules(query);
+			if (rateLimitErrors.length > 0) {
+				toast.error(`Invalid rule configuration:\n${rateLimitErrors.join("\n")}`);
+				return;
+			}
 		}
 
 		// Filter out incomplete fallbacks (empty provider)
@@ -251,12 +289,21 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 				reset();
 				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 				setQuery(defaultQuery);
+				setConditionMode("builder");
 				setBuilderKey((prev) => prev + 1);
+				setCelError(null);
 				onOpenChange(false);
 				onSuccess?.();
 			})
 			.catch((error: any) => {
-				toast.error(getErrorMessage(error));
+				const message = getErrorMessage(error);
+				// A malformed CEL expression is a field-level problem — show it beneath the CEL
+				// editor rather than in a toast (which turns a syntax error into a jarring popup).
+				if (conditionMode === "cel" && /cel expression/i.test(message)) {
+					setCelError(message);
+					return;
+				}
+				toast.error(message);
 			});
 	};
 
@@ -264,7 +311,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		reset();
 		setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 		setQuery(defaultQuery);
+		setConditionMode("builder");
 		setBuilderKey((prev) => prev + 1);
+		setCelError(null);
 		onOpenChange(false);
 	};
 
@@ -429,6 +478,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 								providers={availableProviders}
 								models={[]}
 								allowCustomModels={true}
+								allowCelMode={true}
+								initialMode={conditionMode}
+								initialCel={editingRule?.cel_expression ?? ""}
+								onModeChange={handleModeChange}
+								celError={celError}
 							/>
 						</div>
 

--- a/ui/components/ui/custom/celBuilder/celRuleBuilder.tsx
+++ b/ui/components/ui/custom/celBuilder/celRuleBuilder.tsx
@@ -3,10 +3,21 @@
  * Reusable visual query builder for creating CEL expressions
  */
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { cn } from "@/lib/utils";
 import { Check, Copy, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Field, QueryBuilder, RuleGroupType } from "react-querybuilder";
@@ -39,6 +50,8 @@ export interface CELOperatorDefinition {
 	celSyntax: string;
 }
 
+export type CELBuilderMode = "builder" | "cel";
+
 export interface CELRuleBuilderProps {
 	onChange?: (celExpression: string, query: RuleGroupType) => void;
 	initialQuery?: RuleGroupType;
@@ -53,6 +66,23 @@ export interface CELRuleBuilderProps {
 	validateRegex?: (pattern: string) => string | null;
 	/** Additional context passed to the QueryBuilder controlElements */
 	builderContext?: Record<string, any>;
+	/**
+	 * When true, a Builder | CEL toggle is shown. In CEL mode the CEL expression
+	 * becomes hand-editable and drives onChange directly (with an empty query),
+	 * so rules authored outside the visual builder can be viewed and edited.
+	 */
+	allowCelMode?: boolean;
+	/** Mode to open in when allowCelMode is set. Defaults to "builder". */
+	initialMode?: CELBuilderMode;
+	/** Seed text for the editable CEL textarea when opening in CEL mode. */
+	initialCel?: string;
+	/** Notified when the user switches between Builder and CEL mode. */
+	onModeChange?: (mode: CELBuilderMode) => void;
+	/**
+	 * Validation error to surface inline beneath the editable CEL textarea (CEL mode only),
+	 * e.g. a server-side compile error returned on save. Cleared by the parent on edit.
+	 */
+	celError?: string | null;
 	options?: {
 		hideCELExpression?: boolean;
 	};
@@ -72,6 +102,11 @@ export function CELRuleBuilder({
 	convertToCEL,
 	validateRegex,
 	builderContext,
+	allowCelMode = false,
+	initialMode = "builder",
+	initialCel = "",
+	onModeChange,
+	celError = null,
 	options = {
 		hideCELExpression: false,
 	},
@@ -79,11 +114,21 @@ export function CELRuleBuilder({
 	const normalizedInitial = normalizeRoutingRuleGroupQuery(initialQuery ?? defaultQuery);
 	const [query, setQuery] = useState<RuleGroupType>(normalizedInitial);
 	const [celExpression, setCelExpression] = useState("");
+	const [mode, setMode] = useState<CELBuilderMode>(allowCelMode ? initialMode : "builder");
+	/** Hand-editable CEL text, used only in CEL mode. */
+	const [celText, setCelText] = useState(initialCel);
+	/** Guards the Cancel action of the CEL→Builder confirm dialog. */
+	const [confirmSwitchToBuilder, setConfirmSwitchToBuilder] = useState(false);
 	const onChangeRef = useRef(onChange);
 	const convertToCELRef = useRef(convertToCEL);
+	const onModeChangeRef = useRef(onModeChange);
 	/** Skip notifying parent on the first run so opening the editor does not clear an existing CEL from the form when query is empty or invalid. */
 	const skipOnChangeOnMount = useRef(true);
 	const { copy, copied } = useCopyToClipboard();
+
+	useEffect(() => {
+		onModeChangeRef.current = onModeChange;
+	}, [onModeChange]);
 
 	// Keep refs updated so the query effect always invokes the latest callbacks
 	useEffect(() => {
@@ -111,6 +156,38 @@ export function CELRuleBuilder({
 		onChangeRef.current?.(expression, query);
 	}, [query]);
 
+	const handleCelTextChange = (value: string) => {
+		setCelText(value);
+		// CEL mode owns the expression directly; the query builder state is left empty.
+		onChangeRef.current?.(value, defaultQuery);
+	};
+
+	const switchToCel = () => {
+		// Seed the editable text from whatever the builder currently produces so nothing is lost.
+		const seed = convertToCELRef.current(query);
+		setCelText(seed);
+		setMode("cel");
+		onModeChangeRef.current?.("cel");
+		onChangeRef.current?.(seed, defaultQuery);
+	};
+
+	const applySwitchToBuilder = () => {
+		setMode("builder");
+		onModeChangeRef.current?.("builder");
+		const expression = convertToCELRef.current(query);
+		onChangeRef.current?.(expression, query);
+	};
+
+	const requestSwitchToBuilder = () => {
+		// Switching back to the builder discards any hand-written CEL (there is no CEL→query parser),
+		// so confirm first when the text would actually be lost.
+		if (celText.trim() && celText.trim() !== convertToCELRef.current(query).trim()) {
+			setConfirmSwitchToBuilder(true);
+			return;
+		}
+		applySwitchToBuilder();
+	};
+
 	// Show loading state
 	if (isLoading) {
 		return (
@@ -126,49 +203,82 @@ export function CELRuleBuilder({
 		...(validateRegex ? { validateRegex } : {}),
 	};
 
+	const copyValue = mode === "cel" ? celText : celExpression;
+
 	return (
 		<div className="space-y-4">
-			<div className="rounded-md border">
-				<div className="custom-scrollbar flex w-full flex-col overflow-scroll">
-					<QueryBuilderWrapper>
-						<QueryBuilder
-							fields={fields}
-							query={query}
-							onQueryChange={setQuery}
-							context={context}
-							controlClassnames={{ queryBuilder: "queryBuilder-branches" }}
-							operators={operators.map((op) => ({
-								name: op.name,
-								label: op.label,
-							}))}
-							controlElements={{
-								fieldSelector: FieldSelector,
-								operatorSelector: OperatorSelector,
-								valueEditor: ValueEditor,
-								addRuleAction: ActionButton,
-								addGroupAction: ActionButton,
-								removeRuleAction: ActionButton,
-								removeGroupAction: ActionButton,
-								combinatorSelector: CombinatorSelector,
-							}}
-							translations={{
-								addRule: { label: "Add Rule" },
-								addGroup: { label: "Add Rule Group" },
-							}}
-						/>
-					</QueryBuilderWrapper>
+			{allowCelMode && (
+				<div className="flex items-center justify-end">
+					<div className="bg-muted inline-flex rounded-md p-0.5 text-sm">
+						<button
+							type="button"
+							onClick={requestSwitchToBuilder}
+							className={cn(
+								"rounded px-3 py-1 font-medium transition-colors",
+								mode === "builder" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground",
+							)}
+							data-testid="cel-builder-mode-builder"
+						>
+							Builder
+						</button>
+						<button
+							type="button"
+							onClick={switchToCel}
+							className={cn(
+								"rounded px-3 py-1 font-medium transition-colors",
+								mode === "cel" ? "bg-card text-foreground shadow-sm" : "text-muted-foreground",
+							)}
+							data-testid="cel-builder-mode-cel"
+						>
+							CEL
+						</button>
+					</div>
 				</div>
-			</div>
+			)}
 
-			{!options.hideCELExpression && (
+			{mode === "builder" && (
+				<div className="rounded-md border">
+					<div className="custom-scrollbar flex w-full flex-col overflow-scroll">
+						<QueryBuilderWrapper>
+							<QueryBuilder
+								fields={fields}
+								query={query}
+								onQueryChange={setQuery}
+								context={context}
+								controlClassnames={{ queryBuilder: "queryBuilder-branches" }}
+								operators={operators.map((op) => ({
+									name: op.name,
+									label: op.label,
+								}))}
+								controlElements={{
+									fieldSelector: FieldSelector,
+									operatorSelector: OperatorSelector,
+									valueEditor: ValueEditor,
+									addRuleAction: ActionButton,
+									addGroupAction: ActionButton,
+									removeRuleAction: ActionButton,
+									removeGroupAction: ActionButton,
+									combinatorSelector: CombinatorSelector,
+								}}
+								translations={{
+									addRule: { label: "Add Rule" },
+									addGroup: { label: "Add Rule Group" },
+								}}
+							/>
+						</QueryBuilderWrapper>
+					</div>
+				</div>
+			)}
+
+			{(mode === "cel" || !options.hideCELExpression) && (
 				<div className="space-y-2">
 					<div className="flex items-center justify-between">
-						<Label>CEL Expression Preview</Label>
+						<Label>{mode === "cel" ? "CEL Expression" : "CEL Expression Preview"}</Label>
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => copy(celExpression)}
-							disabled={!celExpression}
+							onClick={() => copy(copyValue)}
+							disabled={!copyValue}
 							className="gap-2"
 							type="button"
 						>
@@ -185,9 +295,53 @@ export function CELRuleBuilder({
 							)}
 						</Button>
 					</div>
-					<Textarea value={celExpression || "No rules defined yet"} readOnly className="font-mono text-sm" rows={4} />
+					{mode === "cel" ? (
+						<>
+							<Textarea
+								value={celText}
+								onChange={(e) => handleCelTextChange(e.target.value)}
+								className={cn("font-mono text-sm", celError && "border-destructive focus-visible:ring-destructive")}
+								rows={4}
+								placeholder='e.g. model == "claude-sonnet-4-6"'
+								aria-invalid={!!celError}
+								data-testid="cel-builder-cel-textarea"
+							/>
+							{celError ? (
+								<p className="text-destructive text-xs whitespace-pre-wrap" data-testid="cel-builder-cel-error">
+									{celError}
+								</p>
+							) : (
+								<p className="text-muted-foreground text-xs">Leave empty to match all requests.</p>
+							)}
+						</>
+					) : (
+						<Textarea value={celExpression || "No rules defined yet"} readOnly className="font-mono text-sm" rows={4} />
+					)}
 				</div>
 			)}
+
+			<AlertDialog open={confirmSwitchToBuilder} onOpenChange={setConfirmSwitchToBuilder}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Switch to the visual builder?</AlertDialogTitle>
+						<AlertDialogDescription>
+							The visual builder can&apos;t import a hand-written CEL expression, so your current CEL will be discarded and the builder
+							will start empty. Copy it first if you want to keep it.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => {
+								setConfirmSwitchToBuilder(false);
+								applySwitchToBuilder();
+							}}
+						>
+							Discard CEL &amp; switch
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</div>
 	);
 }

--- a/ui/components/ui/custom/celBuilder/index.ts
+++ b/ui/components/ui/custom/celBuilder/index.ts
@@ -1,2 +1,2 @@
 export { CELRuleBuilder } from "./celRuleBuilder";
-export type { CELRuleBuilderProps, CELFieldDefinition, CELOperatorDefinition } from "./celRuleBuilder";
+export type { CELBuilderMode, CELRuleBuilderProps, CELFieldDefinition, CELOperatorDefinition } from "./celRuleBuilder";


### PR DESCRIPTION
## Summary

Routing rules authored outside the visual builder (e.g. via the API) carry a raw CEL expression but no `query` object. Previously, opening such a rule in the edit sheet would silently discard the CEL expression because the builder initialised in visual mode with an empty query. This PR adds a raw CEL editing mode to the conditions editor so those rules can be viewed, edited, and saved without data loss.

## Changes

- Added a **Builder | CEL toggle** to the `CELRuleBuilder` component. When in CEL mode, the expression is hand-editable in a textarea and drives `onChange` directly, bypassing the visual query builder.
- Rules with a `cel_expression` but no visual `query` now open in CEL mode automatically (`initialConditionMode` helper in `routingRuleSheet.tsx`).
- Switching from CEL back to Builder shows a confirmation dialog warning that the hand-written CEL will be discarded (no CEL→query parser exists), and seeds the CEL textarea from the builder's current output when switching the other direction.
- Server-side CEL compile errors (400 responses) are now surfaced inline beneath the CEL textarea (`celError` prop) rather than as a toast, keeping the error contextual to the field that caused it.
- Builder-only validations (regex patterns, rate limit/budget rules) are skipped when in CEL mode, since those inspect the visual query which does not exist in that mode.
- The info sheet (`routingRuleInfoSheet.tsx`) now distinguishes between "Matches all requests" and "Defined as a CEL expression below" when a rule has a CEL expression but no visual query.
- E2E tests cover: creating a rule in raw CEL mode and verifying it round-trips through edit with the expression intact, and rejecting a malformed CEL expression with an inline error while keeping the sheet open and not creating the rule.
- New page-object helpers: `openEditSheet`, `switchToCelMode`, `fillCelExpression`, `getCelTextareaValue`, `isCelMode`, `celTextarea`, `celError`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build

# E2E
pnpm exec playwright test tests/e2e/features/routing-rules/routing-rules.spec.ts
```

1. Create a routing rule via the API with a raw CEL expression and no `query` field.
2. Open the rule in the UI — it should open in CEL mode with the expression visible in the textarea.
3. Save without changes — the expression should be preserved after reopening.
4. Enter a malformed CEL expression (e.g. unbalanced parenthesis) and save — the sheet should stay open and show an inline error beneath the textarea.
5. Switch from CEL mode to Builder mode with a non-empty expression — a confirmation dialog should appear warning that the CEL will be discarded.

  
  
![image.png](https://app.graphite.com/user-attachments/assets/3a2515aa-ca27-4eda-b3f0-de0ef215bc65.png)





## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII surface area introduced. CEL expressions are validated server-side before persistence.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable