### PR TITLE
fix: convert structured output format to tool for Azure provider in Anthropic chat and responses requests

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -410,9 +410,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			anthropicReq.MCPServers = servers
 		}
 		if bifrostReq.Params.ResponseFormat != nil {
-			// Vertex and Bedrock Mantle don't accept native structured outputs
+			// Vertex, Bedrock Mantle, and Azure don't accept native structured outputs
 			// (output_config.format), so convert to a tool instead.
-			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle {
+			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle || bifrostReq.Provider == schemas.Azure {
 				responseFormatTool := convertChatResponseFormatToTool(ctx, bifrostReq.Params)
 				if responseFormatTool != nil {
 					anthropicReq.Tools = append(anthropicReq.Tools, *responseFormatTool)

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3464,9 +3464,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 		}
 		if bifrostReq.Params.Text != nil {
-			// Vertex and Bedrock Mantle don't accept native structured outputs
+			// Vertex, Bedrock Mantle, and Azure don't accept native structured outputs
 			// (output_config.format), so convert to a tool instead.
-			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle {
+			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle || bifrostReq.Provider == schemas.Azure {
 				if bifrostReq.Params.Text.Format != nil {
 					responseFormatTool := convertResponsesTextFormatToTool(ctx, bifrostReq.Params.Text)
 					if responseFormatTool != nil {

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -345,7 +345,11 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 				bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, passthroughHeaders)
 			}
 		}
-		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers) || hasOutputConfigFormat(req)) {
+		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers)) {
+			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+			return nil
+		}
+		if (provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure) && hasOutputConfigFormat(req) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}


### PR DESCRIPTION
## Summary

Azure does not support Anthropic's native structured output format (`output_config.format`), similar to Vertex and Bedrock Mantle. This PR extends the existing workaround — converting structured output response formats into tools — to also apply when the provider is Azure.

## Changes

- Added `schemas.Azure` to the provider check in both `ToAnthropicChatRequest` and `ToAnthropicResponsesRequest`, so that structured output response formats are converted to tools instead of using native `output_config.format` when targeting Azure.
- Split the Vertex-specific passthrough condition in `checkAnthropicPassthrough` so that `hasOutputConfigFormat` triggers the raw request body override for Vertex, Bedrock Mantle, and Azure, while the prompt caching and fast mode beta header checks remain Vertex-only.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Send a request with a `response_format` / structured output configuration targeting an Azure-hosted Anthropic model and verify the request is converted to a tool call rather than using `output_config.format`, and that the response is returned correctly.

```sh
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable