### PR TITLE
fix: vertex batches anthropic compatibility

### DIFF
--- a/core/providers/gemini/batch_conversion_test.go
+++ b/core/providers/gemini/batch_conversion_test.go
@@ -82,4 +82,31 @@ func TestToGeminiBatchGenerateContentRequest(t *testing.T) {
 		assert.Empty(t, req.Contents)
 		assert.Nil(t, req.SystemInstruction)
 	})
+
+	t.Run("PreservesToolsToolConfigCachedContentAndLabels", func(t *testing.T) {
+		body := map[string]interface{}{
+			"contents": []interface{}{
+				map[string]interface{}{"role": "user", "parts": []interface{}{map[string]interface{}{"text": "hi"}}},
+			},
+			"tools": []interface{}{
+				map[string]interface{}{"functionDeclarations": []interface{}{map[string]interface{}{"name": "get_weather"}}},
+			},
+			"toolConfig": map[string]interface{}{
+				"functionCallingConfig": map[string]interface{}{"mode": "AUTO"},
+			},
+			"cachedContent": "cachedContents/abc",
+			"labels":        map[string]interface{}{"team": "research"},
+		}
+
+		req, err := gemini.ToGeminiBatchGenerateContentRequest(body)
+		require.NoError(t, err)
+
+		require.Len(t, req.Tools, 1)
+		require.Len(t, req.Tools[0].FunctionDeclarations, 1)
+		assert.Equal(t, "get_weather", req.Tools[0].FunctionDeclarations[0].Name)
+		require.NotNil(t, req.ToolConfig)
+		require.NotNil(t, req.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, "cachedContents/abc", req.CachedContent)
+		assert.Equal(t, "research", req.Labels["team"])
+	})
 }

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2493,10 +2493,15 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	}
 
 	if len(jsonData) == 0 {
-		// Build the batch request with proper nested structure
+		// Build the batch request with proper nested structure. Honor a caller-supplied
+		// display name (e.g. genai config.display_name), falling back to a generated one.
+		displayName := fmt.Sprintf("bifrost-batch-%d", time.Now().UnixNano())
+		if request.DisplayName != nil && *request.DisplayName != "" {
+			displayName = *request.DisplayName
+		}
 		batchReq := &GeminiBatchCreateRequest{
 			Batch: GeminiBatchConfig{
-				DisplayName: fmt.Sprintf("bifrost-batch-%d", time.Now().UnixNano()),
+				DisplayName: displayName,
 			},
 		}
 

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -2589,6 +2589,10 @@ type GeminiBatchGenerateContentRequest struct {
 	GenerationConfig  *GenerationConfig `json:"generationConfig,omitempty"`
 	SafetySettings    []SafetySetting   `json:"safetySettings,omitempty"`
 	SystemInstruction *Content          `json:"systemInstruction,omitempty"`
+	Tools             []Tool            `json:"tools,omitempty"`
+	ToolConfig        *ToolConfig       `json:"toolConfig,omitempty"`
+	CachedContent     string            `json:"cachedContent,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
 }
 
 // GeminiBatchStats represents the stats of a batch job.

--- a/core/providers/vertex/batch.go
+++ b/core/providers/vertex/batch.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/gemini"
+	"github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -17,6 +19,10 @@ import (
 // through a batch prediction job (Vertex JSONL has no native custom_id field; the
 // request — labels included — is echoed back in each output line).
 const vertexBatchCustomIDLabel = "bifrost_custom_id"
+
+// vertexAnthropicBatchVersion is the anthropic_version required by Claude-on-Vertex
+// batch instances (same value the chat path injects via the Vertex build config).
+const vertexAnthropicBatchVersion = "vertex-2023-10-16"
 
 // vertexJobStateToBatchStatus maps Vertex JOB_STATE_* values to Bifrost batch statuses.
 func vertexJobStateToBatchStatus(state string) schemas.BatchStatus {
@@ -142,13 +148,19 @@ func parseVertexJobAPIError(body []byte, statusCode int, op string) *schemas.Bif
 // BatchPredictionJob request. The model, display name and input/output GCS config are
 // mapped explicitly; every other field is taken from extra_params (e.g. modelParameters,
 // labels, modelVersionId, encryptionSpec) and merged verbatim into the job body.
-func ToVertexBatchCreateRequest(request *schemas.BifrostBatchCreateRequest, displayName, inputURI, outputURI string) *VertexBatchCreateRequest {
+func ToVertexBatchCreateRequest(ctx *schemas.BifrostContext, request *schemas.BifrostBatchCreateRequest, displayName, inputURI, outputURI string) *VertexBatchCreateRequest {
 	model := ""
 	if request.Model != nil {
 		model = *request.Model
 	}
 	if model != "" && !strings.Contains(model, "/") {
-		model = "publishers/google/models/" + model
+		// Bare model names are resolved to a publisher path; Claude models live under the
+		// Anthropic publisher (publishers/anthropic/models/...), everything else under Google.
+		publisher := "google"
+		if schemas.IsAnthropicModelFamily(ctx, model) {
+			publisher = "anthropic"
+		}
+		model = "publishers/" + publisher + "/models/" + model
 	}
 
 	req := &VertexBatchCreateRequest{
@@ -168,11 +180,28 @@ func ToVertexBatchCreateRequest(request *schemas.BifrostBatchCreateRequest, disp
 	return req
 }
 
+// stripVertexPublisherModelPath reduces a publishers/{publisher}/models/{id} model path to its
+// bare id, reporting whether it matched. Any other shape — a bare name, or a fine-tuned
+// projects/{p}/locations/{l}/models/{id} resource path — is returned unchanged.
+func stripVertexPublisherModelPath(model string) (string, bool) {
+	parts := strings.Split(model, "/")
+	if len(parts) != 4 || parts[0] != "publishers" || parts[2] != "models" || parts[1] == "" || parts[3] == "" {
+		return model, false
+	}
+	return parts[3], true
+}
+
 // vertexConvertRequestsToJSONL converts inline batch request items to Vertex batch JSONL.
-// Each body is converted to Vertex's native GenerateContentRequest shape (the same converter
-// the Gemini provider uses), so OpenAI-style "messages" become "contents"; batchPredictionJobs
-// expects {"request": {contents...}}. Each custom_id is carried in the request labels.
-func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, error) {
+// The instance shape depends on the model family (batchPredictionJobs always wraps it under
+// "request"):
+//   - Gemini/Google: bodies are converted to the native GenerateContentRequest shape (OpenAI
+//     "messages" become "contents"), and each custom_id is carried in the request labels.
+//   - Anthropic/Claude: the instance is an Anthropic Messages body with a native top-level
+//     "custom_id"; OpenAI-style bodies are converted to Anthropic shape, Anthropic-native
+//     bodies pass through with "anthropic_version" ensured.
+func vertexConvertRequestsToJSONL(ctx *schemas.BifrostContext, requests []schemas.BatchRequestItem, model string) ([]byte, error) {
+	isAnthropic := schemas.IsAnthropicModelFamily(ctx, model)
+
 	var buf bytes.Buffer
 	for i, item := range requests {
 		body := item.Body
@@ -181,6 +210,25 @@ func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, 
 		}
 		if body == nil {
 			return nil, fmt.Errorf("batch request item %d (custom_id %q) has no body", i, item.CustomID)
+		}
+
+		if isAnthropic {
+			requestBody, err := vertexAnthropicBatchInstance(ctx, body, model)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert batch request item %d (custom_id %q): %w", i, item.CustomID, err)
+			}
+			// Claude-on-Vertex batch has a native top-level custom_id, not Gemini labels.
+			lineObj := map[string]interface{}{"request": requestBody}
+			if item.CustomID != "" {
+				lineObj["custom_id"] = item.CustomID
+			}
+			line, err := providerUtils.MarshalSorted(lineObj)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal batch request item %d (custom_id %q): %w", i, item.CustomID, err)
+			}
+			buf.Write(line)
+			buf.WriteByte('\n')
+			continue
 		}
 
 		// OpenAI-style bodies (with "messages") are converted to Gemini's request shape; native
@@ -227,6 +275,129 @@ func vertexConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, 
 		buf.WriteByte('\n')
 	}
 	return buf.Bytes(), nil
+}
+
+// vertexAnthropicBatchInstance builds the per-line "request" body for a Claude-on-Vertex batch
+// instance. OpenAI-shaped bodies are converted to the Anthropic Messages shape via the shared
+// converters; bodies already in Anthropic shape pass through with the job-level model dropped
+// and anthropic_version ensured.
+func vertexAnthropicBatchInstance(ctx *schemas.BifrostContext, body map[string]interface{}, model string) (map[string]interface{}, error) {
+	if bodyLooksLikeOpenAIChat(body) {
+		reqBytes, err := sonic.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		var oaiReq openai.OpenAIChatRequest
+		if err := sonic.Unmarshal(reqBytes, &oaiReq); err != nil {
+			return nil, err
+		}
+		bifrostReq := oaiReq.ToBifrostChatRequest(ctx)
+		if bifrostReq == nil {
+			return nil, fmt.Errorf("could not parse OpenAI-style batch body")
+		}
+		if model != "" {
+			bifrostReq.Model = model
+		}
+		// The Vertex build config injects anthropic_version, strips the model field (model is at
+		// the job level), remaps tool versions and strips cache_control scope — same shaping the
+		// chat path uses for Claude-on-Vertex.
+		anthropicBytes, bErr := anthropic.BuildAnthropicChatRequestBody(ctx, bifrostReq, anthropic.AnthropicRequestBuildConfig{
+			Provider: schemas.Vertex,
+			Model:    model,
+		})
+		if bErr != nil {
+			msg := "anthropic request build failed"
+			if bErr.Error != nil && bErr.Error.Message != "" {
+				msg = bErr.Error.Message
+			}
+			return nil, fmt.Errorf("%s", msg)
+		}
+		if len(anthropicBytes) == 0 {
+			// The builder short-circuits to a nil body under large-payload passthrough.
+			return nil, fmt.Errorf("anthropic request build produced an empty body")
+		}
+		out := map[string]interface{}{}
+		if err := sonic.Unmarshal(anthropicBytes, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+
+	// Already Anthropic-shaped: shallow-copy, drop the job-level model, ensure anthropic_version.
+	out := make(map[string]interface{}, len(body)+1)
+	for k, v := range body {
+		out[k] = v
+	}
+	delete(out, "model")
+	if _, ok := out["anthropic_version"]; !ok {
+		out["anthropic_version"] = vertexAnthropicBatchVersion
+	}
+	return out, nil
+}
+
+// bodyLooksLikeOpenAIChat reports whether a batch request body is an OpenAI chat-completions
+// body that must be converted to Anthropic Messages shape. OpenAI and Anthropic both key on
+// "messages", so detection relies on OpenAI-only markers; a plain messages+max_tokens body is
+// valid as-is for Anthropic and is left to pass through. Bodies already declaring
+// anthropic_version are treated as Anthropic-native.
+func bodyLooksLikeOpenAIChat(body map[string]interface{}) bool {
+	if _, ok := body["anthropic_version"]; ok {
+		return false
+	}
+	if _, ok := body["messages"].([]interface{}); !ok {
+		return false
+	}
+	// Top-level keys OpenAI has and the Anthropic Messages body does not. Fields both
+	// APIs share (stream, metadata, service_tier, max_tokens, temperature, top_p) are
+	// deliberately absent — they cannot discriminate.
+	for _, k := range []string{
+		"max_completion_tokens", "frequency_penalty", "presence_penalty", "logit_bias",
+		"response_format", "parallel_tool_calls", "logprobs", "top_logprobs", "n",
+		"stop", "seed", "user", "stream_options", "store", "modalities", "audio",
+		"prediction", "web_search_options", "reasoning_effort", "functions", "function_call",
+	} {
+		if _, ok := body[k]; ok {
+			return true
+		}
+	}
+	// OpenAI accepts a bare string tool_choice ("auto"/"none"/"required"); Anthropic's is always an object.
+	if _, ok := body["tool_choice"].(string); ok {
+		return true
+	}
+	// OpenAI tool wrapper: {"type": "function", "function": {...}} (Anthropic tools are flat).
+	if tools, ok := body["tools"].([]interface{}); ok {
+		for _, t := range tools {
+			if tm, ok := t.(map[string]interface{}); ok {
+				if tm["type"] == "function" || tm["function"] != nil {
+					return true
+				}
+			}
+		}
+	}
+	messages, _ := body["messages"].([]interface{})
+	for _, m := range messages {
+		mm, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// OpenAI carries system/developer prompts and tool results as message roles; Anthropic
+		// uses a top-level "system" field and tool_result content blocks.
+		switch mm["role"] {
+		case "system", "developer", "tool":
+			return true
+		}
+		if mm["tool_calls"] != nil {
+			return true
+		}
+		if parts, ok := mm["content"].([]interface{}); ok {
+			for _, p := range parts {
+				if pm, ok := p.(map[string]interface{}); ok && pm["type"] == "image_url" {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // ============================ Integration Converters ============================
@@ -294,8 +465,16 @@ func ToBifrostBatchCreateRequest(job *VertexBatchPredictionJob) *schemas.Bifrost
 	if job == nil {
 		return req
 	}
+	// The key allowlist, model catalog and batch pricing all key on the bare model id, so a
+	// publishers/{publisher}/models/{id} path is reduced here. The caller's exact path is kept
+	// in ExtraParams below so a rebuilt job body re-emits it instead of re-deriving a publisher.
+	qualifiedModel := ""
 	if job.Model != "" {
-		req.Model = schemas.Ptr(job.Model)
+		model := job.Model
+		if bare, isPublisherPath := stripVertexPublisherModelPath(model); isPublisherPath {
+			qualifiedModel, model = model, bare
+		}
+		req.Model = schemas.Ptr(model)
 	}
 	if job.InputConfig.GcsSource != nil && len(job.InputConfig.GcsSource.Uris) > 0 {
 		req.InputFileID = job.InputConfig.GcsSource.Uris[0]
@@ -316,6 +495,9 @@ func ToBifrostBatchCreateRequest(job *VertexBatchPredictionJob) *schemas.Bifrost
 	// merge cleanly into the outbound BatchPredictionJob body. Each is guarded so zero values
 	// are not forwarded (mirroring the native struct's omitempty tags).
 	extra := map[string]interface{}{}
+	if qualifiedModel != "" {
+		extra["model"] = qualifiedModel
+	}
 	if job.ModelVersionID != "" {
 		extra["modelVersionId"] = job.ModelVersionID
 	}

--- a/core/providers/vertex/batch_conversion_test.go
+++ b/core/providers/vertex/batch_conversion_test.go
@@ -2,9 +2,11 @@ package vertex
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,6 +31,8 @@ func parseVertexJSONLLines(t *testing.T, data []byte) []map[string]interface{} {
 // native {"request": {contents...}} shape (via the shared Gemini converter), and that each
 // custom_id is carried in the request labels for round-trip correlation.
 func TestVertexConvertRequestsToJSONL(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
 	t.Run("ConvertsOpenAIMessagesAndCarriesCustomIDLabel", func(t *testing.T) {
 		requests := []schemas.BatchRequestItem{
 			{
@@ -41,7 +45,7 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 			},
 		}
 
-		data, err := vertexConvertRequestsToJSONL(requests)
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.NoError(t, err)
 
 		lines := parseVertexJSONLLines(t, data)
@@ -72,7 +76,7 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 			},
 		}
 
-		data, err := vertexConvertRequestsToJSONL(requests)
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.NoError(t, err)
 
 		lines := parseVertexJSONLLines(t, data)
@@ -99,7 +103,7 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 			},
 		}
 
-		data, err := vertexConvertRequestsToJSONL(requests)
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.NoError(t, err)
 
 		lines := parseVertexJSONLLines(t, data)
@@ -132,7 +136,7 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 			},
 		}
 
-		data, err := vertexConvertRequestsToJSONL(requests)
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.NoError(t, err)
 
 		lines := parseVertexJSONLLines(t, data)
@@ -149,7 +153,7 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 			{CustomID: "b", Body: map[string]interface{}{"messages": []interface{}{map[string]interface{}{"role": "user", "content": "2"}}}},
 		}
 
-		data, err := vertexConvertRequestsToJSONL(requests)
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.NoError(t, err)
 
 		lines := parseVertexJSONLLines(t, data)
@@ -160,7 +164,255 @@ func TestVertexConvertRequestsToJSONL(t *testing.T) {
 
 	t.Run("ErrorsWhenItemHasNoBody", func(t *testing.T) {
 		requests := []schemas.BatchRequestItem{{CustomID: "empty"}}
-		_, err := vertexConvertRequestsToJSONL(requests)
+		_, err := vertexConvertRequestsToJSONL(ctx, requests, "gemini-1.5-flash")
 		require.Error(t, err)
 	})
+
+	t.Run("AnthropicConvertsOpenAIBodyAndUsesNativeCustomID", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-1",
+				Body: map[string]interface{}{
+					// A system-role message marks this as an OpenAI body needing conversion.
+					"messages": []interface{}{
+						map[string]interface{}{"role": "system", "content": "You are helpful"},
+						map[string]interface{}{"role": "user", "content": "Hello"},
+					},
+					"max_tokens": 50,
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+
+		// custom_id is a native top-level field for Claude batch, not Gemini labels.
+		assert.Equal(t, "req-1", lines[0]["custom_id"])
+
+		request, ok := lines[0]["request"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "vertex-2023-10-16", request["anthropic_version"])
+		assert.Contains(t, request, "messages")
+		assert.NotContains(t, request, "labels")
+		assert.NotContains(t, request, "model") // model lives at the job level
+	})
+
+	t.Run("AnthropicConvertsOpenAIOnlyFields", func(t *testing.T) {
+		// Keys OpenAI has and Anthropic does not: passing them through verbatim makes
+		// Claude reject every record, so each one must force conversion on its own.
+		for field, value := range map[string]interface{}{
+			"stop":             []interface{}{"END"},
+			"seed":             42,
+			"user":             "u1",
+			"store":            true,
+			"reasoning_effort": "low",
+		} {
+			requests := []schemas.BatchRequestItem{
+				{
+					CustomID: "req-" + field,
+					Body: map[string]interface{}{
+						"messages": []interface{}{map[string]interface{}{"role": "user", "content": "Hello"}},
+						// Comfortably above the thinking floor so reasoning_effort converts cleanly.
+						"max_tokens": 4096,
+						field:        value,
+					},
+				},
+			}
+
+			data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+			require.NoError(t, err)
+
+			lines := parseVertexJSONLLines(t, data)
+			require.Len(t, lines, 1)
+			request := lines[0]["request"].(map[string]interface{})
+			assert.NotContains(t, request, field, "%s must not survive into the Anthropic body", field)
+			assert.Equal(t, "vertex-2023-10-16", request["anthropic_version"])
+		}
+
+		// A bare string tool_choice is OpenAI-only; Anthropic's is always an object.
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-tool-choice",
+				Body: map[string]interface{}{
+					"messages":    []interface{}{map[string]interface{}{"role": "user", "content": "Hello"}},
+					"max_tokens":  50,
+					"tool_choice": "auto",
+				},
+			},
+		}
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+		require.NoError(t, err)
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		request := lines[0]["request"].(map[string]interface{})
+		assert.NotEqual(t, "auto", request["tool_choice"])
+	})
+
+	t.Run("AnthropicKeepsSharedFieldsAsNative", func(t *testing.T) {
+		// stream/metadata/service_tier exist on both APIs, so they must not be read as
+		// OpenAI markers — that would send a native body through the lossy converter.
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-shared",
+				Body: map[string]interface{}{
+					"messages":       []interface{}{map[string]interface{}{"role": "user", "content": "Hello"}},
+					"max_tokens":     50,
+					"metadata":       map[string]interface{}{"user_id": "u1"},
+					"service_tier":   "auto",
+					"stop_sequences": []interface{}{"END"},
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		request := lines[0]["request"].(map[string]interface{})
+		assert.Equal(t, "auto", request["service_tier"])
+		assert.Equal(t, []interface{}{"END"}, request["stop_sequences"])
+	})
+
+	t.Run("AnthropicPassesThroughNativeBodyAndDropsModel", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-native",
+				Body: map[string]interface{}{
+					"messages":   []interface{}{map[string]interface{}{"role": "user", "content": "Hi"}},
+					"system":     "be brief",
+					"max_tokens": 64,
+					"model":      "claude-3-5-haiku",
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		require.Len(t, lines, 1)
+		assert.Equal(t, "req-native", lines[0]["custom_id"])
+
+		request := lines[0]["request"].(map[string]interface{})
+		assert.Equal(t, "vertex-2023-10-16", request["anthropic_version"])
+		assert.Equal(t, "be brief", request["system"])
+		assert.EqualValues(t, 64, request["max_tokens"])
+		assert.NotContains(t, request, "model")
+	})
+
+	t.Run("AnthropicPreservesExistingAnthropicVersion", func(t *testing.T) {
+		requests := []schemas.BatchRequestItem{
+			{
+				CustomID: "req-ver",
+				Body: map[string]interface{}{
+					"messages":          []interface{}{map[string]interface{}{"role": "user", "content": "Hi"}},
+					"max_tokens":        16,
+					"anthropic_version": "vertex-2023-10-16",
+				},
+			},
+		}
+
+		data, err := vertexConvertRequestsToJSONL(ctx, requests, "claude-3-5-haiku")
+		require.NoError(t, err)
+
+		lines := parseVertexJSONLLines(t, data)
+		request := lines[0]["request"].(map[string]interface{})
+		assert.Equal(t, "vertex-2023-10-16", request["anthropic_version"])
+	})
+}
+
+// TestToVertexBatchCreateRequestPublisher verifies the batch job model is resolved to the
+// correct publisher path per model family, and that already-qualified paths pass through.
+func TestToVertexBatchCreateRequestPublisher(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	cases := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		{"AnthropicBareName", "claude-3-5-haiku", "publishers/anthropic/models/claude-3-5-haiku"},
+		{"GeminiBareName", "gemini-1.5-flash", "publishers/google/models/gemini-1.5-flash"},
+		{"AlreadyQualifiedPassesThrough", "publishers/anthropic/models/claude-3-5-haiku", "publishers/anthropic/models/claude-3-5-haiku"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &schemas.BifrostBatchCreateRequest{Model: schemas.Ptr(tc.model)}
+			out := ToVertexBatchCreateRequest(ctx, req, "job", "gs://in/input.jsonl", "gs://out/")
+			assert.Equal(t, tc.expected, out.Model)
+		})
+	}
+}
+
+// TestToBifrostBatchCreateRequestModelLookup verifies the native batchPredictionJobs body's
+// model is reduced to the bare id that key/catalog/pricing lookups match on, while the
+// caller's exact publisher path is preserved for a rebuilt job body.
+func TestToBifrostBatchCreateRequestModelLookup(t *testing.T) {
+	cases := []struct {
+		name      string
+		model     string
+		wantModel string
+		wantExtra interface{} // nil when no publisher path was stripped
+	}{
+		{
+			name:      "PublisherPathReducedToBareID",
+			model:     "publishers/anthropic/models/claude-3-5-haiku",
+			wantModel: "claude-3-5-haiku",
+			wantExtra: "publishers/anthropic/models/claude-3-5-haiku",
+		},
+		{
+			name:      "BareNamePassesThrough",
+			model:     "claude-3-5-haiku",
+			wantModel: "claude-3-5-haiku",
+		},
+		{
+			// Fine-tuned models are addressed by resource path, not publisher path.
+			name:      "FineTunedResourcePathPassesThrough",
+			model:     "projects/p/locations/us-central1/models/1234",
+			wantModel: "projects/p/locations/us-central1/models/1234",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			job := &VertexBatchPredictionJob{Model: tc.model}
+			req := ToBifrostBatchCreateRequest(job)
+
+			require.NotNil(t, req.Model)
+			assert.Equal(t, tc.wantModel, *req.Model)
+			if tc.wantExtra == nil {
+				assert.NotContains(t, req.ExtraParams, "model")
+			} else {
+				assert.Equal(t, tc.wantExtra, req.ExtraParams["model"])
+			}
+		})
+	}
+
+	t.Run("RebuiltBodyReEmitsCallerPublisherPath", func(t *testing.T) {
+		// A publisher Bifrost cannot re-derive from the model family: the reduced id must not
+		// come back as publishers/google/... when the outbound body is rebuilt.
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		job := &VertexBatchPredictionJob{Model: "publishers/meta/models/llama-3.1-405b-instruct-maas"}
+		req := ToBifrostBatchCreateRequest(job)
+		assert.Equal(t, "llama-3.1-405b-instruct-maas", *req.Model)
+
+		out := ToVertexBatchCreateRequest(ctx, req, "job", "gs://in/input.jsonl", "gs://out/")
+		body, err := providerUtils.MergeExtraParamsIntoJSON(mustMarshal(t, out), out.GetExtraParams())
+		require.NoError(t, err)
+
+		var decoded map[string]interface{}
+		require.NoError(t, sonic.Unmarshal(body, &decoded))
+		assert.Equal(t, "publishers/meta/models/llama-3.1-405b-instruct-maas", decoded["model"])
+	})
+}
+
+func mustMarshal(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	b, err := sonic.Marshal(v)
+	require.NoError(t, err)
+	return b
 }

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -434,10 +434,12 @@ type VertexBatchJobListResponse struct {
 }
 
 // VertexBatchOutputLine is one line of a predictions-*.jsonl batch output file.
-// The original request is echoed back; labels carry the Bifrost custom_id.
+// The original request is echoed back; the Bifrost custom_id round-trips via the native
+// top-level "custom_id" (Anthropic/Claude jobs) or the request labels (Gemini jobs).
 type VertexBatchOutputLine struct {
-	Status  string `json:"status,omitempty"` // error string for failed records, empty on success
-	Request struct {
+	CustomID string `json:"custom_id,omitempty"` // native custom_id echoed by Anthropic-on-Vertex batch
+	Status   string `json:"status,omitempty"`    // error string for failed records, empty on success
+	Request  struct {
 		Labels map[string]string `json:"labels"`
 	} `json:"request"`
 	Response map[string]interface{} `json:"response,omitempty"`

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -2888,7 +2888,7 @@ func (provider *VertexProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 
 		// Inline mode: convert to JSONL and upload next to the output location (Bedrock pattern).
 		if inputFileID == "" {
-			jsonlData, err := vertexConvertRequestsToJSONL(request.Requests)
+			jsonlData, err := vertexConvertRequestsToJSONL(ctx, request.Requests, *request.Model)
 			if err != nil {
 				return nil, providerUtils.NewBifrostOperationError("failed to convert requests to Vertex JSONL", err)
 			}
@@ -2927,7 +2927,7 @@ func (provider *VertexProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToVertexBatchCreateRequest(request, jobName, inputFileID, outputURI), nil
+			return ToVertexBatchCreateRequest(ctx, request, jobName, inputFileID, outputURI), nil
 		},
 	)
 	if bodyErr != nil {
@@ -3417,8 +3417,13 @@ func (provider *VertexProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 			if err := sonic.Unmarshal(rawLine, &line); err != nil {
 				continue // skip malformed lines rather than failing the whole result set
 			}
+			// Anthropic/Claude jobs echo a native top-level custom_id; Gemini jobs carry it in labels.
+			customID := line.CustomID
+			if customID == "" {
+				customID = line.Request.Labels[vertexBatchCustomIDLabel]
+			}
 			item := schemas.BatchResultItem{
-				CustomID: line.Request.Labels[vertexBatchCustomIDLabel],
+				CustomID: customID,
 			}
 			if line.Response != nil {
 				item.Response = &schemas.BatchResultResponse{

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -160,29 +160,24 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 					provider = schemas.Gemini
 				}
 
-				// Convert Gemini batch request items directly to Bifrost format
+				// Convert Gemini batch request items directly to Bifrost format. Marshalling the
+				// parsed request preserves every modeled field (contents, generationConfig,
+				// safetySettings, systemInstruction, tools, toolConfig, cachedContent, labels)
+				// without hand-listing them, so new fields never silently drop.
 				var requests []schemas.BatchRequestItem
 				if geminiReq.Batch.InputConfig.Requests != nil && len(geminiReq.Batch.InputConfig.Requests.Requests) > 0 {
 					requests = make([]schemas.BatchRequestItem, len(geminiReq.Batch.InputConfig.Requests.Requests))
 					for i, geminiItem := range geminiReq.Batch.InputConfig.Requests.Requests {
-						requestMap := make(map[string]interface{})
-						if geminiItem.Request.Contents != nil {
-							requestMap["contents"] = geminiItem.Request.Contents
+						reqBytes, err := sonic.Marshal(geminiItem.Request)
+						if err != nil {
+							return nil, err
 						}
-						if geminiItem.Request.GenerationConfig != nil {
-							requestMap["generationConfig"] = geminiItem.Request.GenerationConfig
-						}
-						if len(geminiItem.Request.SafetySettings) > 0 {
-							requestMap["safetySettings"] = geminiItem.Request.SafetySettings
-						}
-						if geminiItem.Request.SystemInstruction != nil {
-							requestMap["systemInstruction"] = geminiItem.Request.SystemInstruction
+						body := map[string]interface{}{}
+						if err := sonic.Unmarshal(reqBytes, &body); err != nil {
+							return nil, err
 						}
 
-						requests[i] = schemas.BatchRequestItem{
-							CustomID: "",
-							Body:     requestMap,
-						}
+						requests[i] = schemas.BatchRequestItem{Body: body}
 						// Extract custom_id from metadata
 						if geminiItem.Metadata != nil && geminiItem.Metadata.Key != "" {
 							requests[i].CustomID = geminiItem.Metadata.Key
@@ -195,6 +190,11 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 					Model:          &geminiReq.Model,
 					Requests:       requests,
 					RawRequestBody: getGenAIRawRequestBody(ctx),
+				}
+
+				// Carry the caller-supplied display name (config.display_name) through.
+				if geminiReq.Batch.DisplayName != "" {
+					bifrostBatchReq.DisplayName = &geminiReq.Batch.DisplayName
 				}
 
 				// Handle file-based input

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -139,6 +139,39 @@ func TestGenAIBatchCreateConverterCarriesRawBody(t *testing.T) {
 	assert.Equal(t, true, bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody))
 }
 
+// TestGenAIBatchCreateConverterCarriesDisplayNameAndInlineTools verifies the typed batch
+// create path (used when the request is not an explicit-gemini raw passthrough) carries the
+// batch display name and every modeled inline-request field (tools, cachedContent) through.
+func TestGenAIBatchCreateConverterCarriesDisplayNameAndInlineTools(t *testing.T) {
+	rawBody := []byte(`{"batch":{"displayName":"my-batch","inputConfig":{"requests":{"requests":[{"request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"tools":[{"functionDeclarations":[{"name":"get_weather"}]}],"cachedContent":"cachedContents/abc"},"metadata":{"key":"req-1"}}]}}}}`)
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("model", "gemini-2.5-flash:batchGenerateContent")
+	ctx.Request.Header.SetMethod("POST")
+	// No x-model-provider header, so the typed path (not raw passthrough) is exercised.
+	ctx.Request.SetBody(rawBody)
+
+	req := &gemini.GeminiBatchCreateRequest{}
+	require.NoError(t, sonic.Unmarshal(rawBody, req))
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	require.NoError(t, extractAndSetModelAndRequestType(ctx, bifrostCtx, req))
+
+	route := findGenAIRouteForTest(t, CreateGenAIRouteConfigs("/genai"), "/genai/v1beta/models/{model:*}", "POST")
+	batchReq, err := route.BatchRequestConverter(bifrostCtx, req)
+	require.NoError(t, err)
+	require.NotNil(t, batchReq.CreateRequest)
+
+	// #2: batch display name carried through.
+	require.NotNil(t, batchReq.CreateRequest.DisplayName)
+	assert.Equal(t, "my-batch", *batchReq.CreateRequest.DisplayName)
+
+	// #3: inline tools + cachedContent survive (not dropped by the converter).
+	require.Len(t, batchReq.CreateRequest.Requests, 1)
+	body := batchReq.CreateRequest.Requests[0].Body
+	assert.Contains(t, body, "tools")
+	assert.Equal(t, "cachedContents/abc", body["cachedContent"])
+	assert.Equal(t, "req-1", batchReq.CreateRequest.Requests[0].CustomID)
+}
+
 func TestGenAICachedContentCreateParserRejectsNonStringScalars(t *testing.T) {
 	rawBody := []byte(`{"model":123,"ttl":3600}`)
 	ctx := &fasthttp.RequestCtx{}


### PR DESCRIPTION
## Summary

Adds Claude-on-Vertex batch support and fixes several field-preservation gaps in the Gemini/Vertex batch pipeline. Previously, Vertex batch jobs always routed models under `publishers/google/models/...`, dropping Anthropic Claude models; inline batch request bodies silently discarded fields like `tools`, `toolConfig`, `cachedContent`, and `labels`; and the batch display name supplied by callers was ignored.

## Changes

- **Claude-on-Vertex batch routing**: `ToVertexBatchCreateRequest` now resolves bare model names to `publishers/anthropic/models/...` for Anthropic model families and `publishers/google/models/...` for everything else, using `schemas.IsAnthropicModelFamily`.
- **Anthropic JSONL instance building**: `vertexConvertRequestsToJSONL` detects Anthropic model families and emits Claude-on-Vertex batch instances — OpenAI-shaped bodies are converted via the shared `BuildAnthropicChatRequestBody` converter; Anthropic-native bodies pass through with `model` dropped and `anthropic_version` ensured. The native top-level `custom_id` field is used instead of Gemini request labels.
- **`bodyLooksLikeOpenAIChat` heuristic**: Distinguishes OpenAI chat bodies from Anthropic-native bodies by checking for OpenAI-only markers (`max_completion_tokens`, `frequency_penalty`, `image_url` content parts, `system`/`developer`/`tool` message roles, etc.) while treating any body already declaring `anthropic_version` as Anthropic-native.
- **Custom ID round-trip for Anthropic output**: `batchResultsByKey` now reads `line.CustomID` (native Anthropic field) first, falling back to the Gemini label for Google jobs.
- **`GeminiBatchGenerateContentRequest` extended**: Added `Tools`, `ToolConfig`, `CachedContent`, and `Labels` fields so these are no longer silently dropped during struct conversion.
- **GenAI integration inline-request serialization**: Replaced the hand-listed field mapping with a marshal/unmarshal round-trip through `sonic`, so all modeled fields on `GeminiBatchGenerateContentRequest` are preserved automatically without needing to enumerate them.
- **Batch display name forwarded**: The `config.display_name` from a GenAI batch create request is now carried into `BifrostBatchCreateRequest.DisplayName` and used when building the Gemini/Vertex job, falling back to the generated timestamp name only when absent.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
go test ./core/providers/vertex/...
go test ./transports/bifrost-http/integrations/...
```

New test cases cover:
- `TestVertexConvertRequestsToJSONL/AnthropicConvertsOpenAIBodyAndUsesNativeCustomID` — verifies OpenAI-shaped bodies are converted and `custom_id` is a native top-level field.
- `TestVertexConvertRequestsToJSONL/AnthropicPassesThroughNativeBodyAndDropsModel` — verifies Anthropic-native bodies pass through with `model` stripped and `anthropic_version` injected.
- `TestToVertexBatchCreateRequestPublisher` — verifies `claude-*` models resolve to `publishers/anthropic/models/...` and Gemini models to `publishers/google/models/...`.
- `TestToGeminiBatchGenerateContentRequest/PreservesToolsToolConfigCachedContentAndLabels` — verifies the extended struct fields survive conversion.
- `TestGenAIBatchCreateConverterCarriesDisplayNameAndInlineTools` — verifies `displayName` and inline `tools`/`cachedContent` are not dropped by the GenAI integration converter.

## Breaking changes

- [x] Yes
- [ ] No

`ToVertexBatchCreateRequest` and `vertexConvertRequestsToJSONL` now require a `*schemas.BifrostContext` as their first argument. Any direct callers outside the package must update their call sites.

## Related issues

## Security considerations

No new auth flows, secrets handling, or PII processing introduced. The Anthropic version string (`vertex-2023-10-16`) is a static constant matching the value already used by the Vertex chat path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable