### PR TITLE
chore: fixes migration tests

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -719,6 +719,78 @@ EOF
   log_info "Generated faker SQL: $output_file"
 }
 
+# Generate v1.6.3-era config-store coverage rows for SQLite.
+generate_v163_config_store_insert_sqlite() {
+  local output_file="$1"
+  local config_db="$2"
+
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- v1.6.3-era config-store coverage rows (SQLite-only)" >> "$output_file"
+
+  if column_exists_sqlite "$config_db" "config_client" "mcp_server_auth_mode"; then
+    echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+  fi
+  if column_exists_sqlite "$config_db" "config_client" "oauth2_server_config_json"; then
+    echo "UPDATE config_client SET oauth2_server_config_json = '{\"auth_code_ttl\":300,\"access_token_ttl\":600}' WHERE id = 1;" >> "$output_file"
+  fi
+
+  for col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name; do
+    if column_exists_sqlite "$config_db" "config_keys" "$col"; then
+      echo "UPDATE config_keys SET $col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+  done
+
+  if column_exists_sqlite "$config_db" "governance_model_pricing" "is_deprecated"; then
+    echo "UPDATE governance_model_pricing SET is_deprecated = 0 WHERE model = 'gpt-4';" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET is_deprecated = 1 WHERE model = 'claude-3-opus';" >> "$output_file"
+  fi
+
+  if column_exists_sqlite "$config_db" "governance_virtual_keys" "expires_at"; then
+    echo "UPDATE governance_virtual_keys SET expires_at = datetime('now', '+1 day') WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET expires_at = datetime('now', '+2 day') WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+}
+
+# Generate v1.6.3-era OAuth2 coverage rows for SQLite.
+generate_v163_oauth2_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
+
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  # oauth2_clients, oauth2_authorize_requests, and oauth2_refresh_tokens are each guarded
+  # individually rather than assuming presence of one implies presence of the others.
+  local oauth2_clients_exists oauth2_authorize_requests_exists oauth2_refresh_tokens_exists
+  oauth2_clients_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='oauth2_clients';" 2>/dev/null || echo "0")
+  oauth2_authorize_requests_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='oauth2_authorize_requests';" 2>/dev/null || echo "0")
+  oauth2_refresh_tokens_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='oauth2_refresh_tokens';" 2>/dev/null || echo "0")
+
+  if [ "$oauth2_clients_exists" = "1" ]; then
+    echo "" >> "$output_file"
+    echo "-- oauth2_clients" >> "$output_file"
+    echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'oauth2-client-migration-test-001', 'Migration Test OAuth2 Client', '[\"https://bifrost.example.com/oauth/callback\"]', '[\"authorization_code\",\"refresh_token\"]', 'openid profile', $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  fi
+
+  if [ "$oauth2_authorize_requests_exists" = "1" ] && [ "$oauth2_clients_exists" = "1" ]; then
+    echo "" >> "$output_file"
+    echo "-- oauth2_authorize_requests" >> "$output_file"
+    echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authorize-migration-test-001', 'oauth2-client-migration-test-001', 'https://bifrost.example.com/oauth/callback', 'oauth2-state-migration-test-001', 'openid profile', 'https://mcp.example.com', 'migration-test-code-challenge', 'S256', 'pending', 'vk', 'vk-migration-test-1', NULL, datetime('now', '+15 minutes'), $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  fi
+
+  if [ "$oauth2_refresh_tokens_exists" = "1" ] && [ "$oauth2_clients_exists" = "1" ]; then
+    echo "" >> "$output_file"
+    echo "-- oauth2_refresh_tokens" >> "$output_file"
+    echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-refresh-migration-test-001', 'migration-test-refresh-token-hash-001', 'oauth2-authorize-migration-test-001', 'oauth2-client-migration-test-001', 'vk', 'vk-migration-test-1', 'openid profile', 'https://mcp.example.com', NULL, NULL, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  fi
+}
+
 # Append dynamic INSERTs to faker SQL based on current schema
 # Must be called AFTER the database schema is created (e.g., after bifrost starts/stops)
 # Handles columns that may not exist in older schema versions
@@ -752,6 +824,8 @@ append_dynamic_mcp_clients_insert() {
     future="datetime('now', '+1 hour')"
     past="datetime('now', '-1 day')"
     generate_mcp_clients_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_v163_config_store_insert_sqlite "$faker_sql" "$config_db"
+    generate_v163_oauth2_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_async_jobs_insert_sqlite "$now" "$future" "$faker_sql"
     generate_prompt_repo_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_per_user_oauth_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
@@ -1902,6 +1976,65 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET alias_model_family = NULL WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.6.3 columns and tables - config store / OAuth2 / governance
+  # -------------------------------------------------------------------------
+
+  if column_exists_postgres "config_client" "mcp_server_auth_mode"; then
+    echo "UPDATE config_client SET mcp_server_auth_mode = 'headers' WHERE id = 1;" >> "$output_file"
+  fi
+  if column_exists_postgres "config_client" "oauth2_server_config_json"; then
+    echo "UPDATE config_client SET oauth2_server_config_json = '{\"auth_code_ttl\":300,\"access_token_ttl\":600}' WHERE id = 1;" >> "$output_file"
+  fi
+
+  for col in bedrock_mantle_access_key bedrock_mantle_secret_key bedrock_mantle_session_token bedrock_mantle_region bedrock_mantle_role_arn bedrock_mantle_external_id bedrock_mantle_role_session_name; do
+    if column_exists_postgres "config_keys" "$col"; then
+      echo "UPDATE config_keys SET $col = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+  done
+
+  if column_exists_postgres "config_mcp_clients" "tool_execution_timeout"; then
+    echo "UPDATE config_mcp_clients SET tool_execution_timeout = 30 WHERE client_id = 'mcp-migration-test-001';" >> "$output_file"
+  fi
+
+  if column_exists_postgres "governance_model_pricing" "is_deprecated"; then
+    echo "UPDATE governance_model_pricing SET is_deprecated = false WHERE model = 'gpt-4';" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET is_deprecated = true WHERE model = 'claude-3-opus';" >> "$output_file"
+  fi
+
+  if column_exists_postgres "governance_virtual_keys" "expires_at"; then
+    echo "UPDATE governance_virtual_keys SET expires_at = NOW() + INTERVAL '1 day' WHERE id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_keys SET expires_at = NOW() + INTERVAL '2 day' WHERE id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # oauth2_clients, oauth2_authorize_requests, and oauth2_refresh_tokens are each guarded
+  # individually rather than assuming presence of one implies presence of the others.
+  local oauth2_clients_exists=0
+  if column_exists_postgres "oauth2_clients" "id"; then
+    oauth2_clients_exists=1
+    {
+      echo ""
+      echo "-- oauth2_clients"
+      echo "INSERT INTO oauth2_clients (id, client_id, client_name, redirect_uris_json, grant_types_json, scope, created_at) VALUES ('oauth2-client-migration-test-001', 'oauth2-client-migration-test-001', 'Migration Test OAuth2 Client', '[\"https://bifrost.example.com/oauth/callback\"]', '[\"authorization_code\",\"refresh_token\"]', 'openid profile', NOW()) ON CONFLICT DO NOTHING;"
+    } >> "$output_file"
+  fi
+
+  if [ "$oauth2_clients_exists" = "1" ] && column_exists_postgres "oauth2_authorize_requests" "id"; then
+    {
+      echo ""
+      echo "-- oauth2_authorize_requests"
+      echo "INSERT INTO oauth2_authorize_requests (id, client_id, redirect_uri, state, scope, resource, code_challenge, code_challenge_method, status, bf_mode, bf_sub, code_hash, expires_at, created_at, updated_at) VALUES ('oauth2-authorize-migration-test-001', 'oauth2-client-migration-test-001', 'https://bifrost.example.com/oauth/callback', 'oauth2-state-migration-test-001', 'openid profile', 'https://mcp.example.com', 'migration-test-code-challenge', 'S256', 'pending', 'vk', 'vk-migration-test-1', NULL, NOW() + INTERVAL '15 minutes', NOW(), NOW()) ON CONFLICT DO NOTHING;"
+    } >> "$output_file"
+  fi
+
+  if [ "$oauth2_clients_exists" = "1" ] && column_exists_postgres "oauth2_refresh_tokens" "id"; then
+    {
+      echo ""
+      echo "-- oauth2_refresh_tokens"
+      echo "INSERT INTO oauth2_refresh_tokens (id, token_hash, family_id, client_id, bf_mode, bf_sub, scope, resource, revoked_at, last_used_at, created_at) VALUES ('oauth2-refresh-migration-test-001', 'migration-test-refresh-token-hash-001', 'oauth2-authorize-migration-test-001', 'oauth2-client-migration-test-001', 'vk', 'vk-migration-test-1', 'openid profile', 'https://mcp.example.com', NULL, NULL, NOW()) ON CONFLICT DO NOTHING;"
+    } >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -3005,15 +3138,15 @@ extract_faker_columns() {
 
   # Extract INSERT statements and parse table/columns
   # Handles both "INSERT INTO table (cols)" and "INSERT INTO table (cols) SELECT ..."
-  grep -E "^INSERT INTO [a-z_]+ \(" "$faker_sql" | \
-    sed -E 's/INSERT INTO ([a-z_]+) \(([^)]+)\).*/\1:\2/' | \
+  grep -E "^INSERT INTO [a-z0-9_]+ \(" "$faker_sql" | \
+    sed -E 's/INSERT INTO ([a-z0-9_]+) \(([^)]+)\).*/\1:\2/' | \
     tr -d ' ' | sort -u > "$output_file"
 
   # Also extract UPDATE SET columns (for dynamically added columns)
   # Pattern: UPDATE table SET col = value WHERE ...
   # Note: Column names can contain digits (e.g., input_cost_per_token_above_128k_tokens)
-  grep -E "^UPDATE [a-z_]+ SET [a-z0-9_]+" "$faker_sql" | \
-    sed -E 's/UPDATE ([a-z_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
+  grep -E "^UPDATE [a-z0-9_]+ SET [a-z0-9_]+" "$faker_sql" | \
+    sed -E 's/UPDATE ([a-z0-9_]+) SET ([a-z0-9_]+) =.*/\1:\2/' | \
     tr -d ' ' | sort -u >> "$output_file"
 }
 
@@ -3068,6 +3201,11 @@ generate_mcp_clients_insert_postgres() {
   if column_exists_postgres "config_mcp_clients" "oauth_config_id"; then
     cols="$cols, oauth_config_id"
     vals="$vals, 'oauth-config-migration-test-001'"
+  fi
+
+  if column_exists_postgres "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    vals="$vals, 30"
   fi
 
   # config_mcp_clients.encryption_status (added in v1.4.8)
@@ -3334,6 +3472,11 @@ generate_mcp_clients_insert_sqlite() {
   if column_exists_sqlite "$config_db" "config_mcp_clients" "oauth_config_id"; then
     cols="$cols, oauth_config_id"
     vals="$vals, 'oauth-config-migration-test-001'"
+  fi
+
+  if column_exists_sqlite "$config_db" "config_mcp_clients" "tool_execution_timeout"; then
+    cols="$cols, tool_execution_timeout"
+    vals="$vals, 30"
   fi
 
   # config_mcp_clients.encryption_status (added in v1.4.8)
@@ -4582,6 +4725,39 @@ compare_postgres_snapshots() {
         print out
       }
     ' | sort > "$after_comparable"
+
+    # governance_rate_limits: ratelimit-migration-test-1 has a 1-minute reset window, so
+    # PerformStartupResets may legitimately zero its usage counters and advance its
+    # last_reset timestamps on startup. Blank out only those four fields for that one row
+    # (on both sides) instead of skipping the whole row, so immutable fields like
+    # token_max_limit / token_reset_duration are still verified for it. ratelimit-migration-test-2
+    # (1-day window, never expected to reset) is compared unchanged, including its usage/reset
+    # columns.
+    if [ "$table" = "governance_rate_limits" ]; then
+      local reset_field_idx=""
+      local reset_field_pos=1
+      for compare_col in $compare_cols; do
+        case "$compare_col" in
+          token_current_usage|token_last_reset|request_current_usage|request_last_reset)
+            reset_field_idx="${reset_field_idx:+$reset_field_idx }$reset_field_pos"
+            ;;
+        esac
+        reset_field_pos=$((reset_field_pos + 1))
+      done
+      if [ -n "$reset_field_idx" ]; then
+        for comparable_file in "$before_comparable" "$after_comparable"; do
+          awk -F'|' -v OFS='|' -v idxs="$reset_field_idx" '
+            BEGIN { n = split(idxs, arr, " ") }
+            {
+              if ($1 == "ratelimit-migration-test-1") {
+                for (i = 1; i <= n; i++) $arr[i] = "<reset-managed>"
+              }
+              print
+            }
+          ' "$comparable_file" > "${comparable_file}.tmp" && mv "${comparable_file}.tmp" "$comparable_file"
+        done
+      fi
+    fi
 
     # For grow-allowed tables, restrict the value comparison to the seeded test rows. The
     # migration-added rows carry random UUID ids and are not part of the data contract, so


### PR DESCRIPTION
## Summary

Extends the migration test suite to cover v1.6.3-era schema additions, ensuring that new columns and tables introduced in v1.6.3 are exercised during upgrade path validation for both SQLite and PostgreSQL backends.

## Changes

- Added `generate_v163_config_store_insert_sqlite` to populate v1.6.3 config-store columns (`mcp_server_auth_mode`, `oauth2_server_config_json`, Bedrock Mantle credential columns, `is_deprecated` on `governance_model_pricing`, and `expires_at` on `governance_virtual_keys`) when they exist in the SQLite schema.
- Added `generate_v163_oauth2_insert_sqlite` to insert test rows into `oauth2_clients`, `oauth2_authorize_requests`, and `oauth2_refresh_tokens` for SQLite when those tables are present, with each table guarded independently rather than assuming presence of one implies the others.
- Added equivalent v1.6.3 coverage blocks to `append_dynamic_columns_postgres` for the same config-store columns and OAuth2 tables on PostgreSQL.
- Added `tool_execution_timeout` column handling to `generate_mcp_clients_insert_postgres` and `generate_mcp_clients_insert_sqlite` so the new MCP client column is included in INSERT statements when present.
- Fixed `extract_faker_columns` regex patterns to allow digits in table names (`[a-z0-9_]+`), enabling correct extraction of INSERT/UPDATE statements targeting tables like `oauth2_clients`.
- Added selective field masking for `governance_rate_limits` in the PostgreSQL snapshot comparison: `token_current_usage`, `token_last_reset`, `request_current_usage`, and `request_last_reset` are blanked out only for `ratelimit-migration-test-1` (1-minute reset window) since `PerformStartupResets` may legitimately mutate those counters on startup, while `ratelimit-migration-test-2` (1-day window) is still compared in full.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The migration test workflow exercises these paths automatically. To validate locally, trigger the migration test script against a v1.6.3 database snapshot and confirm that:

1. The faker SQL file contains INSERT/UPDATE statements for `oauth2_clients`, `oauth2_authorize_requests`, `oauth2_refresh_tokens`, `governance_model_pricing`, and `governance_virtual_keys`.
2. The PostgreSQL snapshot comparison does not flag `governance_rate_limits` usage counters as unexpected diffs for `ratelimit-migration-test-1`.
3. The `config_mcp_clients` INSERT includes `tool_execution_timeout = 30` when the column exists.

```sh
bash .github/workflows/scripts/run-migration-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets, auth flows, or PII handling introduced. OAuth2 test data uses placeholder values scoped entirely to the migration test environment.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable