### PR TITLE
[fix]: Preserve parent request filters in Postgres log aggregates

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,3 +1,4 @@
+- fix: route parent request log filters through the raw table (thanks [@G-XD](https://github.com/G-XD)!)
 - feat: add durable background-job `sidekiq` table, store methods, and runner with recovery and reaper
 - feat: pass created-by user ID and runner ID through sidekiq job lifecycle, add `GetInFlightSidekiqJobByKind` to config store interface
 - feat: show canonical model names in dashboard model rankings (thanks [@satyamkrishna](https://github.com/satyamkrishna)!)

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -782,6 +782,7 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Durat
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
 		len(f.MetadataFilters) == 0 &&
+		f.ParentRequestID == "" &&
 		canUseMatViewStatusFilter(f.Status) &&
 		len(f.RoutingEngineUsed) == 0 &&
 		len(f.StopReasons) == 0 &&

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -75,15 +75,16 @@ func TestTeamOrBUFanoutFrom(t *testing.T) {
 	assert.False(t, ok)
 }
 
-// TestCanUseMatViewFilters_ExcludesTeamBU verifies that a team or business-unit
-// filter disqualifies the matview path: mv_logs_hourly only has the scalar
-// primary, so these must fall through to the raw (array-or-scalar) path to stay
+// TestCanUseMatViewFilters_ExcludesUnsupportedFilters verifies that filters
+// unavailable in mv_logs_hourly fall through to the raw path. Team and
+// business-unit filters also require raw array-or-scalar matching to stay
 // complete. Other filters (e.g. provider) remain matview-eligible.
-func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
+func TestCanUseMatViewFilters_ExcludesUnsupportedFilters(t *testing.T) {
 	assert.True(t, canUseMatViewFilters(SearchFilters{}), "empty filters → matview eligible")
 	assert.True(t, canUseMatViewFilters(SearchFilters{Providers: []string{"openai"}}), "provider filter stays matview-eligible")
 	assert.True(t, canUseMatViewFilters(SearchFilters{Status: []string{"cancelled"}}), "cancelled is materialized as a terminal status")
 
+	assert.False(t, canUseMatViewFilters(SearchFilters{ParentRequestID: "session-1"}), "parent request filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{Status: []string{"processing"}}), "processing is not present in mv_logs_hourly")
 	assert.False(t, canUseMatViewFilters(SearchFilters{TeamIDs: []string{"t1"}}), "team filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{BusinessUnitIDs: []string{"bu1"}}), "BU filter must force the raw path")


### PR DESCRIPTION
## Summary

Prevent PostgreSQL aggregate queries containing `ParentRequestID` from using `mv_logs_hourly`.

The materialized view does not contain a parent-request dimension, so these queries must use the raw `logs` table to preserve the requested session scope.

## Changes

* Mark non-empty `ParentRequestID` as incompatible with the materialized-view path.
* Route affected aggregate queries through the raw table.
* Add regression coverage for the materialized-view eligibility check.
* Add the required framework changelog entry.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [X] Framework
- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd framework

go test ./logstore -run TestCanUseMatViewFilters_ExcludesUnsupportedFilters -count=1
```

## Screenshots/Recordings

Not applicable. This change has no UI impact.

## Breaking changes

- [ ] Yes
- [X] No

No API or configuration changes are introduced.

## Related issues

Closes maximhq/bifrost#5315

## Security considerations

No.

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [X] I updated documentation where needed
- [X] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable