### PR TITLE
test: extend structured-output tool-conversion tests to cover Vertex, BedrockMantle, and Azure providers

### DIFF
--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -929,13 +929,159 @@ func makeSOResponseFormat(schemaName string) interface{} {
 	}
 }
 
-// TestToAnthropicChatRequest_StructuredOutput_Vertex_NoThinking verifies that when
-// response_format=json_schema is passed to a Vertex-targeted request without thinking,
-// Bifrost adds a synthetic bf_so_* tool AND forces tool_choice to that tool.
-func TestToAnthropicChatRequest_StructuredOutput_Vertex_NoThinking(t *testing.T) {
+// toolConversionProviders are the providers whose Anthropic-Messages-compatible
+// endpoints reject native `output_config.format` and must instead receive
+// structured output as a synthetic bf_so_* tool call. Any provider added here
+// in the future must also be added to the branch under test in chat.go/responses.go.
+var toolConversionProviders = []schemas.ModelProvider{schemas.Vertex, schemas.BedrockMantle, schemas.Azure}
+
+// TestToAnthropicChatRequest_StructuredOutput_ToolConversion_NoThinking verifies that when
+// response_format=json_schema is sent to a provider whose native Anthropic endpoint rejects
+// output_config.format, Bifrost adds a synthetic bf_so_* tool AND forces tool_choice to it.
+func TestToAnthropicChatRequest_StructuredOutput_ToolConversion_NoThinking(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		t.Run(string(provider), func(t *testing.T) {
+			rf := makeSOResponseFormat("my_schema")
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: provider,
+				Model:    "claude-opus-4-6",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+				},
+				Params: &schemas.ChatParameters{
+					ResponseFormat: &rf,
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.OutputConfig != nil {
+				t.Errorf("expected OutputConfig to stay unset for %s (native field unsupported), got %+v", provider, result.OutputConfig)
+			}
+
+			// A synthetic tool with the bf_so_ prefix must be present.
+			var soTool *AnthropicTool
+			for i := range result.Tools {
+				if len(result.Tools[i].Name) > 6 && result.Tools[i].Name[:6] == "bf_so_" {
+					soTool = &result.Tools[i]
+					break
+				}
+			}
+			if soTool == nil {
+				t.Fatalf("expected a synthetic bf_so_* tool to be added for %s structured output", provider)
+			}
+
+			// ToolChoice must be set and must point at the SO tool.
+			if result.ToolChoice == nil {
+				t.Fatal("expected ToolChoice to be set when thinking is disabled")
+			}
+			if result.ToolChoice.Type != "tool" {
+				t.Errorf("expected ToolChoice.Type=tool, got %q", result.ToolChoice.Type)
+			}
+			if result.ToolChoice.Name != soTool.Name {
+				t.Errorf("expected ToolChoice.Name=%q, got %q", soTool.Name, result.ToolChoice.Name)
+			}
+		})
+	}
+}
+
+// TestToAnthropicChatRequest_StructuredOutput_ToolConversion_ThinkingEffort verifies that when
+// response_format=json_schema + reasoning_effort='medium' is sent to a tool-conversion provider,
+// Bifrost still adds the synthetic tool but does NOT set tool_choice (to avoid Anthropic's
+// "Thinking may not be enabled when tool_choice forces tool use" 400 error).
+func TestToAnthropicChatRequest_StructuredOutput_ToolConversion_ThinkingEffort(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		t.Run(string(provider), func(t *testing.T) {
+			rf := makeSOResponseFormat("my_schema")
+			effort := "medium"
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: provider,
+				Model:    "claude-opus-4-6",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: new(16000),
+					ResponseFormat:      &rf,
+					Reasoning:           &schemas.ChatReasoning{Effort: &effort},
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Synthetic tool must still be present so the model knows the schema.
+			found := false
+			for _, tool := range result.Tools {
+				if len(tool.Name) > 6 && tool.Name[:6] == "bf_so_" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected synthetic bf_so_* tool to be present for %s even with thinking enabled", provider)
+			}
+
+			// ToolChoice must NOT be set — forcing it would trigger a 400 from Anthropic.
+			if result.ToolChoice != nil {
+				t.Errorf("expected ToolChoice to be nil when thinking is enabled (effort=%q) for %s, got %+v", effort, provider, result.ToolChoice)
+			}
+		})
+	}
+}
+
+// TestToAnthropicChatRequest_StructuredOutput_ToolConversion_ThinkingMaxTokens is the same as
+// the effort variant but uses explicit budget_tokens reasoning instead.
+func TestToAnthropicChatRequest_StructuredOutput_ToolConversion_ThinkingMaxTokens(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		t.Run(string(provider), func(t *testing.T) {
+			rf := makeSOResponseFormat("my_schema")
+			maxTok := 4000
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: provider,
+				Model:    "claude-opus-4-6",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: new(16000),
+					ResponseFormat:      &rf,
+					Reasoning:           &schemas.ChatReasoning{MaxTokens: &maxTok},
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+			result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.ToolChoice != nil {
+				t.Errorf("expected ToolChoice to be nil when thinking (MaxTokens) is enabled for %s, got %+v", provider, result.ToolChoice)
+			}
+		})
+	}
+}
+
+// TestToAnthropicChatRequest_StructuredOutput_NativeOutputConfig_Anthropic verifies the
+// negative case: a provider whose native Anthropic endpoint DOES support output_config.format
+// (i.e. Anthropic itself) gets the native field set and no synthetic tool is added. This is
+// the control that the regression (Azure missing from toolConversionProviders) would have
+// broken in reverse — Azure incorrectly took this branch instead of the tool-conversion one.
+func TestToAnthropicChatRequest_StructuredOutput_NativeOutputConfig_Anthropic(t *testing.T) {
 	rf := makeSOResponseFormat("my_schema")
 	bifrostReq := &schemas.BifrostChatRequest{
-		Provider: schemas.Vertex,
+		Provider: schemas.Anthropic,
 		Model:    "claude-opus-4-6",
 		Input: []schemas.ChatMessage{
 			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
@@ -952,102 +1098,14 @@ func TestToAnthropicChatRequest_StructuredOutput_Vertex_NoThinking(t *testing.T)
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// A synthetic tool with the bf_so_ prefix must be present.
-	var soTool *AnthropicTool
-	for i := range result.Tools {
-		if len(result.Tools[i].Name) > 6 && result.Tools[i].Name[:6] == "bf_so_" {
-			soTool = &result.Tools[i]
-			break
-		}
-	}
-	if soTool == nil {
-		t.Fatal("expected a synthetic bf_so_* tool to be added for Vertex structured output")
+	if result.OutputConfig == nil || result.OutputConfig.Format == nil {
+		t.Fatal("expected OutputConfig.Format to be set natively for Anthropic")
 	}
 
-	// ToolChoice must be set and must point at the SO tool.
-	if result.ToolChoice == nil {
-		t.Fatal("expected ToolChoice to be set when thinking is disabled")
-	}
-	if result.ToolChoice.Type != "tool" {
-		t.Errorf("expected ToolChoice.Type=tool, got %q", result.ToolChoice.Type)
-	}
-	if result.ToolChoice.Name != soTool.Name {
-		t.Errorf("expected ToolChoice.Name=%q, got %q", soTool.Name, result.ToolChoice.Name)
-	}
-}
-
-// TestToAnthropicChatRequest_StructuredOutput_Vertex_ThinkingEffort verifies that when
-// response_format=json_schema + reasoning_effort='medium' is sent to Vertex, Bifrost
-// still adds the synthetic tool but does NOT set tool_choice (to avoid Anthropic's
-// "Thinking may not be enabled when tool_choice forces tool use" 400 error).
-func TestToAnthropicChatRequest_StructuredOutput_Vertex_ThinkingEffort(t *testing.T) {
-	rf := makeSOResponseFormat("my_schema")
-	effort := "medium"
-	bifrostReq := &schemas.BifrostChatRequest{
-		Provider: schemas.Vertex,
-		Model:    "claude-opus-4-6",
-		Input: []schemas.ChatMessage{
-			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
-		},
-		Params: &schemas.ChatParameters{
-			MaxCompletionTokens: new(16000),
-			ResponseFormat:      &rf,
-			Reasoning:           &schemas.ChatReasoning{Effort: &effort},
-		},
-	}
-
-	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
-	defer cancel()
-	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Synthetic tool must still be present so the model knows the schema.
-	found := false
 	for _, tool := range result.Tools {
 		if len(tool.Name) > 6 && tool.Name[:6] == "bf_so_" {
-			found = true
-			break
+			t.Errorf("did not expect a synthetic bf_so_* tool for Anthropic, got %q", tool.Name)
 		}
-	}
-	if !found {
-		t.Fatal("expected synthetic bf_so_* tool to be present even with thinking enabled")
-	}
-
-	// ToolChoice must NOT be set — forcing it would trigger a 400 from Anthropic.
-	if result.ToolChoice != nil {
-		t.Errorf("expected ToolChoice to be nil when thinking is enabled (effort=%q), got %+v", effort, result.ToolChoice)
-	}
-}
-
-// TestToAnthropicChatRequest_StructuredOutput_Vertex_ThinkingMaxTokens is the same as
-// the effort variant but uses explicit budget_tokens reasoning instead.
-func TestToAnthropicChatRequest_StructuredOutput_Vertex_ThinkingMaxTokens(t *testing.T) {
-	rf := makeSOResponseFormat("my_schema")
-	maxTok := 4000
-	bifrostReq := &schemas.BifrostChatRequest{
-		Provider: schemas.Vertex,
-		Model:    "claude-opus-4-6",
-		Input: []schemas.ChatMessage{
-			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
-		},
-		Params: &schemas.ChatParameters{
-			MaxCompletionTokens: new(16000),
-			ResponseFormat:      &rf,
-			Reasoning:           &schemas.ChatReasoning{MaxTokens: &maxTok},
-		},
-	}
-
-	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
-	defer cancel()
-	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.ToolChoice != nil {
-		t.Errorf("expected ToolChoice to be nil when thinking (MaxTokens) is enabled, got %+v", result.ToolChoice)
 	}
 }
 

--- a/core/providers/anthropic/responses_test.go
+++ b/core/providers/anthropic/responses_test.go
@@ -1,0 +1,118 @@
+package anthropic
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// makeResponsesTextFormat returns a minimal json_schema text config for the
+// Responses API structured-output request path.
+func makeResponsesTextFormat(schemaName string) *schemas.ResponsesTextConfig {
+	properties := map[string]any{
+		"color":  map[string]interface{}{"type": "string"},
+		"animal": map[string]interface{}{"type": "string"},
+	}
+	return &schemas.ResponsesTextConfig{
+		Format: &schemas.ResponsesTextConfigFormat{
+			Type: "json_schema",
+			Name: schemas.Ptr(schemaName),
+			JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
+				Type:       schemas.Ptr("object"),
+				Properties: &properties,
+				Required:   []string{"color", "animal"},
+			},
+		},
+	}
+}
+
+// TestToAnthropicResponsesRequest_StructuredOutput_ToolConversion verifies that,
+// mirroring the Chat Completions path, providers whose native Anthropic endpoint
+// rejects output_config.format get structured output converted into a synthetic
+// bf_so_*/json_response tool instead. Any provider added to toolConversionProviders
+// in the future must also be added to the branch under test in responses.go.
+func TestToAnthropicResponsesRequest_StructuredOutput_ToolConversion(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		t.Run(string(provider), func(t *testing.T) {
+			req := &schemas.BifrostResponsesRequest{
+				Provider: provider,
+				Model:    "claude-opus-4-6",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hello"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Text: makeResponsesTextFormat("my_schema"),
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			result, err := ToAnthropicResponsesRequest(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.OutputConfig != nil {
+				t.Errorf("expected OutputConfig to stay unset for %s (native field unsupported), got %+v", provider, result.OutputConfig)
+			}
+
+			found := false
+			for _, tool := range result.Tools {
+				if tool.Name == "bf_so_my_schema" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected a synthetic tool named %q to be added for %s structured output", "bf_so_my_schema", provider)
+			}
+
+			if result.ToolChoice == nil || result.ToolChoice.Name != "bf_so_my_schema" {
+				t.Errorf("expected ToolChoice to be forced to the synthetic tool for %s, got %+v", provider, result.ToolChoice)
+			}
+		})
+	}
+}
+
+// TestToAnthropicResponsesRequest_StructuredOutput_NativeOutputConfig_Anthropic is the
+// negative-case control: Anthropic itself supports output_config.format natively, so no
+// synthetic tool should be added. This is the branch that Azure incorrectly took before
+// being added to toolConversionProviders.
+func TestToAnthropicResponsesRequest_StructuredOutput_NativeOutputConfig_Anthropic(t *testing.T) {
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-6",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("Hello"),
+				},
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			Text: makeResponsesTextFormat("my_schema"),
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.OutputConfig == nil || result.OutputConfig.Format == nil {
+		t.Fatal("expected OutputConfig.Format to be set natively for Anthropic")
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Name == "bf_so_my_schema" {
+			t.Errorf("did not expect a synthetic tool for Anthropic, got %q", tool.Name)
+		}
+	}
+}

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
 )
 
 // TestMustConvertInPassthrough pins the passthrough routing decision that fixes
@@ -137,5 +138,56 @@ func TestAnthropicContainerUploadSurvivesNormalization(t *testing.T) {
 	}
 	if *containerFileID != fileID {
 		t.Errorf("file_id = %q, want %q", *containerFileID, fileID)
+	}
+}
+
+// TestCheckAnthropicPassthrough_OutputConfigEscapeHatch verifies that a Claude Code
+// request carrying a raw output_config.format is forced off the raw-passthrough path
+// (UseRawRequestBody=false) for every provider whose native Anthropic endpoint rejects
+// that field (Vertex, Bedrock Mantle, Azure), so the field gets converted/stripped
+// downstream instead of being forwarded verbatim. Anthropic itself supports the field
+// natively and must stay on the raw path.
+func TestCheckAnthropicPassthrough_OutputConfigEscapeHatch(t *testing.T) {
+	cases := []struct {
+		name       string
+		model      string
+		wantRawOff bool
+	}{
+		{"vertex", "vertex/claude-haiku-4-5", true},
+		{"bedrock_mantle", "bedrock_mantle/claude-haiku-4-5", true},
+		{"azure", "azure/claude-haiku-4-5", true},
+		{"anthropic", "anthropic/claude-haiku-4-5", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqCtx := &fasthttp.RequestCtx{}
+			reqCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+			reqCtx.Request.Header.Set("user-agent", "claude-code/1.0")
+			reqCtx.Request.Header.Set("x-api-key", "sk-ant-test")
+
+			bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+			defer cancel()
+
+			req := &anthropic.AnthropicMessageRequest{
+				Model:     tc.model,
+				MaxTokens: 1024,
+				OutputConfig: &anthropic.AnthropicOutputConfig{
+					Format: []byte(`{"type":"json_schema","json_schema":{"name":"my_schema"}}`),
+				},
+			}
+
+			if err := checkAnthropicPassthrough(reqCtx, bifrostCtx, req); err != nil {
+				t.Fatalf("checkAnthropicPassthrough: %v", err)
+			}
+
+			useRaw, _ := bifrostCtx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool)
+			if tc.wantRawOff && useRaw {
+				t.Errorf("expected UseRawRequestBody=false for %s (output_config.format unsupported natively), got true", tc.model)
+			}
+			if !tc.wantRawOff && !useRaw {
+				t.Errorf("expected UseRawRequestBody to stay true for %s, got false", tc.model)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Azure was missing from the set of providers whose Anthropic-compatible endpoints reject the native `output_config.format` field for structured output. This caused Azure requests with `response_format=json_schema` to bypass the synthetic `bf_so_*` tool-conversion path and forward the unsupported field verbatim, resulting in 400 errors from the upstream API. This PR adds Azure to the tool-conversion provider set and hardens the test coverage to catch this class of regression across all affected providers.

## Changes

- Introduced a shared `toolConversionProviders` slice (`Vertex`, `BedrockMantle`, `Azure`) used by all structured-output tests, replacing per-provider duplicated test functions with table-driven subtests.
- Refactored the three existing Vertex-only Chat Completions structured-output tests into provider-parameterized loops covering all tool-conversion providers, and added a negative-case control test asserting that Anthropic itself uses the native `OutputConfig.Format` path without a synthetic tool.
- Added a new `responses_test.go` covering the same tool-conversion vs. native `OutputConfig` branching for the Responses API (`ToAnthropicResponsesRequest`), including both the positive (tool-conversion) and negative (Anthropic native) cases.
- Added `TestCheckAnthropicPassthrough_OutputConfigEscapeHatch` to the HTTP integration tests, verifying that Claude Code passthrough requests carrying `output_config.format` are forced off the raw-passthrough path (`UseRawRequestBody=false`) for Vertex, BedrockMantle, and Azure, while Anthropic remains on the raw path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
go test ./transports/bifrost-http/integrations/...
```

All new and refactored tests should pass. Confirm that:
- Each of `Vertex`, `BedrockMantle`, and `Azure` produces a synthetic `bf_so_*` tool and no `OutputConfig` when `response_format=json_schema` is set.
- `Anthropic` produces a populated `OutputConfig.Format` and no synthetic tool.
- The passthrough escape-hatch correctly sets `UseRawRequestBody=false` for the three non-native providers and leaves it `true` for Anthropic.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable