### PR TITLE
[Fix]: Redis vectorstore - escape all RedisSearch special characters in TAG query values

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/redis/go-redis/v9"
@@ -1557,35 +1558,23 @@ func (s *RedisStore) RequiresVectors() bool {
 }
 
 // escapeSearchValue escapes special characters in search values.
+// RediSearch treats every punctuation character as special inside a TAG query
+// (@field:{value}, DIALECT 2), so escape all non-alphanumeric ASCII characters
+// instead of enumerating specials: an unescaped character either fails the
+// query with a syntax error (e.g. ":" in "gemma31b-q6:latest") or silently
+// matches nothing (e.g. "/" in "openai/gpt-4o").
 func escapeSearchValue(value string) string {
-	// Escape special RediSearch characters
-	replacer := strings.NewReplacer(
-		"(", "\\(",
-		")", "\\)",
-		"[", "\\[",
-		"]", "\\]",
-		"{", "\\{",
-		"}", "\\}",
-		"*", "\\*",
-		"?", "\\?",
-		"|", "\\|",
-		"&", "\\&",
-		"!", "\\!",
-		"@", "\\@",
-		"#", "\\#",
-		"$", "\\$",
-		"%", "\\%",
-		"^", "\\^",
-		"~", "\\~",
-		"`", "\\`",
-		"\"", "\\\"",
-		"'", "\\'",
-		" ", "\\ ",
-		"-", "\\-",
-		".", "\\.",
-		",", "\\,",
-	)
-	return replacer.Replace(value)
+	var b strings.Builder
+	b.Grow(len(value) * 2)
+	for _, r := range value {
+		isSafe := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '_' || r > unicode.MaxASCII
+		if !isSafe {
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // Binary embedding conversion helpers

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode"
+	"unicode/utf8"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/redis/go-redis/v9"
@@ -1563,16 +1563,19 @@ func (s *RedisStore) RequiresVectors() bool {
 // instead of enumerating specials: an unescaped character either fails the
 // query with a syntax error (e.g. ":" in "gemma31b-q6:latest") or silently
 // matches nothing (e.g. "/" in "openai/gpt-4o").
+// Iterates bytes, not runes, so non-ASCII and even malformed UTF-8 pass
+// through byte-for-byte, matching the raw bytes Redis stored.
 func escapeSearchValue(value string) string {
 	var b strings.Builder
 	b.Grow(len(value) * 2)
-	for _, r := range value {
-		isSafe := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
-			(r >= '0' && r <= '9') || r == '_' || r > unicode.MaxASCII
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		isSafe := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '_' || c >= utf8.RuneSelf
 		if !isSafe {
 			b.WriteByte('\\')
 		}
-		b.WriteRune(r)
+		b.WriteByte(c)
 	}
 	return b.String()
 }

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -143,6 +143,9 @@ func (ts *RedisTestSetup) ensureNamespaceExists(t *testing.T) {
 		"content": {
 			DataType: VectorStorePropertyTypeString,
 		},
+		"model": {
+			DataType: VectorStorePropertyTypeString,
+		},
 		"response": {
 			DataType: VectorStorePropertyTypeString,
 		},
@@ -826,6 +829,112 @@ func TestBuildRedisQueryCondition_NumericEquality(t *testing.T) {
 	}
 }
 
+func TestEscapeSearchValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "plain alphanumeric unchanged",
+			value:    "gpt4o_mini",
+			expected: "gpt4o_mini",
+		},
+		{
+			name:     "colon in ollama-style model tag",
+			value:    "gemma31b-q6:latest",
+			expected: `gemma31b\-q6\:latest`,
+		},
+		{
+			name:     "slash in provider-prefixed model",
+			value:    "openai/gpt-4o",
+			expected: `openai\/gpt\-4o`,
+		},
+		{
+			name:     "equals plus and semicolon",
+			value:    "a=b+c;d",
+			expected: `a\=b\+c\;d`,
+		},
+		{
+			name:     "angle brackets",
+			value:    "a<b>c",
+			expected: `a\<b\>c`,
+		},
+		{
+			name:     "literal backslash",
+			value:    `a\b`,
+			expected: `a\\b`,
+		},
+		{
+			name:     "space and punctuation",
+			value:    "my model.v1,x",
+			expected: `my\ model\.v1\,x`,
+		},
+		{
+			name:     "previously covered specials still escaped",
+			value:    `(){}[]*?|&!@#$%^~` + "`" + `"'`,
+			expected: `\(\)\{\}\[\]\*\?\|\&\!\@\#\$\%\^\~\` + "`" + `\"\'`,
+		},
+		{
+			name:     "non-ascii unchanged",
+			value:    "модель-テスト",
+			expected: `модель\-テスト`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, escapeSearchValue(tt.value))
+		})
+	}
+}
+
+func TestBuildRedisQueryCondition_TagValueEscaping(t *testing.T) {
+	fieldTypes := map[string]VectorStorePropertyType{
+		"model": VectorStorePropertyTypeString,
+	}
+
+	tests := []struct {
+		name     string
+		query    Query
+		expected string
+	}{
+		{
+			name: "equal with colon in model tag",
+			query: Query{
+				Field:    "model",
+				Operator: QueryOperatorEqual,
+				Value:    "gemma31b-q6:latest",
+			},
+			expected: `@model:{gemma31b\-q6\:latest}`,
+		},
+		{
+			name: "not equal with slash-prefixed model",
+			query: Query{
+				Field:    "model",
+				Operator: QueryOperatorNotEqual,
+				Value:    "openai/gpt-4o",
+			},
+			expected: `-@model:{openai\/gpt\-4o}`,
+		},
+		{
+			name: "contains any escapes each value",
+			query: Query{
+				Field:    "model",
+				Operator: QueryOperatorContainsAny,
+				Value:    []interface{}{"a:b", "c/d"},
+			},
+			expected: `(@model:{a\:b} | @model:{c\/d})`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, buildRedisQueryCondition(tt.query, fieldTypes))
+		})
+	}
+}
+
 func ptr(v string) *string {
 	return bifrost.Ptr(v)
 }
@@ -1377,6 +1486,41 @@ func TestRedisStore_VectorSearch(t *testing.T) {
 		require.NoError(t, err)
 		// Should return fewer results due to high threshold
 		t.Logf("High threshold search returned %d results", len(results))
+	})
+
+	t.Run("Vector search with special characters in tag filter", func(t *testing.T) {
+		// Regression test for #5333: TAG values containing ":" (e.g. Ollama model
+		// names like "gemma31b-q6:latest") or "/" (provider-prefixed models like
+		// "openai/gpt-4o") must be escaped or FT.SEARCH fails with a syntax error
+		// or silently returns no results.
+		specialDocs := []struct {
+			key       string
+			embedding []float32
+			model     string
+		}{
+			{generateUUID(), generateTestEmbedding(RedisTestDimension), "gemma31b-q6:latest"},
+			{generateUUID(), generateTestEmbedding(RedisTestDimension), "openai/gpt-4o"},
+		}
+
+		for _, doc := range specialDocs {
+			err := setup.Store.Add(setup.ctx, TestNamespace, doc.key, doc.embedding, map[string]interface{}{
+				"type":  "tech",
+				"model": doc.model,
+			})
+			require.NoError(t, err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		for _, doc := range specialDocs {
+			queries := []Query{
+				{Field: "model", Operator: QueryOperatorEqual, Value: doc.model},
+			}
+			results, err := setup.Store.GetNearest(setup.ctx, TestNamespace, doc.embedding, queries, []string{"type", "model"}, 0.1, 10)
+			require.NoError(t, err, "search must not fail for model %q", doc.model)
+			require.Len(t, results, 1, "expected exactly the doc tagged %q", doc.model)
+			assert.Equal(t, doc.model, results[0].Properties["model"])
+		}
 	})
 }
 

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -880,6 +880,11 @@ func TestEscapeSearchValue(t *testing.T) {
 			value:    "модель-テスト",
 			expected: `модель\-テスト`,
 		},
+		{
+			name:     "malformed utf-8 bytes preserved",
+			value:    "a\xffb",
+			expected: "a\xffb",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Semantic cache lookups silently never hit when a TAG filter value contains `:` or `/`, which is most  Ollama-style (`gemma31b-q6:latest`) and provider-prefixed (`openai/gpt-4o`) model names. Root cause: `escapeSearchValue()` in `framework/vectorstore/redis.go` escaped a hand-written list of 22 special characters and missed `:` `;` `/` `<` `>` `=` `+` and `\`.


Two failure modes, confirmed against a live redis-stack (RediSearch, DIALECT 2):

- `:` or `;` unescaped: FT.SEARCH fails with `Syntax error`, plugin logs "semantic search skipped", every request stored fresh.
- `/` `=` `+` `<` `>` `\` unescaped: query parses but matches nothing. No error, no log. This one is worse than the syntax error because it is fully silent.

## Changes

- Rewrote `escapeSearchValue()` from a character blocklist to an allowlist: escape every ASCII character that is not alphanumeric or underscore, pass non-ASCII through. An enumerated list is how this bug happened; the allowlist cannot regress by omission.
- Added `TestEscapeSearchValue` and `TestBuildRedisQueryCondition_TagValueEscaping` unit tests.
- Added a live regression subtest to `TestRedisStore_VectorSearch` that stores docs tagged `gemma31b-q6:latest` and `openai/gpt-4o` and filters on them through `GetNearest` (the exact semantic cache path). Without the fix it fails with the exact error from the issue; with the fix it passes. Added `model` to the test namespace schema for this.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test
```sh
# unit tests, no services needed
cd framework
go test ./vectorstore/ -run 'TestEscapeSearchValue|TestBuildRedisQueryCondition'

# live regression test against redis-stack
docker run -d --rm --name redis-5333 -p 6399:6379 redis/redis-stack-server:latest
REDIS_ADDR=localhost:6399 go test ./vectorstore/ -run 'TestRedisStore_VectorSearch' -v
docker stop redis-5333
```

Manual repro of the underlying issue:

FT.CREATE testidx PREFIX 1 td: SCHEMA model TAG
HSET td:1 model "gemma31b-q6:latest"
FT.SEARCH testidx "@model:{gemma31b\-q6:latest}" DIALECT 2    # old escaping -> Syntax error
FT.SEARCH testidx "@model:{gemma31b\-q6\:latest}" DIALECT 2   # new escaping -> 1 hit

## Breaking changes

- [x] No

Stored data is unaffected; only query-side escaping changes. Escaping alphanumerics is never needed, so previously working values behave identically (covered by a test asserting all 22 previously escaped characters still escape the same way).


## Related issues
Closes #5333 

## Security considerations
Reduces query-injection surface: metadata values can no longer alter RediSearch query structure.

Two notes:

- `TestRedisConfig_Validation` and the two TLS tests fail locally with or without this change (they need TLS Redis on 6379/6380), so don't let that scare you after `go test ./vectorstore/`, it's pre-existing.
- Full `go test ./...` in framework will try to hit Weaviate/Qdrant/Pinecone too; the targeted commands above are the meaningful ones for this PR.


## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


