### PR TITLE
feat: add `appendFallbacksToPinned` load-balancer option to Helm chart

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -692,6 +692,9 @@ false
 {{- if hasKey .Values.bifrost.loadBalancer "routeSelectionEnabled" }}
 {{- $_ := set $lb "route_selection_enabled" .Values.bifrost.loadBalancer.routeSelectionEnabled }}
 {{- end }}
+{{- if hasKey .Values.bifrost.loadBalancer "appendFallbacksToPinned" }}
+{{- $_ := set $lb "append_fallbacks_to_pinned" .Values.bifrost.loadBalancer.appendFallbacksToPinned }}
+{{- end }}
 {{- if hasKey .Values.bifrost.loadBalancer "rerouteFailedDirections" }}
 {{- $_ := set $lb "reroute_failed_directions" .Values.bifrost.loadBalancer.rerouteFailedDirections }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2807,6 +2807,10 @@
               "type": "boolean",
               "description": "Enable adaptive per-key (route) selection. Defaults to true; omit to leave on."
             },
+            "appendFallbacksToPinned": {
+              "type": "boolean",
+              "description": "When a request already carries a provider, append the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to false."
+            },
             "rerouteFailedDirections": {
               "type": "boolean",
               "description": "When a pinned provider's direction is unhealthy, re-route the request to a healthy provider. Defaults to false."

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1049,6 +1049,7 @@ bifrost:
     enabled: false
     # directionSelectionEnabled: true   # Enable adaptive provider selection. Defaults to true; omit to leave on.
     # routeSelectionEnabled: true       # Enable adaptive per-key (route) selection. Defaults to true; omit to leave on.
+    # appendFallbacksToPinned: false    # When a request already carries a provider, append the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to false.
     # rerouteFailedDirections: false    # Re-route to a healthy provider when a pinned direction is unhealthy. Defaults to false.
     # pruneFailedFallbacks: false       # Drop unhealthy directions from a request's configured fallbacks. Defaults to false.
     trackerConfig: {}


### PR DESCRIPTION
## Summary

Adds support for a new `appendFallbacksToPinned` load balancer option in the Bifrost Helm chart. When enabled, requests that already specify a provider will have healthy providers eligible for the requested model automatically appended as fallbacks behind any fallbacks already configured on the request.

## Changes

- Added `appendFallbacksToPinned` to the Helm template helper so it is conditionally included in the rendered load balancer config when set
- Added `appendFallbacksToPinned` to the JSON schema with a description and boolean type
- Added a commented-out example entry in `values.yaml` documenting the new option and its default (`false`)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart with `appendFallbacksToPinned: true` set under `bifrost.loadBalancer` and send a request with a pinned provider. Verify that healthy providers eligible for the requested model are appended as fallbacks in the load balancer routing behavior.

```sh
helm template bifrost ./helm-charts/bifrost --set bifrost.loadBalancer.enabled=true --set bifrost.loadBalancer.appendFallbacksToPinned=true
```

Confirm that `append_fallbacks_to_pinned: true` appears in the rendered output. Also verify that omitting the value entirely results in the key being absent from the rendered config (preserving the default `false` behavior).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a routing behavior toggle with no impact on authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable