### PR TITLE
fix: apply routing rules to WebSocket Responses requests

### DIFF
--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -113,6 +113,7 @@ type authHeaders struct {
 	googAPIKey    string
 	baggage       string
 	headers       map[string][]string
+	queryParams   map[string]string
 }
 
 // captureAuthHeaders captures the auth headers from the request.
@@ -129,6 +130,12 @@ func captureAuthHeaders(ctx *fasthttp.RequestCtx) *authHeaders {
 	for key, value := range ctx.Request.Header.All() {
 		k := strings.ToLower(string(key))
 		ah.headers[k] = append(ah.headers[k], string(value))
+	}
+	if queryArgs := ctx.URI().QueryArgs(); queryArgs.Len() > 0 {
+		ah.queryParams = make(map[string]string, queryArgs.Len())
+		for key, value := range queryArgs.All() {
+			ah.queryParams[strings.ToLower(string(key))] = string(value)
+		}
 	}
 	return ah
 }
@@ -212,6 +219,59 @@ func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *a
 	}
 	if parentRequestID, _ := bifrostCtx.Value(schemas.BifrostContextKeyParentRequestID).(string); parentRequestID == "" {
 		bifrostCtx.SetValue(schemas.BifrostContextKeyParentRequestID, session.ID())
+	}
+
+	// Run PreRequestHook so governance routing rules / load balancing can rewrite
+	// provider/model before we select the upstream. The native WS path below bypasses
+	// handleStreamRequest (where these hooks normally run), so without this the request
+	// would always stick to the provider parsed from the model string (default: openai).
+	// Mirrors the realtime handler (wsrealtime.go handleUpgrade).
+	// Surface upgrade-request headers/query so CEL rules (headers[...] / params[...])
+	// see the same shape they would for normal HTTP requests.
+	if auth != nil {
+		if len(auth.headers) > 0 {
+			flatHeaders := make(map[string]string, len(auth.headers))
+			for k, values := range auth.headers {
+				if len(values) > 0 {
+					flatHeaders[k] = values[0]
+				}
+			}
+			bifrostCtx.SetValue(schemas.BifrostContextKeyRequestHeaders, flatHeaders)
+		}
+		if len(auth.queryParams) > 0 {
+			bifrostCtx.SetValue(schemas.BifrostContextKeyRequestQuery, auth.queryParams)
+		}
+	}
+	preReq := &schemas.BifrostRequest{
+		RequestType:      schemas.WebSocketResponsesRequest,
+		ResponsesRequest: bifrostReq,
+	}
+	h.client.RunPreRequestHooks(bifrostCtx, preReq)
+	routedProvider, routedModel, _ := preReq.GetRequestFields()
+	if routedProvider == "" {
+		// Mirror the empty-provider check in core handleRequest: no routing layer could
+		// resolve a provider for this model.
+		cancel()
+		writeWSError(session, 400, "invalid_request_error", "no provider could be resolved for model "+bifrostReq.Model)
+		return
+	}
+	bifrostReq.Provider = routedProvider
+	if routedModel != "" {
+		bifrostReq.Model = routedModel
+	}
+
+	// Recompute the store override if routing changed the provider — DisableStore is a
+	// per-provider setting and must reflect the provider the request will actually hit.
+	if routedProvider != provider {
+		if providerCfg, cfgErr := h.config.GetProviderConfigRaw(routedProvider); cfgErr == nil &&
+			providerCfg.OpenAIConfig != nil && providerCfg.OpenAIConfig.DisableStore {
+			event.Store = schemas.Ptr(false)
+		} else {
+			event.Store = schemas.Ptr(true)
+		}
+		if bifrostReq.Params != nil {
+			bifrostReq.Params.Store = event.Store
+		}
 	}
 
 	// Rewrite the raw event for upstream: strip provider/ prefix from model,


### PR DESCRIPTION
## Summary

WebSocket Responses requests (`GET /v1/responses` upgrade + `response.create` events) bypassed governance routing rules and load balancing. The handler parsed the provider directly from the model string (defaulting to OpenAI) and dialed the native WS upstream without ever running `PreRequestHook`, where routing rules are evaluated. Clients like Codex sending `gpt-*` models therefore always hit OpenAI regardless of configured routing rules.

The realtime WS handler already solved this (`wsrealtime.go` `handleUpgrade` runs `RunPreRequestHooks` explicitly); this PR brings the Responses WS handler in line with it.

## Changes

- capture upgrade-request query params in `authHeaders` (the fasthttp ctx is recycled after the handler returns, so they must be snapshotted at upgrade time)
- in `handleResponseCreate`, surface upgrade-request headers/query on the context so CEL routing rules (`headers[...]` / `params[...]`) see the same shape as normal HTTP requests
- run `RunPreRequestHooks` before upstream selection so governance routing rules / load balancing can rewrite provider/model (matched rules also commit their key pin via `BifrostContextKeyRoutingPinnedAPIKeyID`)
- read back the routed provider/model into the request; fail with 400 when no provider resolves (mirrors the empty-provider check in core `handleRequest`)
- recompute the per-provider `DisableStore` store override when routing changes the provider

Routing to a provider without native WS support falls back to the HTTP bridge as before, which handles format translation via the standard inference pipeline. The second `RunPreRequestHooks` inside the HTTP bridge path is idempotent: rules are evaluated against the already-rewritten model.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go build ./transports/bifrost-http/handlers/
go vet ./transports/bifrost-http/handlers/
go test ./transports/bifrost-http/handlers/
```

Manual verification: configure a routing rule targeting `gpt-*` models to a non-OpenAI provider, connect a WS Responses client (e.g. Codex), and send a `response.create` event with a `gpt-*` model. Before this fix the request always went to OpenAI via the native WS upstream; after the fix it follows the routing rule (falling back to the HTTP bridge when the routed provider has no native WS support).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

WebSocket Responses requests ignore configured routing rules and always route to OpenAI.

## Security considerations

Headers surfaced on the routing context are the same set already captured for auth handling; forwarded-header allowlist/denylist filtering (`isSecurityDeniedExtraHeader`, header matcher) is unchanged.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
