### PR TITLE
[fix]: Anthropic provider - stop double-counting cache-read tokens in streaming usage

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: stop double-counting cache-read tokens in Anthropic streaming usage accumulator (thanks [@is911](https://github.com/is911)!)
 - feat: add Sarvam AI provider with chat, text-to-speech, and speech-to-text support (thanks [@Purvi09](https://github.com/Purvi09)!)
 - feat: add ElevenLabs sound effects (text-to-sound) support (thanks [@SecretSun](https://github.com/SecretSun)!)
 - feat: add `ProjectID` to Bedrock and Bedrock Mantle key configs with per-alias overrides for Bedrock, Bedrock Mantle, and Vertex

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -608,6 +608,13 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 // totals only after the full stream, so the streaming accumulator must apply the
 // same fold before billing - including on a mid-stream cancel/timeout. The += is
 // not idempotent; callers guard with a flag to apply it exactly once.
+//
+// NOTE: this fold is ONLY correct when usage.PromptTokens still holds the
+// PRELIMINARY message_start.input_tokens (the full prompt before the cache
+// breakdown is known). When applyStreamUsageEvent has already processed a
+// message_delta event, the cache breakdown is already folded into PromptTokens
+// and the caller MUST skip this fold (else it double-counts). The streaming
+// chat handler tracks this via the deltaProcessed flag.
 func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
 	if usage == nil || usage.PromptTokensDetails == nil {
 		return
@@ -615,6 +622,138 @@ func normalizeCachedUsage(usage *schemas.BifrostLLMUsage) {
 	cached := usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
 	usage.PromptTokens += cached
 	usage.TotalTokens += cached
+}
+
+// applyStreamUsageEvent folds a single Anthropic stream event's usage snapshot
+// into the accumulating Bifrost usage and returns whether the event was a
+// message_delta whose usage was applied as the authoritative final snapshot.
+//
+// Per the Anthropic Messages API streaming spec, a stream emits two usage
+// snapshots:
+//   - message_start: preliminary usage nested under message.usage; the full
+//     prompt as input_tokens, cache fields typically still zero because the
+//     cache breakdown is not yet computed.
+//   - message_delta: authoritative post-cache breakdown; input_tokens is the
+//     UNCACHED tail, and cache_creation_input_tokens + cache_read_input_tokens
+//     decompose the cached portion of the same total.
+//
+// message_delta.usage OVERWRITES message_start.usage wholesale (it does NOT
+// merge-with or add-to). The authoritative prompt total is
+//
+//	delta.input_tokens + delta.cache_creation_input_tokens + delta.cache_read_input_tokens.
+//
+// All input-side fields on both BifrostLLMUsage and AnthropicUsage are
+// non-pointer Go int, so JSON deserialization cannot distinguish "field absent"
+// from "field present-but-zero" — this is why the message_delta branch uses an
+// EVENT-LEVEL unconditional overwrite rather than per-field `if != 0` checks
+// (which would wrongly skip a legitimately-zero input_tokens on an
+// all-cache-hit delta).
+//
+// startSnapshot is the message_start event's usage, captured by the caller; it
+// backs the impossible-zero guard. A conformant Anthropic prompt always has
+// PromptTokens >= 1 (input_tokens >= 1 for any non-empty request), so
+// PromptTokens == 0 after the overwrite is a DEFINITIVE signal of a
+// non-conformant Anthropic-compatible provider that emitted a partial-usage
+// message_delta (input_tokens=0 with cache fields omitted, deserializing to
+// zero for non-pointer Go int). The guard restores the start-side snapshot as
+// the best available approximation. The guard is DEAD CODE for spec-conformant
+// providers (zero behavior change).
+//
+// The caller MUST skip the end-of-stream normalizeCachedUsage fold when this
+// returns true, because the cache breakdown is already folded into
+// PromptTokens by the overwrite (folding again would double-count).
+func applyStreamUsageEvent(
+	usage *schemas.BifrostLLMUsage,
+	eventType AnthropicStreamEventType,
+	usageToProcess *AnthropicUsage,
+	startSnapshot *AnthropicUsage,
+) bool {
+	if usage == nil || usageToProcess == nil {
+		return false
+	}
+
+	if eventType == AnthropicStreamEventTypeMessageDelta {
+		// Authoritative final snapshot: overwrite input-side fields wholesale.
+		if usage.PromptTokensDetails == nil {
+			usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+		usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+		if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+			if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+				usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+				usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+			}
+			if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+				usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+			}
+		}
+		// Reconstruct the authoritative prompt total from delta's three
+		// components (uncached tail + cache creation + cache read).
+		usage.PromptTokens = usageToProcess.InputTokens + usageToProcess.CacheReadInputTokens + usageToProcess.CacheCreationInputTokens
+		// OutputTokens on message_delta is the cumulative output count.
+		if usageToProcess.OutputTokens > usage.CompletionTokens {
+			usage.CompletionTokens = usageToProcess.OutputTokens
+		}
+		// Impossible-zero guard: restore start-side when a non-conformant
+		// provider emits a partial-usage delta (input=0 + cache fields omitted).
+		if usage.PromptTokens == 0 && startSnapshot != nil && startSnapshot.InputTokens > 0 {
+			usage.PromptTokens = startSnapshot.InputTokens
+			usage.PromptTokensDetails.CachedReadTokens = startSnapshot.CacheReadInputTokens
+			usage.PromptTokensDetails.CachedWriteTokens = startSnapshot.CacheCreationInputTokens
+		}
+		calculatedTotal := usage.PromptTokens + usage.CompletionTokens
+		if calculatedTotal > usage.TotalTokens {
+			usage.TotalTokens = calculatedTotal
+		}
+		return true
+	}
+
+	// message_start (or any non-delta event carrying usage): max-keep capture.
+	// This serves as the fallback when message_delta never arrives (early
+	// stream termination); normalizeCachedUsage folds cache into prompt at
+	// stream end for that case via the normalizeUsage closure.
+	if usageToProcess.InputTokens > usage.PromptTokens {
+		usage.PromptTokens = usageToProcess.InputTokens
+	}
+	if usageToProcess.OutputTokens > usage.CompletionTokens {
+		usage.CompletionTokens = usageToProcess.OutputTokens
+	}
+	calculatedTotal := usage.PromptTokens + usage.CompletionTokens
+	if calculatedTotal > usage.TotalTokens {
+		usage.TotalTokens = calculatedTotal
+	}
+	// Handle cached tokens if present
+	if usageToProcess.CacheReadInputTokens > 0 {
+		if usage.PromptTokensDetails == nil {
+			usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
+			usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
+		}
+	}
+	if usageToProcess.CacheCreationInputTokens > 0 {
+		if usage.PromptTokensDetails == nil {
+			usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+		}
+		if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
+			usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+		}
+		if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+			if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+				usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+			}
+			if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+				usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+			}
+			if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+				usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+			}
+		}
+	}
+	return false
 }
 
 func accumulateAnthropicResponsesUsage(usage *schemas.ResponsesResponseUsage, billedUsage *schemas.BifrostLLMUsage, usageToProcess *AnthropicUsage) {
@@ -883,6 +1022,16 @@ func HandleAnthropicChatCompletionStreaming(
 		var finishReason *string
 
 		usage := &schemas.BifrostLLMUsage{}
+		// startSnapshot captures the message_start event's preliminary usage; it
+		// backs the impossible-zero guard in applyStreamUsageEvent (restoring the
+		// start-side when a non-conformant provider emits a partial-usage delta)
+		// and the delta-absent fallback when the stream ends before message_delta.
+		var startSnapshot *AnthropicUsage
+		// deltaProcessed is set true once applyStreamUsageEvent processes a
+		// message_delta event (the authoritative final snapshot). When true the
+		// normalizeUsage closure skips the normalizeCachedUsage fold because the
+		// cache breakdown is already folded into PromptTokens by the overwrite.
+		deltaProcessed := false
 		// Served billing modifiers (top-level response fields, not usage) captured
 		// across events and set on the final chunk: fast mode and data residency.
 		var servedSpeed *string
@@ -896,14 +1045,18 @@ func HandleAnthropicChatCompletionStreaming(
 		// path calls normalizeUsage() after the loop; on a mid-stream cancel/timeout
 		// the deferred call below runs first (LIFO, registered after the cancellation
 		// handler at the top of the goroutine) so HandleStreamCancellation/Timeout
-		// bills the normalized totals.
+		// bills the normalized totals. The fold is SKIPPED when a message_delta
+		// event already reconstructed PromptTokens from the authoritative cache
+		// breakdown (deltaProcessed) — folding again would double-count.
 		usageNormalized := false
 		normalizeUsage := func() {
 			if usageNormalized {
 				return
 			}
 			usageNormalized = true
-			normalizeCachedUsage(usage)
+			if !deltaProcessed {
+				normalizeCachedUsage(usage)
+			}
 		}
 		defer func() {
 			if ctx.Err() != nil {
@@ -961,6 +1114,12 @@ func HandleAnthropicChatCompletionStreaming(
 			} else if event.Message != nil && event.Message.Usage != nil {
 				usageToProcess = event.Message.Usage
 			}
+			// Capture the message_start usage snapshot; it backs the
+			// impossible-zero guard in applyStreamUsageEvent for non-conformant
+			// providers and the delta-absent fallback path.
+			if event.Type == AnthropicStreamEventTypeMessageStart && usageToProcess != nil {
+				startSnapshot = usageToProcess
+			}
 			if usageToProcess != nil {
 				// Web search request count → billed as search queries (server tool use).
 				if usageToProcess.ServerToolUse != nil && usageToProcess.ServerToolUse.WebSearchRequests > 0 {
@@ -982,47 +1141,14 @@ func HandleAnthropicChatCompletionStreaming(
 					servedInferenceGeo = usageToProcess.InferenceGeo
 					usage.InferenceGeo = usageToProcess.InferenceGeo
 				}
-				// Collect usage information and send at the end of the stream
-				// Here in some cases usage comes before final message
-				// So we need to check if the response.Usage is nil and then if usage != nil
-				// then add up all tokens
-				if usageToProcess.InputTokens > usage.PromptTokens {
-					usage.PromptTokens = usageToProcess.InputTokens
-				}
-				if usageToProcess.OutputTokens > usage.CompletionTokens {
-					usage.CompletionTokens = usageToProcess.OutputTokens
-				}
-				calculatedTotal := usage.PromptTokens + usage.CompletionTokens
-				if calculatedTotal > usage.TotalTokens {
-					usage.TotalTokens = calculatedTotal
-				}
-				// Handle cached tokens if present
-				if usageToProcess.CacheReadInputTokens > 0 {
-					if usage.PromptTokensDetails == nil {
-						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-					}
-					if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedReadTokens {
-						usage.PromptTokensDetails.CachedReadTokens = usageToProcess.CacheReadInputTokens
-					}
-				}
-				if usageToProcess.CacheCreationInputTokens > 0 {
-					if usage.PromptTokensDetails == nil {
-						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
-					}
-					if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
-						usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
-					}
-					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
-						if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
-							usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
-						}
-						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
-							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
-						}
-						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
-							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
-						}
-					}
+				// Fold the event's usage snapshot into the accumulator. On
+				// message_delta this overwrites message_start wholesale and
+				// reconstructs PromptTokens from the authoritative cache
+				// breakdown (delta.input + cache_creation + cache_read); on
+				// message_start (or any other event) it max-keeps the
+				// preliminary values as the delta-absent fallback.
+				if applyStreamUsageEvent(usage, event.Type, usageToProcess, startSnapshot) {
+					deltaProcessed = true
 				}
 			}
 			if event.Message != nil {

--- a/core/providers/anthropic/streamcacheusage_test.go
+++ b/core/providers/anthropic/streamcacheusage_test.go
@@ -1,0 +1,179 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// streamUsageEvent pairs an Anthropic stream event type with its usage snapshot,
+// for the synthetic-fixture tests below.
+type streamUsageEvent struct {
+	eventType AnthropicStreamEventType
+	usage     *AnthropicUsage
+}
+
+// accumulateStreamUsage mirrors the usage-accumulation pipeline inside
+// HandleAnthropicChatCompletionStreaming: it feeds a synthetic event sequence
+// through applyStreamUsageEvent (capturing message_start as the start-side
+// snapshot and tracking whether message_delta overwrote it) and applies the
+// end-of-stream normalizeCachedUsage fold only when no message_delta arrived.
+// This is the smallest extraction that lets the fixture tests exercise the
+// exact production code path without a live SSE harness.
+func accumulateStreamUsage(events []streamUsageEvent) *schemas.BifrostLLMUsage {
+	usage := &schemas.BifrostLLMUsage{}
+	var startSnapshot *AnthropicUsage
+	deltaProcessed := false
+	for _, ev := range events {
+		if ev.eventType == AnthropicStreamEventTypeMessageStart && ev.usage != nil {
+			startSnapshot = ev.usage
+		}
+		if applyStreamUsageEvent(usage, ev.eventType, ev.usage, startSnapshot) {
+			deltaProcessed = true
+		}
+	}
+	if !deltaProcessed {
+		normalizeCachedUsage(usage)
+	}
+	return usage
+}
+
+// TestAnthropicStreamCacheReadNotDoubleCounted reproduces the operator's turn-2
+// production evidence: an Anthropic-protocol stream where the provider emits
+// cache-read tokens only in the final message_delta (not at message_start).
+//
+// Per the Anthropic Messages API spec, message_delta.usage is the AUTHORITATIVE
+// post-cache breakdown: input_tokens is the uncached tail, and
+// cache_read_input_tokens decomposes the cached portion of the same total.
+// message_delta.usage OVERWRITES message_start.usage wholesale — it does NOT
+// merge-with or add-to. The authoritative prompt total is therefore
+// delta.input_tokens + delta.cache_creation_input_tokens + delta.cache_read_input_tokens
+// = 308 + 0 + 20224 = 20532.
+//
+// The prior accumulator used a max-keep guard on input_tokens for BOTH events,
+// which retained message_start.input_tokens (the full 20532 prompt) and then
+// folded cache_read on top at stream end via normalizeCachedUsage, producing
+// 20532 + 20224 = 40756 — a ~2x double-count of the cached portion. This test
+// asserts the post-fix correct value (20532); pre-fix it failed at 40756.
+func TestAnthropicStreamCacheReadNotDoubleCounted(t *testing.T) {
+	usage := accumulateStreamUsage([]streamUsageEvent{
+		{
+			eventType: AnthropicStreamEventTypeMessageStart,
+			usage: &AnthropicUsage{
+				InputTokens:              20532,
+				CacheReadInputTokens:     0,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             1,
+			},
+		},
+		{
+			eventType: AnthropicStreamEventTypeMessageDelta,
+			usage: &AnthropicUsage{
+				InputTokens:              308,
+				CacheReadInputTokens:     20224,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             300,
+			},
+		},
+	})
+
+	if usage.PromptTokens != 20532 {
+		t.Fatalf("prompt_tokens = %d, want 20532 (delta.input 308 + cache_read 20224 + cache_creation 0)", usage.PromptTokens)
+	}
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedReadTokens != 20224 {
+		got := 0
+		if usage.PromptTokensDetails != nil {
+			got = usage.PromptTokensDetails.CachedReadTokens
+		}
+		t.Fatalf("cached_read_tokens = %d, want 20224 (cache breakdown preserved, not dropped)", got)
+	}
+}
+
+// TestAnthropicStreamNoCacheReadUnchanged is the no-cache non-regression guard
+// (operator's turn-1 evidence): when no cache read occurs, the delta's
+// input_tokens equals the start's input_tokens, and the correct prompt_tokens
+// is unchanged at 20458. This test MUST pass both pre- and post-fix — it
+// proves the overwrite fix does not break the no-cache path.
+func TestAnthropicStreamNoCacheReadUnchanged(t *testing.T) {
+	usage := accumulateStreamUsage([]streamUsageEvent{
+		{
+			eventType: AnthropicStreamEventTypeMessageStart,
+			usage: &AnthropicUsage{
+				InputTokens:              20458,
+				CacheReadInputTokens:     0,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             1,
+			},
+		},
+		{
+			eventType: AnthropicStreamEventTypeMessageDelta,
+			usage: &AnthropicUsage{
+				InputTokens:              20458,
+				CacheReadInputTokens:     0,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             200,
+			},
+		},
+	})
+
+	if usage.PromptTokens != 20458 {
+		t.Fatalf("prompt_tokens = %d, want 20458 (no-cache path unchanged)", usage.PromptTokens)
+	}
+}
+
+// TestAnthropicStreamUsage_NonConformantDeltaOmitsCacheFields proves the
+// impossible-zero guard is load-bearing (plan consensus arch-002). A
+// non-conformant Anthropic-compatible provider may emit a partial-usage
+// message_delta with input_tokens=0 AND OMIT cache_creation_input_tokens +
+// cache_read_input_tokens entirely; for non-pointer Go int, omitted fields
+// deserialize to 0, so the unconditional event-level overwrite would
+// reconstruct PromptTokens = 0+0+0 = 0 — an impossible value for a real
+// Anthropic prompt (input_tokens >= 1 always). The guard detects this
+// (PromptTokens == 0 && startSnapshot.InputTokens > 0) and restores the
+// start-side snapshot as the best available approximation.
+//
+// This test synthesizes the non-conformant case: message_start carries the
+// full breakdown (input=20532, cache_read=20224), then message_delta is
+// degenerate (input=0, cache fields omitted). Pre-fix (overwrite without
+// guard) prompt_tokens = 0; post-fix (overwrite + guard) prompt_tokens = 20532.
+// The test asserts 20532, so it fails pre-fix at 0 — proving the guard fires.
+//
+// DISCRIMINATOR from TestAnthropicStreamCacheReadNotDoubleCounted: both expect
+// 20532 post-fix, but via different code paths — turn-2 reconstructs
+// 308+0+20224=20532 from the delta; turn-3 restores start-side 20532 via the
+// impossible-zero guard. The distinct test names disambiguate.
+func TestAnthropicStreamUsage_NonConformantDeltaOmitsCacheFields(t *testing.T) {
+	usage := accumulateStreamUsage([]streamUsageEvent{
+		{
+			eventType: AnthropicStreamEventTypeMessageStart,
+			usage: &AnthropicUsage{
+				InputTokens:              20532,
+				CacheReadInputTokens:     20224,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             1,
+			},
+		},
+		{
+			eventType: AnthropicStreamEventTypeMessageDelta,
+			usage: &AnthropicUsage{
+				// Non-conformant: input_tokens=0 AND cache fields omitted
+				// (deserialize to 0 for non-pointer Go int).
+				InputTokens:              0,
+				CacheReadInputTokens:     0,
+				CacheCreationInputTokens: 0,
+				OutputTokens:             300,
+			},
+		},
+	})
+
+	if usage.PromptTokens != 20532 {
+		t.Fatalf("prompt_tokens = %d, want 20532 (impossible-zero guard must restore start-side when non-conformant delta omits cache fields)", usage.PromptTokens)
+	}
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.CachedReadTokens != 20224 {
+		got := 0
+		if usage.PromptTokensDetails != nil {
+			got = usage.PromptTokensDetails.CachedReadTokens
+		}
+		t.Fatalf("cached_read_tokens = %d, want 20224 (guard must restore start-side cache breakdown)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a ~2× prompt-token inflation in Anthropic-protocol streaming usage accounting. The streaming accumulator in `HandleAnthropicChatCompletionStreaming` used a `max-keep` guard on `input_tokens` that did not branch on event type, so the authoritative `message_delta.input_tokens` (the uncached tail, smaller) was rejected in favor of the stale `message_start.input_tokens` (the full prompt). Then `normalizeCachedUsage` folded `cache_read_input_tokens` on top at stream end → `message_start.input_tokens + message_delta.cache_read_input_tokens` → double-count on every cached request from turn 2 onward.

Closes #5354.

**One-line root cause:** the accumulator merged the two Anthropic usage snapshots via `max-keep` instead of treating `message_delta.usage` as authoritative, then folded `cache_read` on top of an already-inclusive prompt total.

**Before / after formula:**
- BEFORE (buggy):  `prompt_tokens = message_start.input_tokens + message_delta.cache_read_input_tokens`
- AFTER (fixed):   `prompt_tokens = message_delta.input_tokens + message_delta.cache_creation_input_tokens + message_delta.cache_read_input_tokens`

### Evidence (3 consecutive turns, same session, provider: bifrost-kimi-anthropic / kimi-code/k3)

| Turn | `message_start` (input/cache_read) | `message_delta` (input/cache_read) | Correct total | Bifrost recorded (pre-fix) | Post-fix |
|------|-----------------------------------|-----------------------------------|---------------|----------------------------|----------|
| 1    | 20458 / 0                         | 20458 / 0                         | 20458         | 20458 ✓                    | 20458 ✓  |
| 2    | 20532 / 0                         | 308 / 20224                       | 20532         | 40756 ✗ (=20532+20224)     | 20532 ✓  |
| 3    | 20621 / 0                         | 141 / 20480                       | 20621         | 41101 ✗ (=20621+20480)     | 20621 ✓  |

Turn 1 was correct only because no cache read occurred (delta.cache_read == 0, so the buggy sum reduced to start.input). From turn 2 on, the buggy accumulator double-counted the cached portion. Reproduction signature: first request accurate, every subsequent request ~2×, growing by ~2× the real per-turn conversation growth.

## Changes

- **`core/providers/anthropic/anthropic.go`** — Extracted the event-loop usage-accumulation block into a new helper `applyStreamUsageEvent(usage, eventType, usageToProcess, startSnapshot)` that branches on the Anthropic stream event type:
  - On `message_delta`: event-level unconditional overwrite of `InputTokens`, `CacheCreationInputTokens`, `CacheReadInputTokens` from delta (NOT per-field `if != 0` checks — those would conflate absent-with-zero for non-pointer Go `int` fields); reconstruct `PromptTokens = delta.InputTokens + delta.CacheCreationInputTokens + delta.CacheReadInputTokens`.
  - On `message_start` (or any non-delta event carrying usage): preserves existing `max-keep` as the fallback for early-terminated streams.
  - Impossible-zero guard (`PromptTokens == 0 && startSnapshot.InputTokens > 0` → restore start-side values) for non-conformant Anthropic-compatible providers that emit a partial-usage `message_delta` (input=0 with cache fields omitted, deserializing to all-zeros). Dead code for spec-conformant providers — a real Anthropic prompt always has `PromptTokens >= 1`.
  - End-of-stream `normalizeCachedUsage` fold is skipped when `message_delta` was processed (`deltaProcessed` flag) — the cache breakdown is already folded into `PromptTokens` by the overwrite.
- **`core/providers/anthropic/streamcacheusage_test.go`** (new) — Three fixtures (see How to test).
- **`core/changelog.md`** — Entry at the top per contributing guide.

### Design decision / trade-off
The fix uses an **event-level overwrite** rather than per-field `if != 0` merge. Per-field checks would conflate absent-with-zero for non-pointer Go `int` fields (JSON deserialization of an omitted field produces 0), so a delta that legitimately omits `cache_read` would be indistinguishable from a delta that reports `cache_read=0`. The event-level overwrite (with the impossible-zero guard as a safety net) is the only spec-correct option for the non-pointer field shape.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version    # 1.22+ (tested on 1.26)
go test ./core/providers/anthropic/... -run TestAnthropicStream -v
go test ./core/providers/anthropic/...
go vet ./...
go build ./...
```

**New fixtures:**

1. `TestAnthropicStreamCacheReadNotDoubleCounted` — the primary regression guard. Turn-2 stream: `message_start` input=20532/cache_read=0 → `message_delta` input=308/cache_read=20224/cache_creation=0. Asserts `prompt_tokens == 20532` (i.e., 308 + 0 + 20224). Pre-fix this test FAILS recording 40756 (proves the test bites); post-fix PASSES recording 20532.
2. `TestAnthropicStreamNoCacheReadUnchanged` — turn-1 non-regression (no cache). `message_start` input=20458 → `message_delta` input=20458/cache_read=0. Asserts `prompt_tokens == 20458`. Passes both pre- and post-fix.
3. `TestAnthropicStreamUsage_NonConformantDeltaOmitsCacheFields` — proves the impossible-zero guard is load-bearing. `message_start` input=20532/cache_read=20224 → `message_delta` input=0 with cache fields omitted (→ deserialize to 0). Asserts `prompt_tokens == 20532` (start-side restored by the guard), NOT 0.

**Existing tests:** `go test ./core/providers/anthropic/...` shows zero pass/fail diff vs `dev` baseline.

## Screenshots/Recordings

N/A (no UI changes).

## Breaking changes

- [ ] Yes
- [x] No

Behavior change: `prompt_tokens` for Anthropic-protocol streams with prompt caching will be ~50% lower than before (correct instead of ~2× inflated). Any downstream consumer that calibrated against the inflated values (cost baselines, governance budgets, telemetry dashboards) will see a one-time step-change to the correct values. The corrected values match the Anthropic Messages API spec.

## Related issues

Closes #5354

## Security considerations

None. This is a usage-accounting fix; no auth, secrets, PII, or sandboxing surfaces are touched. The corrected `prompt_tokens` flows into existing cost/governance/telemetry paths unchanged.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines (commit format `[fix]:`, affected packages listed, `core/changelog.md` updated)
- [x] I added/updated tests where appropriate (3 new fixtures, including a turn-2 regression guard that fails pre-fix)
- [x] I updated documentation where needed (changelog entry)
- [x] I verified builds succeed (Go) — `go build ./...`, `go vet ./...` green
- [ ] I verified the CI pipeline passes locally if applicable — CI runs on push; local `go test ./core/providers/anthropic/...` green

## Follow-up flags (out of scope for this PR)

1. **Anthropic Responses API path** (`HandleAnthropicResponsesStream` + `accumulateAnthropicResponsesUsage`) uses a separate accumulator that was NOT audited for the same bug class. Worth a parallel audit if the Responses API exhibits similar double-counting.
2. **OpenAI streaming path** — independently audited and confirmed **structurally immune** (single-snapshot emission + no cache-fold step; `normalizeCachedUsage` has 0 matches in `core/providers/openai/`). No fix needed.
3. **Bedrock provider** (`core/providers/bedrock/bedrock.go`) has its own `normalizeCachedUsage` — not audited; recommend a separate diagnostic if Bedrock routes Anthropic-protocol streams.
4. `cache_creation_input_tokens` is consistently 0 from the kimi-code provider — upstream provider quirk, not a Bifrost bug. Not fixed.

## Known limitations (provider conformance assumption)

The fix assumes Anthropic-compatible providers either (a) repeat cache fields at `message_delta` per the Anthropic Messages API spec, or (b) omit the entire `message_delta.usage` (delta-absent fallback). Non-conformant providers that emit a PARTIAL-usage `message_delta` (input_tokens=0 with cache fields omitted — deserializing to all-zeros for non-pointer Go `int`) are handled by the impossible-zero guard. The guard is dead code for spec-conformant providers (zero behavior change). The guard does not log when it fires (the accumulator is currently logger-free; a structured-log line for non-conformance detection is a possible future enhancement).
