### PR TITLE
docs: add retrieve, delete, cancel, and list input items endpoints for stored responses

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -5090,6 +5090,411 @@
         ]
       }
     },
+    "/v1/responses/{response_id}": {
+      "get": {
+        "operationId": "retrieveResponse",
+        "summary": "Retrieve a response",
+        "description": "Retrieves a stored response by ID.\n",
+        "tags": [
+          "Responses"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the response to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Provider the response was created with (defaults to `openai`)",
+            "schema": {
+              "$ref": "#/components/schemas/ModelProvider"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional fields to include (repeatable)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "starting_after",
+            "in": "query",
+            "description": "Sequence number of the event after which to start the response",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "include_obfuscation",
+            "in": "query",
+            "description": "Whether to include obfuscation on the response",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteResponse",
+        "summary": "Delete a response",
+        "description": "Deletes a stored response.\n",
+        "tags": [
+          "Responses"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the response to delete",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Provider the response was created with (defaults to `openai`)",
+            "schema": {
+              "$ref": "#/components/schemas/ModelProvider"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponsesDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/responses/{response_id}/cancel": {
+      "post": {
+        "operationId": "cancelResponse",
+        "summary": "Cancel a response",
+        "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n",
+        "tags": [
+          "Responses"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the response to cancel",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Provider the response was created with (defaults to `openai`)",
+            "schema": {
+              "$ref": "#/components/schemas/ModelProvider"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/responses/{response_id}/input_items": {
+      "get": {
+        "operationId": "listResponseInputItems",
+        "summary": "List response input items",
+        "description": "Lists the input items of a stored response.\n",
+        "tags": [
+          "Responses"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the response",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "description": "Provider the response was created with (defaults to `openai`)",
+            "schema": {
+              "$ref": "#/components/schemas/ModelProvider"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Cursor for pagination (item ID to list items after)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional fields to include (repeatable)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of input items to return",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponsesInputItemsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
     "/v1/batches": {
       "post": {
         "operationId": "createBatch",
@@ -12204,6 +12609,411 @@
           },
           "400": {
             "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/openai/v1/responses/{response_id}": {
+      "get": {
+        "operationId": "openaiRetrieveResponse",
+        "summary": "Retrieve a response (OpenAI format)",
+        "description": "Retrieves a stored response by ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
+        "tags": [
+          "OpenAI Integration"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the response to retrieve"
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Provider the response was created with (defaults to `openai`)"
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional fields to include (repeatable)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "starting_after",
+            "in": "query",
+            "description": "Sequence number of the event after which to start the response",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "include_obfuscation",
+            "in": "query",
+            "description": "Whether to include obfuscation on the response",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "openaiDeleteResponse",
+        "summary": "Delete a response (OpenAI format)",
+        "description": "Deletes a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
+        "tags": [
+          "OpenAI Integration"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the response to delete"
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Provider the response was created with (defaults to `openai`)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponsesDeleteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/openai/v1/responses/{response_id}/cancel": {
+      "post": {
+        "operationId": "openaiCancelResponse",
+        "summary": "Cancel a response (OpenAI format)",
+        "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/cancel`).\n",
+        "tags": [
+          "OpenAI Integration"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the response to cancel"
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Provider the response was created with (defaults to `openai`)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/openai/v1/responses/{response_id}/input_items": {
+      "get": {
+        "operationId": "openaiListResponseInputItems",
+        "summary": "List response input items (OpenAI format)",
+        "description": "Lists the input items of a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/input_items`).\n",
+        "tags": [
+          "OpenAI Integration"
+        ],
+        "parameters": [
+          {
+            "name": "response_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the response"
+          },
+          {
+            "name": "provider",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Provider the response was created with (defaults to `openai`)"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Cursor for pagination (item ID to list items after)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Additional fields to include (repeatable)",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of input items to return",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponsesInputItemsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -65765,6 +66575,503 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "BifrostResponsesDeleteResponse": {
+        "type": "object",
+        "description": "Wire shape for a successful delete of a stored response.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "BifrostResponsesInputItemsResponse": {
+        "type": "object",
+        "description": "List payload for a response's input items.",
+        "properties": {
+          "object": {
+            "type": "string"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "message",
+                    "file_search_call",
+                    "computer_call",
+                    "computer_call_output",
+                    "web_search_call",
+                    "web_fetch_call",
+                    "function_call",
+                    "function_call_output",
+                    "code_interpreter_call",
+                    "local_shell_call",
+                    "local_shell_call_output",
+                    "mcp_call",
+                    "custom_tool_call",
+                    "custom_tool_call_output",
+                    "image_generation_call",
+                    "mcp_list_tools",
+                    "mcp_approval_request",
+                    "mcp_approval_responses",
+                    "reasoning",
+                    "item_reference",
+                    "refusal"
+                  ]
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
+                },
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
+                },
+                "content": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "call_id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "arguments": {
+                  "type": "string"
+                },
+                "output": {
+                  "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Computer tool call output (computer_screenshot).",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "computer_screenshot"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "action": {
+                  "type": "object"
+                },
+                "error": {
+                  "type": "string"
+                },
+                "queries": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "results": {
+                  "type": "array",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "summary": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "text"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "summary_text"
+                        ]
+                      },
+                      "text": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "encrypted_content": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "first_id": {
+            "type": "string"
+          },
+          "last_id": {
+            "type": "string"
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -187,6 +187,12 @@ paths:
     $ref: './paths/inference/count-tokens.yaml#/count-tokens'
   /v1/responses/compact:
     $ref: './paths/inference/compaction.yaml#/compact'
+  /v1/responses/{response_id}:
+    $ref: './paths/inference/responses.yaml#/responses-by-id'
+  /v1/responses/{response_id}/cancel:
+    $ref: './paths/inference/responses.yaml#/responses-cancel'
+  /v1/responses/{response_id}/input_items:
+    $ref: './paths/inference/responses.yaml#/responses-input-items'
   /v1/batches:
     $ref: './paths/inference/batches.yaml#/batches'
   /v1/batches/{batch_id}:
@@ -288,6 +294,12 @@ paths:
     $ref: './paths/integrations/openai/responses.yaml#/azure-responses'
   /openai/v1/responses/input_tokens:
     $ref: './paths/integrations/openai/responses.yaml#/responses-input-tokens'
+  /openai/v1/responses/{response_id}:
+    $ref: './paths/integrations/openai/responses.yaml#/responses-by-id'
+  /openai/v1/responses/{response_id}/cancel:
+    $ref: './paths/integrations/openai/responses.yaml#/responses-cancel'
+  /openai/v1/responses/{response_id}/input_items:
+    $ref: './paths/integrations/openai/responses.yaml#/responses-input-items'
 
   # Context Compaction
   /openai/v1/responses/compact:
@@ -1243,6 +1255,10 @@ components:
       $ref: './schemas/inference/responses.yaml#/ResponsesRequest'
     ResponsesResponse:
       $ref: './schemas/inference/responses.yaml#/ResponsesResponse'
+    BifrostResponsesDeleteResponse:
+      $ref: './schemas/inference/responses.yaml#/BifrostResponsesDeleteResponse'
+    BifrostResponsesInputItemsResponse:
+      $ref: './schemas/inference/responses.yaml#/BifrostResponsesInputItemsResponse'
 
     # ==================== Rerank ====================
     RerankRequest:

--- a/docs/openapi/paths/inference/responses.yaml
+++ b/docs/openapi/paths/inference/responses.yaml
@@ -78,3 +78,199 @@ responses:
     - BasicAuth: []
     - VirtualKeyAuth: []
     - ApiKeyAuth: []
+
+responses-by-id:
+  get:
+    operationId: retrieveResponse
+    summary: Retrieve a response
+    description: |
+      Retrieves a stored response by ID.
+    tags:
+    - Responses
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      description: The ID of the response to retrieve
+      schema:
+        type: string
+    - name: provider
+      in: query
+      description: Provider the response was created with (defaults to `openai`)
+      schema:
+        $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    - name: include
+      in: query
+      description: Additional fields to include (repeatable)
+      schema:
+        type: array
+        items:
+          type: string
+    - name: starting_after
+      in: query
+      description: Sequence number of the event after which to start the response
+      schema:
+        type: integer
+    - name: include_obfuscation
+      in: query
+      description: Whether to include obfuscation on the response
+      schema:
+        type: boolean
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/responses.yaml#/ResponsesResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+  delete:
+    operationId: deleteResponse
+    summary: Delete a response
+    description: |
+      Deletes a stored response.
+    tags:
+    - Responses
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      description: The ID of the response to delete
+      schema:
+        type: string
+    - name: provider
+      in: query
+      description: Provider the response was created with (defaults to `openai`)
+      schema:
+        $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/responses.yaml#/BifrostResponsesDeleteResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+responses-cancel:
+  post:
+    operationId: cancelResponse
+    summary: Cancel a response
+    description: |
+      Cancels an in-flight response. Only responses created with `background: true`
+      can be cancelled.
+    tags:
+    - Responses
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      description: The ID of the response to cancel
+      schema:
+        type: string
+    - name: provider
+      in: query
+      description: Provider the response was created with (defaults to `openai`)
+      schema:
+        $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/responses.yaml#/ResponsesResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+responses-input-items:
+  get:
+    operationId: listResponseInputItems
+    summary: List response input items
+    description: |
+      Lists the input items of a stored response.
+    tags:
+    - Responses
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      description: The ID of the response
+      schema:
+        type: string
+    - name: provider
+      in: query
+      description: Provider the response was created with (defaults to `openai`)
+      schema:
+        $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    - name: after
+      in: query
+      description: Cursor for pagination (item ID to list items after)
+      schema:
+        type: string
+    - name: include
+      in: query
+      description: Additional fields to include (repeatable)
+      schema:
+        type: array
+        items:
+          type: string
+    - name: limit
+      in: query
+      description: Maximum number of input items to return
+      schema:
+        type: integer
+        minimum: 1
+    - name: order
+      in: query
+      description: Sort order
+      schema:
+        type: string
+        enum: [asc, desc]
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/responses.yaml#/BifrostResponsesInputItemsResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/paths/integrations/openai/responses.yaml
+++ b/docs/openapi/paths/integrations/openai/responses.yaml
@@ -175,3 +175,207 @@ responses-input-tokens:
     - BasicAuth: []
     - VirtualKeyAuth: []
     - ApiKeyAuth: []
+
+responses-by-id:
+  get:
+    operationId: openaiRetrieveResponse
+    summary: Retrieve a response (OpenAI format)
+    description: |
+      Retrieves a stored response by ID.
+
+      **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).
+    tags:
+    - OpenAI Integration
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The ID of the response to retrieve
+    - name: provider
+      in: query
+      schema:
+        type: string
+      description: Provider the response was created with (defaults to `openai`)
+    - name: include
+      in: query
+      description: Additional fields to include (repeatable)
+      schema:
+        type: array
+        items:
+          type: string
+    - name: starting_after
+      in: query
+      description: Sequence number of the event after which to start the response
+      schema:
+        type: integer
+    - name: include_obfuscation
+      in: query
+      description: Whether to include obfuscation on the response
+      schema:
+        type: boolean
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../../schemas/integrations/openai/responses.yaml#/OpenAIResponsesResponse'
+      '400':
+        $ref: '../../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+  delete:
+    operationId: openaiDeleteResponse
+    summary: Delete a response (OpenAI format)
+    description: |
+      Deletes a stored response.
+
+      **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).
+    tags:
+    - OpenAI Integration
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The ID of the response to delete
+    - name: provider
+      in: query
+      schema:
+        type: string
+      description: Provider the response was created with (defaults to `openai`)
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../../schemas/inference/responses.yaml#/BifrostResponsesDeleteResponse'
+      '400':
+        $ref: '../../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+responses-cancel:
+  post:
+    operationId: openaiCancelResponse
+    summary: Cancel a response (OpenAI format)
+    description: |
+      Cancels an in-flight response. Only responses created with `background: true`
+      can be cancelled.
+
+      **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/cancel`).
+    tags:
+    - OpenAI Integration
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The ID of the response to cancel
+    - name: provider
+      in: query
+      schema:
+        type: string
+      description: Provider the response was created with (defaults to `openai`)
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../../schemas/integrations/openai/responses.yaml#/OpenAIResponsesResponse'
+      '400':
+        $ref: '../../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+responses-input-items:
+  get:
+    operationId: openaiListResponseInputItems
+    summary: List response input items (OpenAI format)
+    description: |
+      Lists the input items of a stored response.
+
+      **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/input_items`).
+    tags:
+    - OpenAI Integration
+    parameters:
+    - name: response_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The ID of the response
+    - name: provider
+      in: query
+      schema:
+        type: string
+      description: Provider the response was created with (defaults to `openai`)
+    - name: after
+      in: query
+      description: Cursor for pagination (item ID to list items after)
+      schema:
+        type: string
+    - name: include
+      in: query
+      description: Additional fields to include (repeatable)
+      schema:
+        type: array
+        items:
+          type: string
+    - name: limit
+      in: query
+      description: Maximum number of input items to return
+      schema:
+        type: integer
+        minimum: 1
+    - name: order
+      in: query
+      description: Sort order
+      schema:
+        type: string
+        enum: [asc, desc]
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../../schemas/inference/responses.yaml#/BifrostResponsesInputItemsResponse'
+      '400':
+        $ref: '../../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/schemas/inference/responses.yaml
+++ b/docs/openapi/schemas/inference/responses.yaml
@@ -714,3 +714,35 @@ ResponsesStreamResponseType:
     - response.custom_tool_call_input.delta
     - response.custom_tool_call_input.done
     - error
+
+BifrostResponsesDeleteResponse:
+  type: object
+  description: Wire shape for a successful delete of a stored response.
+  properties:
+    id:
+      type: string
+    object:
+      type: string
+    deleted:
+      type: boolean
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+BifrostResponsesInputItemsResponse:
+  type: object
+  description: List payload for a response's input items.
+  properties:
+    object:
+      type: string
+    data:
+      type: array
+      items:
+        $ref: '#/ResponsesMessage'
+    has_more:
+      type: boolean
+    first_id:
+      type: string
+    last_id:
+      type: string
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'


### PR DESCRIPTION
## Summary

Adds OpenAPI documentation for the retrieve, delete, cancel, and list-input-items response endpoints, which were previously undocumented. These endpoints allow callers to manage stored responses by ID.

## Changes

- Added `GET /v1/responses/{response_id}` to retrieve a stored response by ID, with support for `include`, `starting_after`, and `include_obfuscation` query parameters.
- Added `DELETE /v1/responses/{response_id}` to delete a stored response.
- Added `POST /v1/responses/{response_id}/cancel` to cancel an in-flight background response.
- Added `GET /v1/responses/{response_id}/input_items` to list a response's input items with pagination (`after`, `limit`, `order`) and `include` support.
- Mirrored all four endpoints under the `/openai/v1/` prefix for OpenAI-format integration consumers.
- Introduced `BifrostResponsesDeleteResponse` schema describing the delete confirmation payload (`id`, `object`, `deleted`).
- Introduced `BifrostResponsesInputItemsResponse` schema describing the paginated list payload for input items, including the full set of supported item types, content variants, annotations, and logprobs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the generated `openapi.json` reflects the new paths and schemas by diffing against the previous version or loading the spec into an OpenAPI viewer (e.g., Swagger UI or Redoc) and confirming the four new endpoint groups appear under the `Responses` and `OpenAI Integration` tags with correct parameters and response shapes.

## Breaking changes

- [x] No

## Security considerations

All new endpoints inherit the same four authentication schemes (`BearerAuth`, `BasicAuth`, `VirtualKeyAuth`, `ApiKeyAuth`) already used by existing response endpoints. No new auth surface is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable