### PR TITLE
helm: keep alive timeout config

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -421,6 +421,9 @@ false
 {{- if hasKey $providerConfig.network_config "stream_idle_timeout_in_seconds" }}
 {{- $_ := set $networkConfig "stream_idle_timeout_in_seconds" $providerConfig.network_config.stream_idle_timeout_in_seconds }}
 {{- end }}
+{{- if hasKey $providerConfig.network_config "keep_alive_timeout_in_seconds" }}
+{{- $_ := set $networkConfig "keep_alive_timeout_in_seconds" $providerConfig.network_config.keep_alive_timeout_in_seconds }}
+{{- end }}
 {{- if hasKey $providerConfig.network_config "max_conns_per_host" }}
 {{- $_ := set $networkConfig "max_conns_per_host" $providerConfig.network_config.max_conns_per_host }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5437,6 +5437,12 @@
           "maximum": 3600,
           "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
         },
+        "keep_alive_timeout_in_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3600,
+          "description": "Idle keep-alive for pooled connections, in seconds. Set below the upstream server's keep-alive so Bifrost drops idle connections before the server closes them. Default: 30."
+        },
         "max_conns_per_host": {
           "type": "integer",
           "minimum": 1,

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -372,6 +372,7 @@ bifrost:
     #     retry_backoff_initial_ms: 500                 # Initial retry backoff in ms
     #     retry_backoff_max_ms: 5000                    # Max retry backoff in ms
     #     stream_idle_timeout_in_seconds: 60            # Max wait for next stream chunk (default: 60)
+    #     keep_alive_timeout_in_seconds: 30             # Idle keep-alive for pooled connections; keep below upstream's (default: 30)
     #     max_conns_per_host: 5000                      # Max TCP connections per host (default: 5000)
     #     enforce_http2: false                           # Force HTTP/2 on provider connections (e.g. Bedrock)
     #     insecure_skip_verify: false                   # Disable TLS certificate verification (last resort)


### PR DESCRIPTION
## Summary

Adds support for a `keep_alive_timeout_in_seconds` network configuration option in Bifrost, allowing operators to control the idle keep-alive duration for pooled upstream connections. This helps prevent connection errors caused by the upstream server closing idle connections before Bifrost does.

## Changes

- Added `keep_alive_timeout_in_seconds` to the Helm chart template helper so the value is passed through to the generated config when specified.
- Added a JSON schema definition for `keep_alive_timeout_in_seconds` with a valid range of 1–3600 seconds and a descriptive note recommending it be set below the upstream server's keep-alive timeout.
- Added a commented-out example in `values.yaml` documenting the new option and its default of 30 seconds.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy Bifrost with a provider that includes `keep_alive_timeout_in_seconds` set in its `network_config`, for example:

```yaml
bifrost:
  providers:
    - name: my-provider
      network_config:
        keep_alive_timeout_in_seconds: 25
```

Verify the generated config contains `keep_alive_timeout_in_seconds: 25` and that Bifrost correctly drops idle pooled connections before the upstream server's keep-alive timeout expires.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a connection pool tuning parameter with no auth, secrets, or PII implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable