### PR TITLE
community: add Latchshot to MCP library

### DIFF
--- a/community/mcp-library/servers.json
+++ b/community/mcp-library/servers.json
@@ -2297,6 +2297,27 @@
         "automation"
       ],
       "icon_url": "https://xquik.com/icons/mcp/xquik.png"
+    },
+    {
+      "name": "Latchshot",
+      "description": "Capture screenshots and PDFs of public web pages as inline MCP artifacts, with render diagnostics and usage reporting.",
+      "category": "Developer Tools",
+      "connection_type": "http",
+      "connection_url": "https://latchshot.fly.dev/mcp",
+      "auth_type": "headers",
+      "required_header_keys": [
+        "Authorization"
+      ],
+      "docs_url": "https://latchshot.fly.dev/guides/screenshot-mcp-server.html",
+      "publisher": "Latchshot",
+      "tags": [
+        "screenshots",
+        "pdf",
+        "browser-automation",
+        "rendering",
+        "remote"
+      ],
+      "icon_url": "https://latchshot.fly.dev/favicon.svg"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add Latchshot, a hosted screenshot and PDF MCP server, to the community catalog
- configure its Streamable HTTP endpoint and required `Authorization` header name
- link its public setup guide and hosted icon

I maintain Latchshot and am submitting this listing directly.

## Validation

- `jq empty community/mcp-library/servers.json`
- `npx --yes ajv-cli validate -s community/mcp-library/schema.json -d community/mcp-library/servers.json --spec=draft7`
- confirmed the docs and icon URLs return HTTP 200
- confirmed an unauthenticated MCP initialize request returns HTTP 401 with Bearer-token guidance

No secret values are included.