### PR TITLE
feat(mcp-guardrails): add MCP log redaction changes

### DIFF
--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -549,24 +549,28 @@ func TestClickHouseMCPToolLogs(t *testing.T) {
 		chTestMCPToolLog("ch-mcp-1", ts),
 		chTestMCPToolLog("ch-mcp-2", ts.Add(time.Millisecond)),
 	}
+	entries[0].RedactionMapping = `plain:{"input":{"EMAIL-1":"private@example.com"}}`
 	require.NoError(t, store.BatchCreateMCPToolLogsIfNotExists(ctx, entries))
 	require.NoError(t, store.BatchCreateMCPToolLogsIfNotExists(ctx, nil)) // no-op
 
 	found, err := store.FindMCPToolLog(ctx, "ch-mcp-1")
 	require.NoError(t, err)
 	assert.Equal(t, "search_web", found.ToolName)
+	assert.Equal(t, entries[0].RedactionMapping, found.RedactionMapping)
 
 	// Map update.
 	latency := 42.0
 	require.NoError(t, store.UpdateMCPToolLog(ctx, "ch-mcp-1", map[string]interface{}{
-		"status":  "success",
-		"latency": latency,
+		"status":            "success",
+		"latency":           latency,
+		"redaction_mapping": `plain:{"output":{"EMAIL-2":"result@example.com"}}`,
 	}))
 	found, err = store.FindMCPToolLog(ctx, "ch-mcp-1")
 	require.NoError(t, err)
 	assert.Equal(t, "success", found.Status)
 	require.NotNil(t, found.Latency)
 	assert.Equal(t, 42.0, *found.Latency)
+	assert.Contains(t, found.RedactionMapping, "result@example.com")
 	assert.Equal(t, int64(1), chCountRows(t, store.db, "mcp_tool_logs", "ch-mcp-1"))
 
 	// Struct update preserves untouched fields and the dedup key.

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -1156,6 +1156,10 @@ func applyMCPToolLogUpdateMap(target *MCPToolLog, updates map[string]interface{}
 				target.Metadata = v
 				target.MetadataParsed = nil
 			}
+		case "redaction_mapping":
+			if v, ok := value.(string); ok {
+				target.RedactionMapping = v
+			}
 		case "latency":
 			if v, ok := numericToFloat64(value); ok {
 				target.Latency = &v
@@ -1220,6 +1224,9 @@ func applyMCPToolLogUpdateStruct(target *MCPToolLog, update *MCPToolLog) error {
 	if update.Metadata != "" {
 		target.Metadata = update.Metadata
 		target.MetadataParsed = nil
+	}
+	if update.RedactionMapping != "" {
+		target.RedactionMapping = update.RedactionMapping
 	}
 	if !update.CreatedAt.IsZero() {
 		target.CreatedAt = update.CreatedAt
@@ -1301,6 +1308,9 @@ func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]any, er
 	}
 	if update.Metadata != "" {
 		out["metadata"] = update.Metadata
+	}
+	if update.RedactionMapping != "" {
+		out["redaction_mapping"] = update.RedactionMapping
 	}
 	if !update.CreatedAt.IsZero() {
 		out["created_at"] = update.CreatedAt

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -267,6 +267,7 @@ func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
 		ResultParsed: map[string]any{
 			"ok": true,
 		},
+		RedactionMapping: `plain:{"input":{"EMAIL-1":"private@example.com"}}`,
 	}
 
 	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
@@ -277,6 +278,7 @@ func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
 	assert.True(t, dbOnly.HasObject)
 	assert.Empty(t, dbOnly.Result)
 	assert.Nil(t, dbOnly.ResultParsed)
+	assert.Equal(t, entry.RedactionMapping, dbOnly.RedactionMapping)
 	preview, ok := dbOnly.ArgumentsParsed.(string)
 	require.True(t, ok)
 	assert.Len(t, []rune(preview), 200)
@@ -286,6 +288,7 @@ func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
 	assert.True(t, found.HasObject)
 	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["input"])
 	assert.Equal(t, true, found.ResultParsed.(map[string]interface{})["ok"])
+	assert.Equal(t, entry.RedactionMapping, found.RedactionMapping)
 }
 
 func TestHybrid_BatchCreateMCPToolLogsIfNotExists(t *testing.T) {
@@ -379,7 +382,8 @@ func TestHybrid_UpdateMCPToolLogOffloadsFullLog(t *testing.T) {
 	waitForUploads(t, func() bool { return objStore.Len() == 1 })
 
 	require.NoError(t, hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
-		Status: "success",
+		Status:           "success",
+		RedactionMapping: `plain:{"output":{"EMAIL-2":"result@example.com"}}`,
 		ResultParsed: map[string]any{
 			"answer": "done",
 		},
@@ -400,11 +404,13 @@ func TestHybrid_UpdateMCPToolLogOffloadsFullLog(t *testing.T) {
 	assert.Equal(t, "success", dbOnly.Status)
 	assert.Empty(t, dbOnly.Result)
 	assert.Nil(t, dbOnly.ResultParsed)
+	assert.Contains(t, dbOnly.RedactionMapping, "result@example.com")
 
 	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
 	require.NoError(t, err)
 	assert.Equal(t, "find this", found.ArgumentsParsed.(map[string]interface{})["query"])
 	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+	assert.Equal(t, dbOnly.RedactionMapping, found.RedactionMapping)
 }
 
 func TestHybrid_UpdateMCPToolLogRequiresObjectHydration(t *testing.T) {

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -274,6 +274,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_recreate_filter_customers_matview_multivalue"}, run: migrationRecreateFilterCustomersMatView},
 	{IDs: []string{"logs_add_canonical_model_columns_v2"}, run: migrationAddCanonicalModelColumns},
 	{IDs: []string{"logs_add_redaction_mapping_column"}, run: migrationAddRedactionMappingColumn},
+	{IDs: []string{"mcp_tool_logs_add_redaction_mapping_column"}, run: migrationAddMCPRedactionMappingColumn},
 	{IDs: []string{"webhook_deliveries_init"}, run: migrationCreateWebhookDeliveriesTable},
 	{IDs: []string{"async_jobs_add_webhook_endpoint_id_column"}, run: migrationAddWebhookEndpointIDColumn},
 	{IDs: []string{"async_jobs_add_request_id_column"}, run: migrationAddAsyncJobRequestIDColumn},
@@ -3589,6 +3590,31 @@ func migrationAddRedactionMappingColumn(ctx context.Context, db *gorm.DB, logger
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding redaction_mapping column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPRedactionMappingColumn adds the reversible redaction mapping
+// column to MCP tool logs while keeping its lifecycle coupled to the log row.
+func migrationAddMCPRedactionMappingColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "mcp_tool_logs_add_redaction_mapping_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &MCPToolLog{}, "redaction_mapping")
+		},
+		Rollback: func(*gorm.DB) error {
+			// No-op rollback: dropping the column would permanently destroy
+			// reveal data for already-redacted MCP logs.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding MCP redaction_mapping column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -3,15 +3,34 @@ package logstore
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
+
+// TestMigrationAddMCPRedactionMappingColumn verifies the MCP mapping column is additive, idempotent, and preserves existing rows.
+func TestMigrationAddMCPRedactionMappingColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "migrations.db")), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE TABLE mcp_tool_logs (id TEXT PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("INSERT INTO mcp_tool_logs (id) VALUES (?)", "mcp-existing").Error)
+
+	ctx := context.Background()
+	require.NoError(t, migrationAddMCPRedactionMappingColumn(ctx, db, testLogger{}))
+	require.True(t, db.Migrator().HasColumn(&MCPToolLog{}, "RedactionMapping"))
+	require.NoError(t, migrationAddMCPRedactionMappingColumn(ctx, db, testLogger{}))
+
+	var count int64
+	require.NoError(t, db.Table("mcp_tool_logs").Where("id = ?", "mcp-existing").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
 
 // pgTestSchema is this package's dedicated Postgres schema. Test packages
 // (configstore, configstore/tables, logstore) run in parallel against the same

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -399,6 +399,7 @@ func MarshalMCPToolLogPayload(l *MCPToolLog) ([]byte, error) {
 func MergeMCPToolLogPayloadFromJSON(l *MCPToolLog, data []byte) error {
 	hasObject := l.HasObject
 	virtualKey := l.VirtualKey
+	redactionMapping := l.RedactionMapping
 
 	var payload MCPToolLog
 	if err := sonic.Unmarshal(data, &payload); err != nil {
@@ -410,6 +411,7 @@ func MergeMCPToolLogPayloadFromJSON(l *MCPToolLog, data []byte) error {
 	*l = payload
 	l.HasObject = hasObject
 	l.VirtualKey = virtualKey
+	l.RedactionMapping = redactionMapping
 	return nil
 }
 

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -206,12 +206,17 @@ func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
 		MetadataParsed: map[string]interface{}{
 			"trace": "abc",
 		},
+		RedactionData: &schemas.RedactionData{
+			ReversibleMappings: schemas.RedactionMapsByPhase{Input: map[string]string{"EMAIL-1": "private@example.com"}},
+		},
+		RedactionMapping: `plain:{"input":{"EMAIL-1":"private@example.com"}}`,
 	}
 
 	data, err := MarshalMCPToolLogPayload(entry)
 	require.NoError(t, err)
+	assert.NotContains(t, string(data), "private@example.com")
 
-	dbEntry := &MCPToolLog{HasObject: true}
+	dbEntry := &MCPToolLog{HasObject: true, RedactionMapping: entry.RedactionMapping}
 	err = MergeMCPToolLogPayloadFromJSON(dbEntry, data)
 	require.NoError(t, err)
 
@@ -225,6 +230,23 @@ func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
 	assert.Equal(t, true, dbEntry.ResultParsed.(map[string]interface{})["ok"])
 	assert.Equal(t, "stored for round trip", dbEntry.ErrorDetailsParsed.Error.Message)
 	assert.Equal(t, "abc", dbEntry.MetadataParsed["trace"])
+	assert.Equal(t, entry.RedactionMapping, dbEntry.RedactionMapping)
+	assert.Nil(t, dbEntry.RedactionData)
+}
+
+// TestMCPToolLogRedactionMappingJSONVisibility verifies only the authorized virtual mapping is API-visible.
+func TestMCPToolLogRedactionMappingJSONVisibility(t *testing.T) {
+	entry := &MCPToolLog{
+		RedactionMapping: `plain:{"input":{"EMAIL-1":"private@example.com"}}`,
+		RevealRedactionMapping: &schemas.RedactionMapsByPhase{
+			Input: map[string]string{"EMAIL-1": "revealed@example.com"},
+		},
+	}
+
+	data, err := sonic.Marshal(entry)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "private@example.com")
+	assert.Contains(t, string(data), `"redaction_mapping":{"input":{"EMAIL-1":"revealed@example.com"}}`)
 }
 
 func TestPrepareMCPToolDBEntry_KeepsOnlyInputPreview(t *testing.T) {

--- a/framework/logstore/rdb_perf_test.go
+++ b/framework/logstore/rdb_perf_test.go
@@ -474,6 +474,7 @@ func TestMCPToolLogCreateSerializesFields(t *testing.T) {
 		ResultParsed: map[string]any{
 			"ok": true,
 		},
+		RedactionMapping: `plain:{"input":{"EMAIL-1":"private@example.com"}}`,
 	}
 
 	if err := store.CreateMCPToolLog(context.Background(), entry); err != nil {
@@ -489,6 +490,9 @@ func TestMCPToolLogCreateSerializesFields(t *testing.T) {
 	}
 	if logEntry.Result == "" {
 		t.Fatalf("expected Result to be serialized")
+	}
+	if logEntry.RedactionMapping != entry.RedactionMapping {
+		t.Fatalf("RedactionMapping = %q, want %q", logEntry.RedactionMapping, entry.RedactionMapping)
 	}
 }
 
@@ -574,7 +578,8 @@ func TestUpdateMCPToolLogSerializesStructEntry(t *testing.T) {
 	}
 
 	if err := store.UpdateMCPToolLog(context.Background(), entry.ID, MCPToolLog{
-		Status: "success",
+		Status:           "success",
+		RedactionMapping: `plain:{"output":{"EMAIL-2":"result@example.com"}}`,
 		ResultParsed: map[string]any{
 			"message": "done",
 		},
@@ -588,6 +593,9 @@ func TestUpdateMCPToolLogSerializesStructEntry(t *testing.T) {
 	}
 	if logEntry.Result == "" {
 		t.Fatalf("expected Result to be serialized on UpdateMCPToolLog")
+	}
+	if logEntry.RedactionMapping == "" {
+		t.Fatal("expected RedactionMapping to be updated")
 	}
 }
 

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1081,6 +1081,10 @@ type MCPToolLog struct {
 	HasObject      bool      `gorm:"default:false" json:"-"`                                                      // True when payload is stored in object storage
 	CreatedAt      time.Time `gorm:"index;not null" json:"created_at"`
 
+	RedactionData          *schemas.RedactionData        `gorm:"-" json:"-"`                           // Transient guardrail redaction data consumed by enterprise logstore wrappers
+	RedactionMapping       string                        `gorm:"type:text" json:"-"`                   // Reversible redaction mapping written by enterprise logstore wrappers; deleted with the row
+	RevealRedactionMapping *schemas.RedactionMapsByPhase `gorm:"-" json:"redaction_mapping,omitempty"` // Virtual field populated only on permitted MCP log-detail reads
+
 	// Endpoint-agent context. These are populated for tool calls observed on a
 	// developer machine by the Bifrost Edge agent (rather than proxied by the
 	// gateway). Source distinguishes the origin: empty/null for gateway-proxied

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -108,14 +108,35 @@ func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logsto
 	}
 }
 
-// attachLogRedactionData copies guardrail redaction data into the log entry for async writers.
-func attachLogRedactionData(ctx *schemas.BifrostContext, entry *logstore.Log, contentLoggingEnabled bool) {
-	if ctx == nil || entry == nil || !contentLoggingEnabled {
-		return
+// redactionDataForLogging returns an owned request snapshot for asynchronous log writers.
+func redactionDataForLogging(ctx *schemas.BifrostContext, contentLoggingEnabled bool) *schemas.RedactionData {
+	if ctx == nil || !contentLoggingEnabled {
+		return nil
 	}
 	if data, ok := schemas.RedactionDataFromContext(ctx); ok {
 		snapshot := data.Clone()
-		entry.RedactionData = &snapshot
+		return &snapshot
+	}
+	return nil
+}
+
+// attachLogRedactionData copies guardrail redaction data into an LLM log entry.
+func attachLogRedactionData(ctx *schemas.BifrostContext, entry *logstore.Log, contentLoggingEnabled bool) {
+	if entry == nil {
+		return
+	}
+	if snapshot := redactionDataForLogging(ctx, contentLoggingEnabled); snapshot != nil {
+		entry.RedactionData = snapshot
+	}
+}
+
+// attachMCPLogRedactionData copies guardrail redaction data into an MCP tool log entry.
+func attachMCPLogRedactionData(ctx *schemas.BifrostContext, entry *logstore.MCPToolLog, contentLoggingEnabled bool) {
+	if entry == nil {
+		return
+	}
+	if snapshot := redactionDataForLogging(ctx, contentLoggingEnabled); snapshot != nil {
+		entry.RedactionData = snapshot
 	}
 }
 
@@ -1888,6 +1909,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 	p.mu.Lock()
 	callback := p.mcpToolLogCallback
 	p.mu.Unlock()
+	attachMCPLogRedactionData(ctx, entry, p.contentLoggingEnabled(ctx))
 	p.enqueueMCPToolLogEntry(entry, callback)
 
 	return resp, bifrostErr, nil

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -1048,6 +1048,12 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamID, "team-1")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, "customer-1")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceBusinessUnitID, "bu-1")
+	schemas.SetRedactionDataOnContext(ctx, schemas.RedactionData{
+		ReversibleMappings: schemas.RedactionMapsByPhase{
+			Input:  map[string]string{"EMAIL-1": "private@example.com"},
+			Output: map[string]string{"EMAIL-2": "result@example.com"},
+		},
+	})
 
 	toolName := "docs-search"
 	_, _, err = plugin.PreMCPHook(ctx, &schemas.BifrostMCPRequest{
@@ -1066,6 +1072,17 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	if _, err := store.FindMCPToolLog(context.Background(), "mcp-batch-flow"); !errors.Is(err, logstore.ErrNotFound) {
 		t.Fatalf("expected MCP log to stay in memory before PostMCPHook, got err=%v", err)
 	}
+	pendingValue, ok := plugin.pendingMCPLogsToInject.Load("mcp-batch-flow")
+	if !ok {
+		t.Fatal("expected pending MCP log entry")
+	}
+	pendingEntry, ok := pendingValue.(*logstore.MCPToolLog)
+	if !ok {
+		t.Fatalf("pending MCP log entry has type %T", pendingValue)
+	}
+	if pendingEntry.RedactionData != nil {
+		t.Fatal("expected redaction data to be attached only after PostMCPHook")
+	}
 
 	result := `{"answer":"done"}`
 	_, _, err = plugin.PostMCPHook(ctx, &schemas.BifrostMCPResponse{
@@ -1082,6 +1099,12 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	}, nil)
 	if err != nil {
 		t.Fatalf("PostMCPHook() error = %v", err)
+	}
+	if pendingEntry.RedactionData == nil {
+		t.Fatal("expected PostMCPHook to attach redaction data")
+	}
+	if got := pendingEntry.RedactionData.ReversibleMappings.Output["EMAIL-2"]; got != "result@example.com" {
+		t.Fatalf("output redaction mapping = %q, want %q", got, "result@example.com")
 	}
 
 	if err := plugin.Cleanup(); err != nil {

--- a/plugins/logging/redaction_test.go
+++ b/plugins/logging/redaction_test.go
@@ -85,3 +85,34 @@ func TestAttachLogRedactionDataIgnoresMissingContext(t *testing.T) {
 
 	assert.Nil(t, entry.RedactionData)
 }
+
+// TestAttachMCPLogRedactionDataCopiesContextValue verifies MCP entries receive an owned redaction snapshot.
+func TestAttachMCPLogRedactionDataCopiesContextValue(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	reversibleMappings := map[string]string{"EMAIL-1": "alex_rivera@gmail.com"}
+	schemas.SetRedactionDataOnContext(ctx, schemas.RedactionData{
+		ReversibleMappings: schemas.RedactionMapsByPhase{Input: reversibleMappings},
+	})
+	entry := &logstore.MCPToolLog{}
+
+	attachMCPLogRedactionData(ctx, entry, true)
+	reversibleMappings["EMAIL-1"] = "mutated@example.com"
+
+	require.NotNil(t, entry.RedactionData)
+	assert.Equal(t, "alex_rivera@gmail.com", entry.RedactionData.ReversibleMappings.Input["EMAIL-1"])
+}
+
+// TestAttachMCPLogRedactionDataSkipsUnavailableContent verifies disabled logging and missing inputs never attach sensitive data.
+func TestAttachMCPLogRedactionDataSkipsUnavailableContent(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	schemas.SetRedactionDataOnContext(ctx, schemas.RedactionData{
+		ReversibleMappings: schemas.RedactionMapsByPhase{Input: map[string]string{"EMAIL-1": "alex_rivera@gmail.com"}},
+	})
+	entry := &logstore.MCPToolLog{}
+
+	attachMCPLogRedactionData(ctx, entry, false)
+	attachMCPLogRedactionData(nil, entry, true)
+	attachMCPLogRedactionData(ctx, nil, true)
+
+	assert.Nil(t, entry.RedactionData)
+}

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -29,10 +29,11 @@ import (
 
 // LoggingHandler manages HTTP requests for logging operations
 type LoggingHandler struct {
-	logManager                  logging.LogManager
-	redactedKeysManager         RedactedKeysManager
-	config                      *lib.Config
-	logRedactionMappingResolver LogRedactionMappingResolver
+	logManager                     logging.LogManager
+	redactedKeysManager            RedactedKeysManager
+	config                         *lib.Config
+	logRedactionMappingResolver    LogRedactionMappingResolver
+	mcpLogRedactionMappingResolver MCPLogRedactionMappingResolver
 
 	// filterDataCache memoizes /api/logs/filterdata response bodies. Filter
 	// dropdowns don't need request-fresh data and the underlying matview-backed
@@ -331,6 +332,14 @@ type LogRedactionMappingResolver interface {
 	ResolveLogRedactionMapping(ctx *fasthttp.RequestCtx, log *logstore.Log) (*schemas.RedactionMapsByPhase, error)
 }
 
+// MCPLogRedactionMappingResolver optionally exposes decoded redaction mappings on MCP log-detail responses.
+type MCPLogRedactionMappingResolver interface {
+	// ResolveMCPLogRedactionMapping returns phase-scoped placeholder-to-original mappings when the caller may reveal them.
+	// Implementations should return nil, nil when the caller is not authorized or no mapping is available.
+	// Errors are treated as reveal-data failures only; the base MCP log detail response is still served.
+	ResolveMCPLogRedactionMapping(ctx *fasthttp.RequestCtx, log *logstore.MCPToolLog) (*schemas.RedactionMapsByPhase, error)
+}
+
 // NewLoggingHandler creates a new logging handler instance
 func NewLoggingHandler(logManager logging.LogManager, redactedKeysManager RedactedKeysManager, config *lib.Config) *LoggingHandler {
 	return &LoggingHandler{
@@ -343,6 +352,11 @@ func NewLoggingHandler(logManager logging.LogManager, redactedKeysManager Redact
 // SetLogRedactionMappingResolver wires the optional resolver used by Enterprise log-detail reads.
 func (h *LoggingHandler) SetLogRedactionMappingResolver(resolver LogRedactionMappingResolver) {
 	h.logRedactionMappingResolver = resolver
+}
+
+// SetMCPLogRedactionMappingResolver wires the optional resolver used by Enterprise MCP log-detail reads.
+func (h *LoggingHandler) SetMCPLogRedactionMappingResolver(resolver MCPLogRedactionMappingResolver) {
+	h.mcpLogRedactionMappingResolver = resolver
 }
 
 func (h *LoggingHandler) shouldHideDeletedVirtualKeysInFilters() bool {
@@ -2602,6 +2616,14 @@ func (h *LoggingHandler) getMCPLogByID(ctx *fasthttp.RequestCtx) {
 		}
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get MCP log: %v", err))
 		return
+	}
+	if h.mcpLogRedactionMappingResolver != nil && log.RedactionMapping != "" {
+		mapping, resolveErr := h.mcpLogRedactionMappingResolver.ResolveMCPLogRedactionMapping(ctx, log)
+		if resolveErr != nil {
+			logger.Error("failed to resolve redaction mapping for MCP log %s: %v", id, resolveErr)
+		} else if mapping != nil && mapping.HasReplacements() {
+			log.RevealRedactionMapping = mapping
+		}
 	}
 
 	if log.VirtualKeyID != nil && log.VirtualKeyName != nil && *log.VirtualKeyID != "" && *log.VirtualKeyName != "" {

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -47,6 +48,63 @@ func TestShouldUseFilterDataCacheRejectsScopedContext(t *testing.T) {
 	})
 	if shouldUseFilterDataCache(ctx, "") {
 		t.Fatal("expected scoped request to bypass filterdata cache")
+	}
+}
+
+// TestGetMCPLogByIDRedactionMapping verifies raw mappings stay hidden and only resolver-approved mappings are returned.
+func TestGetMCPLogByIDRedactionMapping(t *testing.T) {
+	SetLogger(&mockLogger{})
+	revealed := &schemas.RedactionMapsByPhase{
+		Input: map[string]string{"EMAIL-1": "revealed@example.com"},
+	}
+	tests := []struct {
+		name        string
+		resolver    *staticMCPLogRedactionResolver
+		wantMapping bool
+		wantCalls   int
+	}{
+		{name: "no resolver"},
+		{name: "authorized mapping", resolver: &staticMCPLogRedactionResolver{mapping: revealed}, wantMapping: true, wantCalls: 1},
+		{name: "resolver error", resolver: &staticMCPLogRedactionResolver{err: errors.New("decode failed")}, wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &dashboardLogManager{mcpLog: &logstore.MCPToolLog{
+				ID:               "mcp-1",
+				RedactionMapping: `plain:{"input":{"EMAIL-1":"private@example.com"}}`,
+			}}
+			handler := &LoggingHandler{logManager: manager}
+			if tt.resolver != nil {
+				handler.SetMCPLogRedactionMappingResolver(tt.resolver)
+			}
+			ctx := &fasthttp.RequestCtx{}
+			ctx.SetUserValue("id", "mcp-1")
+
+			handler.getMCPLogByID(ctx)
+
+			if ctx.Response.StatusCode() != fasthttp.StatusOK {
+				t.Fatalf("status = %d, want %d", ctx.Response.StatusCode(), fasthttp.StatusOK)
+			}
+			var response struct {
+				RedactionMapping *schemas.RedactionMapsByPhase `json:"redaction_mapping"`
+			}
+			if err := json.Unmarshal(ctx.Response.Body(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if bytes.Contains(ctx.Response.Body(), []byte("private@example.com")) {
+				t.Fatalf("raw persisted mapping leaked in response: %s", ctx.Response.Body())
+			}
+			if tt.wantMapping != (response.RedactionMapping != nil) {
+				t.Fatalf("redaction mapping present = %t, want %t", response.RedactionMapping != nil, tt.wantMapping)
+			}
+			if tt.wantMapping && response.RedactionMapping.Input["EMAIL-1"] != "revealed@example.com" {
+				t.Fatalf("revealed mapping = %#v", response.RedactionMapping)
+			}
+			if tt.resolver != nil && tt.resolver.calls != tt.wantCalls {
+				t.Fatalf("resolver calls = %d, want %d", tt.resolver.calls, tt.wantCalls)
+			}
+		})
 	}
 }
 
@@ -374,6 +432,7 @@ func (s *fakeSidekiqStore) ListClaimableSidekiqJobs(ctx context.Context, staleBe
 
 type dashboardLogManager struct {
 	failStats              bool
+	mcpLog                 *logstore.MCPToolLog
 	lastLLMFilters         logstore.SearchFilters
 	lastMCPFilters         logstore.MCPToolLogSearchFilters
 	lastRecalculateFilters logstore.SearchFilters
@@ -502,7 +561,11 @@ func (m *dashboardLogManager) RunCostRecalcJob(ctx context.Context, metaJSON str
 	return metaJSON, nil
 }
 func (m *dashboardLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
-	return nil, nil
+	if m.mcpLog == nil {
+		return nil, nil
+	}
+	entry := *m.mcpLog
+	return &entry, nil
 }
 func (m *dashboardLogManager) SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error) {
 	return nil, nil
@@ -531,6 +594,19 @@ func (m *dashboardLogManager) GetMCPTopTools(ctx context.Context, filters logsto
 }
 
 func (m *dashboardLogManager) DeleteMCPToolLogs(ctx context.Context, ids []string) error { return nil }
+
+// staticMCPLogRedactionResolver records calls and returns a configured reveal result.
+type staticMCPLogRedactionResolver struct {
+	mapping *schemas.RedactionMapsByPhase
+	err     error
+	calls   int
+}
+
+// ResolveMCPLogRedactionMapping returns the configured test result.
+func (r *staticMCPLogRedactionResolver) ResolveMCPLogRedactionMapping(_ *fasthttp.RequestCtx, _ *logstore.MCPToolLog) (*schemas.RedactionMapsByPhase, error) {
+	r.calls++
+	return r.mapping, r.err
+}
 
 func (m *dashboardLogManager) CreateUserAgentMapping(ctx context.Context, mapping *logstore.UserAgentMapping) (*logstore.UserAgentMapping, error) {
 	return nil, nil

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -142,6 +142,12 @@ type LogRedactionMappingResolverProvider interface {
 	GetLogRedactionMappingResolver() handlers.LogRedactionMappingResolver
 }
 
+// MCPLogRedactionMappingResolverProvider is implemented by servers that can attach reveal data to MCP log-detail responses.
+type MCPLogRedactionMappingResolverProvider interface {
+	// GetMCPLogRedactionMappingResolver returns the resolver used by the logging handler.
+	GetMCPLogRedactionMappingResolver() handlers.MCPLogRedactionMappingResolver
+}
+
 // BifrostHTTPServer represents a HTTP server instance.
 type BifrostHTTPServer struct {
 	Ctx    *schemas.BifrostContext
@@ -1794,6 +1800,9 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 		loggingHandler = handlers.NewLoggingHandler(loggerPlugin.GetPluginLogManager(), s, s.Config)
 		if resolverProvider, ok := callbacks.(LogRedactionMappingResolverProvider); ok {
 			loggingHandler.SetLogRedactionMappingResolver(resolverProvider.GetLogRedactionMappingResolver())
+		}
+		if resolverProvider, ok := callbacks.(MCPLogRedactionMappingResolverProvider); ok {
+			loggingHandler.SetMCPLogRedactionMappingResolver(resolverProvider.GetMCPLogRedactionMappingResolver())
 		}
 		// Wire the sidekiq runner so cost recalculation runs as a durable background
 		// job. Registering the handler here (before RecoverIncomplete) lets a job


### PR DESCRIPTION
## Summary

Extends the reversible redaction mapping feature to MCP tool logs. Previously, guardrail redaction mappings (placeholder-to-original PII mappings) were only stored and surfaced for LLM logs. This PR adds the same capability to `MCPToolLog`, persisting the mapping in a new `redaction_mapping` database column and exposing it on authorized MCP log-detail API responses.

## Changes

- Added `RedactionMapping`, `RedactionData`, and `RevealRedactionMapping` fields to `MCPToolLog`. The raw mapping is never serialized to JSON directly; only the resolver-approved `RevealRedactionMapping` virtual field is exposed on API responses.
- Added `migrationAddMCPRedactionMappingColumn` to create the `redaction_mapping` column on `mcp_tool_logs` with a no-op rollback (dropping the column would destroy reveal data for already-redacted rows).
- Updated `applyMCPToolLogUpdateMap`, `applyMCPToolLogUpdateStruct`, and `prepareMCPToolLogDBUpdatesFromStruct` in `hybrid.go` to propagate `RedactionMapping` through map-based and struct-based update paths.
- Updated `MergeMCPToolLogPayloadFromJSON` in `payload.go` to preserve `RedactionMapping` when merging object-storage payloads back into a DB row, and ensured `RedactionData` is excluded from the serialized payload so raw PII is never written to object storage.
- Extracted `redactionDataForLogging` as a shared helper and added `attachMCPLogRedactionData`, which is called in `PostMCPHook` so redaction data is attached only after the tool response is available (not during the pre-hook).
- Added `MCPLogRedactionMappingResolver` interface and `SetMCPLogRedactionMappingResolver` on `LoggingHandler`. The `getMCPLogByID` handler now calls the resolver when a mapping is present and attaches the decoded result to `RevealRedactionMapping` before serializing the response.
- Added `MCPLogRedactionMappingResolverProvider` to the server registration path so enterprise server implementations can wire the resolver without modifying core.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... ./plugins/logging/... ./transports/bifrost-http/handlers/...
```

Key test scenarios covered:

- `TestMigrationAddMCPRedactionMappingColumn` — verifies the migration is additive, idempotent, and preserves existing rows.
- `TestMCPToolLogPayload_RoundTripFullLog` — verifies `RedactionData` is excluded from the serialized payload and `RedactionMapping` survives a marshal/unmarshal round-trip.
- `TestMCPToolLogRedactionMappingJSONVisibility` — verifies the raw persisted mapping is never present in API output and only the resolver-approved mapping appears.
- `TestGetMCPLogByIDRedactionMapping` — verifies the handler serves the base response when no resolver is set, attaches the revealed mapping when authorized, and continues serving the base response on resolver errors without leaking the raw mapping.
- `TestMCPHooksDeferDBWriteUntilPostHookBatch` — verifies redaction data is not attached during `PreMCPHook` and is correctly attached after `PostMCPHook`.
- `TestAttachMCPLogRedactionDataCopiesContextValue` / `TestAttachMCPLogRedactionDataSkipsUnavailableContent` — verifies snapshot isolation and that disabled content logging or nil inputs never attach sensitive data.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- The raw `redaction_mapping` column value (which contains original PII) is tagged `json:"-"` and is never included in any API response.
- Only the `RevealRedactionMapping` virtual field, populated exclusively by an authorized resolver, is serialized in responses.
- `RedactionData` is excluded from object-storage payloads, ensuring PII is not written outside the database row.
- The migration rollback is intentionally a no-op to prevent accidental destruction of reveal data.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable