### PR TITLE
fix: adds sgl anthropic compatible apis via key level setting

### DIFF
--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -124,6 +124,7 @@ var AnthropicProviderRequestDefaultsMap = map[schemas.ModelProvider]AnthropicPro
 		RemapToolVersions:         true,
 		InjectBetaHeadersIntoBody: true,
 	},
+	schemas.SGL: {},
 }
 
 // BuildAnthropicResponsesRequestBody is the single implementation of the

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -3353,3 +3353,11 @@ func IsClaudeCodeRequest(ctx *schemas.BifrostContext) bool {
 	}
 	return false
 }
+
+// ResolveUseAnthropicEndpoints reports whether the request should be routed through Anthropic-compatible endpoints
+func ResolveUseAnthropicEndpoints(ctx *schemas.BifrostContext, key schemas.Key) bool {
+	if ra := schemas.GetResolvedAlias(ctx); ra != nil && ra.Config != nil && ra.Config.UseAnthropicEndpoints != nil {
+		return *ra.Config.UseAnthropicEndpoints
+	}
+	return key.UseAnthropicEndpoints != nil && *key.UseAnthropicEndpoints
+}

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -7,11 +7,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
+
+// sglAnthropicVersion is the Anthropic API version sent as the "anthropic-version" header on
+// SGLang's Anthropic-compatible endpoint.
+const sglAnthropicVersion = "2023-06-01"
 
 // SGLProvider implements the Provider interface for SGL's API.
 type SGLProvider struct {
@@ -80,6 +85,13 @@ func (provider *SGLProvider) getBaseURL(key schemas.Key) string {
 	return ""
 }
 
+// anthropicHeaders builds the auth and version headers for SGL's Anthropic-compatible endpoint.
+func anthropicHeaders(key schemas.Key) map[string]string {
+	headers := openai.BearerAuthHeader(key)
+	headers["anthropic-version"] = sglAnthropicVersion
+	return headers
+}
+
 // baseURLOrError returns the resolved base URL or a BifrostError when none is configured.
 func (provider *SGLProvider) baseURLOrError(key schemas.Key) (string, *schemas.BifrostError) {
 	u := provider.getBaseURL(key)
@@ -124,7 +136,10 @@ func (provider *SGLProvider) ListModels(ctx *schemas.BifrostContext, keys []sche
 	)
 }
 
-// TextCompletion performs a text completion request to the SGL API.
+// TextCompletion performs a text completion request to the SGL API. UseAnthropicEndpoints has
+// no effect here: Anthropic's legacy text-completions surface has no reusable shared handler
+// and SGLang's Anthropic-compatible layer doesn't expose one either, so this always uses the
+// OpenAI-compatible /v1/completions endpoint.
 func (provider *SGLProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 	baseURL, bifrostErr := provider.baseURLOrError(key)
@@ -176,13 +191,35 @@ func (provider *SGLProvider) TextCompletionStream(ctx *schemas.BifrostContext, p
 	)
 }
 
-// ChatCompletion performs a chat completion request to the SGL API.
+// ChatCompletion performs a chat completion request to the SGL API. When the key (or the
+// resolved alias) has UseAnthropicEndpoints set, the request is routed through SGLang's
+// Anthropic-compatible Messages endpoint instead of its OpenAI-compatible one.
 func (provider *SGLProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 	baseURL, bifrostErr := provider.baseURLOrError(key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+
+	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		return anthropic.HandleAnthropicChatCompletionRequest(
+			ctx,
+			provider.client,
+			baseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  provider.GetProviderKey(),
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			anthropicHeaders(key),
+			provider.networkConfig.ExtraHeaders,
+			nil,
+			provider.logger,
+		)
+	}
+
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
@@ -210,6 +247,39 @@ func (provider *SGLProvider) ChatCompletionStream(ctx *schemas.BifrostContext, p
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+
+	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		url := baseURL + providerUtils.GetPathFromContext(ctx, "/v1/messages")
+		jsonData, bifrostErr := anthropic.BuildAnthropicChatRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+			Provider:                  provider.GetProviderKey(),
+			IsStreaming:               true,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		return anthropic.HandleAnthropicChatCompletionStreaming(
+			ctx,
+			provider.streamingClient,
+			url,
+			jsonData,
+			anthropicHeaders(key),
+			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			provider.networkConfig.BetaHeaderOverrides,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(),
+			postHookRunner,
+			nil,
+			nil,
+			provider.logger,
+			postHookSpanFinalizer,
+		)
+	}
+
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
@@ -233,8 +303,36 @@ func (provider *SGLProvider) ChatCompletionStream(ctx *schemas.BifrostContext, p
 	)
 }
 
-// Responses performs a responses request to the SGL API.
+// Responses performs a responses request to the SGL API. When the key (or the resolved alias)
+// has UseAnthropicEndpoints set, the request is routed through SGLang's Anthropic-compatible
+// Messages endpoint directly (rather than falling back through ChatCompletion), since the
+// Anthropic responses handler operates on the Responses-shaped request natively.
 func (provider *SGLProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+		baseURL, bifrostErr := provider.baseURLOrError(key)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		return anthropic.HandleAnthropicResponsesRequest(
+			ctx,
+			provider.client,
+			baseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			request,
+			anthropic.AnthropicRequestBuildConfig{
+				Provider:                  provider.GetProviderKey(),
+				ValidateTools:             true,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+				ShouldSendBackRawResponse: provider.sendBackRawResponse,
+			},
+			anthropicHeaders(key),
+			provider.networkConfig.ExtraHeaders,
+			nil,
+			provider.logger,
+		)
+	}
+
 	chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
 	if err != nil {
 		return nil, err
@@ -247,6 +345,44 @@ func (provider *SGLProvider) Responses(ctx *schemas.BifrostContext, key schemas.
 
 // ResponsesStream performs a streaming responses request to the SGL API.
 func (provider *SGLProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+		baseURL, bifrostErr := provider.baseURLOrError(key)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		url := baseURL + providerUtils.GetPathFromContext(ctx, "/v1/messages")
+		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+			Provider:                  provider.GetProviderKey(),
+			IsStreaming:               true,
+			ValidateTools:             true,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
+			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
+			ShouldSendBackRawResponse: provider.sendBackRawResponse,
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		return anthropic.HandleAnthropicResponsesStream(
+			ctx,
+			provider.streamingClient,
+			url,
+			jsonData,
+			anthropicHeaders(key),
+			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			provider.networkConfig.BetaHeaderOverrides,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(),
+			postHookRunner,
+			nil,
+			nil,
+			provider.logger,
+			postHookSpanFinalizer,
+		)
+	}
+
 	ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
 	return provider.ChatCompletionStream(
 		ctx,

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -141,6 +141,7 @@ type Key struct {
 	SGLKeyConfig           *SGLKeyConfig           `json:"sgl_key_config,omitempty"`            // SGLang-specific key configuration
 	Enabled                *bool                   `json:"enabled,omitempty"`                   // Whether the key is active (default:true)
 	UseForBatchAPI         *bool                   `json:"use_for_batch_api,omitempty"`         // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
+	UseAnthropicEndpoints  *bool                   `json:"use_anthropic_endpoints,omitempty"`   // Whether to use anthropic endpoints for this key
 	ConfigHash             string                  `json:"config_hash,omitempty"`               // Hash of config.json version, used for change detection
 	Status                 KeyStatusType           `json:"status,omitempty"`                    // Status of key
 	Description            string                  `json:"description,omitempty"`               // Description of key
@@ -229,7 +230,8 @@ type AliasConfig struct {
 	// top-level (rather than inside each provider sub-config) so the flat "project_id"
 	// JSON key does not collide between embedded sub-configs — Go/sonic silently drop
 	// a field name shared by multiple same-depth anonymous structs.
-	ProjectID *SecretVar `json:"project_id,omitempty"`
+	ProjectID             *SecretVar `json:"project_id,omitempty"`
+	UseAnthropicEndpoints *bool      `json:"use_anthropic_endpoints,omitempty"` // Whether to use anthropic endpoints for this alias
 
 	*AzureAliasCfg
 	*VertexAliasCfg
@@ -247,6 +249,7 @@ func (ac AliasConfig) isLegacyShape() bool {
 		ac.Description == "" &&
 		ac.Region == nil &&
 		ac.ProjectID == nil &&
+		ac.UseAnthropicEndpoints == nil &&
 		ac.AzureAliasCfg == nil &&
 		ac.VertexAliasCfg == nil &&
 		ac.BedrockAliasCfg == nil &&

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 )
@@ -523,7 +522,13 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		if key.UseForBatchAPI != nil {
 			redactedConfig.Keys[i].UseForBatchAPI = key.UseForBatchAPI
 		} else {
-			redactedConfig.Keys[i].UseForBatchAPI = bifrost.Ptr(false)
+			redactedConfig.Keys[i].UseForBatchAPI = new(false)
+		}
+		// Add back use anthropic endpoints
+		if key.UseAnthropicEndpoints != nil {
+			redactedConfig.Keys[i].UseAnthropicEndpoints = key.UseAnthropicEndpoints
+		} else {
+			redactedConfig.Keys[i].UseAnthropicEndpoints = new(false)
 		}
 
 		// Add model discovery status and error
@@ -852,6 +857,14 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	}
 	if useForBatchAPI {
 		hash.Write([]byte("useForBatchAPI:true"))
+	}
+	// Hash UseAnthropicEndpoints (nil = default false for new keys)
+	useAnthropicEndpoints := false
+	if key.UseAnthropicEndpoints != nil {
+		useAnthropicEndpoints = *key.UseAnthropicEndpoints
+	}
+	if useAnthropicEndpoints {
+		hash.Write([]byte("useAnthropicEndpoints:true"))
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -451,6 +451,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_webhook_jobs_table"}, run: migrationAddWebhookJobsTable},
 	{IDs: []string{"add_webhook_config_client_column"}, run: migrationAddWebhookConfigClientColumn},
 	{IDs: []string{"add_oauth_config_resource_column"}, run: migrationAddOauthConfigResourceColumn},
+	{IDs: []string{"add_use_anthropic_endpoints_column"}, run: migrationAddUseAnthropicEndpointsColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -3140,6 +3141,34 @@ func migrationAddUseForBatchAPIColumnAndS3BucketsConfig(ctx context.Context, db 
 
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running use_for_batch_api migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddUseAnthropicEndpointsColumn adds the use_anthropic_endpoints column to the config_keys table.
+func migrationAddUseAnthropicEndpointsColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_use_anthropic_endpoints_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableKey{}, "use_anthropic_endpoints"); err != nil {
+				return fmt.Errorf("failed to add use_anthropic_endpoints column: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableKey{}, "use_anthropic_endpoints"); err != nil {
+				return fmt.Errorf("failed to drop use_anthropic_endpoints column: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_use_anthropic_endpoints_column migration: %s", err.Error())
 	}
 	return nil
 }
@@ -7771,7 +7800,6 @@ func migrationAddMCPClientDiscoveredToolsColumns(ctx context.Context, db *gorm.D
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_client_discovered_tools_columns migration: %s", err.Error())
-
 	}
 	return nil
 }
@@ -7875,7 +7903,6 @@ func migrationAddFlexTierPricingColumns(ctx context.Context, db *gorm.DB, logger
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running flex tier pricing columns migration: %s", err.Error())
-
 	}
 	return nil
 }
@@ -8304,7 +8331,6 @@ func migrationNormalizeOtelTraceType(ctx context.Context, db *gorm.DB, logger sc
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running normalize_otel_trace_type migration: %s", err.Error())
-
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -152,6 +152,7 @@ func schemaKeyFromTableKey(dbKey tables.TableKey) schemas.Key {
 		Weight:                 getWeight(dbKey.Weight),
 		Enabled:                dbKey.Enabled,
 		UseForBatchAPI:         dbKey.UseForBatchAPI,
+		UseAnthropicEndpoints:  dbKey.UseAnthropicEndpoints,
 		AzureKeyConfig:         dbKey.AzureKeyConfig,
 		VertexKeyConfig:        dbKey.VertexKeyConfig,
 		BedrockKeyConfig:       dbKey.BedrockKeyConfig,
@@ -180,6 +181,7 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 		Weight:                 &key.Weight,
 		Enabled:                key.Enabled,
 		UseForBatchAPI:         key.UseForBatchAPI,
+		UseAnthropicEndpoints:  key.UseAnthropicEndpoints,
 		AzureKeyConfig:         key.AzureKeyConfig,
 		VertexKeyConfig:        key.VertexKeyConfig,
 		BedrockKeyConfig:       key.BedrockKeyConfig,
@@ -717,6 +719,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				Weight:                 &key.Weight,
 				Enabled:                key.Enabled,
 				UseForBatchAPI:         key.UseForBatchAPI,
+				UseAnthropicEndpoints:  key.UseAnthropicEndpoints,
 				AzureKeyConfig:         key.AzureKeyConfig,
 				VertexKeyConfig:        key.VertexKeyConfig,
 				BedrockKeyConfig:       key.BedrockKeyConfig,
@@ -947,6 +950,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			Weight:                 &key.Weight,
 			Enabled:                key.Enabled,
 			UseForBatchAPI:         key.UseForBatchAPI,
+			UseAnthropicEndpoints:  key.UseAnthropicEndpoints,
 			AzureKeyConfig:         key.AzureKeyConfig,
 			VertexKeyConfig:        key.VertexKeyConfig,
 			BedrockKeyConfig:       key.BedrockKeyConfig,
@@ -1088,6 +1092,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 			Weight:                 &key.Weight,
 			Enabled:                key.Enabled,
 			UseForBatchAPI:         key.UseForBatchAPI,
+			UseAnthropicEndpoints:  key.UseAnthropicEndpoints,
 			AzureKeyConfig:         key.AzureKeyConfig,
 			VertexKeyConfig:        key.VertexKeyConfig,
 			BedrockKeyConfig:       key.BedrockKeyConfig,
@@ -1976,6 +1981,7 @@ func (s *RDBConfigStore) GetProtectedMCPLibrarySlugs(ctx context.Context) ([]str
 	}
 	return slugs, nil
 }
+
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient
 	if err := s.DB().WithContext(ctx).Where("client_id = ?", id).First(&mcpClient).Error; err != nil {

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -84,6 +84,10 @@ type TableKey struct {
 	// Batch API configuration
 	UseForBatchAPI *bool `gorm:"default:false" json:"use_for_batch_api,omitempty"` // Whether this key can be used for batch API operations
 
+	// UseAnthropicEndpoints routes inference through the provider's Anthropic-compatible
+	// endpoints instead of its OpenAI-compatible ones.
+	UseAnthropicEndpoints *bool `gorm:"default:false" json:"use_anthropic_endpoints,omitempty"`
+
 	Status      string `gorm:"type:varchar(50);default:'unknown'" json:"status"`
 	Description string `gorm:"type:text" json:"description,omitempty"`
 
@@ -135,6 +139,10 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 	if k.UseForBatchAPI == nil {
 		useForBatchAPI := false // DB default
 		k.UseForBatchAPI = &useForBatchAPI
+	}
+	if k.UseAnthropicEndpoints == nil {
+		useAnthropicEndpoints := false // DB default
+		k.UseAnthropicEndpoints = &useAnthropicEndpoints
 	}
 	// IMPORTANT: All *SecretVar fields assigned from provider config structs (AzureKeyConfig,
 	// VertexKeyConfig, BedrockKeyConfig) MUST be value-copied before assignment. The caller
@@ -655,6 +663,10 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 	if k.UseForBatchAPI == nil {
 		useForBatchAPI := false // DB default
 		k.UseForBatchAPI = &useForBatchAPI
+	}
+	if k.UseAnthropicEndpoints == nil {
+		useAnthropicEndpoints := false // DB default
+		k.UseAnthropicEndpoints = &useAnthropicEndpoints
 	}
 	// Reconstruct Azure config if fields are present
 	if k.AzureEndpoint != nil || k.AzureClientID != nil || k.AzureClientSecret != nil || k.AzureTenantID != nil || (k.AzureScopesJSON != nil && *k.AzureScopesJSON != "") {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1556,6 +1556,7 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 					SGLKeyConfig:           dbKey.SGLKeyConfig,
 					Enabled:                dbKey.Enabled,
 					UseForBatchAPI:         dbKey.UseForBatchAPI,
+					UseAnthropicEndpoints:  dbKey.UseAnthropicEndpoints,
 				})
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v, falling back to name comparison", dbKey.Name, provider, err)
@@ -1638,6 +1639,7 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 					SGLKeyConfig:           dbKey.SGLKeyConfig,
 					Enabled:                dbKey.Enabled,
 					UseForBatchAPI:         dbKey.UseForBatchAPI,
+					UseAnthropicEndpoints:  dbKey.UseAnthropicEndpoints,
 				})
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v", dbKey.Name, provider, err)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -420,7 +420,7 @@
           "$ref": "#/$defs/provider"
         },
         "deepseek": {
-          "$ref": "#/$defs/provider"
+          "$ref": "#/$defs/provider_with_deepseek_config"
         },
         "vllm": {
           "$ref": "#/$defs/provider_with_vllm_config"
@@ -429,7 +429,7 @@
           "$ref": "#/$defs/provider"
         },
         "fireworks": {
-          "$ref": "#/$defs/provider"
+          "$ref": "#/$defs/provider_with_fireworks_config"
         },
         "nebius": {
           "$ref": "#/$defs/provider"
@@ -3813,6 +3813,10 @@
                   "use_deployments_endpoint": {
                     "type": "boolean",
                     "description": "Replicate: use the deployments endpoint instead of the predictions endpoint for this alias."
+                  },
+                  "use_anthropic_endpoints": {
+                    "type": "boolean",
+                    "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints."
                   }
                 },
                 "required": ["model_id"],
@@ -4067,9 +4071,48 @@
               },
               "required": ["url"],
               "additionalProperties": false
+            },
+            "use_anthropic_endpoints": {
+              "type": "boolean",
+              "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints.",
+              "default": false
             }
           },
           "required": ["sgl_key_config"]
+        }
+      ]
+    },
+    "deepseek_key": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_key"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "use_anthropic_endpoints": {
+              "type": "boolean",
+              "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints.",
+              "default": false
+            }
+          }
+        }
+      ]
+    },
+    "fireworks_key": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_key"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "use_anthropic_endpoints": {
+              "type": "boolean",
+              "description": "Routes chat completions and responses requests through Anthropic-compatible endpoints.",
+              "default": false
+            }
+          }
         }
       ]
     },
