### PR TITLE
feat: add `bifrost.webhooks` and `bifrost.client.webhookConfig` Helm values with schema validation

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -274,6 +274,13 @@ false
 {{- if hasKey .Values.bifrost.client "dumpErrorsInConsoleLogs" }}
 {{- $_ := set $client "dump_errors_in_console_logs" .Values.bifrost.client.dumpErrorsInConsoleLogs }}
 {{- end }}
+{{- if .Values.bifrost.client.webhookConfig }}
+{{- $webhookConfig := dict }}
+{{- if .Values.bifrost.client.webhookConfig.deliveryHistoryRetentionDays }}
+{{- $_ := set $webhookConfig "delivery_history_retention_days" .Values.bifrost.client.webhookConfig.deliveryHistoryRetentionDays }}
+{{- end }}
+{{- $_ := set $client "webhook_config" $webhookConfig }}
+{{- end }}
 {{- if .Values.bifrost.client.headerFilterConfig }}
 {{- $headerFilter := dict }}
 {{- if .Values.bifrost.client.headerFilterConfig.allowlist }}
@@ -762,6 +769,29 @@ false
 {{- end }}
 {{- end }}
 {{- $_ := set $config "alerting" .Values.bifrost.alerting }}
+{{- end }}
+{{- /* Webhooks */ -}}
+{{- if .Values.bifrost.webhooks }}
+{{- $seenWebhookNames := list }}
+{{- range .Values.bifrost.webhooks }}
+{{- if not .name }}
+{{- fail "ERROR: bifrost.webhooks[].name is required for every webhook endpoint." }}
+{{- end }}
+{{- if has .name $seenWebhookNames }}
+{{- fail (printf "ERROR: bifrost.webhooks[].name '%s' is used by more than one endpoint. Names must be unique; startup reconciliation identifies endpoints by name." .name) }}
+{{- end }}
+{{- $seenWebhookNames = append $seenWebhookNames .name }}
+{{- if not .url }}
+{{- fail (printf "ERROR: bifrost.webhooks[].url is required for webhook endpoint '%s'." .name) }}
+{{- end }}
+{{- if not .events }}
+{{- fail (printf "ERROR: bifrost.webhooks[].events is required for webhook endpoint '%s'." .name) }}
+{{- end }}
+{{- if ne (len .events) (len (uniq .events)) }}
+{{- fail (printf "ERROR: bifrost.webhooks[].events for endpoint '%s' contains duplicate entries. Each event may be listed at most once." .name) }}
+{{- end }}
+{{- end }}
+{{- $_ := set $config "webhooks" .Values.bifrost.webhooks }}
 {{- end }}
 {{- /* Config Store */ -}}
 {{- if .Values.storage.configStore.enabled }}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -692,6 +692,9 @@ false
 {{- if hasKey .Values.bifrost.loadBalancer "routeSelectionEnabled" }}
 {{- $_ := set $lb "route_selection_enabled" .Values.bifrost.loadBalancer.routeSelectionEnabled }}
 {{- end }}
+{{- if hasKey .Values.bifrost.loadBalancer "appendFallbacksToPinned" }}
+{{- $_ := set $lb "append_fallbacks_to_pinned" .Values.bifrost.loadBalancer.appendFallbacksToPinned }}
+{{- end }}
 {{- if hasKey .Values.bifrost.loadBalancer "rerouteFailedDirections" }}
 {{- $_ := set $lb "reroute_failed_directions" .Values.bifrost.loadBalancer.rerouteFailedDirections }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -393,6 +393,19 @@
               "description": "Dump full error details to the server console logs. Useful for debugging; may be noisy in production.",
               "default": false
             },
+            "webhookConfig": {
+              "type": "object",
+              "description": "Global webhook delivery settings; per-endpoint tuning lives on each bifrost.webhooks[] entry.",
+              "properties": {
+                "deliveryHistoryRetentionDays": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 30,
+                  "description": "How long delivery history records are kept before being reaped."
+                }
+              },
+              "additionalProperties": false
+            },
             "logRetentionDays": {
               "type": "integer",
               "minimum": 1,
@@ -3519,6 +3532,116 @@
             }
           },
           "additionalProperties": false
+        },
+        "webhooks": {
+          "type": "array",
+          "description": "Webhook endpoint declarations synced into the database at startup, reconciled by name. Rendered directly as top-level webhooks in config.json.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable endpoint ID. Generated when omitted."
+              },
+              "name": {
+                "type": "string",
+                "description": "Unique endpoint name."
+              },
+              "url": {
+                "type": "string",
+                "description": "Delivery URL. HTTPS required unless allow_private_network is set; credentials and fragments are rejected; link-local and metadata addresses are always blocked."
+              },
+              "secret": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": { "type": "string" },
+                      "env_var": { "type": "string" },
+                      "from_env": { "type": "boolean" }
+                    },
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Signing secret in the whsec_ format. Best supplied as an env reference (\"env.MY_VAR\"); generated when omitted."
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["async_job.completed", "async_job.failed"]
+                },
+                "uniqueItems": true,
+                "description": "Events this endpoint subscribes to. Each event may be listed at most once; duplicates are rejected by the runtime validator and disable the endpoint at startup."
+              },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "anyOf": [
+                    { "type": "string" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "value": { "type": "string" },
+                        "env_var": { "type": "string" },
+                        "from_env": { "type": "boolean" }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "description": "Custom headers sent with every delivery. Values support env var syntax (\"env.MY_VAR\") and are encrypted at rest. Reserved delivery headers (webhook-id, webhook-timestamp, webhook-signature, content-type, etc.) cannot be overridden."
+              },
+              "include_response": {
+                "type": "boolean",
+                "default": false,
+                "description": "Inline the job response into delivery payloads, capped by max_response_payload_kbs."
+              },
+              "allow_private_network": {
+                "type": "boolean",
+                "default": false,
+                "description": "Permit private-network receivers and plain http. Link-local and metadata addresses stay blocked."
+              },
+              "disabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Register the endpoint without delivering to it."
+              },
+              "max_retries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "How many times a failed delivery is retried after its first attempt (default: 4)."
+              },
+              "retry_backoff_initial_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Delay before the first retry in seconds; each further retry doubles it (default: 30)."
+              },
+              "retry_backoff_max_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Cap on the per-retry delay in seconds (default: 1800)."
+              },
+              "attempt_timeout_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "End-to-end bound for one delivery attempt in seconds (default: 10)."
+              },
+              "max_response_payload_kbs": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Cap for inlined response payloads in KB when include_response is set (default: 256). Oversized responses are omitted and flagged with response_omitted."
+              },
+              "max_concurrent_deliveries": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Concurrent in-flight deliveries to this endpoint per node (default: 10)."
+              }
+            },
+            "required": ["name", "url", "events"],
+            "additionalProperties": false
+          }
         },
         "auditLogs": {
           "type": "object",

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2807,6 +2807,10 @@
               "type": "boolean",
               "description": "Enable adaptive per-key (route) selection. Defaults to true; omit to leave on."
             },
+            "appendFallbacksToPinned": {
+              "type": "boolean",
+              "description": "When a request already carries a provider, append the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to false."
+            },
             "rerouteFailedDirections": {
               "type": "boolean",
               "description": "When a pinned provider's direction is unhealthy, re-route the request to a healthy provider. Defaults to false."

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -282,6 +282,9 @@ bifrost:
     disableContentLogging: false
     disableDbPingsInHealth: false
     dumpErrorsInConsoleLogs: false
+    # Global webhook delivery settings; per-endpoint tuning lives on each bifrost.webhooks[] entry.
+    # webhookConfig:
+    #   deliveryHistoryRetentionDays: 30   # How long delivery history records are kept before being reaped.
     logRetentionDays: 365
     # Deprecated: use enforceAuthOnInference instead.
     enforceGovernanceHeader: false
@@ -1175,6 +1178,25 @@ bifrost:
   #       # Optionally target a specific budget:
   #       # target_type: budget
   #       # target_id: "budget-1"
+
+  # Webhooks: endpoint declarations synced into the database at startup, reconciled by name.
+  # Rendered directly as top-level `webhooks` in config.json.
+  # webhooks:
+  #   - name: "async-jobs"
+  #     url: "https://my-internal-hook.corp/webhooks/async-jobs"
+  #     secret: "env.WEBHOOK_SIGNING_SECRET"   # whsec_ format; generated when omitted
+  #     events: ["async_job.completed", "async_job.failed"]
+  #     headers:
+  #       Authorization: "env.WEBHOOK_AUTH_HEADER"
+  #     include_response: false        # Inline the job response into delivery payloads
+  #     allow_private_network: false   # Permit private-network receivers and plain http
+  #     disabled: false
+  #     max_retries: 4
+  #     retry_backoff_initial_seconds: 30
+  #     retry_backoff_max_seconds: 1800
+  #     attempt_timeout_seconds: 10
+  #     max_response_payload_kbs: 256
+  #     max_concurrent_deliveries: 10
 
   # Audit logs configuration for CADF-compliant activity logging
   auditLogs:

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1049,6 +1049,7 @@ bifrost:
     enabled: false
     # directionSelectionEnabled: true   # Enable adaptive provider selection. Defaults to true; omit to leave on.
     # routeSelectionEnabled: true       # Enable adaptive per-key (route) selection. Defaults to true; omit to leave on.
+    # appendFallbacksToPinned: false    # When a request already carries a provider, append the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to false.
     # rerouteFailedDirections: false    # Re-route to a healthy provider when a pinned direction is unhealthy. Defaults to false.
     # pruneFailedFallbacks: false       # Drop unhealthy directions from a request's configured fallbacks. Defaults to false.
     trackerConfig: {}


### PR DESCRIPTION
## Summary

Adds declarative webhook endpoint support to the Bifrost Helm chart, allowing operators to define webhook endpoints in `values.yaml` that are synced into the database at startup and reconciled by name. Also introduces a global `webhookConfig` block under `bifrost.client` for controlling delivery history retention.

## Changes

- Added `bifrost.webhooks[]` array to `values.yaml` and `values.schema.json`, supporting full per-endpoint configuration including URL, signing secret, subscribed events, custom headers, retry behavior, timeouts, concurrency limits, and response inlining.
- Added template logic in `_helpers.tpl` to validate that each webhook entry has `name`, `url`, and `events` defined, failing fast with descriptive error messages if any are missing, then rendering the list into `config.json`.
- Added `bifrost.client.webhookConfig` to `values.yaml` and `values.schema.json` with a `deliveryHistoryRetentionDays` field (default: 30) controlling how long delivery history records are retained before being reaped.
- Schema enforces `minimum: 1` on all integer fields and restricts `events` to `async_job.completed` and `async_job.failed`. Secrets and header values support both plain strings and env var reference objects.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Enable webhooks in your `values.yaml` and render the chart to confirm the output:

```sh
helm template bifrost ./helm-charts/bifrost \
  --set 'bifrost.webhooks[0].name=async-jobs' \
  --set 'bifrost.webhooks[0].url=https://example.com/hook' \
  --set 'bifrost.webhooks[0].events[0]=async_job.completed'
```

Verify that `config.json` in the rendered output contains a `webhooks` key with the expected endpoint definition.

To test validation failures, omit a required field (e.g., `url`) and confirm `helm template` exits with the expected error message.

To test `webhookConfig`:

```sh
helm template bifrost ./helm-charts/bifrost \
  --set 'bifrost.client.webhookConfig.deliveryHistoryRetentionDays=14'
```

Confirm `delivery_history_retention_days: 14` appears under `client` in the rendered `config.json`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- Webhook signing secrets should be supplied via env var references (e.g., `env.WEBHOOK_SIGNING_SECRET`) rather than plain strings to avoid embedding secrets in Helm values or rendered manifests.
- Custom header values also support env var references and are documented as encrypted at rest.
- `allow_private_network` defaults to `false`; link-local and metadata addresses remain blocked regardless of this setting.
- HTTPS is required for delivery URLs unless `allow_private_network` is explicitly enabled.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable