### PR TITLE
fix: resolve merge conflict in `TableClientConfig`

### DIFF
--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -22,7 +22,6 @@ const (
 
 // TableClientConfig represents global client configuration in the database
 type TableClientConfig struct {
-<<<<<<< HEAD
 	ID                                    uint                           `gorm:"primaryKey;autoIncrement" json:"id"`
 	DropExcessRequests                    bool                           `gorm:"default:false" json:"drop_excess_requests"`
 	PrometheusLabelsJSON                  string                         `gorm:"type:text" json:"-"` // JSON serialized []string
@@ -57,41 +56,6 @@ type TableClientConfig struct {
 	AllowPerRequestContentStorageOverride bool                           `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
 	AllowPerRequestRawOverride            bool                           `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
 	AllowDirectKeys                       bool                           `gorm:"default:false" json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key header
-=======
-	ID                                    uint   `gorm:"primaryKey;autoIncrement" json:"id"`
-	DropExcessRequests                    bool   `gorm:"default:false" json:"drop_excess_requests"`
-	PrometheusLabelsJSON                  string `gorm:"type:text" json:"-"` // JSON serialized []string
-	AllowedOriginsJSON                    string `gorm:"type:text" json:"-"` // JSON serialized []string
-	AllowedHeadersJSON                    string `gorm:"type:text" json:"-"` // JSON serialized []string
-	HeaderFilterConfigJSON                string `gorm:"type:text" json:"-"` // JSON serialized GlobalHeaderFilterConfig
-	MetadataJSON                          string `gorm:"type:text" json:"-"` // JSON serialized map[string]any for UI/admin preferences (e.g. onboarding_dismissed). Bypasses config.json sync.
-	InitialPoolSize                       int    `gorm:"default:300" json:"initial_pool_size"`
-	EnableLogging                         *bool  `gorm:"default:true" json:"enable_logging"`
-	DisableContentLogging                 bool   `gorm:"default:false" json:"disable_content_logging"` // DisableContentLogging controls whether sensitive content (inputs, outputs, embeddings, etc.) is logged
-	DisableDBPingsInHealth                bool   `gorm:"default:false" json:"disable_db_pings_in_health"`
-	DumpErrorsInConsoleLogs               bool   `gorm:"default:false" json:"dump_errors_in_console_logs"`       // Dump full error details to the server console logs
-	LogRetentionDays                      int    `gorm:"default:365" json:"log_retention_days" validate:"min=1"` // Number of days to retain logs (minimum 1 day)
-	EnforceAuthOnInference                bool   `gorm:"default:false" json:"enforce_auth_on_inference"`
-	EnforceGovernanceHeader               bool   `gorm:"" json:"enforce_governance_header"`
-	EnforceSCIMAuth                       bool   `gorm:"default:false" json:"enforce_scim_auth"`
-	MaxRequestBodySizeMB                  int    `gorm:"default:100" json:"max_request_body_size_mb"`
-	MCPAgentDepth                         int    `gorm:"default:10" json:"mcp_agent_depth"`
-	MCPToolExecutionTimeout               int    `gorm:"default:30" json:"mcp_tool_execution_timeout"`                    // Timeout for individual tool execution in seconds (default: 30)
-	MCPCodeModeBindingLevel               string `gorm:"default:server" json:"mcp_code_mode_binding_level"`               // How tools are exposed in VFS: "server" or "tool"
-	MCPToolSyncInterval                   int    `gorm:"default:10" json:"mcp_tool_sync_interval"`                        // Global tool sync interval in minutes (default: 10, 0 = disabled)
-	MCPDisableAutoToolInject              bool   `gorm:"default:false" json:"mcp_disable_auto_tool_inject"`               // When true, MCP tools are not injected into requests by default
-	MCPEnableTempTokenAuth                bool   `gorm:"default:false" json:"mcp_enable_temp_token_auth"`                 // When true, scoped temp tokens can authorize MCP per-user OAuth and per-user-headers auth pages. User-mode flows never mint regardless.
-	AsyncJobResultTTL                     int    `gorm:"default:3600" json:"async_job_result_ttl"`                        // Default TTL for async job results in seconds (default: 3600 = 1 hour)
-	RequiredHeadersJSON                   string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
-	LoggingHeadersJSON                    string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
-	HideDeletedVirtualKeysInFilters       bool   `gorm:"default:false" json:"hide_deleted_virtual_keys_in_filters"`       // Hide deleted virtual keys in logs filter dropdowns
-	RoutingChainMaxDepth                  int    `gorm:"default:10" json:"routing_chain_max_depth"`                       // Maximum depth for routing rule chain evaluation (default: 10)
-	MCPExternalClientURL                  string `gorm:"type:varchar(512)" json:"mcp_external_client_url,omitempty"`      // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers
-	WhitelistedRoutesJSON                 string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
-	AllowPerRequestContentStorageOverride bool   `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
-	AllowPerRequestRawOverride            bool   `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage
-	AllowDirectKeys                       bool   `gorm:"default:false" json:"allow_direct_keys"`                          // Allow callers to bypass the registered key pool via x-bf-direct-key header
->>>>>>> ffd055569 (feat: add webhook endpoint admin API, in-memory store, config.json sync, and per-endpoint delivery tuning (#5251))
 
 	// Compat plugin feature flags
 	CompatConvertTextToChat      bool `gorm:"column:compat_convert_text_to_chat;default:false" json:"-"`


### PR DESCRIPTION
## Summary

Resolves a merge conflict in `framework/configstore/tables/clientconfig.go` that left both `HEAD` and the incoming branch's version of `TableClientConfig` in the file simultaneously.

## Changes

- Removed the duplicate `TableClientConfig` struct definition introduced by a failed merge, retaining the correct version with proper field types (e.g., `*bool` for `EnableLogging`, typed foreign key references) and full field alignment

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go build ./...
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to #5251

## Security considerations

None. This is a conflict resolution with no behavioral changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable