### PR TITLE
[Fix]: Gemini provider - preserve non-whitelisted imageConfig aspect ratios on the native GenAI path

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4620,3 +4620,96 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 		assert.Empty(t, bifrostResp.Choices[0].ChatStreamResponseChoice.Delta.Annotations)
 	})
 }
+
+// TestNonWhitelistedAspectRatioRoundtrip verifies that aspect ratios outside the
+// size-conversion whitelist (e.g. 2:3, 21:9, 8:1) survive the native GenAI
+// ingress→egress round trip verbatim instead of degrading to 1:1 (issue #5324).
+func TestNonWhitelistedAspectRatioRoundtrip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	pngPixel, _ := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+	)
+
+	ratios := []string{"2:3", "3:2", "4:5", "5:4", "21:9", "4:1", "8:1", "1:8"}
+
+	for _, ratio := range ratios {
+		t.Run("generation_"+ratio, func(t *testing.T) {
+			inReq := &gemini.GeminiGenerationRequest{
+				Model: "gemini-3.1-flash-image-preview",
+				GenerationConfig: gemini.GenerationConfig{
+					ResponseModalities: []gemini.Modality{gemini.ModalityImage},
+					ImageConfig:        &gemini.GeminiImageConfig{AspectRatio: ratio},
+				},
+				Contents: []gemini.Content{{
+					Role:  "user",
+					Parts: []*gemini.Part{{Text: "wide banner"}},
+				}},
+			}
+
+			bifrostReq := inReq.ToBifrostImageGenerationRequest(ctx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params.AspectRatio, "aspect ratio must be carried verbatim")
+			assert.Equal(t, ratio, *bifrostReq.Params.AspectRatio)
+
+			outReq := gemini.ToGeminiImageGenerationRequest(bifrostReq)
+			require.NotNil(t, outReq)
+			require.NotNil(t, outReq.GenerationConfig.ImageConfig)
+			assert.Equal(t, ratio, outReq.GenerationConfig.ImageConfig.AspectRatio,
+				"aspect ratio must not degrade to 1:1 on the generation path")
+		})
+
+		t.Run("edit_"+ratio, func(t *testing.T) {
+			inReq := &gemini.GeminiGenerationRequest{
+				Model: "gemini-3.1-flash-image-preview",
+				GenerationConfig: gemini.GenerationConfig{
+					ResponseModalities: []gemini.Modality{gemini.ModalityImage},
+					ImageConfig:        &gemini.GeminiImageConfig{AspectRatio: ratio},
+				},
+				Contents: []gemini.Content{{
+					Role: "user",
+					Parts: []*gemini.Part{
+						{InlineData: &gemini.Blob{MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(pngPixel)}},
+						{Text: "extend this creative into a wide banner"},
+					},
+				}},
+			}
+
+			bifrostReq := inReq.ToBifrostImageEditRequest(ctx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params.AspectRatio, "aspect ratio must be carried verbatim on edit path")
+			assert.Equal(t, ratio, *bifrostReq.Params.AspectRatio)
+
+			outReq := gemini.ToGeminiImageEditRequest(bifrostReq)
+			require.NotNil(t, outReq)
+			require.NotNil(t, outReq.GenerationConfig.ImageConfig)
+			assert.Equal(t, ratio, outReq.GenerationConfig.ImageConfig.AspectRatio,
+				"aspect ratio must not degrade to 1:1 on the edit path")
+		})
+	}
+}
+
+// TestImagenImageEditAspectRatio verifies the explicit aspect_ratio on edit params
+// takes precedence over the size-derived value on the Imagen :predict edit path.
+func TestImagenImageEditAspectRatio(t *testing.T) {
+	pngPixel, _ := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+	)
+	bifrostReq := &schemas.BifrostImageEditRequest{
+		Model: "imagen-3.0-capability-001",
+		Input: &schemas.ImageEditInput{
+			Prompt: "extend the banner",
+			Images: []schemas.ImageInput{{Image: pngPixel}},
+		},
+		Params: &schemas.ImageEditParameters{
+			Size:        schemas.Ptr("1024x1024"),
+			AspectRatio: schemas.Ptr("21:9"),
+		},
+	}
+
+	imagenReq := gemini.ToImagenImageEditRequest(bifrostReq)
+	require.NotNil(t, imagenReq)
+	require.NotNil(t, imagenReq.Parameters.AspectRatio)
+	assert.Equal(t, "21:9", *imagenReq.Parameters.AspectRatio,
+		"explicit aspect_ratio must override size-derived ratio on edit path")
+}

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -102,6 +102,11 @@ func (request *GeminiGenerationRequest) ToBifrostImageGenerationRequest(ctx *sch
 				bifrostReq.Params.Size = &size
 			}
 		}
+		// Carry the caller's aspect ratio verbatim — the size round trip above only
+		// preserves a small whitelist of ratios and degrades the rest to square.
+		if ratio := strings.TrimSpace(ic.AspectRatio); ratio != "" {
+			bifrostReq.Params.AspectRatio = &ratio
+		}
 	}
 
 	return bifrostReq
@@ -305,6 +310,11 @@ func (request *GeminiGenerationRequest) ToBifrostImageEditRequest(ctx *schemas.B
 			if size != "" {
 				bifrostReq.Params.Size = &size
 			}
+		}
+		// Carry the caller's aspect ratio verbatim — the size round trip above only
+		// preserves a small whitelist of ratios and degrades the rest to square.
+		if ratio := strings.TrimSpace(ic.AspectRatio); ratio != "" {
+			bifrostReq.Params.AspectRatio = &ratio
 		}
 	}
 
@@ -777,15 +787,18 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	if bifrostReq.Params != nil {
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 
-		// Derive aspect ratio + resolution from size (edit params carry no typed aspect_ratio).
+		// Prefer explicit aspect_ratio; fall back to deriving aspect ratio + resolution from size.
+		imageConfig := &GeminiImageConfig{}
 		if bifrostReq.Params.Size != nil && strings.ToLower(*bifrostReq.Params.Size) != "auto" {
 			aspectRatio, imageSize := utils.ConvertSizeToAspectRatioAndResolution(*bifrostReq.Params.Size)
-			if aspectRatio != "" || imageSize != "" {
-				geminiReq.GenerationConfig.ImageConfig = &GeminiImageConfig{
-					ImageSize:   imageSize,
-					AspectRatio: aspectRatio,
-				}
-			}
+			imageConfig.AspectRatio = aspectRatio
+			imageConfig.ImageSize = imageSize
+		}
+		if bifrostReq.Params.AspectRatio != nil && *bifrostReq.Params.AspectRatio != "" {
+			imageConfig.AspectRatio = *bifrostReq.Params.AspectRatio
+		}
+		if imageConfig.AspectRatio != "" || imageConfig.ImageSize != "" {
+			geminiReq.GenerationConfig.ImageConfig = imageConfig
 		}
 
 		// Handle extra parameters
@@ -1070,6 +1083,10 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 			if aspectRatio != "" {
 				req.Parameters.AspectRatio = &aspectRatio
 			}
+		}
+		// Prefer explicit aspect_ratio over the size-derived value.
+		if bifrostReq.Params.AspectRatio != nil && *bifrostReq.Params.AspectRatio != "" {
+			req.Parameters.AspectRatio = bifrostReq.Params.AspectRatio
 		}
 
 		if bifrostReq.Params.OutputFormat != nil {

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -105,7 +105,7 @@ func (request *GeminiGenerationRequest) ToBifrostImageGenerationRequest(ctx *sch
 		// Carry the caller's aspect ratio verbatim — the size round trip above only
 		// preserves a small whitelist of ratios and degrades the rest to square.
 		if ratio := strings.TrimSpace(ic.AspectRatio); ratio != "" {
-			bifrostReq.Params.AspectRatio = &ratio
+			bifrostReq.Params.AspectRatio = new(ratio)
 		}
 	}
 
@@ -314,7 +314,7 @@ func (request *GeminiGenerationRequest) ToBifrostImageEditRequest(ctx *schemas.B
 		// Carry the caller's aspect ratio verbatim — the size round trip above only
 		// preserves a small whitelist of ratios and degrades the rest to square.
 		if ratio := strings.TrimSpace(ic.AspectRatio); ratio != "" {
-			bifrostReq.Params.AspectRatio = &ratio
+			bifrostReq.Params.AspectRatio = new(ratio)
 		}
 	}
 

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -123,7 +123,7 @@ func (r *BifrostImageGenerationResponse) BackfillParams(req *BifrostRequest) {
 
 // getNumInputImagesSizeQualityAndAspectRatioFromRequest extracts request params for cost
 // calculation and logging. Quality is only returned when it is one of low, medium, high, auto.
-// AspectRatio is only carried by image generation requests.
+// AspectRatio is carried by image generation and image edit requests.
 func getNumInputImagesSizeQualityAndAspectRatioFromRequest(req *BifrostRequest) (numInputImages int, size string, quality string, aspectRatio string) {
 	if req == nil {
 		return 0, "", "", ""
@@ -155,6 +155,9 @@ func getNumInputImagesSizeQualityAndAspectRatioFromRequest(req *BifrostRequest) 
 			}
 			if p.Quality != nil {
 				quality = normalizeImageQuality(*p.Quality)
+			}
+			if p.AspectRatio != nil {
+				aspectRatio = *p.AspectRatio
 			}
 		}
 	case req.ImageVariationRequest != nil:
@@ -327,6 +330,7 @@ type ImageEditParameters struct {
 	NegativePrompt    *string                `json:"negative_prompt,omitempty"`     // negative prompt for image editing
 	Seed              *int                   `json:"seed,omitempty"`                // seed for image editing
 	NumInferenceSteps *int                   `json:"num_inference_steps,omitempty"` // number of inference steps
+	AspectRatio       *string                `json:"aspect_ratio,omitempty"`        // aspect ratio of the image
 	ExtraParams       map[string]interface{} `json:"-"`
 }
 

--- a/transports/bifrost-http/handlers/imageedit_prepare_test.go
+++ b/transports/bifrost-http/handlers/imageedit_prepare_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"bytes"
+	"mime/multipart"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+// buildImageEditForm builds a minimal multipart image-edit request body.
+func buildImageEditForm(t *testing.T, fields map[string]string) (*fasthttp.RequestCtx, error) {
+	t.Helper()
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	for key, value := range fields {
+		if err := w.WriteField(key, value); err != nil {
+			return nil, err
+		}
+	}
+	fw, err := w.CreateFormFile("image", "input.png")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fw.Write([]byte{0x89, 0x50, 0x4e, 0x47}); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.SetContentType(w.FormDataContentType())
+	ctx.Request.SetBody(body.Bytes())
+	return ctx, nil
+}
+
+// TestPrepareImageEditRequest_AspectRatio verifies the multipart image-edit
+// parser maps the aspect_ratio form field into the typed parameter instead of
+// letting it fall through to ExtraParams (issue #5324 follow-up).
+func TestPrepareImageEditRequest_AspectRatio(t *testing.T) {
+	ctx, err := buildImageEditForm(t, map[string]string{
+		"model":        "gemini/gemini-3.1-flash-image",
+		"prompt":       "extend into a wide banner",
+		"aspect_ratio": "21:9",
+	})
+	if err != nil {
+		t.Fatalf("build form: %v", err)
+	}
+
+	_, bifrostReq, err := prepareImageEditRequest(ctx, nil)
+	if err != nil {
+		t.Fatalf("prepareImageEditRequest: %v", err)
+	}
+	if bifrostReq.Params == nil || bifrostReq.Params.AspectRatio == nil {
+		t.Fatal("aspect_ratio form field not mapped to typed parameter")
+	}
+	if *bifrostReq.Params.AspectRatio != "21:9" {
+		t.Errorf("aspect_ratio: got %q, want %q", *bifrostReq.Params.AspectRatio, "21:9")
+	}
+	if _, ok := bifrostReq.Params.ExtraParams["aspect_ratio"]; ok {
+		t.Error("aspect_ratio leaked into ExtraParams despite being a known field")
+	}
+}
+
+// TestPrepareImageEditRequest_NoAspectRatio verifies the field stays nil when absent.
+func TestPrepareImageEditRequest_NoAspectRatio(t *testing.T) {
+	ctx, err := buildImageEditForm(t, map[string]string{
+		"model":  "gemini/gemini-3.1-flash-image",
+		"prompt": "extend into a wide banner",
+	})
+	if err != nil {
+		t.Fatalf("build form: %v", err)
+	}
+
+	_, bifrostReq, err := prepareImageEditRequest(ctx, nil)
+	if err != nil {
+		t.Fatalf("prepareImageEditRequest: %v", err)
+	}
+	if bifrostReq.Params != nil && bifrostReq.Params.AspectRatio != nil {
+		t.Errorf("aspect_ratio should be nil when not sent, got %q", *bifrostReq.Params.AspectRatio)
+	}
+}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -291,6 +291,7 @@ var imageEditParamsKnownFields = map[string]bool{
 	"negative_prompt":     true,
 	"seed":                true,
 	"num_inference_steps": true,
+	"aspect_ratio":        true,
 	"stream":              true,
 }
 
@@ -2363,6 +2364,9 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (*Ima
 	}
 	if sizeValues := form.Value["size"]; len(sizeValues) > 0 && sizeValues[0] != "" {
 		req.ImageEditParameters.Size = &sizeValues[0]
+	}
+	if aspectRatioValues := form.Value["aspect_ratio"]; len(aspectRatioValues) > 0 && aspectRatioValues[0] != "" {
+		req.ImageEditParameters.AspectRatio = &aspectRatioValues[0]
 	}
 	if qualityValues := form.Value["quality"]; len(qualityValues) > 0 && qualityValues[0] != "" {
 		req.ImageEditParameters.Quality = &qualityValues[0]


### PR DESCRIPTION
## Summary
Native GenAI requests (`/genai` → `generateContent`) with `imageConfig.aspectRatio` outside a 5-value whitelist (`1:1`, `3:4`, `4:3`, `9:16`, `16:9`) silently degraded to `1:1`: ingress collapsed the ratio into a `WxH` size string (`convertImagenFormatToSize`, unknown → `1024x1024`), and egress re-derived the ratio from that size (`ConvertSizeToAspectRatioAndResolution`, `1024x1024` → `1:1`). Ratios Gemini image models natively support (`2:3`, `3:2`, `4:5`, `5:4`, `21:9`, `4:1`, `8:1`, `1:4`, `1:8`) all produced square images with no error.

#4798 added a typed `aspect_ratio` param that egress prefers, but only on image generation params, and the native ingress never populated it, so the native path never benefited.

Verified with a round-trip harness over the real converters: before, `2:3 / 21:9 / 8:1 / 5:4` → `1:1` on both generation and edit paths; after, every ratio survives verbatim, and the 5 whitelisted ratios behave identically to before.

## Changes
- Native ingress (`ToBifrostImageGenerationRequest`, `ToBifrostImageEditRequest`) also populates `Params.AspectRatio` verbatim from `imageConfig.aspectRatio` — no whitelist. The existing size derivation is untouched (cost calculation and size-based providers keep working).
- Added `AspectRatio *string` to `ImageEditParameters` (generation already had it). Additive, non-breaking.
- Both edit egress paths (`ToGeminiImageEditRequest`, `ToImagenImageEditRequest`) honor explicit `aspect_ratio` with precedence over the size-derived value, mirroring the generation path.
- Cost/logging extraction (`getNumInputImagesSizeQualityAndAspectRatioFromRequest`) reads the new edit-param field.
- Unknown-but-invalid ratios now reach Gemini and fail visibly there instead of being silently rewritten to `1:1`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/gemini/ -run 'TestNonWhitelistedAspectRatioRoundtrip|TestImagenImageEditAspectRatio' -v
go test ./providers/gemini/ ./schemas/
```

## Breaking changes
- [x] No

Whitelisted ratios and all size-based flows behave exactly as before; the typed field only adds information.

## Related issues
Closes #5324 

## Security considerations
None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


