### PR TITLE
feat: persist logs page-size preference in localStorage and exclude `error_details` from list query

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -938,7 +938,11 @@ func (s *RDBLogStore) listSelectColumns() string {
 		"business_unit_id", "business_unit_name",
 		"team_ids", "team_names", "customer_ids", "customer_names", "business_unit_ids", "business_unit_names",
 		"speech_input", "transcription_input", "image_generation_input", "video_generation_input",
-		"latency", "token_usage", "cost", "status", "error_details", "stream",
+		// error_details is intentionally excluded from the list select: for status=error
+		// rows it can carry the provider's full (unbounded) error payload, and 25+ such
+		// rows can push the /api/logs response past Cloud Run's 32MB body limit (500s).
+		// The full error is still served by the detail endpoint (GetLog / GET /api/logs/{id}).
+		"latency", "token_usage", "cost", "status", "stream",
 		fmt.Sprintf("substr(content_summary, 1, %d) AS content_summary", maxContentSummaryBytes),
 		"metadata", "cache_debug",
 		"is_large_payload_request", "is_large_payload_response",

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -8,8 +8,9 @@ import {
 	usePinOffsets,
 } from "@/components/table";
 import { Button } from "@/components/ui/button";
+import { ComboboxSelect, type ComboboxSelectOption } from "@/components/ui/combobox";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
-import { useTablePageSize } from "@/hooks/useTablePageSize";
+import { DEFAULT_PAGE_SIZE_OPTIONS, useTablePageSizePreference } from "@/lib/hooks/useTablePageSizePreference";
 import type { LogEntry, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import type { ColumnOrderState, ColumnPinningState, VisibilityState } from "@tanstack/react-table";
@@ -56,8 +57,7 @@ export function LogsDataTable({
 	onReorderColumns,
 }: DataTableProps) {
 	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
-	const tableContainerRef = useRef<HTMLDivElement>(null);
-	const calculatedPageSize = useTablePageSize(tableContainerRef);
+	const [pageSizePref, setPageSizePref, pageSizeHydrated] = useTablePageSizePreference("bifrost.logs.pageSize");
 
 	const fixedColumnIds = useMemo(() => new Set<string>(["actions"]), []);
 
@@ -89,15 +89,35 @@ export function LogsDataTable({
 	paginationRef.current = pagination;
 	onPaginationChangeRef.current = onPaginationChange;
 
+	// Apply the page-size preference as the `limit` query param. Wait until the
+	// localStorage value has hydrated — writing the pre-hydration default would
+	// clobber an explicit `limit` already present in the URL (nuqs clears the
+	// default from the URL), causing the param to flip-flop across refreshes.
 	useEffect(() => {
-		if (calculatedPageSize && calculatedPageSize > paginationRef.current.limit) {
+		if (!pageSizeHydrated) return;
+		if (paginationRef.current.limit !== pageSizePref) {
 			onPaginationChangeRef.current({
 				...paginationRef.current,
-				limit: calculatedPageSize,
+				limit: pageSizePref,
 				offset: 0,
 			});
 		}
-	}, [calculatedPageSize]);
+	}, [pageSizePref, pageSizeHydrated]);
+
+	const pageSizeOptions = useMemo<ComboboxSelectOption[]>(
+		() => DEFAULT_PAGE_SIZE_OPTIONS.map((size) => ({ label: String(size), value: String(size) })),
+		[],
+	);
+
+	const handlePageSizeChange = useCallback(
+		(value: string | null) => {
+			if (!value) return;
+			const next = Number(value);
+			setPageSizePref(next);
+			onPaginationChange({ ...pagination, limit: next, offset: 0 });
+		},
+		[onPaginationChange, pagination, setPageSizePref],
+	);
 
 	const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
 		const newSorting = typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
@@ -145,7 +165,7 @@ export function LogsDataTable({
 
 	return (
 		<div className="flex h-full flex-col gap-2">
-			<div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
+			<div className="min-h-0 flex-1 overflow-hidden rounded-sm border">
 				<Table containerClassName="h-full overflow-auto">
 					<thead className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]")}>
 						{table.getHeaderGroups().map((headerGroup) => (
@@ -249,34 +269,49 @@ export function LogsDataTable({
 					{startItem.toLocaleString()}-{endItem.toLocaleString()} of {totalItems.toLocaleString()} entries
 				</div>
 
-				<div className="flex items-center gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => goToPage(currentPage - 1)}
-						disabled={currentPage <= 1}
-						data-testid="prev-page"
-						aria-label="Previous page"
-					>
-						<ChevronLeft className="size-3" />
-					</Button>
-
-					<div className="flex items-center gap-1">
-						<span>Page</span>
-						<span>{currentPage}</span>
-						<span>of {totalPages}</span>
+				<div className="flex items-center gap-3">
+					<div className="flex items-center gap-1.5">
+						<span className="text-muted-foreground">Rows per page</span>
+						<ComboboxSelect
+							options={pageSizeOptions}
+							value={String(pageSizePref)}
+							onValueChange={handlePageSizeChange}
+							disableSearch
+							hideClear
+							className="h-7 w-fit gap-1 text-xs"
+							data-testid="page-size-select"
+						/>
 					</div>
 
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => goToPage(currentPage + 1)}
-						disabled={totalPages === 0 || currentPage >= totalPages}
-						data-testid="next-page"
-						aria-label="Next page"
-					>
-						<ChevronRight className="size-3" />
-					</Button>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => goToPage(currentPage - 1)}
+							disabled={currentPage <= 1}
+							data-testid="prev-page"
+							aria-label="Previous page"
+						>
+							<ChevronLeft className="size-3" />
+						</Button>
+
+						<div className="flex items-center gap-1">
+							<span>Page</span>
+							<span>{currentPage}</span>
+							<span>of {totalPages}</span>
+						</div>
+
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => goToPage(currentPage + 1)}
+							disabled={totalPages === 0 || currentPage >= totalPages}
+							data-testid="next-page"
+							aria-label="Next page"
+						>
+							<ChevronRight className="size-3" />
+						</Button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/ui/lib/hooks/useTablePageSizePreference.ts
+++ b/ui/lib/hooks/useTablePageSizePreference.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/** Default fixed page-size options offered in a table's page-size dropdown. */
+export const DEFAULT_PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 200] as const;
+
+/** Default page size used when no preference is stored. */
+export const DEFAULT_PAGE_SIZE = 25;
+
+/**
+ * Persists a table's preferred page size in localStorage under `storageKey`.
+ *
+ * Reusable across any table — pass a unique key per table (e.g.
+ * "bifrost.logs.pageSize", "bifrost.mcpLogs.pageSize"). Returns a
+ * `[pageSize, setPageSize, hydrated]` tuple. The value is sent as the `limit`
+ * query param on the list request. Defaults to `defaultPageSize` until a
+ * stored value is hydrated.
+ *
+ * A persisted value is only accepted if it is one of `allowedSizes`. This
+ * guards against a stale or hand-edited localStorage entry (e.g. `1000000`)
+ * being sent as the query limit, which would bypass the dropdown's maximum and
+ * recreate the oversized-response / expensive-query problem this hook prevents.
+ *
+ * `hydrated` is false until the localStorage read completes. Callers that sync
+ * the preference into URL state must wait for it — writing the pre-hydration
+ * default can clobber an explicit value already in the URL.
+ *
+ * Safe for SSR/Next.js — reads localStorage lazily in an effect to avoid
+ * hydration mismatches.
+ */
+export function useTablePageSizePreference(
+	storageKey: string,
+	defaultPageSize: number = DEFAULT_PAGE_SIZE,
+	allowedSizes: readonly number[] = DEFAULT_PAGE_SIZE_OPTIONS,
+): [number, (value: number) => void, boolean] {
+	const [pageSize, setPageSizeState] = useState<number>(defaultPageSize);
+	const [hydrated, setHydrated] = useState(false);
+
+	// Hydrate from localStorage after mount (client-only).
+	useEffect(() => {
+		try {
+			const stored = localStorage.getItem(storageKey);
+			if (stored) {
+				const parsed = Number(stored);
+				// Only accept a stored value that is one of the offered options —
+				// never trust an arbitrary integer as the query limit.
+				if (allowedSizes.some((size) => size === parsed)) {
+					setPageSizeState(parsed);
+				}
+			}
+		} catch {
+			// localStorage unavailable (e.g. SSR, privacy mode) — keep default.
+		}
+		setHydrated(true);
+	}, [storageKey, allowedSizes]);
+
+	const setPageSize = useCallback(
+		(value: number) => {
+			setPageSizeState(value);
+			try {
+				localStorage.setItem(storageKey, String(value));
+			} catch {
+				// localStorage unavailable — preference won't persist.
+			}
+		},
+		[storageKey],
+	);
+
+	return [pageSize, setPageSize, hydrated];
+}


### PR DESCRIPTION
## Summary

This PR fixes a Cloud Run 500 error caused by the `/api/logs` response exceeding the 32MB body limit when many error-status log rows are returned, and replaces the auto-calculated table page size with a user-controlled, localStorage-persisted page size preference.

## Changes

- **Exclude `error_details` from the logs list query**: The `error_details` column is dropped from `listSelectColumns` in `rdb.go` because it can carry unbounded provider error payloads. With 25+ such rows, the combined response body can exceed Cloud Run's 32MB limit and return a 500. The full error detail remains available via the individual log detail endpoint (`GET /api/logs/{id}`).
- **Replace auto-sized page size with a user preference**: The `useTablePageSize` hook (which inferred page size from container height) is replaced by `useTablePageSizePreference`, which stores the user's chosen page size in localStorage under a per-table key (e.g. `bifrost.logs.pageSize`). The preference is hydrated lazily after mount to avoid SSR/hydration mismatches and defaults to 25.
- **Add a "Rows per page" dropdown to the logs table footer**: A `ComboboxSelect` with options `[10, 25, 50, 100, 200]` is added to the pagination controls, allowing users to explicitly choose how many rows to load per page. The selection is persisted across sessions.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] UI (React)

## How to test

1. Navigate to the logs table in the UI.
2. Confirm a "Rows per page" dropdown appears in the pagination footer with options 10, 25, 50, 100, and 200.
3. Select a page size, reload the page, and verify the selection is restored from localStorage.
4. Confirm that log list responses no longer include `error_details` in the payload, and that the full error is still visible when opening an individual log entry.
5. Verify that workspaces with many error-status logs no longer trigger 500 responses from `/api/logs`.

```sh
# Core
go test ./framework/logstore/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Screenshots/Recordings

Before: Page size was inferred from container height with no user control.
After: A "Rows per page" dropdown is shown in the pagination bar, and the selection persists across page reloads.

## Breaking changes

- [x] No

The `error_details` field is removed from list responses but remains available on the detail endpoint. Clients relying on `error_details` in the list response will need to fetch individual log entries to retrieve it.

## Related issues

Closes the Cloud Run 32MB body limit 500 error on `/api/logs`.

## Security considerations

No new auth, secrets, or PII exposure. Removing `error_details` from the list response reduces the amount of potentially sensitive provider error data sent in bulk responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable