### PR TITLE
docs: add `append_fallbacks_to_pinned` as a fifth load-balancer switch and update all references to pinned-request fallback behavior

### DIFF
--- a/docs/enterprise/adaptive-load-balancing.mdx
+++ b/docs/enterprise/adaptive-load-balancing.mdx
@@ -152,23 +152,24 @@ The system is designed to be self-healing: it penalizes failing routes quickly, 
 
 ## Configuration
 
-Adaptive load balancing ships **pre-tuned** - the scoring weights, thresholds, and recovery timings are not user-configurable by design. The operator controls are four switches:
+Adaptive load balancing ships **pre-tuned** - the scoring weights, thresholds, and recovery timings are not user-configurable by design. The operator controls are five switches:
 
 | Setting | Default | Effect |
 |---------|---------|--------|
-| **Provider selection** (`direction_selection_enabled`) | On | Whether the system picks the provider (Level 1). A request that already carries a provider keeps it as the primary, but still gets the healthy providers eligible for its model appended as fallbacks behind any it configured. Off ⇒ Level 1 leaves the request's provider and fallback list untouched (key selection is toggled separately). |
+| **Provider selection** (`direction_selection_enabled`) | On | Whether the system picks the provider (Level 1). A request that already carries a provider keeps it as the primary. Off ⇒ Level 1 leaves the request's provider and fallback list untouched (key selection is toggled separately). |
 | **Key selection** (`route_selection_enabled`) | On | Whether per-key (Level 2) selection is adaptive. Off ⇒ keys are chosen by static weighted-random (metrics are still tracked). |
+| **Append fallbacks to pinned requests** (`append_fallbacks_to_pinned`) | Off | A request that already carries a provider still gets the healthy providers eligible for its model appended as fallbacks behind any it configured (with pruning and model normalization applied). Off ⇒ a pinned request passes through untouched, apart from re-routing below. |
 | **Re-route failed providers** (`reroute_failed_directions`) | Off | If a pinned provider's direction is circuit-broken, re-route the request to a healthy provider for the same model. When no healthier provider exists, the pinned provider is kept. |
 | **Prune failed fallbacks** (`prune_failed_fallbacks`) | Off | Drop circuit-broken providers from a request's configured fallback list. |
 
-The two selection switches default **on**; the two failed-direction behaviors are **opt-in**. All four take effect live (no restart) and propagate across the cluster.
+The two selection switches default **on**; the three pinned/failed-direction behaviors are **opt-in**. All five take effect live (no restart) and propagate across the cluster.
 
-All four switches can be changed from the dashboard, via the API, or in `config.json`.
+All five switches can be changed from the dashboard, via the API, or in `config.json`.
 
 <Tabs>
 <Tab title="Web UI">
 
-The load balancer settings page exposes the four switches; changes apply immediately across the cluster.
+The load balancer settings page exposes the five switches; changes apply immediately across the cluster.
 
 <Frame>
   <img src="/media/ui-load-balancing-settings.png" alt="Load Balancer Settings" />
@@ -183,12 +184,13 @@ Read and update the settings through `/api/load-balancer-config`:
 # Read the current settings
 curl http://localhost:8080/api/load-balancer-config
 
-# Update the settings - always send all four fields
+# Update the settings - always send all five fields
 curl -X PUT http://localhost:8080/api/load-balancer-config \
   -H "Content-Type: application/json" \
   -d '{
     "direction_selection_enabled": true,
     "route_selection_enabled": true,
+    "append_fallbacks_to_pinned": false,
     "reroute_failed_directions": true,
     "prune_failed_fallbacks": false
   }'
@@ -197,7 +199,7 @@ curl -X PUT http://localhost:8080/api/load-balancer-config \
 The update is persisted, applied to the running nodes immediately, and broadcast to cluster peers.
 
 <Warning>
-The `PUT` body is a full replacement, not a patch: any field omitted from the request body is set to `false`. Always send all four fields - sending only the field you want to change silently turns off the others (including the default-on selection switches).
+The `PUT` body is a full replacement, not a patch: any field omitted from the request body is set to `false`. Always send all five fields - sending only the field you want to change silently turns off the others (including the default-on selection switches).
 </Warning>
 
 </Tab>
@@ -210,6 +212,7 @@ Add a top-level `load_balancer_config` block:
   "load_balancer_config": {
     "direction_selection_enabled": true,
     "route_selection_enabled": true,
+    "append_fallbacks_to_pinned": false,
     "reroute_failed_directions": true,
     "prune_failed_fallbacks": false
   }
@@ -223,7 +226,7 @@ Unlike the API, this block is presence-aware: omitted fields keep their current 
 
 ## Scope & Limitations
 
-- **Pinned requests still get fallbacks**: With provider selection on, a request that pins a provider — even one that configures no fallbacks of its own — receives the healthy providers eligible for its model as a fallback chain, so a failing primary fails over instead of failing fast. To keep a request's provider and fallback list untouched, turn provider selection off (key selection within the provider is governed by its own switch).
+- **Pinned requests can still get fallbacks**: With provider selection on and the append-fallbacks-to-pinned switch enabled, a request that pins a provider — even one that configures no fallbacks of its own — receives the healthy providers eligible for its model as a fallback chain, so a failing primary fails over instead of failing fast. With the switch off (its default), a pinned request's provider and fallback list are left untouched.
 - **Per-node weights**: Each node load-balances on its own observed metrics. The only signal shared across nodes is a rate-limit (TPM) backoff, and only within the same region - there is no global weight consensus or cross-region coordination. This is deliberate: latency and error profiles differ per region, so importing another region's metrics would pollute a node's view of route health.
 - **~5-second adaptation**: Weight and state changes lag live traffic by up to one recompute cycle. Immediate per-request resilience (key rotation and fallback failover) is handled separately and is not subject to this delay.
 - **Optimistic cold start**: A brand-new key or provider enters at full weight and competes at roughly fair share before it has been measured, then self-corrects within a cycle or two.

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -1075,7 +1075,7 @@ flowchart TB
 
 ### Level 1: Direction (Provider Selection)
 
-**When it runs**: **Always** (while the provider-selection switch is on). When no provider has been selected yet, it picks one. When an earlier layer (governance, routing rules, or an explicit `provider/` prefix) already pinned one, that provider keeps the primary slot — but Level 1 still appends its sorted healthy providers as fallbacks behind any the request configured, and, when the re-route toggle is on, moves a circuit-broken pinned provider to a healthy one
+**When it runs**: **Always** (while the provider-selection switch is on). When no provider has been selected yet, it picks one. When an earlier layer (governance, routing rules, or an explicit `provider/` prefix) already pinned one, that provider keeps the primary slot — and with the append-fallbacks-to-pinned switch on, Level 1 still appends its sorted healthy providers as fallbacks behind any the request configured. When the re-route toggle is on, a circuit-broken pinned provider is moved to a healthy one. With both of those switches off (their defaults), a pinned request passes through untouched
 
 **How it works**:
 
@@ -1193,7 +1193,7 @@ When both methods are available in your Bifrost deployment, they work together i
 
 <Warning>
 **Key Insight**: Load balancing has **two levels**:
-- **Level 1 (Direction/Provider)**: Always runs. A pre-specified provider keeps the primary slot, but Level 1 still appends its healthy providers as fallbacks — and can re-route a circuit-broken pinned provider when that toggle is on
+- **Level 1 (Direction/Provider)**: Always runs. A pre-specified provider keeps the primary slot; with the append-fallbacks-to-pinned toggle on, Level 1 still appends its healthy providers as fallbacks — and it can re-route a circuit-broken pinned provider when that toggle is on
 - **Level 2 (Route/Key)**: **Always runs**, even when provider is specified
 
 This means key-level optimization works regardless of how the provider was chosen!
@@ -1212,7 +1212,7 @@ flowchart TD
         AddPrefix["Set req.Provider/Model:<br/>azure/gpt-4o"]
         PrefixCheck{"req.Provider<br/>already set?"}
         LBProvider["Enterprise LB:<br/>Performance-based selection"]
-        LBPinned["Enterprise LB:<br/>Keep pinned provider,<br/>append healthy fallbacks"]
+        LBPinned["Enterprise LB:<br/>Keep pinned provider<br/>(+ healthy fallbacks<br/>when toggle on)"]
         AddLBPrefix["Set req.Provider/Model:<br/>openai/gpt-4o"]
         Resolver["model-catalog-resolver:<br/>Fill from catalog (last fallback)"]
     end
@@ -1243,7 +1243,7 @@ All three routing layers (governance, enterprise LB Level 1, model-catalog-resol
 
 2. **Enterprise Load Balancer Level 1** (PreRequestHook, builtin)
    - Runs after governance and always evaluates the eligible provider set for the model
-   - If `req.Provider` is already set (by governance or by an explicit `provider/model` prefix from the user): keeps it as the primary and appends its healthy providers as fallbacks behind any configured ones; with the re-route toggle on, a circuit-broken pinned provider is moved to a healthy one (kept when nothing healthier exists)
+   - If `req.Provider` is already set (by governance or by an explicit `provider/model` prefix from the user): keeps it as the primary; with the append-fallbacks-to-pinned toggle on, appends its healthy providers as fallbacks behind any configured ones, and with the re-route toggle on, a circuit-broken pinned provider is moved to a healthy one (kept when nothing healthier exists). With both toggles off (their defaults), the pinned request passes through untouched
    - If not: performs performance-based provider selection across catalog providers
    - **Result**: `req.Provider`/`req.Model` set; `req.Fallbacks` extended with the sorted healthy fallback chain
 
@@ -1341,7 +1341,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 1. **Governance** applies first (respects explicit user config) → selects Azure provider
 2. Model becomes `azure/gpt-4o`
-3. **Load Balancing Level 1** finds the provider already set (Azure, from governance) and keeps it as the primary, appending the healthy providers eligible for the model as fallbacks behind any governance-configured ones
+3. **Load Balancing Level 1** finds the provider already set (Azure, from governance) and keeps it as the primary — appending the healthy providers eligible for the model as fallbacks behind any governance-configured ones when the append-fallbacks-to-pinned switch is on
 4. **Load Balancing Level 2** still runs! Selects best Azure key based on performance:
    - `azure-key-1`: 99% success rate, 150ms avg latency → score 0.95
    - `azure-key-2`: 85% success rate, 200ms avg latency → score 0.60 (degraded)
@@ -1370,7 +1370,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 **Behavior:**
 
 1. **Governance** skips — no Virtual Key is attached, and the explicit `openai/` prefix already pinned the provider
-2. **Load Balancing Level 1** finds the provider already set (OpenAI, from the model prefix) and keeps it as the primary, appending the healthy providers eligible for the model as fallbacks behind it
+2. **Load Balancing Level 1** finds the provider already set (OpenAI, from the model prefix) and keeps it as the primary — appending the healthy providers eligible for the model as fallbacks behind it when the append-fallbacks-to-pinned switch is on
 3. **Load Balancing Level 2** still runs! Selects best OpenAI key based on current metrics
 4. Request forwarded to OpenAI with optimal key
 
@@ -1386,7 +1386,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 | VK with provider_configs         | **Governance** (weighted random)                | **Standard** or **Adaptive** (if enabled)   |
 | VK without provider_configs + LB | **Blocked** (empty = no providers allowed)      | N/A                                         |
 | No VK + LB                       | **Load Balancing Level 1** (performance)        | **Load Balancing Level 2** (performance)    |
-| Model with provider prefix + LB  | **Honored** (kept as primary; healthy fallbacks appended) | **Load Balancing Level 2** (performance) ✅ |
+| Model with provider prefix + LB  | **Honored** (kept as primary; healthy fallbacks appended when the append-fallbacks-to-pinned switch is on) | **Load Balancing Level 2** (performance) ✅ |
 | No Load Balancing enabled        | **Governance** or **User** or **Model Catalog** | **Standard** (static weights)               |
 
 <Note>
@@ -1428,7 +1428,7 @@ flowchart TD
             VKValidation["Virtual Key Validation"]
             GovRouting["VK Provider Selection<br/>(weighted random)"]
         end
-        LB1["Enterprise LB Level 1:<br/>Provider Selection<br/>(pinned provider kept,<br/>healthy fallbacks appended)"]
+        LB1["Enterprise LB Level 1:<br/>Provider Selection<br/>(pinned provider kept;<br/>fallbacks appended when<br/>toggle on)"]
         Resolver["model-catalog-resolver:<br/>Fill provider from catalog<br/>(final fallback)"]
     end
 
@@ -1447,7 +1447,7 @@ All routing layers below execute inside the **PreRequestHook** phase in registra
 1. **Routing rules evaluate first** in scope precedence order (VirtualKey → Team → Customer → Global)
 2. **If a routing rule matches**: provider/model/fallbacks are overridden, the VK `provider_configs` weighted selection is skipped
 3. **If no routing rule matches**: VK provider selection runs (weighted random)
-4. **Enterprise LB Level 1**: keeps a pre-set `req.Provider` as the primary while appending healthy fallbacks (re-routing it only when its direction is circuit-broken and the toggle is on); otherwise performs performance-based selection
+4. **Enterprise LB Level 1**: keeps a pre-set `req.Provider` as the primary, appending healthy fallbacks when the append-fallbacks-to-pinned toggle is on (and re-routing it only when its direction is circuit-broken and the re-route toggle is on); otherwise performs performance-based selection
 5. **model-catalog-resolver**: last fallback — fills `req.Provider` from the catalog if no earlier plugin set it
 6. **Empty-provider validation** (core): returns 400 if `req.Provider` is still empty after the phase
 7. **Load balancing Level 2** (key selection, core, per attempt): always runs to select the best key within the determined provider
@@ -1571,7 +1571,7 @@ Routing Rules work **before** load balancing:
 ```
 Routing Rules decide: openai/gpt-4o
                     ↓
-Load Balancing Level 1: Honors the routing-rule provider, appends healthy fallbacks
+Load Balancing Level 1: Honors the routing-rule provider (appends healthy fallbacks when the append-fallbacks-to-pinned switch is on)
                     ↓
 Load Balancing Level 2: Selects best OpenAI key based on performance
 ```

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6008,6 +6008,10 @@
           "type": "boolean",
           "description": "Enable adaptive per-key (route) selection. Defaults to true; omit to leave on."
         },
+        "append_fallbacks_to_pinned": {
+          "type": "boolean",
+          "description": "When a request already carries a provider, append the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to false."
+        },
         "reroute_failed_directions": {
           "type": "boolean",
           "description": "When a pinned provider's direction is unhealthy, re-route the request to a healthy provider. Defaults to false."


### PR DESCRIPTION
## Summary

Introduces a new `append_fallbacks_to_pinned` configuration switch for the adaptive load balancer, separating the behavior of appending healthy fallbacks to pinned (pre-specified provider) requests into its own explicit opt-in toggle. Previously, this behavior was always active when provider selection was enabled; it is now off by default, giving operators finer control over how pinned requests are handled.

## Changes

- Added `append_fallbacks_to_pinned` as a fifth load balancer configuration switch, defaulting to `off`
- Decoupled fallback-appending behavior for pinned requests from the `direction_selection_enabled` switch — a pinned request now passes through untouched unless `append_fallbacks_to_pinned` is explicitly enabled
- Updated all references across the adaptive load balancing and provider routing docs to reflect five switches instead of four, including the API `PUT` body examples, `config.json` block, and the scope/limitations section
- Clarified that the `PUT /api/load-balancer-config` endpoint requires all five fields to avoid silently disabling others
- Updated flowcharts, routing layer descriptions, and routing decision tables to accurately describe the conditional nature of fallback appending for pinned requests

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated docs to confirm:

1. The configuration table lists five switches with correct defaults (`append_fallbacks_to_pinned` defaults to `off`)
2. The API example `PUT` body includes all five fields
3. The `config.json` example block includes `append_fallbacks_to_pinned: false`
4. All references to "four switches" have been replaced with "five switches"
5. Pinned-request behavior descriptions consistently reflect that fallback appending is conditional on the new toggle

## Breaking changes

- [x] Yes
- [ ] No

The default behavior for pinned requests changes: healthy fallbacks are **no longer appended automatically** when a provider is pinned. Operators who relied on this implicit behavior must explicitly enable `append_fallbacks_to_pinned: true` to restore it. Any existing `PUT /api/load-balancer-config` calls that omit the new field will have it default to `false`.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable