### PR TITLE
fix: strip temperature for OpenAI/Azure reasoning models on Chat Completions and Responses paths

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -71,6 +71,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 	switch bifrostReq.Provider {
 	case schemas.OpenAI, schemas.Azure:
 		openaiReq.normalizeReasoningEffort(caps)
+		openaiReq.stripTemperatureForReasoningModels(capModel)
 		// URL-sourced documents are NOT inlined here. Chat Completions rejects file_url, so they
 		// still have to be resolved before the request goes out - but that is a network fetch that
 		// can fail, and this function has no way to report a failure. Callers invoke
@@ -191,6 +192,17 @@ func (req *OpenAIChatRequest) normalizeReasoningEffort(caps schemas.ModelCaps) {
 			// Clear max_tokens since OpenAI doesn't use it
 			req.ChatParameters.Reasoning.MaxTokens = nil
 		}
+	}
+}
+
+// stripTemperatureForReasoningModels drops the temperature parameter for OpenAI/Azure
+// reasoning models (o1/o3/o4 series, gpt-oss, GPT-5.x), which reject any non-default
+// temperature value with a 400 error. Unlike top_p, GPT-5.x rejects temperature even
+// at the default "none" reasoning effort, so this strips unconditionally rather than
+// only for always-reasoning (-pro/-codex) variants.
+func (req *OpenAIChatRequest) stripTemperatureForReasoningModels(capModel string) {
+	if req.ChatParameters.Temperature != nil && IsOpenAIReasoningModel(capModel) {
+		req.ChatParameters.Temperature = nil
 	}
 }
 

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -365,6 +365,9 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			req.ResponsesParameters.Reasoning.Effort != nil {
 			effort = *req.ResponsesParameters.Reasoning.Effort
 		}
+		if IsOpenAIReasoningModel(capModel) && (bifrostReq.Provider == schemas.OpenAI || bifrostReq.Provider == schemas.Azure) {
+			req.ResponsesParameters.Temperature = nil
+		}
 		if topPUnsupported(caps, capModel, effort) {
 			req.ResponsesParameters.TopP = nil
 		}


### PR DESCRIPTION
## Summary

OpenAI/Azure reasoning models (o1/o3/o4, gpt-oss, GPT-5.x) reject any non-default `temperature`, but Bifrost forwarded it unstripped on both the Chat Completions and Responses request paths.

## Changes

- `ToOpenAIChatRequest`: strip `temperature` for reasoning models, scoped to the `schemas.OpenAI`/`schemas.Azure` case only, mirroring the existing `reasoning_effort` normalization in the same switch branch.
- `ToOpenAIResponsesRequest`: strip `temperature` alongside the existing `top_p`-stripping block for reasoning models — scoped specifically to `schemas.OpenAI`/`schemas.Azure` (unlike the pre-existing `top_p` strip, which applies to any provider sharing this request builder) since other providers hosting reasoning-named models (e.g. Fireworks/OpenRouter `gpt-oss`) don't share this restriction.

## Type of change

- [x] Bug fix

## Breaking changes

- [x] No

## How to test

```sh
go build ./...
go test ./core/providers/openai/...
```

## Test report

| Path | Before | After |
|---|---|---|
| `/v1/chat/completions` (`model=openai/gpt-5.5`, `temperature=0.3`) | `temperature` present in outbound body | `temperature` absent |
| `/v1/responses` (`model=openai/gpt-5.5`, `temperature=0.3`) | `temperature` present in outbound body | `temperature` absent |

Full raw before/after logs (official SDK, live temp instance) in a PR comment below.

Fixes #5321
