### PR TITLE
fixes query creation from user input

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1566,7 +1566,10 @@ func (s *RDBLogStore) getProviderLatencyHistogramFromMatView(ctx context.Context
 // getDimensionCostHistogramFromMatView returns time-bucketed cost data grouped by
 // the specified dimension column from mv_logs_hourly.
 func (s *RDBLogStore) getDimensionCostHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionCostHistogramResult, error) {
-	dimCol := string(dimension)
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
+		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
+	}
 	var results []struct {
 		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
 		DimValue        string  `gorm:"column:dim_value"`
@@ -1620,7 +1623,10 @@ func (s *RDBLogStore) getDimensionCostHistogramFromMatView(ctx context.Context, 
 // getDimensionTokenHistogramFromMatView returns time-bucketed token usage grouped by
 // the specified dimension column from mv_logs_hourly.
 func (s *RDBLogStore) getDimensionTokenHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionTokenHistogramResult, error) {
-	dimCol := string(dimension)
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
+		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
+	}
 	var results []struct {
 		BucketTimestamp  int64  `gorm:"column:bucket_timestamp"`
 		DimValue         string `gorm:"column:dim_value"`
@@ -1691,7 +1697,10 @@ func (s *RDBLogStore) getDimensionTokenHistogramFromMatView(ctx context.Context,
 // getDimensionLatencyHistogramFromMatView returns time-bucketed latency percentiles
 // grouped by the specified dimension column from mv_logs_hourly.
 func (s *RDBLogStore) getDimensionLatencyHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionLatencyHistogramResult, error) {
-	dimCol := string(dimension)
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
+		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
+	}
 	var results []struct {
 		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
 		DimValue        string  `gorm:"column:dim_value"`

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -3117,13 +3117,13 @@ func (s *RDBLogStore) buildProviderLatencyHistogramResult(computedBuckets map[in
 // GetDimensionCostHistogram returns time-bucketed cost data grouped by the specified dimension.
 // Uses the mv_logs_hourly materialized view on PostgreSQL when eligible; falls back to raw queries otherwise.
 func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionCostHistogramResult, error) {
-	if !ValidHistogramDimensions[dimension] {
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
 		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
 	}
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
 	// Rollup dimensions (team / business unit / customer / user / virtual key)
 	// attribute each request to a single owner and bucket owner-less traffic as
@@ -3218,13 +3218,13 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 // GetDimensionTokenHistogram returns time-bucketed token usage grouped by the specified dimension.
 // Uses the mv_logs_hourly materialized view on PostgreSQL when eligible; falls back to raw queries otherwise.
 func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionTokenHistogramResult, error) {
-	if !ValidHistogramDimensions[dimension] {
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
 		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
 	}
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
 	// Internal org-rollup dimensions (team / business unit / customer) attribute
 	// each request to a single owner and bucket owner-less traffic as
@@ -3339,7 +3339,8 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 // Uses the mv_logs_hourly materialized view on PostgreSQL when eligible; falls back to raw queries otherwise.
 // The fallback path computes AVG latency only (no percentiles) since percentile_cont is Postgres-specific.
 func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionLatencyHistogramResult, error) {
-	if !ValidHistogramDimensions[dimension] {
+	dimCol, ok := histogramDimensionColumn(dimension)
+	if !ok {
 		return nil, fmt.Errorf("invalid histogram dimension: %s", dimension)
 	}
 	if bucketSizeSeconds <= 0 {
@@ -3348,7 +3349,6 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		return s.getDimensionLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
-	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1605,6 +1605,26 @@ var ValidHistogramDimensions = map[HistogramDimension]bool{
 	DimensionBusinessUnit: true,
 }
 
+// histogramDimensionColumn maps a validated dimension to its SQL column name.
+// Query builders must use the returned literal, never string(dimension): the
+// dimension value originates from a request query parameter, and returning a
+// compile-time constant here is what keeps user input out of SQL text.
+func histogramDimensionColumn(dimension HistogramDimension) (string, bool) {
+	switch dimension {
+	case DimensionProvider:
+		return "provider", true
+	case DimensionTeam:
+		return "team_id", true
+	case DimensionCustomer:
+		return "customer_id", true
+	case DimensionUser:
+		return "user_id", true
+	case DimensionBusinessUnit:
+		return "business_unit_id", true
+	}
+	return "", false
+}
+
 // Dimension-level histogram types (generic version of Provider histograms)
 
 // DimensionCostHistogramBucket represents a single time bucket for dimension-grouped cost data


### PR DESCRIPTION
## Summary

Replaces direct `string(dimension)` casts used to build SQL column names with a centralized `histogramDimensionColumn` function that returns a compile-time constant string. This eliminates a potential SQL injection vector where user-supplied query parameter values could flow directly into raw SQL text.



## Changes

- Introduced `histogramDimensionColumn(dimension HistogramDimension) (string, bool)` in `tables.go`, which maps each valid `HistogramDimension` to a hardcoded SQL column name via a `switch` statement. The returned string is always a literal constant, never derived from user input.
- Replaced `dimCol := string(dimension)` and `ValidHistogramDimensions[dimension]` map lookups in `GetDimensionCostHistogram`, `GetDimensionTokenHistogram`, and `GetDimensionLatencyHistogram` (in `rdb.go`) with a single call to `histogramDimensionColumn`, consolidating validation and column resolution into one step.
- Applied the same replacement in the three corresponding materialized view query builders in `matviews.go`.
- The `ValidHistogramDimensions` map is retained for any existing callers but is no longer used as the validation gate in these query paths.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that passing an unrecognized `HistogramDimension` value to any of the three `GetDimension*Histogram` functions returns an error and does not execute a query. Verify that all valid dimension values (`provider`, `team_id`, `customer_id`, `user_id`, `business_unit_id`) continue to produce correct query results.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The previous code cast the `HistogramDimension` value (which originates from a request query parameter) directly to a string and interpolated it into SQL. Although a map-based allowlist check preceded the cast, the column name used in the query was still derived from user input. `histogramDimensionColumn` ensures the string placed into SQL is always a compile-time constant, fully decoupling user input from SQL text.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable