### PR TITLE
chore: update helm charts with retain_content_in_object_storage

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,6 +8,10 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
+### 2.1.30
+
+- Added `bifrost.client.retainContentInObjectStorage` (default off, commented out) to keep full request/response content in object storage when content logging is disabled — via the global `disableContentLogging` setting or the `x-bf-disable-content-logging` header — instead of dropping it. The content is hidden: the database row stays metadata-only and the UI/API never fetch the payload back, so it is only readable with direct access to the bucket. Requires `storage.logsStore.objectStorage.enabled: true`; without it the content is dropped as before. Renders into `client.retain_content_in_object_storage`.
+
 ### 2.1.29
 
 - Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to the Okta, Entra, SailPoint, and generic OIDC SCIM providers, so inbound SCIM provisioning can be seeded declaratively instead of via the dashboard. Both render into `scim_config.config`. Generate a token with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` (supports `env.` prefix).

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -259,6 +259,9 @@ false
 {{- if hasKey .Values.bifrost.client "disableContentLogging" }}
 {{- $_ := set $client "disable_content_logging" .Values.bifrost.client.disableContentLogging }}
 {{- end }}
+{{- if hasKey .Values.bifrost.client "retainContentInObjectStorage" }}
+{{- $_ := set $client "retain_content_in_object_storage" .Values.bifrost.client.retainContentInObjectStorage }}
+{{- end }}
 {{- if hasKey .Values.bifrost.client "allowPerRequestContentStorageOverride" }}
 {{- $_ := set $client "allow_per_request_content_storage_override" .Values.bifrost.client.allowPerRequestContentStorageOverride }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -373,6 +373,11 @@
               "type": "boolean",
               "description": "Disable logging of sensitive content (inputs, outputs, embeddings, etc.)"
             },
+            "retainContentInObjectStorage": {
+              "type": "boolean",
+              "description": "When content logging is disabled, offload the full content to object storage as hidden instead of dropping it. Hidden content is never served back through the API/UI — the database row stays metadata-only and is only readable with direct access to the storage bucket. Requires object storage to be configured on the logs store.",
+              "default": false
+            },
             "allowPerRequestContentStorageOverride": {
               "type": "boolean",
               "description": "Allow individual requests to override content storage via the x-bf-disable-content-logging header or context key, and to opt in to raw-byte persistence in logs via x-bf-store-raw-request-response. When false (default), the global disable_content_logging setting is authoritative and per-request storage overrides are ignored. Does not control sending raw bytes back to callers.",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -280,6 +280,13 @@ bifrost:
       - "*"
     enableLogging: true
     disableContentLogging: false
+    # retainContentInObjectStorage -- When content logging is disabled (global setting above or
+    # the x-bf-disable-content-logging header), offload the full content to object storage as
+    # hidden instead of dropping it. Hidden content is never served back through the API/UI: the
+    # database row stays metadata-only and the payload is only readable with direct access to the
+    # bucket. Requires storage.logsStore.objectStorage.enabled: true; without it the content is
+    # dropped as before.
+    # retainContentInObjectStorage: false
     disableDbPingsInHealth: false
     dumpErrorsInConsoleLogs: false
     logRetentionDays: 365


### PR DESCRIPTION
## Summary

Adds a new `bifrost.client.retainContentInObjectStorage` Helm value that allows full request/response content to be offloaded to object storage as hidden data when content logging is disabled, rather than being dropped entirely. This gives operators a way to preserve content for direct bucket-level access without exposing it through the API or UI.

## Changes

- Added `retainContentInObjectStorage` to `values.yaml` (commented out by default, defaults to `false`) which renders into `client.retain_content_in_object_storage` in the generated config
- Added the corresponding template logic in `_helpers.tpl` to conditionally set `retain_content_in_object_storage` when the key is present
- Added the field to `values.schema.json` with a description and default value of `false`
- Documented the new field in `README.md` under changelog entry `2.1.30`

When enabled, content that would otherwise be dropped due to `disableContentLogging` or the `x-bf-disable-content-logging` header is instead written to object storage. The database row remains metadata-only and the payload is never returned via the API or UI — it is only accessible with direct bucket access. Requires `object_storage` to be configured on `bifrost.logsStore`; without it, content is dropped as before.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy Bifrost with the following values set:

```yaml
bifrost:
  logsStore: object_storage  # required
  client:
    disableContentLogging: true
    retainContentInObjectStorage: true
```

Send a request through Bifrost and verify:
- The database row contains only metadata (no content payload)
- The API and UI do not return the content payload
- The full content is present in the configured object storage bucket

Without `object_storage` configured on `bifrost.logsStore`, verify that content is dropped as before even when `retainContentInObjectStorage: true`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Content written to object storage under this feature is intentionally hidden from the API and UI, but is readable by anyone with direct access to the storage bucket. Operators should ensure appropriate bucket-level access controls are in place before enabling this option, particularly when handling PII or sensitive model inputs/outputs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable