### PR TITLE
feat: release Bifrost Helm chart v2.1.30 with webhooks, appendFallbacksToPinned, retainContentInObjectStorage, and keep-alive timeout

### DIFF
--- a/docs/changelogs/helm-v2.1.30.mdx
+++ b/docs/changelogs/helm-v2.1.30.mdx
@@ -1,0 +1,15 @@
+---
+title: "v2.1.30"
+description: "Helm v2.1.30 changelog - 2026-07-20"
+---
+
+<Update label="Bifrost Helm" description="v2.1.30">
+
+## Changelog
+
+- Added `bifrost.client.retainContentInObjectStorage` (default off, commented out) to keep full request/response content in object storage when content logging is disabled — via the global `disableContentLogging` setting or the `x-bf-disable-content-logging` header — instead of dropping it. The content is hidden: the database row stays metadata-only and the UI/API never fetch the payload back, so it is only readable with direct access to the bucket. Requires `storage.logsStore.objectStorage.enabled: true`; without it the content is dropped as before. Renders into `client.retain_content_in_object_storage`.
+- Added `bifrost.loadBalancer.appendFallbacksToPinned`. When a request already carries a provider, appends the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to `false`. Renders into `load_balancer_config.append_fallbacks_to_pinned`.
+- Added `bifrost.webhooks[]` for declaring webhook endpoints synced into the database at startup, reconciled by name (`name`, `url`, `secret`, `events`, `headers`, `include_response`, `allow_private_network`, `disabled`, retry/timeout/concurrency tuning). Renders directly into top-level `webhooks`. Duplicate names or duplicate events within one endpoint fail chart rendering. Added `bifrost.client.webhookConfig.deliveryHistoryRetentionDays` for global delivery-history retention, rendering into `client.webhook_config.delivery_history_retention_days`.
+- Added `keep_alive_timeout_in_seconds` to `bifrost.providers.<name>.network_config`. Sets the idle keep-alive for pooled provider connections; set below the upstream server's keep-alive so Bifrost drops idle connections before the server closes them. Defaults to 30s. Renders into `network_config.keep_alive_timeout_in_seconds`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1020,6 +1020,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.30",
               "changelogs/helm-v2.1.29",
               "changelogs/helm-v2.1.28",
               "changelogs/helm-v2.1.27",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.29
+version: 2.1.30
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,13 +4,16 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.29
+**Latest Version:** 2.1.30
 
 ## Changelog
 
 ### 2.1.30
 
 - Added `bifrost.client.retainContentInObjectStorage` (default off, commented out) to keep full request/response content in object storage when content logging is disabled — via the global `disableContentLogging` setting or the `x-bf-disable-content-logging` header — instead of dropping it. The content is hidden: the database row stays metadata-only and the UI/API never fetch the payload back, so it is only readable with direct access to the bucket. Requires `storage.logsStore.objectStorage.enabled: true`; without it the content is dropped as before. Renders into `client.retain_content_in_object_storage`.
+- Added `bifrost.loadBalancer.appendFallbacksToPinned`. When a request already carries a provider, appends the healthy providers eligible for its model as fallbacks behind any it configured. Defaults to `false`. Renders into `load_balancer_config.append_fallbacks_to_pinned`.
+- Added `bifrost.webhooks[]` for declaring webhook endpoints synced into the database at startup, reconciled by name (`name`, `url`, `secret`, `events`, `headers`, `include_response`, `allow_private_network`, `disabled`, retry/timeout/concurrency tuning). Renders directly into top-level `webhooks`. Duplicate names or duplicate events within one endpoint fail chart rendering. Added `bifrost.client.webhookConfig.deliveryHistoryRetentionDays` for global delivery-history retention, rendering into `client.webhook_config.delivery_history_retention_days`.
+- Added `keep_alive_timeout_in_seconds` to `bifrost.providers.<name>.network_config`. Sets the idle keep-alive for pooled provider connections; set below the upstream server's keep-alive so Bifrost drops idle connections before the server closes them. Defaults to 30s. Renders into `network_config.keep_alive_timeout_in_seconds`.
 
 ### 2.1.29
 


### PR DESCRIPTION
## Summary

Releases Bifrost Helm chart v2.1.30, adding four new configuration options: retained object storage content when content logging is disabled, fallback appending for pinned provider requests, declarative webhook endpoint management, and a configurable keep-alive timeout for provider connections.

## Changes

- Added `bifrost.client.retainContentInObjectStorage` to preserve full request/response payloads in object storage even when content logging is disabled (via `disableContentLogging` or `x-bf-disable-content-logging`). Content remains hidden from the UI/API and is only accessible via direct bucket access. Requires `storage.logsStore.objectStorage.enabled: true`. Renders into `client.retain_content_in_object_storage`.
- Added `bifrost.loadBalancer.appendFallbacksToPinned` (default `false`) to append healthy eligible providers as fallbacks behind any configured by a pinned request. Renders into `load_balancer_config.append_fallbacks_to_pinned`.
- Added `bifrost.webhooks[]` for declaring webhook endpoints reconciled by name at startup, supporting full configuration including retry, timeout, and concurrency tuning. Duplicate names or duplicate events within a single endpoint fail chart rendering. Added `bifrost.client.webhookConfig.deliveryHistoryRetentionDays` for global delivery-history retention. Renders into top-level `webhooks` and `client.webhook_config.delivery_history_retention_days`.
- Added `keep_alive_timeout_in_seconds` to `bifrost.providers.<name>.network_config` to control idle keep-alive duration for pooled provider connections. Defaults to 30s. Should be set below the upstream server's keep-alive to avoid the server closing connections first. Renders into `network_config.keep_alive_timeout_in_seconds`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the chart at v2.1.30 and validate each new field:

```sh
# Verify chart version
helm show chart ./helm-charts/bifrost | grep version

# Test retainContentInObjectStorage renders correctly
helm template bifrost ./helm-charts/bifrost --set bifrost.client.retainContentInObjectStorage=true | grep retain_content_in_object_storage

# Test appendFallbacksToPinned renders correctly
helm template bifrost ./helm-charts/bifrost --set bifrost.loadBalancer.appendFallbacksToPinned=true | grep append_fallbacks_to_pinned

# Test keep_alive_timeout_in_seconds renders correctly
helm template bifrost ./helm-charts/bifrost | grep keep_alive_timeout_in_seconds

# Test webhook rendering and duplicate-name/event validation
helm template bifrost ./helm-charts/bifrost -f <webhooks-values.yaml> | grep -A 20 "^webhooks"
```

Confirm that providing duplicate webhook names or duplicate events within a single webhook endpoint causes `helm template` to fail with a rendering error.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

`bifrost.client.retainContentInObjectStorage` stores request/response payloads in object storage even when content logging is disabled. Access to this data is gated by direct bucket permissions only — the UI and API never expose it. Ensure bucket access controls are appropriately restricted before enabling this option, particularly in environments handling sensitive or PII-containing payloads.

Webhook `secret` values declared in `bifrost.webhooks[]` are written into the Helm-rendered configuration; ensure these are managed via Kubernetes secrets or a secrets management solution rather than plain values files.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable