### PR TITLE
fix: bedrock reasoning double emission

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -6870,3 +6870,65 @@ func TestReasoningConfigSurvivesHTTPUnmarshal(t *testing.T) {
 		assert.Equal(t, "high", *out.Params.Reasoning.Effort)
 	})
 }
+
+// TestReasoningConfigNoDoubleEmissionOnEgress guards against issue #5108's
+// follow-on regression: a reasoning key consumed into Params.Reasoning on ingress
+// must not also be forwarded verbatim via additionalModelRequestFieldPaths, or the
+// Bedrock egress carries two copies and Converse rejects the collision
+// ("The additional field thinking/type conflicts with an existing field").
+func TestReasoningConfigNoDoubleEmissionOnEgress(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	cases := []struct {
+		name        string
+		model       string
+		inputField  string
+		inputConfig string
+		wantKey     string // the single reasoning key expected on egress
+	}{
+		{"anthropic_reasoning_config", "us.anthropic.claude-haiku-4-5-20251001-v1:0", "reasoning_config", `{"type": "enabled", "budget_tokens": 1500}`, "thinking"},
+		{"anthropic_thinking", "us.anthropic.claude-haiku-4-5-20251001-v1:0", "thinking", `{"type": "enabled", "budget_tokens": 1500}`, "thinking"},
+		{"nova_reasoningConfig", "amazon.nova-premier-v1:0", "reasoningConfig", `{"type": "enabled", "maxReasoningEffort": "high"}`, "reasoningConfig"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := []byte(`{
+				"messages": [{"role": "user", "content": [{"text": "What's my best offer?"}]}],
+				"inferenceConfig": {"maxTokens": 4096},
+				"additionalModelRequestFields": {"` + tc.inputField + `": ` + tc.inputConfig + `}
+			}`)
+
+			var req bedrock.BedrockConverseRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			req.ModelID = tc.model
+
+			// Ingress: Bedrock Converse -> Bifrost
+			mid, err := req.ToBifrostResponsesRequest(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, mid.Params, "Params is nil")
+			require.NotNil(t, mid.Params.Reasoning, "reasoning was not consumed on ingress")
+
+			// Egress: Bifrost -> Bedrock Converse
+			out, err := bedrock.ToBedrockResponsesRequest(ctx, mid)
+			require.NoError(t, err)
+			require.NotNil(t, out.AdditionalModelRequestFields)
+
+			// Exactly one reasoning key on the wire, and never both spellings.
+			_, hasThinking := out.AdditionalModelRequestFields.Get("thinking")
+			_, hasReasoningConfig := out.AdditionalModelRequestFields.Get("reasoning_config")
+			_, hasNova := out.AdditionalModelRequestFields.Get("reasoningConfig")
+
+			assert.False(t, hasThinking && hasReasoningConfig,
+				"both thinking and reasoning_config emitted — Bedrock would reject the collision")
+
+			switch tc.wantKey {
+			case "thinking":
+				assert.True(t, hasThinking, "expected thinking on egress")
+				assert.False(t, hasReasoningConfig, "reasoning_config must not be forwarded verbatim once consumed")
+			case "reasoningConfig":
+				assert.True(t, hasNova, "expected Nova reasoningConfig on egress")
+			}
+		})
+	}
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2187,10 +2187,23 @@ func (request *BedrockConverseRequest) ToBifrostResponsesRequest(ctx *schemas.Bi
 
 	// Convert additional model request fields to extra params
 	if request.AdditionalModelRequestFields.Len() > 0 {
-		if bifrostReq.Params.ExtraParams == nil {
-			bifrostReq.Params.ExtraParams = make(map[string]interface{})
+		fieldsToForward := request.AdditionalModelRequestFields
+		// Reasoning keys already consumed into Params.Reasoning get re-synthesized on
+		// egress; forwarding them verbatim too puts two copies on the wire and Bedrock
+		// rejects the collision (e.g. reasoning_config expands to thinking, clashing
+		// with the emitted thinking). output_config is left in place — egress deep-merges it.
+		if bifrostReq.Params.Reasoning != nil {
+			fieldsToForward = request.AdditionalModelRequestFields.Clone()
+			fieldsToForward.Delete("thinking")
+			fieldsToForward.Delete("reasoning_config")
+			fieldsToForward.Delete("reasoningConfig")
 		}
-		bifrostReq.Params.ExtraParams["additionalModelRequestFieldPaths"] = request.AdditionalModelRequestFields
+		if fieldsToForward.Len() > 0 {
+			if bifrostReq.Params.ExtraParams == nil {
+				bifrostReq.Params.ExtraParams = make(map[string]interface{})
+			}
+			bifrostReq.Params.ExtraParams["additionalModelRequestFieldPaths"] = fieldsToForward
+		}
 	}
 
 	// Convert additional model response field paths to extra params

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -41247,6 +41247,215 @@
           ]
         }
       ]
+    },
+    {
+      "name": "28. Bedrock reasoning double-emission on additionalModelRequestFields (#5108 / PR #5109)",
+      "description": "Regression for the #5108 follow-on fixed in PR #5109. A reasoning key (reasoning_config / thinking / Nova reasoningConfig) consumed into Params.Reasoning on Bedrock Converse ingress was ALSO forwarded verbatim via additionalModelRequestFieldPaths. The Bedrock egress then carried two copies (the re-synthesized thinking plus the passthrough reasoning_config, which Bedrock expands into thinking), and Converse rejected the collision: \"The additional field thinking/type conflicts with an existing field\". The fix strips the consumed reasoning key from the verbatim passthrough so exactly one reasoning field reaches Bedrock. Cases 1-3 pin the integration route (/bedrock converse) that actually reproduced the bug; case 4 is a native /v1 control (the native path has no passthrough, so it never collided) guarding the invariant from that entry point.",
+      "item": [
+        {
+          "name": "Bedrock reasoning_config no double-emission (Sonnet 4.6, /bedrock converse) - #5108",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Regression #5108 / PR #5109. Exact user repro: client sends reasoning_config inside",
+                  "// additionalModelRequestFields on the /bedrock Converse route. Before the fix the egress",
+                  "// forwarded reasoning_config verbatim alongside the emitted thinking -> Converse collision.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('no thinking/reasoning double-emission collision on converse egress - #5108', function () {",
+                  "  var t = pm.response.text() || '';",
+                  "  pm.expect(t, 'Bedrock rejected a duplicated reasoning field: ' + t).to.not.match(/conflicts with an existing field/i);",
+                  "  pm.expect(t, 'Bedrock asked to remove a duplicated thinking field: ' + t).to.not.match(/Remove thinking\\//i);",
+                  "});",
+                  "pm.test('converse request succeeded - #5108', function () {",
+                  "  pm.expect(pm.response.code, 'expected success, got ' + pm.response.code + ': ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"text\": \"What's my best offer?\"\n        }\n      ]\n    }\n  ],\n  \"inferenceConfig\": {\n    \"maxTokens\": 4096\n  },\n  \"additionalModelRequestFields\": {\n    \"reasoning_config\": {\n      \"type\": \"enabled\",\n      \"budget_tokens\": 1500\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/global.anthropic.claude-sonnet-4-6/converse",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "global.anthropic.claude-sonnet-4-6",
+                "converse"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Bedrock reasoning_config no double-emission (Sonnet 4.6, /bedrock converse-stream) - #5108",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Regression #5108 / PR #5109 (streaming). The collision is request-validation, so it",
+                  "// surfaces as a synchronous 400 even on converse-stream. Assert it does not occur.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('no thinking/reasoning double-emission collision on converse-stream egress - #5108', function () {",
+                  "  var t = pm.response.text() || '';",
+                  "  pm.expect(t, 'Bedrock rejected a duplicated reasoning field: ' + t).to.not.match(/conflicts with an existing field/i);",
+                  "  pm.expect(t, 'Bedrock asked to remove a duplicated thinking field: ' + t).to.not.match(/Remove thinking\\//i);",
+                  "});",
+                  "pm.test('converse-stream request succeeded - #5108', function () {",
+                  "  pm.expect(pm.response.code, 'expected success, got ' + pm.response.code + ': ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"text\": \"What's my best offer?\"\n        }\n      ]\n    }\n  ],\n  \"inferenceConfig\": {\n    \"maxTokens\": 4096\n  },\n  \"additionalModelRequestFields\": {\n    \"reasoning_config\": {\n      \"type\": \"enabled\",\n      \"budget_tokens\": 1500\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/global.anthropic.claude-sonnet-4-6/converse-stream",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "global.anthropic.claude-sonnet-4-6",
+                "converse-stream"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Bedrock thinking spelling no double-emission (Sonnet 4.6, /bedrock converse) - #5108",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Regression #5108 / PR #5109. The fix strips the consumed key for ALL spellings; this",
+                  "// pins that the native `thinking` spelling is still delivered to Bedrock (not dropped)",
+                  "// and does not collide with the re-synthesized thinking.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('no thinking/reasoning double-emission collision on converse egress - #5108', function () {",
+                  "  var t = pm.response.text() || '';",
+                  "  pm.expect(t, 'Bedrock rejected a duplicated reasoning field: ' + t).to.not.match(/conflicts with an existing field/i);",
+                  "  pm.expect(t, 'Bedrock asked to remove a duplicated thinking field: ' + t).to.not.match(/Remove thinking\\//i);",
+                  "});",
+                  "pm.test('converse request succeeded - #5108', function () {",
+                  "  pm.expect(pm.response.code, 'expected success, got ' + pm.response.code + ': ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"text\": \"What's my best offer?\"\n        }\n      ]\n    }\n  ],\n  \"inferenceConfig\": {\n    \"maxTokens\": 4096\n  },\n  \"additionalModelRequestFields\": {\n    \"thinking\": {\n      \"type\": \"enabled\",\n      \"budget_tokens\": 1500\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/bedrock/model/global.anthropic.claude-sonnet-4-6/converse",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "bedrock",
+                "model",
+                "global.anthropic.claude-sonnet-4-6",
+                "converse"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Native /v1 chat -> bedrock reasoning single thinking (Sonnet 4.6) - #5108",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Regression #5108 / PR #5109 (native entry point). The native path carries no",
+                  "// additionalModelRequestFields passthrough, so it never collided - this is a control",
+                  "// that guards the invariant from the native side and that reasoning still reaches Bedrock.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('native reasoning to bedrock: no collision - #5108', function () {",
+                  "  var t = pm.response.text() || '';",
+                  "  pm.expect(t, 'Bedrock rejected a duplicated reasoning field: ' + t).to.not.match(/conflicts with an existing field/i);",
+                  "  pm.expect(t, 'Bedrock asked to remove a duplicated thinking field: ' + t).to.not.match(/Remove thinking\\//i);",
+                  "});",
+                  "pm.test('native chat request succeeded - #5108', function () {",
+                  "  pm.expect(pm.response.code, 'expected success, got ' + pm.response.code + ': ' + pm.response.text()).to.be.below(400);",
+                  "  if (pm.response.code < 400) {",
+                  "    var j = pm.response.json();",
+                  "    var cnt = (j.choices && j.choices[0] && j.choices[0].message && j.choices[0].message.content) || '';",
+                  "    pm.expect(cnt, 'expected non-empty content').to.be.a('string').and.not.empty;",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/global.anthropic.claude-sonnet-4-6\",\n  \"max_tokens\": 4096,\n  \"thinking\": {\n    \"type\": \"enabled\",\n    \"budget_tokens\": 1500\n  },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What's my best offer?\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a follow-on regression from #5108 where a reasoning key (`reasoning_config`, `thinking`, or Nova's `reasoningConfig`) consumed into `Params.Reasoning` during Bedrock Converse ingress was also forwarded verbatim via `additionalModelRequestFieldPaths`. This caused the Bedrock egress to carry two copies of the reasoning field — the re-synthesized `thinking` plus the passthrough — and Converse rejected the collision with `"The additional field thinking/type conflicts with an existing field"`.

## Changes

- In `ToBifrostResponsesRequest`, when `Params.Reasoning` has been populated, the consumed reasoning keys (`thinking`, `reasoning_config`, `reasoningConfig`) are stripped from the cloned `additionalModelRequestFields` before forwarding via `additionalModelRequestFieldPaths`. Non-reasoning fields like `output_config` are left in place and continue to be deep-merged on egress.
- Added `TestReasoningConfigNoDoubleEmissionOnEgress` covering all three reasoning key spellings (Anthropic `reasoning_config`, Anthropic `thinking`, and Nova `reasoningConfig`) to assert that exactly one reasoning key appears on the egress wire and no collision occurs.
- Added four E2E Postman collection cases under a new group pinning the `/bedrock converse`, `/bedrock converse-stream`, and native `/v1/chat/completions` entry points, asserting that Bedrock never returns a field-collision error.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestReasoningConfigNoDoubleEmission -v
go test ./core/providers/bedrock/... -v
```

Send a Bedrock Converse request with `reasoning_config` inside `additionalModelRequestFields` to the `/bedrock/model/<model>/converse` route and confirm the response does not contain `"conflicts with an existing field"` or `"Remove thinking/"`.

## Breaking changes

- [x] No

## Related issues

Closes #5108

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable