### PR TITLE
feat: adds user email export to connectors

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6058,6 +6058,9 @@ func executeRequestWithRetries[T any](
 		if userName, ok := ctx.Value(schemas.BifrostContextKeyUserName).(string); ok && userName != "" {
 			tracer.SetAttribute(handle, schemas.AttrBifrostUserName, userName)
 		}
+		if userEmail, ok := ctx.Value(schemas.BifrostContextKeyUserEmail).(string); ok && userEmail != "" {
+			tracer.SetAttribute(handle, schemas.AttrBifrostUserEmail, userEmail)
+		}
 		if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
 			tracer.SetAttribute(handle, schemas.AttrFallbackIndex, fallbackIndex) // legacy: gen_ai.* placement of bifrost-internal attr
 			tracer.SetAttribute(handle, schemas.AttrBifrostFallbackIndex, fallbackIndex)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -332,6 +332,7 @@ const (
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "bifrost-user-id"                    // string (to store the user ID (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyUserName                            BifrostContextKey = "bifrost-user-name"                  // string (to store the user name (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyUserEmail                           BifrostContextKey = "bifrost-user-email"                 // string (to store the user email (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyQueryScope                          BifrostContextKey = "bifrost-query-scope"                // configstore.QueryScope (func that mutates a query; set by upstream wrapper - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyVisibilityFilterProvider            BifrostContextKey = "bifrost-visibility-filter-provider" // DEPRECATED: replaced by BifrostContextKeyQueryScope. Will be removed once all callers migrate.
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"

--- a/core/schemas/enrichment.go
+++ b/core/schemas/enrichment.go
@@ -78,6 +78,7 @@ var EnrichmentDims = []EnrichmentDim{
 	//     BigQuery columns and span attributes, never as metric labels/tags. ---
 	{Name: "user_id", SpanAttr: AttrBifrostUserID},
 	{Name: "user_name", SpanAttr: AttrBifrostUserName},
+	{Name: "user_email", SpanAttr: AttrBifrostUserEmail},
 	{Name: "team_ids", SpanAttr: AttrBifrostTeamIDs, Multi: true},
 	{Name: "team_names", SpanAttr: AttrBifrostTeamNames, Multi: true},
 	{Name: "customer_ids", SpanAttr: AttrBifrostCustomerIDs, Multi: true},

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -730,6 +730,7 @@ const (
 	AttrBifrostBusinessUnitNames   = "bifrost.business_unit.names"
 	AttrBifrostUserID              = "bifrost.user.id"
 	AttrBifrostUserName            = "bifrost.user.name"
+	AttrBifrostUserEmail           = "bifrost.user.email"
 	AttrBifrostRetries             = "bifrost.retries"
 	AttrBifrostFallbackIndex       = "bifrost.fallback_index"
 	AttrBifrostAlias               = "bifrost.alias"                // original requested model when it differs from the resolved model

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -161,7 +161,7 @@ func PopulateContextAttributes(
 	teamID, teamName string,
 	customerID, customerName string,
 	businessUnitID, businessUnitName string,
-	userID, userName string,
+	userID, userName, userEmail string,
 	numberOfRetries, fallbackIndex int,
 ) {
 	// Each AttrXxx (gen_ai.*) emission below is LEGACY namespace pollution: a
@@ -213,6 +213,9 @@ func PopulateContextAttributes(
 	}
 	if userName != "" {
 		attrs[schemas.AttrBifrostUserName] = userName
+	}
+	if userEmail != "" {
+		attrs[schemas.AttrBifrostUserEmail] = userEmail
 	}
 	attrs[schemas.AttrNumberOfRetries] = numberOfRetries // legacy: gen_ai.* placement of bifrost-internal attr
 	attrs[schemas.AttrFallbackIndex] = fallbackIndex     // legacy: gen_ai.* placement of bifrost-internal attr


### PR DESCRIPTION
## Summary

Adds `user_email` as a tracked attribute in Bifrost tracing and enrichment, alongside the existing `user_id` and `user_name` fields. This allows user email to be captured from the enterprise auth middleware context and propagated through spans and BigQuery enrichment dimensions.

## Changes

- Added `BifrostContextKeyUserEmail` context key (`"bifrost-user-email"`) for storing user email set by the enterprise auth middleware
- Added `AttrBifrostUserEmail` span attribute constant (`"bifrost.user.email"`)
- Added `user_email` to `EnrichmentDims` for BigQuery column and span attribute propagation
- Extended `PopulateContextAttributes` to accept and emit `userEmail` alongside `userID` and `userName`
- Added span attribute setting in `executeRequestWithRetries` when a user email is present in context

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that spans emitted during request execution include `bifrost.user.email` when a user email is present in the context, and that the enrichment pipeline maps it to the `user_email` BigQuery column.

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

User email is PII. It is sourced exclusively from the enterprise auth middleware context and should not be set manually. Ensure downstream span exporters and BigQuery destinations handling `user_email` apply appropriate access controls consistent with those already in place for `user_id` and `user_name`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable