### PR TITLE
fix: use `time.Now().Add` instead of channel receive for deadline and bypass webhook check in nil-dispatcher test

### DIFF
--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -88,7 +88,7 @@ func waitForJobStatus(t *testing.T, store LogStore, jobID string) *AsyncJob {
 func TestSubmitJob_PropagatesContextValues(t *testing.T) {
 	executor := newTestAsyncExecutor(t)
 
-	capturedCtx := schemas.NewBifrostContext(context.Background(), <-time.After(1*time.Minute))
+	capturedCtx := schemas.NewBifrostContext(context.Background(), time.Now().Add(1*time.Minute))
 	capturedCtx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
 	capturedCtx.SetValue(schemas.BifrostContextKey("x-bf-eh-custom"), "custom-value")
 	capturedCtx.SetValue(schemas.BifrostContextKey("x-bf-prom-env"), "production")
@@ -405,11 +405,17 @@ func TestExecuteJob_WebhookEnqueuedOnPanic(t *testing.T) {
 }
 
 func TestExecuteJob_NilDispatcherIsSafe(t *testing.T) {
+	// No webhook endpoint is set in context: SubmitJob fails fast when one is
+	// requested without a dispatcher wired, so this only exercises executeJob's
+	// terminal-state notifyWebhook path with a nil dispatcher.
 	executor := newWebhookTestExecutor(t, nil)
 
-	job := submitWebhookTestJob(t, executor, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	job, err := executor.SubmitJob(ctx, 3600, func(*schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
 		return map[string]string{"status": "ok"}, nil
-	})
+	}, schemas.ChatCompletionRequest)
+	require.NoError(t, err)
+	require.NotNil(t, job)
 
 	stored := waitForJobStatus(t, executor.logstore, job.ID)
 	assert.Equal(t, schemas.AsyncJobStatusCompleted, stored.Status)


### PR DESCRIPTION
## Summary

Fixes two issues in the async job test suite: an incorrect use of a channel receive expression as a deadline argument, and a test that bypassed `SubmitJob` entirely by calling an internal helper that skipped webhook endpoint validation.

## Changes

- Replaced `<-time.After(1*time.Minute)` with `time.Now().Add(1*time.Minute)` in `TestSubmitJob_PropagatesContextValues`. The original code was passing the result of receiving from a `time.After` channel (a `time.Time` value received after a 1-minute block) as the deadline, which would have caused the test to hang for a full minute before proceeding.
- Rewrote `TestExecuteJob_NilDispatcherIsSafe` to call `executor.SubmitJob` directly instead of the `submitWebhookTestJob` helper. The helper assumed a webhook endpoint was present in the context; without one, `SubmitJob` fails fast. The test now uses `schemas.NoDeadline` and explicitly asserts no error and a non-nil job before waiting for completion, correctly exercising the `executeJob` terminal-state `notifyWebhook` path with a nil dispatcher.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/...
```

Both tests should pass without hanging or panicking.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable