### PR TITLE
fix: complete Cohere streaming Responses terminal events with the output array and reasoning payloads

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -4,6 +4,7 @@
 - feat: add `additional_tools` message type support
 - feat: force single-region config in Vertex key config
 - feat: phase-scoped redaction and revealing with transient redaction data field, plus `ClearPausedStreamBuffer` for pause-accumulate stream flows
+- fix: complete Cohere streaming Responses terminal events, response.completed now carries the output array and stop reason, reasoning done events keep the accumulated thinking text, and citation annotations carry their item id (closes #5385) (thanks [@fus3r](https://github.com/fus3r)!)
 - fix: complete visible thinking items on the streaming Responses surface so reasoning_summary_text.done, output_item.done, and response.completed carry the accumulated reasoning text and signature (thanks [@fus3r](https://github.com/fus3r)!)
 - fix: map web search options to Google Search grounding in the Gemini API
 - fix: parse `SecretVar` JSON with `ref`/`env_var` fields even when `value` is absent

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -28,6 +28,8 @@ type CohereResponsesStreamState struct {
 	HasEmittedCreated             bool           // Whether we've emitted response.created
 	HasEmittedInProgress          bool           // Whether we've emitted response.in_progress
 	ToolPlanOutputIndex           *int           // Output index for tool plan text item (if created)
+	OutputItems                   map[int]*schemas.ResponsesMessage // Maps output_index to accumulated output item for response.completed
+	AnnotationsByOutputIndex      map[int][]schemas.ResponsesOutputMessageContentTextAnnotation // Maps output_index to citation annotations for done events and response.completed
 }
 
 // cohereResponsesStreamStatePool provides a pool for Cohere responses stream state objects.
@@ -41,6 +43,8 @@ var cohereResponsesStreamStatePool = sync.Pool{
 			ReasoningContentIndices:       make(map[int]bool),
 			AnnotationIndexToContentIndex: make(map[int]int),
 			TextBuffers:                   make(map[int]*strings.Builder),
+			OutputItems:                   make(map[int]*schemas.ResponsesMessage),
+			AnnotationsByOutputIndex:      make(map[int][]schemas.ResponsesOutputMessageContentTextAnnotation),
 			CurrentOutputIndex:            0,
 			CreatedAt:                     int(time.Now().Unix()),
 			HasEmittedCreated:             false,
@@ -89,6 +93,16 @@ func acquireCohereResponsesStreamState() *CohereResponsesStreamState {
 		state.TextBuffers = make(map[int]*strings.Builder)
 	} else {
 		clear(state.TextBuffers)
+	}
+	if state.OutputItems == nil {
+		state.OutputItems = make(map[int]*schemas.ResponsesMessage)
+	} else {
+		clear(state.OutputItems)
+	}
+	if state.AnnotationsByOutputIndex == nil {
+		state.AnnotationsByOutputIndex = make(map[int][]schemas.ResponsesOutputMessageContentTextAnnotation)
+	} else {
+		clear(state.AnnotationsByOutputIndex)
 	}
 	// Reset other fields
 	state.CurrentOutputIndex = 0
@@ -147,6 +161,16 @@ func (state *CohereResponsesStreamState) flush() {
 	} else {
 		clear(state.TextBuffers)
 	}
+	if state.OutputItems == nil {
+		state.OutputItems = make(map[int]*schemas.ResponsesMessage)
+	} else {
+		clear(state.OutputItems)
+	}
+	if state.AnnotationsByOutputIndex == nil {
+		state.AnnotationsByOutputIndex = make(map[int][]schemas.ResponsesOutputMessageContentTextAnnotation)
+	} else {
+		clear(state.AnnotationsByOutputIndex)
+	}
 	state.CurrentOutputIndex = 0
 	state.MessageID = nil
 	state.Model = nil
@@ -174,6 +198,124 @@ func (state *CohereResponsesStreamState) getOrCreateOutputIndex(contentIndex *in
 	state.CurrentOutputIndex++
 	state.ContentIndexToOutputIndex[*contentIndex] = outputIndex
 	return outputIndex
+}
+
+// trackOutputItems records a copy of every emitted output_item.added/done by
+// output index so response.completed can carry the full output array. The done
+// event for an item overwrites its added shell. Items are stored as copies so
+// later bookkeeping never mutates an event already handed to the caller.
+func (state *CohereResponsesStreamState) trackOutputItems(events []*schemas.BifrostResponsesStreamResponse) {
+	for _, event := range events {
+		if event == nil || event.OutputIndex == nil || event.Item == nil {
+			continue
+		}
+		if event.Type != schemas.ResponsesStreamResponseTypeOutputItemAdded &&
+			event.Type != schemas.ResponsesStreamResponseTypeOutputItemDone {
+			continue
+		}
+		itemCopy := *event.Item
+		state.OutputItems[*event.OutputIndex] = &itemCopy
+	}
+}
+
+// emitTracked records any output items carried by the batch and returns it as
+// a non-terminal converter result.
+func (state *CohereResponsesStreamState) emitTracked(responses []*schemas.BifrostResponsesStreamResponse) ([]*schemas.BifrostResponsesStreamResponse, *schemas.BifrostError, bool) {
+	state.trackOutputItems(responses)
+	return responses, nil, false
+}
+
+// annotationsForOutputIndex returns a copy of the citation annotations
+// accumulated for an output index, or an empty slice when none streamed.
+func (state *CohereResponsesStreamState) annotationsForOutputIndex(outputIndex int) []schemas.ResponsesOutputMessageContentTextAnnotation {
+	annotations := make([]schemas.ResponsesOutputMessageContentTextAnnotation, len(state.AnnotationsByOutputIndex[outputIndex]))
+	copy(annotations, state.AnnotationsByOutputIndex[outputIndex])
+	return annotations
+}
+
+// closeToolPlanItem completes an open tool-plan message item, emitting its
+// output_text.done, content_part.done, and output_item.done with the
+// accumulated text, and returns the extended event slice. No-op when no
+// tool-plan item is open.
+func (state *CohereResponsesStreamState) closeToolPlanItem(sequenceNumber int, responses []*schemas.BifrostResponsesStreamResponse) []*schemas.BifrostResponsesStreamResponse {
+	if state.ToolPlanOutputIndex == nil {
+		return responses
+	}
+	outputIndex := *state.ToolPlanOutputIndex
+	itemID := state.ItemIDs[outputIndex]
+	accText := ""
+	if buf := state.TextBuffers[outputIndex]; buf != nil {
+		accText = buf.String()
+	}
+
+	// Emit output_text.done with accumulated text
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    schemas.Ptr(outputIndex),
+		ContentIndex:   schemas.Ptr(0),
+		ItemID:         &itemID,
+		Text:           &accText,
+		LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
+	})
+
+	// Emit content_part.done with accumulated text
+	partText := accText
+	part := &schemas.ResponsesMessageContentBlock{
+		Type: schemas.ResponsesOutputMessageContentTypeText,
+		Text: &partText,
+		ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+			LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+			Annotations: state.annotationsForOutputIndex(outputIndex),
+		},
+	}
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    schemas.Ptr(outputIndex),
+		ContentIndex:   schemas.Ptr(0),
+		ItemID:         &itemID,
+		Part:           part,
+	})
+
+	// Emit output_item.done with content blocks
+	itemText := accText
+	statusCompleted := "completed"
+	messageType := schemas.ResponsesMessageTypeMessage
+	role := schemas.ResponsesInputMessageRoleAssistant
+	doneItem := &schemas.ResponsesMessage{
+		Type:   &messageType,
+		Role:   &role,
+		Status: &statusCompleted,
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &itemText,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						Annotations: state.annotationsForOutputIndex(outputIndex),
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					},
+				},
+			},
+		},
+	}
+	if itemID != "" {
+		doneItem.ID = &itemID
+	}
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    schemas.Ptr(outputIndex),
+		ContentIndex:   schemas.Ptr(0),
+		Item:           doneItem,
+	})
+	delete(state.TextBuffers, outputIndex)
+	if mapped, ok := state.ContentIndexToOutputIndex[0]; ok && mapped == outputIndex {
+		delete(state.ContentIndexToOutputIndex, 0)
+	}
+	state.ToolPlanOutputIndex = nil // Mark as closed
+	return responses
 }
 
 // convertCohereContentBlockToBifrost converts CohereContentBlock to schemas.ContentBlock for Responses
@@ -267,82 +409,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 		// Content block start - emit output_item.added (OpenAI-style)
 		// First, close tool plan message item if it's still open
 		var responses []*schemas.BifrostResponsesStreamResponse
-		if state.ToolPlanOutputIndex != nil {
-			outputIndex := *state.ToolPlanOutputIndex
-			itemID := state.ItemIDs[outputIndex]
-			accText := ""
-			if buf := state.TextBuffers[outputIndex]; buf != nil {
-				accText = buf.String()
-			}
-
-			// Emit output_text.done with accumulated text
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				ItemID:         &itemID,
-				Text:           &accText,
-				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
-			})
-
-			// Emit content_part.done with accumulated text
-			partText := accText
-			part := &schemas.ResponsesMessageContentBlock{
-				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &partText,
-				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-				},
-			}
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				ItemID:         &itemID,
-				Part:           part,
-			})
-
-			// Emit output_item.done with content blocks
-			itemText := accText
-			statusCompleted := "completed"
-			messageType := schemas.ResponsesMessageTypeMessage
-			role := schemas.ResponsesInputMessageRoleAssistant
-			doneItem := &schemas.ResponsesMessage{
-				Type:   &messageType,
-				Role:   &role,
-				Status: &statusCompleted,
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{
-						{
-							Type: schemas.ResponsesOutputMessageContentTypeText,
-							Text: &itemText,
-							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-							},
-						},
-					},
-				},
-			}
-			if itemID != "" {
-				doneItem.ID = &itemID
-			}
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				Item:           doneItem,
-			})
-			delete(state.TextBuffers, outputIndex)
-			if mapped, ok := state.ContentIndexToOutputIndex[0]; ok && mapped == outputIndex {
-				delete(state.ContentIndexToOutputIndex, 0)
-			}
-			state.ToolPlanOutputIndex = nil // Mark as closed
-		}
+		responses = state.closeToolPlanItem(sequenceNumber, responses)
 
 		if chunk.Delta != nil && chunk.Index != nil && chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.CohereStreamContentObject != nil {
 			outputIndex := state.getOrCreateOutputIndex(chunk.Index)
@@ -397,7 +464,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					ItemID:         &itemID,
 					Part:           part,
 				})
-				return responses, nil, false
+				return state.emitTracked(responses)
 			case CohereContentBlockTypeThinking:
 				// Thinking/reasoning content - emit as reasoning item
 				messageType := schemas.ResponsesMessageTypeReasoning
@@ -445,11 +512,11 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					Part:           part,
 				})
 
-				return responses, nil, false
+				return state.emitTracked(responses)
 			}
 		}
 		if len(responses) > 0 {
-			return responses, nil, false
+			return state.emitTracked(responses)
 		}
 	case StreamEventContentDelta:
 		if chunk.Index != nil && chunk.Delta != nil {
@@ -481,13 +548,23 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 
 			// Handle thinking content delta
 			if chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.CohereStreamContentObject != nil && chunk.Delta.Message.Content.CohereStreamContentObject.Thinking != nil && *chunk.Delta.Message.Content.CohereStreamContentObject.Thinking != "" {
-				// Emit reasoning_summary_text.delta for thinking content
+				// Accumulate thinking text so the terminal events can carry it
+				if state.TextBuffers[outputIndex] == nil {
+					state.TextBuffers[outputIndex] = &strings.Builder{}
+				}
+				state.TextBuffers[outputIndex].WriteString(*chunk.Delta.Message.Content.CohereStreamContentObject.Thinking)
+
+				// Emit reasoning_summary_text.delta for thinking content.
+				// Cohere thinking has a single summary part per item, so the
+				// summary index is always 0 (the field is required by the
+				// OpenAI event shape).
 				itemID := state.ItemIDs[outputIndex]
 				response := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
 					SequenceNumber: sequenceNumber,
 					OutputIndex:    schemas.Ptr(outputIndex),
 					ContentIndex:   chunk.Index,
+					SummaryIndex:   schemas.Ptr(0),
 					Delta:          chunk.Delta.Message.Content.CohereStreamContentObject.Thinking,
 				}
 				if itemID != "" {
@@ -505,7 +582,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 			var responses []*schemas.BifrostResponsesStreamResponse
 			isReasoning := state.ReasoningContentIndices[*chunk.Index]
 
-			// Grab accumulated text up front (empty string for reasoning blocks)
+			// Grab accumulated text up front
 			accText := ""
 			if buf := state.TextBuffers[outputIndex]; buf != nil {
 				accText = buf.String()
@@ -513,24 +590,26 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 
 			// Check if this content index is a reasoning block
 			if isReasoning {
-				// Emit reasoning_summary_text.done (reasoning equivalent of output_text.done)
-				emptyText := ""
+				// Emit reasoning_summary_text.done with the accumulated thinking text
+				reasoningDoneText := accText
 				reasoningDoneResponse := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone,
 					SequenceNumber: sequenceNumber + len(responses),
 					OutputIndex:    schemas.Ptr(outputIndex),
 					ContentIndex:   chunk.Index,
-					Text:           &emptyText,
+					SummaryIndex:   schemas.Ptr(0),
+					Text:           &reasoningDoneText,
 				}
 				if itemID != "" {
 					reasoningDoneResponse.ItemID = &itemID
 				}
 				responses = append(responses, reasoningDoneResponse)
 
-				// Emit content_part.done for reasoning
+				// Emit content_part.done for reasoning with the accumulated text
+				partText := accText
 				part := &schemas.ResponsesMessageContentBlock{
 					Type: schemas.ResponsesOutputMessageContentTypeReasoning,
-					Text: &emptyText,
+					Text: &partText,
 				}
 				partDoneResponse := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
@@ -544,8 +623,9 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				}
 				responses = append(responses, partDoneResponse)
 
-				// Clear the reasoning content index tracking
+				// Clear the reasoning content index tracking and text buffer
 				delete(state.ReasoningContentIndices, *chunk.Index)
+				delete(state.TextBuffers, outputIndex)
 			} else {
 				// Regular text block - emit output_text.done with accumulated text
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
@@ -558,14 +638,15 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 				})
 
-				// Emit content_part.done with accumulated text
+				// Emit content_part.done with accumulated text and any
+				// citation annotations that already streamed for this item
 				partText := accText
 				part := &schemas.ResponsesMessageContentBlock{
 					Type: schemas.ResponsesOutputMessageContentTypeText,
 					Text: &partText,
 					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+						Annotations: state.annotationsForOutputIndex(outputIndex),
 					},
 				}
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
@@ -593,6 +674,20 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 						Summary: []schemas.ResponsesReasoningSummary{},
 					},
 				}
+				// Carry the accumulated thinking text as a reasoning content
+				// block, the same shape the non-streaming converter produces
+				// (and the request converter can replay).
+				if accText != "" {
+					reasoningText := accText
+					doneItem.Content = &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+								Text: &reasoningText,
+							},
+						},
+					}
+				}
 			} else {
 				contentBlocks := []schemas.ResponsesMessageContentBlock{}
 				if accText != "" {
@@ -602,7 +697,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 							Type: schemas.ResponsesOutputMessageContentTypeText,
 							Text: &itemText,
 							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								Annotations: state.annotationsForOutputIndex(outputIndex),
 								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 							},
 						},
@@ -629,7 +724,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				ContentIndex:   chunk.Index,
 				Item:           doneItem,
 			})
-			return responses, nil, false
+			return state.emitTracked(responses)
 		}
 	case StreamEventToolPlanDelta:
 		if chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolPlan != nil && *chunk.Delta.Message.ToolPlan != "" {
@@ -723,82 +818,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 	case StreamEventToolCallStart:
 		// First, close tool plan message item if it's still open
 		var responses []*schemas.BifrostResponsesStreamResponse
-		if state.ToolPlanOutputIndex != nil {
-			outputIndex := *state.ToolPlanOutputIndex
-			itemID := state.ItemIDs[outputIndex]
-			accText := ""
-			if buf := state.TextBuffers[outputIndex]; buf != nil {
-				accText = buf.String()
-			}
-
-			// Emit output_text.done with accumulated text
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				ItemID:         &itemID,
-				Text:           &accText,
-				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
-			})
-
-			// Emit content_part.done with accumulated text
-			partText := accText
-			part := &schemas.ResponsesMessageContentBlock{
-				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &partText,
-				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-				},
-			}
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				ItemID:         &itemID,
-				Part:           part,
-			})
-
-			// Emit output_item.done with content blocks
-			itemText := accText
-			statusCompleted := "completed"
-			messageType := schemas.ResponsesMessageTypeMessage
-			role := schemas.ResponsesInputMessageRoleAssistant
-			doneItem := &schemas.ResponsesMessage{
-				Type:   &messageType,
-				Role:   &role,
-				Status: &statusCompleted,
-				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{
-						{
-							Type: schemas.ResponsesOutputMessageContentTypeText,
-							Text: &itemText,
-							ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-								Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-								LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-							},
-						},
-					},
-				},
-			}
-			if itemID != "" {
-				doneItem.ID = &itemID
-			}
-			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-				Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
-				SequenceNumber: sequenceNumber + len(responses),
-				OutputIndex:    schemas.Ptr(outputIndex),
-				ContentIndex:   schemas.Ptr(0),
-				Item:           doneItem,
-			})
-			delete(state.TextBuffers, outputIndex)
-			if mapped, ok := state.ContentIndexToOutputIndex[0]; ok && mapped == outputIndex {
-				delete(state.ContentIndexToOutputIndex, 0)
-			}
-			state.ToolPlanOutputIndex = nil // Mark as closed
-		}
+		responses = state.closeToolPlanItem(sequenceNumber, responses)
 
 		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolCalls != nil && chunk.Delta.Message.ToolCalls.CohereToolCallObject != nil {
 			// Tool call start - emit output_item.added with type "function_call" and status "in_progress"
@@ -846,11 +866,11 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 					OutputIndex:    schemas.Ptr(outputIndex),
 					Item:           item,
 				})
-				return responses, nil, false
+				return state.emitTracked(responses)
 			}
 		}
 		if len(responses) > 0 {
-			return responses, nil, false
+			return state.emitTracked(responses)
 		}
 		return nil, nil, false
 	case StreamEventToolCallDelta:
@@ -936,7 +956,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				Item:           doneItem,
 			})
 
-			return responses, nil, false
+			return state.emitTracked(responses)
 		}
 		return nil, nil, false
 	case StreamEventCitationStart:
@@ -992,14 +1012,22 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 				state.AnnotationIndexToContentIndex[*chunk.Index] = citation.ContentIndex
 			}
 
-			return []*schemas.BifrostResponsesStreamResponse{{
+			// Record the annotation so the text item's done events and the
+			// final snapshot can carry it
+			state.AnnotationsByOutputIndex[outputIndex] = append(state.AnnotationsByOutputIndex[outputIndex], *annotation)
+
+			annotationResponse := &schemas.BifrostResponsesStreamResponse{
 				Type:            schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
 				SequenceNumber:  sequenceNumber,
 				ContentIndex:    schemas.Ptr(citation.ContentIndex),
 				Annotation:      annotation,
 				OutputIndex:     schemas.Ptr(outputIndex),
 				AnnotationIndex: chunk.Index,
-			}}, nil, false
+			}
+			if itemID := state.ItemIDs[outputIndex]; itemID != "" {
+				annotationResponse.ItemID = &itemID
+			}
+			return []*schemas.BifrostResponsesStreamResponse{annotationResponse}, nil, false
 		}
 		return nil, nil, false
 	case StreamEventCitationEnd:
@@ -1016,17 +1044,27 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 			contentIndexPtr := &contentIndex
 			outputIndex := state.getOrCreateOutputIndex(contentIndexPtr)
 
-			return []*schemas.BifrostResponsesStreamResponse{{
+			annotationDoneResponse := &schemas.BifrostResponsesStreamResponse{
 				Type:            schemas.ResponsesStreamResponseTypeOutputTextAnnotationDone,
 				SequenceNumber:  sequenceNumber,
 				ContentIndex:    &contentIndex,
 				OutputIndex:     schemas.Ptr(outputIndex),
 				AnnotationIndex: chunk.Index,
-			}}, nil, false
+			}
+			if itemID := state.ItemIDs[outputIndex]; itemID != "" {
+				annotationDoneResponse.ItemID = &itemID
+			}
+			return []*schemas.BifrostResponsesStreamResponse{annotationDoneResponse}, nil, false
 		}
 		return nil, nil, false
 	case StreamEventMessageEnd:
 		// Message end - emit response.completed (OpenAI-style)
+		// Close the tool-plan item first, in case a tool plan streamed without
+		// any subsequent content block or tool call.
+		var responses []*schemas.BifrostResponsesStreamResponse
+		responses = state.closeToolPlanItem(sequenceNumber, responses)
+		state.trackOutputItems(responses)
+
 		response := &schemas.BifrostResponsesResponse{
 			CreatedAt: state.CreatedAt,
 		}
@@ -1038,6 +1076,9 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 		}
 
 		if chunk.Delta != nil {
+			if chunk.Delta.FinishReason != nil {
+				response.StopReason = schemas.Ptr(ConvertCohereFinishReasonToBifrost(*chunk.Delta.FinishReason))
+			}
 			if chunk.Delta.Usage != nil {
 				usage := &schemas.ResponsesResponseUsage{}
 
@@ -1060,11 +1101,72 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 			}
 		}
 
-		return []*schemas.BifrostResponsesStreamResponse{{
+		// Fold citation annotations that streamed after their text item had
+		// already completed into the tracked item, so the final snapshot keeps
+		// them. The accumulated list replaces the block's annotations, which
+		// keeps this idempotent when the done event already carried them.
+		// Items are cloned before mutation so events already handed to the
+		// caller are never touched.
+		for outputIndex, annotations := range state.AnnotationsByOutputIndex {
+			if len(annotations) == 0 {
+				continue
+			}
+			item, exists := state.OutputItems[outputIndex]
+			if !exists || item.Content == nil {
+				continue
+			}
+			blockIndex := -1
+			for i, block := range item.Content.ContentBlocks {
+				if block.Type == schemas.ResponsesOutputMessageContentTypeText {
+					blockIndex = i
+					break
+				}
+			}
+			if blockIndex == -1 {
+				continue
+			}
+			itemCopy := *item
+			contentCopy := *item.Content
+			blocksCopy := make([]schemas.ResponsesMessageContentBlock, len(contentCopy.ContentBlocks))
+			copy(blocksCopy, contentCopy.ContentBlocks)
+			blockCopy := blocksCopy[blockIndex]
+			textMeta := schemas.ResponsesOutputMessageContentText{}
+			if blockCopy.ResponsesOutputMessageContentText != nil {
+				textMeta = *blockCopy.ResponsesOutputMessageContentText
+			}
+			textMeta.Annotations = state.annotationsForOutputIndex(outputIndex)
+			blockCopy.ResponsesOutputMessageContentText = &textMeta
+			blocksCopy[blockIndex] = blockCopy
+			contentCopy.ContentBlocks = blocksCopy
+			itemCopy.Content = &contentCopy
+			state.OutputItems[outputIndex] = &itemCopy
+		}
+
+		// Populate the Output array from accumulated items for
+		// response.completed, sorted by output index, mirroring the Anthropic
+		// stream ingress. The bound covers tool-plan items, which take output
+		// index 0 without advancing the counter.
+		if len(state.OutputItems) > 0 {
+			maxOutputIndex := state.CurrentOutputIndex
+			for outputIndex := range state.OutputItems {
+				if outputIndex >= maxOutputIndex {
+					maxOutputIndex = outputIndex + 1
+				}
+			}
+			response.Output = make([]schemas.ResponsesMessage, 0, len(state.OutputItems))
+			for i := 0; i < maxOutputIndex; i++ {
+				if item, exists := state.OutputItems[i]; exists {
+					response.Output = append(response.Output, *item)
+				}
+			}
+		}
+
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 			Type:           schemas.ResponsesStreamResponseTypeCompleted,
-			SequenceNumber: sequenceNumber,
+			SequenceNumber: sequenceNumber + len(responses),
 			Response:       response,
-		}}, nil, true
+		})
+		return responses, nil, true
 	case StreamEventDebug:
 		return nil, nil, false
 	}
@@ -1258,6 +1360,10 @@ func (response *CohereChatResponse) ToBifrostResponsesResponse() *schemas.Bifros
 	bifrostResp := &schemas.BifrostResponsesResponse{
 		ID:        schemas.Ptr(response.ID),
 		CreatedAt: int(time.Now().Unix()), // Set current timestamp
+	}
+
+	if response.FinishReason != nil {
+		bifrostResp.StopReason = schemas.Ptr(ConvertCohereFinishReasonToBifrost(*response.FinishReason))
 	}
 
 	// Convert usage information

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -729,15 +729,18 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 	case StreamEventToolPlanDelta:
 		if chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolPlan != nil && *chunk.Delta.Message.ToolPlan != "" {
 			// Tool plan delta - treat as normal text (Option A)
-			// Use output_index 0 for text message if it exists, otherwise create new
 			outputIndex := 0
 			var responses []*schemas.BifrostResponsesStreamResponse
 
 			if state.ToolPlanOutputIndex != nil {
 				outputIndex = *state.ToolPlanOutputIndex
 			} else {
-				// Create message item first if it doesn't exist
-				outputIndex = 0
+				// Create message item first if it doesn't exist. Allocate the
+				// index through the counter so a later content block cannot
+				// reuse it and overwrite the tool-plan item in the completed
+				// output array.
+				outputIndex = state.CurrentOutputIndex
+				state.CurrentOutputIndex++
 				state.ToolPlanOutputIndex = &outputIndex
 				state.ContentIndexToOutputIndex[0] = outputIndex
 

--- a/core/providers/cohere/streamterminalevents_test.go
+++ b/core/providers/cohere/streamterminalevents_test.go
@@ -442,6 +442,42 @@ func TestCohereResponsesStreamToolPlanClosedAtMessageEnd(t *testing.T) {
 	assert.Less(t, itemDoneIndex, completedIndex, "output_item.done must precede response.completed")
 }
 
+// TestCohereResponsesStreamToolPlanThenContentKeepsBothItems pins that a
+// content block following a tool plan gets its own output index, so the
+// completed output array keeps both items and annotations stay on the item
+// they belong to.
+func TestCohereResponsesStreamToolPlanThenContentKeepsBothItems(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-plan-content"),
+		cohereToolPlanDeltaEvent("Plan the answer."),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "Final answer."),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 4, 5),
+	})
+
+	added := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputItemAdded)
+	require.Len(t, added, 2)
+	require.NotNil(t, added[0].OutputIndex)
+	require.NotNil(t, added[1].OutputIndex)
+	assert.NotEqual(t, *added[0].OutputIndex, *added[1].OutputIndex, "items must not share an output index")
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 2, "both the tool-plan item and the content item must survive in the output array")
+	require.NotNil(t, response.Output[0].Content)
+	require.Len(t, response.Output[0].Content.ContentBlocks, 1)
+	require.NotNil(t, response.Output[0].Content.ContentBlocks[0].Text)
+	assert.Equal(t, "Plan the answer.", *response.Output[0].Content.ContentBlocks[0].Text)
+	require.NotNil(t, response.Output[1].Content)
+	require.Len(t, response.Output[1].Content.ContentBlocks, 1)
+	require.NotNil(t, response.Output[1].Content.ContentBlocks[0].Text)
+	assert.Equal(t, "Final answer.", *response.Output[1].Content.ContentBlocks[0].Text)
+}
+
 // TestCohereResponsesStreamStateRecycleTerminalClean pins that a recycled
 // stream state starts with clean bookkeeping: nothing from a previous stream
 // leaks into the next stream's response.completed.

--- a/core/providers/cohere/streamterminalevents_test.go
+++ b/core/providers/cohere/streamterminalevents_test.go
@@ -1,0 +1,539 @@
+package cohere
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCohereResponsesStream replays a native Cohere event sequence through
+// ToBifrostResponsesStream with a fresh stream state, the way the provider's
+// stream loop does, and returns every emitted Responses stream event.
+func runCohereResponsesStream(t *testing.T, state *CohereResponsesStreamState, events []CohereStreamEvent) []*schemas.BifrostResponsesStreamResponse {
+	t.Helper()
+	var collected []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for i := range events {
+		responses, bifrostErr, _ := events[i].ToBifrostResponsesStream(seq, state)
+		require.Nil(t, bifrostErr, "unexpected error on event %d", i)
+		collected = append(collected, responses...)
+		seq += len(responses)
+	}
+	return collected
+}
+
+func filterStreamEvents(events []*schemas.BifrostResponsesStreamResponse, eventType schemas.ResponsesStreamResponseType) []*schemas.BifrostResponsesStreamResponse {
+	var matched []*schemas.BifrostResponsesStreamResponse
+	for _, event := range events {
+		if event != nil && event.Type == eventType {
+			matched = append(matched, event)
+		}
+	}
+	return matched
+}
+
+func completedResponse(t *testing.T, events []*schemas.BifrostResponsesStreamResponse) *schemas.BifrostResponsesResponse {
+	t.Helper()
+	completed := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeCompleted)
+	require.Len(t, completed, 1, "expected exactly one response.completed event")
+	require.NotNil(t, completed[0].Response)
+	return completed[0].Response
+}
+
+func cohereMessageStartEvent(id string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type: StreamEventMessageStart,
+		ID:   schemas.Ptr(id),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{Role: schemas.Ptr("assistant")},
+		},
+	}
+}
+
+func cohereContentStartEvent(index int, blockType CohereContentBlockType) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type:  StreamEventContentStart,
+		Index: schemas.Ptr(index),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				Content: &CohereStreamContentStruct{
+					CohereStreamContentObject: &CohereStreamContent{Type: blockType},
+				},
+			},
+		},
+	}
+}
+
+func cohereTextDeltaEvent(index int, text string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type:  StreamEventContentDelta,
+		Index: schemas.Ptr(index),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				Content: &CohereStreamContentStruct{
+					CohereStreamContentObject: &CohereStreamContent{Text: schemas.Ptr(text)},
+				},
+			},
+		},
+	}
+}
+
+func cohereThinkingDeltaEvent(index int, thinking string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type:  StreamEventContentDelta,
+		Index: schemas.Ptr(index),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				Content: &CohereStreamContentStruct{
+					CohereStreamContentObject: &CohereStreamContent{Thinking: schemas.Ptr(thinking)},
+				},
+			},
+		},
+	}
+}
+
+func cohereContentEndEvent(index int) CohereStreamEvent {
+	return CohereStreamEvent{Type: StreamEventContentEnd, Index: schemas.Ptr(index)}
+}
+
+func cohereToolPlanDeltaEvent(text string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type: StreamEventToolPlanDelta,
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{ToolPlan: schemas.Ptr(text)},
+		},
+	}
+}
+
+func cohereToolCallStartEvent(index int, callID, name string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type:  StreamEventToolCallStart,
+		Index: schemas.Ptr(index),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				ToolCalls: &CohereStreamToolCallStruct{
+					CohereToolCallObject: &CohereToolCall{
+						ID:       schemas.Ptr(callID),
+						Type:     "function",
+						Function: &CohereFunction{Name: schemas.Ptr(name)},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cohereToolCallDeltaEvent(index int, argumentsFragment string) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type:  StreamEventToolCallDelta,
+		Index: schemas.Ptr(index),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				ToolCalls: &CohereStreamToolCallStruct{
+					CohereToolCallObject: &CohereToolCall{
+						Function: &CohereFunction{Arguments: argumentsFragment},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cohereToolCallEndEvent(index int) CohereStreamEvent {
+	return CohereStreamEvent{Type: StreamEventToolCallEnd, Index: schemas.Ptr(index)}
+}
+
+func cohereCitationStartEvent(annotationIndex, contentIndex, start, end int, title, url string) CohereStreamEvent {
+	document := json.RawMessage(`{"id":"doc-1","title":"` + title + `","url":"` + url + `","snippet":"cited text"}`)
+	return CohereStreamEvent{
+		Type:  StreamEventCitationStart,
+		Index: schemas.Ptr(annotationIndex),
+		Delta: &CohereStreamDelta{
+			Message: &CohereStreamMessage{
+				Citations: &CohereStreamCitationStruct{
+					CohereStreamCitationObject: &CohereCitation{
+						Start:        start,
+						End:          end,
+						ContentIndex: contentIndex,
+						Sources: []CohereSource{
+							{Type: "document", Document: &document},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func cohereCitationEndEvent(annotationIndex int) CohereStreamEvent {
+	return CohereStreamEvent{Type: StreamEventCitationEnd, Index: schemas.Ptr(annotationIndex)}
+}
+
+func cohereMessageEndEvent(finishReason CohereFinishReason, inputTokens, outputTokens int) CohereStreamEvent {
+	return CohereStreamEvent{
+		Type: StreamEventMessageEnd,
+		Delta: &CohereStreamDelta{
+			FinishReason: &finishReason,
+			Usage: &CohereUsage{
+				Tokens: &CohereTokenUsage{
+					InputTokens:  schemas.Ptr(inputTokens),
+					OutputTokens: schemas.Ptr(outputTokens),
+				},
+			},
+		},
+	}
+}
+
+// TestCohereResponsesStreamThinkingTerminalEvents pins that the reasoning
+// terminal events carry the accumulated thinking text instead of empty shells.
+func TestCohereResponsesStreamThinkingTerminalEvents(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-thinking"),
+		cohereContentStartEvent(0, CohereContentBlockTypeThinking),
+		cohereThinkingDeltaEvent(0, "First step."),
+		cohereThinkingDeltaEvent(0, " Second step."),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 10, 20),
+	})
+
+	reasoningDeltas := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta)
+	require.Len(t, reasoningDeltas, 2)
+	for _, delta := range reasoningDeltas {
+		require.NotNil(t, delta.SummaryIndex, "reasoning_summary_text.delta must carry summary_index")
+		assert.Equal(t, 0, *delta.SummaryIndex)
+	}
+
+	reasoningDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone)
+	require.Len(t, reasoningDone, 1)
+	require.NotNil(t, reasoningDone[0].Text)
+	assert.Equal(t, "First step. Second step.", *reasoningDone[0].Text)
+	require.NotNil(t, reasoningDone[0].SummaryIndex, "reasoning_summary_text.done must carry summary_index")
+	assert.Equal(t, 0, *reasoningDone[0].SummaryIndex)
+
+	partDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeContentPartDone)
+	require.Len(t, partDone, 1)
+	require.NotNil(t, partDone[0].Part)
+	require.NotNil(t, partDone[0].Part.Text)
+	assert.Equal(t, "First step. Second step.", *partDone[0].Part.Text)
+
+	itemDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputItemDone)
+	require.Len(t, itemDone, 1)
+	item := itemDone[0].Item
+	require.NotNil(t, item)
+	require.NotNil(t, item.Type)
+	assert.Equal(t, schemas.ResponsesMessageTypeReasoning, *item.Type)
+	require.NotNil(t, item.Content, "reasoning output_item.done must carry the accumulated text as a content block")
+	require.Len(t, item.Content.ContentBlocks, 1)
+	block := item.Content.ContentBlocks[0]
+	assert.Equal(t, schemas.ResponsesOutputMessageContentTypeReasoning, block.Type)
+	require.NotNil(t, block.Text)
+	assert.Equal(t, "First step. Second step.", *block.Text)
+}
+
+// TestCohereResponsesStreamCompletedCarriesOutput pins that response.completed
+// carries the output array with the streamed message, matching the
+// non-streaming path, plus the mapped stop reason.
+func TestCohereResponsesStreamCompletedCarriesOutput(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-text"),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "Hello "),
+		cohereTextDeltaEvent(0, "world."),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 5, 7),
+	})
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output, "response.completed must carry the output array")
+	require.Len(t, response.Output, 1)
+
+	message := response.Output[0]
+	require.NotNil(t, message.Type)
+	assert.Equal(t, schemas.ResponsesMessageTypeMessage, *message.Type)
+	require.NotNil(t, message.Content)
+	require.Len(t, message.Content.ContentBlocks, 1)
+	require.NotNil(t, message.Content.ContentBlocks[0].Text)
+	assert.Equal(t, "Hello world.", *message.Content.ContentBlocks[0].Text)
+
+	require.NotNil(t, response.StopReason, "response.completed must map the Cohere finish reason")
+	assert.Equal(t, "stop", *response.StopReason)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, 5, response.Usage.InputTokens)
+	assert.Equal(t, 7, response.Usage.OutputTokens)
+}
+
+// TestCohereResponsesStreamCompletedCarriesReasoningAndFunctionCall pins the
+// full output array for a thinking + tool-call turn, ordered by output index.
+func TestCohereResponsesStreamCompletedCarriesReasoningAndFunctionCall(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-tools"),
+		cohereContentStartEvent(0, CohereContentBlockTypeThinking),
+		cohereThinkingDeltaEvent(0, "Check the weather."),
+		cohereContentEndEvent(0),
+		cohereToolCallStartEvent(1, "call_1", "get_weather"),
+		cohereToolCallDeltaEvent(1, `{"location":`),
+		cohereToolCallDeltaEvent(1, `"Paris"}`),
+		cohereToolCallEndEvent(1),
+		cohereMessageEndEvent(FinishReasonToolCall, 12, 34),
+	})
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 2)
+
+	reasoning := response.Output[0]
+	require.NotNil(t, reasoning.Type)
+	assert.Equal(t, schemas.ResponsesMessageTypeReasoning, *reasoning.Type)
+	require.NotNil(t, reasoning.Content)
+	require.Len(t, reasoning.Content.ContentBlocks, 1)
+	require.NotNil(t, reasoning.Content.ContentBlocks[0].Text)
+	assert.Equal(t, "Check the weather.", *reasoning.Content.ContentBlocks[0].Text)
+
+	functionCall := response.Output[1]
+	require.NotNil(t, functionCall.Type)
+	assert.Equal(t, schemas.ResponsesMessageTypeFunctionCall, *functionCall.Type)
+	require.NotNil(t, functionCall.ResponsesToolMessage)
+	require.NotNil(t, functionCall.ResponsesToolMessage.Name)
+	assert.Equal(t, "get_weather", *functionCall.ResponsesToolMessage.Name)
+	require.NotNil(t, functionCall.ResponsesToolMessage.Arguments)
+	assert.Equal(t, `{"location":"Paris"}`, *functionCall.ResponsesToolMessage.Arguments)
+
+	require.NotNil(t, response.StopReason)
+	assert.Equal(t, "tool_calls", *response.StopReason)
+}
+
+// TestCohereResponsesStreamCitationAnnotations pins that citation annotation
+// events carry the item ID of the text item they belong to, and that
+// citations streaming before content-end reach the done events and the final
+// snapshot.
+func TestCohereResponsesStreamCitationAnnotations(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-cite"),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "Paris is the capital of France."),
+		cohereCitationStartEvent(0, 0, 0, 5, "Paris", "https://example.com/paris"),
+		cohereCitationEndEvent(0),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 8, 9),
+	})
+
+	annotationAdded := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded)
+	require.Len(t, annotationAdded, 1)
+	require.NotNil(t, annotationAdded[0].ItemID, "annotation.added must carry the text item's ID")
+	assert.Equal(t, "msg_msg-cite_item_0", *annotationAdded[0].ItemID)
+
+	annotationDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputTextAnnotationDone)
+	require.Len(t, annotationDone, 1)
+	require.NotNil(t, annotationDone[0].ItemID, "annotation.done must carry the text item's ID")
+	assert.Equal(t, "msg_msg-cite_item_0", *annotationDone[0].ItemID)
+
+	itemDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputItemDone)
+	require.Len(t, itemDone, 1)
+	require.NotNil(t, itemDone[0].Item)
+	require.NotNil(t, itemDone[0].Item.Content)
+	require.Len(t, itemDone[0].Item.Content.ContentBlocks, 1)
+	doneBlock := itemDone[0].Item.Content.ContentBlocks[0]
+	require.NotNil(t, doneBlock.ResponsesOutputMessageContentText)
+	require.Len(t, doneBlock.Annotations, 1, "output_item.done must carry citations that streamed before content-end")
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 1)
+	snapshotBlock := response.Output[0].Content.ContentBlocks[0]
+	require.NotNil(t, snapshotBlock.ResponsesOutputMessageContentText)
+	require.Len(t, snapshotBlock.Annotations, 1)
+	annotation := snapshotBlock.Annotations[0]
+	require.NotNil(t, annotation.URL)
+	assert.Equal(t, "https://example.com/paris", *annotation.URL)
+	require.NotNil(t, annotation.Title)
+	assert.Equal(t, "Paris", *annotation.Title)
+	require.NotNil(t, annotation.StartIndex)
+	assert.Equal(t, 0, *annotation.StartIndex)
+	require.NotNil(t, annotation.EndIndex)
+	assert.Equal(t, 5, *annotation.EndIndex)
+}
+
+// TestCohereResponsesStreamCitationAfterContentEndInSnapshot pins that
+// citations streaming after the text item completed still reach the final
+// snapshot, so the handling is order-independent.
+func TestCohereResponsesStreamCitationAfterContentEndInSnapshot(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-late-cite"),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "Paris is the capital of France."),
+		cohereContentEndEvent(0),
+		cohereCitationStartEvent(0, 0, 0, 5, "Paris", "https://example.com/paris"),
+		cohereCitationEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 8, 9),
+	})
+
+	annotationAdded := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded)
+	require.Len(t, annotationAdded, 1)
+	require.NotNil(t, annotationAdded[0].ItemID)
+	assert.Equal(t, "msg_msg-late-cite_item_0", *annotationAdded[0].ItemID)
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 1)
+	snapshotBlock := response.Output[0].Content.ContentBlocks[0]
+	require.NotNil(t, snapshotBlock.ResponsesOutputMessageContentText)
+	require.Len(t, snapshotBlock.Annotations, 1, "late citations must be folded into the final snapshot")
+	require.NotNil(t, snapshotBlock.Annotations[0].URL)
+	assert.Equal(t, "https://example.com/paris", *snapshotBlock.Annotations[0].URL)
+}
+
+// TestCohereResponsesStreamToolPlanClosedAtMessageEnd pins that a tool-plan
+// text item left open when the stream ends is completed before
+// response.completed, and appears in the output array.
+func TestCohereResponsesStreamToolPlanClosedAtMessageEnd(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-plan"),
+		cohereToolPlanDeltaEvent("I will look this up."),
+		cohereMessageEndEvent(FinishReasonComplete, 3, 4),
+	})
+
+	textDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputTextDone)
+	require.Len(t, textDone, 1, "the open tool-plan item must be completed at message-end")
+	require.NotNil(t, textDone[0].Text)
+	assert.Equal(t, "I will look this up.", *textDone[0].Text)
+
+	itemDone := filterStreamEvents(events, schemas.ResponsesStreamResponseTypeOutputItemDone)
+	require.Len(t, itemDone, 1)
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 1)
+	require.NotNil(t, response.Output[0].Content)
+	require.Len(t, response.Output[0].Content.ContentBlocks, 1)
+	require.NotNil(t, response.Output[0].Content.ContentBlocks[0].Text)
+	assert.Equal(t, "I will look this up.", *response.Output[0].Content.ContentBlocks[0].Text)
+
+	completedIndex := -1
+	itemDoneIndex := -1
+	for i, event := range events {
+		switch event.Type {
+		case schemas.ResponsesStreamResponseTypeOutputItemDone:
+			itemDoneIndex = i
+		case schemas.ResponsesStreamResponseTypeCompleted:
+			completedIndex = i
+		}
+	}
+	assert.Less(t, itemDoneIndex, completedIndex, "output_item.done must precede response.completed")
+}
+
+// TestCohereResponsesStreamStateRecycleTerminalClean pins that a recycled
+// stream state starts with clean bookkeeping: nothing from a previous stream
+// leaks into the next stream's response.completed.
+func TestCohereResponsesStreamStateRecycleTerminalClean(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	first := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-run-1"),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "First run text."),
+		cohereCitationStartEvent(0, 0, 0, 5, "One", "https://example.com/one"),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 1, 2),
+	})
+	firstResponse := completedResponse(t, first)
+	require.NotNil(t, firstResponse.Output)
+	require.Len(t, firstResponse.Output, 1)
+
+	// flush is what both release and acquire run, so this is the recycle path.
+	state.flush()
+
+	// The second run reuses output index 0 for a plain text item: leaked
+	// OutputItems would change the item count, and a leaked annotation map
+	// would fold the first run's citation into this run's text block.
+	second := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-run-2"),
+		cohereContentStartEvent(0, CohereContentBlockTypeText),
+		cohereTextDeltaEvent(0, "Second run text."),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 3, 4),
+	})
+	secondResponse := completedResponse(t, second)
+	require.NotNil(t, secondResponse.Output)
+	require.Len(t, secondResponse.Output, 1, "recycled state must not leak items from the previous stream")
+	require.NotNil(t, secondResponse.Output[0].Type)
+	assert.Equal(t, schemas.ResponsesMessageTypeMessage, *secondResponse.Output[0].Type)
+	require.NotNil(t, secondResponse.Output[0].Content)
+	require.Len(t, secondResponse.Output[0].Content.ContentBlocks, 1)
+	block := secondResponse.Output[0].Content.ContentBlocks[0]
+	require.NotNil(t, block.Text)
+	assert.Equal(t, "Second run text.", *block.Text)
+	require.NotNil(t, block.ResponsesOutputMessageContentText)
+	assert.Empty(t, block.Annotations, "annotations from the previous stream must not leak")
+}
+
+// TestCohereResponsesStreamReasoningItemReplayable pins the full replay chain:
+// the reasoning item from response.completed, JSON-echoed the way a client
+// replays history, converts back into a Cohere thinking block.
+func TestCohereResponsesStreamReasoningItemReplayable(t *testing.T) {
+	state := acquireCohereResponsesStreamState()
+	defer releaseCohereResponsesStreamState(state)
+
+	events := runCohereResponsesStream(t, state, []CohereStreamEvent{
+		cohereMessageStartEvent("msg-replay"),
+		cohereContentStartEvent(0, CohereContentBlockTypeThinking),
+		cohereThinkingDeltaEvent(0, "Reason to replay."),
+		cohereContentEndEvent(0),
+		cohereMessageEndEvent(FinishReasonComplete, 2, 3),
+	})
+
+	response := completedResponse(t, events)
+	require.NotNil(t, response.Output)
+	require.Len(t, response.Output, 1)
+
+	echoed, err := json.Marshal(response.Output[0])
+	require.NoError(t, err)
+	var replayed schemas.ResponsesMessage
+	require.NoError(t, json.Unmarshal(echoed, &replayed))
+
+	cohereMessages := ConvertBifrostMessagesToCohereMessages([]schemas.ResponsesMessage{replayed}, nil)
+	require.Len(t, cohereMessages, 1)
+	assert.Equal(t, "assistant", cohereMessages[0].Role)
+	require.NotNil(t, cohereMessages[0].Content)
+	require.Len(t, cohereMessages[0].Content.BlocksContent, 1)
+	replayedBlock := cohereMessages[0].Content.BlocksContent[0]
+	assert.Equal(t, CohereContentBlockTypeThinking, replayedBlock.Type)
+	require.NotNil(t, replayedBlock.Thinking)
+	assert.Equal(t, "Reason to replay.", *replayedBlock.Thinking)
+}
+
+// TestCohereNonStreamResponsesCarriesStopReason pins that the non-streaming
+// Responses conversion maps the Cohere finish reason the way the chat
+// conversion already does.
+func TestCohereNonStreamResponsesCarriesStopReason(t *testing.T) {
+	finishReason := FinishReasonComplete
+	response := (&CohereChatResponse{
+		ID:           "resp-1",
+		FinishReason: &finishReason,
+	}).ToBifrostResponsesResponse()
+
+	require.NotNil(t, response)
+	require.NotNil(t, response.StopReason, "non-streaming Responses must map the Cohere finish reason")
+	assert.Equal(t, "stop", *response.StopReason)
+}


### PR DESCRIPTION
## Summary
Streaming `/v1/responses` on Cohere never completed its terminal events: `response.completed` carried no output array at all (`"output":null`, every item type missing from the final snapshot) and no `stop_reason`, reasoning done events were empty shells (thinking deltas were never buffered, unlike text deltas since #3838), and citation annotation events carried no `item_id`. The non-streaming path returns the output array and the reasoning content correctly, and the Anthropic stream ingress already populates `Output` from per-item bookkeeping, so these were Cohere-only gaps. The streamed reasoning shape was also not replayable: it had neither the content blocks the request converter reads nor a filled summary, so conversations coming from streaming silently lost their thinking blocks on the next turn. Fixes #5385.

## Changes
- Added output-item bookkeeping to `CohereResponsesStreamState` (`OutputItems` map fed by a small `trackOutputItems` helper wherever `output_item.added`/`output_item.done` are emitted) and populate `response.completed.response.output` from it, sorted by output index, mirroring the Anthropic ingress.
- Buffer thinking deltas in `TextBuffers` the way text deltas already are, and emit `reasoning_summary_text.done`, the reasoning `content_part.done`, and the reasoning `output_item.done` with the accumulated text. The done item carries the text as a reasoning content block, the exact shape the non-streaming converter produces, which is what `convertBifrostReasoningToCohereThinking` replays. The reasoning delta and done events also carry `summary_index` (0; Cohere thinking has a single summary part per item), which the official OpenAI event types require.
- Record citation annotations per output index, set `item_id` on `output_text.annotation.added`/`done`, include the already-streamed annotations in the text item's done events, and defensively fold annotations into the completed snapshot regardless of whether they arrive before or after `content-end`, with clone-on-write so already-emitted events are never mutated.
- Map `delta.finish_reason` on `message-end` (and `finish_reason` on the non-streaming Responses conversion) through the existing `ConvertCohereFinishReasonToBifrost`, so `response.completed` and the non-streaming response carry `stop_reason` the way the chat surface already does. This also fixes the Anthropic-format egress synthesizing `end_turn` for Cohere tool-use turns.
- Extracted the tool-plan close block (duplicated verbatim in `content-start` and `tool-call-start`) into a `closeToolPlanItem` helper and also call it on `message-end`, so a stream ending right after a tool plan completes the item before `response.completed`.
- Added a changelog entry.

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas
- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test
```sh
cd core
go test ./providers/cohere/ -run 'TestCohere(ResponsesStream|NonStreamResponses)' -v
go test ./providers/cohere/
```
The nine new tests in `streamterminalevents_test.go` construct Cohere v2 stream event sequences (thinking deltas, text, tool plan, tool calls, citations arriving both during and after their content block) and drive them through `ToBifrostResponsesStream`, pinning: done events carrying the accumulated thinking text, `response.completed` carrying the full output array with the actual payloads and the mapped `stop_reason`, `item_id` on annotation events, citations present in the done events and the final snapshot, the tool-plan item completed at message-end, no state leakage across pooled-state recycling, a full replay chain (completed reasoning item JSON-echoed back through `ConvertBifrostMessagesToCohereMessages` recovers the thinking block), and the non-streaming `stop_reason` mapping. All nine fail on dev without the fix with the exact symptoms above.

## Screenshots/Recordings
Not a UI change.

## Breaking changes
- [ ] Yes
- [x] No

Terminal events that previously carried empty payloads now carry the accumulated ones, and `response.completed` now includes the `output` array and `stop_reason`, matching the non-streaming path. The framework stream accumulator folds deltas and ignores done events, so logged messages are unchanged (verified). The Anthropic-format egress ignores the enriched done payloads and only gains the correct terminal `stop_reason`.

## Related issues
Closes #5385

## Security considerations
None. No new inputs are parsed; the change only carries already-received stream content through to the terminal events.

## Checklist
- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
