### PR TITLE
feat: show server fallback model in logs

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -279,6 +279,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"async_jobs_add_request_id_column"}, run: migrationAddAsyncJobRequestIDColumn},
 	{IDs: []string{"webhook_deliveries_add_request_id_column"}, run: migrationAddWebhookDeliveryRequestIDColumn},
 	{IDs: []string{"logs_add_content_hidden_column"}, run: migrationAddContentHiddenColumn},
+	{IDs: []string{"logs_add_server_side_fallback_model_column"}, run: migrationAddServerSideFallbackModelColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -3763,6 +3764,32 @@ func migrationRecreateFilterCustomersMatView(ctx context.Context, db *gorm.DB, l
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while recreating filter customers matview: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddServerSideFallbackModelColumn adds the server_side_fallback_model
+// column to the logs table. Records the model that actually produced the response
+// when the provider swapped models inside a single call (Anthropic server-side
+// fallback) — which routing never sees, so the log's model column still names what
+// the caller asked for.
+func migrationAddServerSideFallbackModelColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_server_side_fallback_model_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &Log{}, "server_side_fallback_model")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return dropColumnIfExists(tx.WithContext(ctx), logger, &Log{}, "server_side_fallback_model")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding server side fallback model column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -929,7 +929,7 @@ func normalizeAggregateTimestamp(value any) string {
 func (s *RDBLogStore) listSelectColumns() string {
 	baseCols := strings.Join([]string{
 		"id", "parent_request_id", "timestamp", "object_type", "provider", "model", "alias",
-		"canonical_model_name", "alias_model_family",
+		"canonical_model_name", "alias_model_family", "server_side_fallback_model",
 		"number_of_retries", "fallback_index",
 		"selected_key_id", "selected_key_name",
 		"virtual_key_id", "virtual_key_name",

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -137,6 +137,7 @@ type Log struct {
 	Alias                   *string   `gorm:"type:varchar(255);index" json:"alias,omitempty"`          // Set when model was resolved via alias mapping; the original name the caller used
 	CanonicalModelName      *string   `gorm:"type:varchar(255)" json:"canonical_model_name,omitempty"` // Canonical model name configured on the resolved alias, when set
 	AliasModelFamily        *string   `gorm:"type:varchar(255)" json:"alias_model_family,omitempty"`   // Model family configured on the resolved alias, when set
+	ServerSideFallbackModel *string   `gorm:"type:varchar(255)" json:"server_side_fallback_model,omitempty"`
 	NumberOfRetries         int       `gorm:"default:0" json:"number_of_retries"`
 	FallbackIndex           int       `gorm:"default:0" json:"fallback_index"`
 	SelectedKeyID           string    `gorm:"type:varchar(255);index:idx_logs_selected_key_id" json:"selected_key_id"`

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1055,11 +1055,24 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if result != nil {
 		ef := result.GetExtraFields()
 		latency = ef.Latency
+		// Model that actually served the turn when the provider swapped models inside
+		// one call. entry.Model still names what the caller asked for.
+		if ef.RoutingInfo.ServerSideFallbackModel != nil {
+			served := *ef.RoutingInfo.ServerSideFallbackModel
+			entry.ServerSideFallbackModel = &served
+		}
 		if ef.CacheDebug != nil && ef.CacheDebug.CacheHit && ef.CacheDebug.CacheHitLatency != nil {
 			latency = *ef.CacheDebug.CacheHitLatency
 		}
 	} else if bifrostErr != nil {
 		latency = bifrostErr.ExtraFields.Latency
+	}
+
+	if entry.ServerSideFallbackModel == nil && bifrostErr != nil && bifrostErr.ExtraFields.BilledUsage != nil {
+		if served := bifrostErr.ExtraFields.BilledUsage.ServerSideFallbackModel; served != nil {
+			m := *served
+			entry.ServerSideFallbackModel = &m
+		}
 	}
 	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, attemptTrail)
 	applyResolvedAliasInfo(entry, resolvedKeyAlias)

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1005,6 +1005,9 @@ export function LogDetailView({
 							{!isContainer && log.alias_model_family && (
 								<LogEntryDetailsView className="w-full" label="Model Family" value={log.alias_model_family} />
 							)}
+							{!isContainer && log.server_side_fallback_model && (
+								<LogEntryDetailsView className="w-full" label="Served By (fallback)" value={log.server_side_fallback_model} />
+							)}
 							<LogEntryDetailsView
 								className="w-full"
 								label="Type"

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -507,6 +507,10 @@ export interface LogEntry {
 	alias?: string; // Set when model was resolved via alias mapping; the original name the caller used
 	canonical_model_name?: string; // Canonical model name configured on the resolved alias, when set
 	alias_model_family?: string; // Model family configured on the resolved alias, when set
+	// Model that actually produced the response when the provider swapped models inside a
+	// single call (Anthropic server-side fallback). Distinct from fallback_index, which
+	// counts Bifrost's own cross-provider failover attempts.
+	server_side_fallback_model?: string;
 	number_of_retries: number;
 	fallback_index: number;
 	attempt_trail?: KeyAttemptRecord[]; // Per-attempt key selection history


### PR DESCRIPTION
## Summary

Adds a `server_side_fallback_model` field to log entries to capture the model that actually produced a response when a provider (e.g. Anthropic) silently swaps models within a single call. This is distinct from Bifrost's own cross-provider failover (`fallback_index`), since the routing layer never observes the swap — the log's `model` column continues to reflect what the caller originally requested.

## Changes

- Added `server_side_fallback_model` column to the `logs` table via a new migration (`logs_add_server_side_fallback_model_column`), with rollback support.
- Added `ServerSideFallbackModel` field to the `Log` struct and included it in the list-select column set so it is returned in log queries.
- In the logging plugin's `PostLLMHook`, the field is populated from `RoutingInfo.ServerSideFallbackModel` when present on the result.
- In the error/cancel/timeout billing path (`applyErrorBillingFromBilledUsage`), the field is also propagated from accumulated usage since those paths never reach `RoutingInfo`.
- Added `server_side_fallback_model` to the `LogEntry` TypeScript type.
- Surfaced the value in the log detail view UI as **"Served By (fallback)"**, shown only for non-container entries when the field is set.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Trigger a request against an Anthropic model that is known to invoke a server-side fallback. Confirm that:

1. The resulting log row has `server_side_fallback_model` populated with the model that actually served the response, while `model` still reflects the originally requested model.
2. The log detail view in the UI displays the **"Served By (fallback)"** row for that entry.
3. For requests that are cancelled or time out mid-flight, verify the field is still populated when the accumulated usage carries a `ServerSideFallbackModel` value.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Add a before/after screenshot of the log detail sheet showing the new **"Served By (fallback)"** row when applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

No new secrets, auth surfaces, or PII handling introduced. The field records a model name string returned by the provider.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable