### PR TITLE
fix: remove `isFetching` prop from `VirtualKeysTable` and simplify empty state check

### DIFF
--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -36,7 +36,6 @@ export default function GovernanceVirtualKeysPage() {
 		data: virtualKeysData,
 		error: vkError,
 		isLoading: vkLoading,
-		isFetching,
 	} = useGetVirtualKeysQuery(
 		{
 			limit: PAGE_SIZE,
@@ -160,7 +159,6 @@ export default function GovernanceVirtualKeysPage() {
 				onSortChange={handleSortChange}
 				selectedVkId={urlState.selected_vk}
 				onSelectedVkChange={handleSelectedVkChange}
-				isFetching={isFetching}
 			/>
 		</div>
 	);

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -280,7 +280,6 @@ interface VirtualKeysTableProps {
 	onSortChange: (sortBy: string, order: string) => void;
 	selectedVkId: string;
 	onSelectedVkChange: (id: string, options?: { offset?: number }) => void;
-	isFetching?: boolean;
 }
 
 export default function VirtualKeysTable({
@@ -303,7 +302,6 @@ export default function VirtualKeysTable({
 	onSortChange,
 	selectedVkId,
 	onSelectedVkChange,
-	isFetching,
 }: VirtualKeysTableProps) {
 	const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
 	const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null);
@@ -594,7 +592,7 @@ export default function VirtualKeysTable({
 	};
 
 	// True empty state: no VKs at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters && !isFetching) {
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				{showVirtualKeySheet && (


### PR DESCRIPTION
## Summary

Removes the `isFetching` prop from `VirtualKeysTable` and its usage in the governance virtual keys page. Previously, the empty state check was gated on `isFetching` to avoid flashing the empty state while data was loading. This guard has been removed, simplifying the component interface and relying solely on `totalCount` and `hasActiveFilters` to determine when to render the true empty state.

## Changes

- Removed `isFetching` from the `useGetVirtualKeysQuery` destructure in the governance virtual keys page
- Removed `isFetching` prop from `VirtualKeysTableProps` interface and the component's destructured parameters
- Updated the empty state condition from `totalCount === 0 && !hasActiveFilters && !isFetching` to `totalCount === 0 && !hasActiveFilters`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the governance virtual keys page and verify:
1. The empty state renders correctly when no virtual keys exist
2. No unintended empty state flash occurs during initial load or pagination

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable