### PR TITLE
fix: simplify `ApiKeySelectorView` visibility condition for `enforceVirtualKeys`

### DIFF
--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -211,7 +211,7 @@ export function SettingsPanel() {
 									/>
 								</div>
 
-								{((!enforceVirtualKeys && providerKeys.length > 0) || providerVirtualKeys.length > 0) && !!provider && (
+								{!!provider && (enforceVirtualKeys ? providerVirtualKeys.length > 0 : true) && (
 									<ApiKeySelectorView
 										providerKeys={providerKeys}
 										virtualKeys={providerVirtualKeys}


### PR DESCRIPTION
## Summary

Fixes the visibility condition for the `ApiKeySelectorView` component so it correctly shows when a provider is selected, displaying API key options based on whether virtual keys are enforced.

## Changes

- When `enforceVirtualKeys` is true, the `ApiKeySelectorView` now only renders if there are virtual keys available for the selected provider
- When `enforceVirtualKeys` is false, the component renders for any selected provider regardless of whether provider keys exist
- The previous logic incorrectly hid the selector when no non-virtual provider keys were present but virtual keys were not enforced, and required provider keys to exist even when they weren't needed

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Select a provider in the settings panel
2. With `enforceVirtualKeys` disabled, verify the `ApiKeySelectorView` appears regardless of whether provider keys are configured
3. With `enforceVirtualKeys` enabled, verify the `ApiKeySelectorView` only appears when virtual keys exist for the selected provider
4. Verify no selector appears when no provider is selected

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Security considerations

No security implications. This change only affects UI rendering logic for API key selection.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable