### PR TITLE
docs: expand `output` field schema in OpenAPI from generic object to typed `oneOf` (string, content blocks, computer screenshot)

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -1211,7 +1211,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -4604,7 +4786,189 @@
                               "type": "string"
                             },
                             "output": {
-                              "type": "object"
+                              "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "input_text",
+                                          "input_image",
+                                          "input_file",
+                                          "input_audio",
+                                          "output_text",
+                                          "refusal",
+                                          "reasoning_text"
+                                        ]
+                                      },
+                                      "file_id": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "signature": {
+                                        "type": "string"
+                                      },
+                                      "image_url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string"
+                                      },
+                                      "file_data": {
+                                        "type": "string"
+                                      },
+                                      "file_url": {
+                                        "type": "string"
+                                      },
+                                      "filename": {
+                                        "type": "string"
+                                      },
+                                      "file_type": {
+                                        "type": "string"
+                                      },
+                                      "input_audio": {
+                                        "type": "object",
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
+                                        "properties": {
+                                          "format": {
+                                            "type": "string",
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
+                                          },
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "file_citation",
+                                                "url_citation",
+                                                "container_file_citation",
+                                                "file_path"
+                                              ]
+                                            },
+                                            "index": {
+                                              "type": "integer"
+                                            },
+                                            "file_id": {
+                                              "type": "string"
+                                            },
+                                            "text": {
+                                              "type": "string"
+                                            },
+                                            "start_index": {
+                                              "type": "integer"
+                                            },
+                                            "end_index": {
+                                              "type": "integer"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            },
+                                            "container_id": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "bytes": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "logprob": {
+                                              "type": "number"
+                                            },
+                                            "token": {
+                                              "type": "string"
+                                            },
+                                            "top_logprobs": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "logprob": {
+                                                    "type": "number"
+                                                  },
+                                                  "token": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "refusal": {
+                                        "type": "string"
+                                      },
+                                      "cache_control": {
+                                        "$ref": "#/components/schemas/CacheControl"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "Computer tool call output (computer_screenshot).",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "computer_screenshot"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              ]
                             },
                             "action": {
                               "type": "object"
@@ -4934,7 +5298,189 @@
                             "type": "string"
                           },
                           "output": {
-                            "type": "object"
+                            "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "input_text",
+                                        "input_image",
+                                        "input_file",
+                                        "input_audio",
+                                        "output_text",
+                                        "refusal",
+                                        "reasoning_text"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "signature": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    },
+                                    "detail": {
+                                      "type": "string"
+                                    },
+                                    "file_data": {
+                                      "type": "string"
+                                    },
+                                    "file_url": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "file_type": {
+                                      "type": "string"
+                                    },
+                                    "input_audio": {
+                                      "type": "object",
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
+                                      "properties": {
+                                        "format": {
+                                          "type": "string",
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
+                                        },
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "annotations": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "file_citation",
+                                              "url_citation",
+                                              "container_file_citation",
+                                              "file_path"
+                                            ]
+                                          },
+                                          "index": {
+                                            "type": "integer"
+                                          },
+                                          "file_id": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "start_index": {
+                                            "type": "integer"
+                                          },
+                                          "end_index": {
+                                            "type": "integer"
+                                          },
+                                          "filename": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "container_id": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          },
+                                          "top_logprobs": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "bytes": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "logprob": {
+                                                  "type": "number"
+                                                },
+                                                "token": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "refusal": {
+                                      "type": "string"
+                                    },
+                                    "cache_control": {
+                                      "$ref": "#/components/schemas/CacheControl"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "description": "Computer tool call output (computer_screenshot).",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "computer_screenshot"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            ]
                           },
                           "action": {
                             "type": "object"
@@ -11449,7 +11995,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -12217,7 +12945,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -13311,7 +14221,189 @@
                               "type": "string"
                             },
                             "output": {
-                              "type": "object"
+                              "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                              "oneOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "input_text",
+                                          "input_image",
+                                          "input_file",
+                                          "input_audio",
+                                          "output_text",
+                                          "refusal",
+                                          "reasoning_text"
+                                        ]
+                                      },
+                                      "file_id": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "signature": {
+                                        "type": "string"
+                                      },
+                                      "image_url": {
+                                        "type": "string"
+                                      },
+                                      "detail": {
+                                        "type": "string"
+                                      },
+                                      "file_data": {
+                                        "type": "string"
+                                      },
+                                      "file_url": {
+                                        "type": "string"
+                                      },
+                                      "filename": {
+                                        "type": "string"
+                                      },
+                                      "file_type": {
+                                        "type": "string"
+                                      },
+                                      "input_audio": {
+                                        "type": "object",
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
+                                        "properties": {
+                                          "format": {
+                                            "type": "string",
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
+                                          },
+                                          "data": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "annotations": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "type": {
+                                              "type": "string",
+                                              "enum": [
+                                                "file_citation",
+                                                "url_citation",
+                                                "container_file_citation",
+                                                "file_path"
+                                              ]
+                                            },
+                                            "index": {
+                                              "type": "integer"
+                                            },
+                                            "file_id": {
+                                              "type": "string"
+                                            },
+                                            "text": {
+                                              "type": "string"
+                                            },
+                                            "start_index": {
+                                              "type": "integer"
+                                            },
+                                            "end_index": {
+                                              "type": "integer"
+                                            },
+                                            "filename": {
+                                              "type": "string"
+                                            },
+                                            "title": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            },
+                                            "container_id": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "logprobs": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "bytes": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "logprob": {
+                                              "type": "number"
+                                            },
+                                            "token": {
+                                              "type": "string"
+                                            },
+                                            "top_logprobs": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "bytes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "integer"
+                                                    }
+                                                  },
+                                                  "logprob": {
+                                                    "type": "number"
+                                                  },
+                                                  "token": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "refusal": {
+                                        "type": "string"
+                                      },
+                                      "cache_control": {
+                                        "$ref": "#/components/schemas/CacheControl"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "description": "Computer tool call output (computer_screenshot).",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "computer_screenshot"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              ]
                             },
                             "action": {
                               "type": "object"
@@ -13641,7 +14733,189 @@
                             "type": "string"
                           },
                           "output": {
-                            "type": "object"
+                            "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                            "oneOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "input_text",
+                                        "input_image",
+                                        "input_file",
+                                        "input_audio",
+                                        "output_text",
+                                        "refusal",
+                                        "reasoning_text"
+                                      ]
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "signature": {
+                                      "type": "string"
+                                    },
+                                    "image_url": {
+                                      "type": "string"
+                                    },
+                                    "detail": {
+                                      "type": "string"
+                                    },
+                                    "file_data": {
+                                      "type": "string"
+                                    },
+                                    "file_url": {
+                                      "type": "string"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "file_type": {
+                                      "type": "string"
+                                    },
+                                    "input_audio": {
+                                      "type": "object",
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
+                                      "properties": {
+                                        "format": {
+                                          "type": "string",
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
+                                        },
+                                        "data": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "annotations": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "file_citation",
+                                              "url_citation",
+                                              "container_file_citation",
+                                              "file_path"
+                                            ]
+                                          },
+                                          "index": {
+                                            "type": "integer"
+                                          },
+                                          "file_id": {
+                                            "type": "string"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "start_index": {
+                                            "type": "integer"
+                                          },
+                                          "end_index": {
+                                            "type": "integer"
+                                          },
+                                          "filename": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "type": "string"
+                                          },
+                                          "container_id": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          },
+                                          "top_logprobs": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "bytes": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "logprob": {
+                                                  "type": "number"
+                                                },
+                                                "token": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "refusal": {
+                                      "type": "string"
+                                    },
+                                    "cache_control": {
+                                      "$ref": "#/components/schemas/CacheControl"
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "description": "Computer tool call output (computer_screenshot).",
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "computer_screenshot"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            ]
                           },
                           "action": {
                             "type": "object"
@@ -26924,7 +28198,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -29881,7 +31337,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -32952,7 +34590,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -38833,7 +40653,189 @@
                           "type": "string"
                         },
                         "output": {
-                          "type": "object"
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
                         },
                         "action": {
                           "type": "object"
@@ -65383,7 +67385,189 @@
                       "type": "string"
                     },
                     "output": {
-                      "type": "object"
+                      "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "input_text",
+                                  "input_image",
+                                  "input_file",
+                                  "input_audio",
+                                  "output_text",
+                                  "refusal",
+                                  "reasoning_text"
+                                ]
+                              },
+                              "file_id": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "image_url": {
+                                "type": "string"
+                              },
+                              "detail": {
+                                "type": "string"
+                              },
+                              "file_data": {
+                                "type": "string"
+                              },
+                              "file_url": {
+                                "type": "string"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "file_type": {
+                                "type": "string"
+                              },
+                              "input_audio": {
+                                "type": "object",
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
+                                "properties": {
+                                  "format": {
+                                    "type": "string",
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "annotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "file_citation",
+                                        "url_citation",
+                                        "container_file_citation",
+                                        "file_path"
+                                      ]
+                                    },
+                                    "index": {
+                                      "type": "integer"
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "start_index": {
+                                      "type": "integer"
+                                    },
+                                    "end_index": {
+                                      "type": "integer"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "container_id": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "logprobs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "logprob": {
+                                      "type": "number"
+                                    },
+                                    "token": {
+                                      "type": "string"
+                                    },
+                                    "top_logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "refusal": {
+                                "type": "string"
+                              },
+                              "cache_control": {
+                                "$ref": "#/components/schemas/CacheControl"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "description": "Computer tool call output (computer_screenshot).",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "computer_screenshot"
+                              ]
+                            },
+                            "file_id": {
+                              "type": "string"
+                            },
+                            "image_url": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
                     },
                     "action": {
                       "type": "object"
@@ -66103,7 +68287,189 @@
                   "type": "string"
                 },
                 "output": {
-                  "type": "object"
+                  "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Computer tool call output (computer_screenshot).",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "computer_screenshot"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 },
                 "action": {
                   "type": "object"
@@ -67924,7 +70290,189 @@
                   "type": "string"
                 },
                 "output": {
-                  "type": "object"
+                  "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Computer tool call output (computer_screenshot).",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "computer_screenshot"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 },
                 "action": {
                   "type": "object"
@@ -69966,7 +72514,189 @@
                       "type": "string"
                     },
                     "output": {
-                      "type": "object"
+                      "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "input_text",
+                                  "input_image",
+                                  "input_file",
+                                  "input_audio",
+                                  "output_text",
+                                  "refusal",
+                                  "reasoning_text"
+                                ]
+                              },
+                              "file_id": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "signature": {
+                                "type": "string"
+                              },
+                              "image_url": {
+                                "type": "string"
+                              },
+                              "detail": {
+                                "type": "string"
+                              },
+                              "file_data": {
+                                "type": "string"
+                              },
+                              "file_url": {
+                                "type": "string"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "file_type": {
+                                "type": "string"
+                              },
+                              "input_audio": {
+                                "type": "object",
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
+                                "properties": {
+                                  "format": {
+                                    "type": "string",
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "annotations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "file_citation",
+                                        "url_citation",
+                                        "container_file_citation",
+                                        "file_path"
+                                      ]
+                                    },
+                                    "index": {
+                                      "type": "integer"
+                                    },
+                                    "file_id": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "start_index": {
+                                      "type": "integer"
+                                    },
+                                    "end_index": {
+                                      "type": "integer"
+                                    },
+                                    "filename": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "type": "string"
+                                    },
+                                    "container_id": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "logprobs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "logprob": {
+                                      "type": "number"
+                                    },
+                                    "token": {
+                                      "type": "string"
+                                    },
+                                    "top_logprobs": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "bytes": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "logprob": {
+                                            "type": "number"
+                                          },
+                                          "token": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "refusal": {
+                                "type": "string"
+                              },
+                              "cache_control": {
+                                "$ref": "#/components/schemas/CacheControl"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "description": "Computer tool call output (computer_screenshot).",
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "computer_screenshot"
+                              ]
+                            },
+                            "file_id": {
+                              "type": "string"
+                            },
+                            "image_url": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      ]
                     },
                     "action": {
                       "type": "object"
@@ -76262,10 +78992,6 @@
               "type": "string"
             },
             "description": "OAuth scopes requested. Optional - can be discovered from server_url if not provided.\nExample: [\"read\", \"write\"]\n"
-          },
-          "resource": {
-            "type": "string",
-            "description": "OAuth resource indicator (RFC 8707). Optional - omitted when empty. Providers such as Cloudflare managed MCP may require this value to identify the protected MCP resource.\n"
           }
         }
       },
@@ -80150,7 +82876,189 @@
                   "type": "string"
                 },
                 "output": {
-                  "type": "object"
+                  "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Computer tool call output (computer_screenshot).",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "computer_screenshot"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 },
                 "action": {
                   "type": "object"
@@ -80429,7 +83337,189 @@
                   "type": "string"
                 },
                 "output": {
-                  "type": "object"
+                  "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "input_text",
+                              "input_image",
+                              "input_file",
+                              "input_audio",
+                              "output_text",
+                              "refusal",
+                              "reasoning_text"
+                            ]
+                          },
+                          "file_id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          },
+                          "image_url": {
+                            "type": "string"
+                          },
+                          "detail": {
+                            "type": "string"
+                          },
+                          "file_data": {
+                            "type": "string"
+                          },
+                          "file_url": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "file_type": {
+                            "type": "string"
+                          },
+                          "input_audio": {
+                            "type": "object",
+                            "required": [
+                              "format",
+                              "data"
+                            ],
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
+                              },
+                              "data": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "annotations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "file_citation",
+                                    "url_citation",
+                                    "container_file_citation",
+                                    "file_path"
+                                  ]
+                                },
+                                "index": {
+                                  "type": "integer"
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "text": {
+                                  "type": "string"
+                                },
+                                "start_index": {
+                                  "type": "integer"
+                                },
+                                "end_index": {
+                                  "type": "integer"
+                                },
+                                "filename": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "type": "string"
+                                },
+                                "container_id": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                },
+                                "top_logprobs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "bytes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "logprob": {
+                                        "type": "number"
+                                      },
+                                      "token": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "refusal": {
+                            "type": "string"
+                          },
+                          "cache_control": {
+                            "$ref": "#/components/schemas/CacheControl"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Computer tool call output (computer_screenshot).",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "computer_screenshot"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 },
                 "action": {
                   "type": "object"

--- a/docs/openapi/schemas/inference/responses.yaml
+++ b/docs/openapi/schemas/inference/responses.yaml
@@ -97,7 +97,25 @@ ResponsesMessage:
     arguments:
       type: string
     output:
-      type: object
+      description: |
+        Tool call output. A plain string for function/custom/local-shell tool
+        outputs, an array of content blocks for structured function tool
+        outputs, or a computer-tool screenshot object for computer_call_output.
+      oneOf:
+        - type: string
+        - type: array
+          items:
+            $ref: '#/ResponsesMessageContentBlock'
+        - type: object
+          description: Computer tool call output (computer_screenshot).
+          properties:
+            type:
+              type: string
+              enum: [computer_screenshot]
+            file_id:
+              type: string
+            image_url:
+              type: string
     action:
       type: object
     error:


### PR DESCRIPTION
## Summary

The `output` field on tool call result objects in the OpenAPI spec was previously typed as a generic `object`, which was too permissive and provided no useful documentation. This PR replaces that with a properly typed `oneOf` schema that accurately reflects the three possible output shapes: a plain string (for function/custom/local-shell tools), an array of typed content blocks (for structured function tool outputs), or a `computer_screenshot` object (for `computer_call_output`).

Additionally, the `resource` field (OAuth resource indicator per RFC 8707) has been removed from the OAuth configuration schema.

## Changes

- Replaced `"type": "object"` with a `oneOf` schema for the `output` field across all tool call result locations in `openapi.json`, covering all response variants (streaming, non-streaming, and event types).
- Updated the source schema in `docs/openapi/schemas/inference/responses.yaml` to define the `output` field with the same `oneOf` structure, referencing `ResponsesMessageContentBlock` for the array variant and inlining the `computer_screenshot` object variant.
- Removed the `resource` string property from the OAuth configuration schema.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the updated OpenAPI spec is well-formed and that the `output` field correctly validates against the three allowed shapes:

```sh
# Validate the OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.json

# Confirm a plain string, content block array, and computer_screenshot object
# each pass schema validation against the updated `output` oneOf definition.
```

## Breaking changes

- [x] Yes
- [ ] No

The `resource` field has been removed from the OAuth configuration schema. Any clients or tooling that relied on setting `resource` for RFC 8707 OAuth resource indicators will need to be updated. Additionally, consumers that previously passed any arbitrary object as `output` may now receive validation errors if their payloads do not conform to one of the three defined shapes.

## Related issues

N/A

## Security considerations

None. This is a schema documentation change with no impact on authentication, secrets, or data handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable