### PR TITLE
docs: add Response Lifecycle endpoints and expand streaming event types table for OpenAI Responses API

### DIFF
--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -14,6 +14,7 @@ OpenAI is the **baseline schema** for Bifrost. When using OpenAI directly, param
 |-----------|---------------|-----------|----------|
 | Chat Completions | ✅ | ✅ | `/v1/chat/completions` |
 | Responses API | ✅ | ✅ | `/v1/responses` |
+| Responses Lifecycle | ✅ | - | `/v1/responses/{response_id}` |
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | Embeddings | ✅ | - | `/v1/embeddings` |
 | Speech (TTS) | ✅ | ✅ | `/v1/audio/speech` |
@@ -192,7 +193,71 @@ This conversion ensures compatibility across different model architectures for t
 
 **Response:** Includes `id`, `status` (`completed`, `incomplete`, `pending`, `error`), `output` array with message content, and token `usage`.
 
-**Streaming:** Server-Sent Events with types: `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added`, `response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`, `response.incomplete`. `stream_options: { include_usage: true }` is set by default for all streaming calls.
+**Streaming:** Server-Sent Events. `stream_options: { include_usage: true }` is set by default for all streaming calls. Each event carries a `type` field ([`ResponsesStreamResponseType`](https://github.com/maximhq/bifrost/blob/main/core/schemas/responses.go#L3039)) with one of the following values:
+
+| Category | Event Types |
+|----------|-------------|
+| Response lifecycle | `response.created`, `response.queued`, `response.in_progress`, `response.completed`, `response.failed`, `response.incomplete` |
+| Output items & content | `response.output_item.added`, `response.output_item.done`, `response.content_part.added`, `response.content_part.done`, `response.output_text.delta`, `response.output_text.done` |
+| Refusals & annotations | `response.refusal.delta`, `response.refusal.done`, `response.output_text.annotation.added`, `response.output_text.annotation.done` |
+| Function & custom tool calls | `response.function_call_arguments.delta`, `response.function_call_arguments.done`, `response.custom_tool_call_input.delta`, `response.custom_tool_call_input.done` |
+| File search | `response.file_search_call.in_progress`, `response.file_search_call.searching`, `response.file_search_call.results.added`, `response.file_search_call.results.completed` |
+| Web search | `response.web_search_call.in_progress`, `response.web_search_call.searching`, `response.web_search_call.completed`, `response.web_search_call.results.added`, `response.web_search_call.results.completed` |
+| Web fetch | `response.web_fetch_call.in_progress`, `response.web_fetch_call.fetching`, `response.web_fetch_call.completed` |
+| Reasoning summaries | `response.reasoning_summary_part.added`, `response.reasoning_summary_part.done`, `response.reasoning_summary_text.delta`, `response.reasoning_summary_text.done` |
+| Image generation | `response.image_generation_call.in_progress`, `response.image_generation_call.generating`, `response.image_generation_call.partial_image`, `response.image_generation_call.completed` |
+| MCP | `response.mcp_call_arguments.delta`, `response.mcp_call_arguments.done`, `response.mcp_call.in_progress`, `response.mcp_call.completed`, `response.mcp_call.failed`, `response.mcp_list_tools.in_progress`, `response.mcp_list_tools.completed`, `response.mcp_list_tools.failed` |
+| Code interpreter | `response.code_interpreter_call.in_progress`, `response.code_interpreter_call.interpreting`, `response.code_interpreter_call.completed`, `response.code_interpreter_call_code.delta`, `response.code_interpreter_call_code.done` |
+| Keepalive & errors | `response.ping` (sent by few providers, e.g. Anthropic), `error` |
+
+## Response Lifecycle
+
+Manage stored and background responses after creation (requests made with `store: true` or `background: true`). All lifecycle operations accept an optional `provider` query parameter (defaults to `openai`); providers that do not implement these operations return an unsupported operation error.
+
+<Note>
+When multiple API keys are configured for the provider, pin key selection on lifecycle calls (for example, with the `x-bf-api-key-id` header, see [Request Options](/providers/request-options)) so they hit the same upstream account as the create call that produced the `response_id`.
+</Note>
+
+### Retrieve Response
+
+GET `/v1/responses/{response_id}` - Retrieve a stored response ([docs](https://platform.openai.com/docs/api-reference/responses/get))
+
+**Query Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `include` | array | ❌ | Additional fields to include (repeat the parameter for multiple values) |
+| `starting_after` | int | ❌ | Sequence number of the event after which to start the response |
+| `include_obfuscation` | bool | ❌ | Whether to include obfuscation on the response |
+
+**Response:** The full response object, same shape as `POST /v1/responses`.
+
+### Delete Response
+
+DELETE `/v1/responses/{response_id}` - Delete a stored response ([docs](https://platform.openai.com/docs/api-reference/responses/delete))
+
+**Response:** [`BifrostResponsesDeleteResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/responses.go#L126) with `id`, `object`, and `deleted: true`.
+
+### Cancel Response
+
+POST `/v1/responses/{response_id}/cancel` - Cancel an in-flight response ([docs](https://platform.openai.com/docs/api-reference/responses/cancel)). Only responses created with `background: true` can be cancelled.
+
+**Response:** The full response object, same shape as `POST /v1/responses`.
+
+### List Input Items
+
+GET `/v1/responses/{response_id}/input_items` - List the input items of a response ([docs](https://platform.openai.com/docs/api-reference/responses/input-items))
+
+**Query Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `after` | string | ❌ | Pagination cursor (item ID to list items after) |
+| `include` | array | ❌ | Additional fields to include (repeat the parameter for multiple values) |
+| `limit` | int | ❌ | Results per page |
+| `order` | string | ❌ | asc or desc |
+
+**Response:** [`BifrostResponsesInputItemsResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/responses.go#L134) with `object: "list"`, `data` (array of input items), `has_more`, `first_id`, `last_id`. Cursor-based pagination with `has_more` flag.
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the Response Lifecycle API endpoints for the OpenAI provider, covering how to retrieve, delete, cancel, and list input items for stored and background responses. Also expands the streaming event type reference into a structured table covering all supported event categories.

## Changes

- Added `Responses Lifecycle` row to the OpenAI provider feature table with its route (`/v1/responses/{response_id}`)
- Replaced the inline streaming event type list with a categorized table covering all supported `ResponsesStreamResponseType` values across lifecycle, output, tool calls, file/web search, reasoning, image generation, MCP, code interpreter, and error events
- Added a new **Response Lifecycle** section documenting four operations:
  - `GET /v1/responses/{response_id}` — retrieve a stored response
  - `DELETE /v1/responses/{response_id}` — delete a stored response
  - `POST /v1/responses/{response_id}/cancel` — cancel a background response
  - `GET /v1/responses/{response_id}/input_items` — list input items with cursor-based pagination
- Added a note advising users to pin API key selection (via `x-bf-api-key-id`) on lifecycle calls when multiple keys are configured, to ensure requests hit the same upstream account

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated OpenAI provider documentation page and verify:
- The feature table includes the `Responses Lifecycle` row
- The streaming event table is complete and correctly categorized
- All four lifecycle endpoint sections render correctly with their query parameter tables and response descriptions
- Links to schema definitions resolve correctly

## Breaking changes

- [x] No

## Security considerations

The added note about pinning API key selection on lifecycle calls is relevant when multiple keys are configured — users should ensure lifecycle requests are routed to the same upstream account that created the response to avoid authorization errors.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable