### PR TITLE
[fix]: tracing - concurrent requests sharing a W3C traceID no longer lose log rows

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -11,7 +11,8 @@ import (
 // Trace represents a distributed trace that captures the full lifecycle of a request
 type Trace struct {
 	RequestID             string            // Request ID for the trace
-	TraceID               string            // Unique identifier for this trace
+	TraceID               string            // Exported trace identifier; inherited from the W3C traceparent header when present, so concurrent requests of one distributed trace may share it
+	InternalID            string            // Unique per-request handle the trace is stored under; unlike TraceID it is never shared across requests
 	ParentID              string            // Parent trace ID from incoming W3C traceparent header
 	RootSpan              *Span             // The root span of this trace
 	Spans                 []*Span           // All spans in this trace
@@ -171,6 +172,7 @@ func (t *Trace) SnapshotForExport() *Trace {
 	clone := &Trace{
 		RequestID:      t.RequestID,
 		TraceID:        t.TraceID,
+		InternalID:     t.InternalID,
 		ParentID:       t.ParentID,
 		StartTime:      t.StartTime,
 		EndTime:        t.EndTime,
@@ -254,6 +256,7 @@ func (t *Trace) Reset() {
 	defer t.mu.Unlock()
 	t.RequestID = ""
 	t.TraceID = ""
+	t.InternalID = ""
 	t.ParentID = ""
 	t.RootSpan = nil
 	for i := range t.Spans {

--- a/framework/tracing/store.go
+++ b/framework/tracing/store.go
@@ -67,19 +67,27 @@ func NewTraceStore(ttl time.Duration, logger schemas.Logger) *TraceStore {
 	return store
 }
 
-// CreateTrace creates a new trace and stores it, returns trace ID only.
+// CreateTrace creates a new trace and stores it, returns the trace's store key.
 // The inheritedTraceID parameter is the trace ID from an incoming W3C traceparent header.
-// If provided, this trace will use that ID to continue the distributed trace.
-// If empty, a new trace ID will be generated.
+// If provided, the trace's exported TraceID uses that value to continue the
+// distributed trace. If empty, a new trace ID is generated.
+//
+// The returned key is unique per call, NOT the (possibly shared) W3C trace ID:
+// concurrent sibling requests of one distributed trace legitimately carry the
+// same inherited trace ID, and keying the store by it made siblings overwrite
+// each other — the first CompleteTrace stole the entry and the rest flushed
+// nothing (lost log rows, issue #5256). Callers treat the returned value as an
+// opaque handle; the W3C ID lives on trace.TraceID for span export and linking.
 // Note: The parent span ID (for linking to upstream spans) is handled separately
 // via context in StartSpan, not stored on the trace itself.
 func (s *TraceStore) CreateTrace(inheritedTraceID string, requestID ...string) string {
 	trace := s.tracePool.Get().(*schemas.Trace)
 	// Reset and initialize the trace
+	trace.InternalID = generateTraceID()
 	if inheritedTraceID != "" {
 		trace.TraceID = inheritedTraceID
 	} else {
-		trace.TraceID = generateTraceID()
+		trace.TraceID = trace.InternalID
 	}
 	// Note: trace.ParentID is intentionally not set here.
 	// Parent-child relationships are between spans, not traces.
@@ -109,8 +117,8 @@ func (s *TraceStore) CreateTrace(inheritedTraceID string, requestID ...string) s
 	// Reset request headers
 	trace.RequestHeaders = nil
 
-	s.traces.Store(trace.TraceID, trace)
-	return trace.TraceID
+	s.traces.Store(trace.InternalID, trace)
+	return trace.InternalID
 }
 
 // GetTrace retrieves a trace by ID

--- a/framework/tracing/store.go
+++ b/framework/tracing/store.go
@@ -286,9 +286,11 @@ func (s *TraceStore) StartSpan(traceID, name string, kind schemas.SpanKind) *sch
 
 	span := s.spanPool.Get().(*schemas.Span)
 
-	// Reset and initialize the span
+	// Reset and initialize the span. Span.TraceID carries the exported W3C
+	// trace identity (shared across sibling requests of a distributed trace);
+	// store lookups use the unique key passed as traceID, never this field.
 	span.SpanID = generateSpanID()
-	span.TraceID = traceID
+	span.TraceID = trace.TraceID
 	span.Name = name
 	span.Kind = kind
 	span.StartTime = time.Now()
@@ -333,10 +335,11 @@ func (s *TraceStore) StartChildSpan(traceID, parentSpanID, name string, kind sch
 
 	span := s.spanPool.Get().(*schemas.Span)
 
-	// Reset and initialize the span
+	// Reset and initialize the span. As in StartSpan, Span.TraceID carries the
+	// exported W3C trace identity, not the store key.
 	span.SpanID = generateSpanID()
 	span.ParentID = parentSpanID
-	span.TraceID = traceID
+	span.TraceID = trace.TraceID
 	span.Name = name
 	span.Kind = kind
 	span.StartTime = time.Now()

--- a/framework/tracing/store_test.go
+++ b/framework/tracing/store_test.go
@@ -169,10 +169,10 @@ func TestStartChildSpan_WithExternalParentSpanID(t *testing.T) {
 		t.Errorf("root span.ParentID = %q, want external parent %q", rootSpan.ParentID, externalParentSpanID)
 	}
 
-	// span.TraceID is internal linkage to the store entry (the per-request key),
-	// not the W3C ID — exporters read the W3C ID from trace.TraceID.
-	if rootSpan.TraceID != traceID {
-		t.Errorf("root span.TraceID = %q, want store key %q", rootSpan.TraceID, traceID)
+	// Span.TraceID carries the exported W3C identity even though the store
+	// key returned by CreateTrace is a distinct per-request handle.
+	if rootSpan.TraceID != inheritedTraceID {
+		t.Errorf("root span.TraceID = %q, want inherited trace ID %q", rootSpan.TraceID, inheritedTraceID)
 	}
 }
 

--- a/framework/tracing/store_test.go
+++ b/framework/tracing/store_test.go
@@ -1,6 +1,8 @@
 package tracing
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,8 +18,10 @@ func TestCreateTrace_WithInheritedTraceID(t *testing.T) {
 
 	traceID := store.CreateTrace(inheritedTraceID)
 
-	if traceID != inheritedTraceID {
-		t.Errorf("CreateTrace() returned %q, want inherited trace ID %q", traceID, inheritedTraceID)
+	// The returned value is a unique store key, deliberately NOT the inherited
+	// trace ID — concurrent requests may share an inherited ID (issue #5256).
+	if traceID == inheritedTraceID {
+		t.Errorf("CreateTrace() returned the inherited trace ID %q, want a unique store key", traceID)
 	}
 
 	trace := store.GetTrace(traceID)
@@ -26,7 +30,10 @@ func TestCreateTrace_WithInheritedTraceID(t *testing.T) {
 	}
 
 	if trace.TraceID != inheritedTraceID {
-		t.Errorf("trace.TraceID = %q, want %q", trace.TraceID, inheritedTraceID)
+		t.Errorf("trace.TraceID = %q, want inherited %q", trace.TraceID, inheritedTraceID)
+	}
+	if trace.InternalID != traceID {
+		t.Errorf("trace.InternalID = %q, want store key %q", trace.InternalID, traceID)
 	}
 
 	// ParentID should be empty - we no longer set it incorrectly to the trace ID
@@ -162,8 +169,10 @@ func TestStartChildSpan_WithExternalParentSpanID(t *testing.T) {
 		t.Errorf("root span.ParentID = %q, want external parent %q", rootSpan.ParentID, externalParentSpanID)
 	}
 
-	if rootSpan.TraceID != inheritedTraceID {
-		t.Errorf("root span.TraceID = %q, want inherited trace ID %q", rootSpan.TraceID, inheritedTraceID)
+	// span.TraceID is internal linkage to the store entry (the per-request key),
+	// not the W3C ID — exporters read the W3C ID from trace.TraceID.
+	if rootSpan.TraceID != traceID {
+		t.Errorf("root span.TraceID = %q, want store key %q", rootSpan.TraceID, traceID)
 	}
 }
 
@@ -309,5 +318,54 @@ func TestCleanupOldTraces_RemovesOrphanedDeferredSpans(t *testing.T) {
 	}
 	if store.GetTrace(freshTraceID) == nil {
 		t.Error("fresh trace should survive TTL cleanup")
+	}
+}
+
+// TestCreateTrace_ConcurrentSharedInheritedTraceID reproduces issue #5256:
+// concurrent requests carrying the same W3C traceparent trace ID must each get
+// their own store entry, complete independently, and keep the shared TraceID
+// for export. Before keying the store by a unique per-request handle, siblings
+// overwrote each other and most CompleteTrace calls returned nil — those
+// requests' log rows were silently lost.
+func TestCreateTrace_ConcurrentSharedInheritedTraceID(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	const totalRequests = 18
+	const sharedTraceID = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+	keys := make([]string, totalRequests)
+	traces := make([]*schemas.Trace, totalRequests)
+
+	var wg sync.WaitGroup
+	for i := 0; i < totalRequests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := store.CreateTrace(sharedTraceID, fmt.Sprintf("req-%02d", i))
+			keys[i] = key
+			time.Sleep(10 * time.Millisecond) // overlap the lifetimes
+			traces[i] = store.CompleteTrace(key)
+		}(i)
+	}
+	wg.Wait()
+
+	seenKeys := make(map[string]struct{}, totalRequests)
+	for i := 0; i < totalRequests; i++ {
+		if _, dup := seenKeys[keys[i]]; dup {
+			t.Errorf("request %d: store key %q collided with another request", i, keys[i])
+		}
+		seenKeys[keys[i]] = struct{}{}
+
+		if traces[i] == nil {
+			t.Errorf("request %d: CompleteTrace returned nil — trace lost", i)
+			continue
+		}
+		if traces[i].TraceID != sharedTraceID {
+			t.Errorf("request %d: trace.TraceID = %q, want shared W3C ID %q", i, traces[i].TraceID, sharedTraceID)
+		}
+		if traces[i].RequestID != fmt.Sprintf("req-%02d", i) {
+			t.Errorf("request %d: got trace of another request (RequestID %q)", i, traces[i].RequestID)
+		}
 	}
 }

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -204,13 +204,13 @@ func TestTracer_StartSpan_RootSpanWithW3CParent(t *testing.T) {
 		t.Errorf("Root span ParentID = %q, want external parent span ID %q", trace.RootSpan.ParentID, externalParentSpanID)
 	}
 
-	// The exported W3C trace ID is preserved on the trace; spans carry the
-	// internal store key for linkage.
+	// The exported W3C trace ID is preserved on both the trace and its spans;
+	// only the store key returned by CreateTrace is the per-request handle.
 	if trace.TraceID != inheritedTraceID {
 		t.Errorf("trace.TraceID = %q, want inherited %q", trace.TraceID, inheritedTraceID)
 	}
-	if trace.RootSpan.TraceID != traceID {
-		t.Errorf("Root span TraceID = %q, want store key %q", trace.RootSpan.TraceID, traceID)
+	if trace.RootSpan.TraceID != inheritedTraceID {
+		t.Errorf("Root span TraceID = %q, want inherited %q", trace.RootSpan.TraceID, inheritedTraceID)
 	}
 
 	// Verify context has span ID for child span creation
@@ -630,10 +630,10 @@ func TestIntegration_FullDistributedTraceFlow(t *testing.T) {
 			pluginSpan.ParentID, llmSpan.SpanID)
 	}
 
-	// All spans link to the same store entry; the trace itself keeps the
-	// inherited W3C ID for export.
-	if httpSpan.TraceID != traceID || llmSpan.TraceID != traceID || pluginSpan.TraceID != traceID {
-		t.Error("All spans should carry the trace's store key")
+	// All spans carry the inherited W3C trace identity; the store key returned
+	// by CreateTrace is a separate per-request handle.
+	if httpSpan.TraceID != inheritedTraceID || llmSpan.TraceID != inheritedTraceID || pluginSpan.TraceID != inheritedTraceID {
+		t.Error("All spans should have the inherited trace ID")
 	}
 	if trace.TraceID != inheritedTraceID {
 		t.Errorf("trace.TraceID = %q, want inherited %q", trace.TraceID, inheritedTraceID)

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -171,10 +171,12 @@ func TestTracer_StartSpan_RootSpanWithW3CParent(t *testing.T) {
 	inheritedTraceID := "69538b980000000079943934f90c1d40"
 	externalParentSpanID := "aad09d1659b4c7e3"
 
-	// Create trace with inherited trace ID
+	// Create trace with inherited trace ID. The returned value is a unique
+	// per-request store key, not the inherited ID (issue #5256) — the W3C ID
+	// lives on trace.TraceID for export.
 	traceID := tracer.CreateTrace(inheritedTraceID)
-	if traceID != inheritedTraceID {
-		t.Errorf("CreateTrace() = %q, want inherited trace ID %q", traceID, inheritedTraceID)
+	if traceID == inheritedTraceID {
+		t.Errorf("CreateTrace() = %q, want a unique store key distinct from the inherited trace ID", traceID)
 	}
 
 	// Set up context with trace ID and parent span ID (as middleware would do)
@@ -202,9 +204,13 @@ func TestTracer_StartSpan_RootSpanWithW3CParent(t *testing.T) {
 		t.Errorf("Root span ParentID = %q, want external parent span ID %q", trace.RootSpan.ParentID, externalParentSpanID)
 	}
 
-	// Verify trace ID is preserved
-	if trace.RootSpan.TraceID != inheritedTraceID {
-		t.Errorf("Root span TraceID = %q, want %q", trace.RootSpan.TraceID, inheritedTraceID)
+	// The exported W3C trace ID is preserved on the trace; spans carry the
+	// internal store key for linkage.
+	if trace.TraceID != inheritedTraceID {
+		t.Errorf("trace.TraceID = %q, want inherited %q", trace.TraceID, inheritedTraceID)
+	}
+	if trace.RootSpan.TraceID != traceID {
+		t.Errorf("Root span TraceID = %q, want store key %q", trace.RootSpan.TraceID, traceID)
 	}
 
 	// Verify context has span ID for child span creation
@@ -624,9 +630,13 @@ func TestIntegration_FullDistributedTraceFlow(t *testing.T) {
 			pluginSpan.ParentID, llmSpan.SpanID)
 	}
 
-	// All spans should have the same trace ID
-	if httpSpan.TraceID != inheritedTraceID || llmSpan.TraceID != inheritedTraceID || pluginSpan.TraceID != inheritedTraceID {
-		t.Error("All spans should have the inherited trace ID")
+	// All spans link to the same store entry; the trace itself keeps the
+	// inherited W3C ID for export.
+	if httpSpan.TraceID != traceID || llmSpan.TraceID != traceID || pluginSpan.TraceID != traceID {
+		t.Error("All spans should carry the trace's store key")
+	}
+	if trace.TraceID != inheritedTraceID {
+		t.Errorf("trace.TraceID = %q, want inherited %q", trace.TraceID, inheritedTraceID)
 	}
 
 	t.Logf("Trace structure (for Datadog):")

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1619,8 +1619,16 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 	if trace == nil {
 		return nil
 	}
-	// Retrieve pending log entries built by PostLLMHook (stored by traceID)
-	entryVal, ok := p.pendingLogsToInject.LoadAndDelete(trace.TraceID)
+	// Retrieve pending log entries built by PostLLMHook. They are keyed by the
+	// trace's store key (BifrostContextKeyTraceID carries it), which is
+	// trace.InternalID — unique per request even when concurrent requests share
+	// an inherited W3C TraceID. Fall back to TraceID for traces created by
+	// paths that predate InternalID.
+	joinKey := trace.InternalID
+	if joinKey == "" {
+		joinKey = trace.TraceID
+	}
+	entryVal, ok := p.pendingLogsToInject.LoadAndDelete(joinKey)
 	if !ok {
 		return nil
 	}

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1321,12 +1321,20 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 			// Extract trace ID from W3C traceparent header (if present)
 			// This is the 32-char trace ID that links all spans in a distributed trace
 			inheritedTraceID := tracing.ExtractParentID(&ctx.Request.Header)
-			// Create trace in store - only ID returned (trace data stays in store)
+			// Create trace in store - the returned value is a per-request store key,
+			// not necessarily the W3C trace ID (concurrent requests may share an
+			// inherited trace ID, so the store keys them uniquely).
 			traceID := tracer.CreateTrace(inheritedTraceID, requestID)
 			// Surface correlation IDs back to the caller so a request can be pivoted
 			// into its logs (Loki) and trace (Tempo) in Grafana and similar stacks.
+			// The header must carry the W3C trace ID (that is what Tempo indexes),
+			// which equals the store key only when no traceparent was inherited.
+			headerTraceID := inheritedTraceID
+			if headerTraceID == "" {
+				headerTraceID = traceID
+			}
 			ctx.Response.Header.Set("x-request-id", requestID)
-			ctx.Response.Header.Set("x-bifrost-trace-id", traceID)
+			ctx.Response.Header.Set("x-bifrost-trace-id", headerTraceID)
 			// Store dimensions and session ID at the trace level (not as span
 			// attributes) so connectors like BigQuery can export them without
 			// changing the OTEL/Datadog span payloads.


### PR DESCRIPTION
## Summary

Concurrent HTTP requests carrying the same W3C `traceparent` trace ID (normal for sibling calls of one distributed trace) lose LLM log rows. All requests return 200, but only some appear in `/api/logs`, so request counts, token usage, and cost totals silently underreport.

Root cause: `TraceStore` keyed active traces by the trace ID alone. `CreateTrace` did `traces.Store(traceID, ...)`, so each concurrent sibling overwrote the previous entry, and `CompleteTrace`'s `LoadAndDelete(traceID)` handed the entry to whichever request completed first. Every other sibling got nil back and flushed nothing. `deferredSpans` and the stream accumulator were keyed the same way, so streaming requests hit the same collision.

Reproduced at store level with the issue's shape (18 concurrent create/complete cycles, one shared trace ID, unique request IDs): 4/18 flushed, 14 lost. Control with unique trace IDs: 18/18. After the fix: 18/18.

## Changes

* `TraceStore.CreateTrace` now stores each trace under a unique per-request key (`Trace.InternalID`, new field) and returns that key. Every consumer already treats the returned value as an opaque handle carried through context, so no call sites change.
* `trace.TraceID` keeps the inherited W3C value, span export and distributed-trace linking are untouched (OTEL converter reads `trace.TraceID`, verified `span.TraceID` is never read outside tests).
* Logging plugin `Inject` joins pending entries by `InternalID` (this was the second half of the row loss), with a `TraceID` fallback for traces created by paths that predate the field.
* `x-bifrost-trace-id` response header still exposes the W3C trace ID (that is what Tempo/Grafana index), not the internal key.
* Deferred spans and stream accumulators ride the new key automatically, fixing the streaming variant.
* New regression test: 18 concurrent requests sharing one inherited trace ID, asserts every `CompleteTrace` returns the correct request's trace with the shared W3C ID preserved. Passes with `-race`.
* Updated three existing tests that asserted the old "returned value == W3C trace ID" contract, with comments documenting the new one.

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [X] Core (Go)
- [X] Transports (HTTP)
- [ ] Providers/Integrations
- [X] Plugins
- [ ] UI (React)
- [ ] Docs

(core/schemas, framework/tracing, plugins/logging, HTTP middleware)

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
cd framework
go test ./tracing/ -count=1
go test ./tracing/ -count=1 -race -run TestCreateTrace_ConcurrentSharedInheritedTraceID

cd ../plugins/logging && go test ./...
cd ../otel && go test ./...
```

End-to-end: send N concurrent requests with the same traceparent trace ID and unique parent span IDs, then check /api/logs, all N rows should appear.

## Breaking changes

- [X] No

The value flowing through BifrostContextKeyTraceID is now an internal handle rather than the W3C trace ID. Everything in this repo treats it as opaque and passes it back into tracer methods, verified by sweeping all consumers. One thing reviewers should check: if the enterprise overlay has a connector that joins its own pending state on trace.TraceID the way the logging plugin did, it should move to InternalID too (Inject receives it on the trace snapshot).

## Related issues

Closes maximhq/bifrost#5256

## Security considerations

None. Trace IDs were never used for auth; the internal key is random and revealed only via context within the process.

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [X] I updated documentation where needed
- [X] I verified builds succeed (Go and UI)
- [X] I verified the CI pipeline passes locally if applicable