@@ -4511,6 +4554,84 @@
           "$ref": "#/$defs/custom_provider_config"
         }
       },
+      "additionalProperties": false
+    },
+    "provider_with_deepseek_config": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/deepseek_key"
+          },
+          "minItems": 1,
+          "description": "API keys for this provider"
+        },
+        "network_config": {
+          "$ref": "#/$defs/network_config"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrency_and_buffer_size"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxy_config"
+        },
+        "send_back_raw_request": {
+          "type": "boolean",
+          "description": "Include raw request in BifrostResponse (default: false)"
+        },
+        "send_back_raw_response": {
+          "type": "boolean",
+          "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "custom_provider_config": {
+          "$ref": "#/$defs/custom_provider_config"
+        }
+      },
+      "required": ["keys"],
+      "additionalProperties": false
+    },
+    "provider_with_fireworks_config": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/fireworks_key"
+          },
+          "minItems": 1,
+          "description": "API keys for this provider"
+        },
+        "network_config": {
+          "$ref": "#/$defs/network_config"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrency_and_buffer_size"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxy_config"
+        },
+        "send_back_raw_request": {
+          "type": "boolean",
+          "description": "Include raw request in BifrostResponse (default: false)"
+        },
+        "send_back_raw_response": {
+          "type": "boolean",
+          "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "custom_provider_config": {
+          "$ref": "#/$defs/custom_provider_config"
+        }
+      },
+      "required": ["keys"],
       "additionalProperties": false
     },
     "mcp_client_config": {

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -60,6 +60,8 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 	const isVLLM = effectiveProvider === "vllm";
 	const isOllama = effectiveProvider === "ollama";
 	const isSGL = effectiveProvider === "sgl";
+    const isDeepseek = effectiveProvider === "deepseek";
+    const isFireworks = effectiveProvider === "fireworks";
 	const isKeylessProvider = isOllama || isSGL;
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(effectiveProvider);
 
@@ -761,6 +763,27 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 									/>
 								</FormControl>
 								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+			)}
+			{(isSGL || isDeepseek || isFireworks) && (
+				<div className="space-y-4">
+					<FormField
+						control={control}
+						name="key.use_anthropic_endpoints"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center justify-between rounded-sm border p-2">
+								<div className="space-y-1.5">
+									<FormLabel htmlFor="use-anthropic-endpoints-alias-override-switch">Use Anthropic Endpoints</FormLabel>
+									<FormDescription>
+										Routes chat completions and responses requests through Anthropic-compatible endpoints.
+									</FormDescription>
+								</div>
+								<FormControl>
+									<Switch id="use-anthropic-endpoints-alias-override-switch" checked={field.value ?? false} onCheckedChange={field.onChange} />
+								</FormControl>
 							</FormItem>
 						)}
 					/>

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -292,6 +292,28 @@ function ReplicateSection({ config, onChange, disabled }: ProviderSectionProps) 
 	);
 }
 
+function UseAnthropicEndpointsToggleSection({ config, onChange, disabled, providerName }: ProviderSectionProps & { providerName: string }) {
+	return (
+		<div className="space-y-4">
+			<SectionHeader title={`${providerName} overrides`} description={`Override key-level ${providerName} defaults for this deployment.`} />
+			<div className="flex items-start justify-between gap-4 rounded-md border p-3">
+				<div className="space-y-0.5">
+					<label htmlFor="use-anthropic-endpoints-switch" className="text-sm font-medium">Use Anthropic endpoints</label>
+					<p className="text-muted-foreground text-xs">
+						Route chat completions and responses requests through Anthropic-compatible endpoints.
+					</p>
+				</div>
+                <Switch
+                    id="use-anthropic-endpoints-switch"
+                    checked={config.use_anthropic_endpoints ?? false}
+                    onCheckedChange={(checked) => onChange({ use_anthropic_endpoints: checked ? true : undefined })}
+                    disabled={disabled}
+                />
+			</div>
+		</div>
+	);
+}
+
 function ProviderSection({ providerName, ...props }: ProviderSectionProps & { providerName: string }) {
 	switch (providerName) {
 		case "azure":
@@ -304,6 +326,12 @@ function ProviderSection({ providerName, ...props }: ProviderSectionProps & { pr
 			return <BedrockMantleSection {...props} />;
 		case "replicate":
 			return <ReplicateSection {...props} />;
+		case "sgl":
+			return <UseAnthropicEndpointsToggleSection providerName="SGLang" {...props} />;
+        case "deepseek":
+			return <UseAnthropicEndpointsToggleSection providerName="Deepseek" {...props} />;
+        case "fireworks":
+			return <UseAnthropicEndpointsToggleSection providerName="Fireworks" {...props} />;
 		default:
 			return null;
 	}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -73,6 +73,7 @@ export interface AliasConfig {
 	inference_profile_arn?: SecretVar;
 	// Replicate overrides
 	use_deployments_endpoint?: boolean;
+	use_anthropic_endpoints?: boolean;
 }
 
 // AzureKeyConfig matching Go's schemas.AzureKeyConfig
@@ -217,6 +218,7 @@ export interface ModelProviderKey {
 	weight: number;
 	enabled?: boolean;
 	use_for_batch_api?: boolean;
+	use_anthropic_endpoints?: boolean;
 	aliases?: Record<string, AliasConfig>;
 	azure_key_config?: AzureKeyConfig;
 	vertex_key_config?: VertexKeyConfig;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -302,6 +302,7 @@ const aliasConfigObjectSchema = z.object({
 	inference_profile_arn: secretVarSchema.optional(),
 	// Replicate overrides
 	use_deployments_endpoint: z.boolean().optional(),
+	use_anthropic_endpoints: z.boolean().optional(),
 });
 
 // The Go server emits the legacy string wire shape (`{"my-alias": "model-id"}`)
@@ -348,6 +349,7 @@ export const modelProviderKeySchema = z
 		ollama_key_config: ollamaKeyConfigSchema.optional(),
 		sgl_key_config: sglKeyConfigSchema.optional(),
 		use_for_batch_api: z.boolean().optional(),
+		use_anthropic_endpoints: z.boolean().optional(),
 		enabled: z.boolean().optional(),
 	})
 	.refine(


### PR DESCRIPTION
## Summary

Adds a `use_anthropic_endpoints` flag to SGLang keys and aliases that routes chat completion, streaming, and responses requests through SGLang's Anthropic-compatible `/v1/messages` endpoint instead of its default OpenAI-compatible endpoints. This enables users running SGLang with Anthropic-format models to take advantage of native Anthropic request/response semantics without switching providers.

## Changes

- Added `UseAnthropicEndpoints *bool` to `schemas.Key` and `AliasConfig`, with full persistence through the RDB config store and key hash generation.
- Added `ResolveUseAnthropicEndpboints` helper in the Anthropic utils package that checks the resolved alias config first, then falls back to the key-level flag.
- Registered `schemas.SGL` in `AnthropicProviderRequestDefaultsMap` so the Anthropic request builder accepts SGL as a valid provider.
- Updated `SGLProvider.ChatCompletion`, `ChatCompletionStream`, `Responses`, and `ResponsesStream` to branch on the flag and delegate to the shared Anthropic handlers (`HandleAnthropicChatCompletionRequest`, `HandleAnthropicChatCompletionStreaming`, `HandleAnthropicResponsesRequest`, `HandleAnthropicResponsesStream`) with a Bearer auth + `anthropic-version: 2023-06-01` header set.
- `TextCompletion` intentionally always uses the OpenAI-compatible endpoint, as SGLang's Anthropic-compatible layer does not expose a legacy text-completions surface.
- Added a database migration (`add_use_anthropic_endpoints_column`) to add the column to `config_keys`.
- Updated `config.schema.json` to expose `use_anthropic_endpoints` on both the key and alias levels for SGLang.
- Added a UI toggle in the API keys form (key-level) and a new `SGLSection` in the deployments table (alias-level override).
- Updated TypeScript types and Zod schemas to include `use_anthropic_endpoints`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

1. Configure an SGLang provider key with `use_anthropic_endpoints: true` (via config file or UI toggle).
2. Send a chat completion request routed to the SGLang provider and confirm the request is forwarded to `/v1/messages` with `anthropic-version: 2023-06-01` and a Bearer token.
3. Send a streaming chat completion and responses request and confirm the same routing.
4. Confirm that without the flag set (or set to `false`), requests continue to use the OpenAI-compatible endpoints.
5. Set `use_anthropic_endpoints` on an alias config and confirm it overrides the key-level setting.
6. Verify the database migration runs cleanly on a fresh and existing database.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `use_anthropic_endpoints` flag does not introduce new secret handling. Authentication continues to use the existing key secret via Bearer token, consistent with the existing OpenAI-compatible path.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable