### PR TITLE
core gate changes for streaming replay client delivery

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -1146,6 +1146,7 @@ bifrost:
         apply_to: "input"
         sampling_rate: 100
         timeout: 1000
+        stream_replay_event_interval_ms: 25
         provider_config_ids:
           - 1
     providers:
@@ -1167,6 +1168,7 @@ assert_field_value 'guardrails rule[0].enabled' '.guardrails_config.guardrail_ru
 assert_field_value 'guardrails rule[0].apply_to' '.guardrails_config.guardrail_rules.[0].apply_to' '"input"'
 assert_field_value 'guardrails rule[0].sampling_rate' '.guardrails_config.guardrail_rules.[0].sampling_rate' '100'
 assert_field_value 'guardrails rule[0].timeout' '.guardrails_config.guardrail_rules.[0].timeout' '1000'
+assert_field_value 'guardrails rule[0].stream_replay_event_interval_ms' '.guardrails_config.guardrail_rules.[0].stream_replay_event_interval_ms' '25'
 assert_field 'guardrails rule[0].provider_config_ids' '.guardrails_config.guardrail_rules.[0].provider_config_ids'
 
 assert_field 'guardrails_config.guardrail_providers' '.guardrails_config.guardrail_providers'

--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -572,6 +572,8 @@ Any field marked **env.\* supported** accepts a bare `"env.VAR_NAME"` string in 
 
 Rules are CEL expressions that fire when their condition matches. Available CEL variables:
 
+For block-capable streaming output rules, `stream_replay_event_interval_ms` sets the delay between consecutive buffered events after the response is allowed. It defaults to `0`, which sends all buffered events immediately; the dashboard initializes it to `25` when pacing is enabled. When multiple matched block-capable rules specify different positive values, Bifrost uses the largest interval.
+
 | Variable | Type | Description |
 |----------|------|-------------|
 | `model` | `string` | Model name from the request |
@@ -605,6 +607,7 @@ Rules are CEL expressions that fire when their condition matches. Available CEL 
         "apply_to": "output",
         "sampling_rate": 100,
         "timeout": 15,
+        "stream_replay_event_interval_ms": 25,
         "provider_config_ids": [3]
       },
       {

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -510,6 +510,7 @@ Rule fields:
 | `apply_to` | Yes | `"input"`, `"output"`, or `"both"` |
 | `sampling_rate` | No | `0`–`100`; percentage of requests to check (default: 100) |
 | `timeout` | No | Rule timeout in seconds |
+| `stream_replay_event_interval_ms` | No | Delay between buffered events after block-capable output guardrails allow a streaming response. Defaults to `0` (immediate delivery); the dashboard uses `25` when pacing is enabled. |
 | `provider_config_ids` | No | Provider `id`s to invoke when this rule matches |
 
 ```yaml
@@ -534,6 +535,7 @@ bifrost:
         apply_to: "output"
         sampling_rate: 100
         timeout: 15
+        stream_replay_event_interval_ms: 25
         provider_config_ids: [3]
 
       - id: 103

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -159,11 +159,15 @@ flowchart TB
 
 ## Streaming Output Guardrails
 
-When an output guardrail is used with a streaming response, Bifrost accumulates the response until the model is done generating it, then checks the full response. If the response passes, Bifrost sends it to the client. If a guardrail blocks or changes the response, Bifrost applies that result instead.
+Streaming delivery depends on what the matched output guardrails can do:
 
-This adds time before the client receives output: Bifrost waits for response generation and guardrail evaluation to finish. The added wait depends on the model's generation time and the configured guardrail profiles.
+- Detect-only and logs-only rules observe the stream without delaying client delivery.
+- Runtime redaction checks buffered text segments and releases the resulting safe text as the response is generated.
+- If any matched rule can block, Bifrost holds the complete stream until generation and guardrail evaluation finish. If `stream_replay_event_interval_ms` is positive, an allowed stream is replayed with that delay between buffered events; otherwise, it is delivered immediately. A blocked stream returns the guardrail intervention instead.
 
-Input guardrails check the request before Bifrost sends it to the LLM provider.
+Replay pacing is disabled by default. The dashboard initializes the event interval to `25` milliseconds when pacing is enabled, while `0` sends all buffered events immediately. If multiple matched block-capable rules configure different intervals, Bifrost uses the largest value. This behavior applies to streaming Chat Completions, Text Completions, and Responses API requests.
+
+Input guardrails still check the request before Bifrost sends it to the LLM provider.
 
 <Note>
   Gray Swan is a tool-call-specific exception. Text-only streams are delivered directly to the client and are not sent to Cygnal. See [Gray Swan Cygnal](/integrations/guardrails/grayswan#streaming-output-and-tool-calls) for the full behavior.
@@ -353,26 +357,28 @@ curl -X DELETE http://localhost:8080/api/guardrails/rules/1
 <Tab title="Helm">
 
 ```yaml
-guardrails_config:
-  guardrail_rules:
-    - id: 1
-      name: "Block PII in Prompts"
-      description: "Prevent PII from being sent to LLM providers"
-      enabled: true
-      cel_expression: "request.messages.exists(m, m.role == 'user')"
-      apply_to: "input"
-      sampling_rate: 100
-      timeout: 5000
-      provider_config_ids: [1, 2]
-    - id: 2
-      name: "Content Filter for Responses"
-      description: "Filter harmful content from LLM responses"
-      enabled: true
-      cel_expression: "true"
-      apply_to: "output"
-      sampling_rate: 100
-      timeout: 3000
-      provider_config_ids: [2]
+bifrost:
+  guardrails:
+    rules:
+      - id: 1
+        name: "Block PII in Prompts"
+        description: "Prevent PII from being sent to LLM providers"
+        enabled: true
+        cel_expression: "request.messages.exists(m, m.role == 'user')"
+        apply_to: "input"
+        sampling_rate: 100
+        timeout: 5000
+        provider_config_ids: [1, 2]
+      - id: 2
+        name: "Content Filter for Responses"
+        description: "Filter harmful content from LLM responses"
+        enabled: true
+        cel_expression: "true"
+        apply_to: "output"
+        sampling_rate: 100
+        timeout: 3000
+        stream_replay_event_interval_ms: 25
+        provider_config_ids: [2]
 ```
 
 </Tab>
@@ -664,96 +670,97 @@ curl -X DELETE http://localhost:8080/api/guardrails/bedrock \
 <Tab title="Helm">
 
 ```yaml
-guardrails_config:
-  guardrail_providers:
-    - id: 1
-      provider_name: "secrets"
-      policy_name: "Block Leaked Credentials"
-      enabled: true
-      config:
-        ignored_secret_keywords:
-          - "example"
-          - "dummy"
-    - id: 2
-      provider_name: "regex"
-      policy_name: "PII Detection"
-      enabled: true
-      config:
-        patterns:
-          - pattern: "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b"
-            description: "Email address"
-            flags: "i"
-          - pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
-            description: "US Social Security Number"
-    - id: 3
-      provider_name: "bedrock"
-      policy_name: "PII Detection Profile"
-      enabled: true
-      config:
-        guardrail_arn: "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123"
-        guardrail_version: "1"
-        region: "us-east-1"
-        # AWS Authentication (choose one method):
-        # Option 1: Explicit credentials
-        access_key: "env.AWS_ACCESS_KEY_ID"
-        secret_key: "env.AWS_SECRET_ACCESS_KEY"
-        # Option 2: IAM Role - omit access_key and secret_key
-        # (Bifrost will use IAM credentials from the environment)
-    - id: 4
-      provider_name: "azure"
-      policy_name: "Content Safety Profile"
-      enabled: true
-      config:
-        endpoint: "https://your-resource.cognitiveservices.azure.com/"
-        api_key: "env.AZURE_CONTENT_SAFETY_API_KEY"
-        analyze_enabled: true
-        analyze_severity_threshold: "medium"
-        jailbreak_shield_enabled: true
-    - id: 5
-      provider_name: "model-armor"
-      policy_name: "Google Model Armor Production"
-      enabled: true
-      timeout: 30
-      config:
-        auth_type: "default_credential"
-        project_id: "env.GCP_PROJECT_ID"
-        location: "env.GCP_LOCATION"
-        template_id: "env.GMA_TEMPLATE_ID"
-    - id: 6
-      provider_name: "crowdstrike-aidr"
-      policy_name: "CrowdStrike AIDR Production"
-      enabled: true
-      timeout: 30
-      config:
-        api_key: "env.CS_AIDR_TOKEN"
-        base_url: "env.CS_AIDR_BASE_URL"
-        app_id: "bifrost-production"
-        collector_instance_id: "prod-us-east-1"
-    - id: 7
-      provider_name: "grayswan"
-      policy_name: "Custom Safety Rules"
-      enabled: true
-      config:
-        api_key: "env.GRAYSWAN_API_KEY"
-        violation_threshold: 0.5
-        reasoning_mode: "hybrid"
-        rules:
-          no_pii: "Do not allow personally identifiable information"
-          professional_tone: "Ensure responses maintain a professional tone"
-    - id: 8
-      provider_name: "patronus-ai"
-      policy_name: "Patronus Quality Checks"
-      enabled: true
-      config:
-        api_key: "env.PATRONUS_API_KEY"
-        base_url: "https://api.patronus.ai"
-        evaluators:
-          - evaluator: "pii"
-            explain_strategy: "on-fail"
-          - evaluator: "judge"
-            criteria: "patronus:is-concise"
-            explain_strategy: "on-fail"
-        capture: "none"
+bifrost:
+  guardrails:
+    providers:
+      - id: 1
+        provider_name: "secrets"
+        policy_name: "Block Leaked Credentials"
+        enabled: true
+        config:
+          ignored_secret_keywords:
+            - "example"
+            - "dummy"
+      - id: 2
+        provider_name: "regex"
+        policy_name: "PII Detection"
+        enabled: true
+        config:
+          patterns:
+            - pattern: "\\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\b"
+              description: "Email address"
+              flags: "i"
+            - pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+              description: "US Social Security Number"
+      - id: 3
+        provider_name: "bedrock"
+        policy_name: "PII Detection Profile"
+        enabled: true
+        config:
+          guardrail_arn: "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123"
+          guardrail_version: "1"
+          region: "us-east-1"
+          # AWS Authentication (choose one method):
+          # Option 1: Explicit credentials
+          access_key: "env.AWS_ACCESS_KEY_ID"
+          secret_key: "env.AWS_SECRET_ACCESS_KEY"
+          # Option 2: IAM Role - omit access_key and secret_key
+          # (Bifrost will use IAM credentials from the environment)
+      - id: 4
+        provider_name: "azure"
+        policy_name: "Content Safety Profile"
+        enabled: true
+        config:
+          endpoint: "https://your-resource.cognitiveservices.azure.com/"
+          api_key: "env.AZURE_CONTENT_SAFETY_API_KEY"
+          analyze_enabled: true
+          analyze_severity_threshold: "medium"
+          jailbreak_shield_enabled: true
+      - id: 5
+        provider_name: "model-armor"
+        policy_name: "Google Model Armor Production"
+        enabled: true
+        timeout: 30
+        config:
+          auth_type: "default_credential"
+          project_id: "env.GCP_PROJECT_ID"
+          location: "env.GCP_LOCATION"
+          template_id: "env.GMA_TEMPLATE_ID"
+      - id: 6
+        provider_name: "crowdstrike-aidr"
+        policy_name: "CrowdStrike AIDR Production"
+        enabled: true
+        timeout: 30
+        config:
+          api_key: "env.CS_AIDR_TOKEN"
+          base_url: "env.CS_AIDR_BASE_URL"
+          app_id: "bifrost-production"
+          collector_instance_id: "prod-us-east-1"
+      - id: 7
+        provider_name: "grayswan"
+        policy_name: "Custom Safety Rules"
+        enabled: true
+        config:
+          api_key: "env.GRAYSWAN_API_KEY"
+          violation_threshold: 0.5
+          reasoning_mode: "hybrid"
+          rules:
+            no_pii: "Do not allow personally identifiable information"
+            professional_tone: "Ensure responses maintain a professional tone"
+      - id: 8
+        provider_name: "patronus-ai"
+        policy_name: "Patronus Quality Checks"
+        enabled: true
+        config:
+          api_key: "env.PATRONUS_API_KEY"
+          base_url: "https://api.patronus.ai"
+          evaluators:
+            - evaluator: "pii"
+              explain_strategy: "on-fail"
+            - evaluator: "judge"
+              criteria: "patronus:is-concise"
+              explain_strategy: "on-fail"
+          capture: "none"
 ```
 
 </Tab>

--- a/docs/enterprise/guardrails/custom-regex.mdx
+++ b/docs/enterprise/guardrails/custom-regex.mdx
@@ -25,7 +25,7 @@ Custom Regex runs in-process and uses Go's RE2-compatible regexp engine. It does
 Custom Regex currently evaluates text content. It does not inspect image pixels or binary file contents.
 
 <Note>
-  **Streaming output:** When this profile is used in an `output` or `both` rule, Bifrost accumulates the stream until the model response is complete, then checks the full response. It does not check individual stream chunks. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
+  **Streaming output:** Delivery depends on whether the matched patterns detect, redact, or can block. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
 </Note>
 
 ## Pattern Fields

--- a/docs/enterprise/guardrails/redaction.mdx
+++ b/docs/enterprise/guardrails/redaction.mdx
@@ -70,6 +70,8 @@ Redaction mode decides where Bifrost applies the rewrite.
 | Logs only | `logs_only` | Left raw | Redacted with reversible placeholders | Placeholderized content | Yes, for Bifrost logs only |
 | Runtime + reversible logs | `runtime_reversible` | Redacted with reversible placeholders | Redacted with reversible placeholders | Placeholderized content | Yes, for Bifrost logs only |
 
+For streaming output, runtime redaction checks buffered text segments before releasing their redacted content. Logs-only redaction does not delay client delivery. If the same matched rule set can also block, Bifrost holds the complete stream until the final guardrail decision; see [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails).
+
 ### Runtime (`runtime`)
 
 Use `runtime` when sensitive text should not reach the model provider or the caller. Bifrost rewrites detected text in the live request or response and stores the already-redacted value in Bifrost logs.

--- a/docs/enterprise/guardrails/secrets-detection.mdx
+++ b/docs/enterprise/guardrails/secrets-detection.mdx
@@ -52,7 +52,7 @@ For the full behavior matrix, including reveal permissions and connector export 
 | `redaction_mode` | No | `runtime` | `runtime`, `logs_only`, or `runtime_reversible`. Used when `action` is `redact`. |
 
 <Note>
-  **Streaming output:** When this profile is used in an `output` or `both` rule, Bifrost accumulates the stream until the model response is complete, then checks the full response. It does not check individual stream chunks. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
+  **Streaming output:** Delivery depends on whether the profile detects, redacts, or can block. See [Streaming Output Guardrails](/enterprise/guardrails#streaming-output-guardrails) for details.
 </Note>
 
 ## Supported Secret Types

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -430,6 +430,8 @@ func (a *Accumulator) cleanupStreamAccumulator(requestID string, forceEndGate bo
 		// sendOrCancel(errChunk) path on an abandoned consumer channel.
 		acc.gatePendingTerminal = false
 		acc.gateEndError = nil
+		// Orphan cleanup drops the replay buffer, so discard its interval too.
+		acc.gateReplayEventInterval = 0
 		if acc.gateCond != nil {
 			acc.gateCond.Broadcast()
 		}

--- a/framework/streaming/gate.go
+++ b/framework/streaming/gate.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -41,6 +42,18 @@ func (a *Accumulator) ResumeStream(traceID string) {
 	}
 	sa := a.getOrCreateStreamAccumulator(traceID)
 	sa.Resume()
+}
+
+// ResumeStreamWithReplayInterval arms a paced resume that starts after the next chunk joins the paused buffer.
+func (a *Accumulator) ResumeStreamWithReplayInterval(traceID string, eventInterval time.Duration) bool {
+	if traceID == "" || eventInterval <= 0 {
+		return false
+	}
+	v, ok := a.streamAccumulators.Load(traceID)
+	if !ok {
+		return false
+	}
+	return v.(*StreamAccumulator).ResumeWithReplayInterval(eventInterval)
 }
 
 // ClearPausedStreamBuffer drops chunks buffered while a stream is paused.
@@ -216,6 +229,8 @@ func (sa *StreamAccumulator) Pause() {
 	if sa.gateState != StreamStateActive {
 		return
 	}
+	// A new pause must not inherit pacing from an earlier replay.
+	sa.gateReplayEventInterval = 0
 	sa.gateState = StreamStatePaused
 	sa.gatePausedAt = sa.gateSeq
 }
@@ -228,10 +243,60 @@ func (sa *StreamAccumulator) Resume() {
 	if sa.gateState != StreamStatePaused {
 		return
 	}
+	// Plain resume drains immediately, so discard any armed replay interval.
+	sa.gateReplayEventInterval = 0
 	sa.gateState = StreamStateActive
 	if sa.gateCond != nil {
 		sa.gateCond.Broadcast()
 	}
+}
+
+// ResumeWithReplayInterval records a paced-resume request without waking the flusher;
+// the next GateSend activates it after buffering the in-flight chunk.
+func (sa *StreamAccumulator) ResumeWithReplayInterval(eventInterval time.Duration) bool {
+	sa.mu.Lock()
+	defer sa.mu.Unlock()
+	if sa.gateState != StreamStatePaused || eventInterval <= 0 {
+		return false
+	}
+	sa.gateReplayEventInterval = eventInterval
+	return true
+}
+
+// waitForReplayIntervalLocked waits between consecutive buffered event deliveries.
+// It unlocks while waiting so other stream lifecycle operations can proceed,
+// then restores the lock before reporting whether replay should continue.
+func (sa *StreamAccumulator) waitForReplayIntervalLocked() bool {
+	// Snapshot the value while locked so this wait uses one stable interval.
+	interval := sa.gateReplayEventInterval
+	if interval <= 0 {
+		return true
+	}
+	ctx := sa.gateFlusherCtx
+	timer := time.NewTimer(interval)
+	// Do not hold the stream state lock during the configured delay.
+	sa.mu.Unlock()
+	canceled := false
+	if ctx == nil {
+		<-timer.C
+	} else {
+		// Continue when the delay elapses, or stop early if the request is canceled.
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			canceled = true
+		}
+	}
+	// Stop and drain the timer before restoring the caller's locking invariant.
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	// Callers enter and leave this helper with sa.mu held.
+	sa.mu.Lock()
+	return !canceled
 }
 
 // ClearPausedBuffer removes replay chunks captured while the gate is paused.
@@ -245,6 +310,8 @@ func (sa *StreamAccumulator) ClearPausedBuffer() error {
 	}
 	sa.gateReplayBuf = nil
 	sa.gateReplayBufBytes = 0
+	// Dropping the buffer also discards the pacing armed for that buffer.
+	sa.gateReplayEventInterval = 0
 	// A terminal chunk buffered while paused no longer exists; keeping the
 	// pending-terminal marker would make the flusher end the gate on resume
 	// and silently drop the caller's replacement terminal chunk.
@@ -270,6 +337,10 @@ func (sa *StreamAccumulator) End(err *schemas.BifrostError) {
 	defer sa.mu.Unlock()
 	if sa.gateState == StreamStateEnded {
 		return
+	}
+	if sa.gateState == StreamStatePaused {
+		// Ending before paced replay starts falls back to an immediate terminal drain.
+		sa.gateReplayEventInterval = 0
 	}
 	sa.gateState = StreamStateEnded
 	if err != nil {
@@ -324,6 +395,8 @@ func (sa *StreamAccumulator) GateSend(chunk *schemas.BifrostStreamChunk, isFinal
 			// consumer is notified and memory is released. Drops this chunk
 			// and any further chunks for this stream.
 			sa.gateState = StreamStateEnded
+			// Replay cannot continue after overflow forces the gate to end.
+			sa.gateReplayEventInterval = 0
 			sa.gateEndError = &schemas.BifrostError{
 				IsBifrostError: true,
 				Error: &schemas.ErrorField{
@@ -351,6 +424,12 @@ func (sa *StreamAccumulator) GateSend(chunk *schemas.BifrostStreamChunk, isFinal
 			sa.gateFlusherOn = true
 			sa.gateFlusherDone = make(chan struct{})
 			go sa.gateFlusher()
+		}
+		if sa.gateReplayEventInterval > 0 {
+			sa.gateState = StreamStateActive
+			if sa.gateCond != nil {
+				sa.gateCond.Broadcast()
+			}
 		}
 		sa.mu.Unlock()
 		return true
@@ -409,10 +488,15 @@ func (sa *StreamAccumulator) drainBufferLocked() {
 		sa.mu.Unlock()
 		ok := sendOrCancel(ctx, ch, chunk)
 		sa.mu.Lock()
+		if ok && len(sa.gateReplayBuf) > 0 {
+			ok = sa.waitForReplayIntervalLocked()
+		}
 		if !ok {
-			// ctx done; abandon remaining buffer and end the gate.
+			// Delivery or pacing was canceled; abandon the remaining buffer.
 			sa.gateReplayBuf = nil
 			sa.gateReplayBufBytes = 0
+			// Canceled replay is terminal, so its interval is no longer applicable.
+			sa.gateReplayEventInterval = 0
 			sa.gateState = StreamStateEnded
 			return
 		}
@@ -420,6 +504,8 @@ func (sa *StreamAccumulator) drainBufferLocked() {
 	if len(sa.gateReplayBuf) == 0 {
 		sa.gateReplayBuf = nil // release backing array
 		sa.gateReplayBufBytes = 0
+		// Pacing belongs to this buffer and must not survive a completed replay.
+		sa.gateReplayEventInterval = 0
 	}
 }
 

--- a/framework/streaming/gate_test.go
+++ b/framework/streaming/gate_test.go
@@ -217,6 +217,118 @@ func TestGate_FinalChunkWhilePaused(t *testing.T) {
 	}
 }
 
+// TestGate_ResumeWithReplayIntervalIncludesNextChunk verifies paced resume stays
+// paused until the in-flight final chunk joins the canonical gate buffer.
+func TestGate_ResumeWithReplayIntervalIncludesNextChunk(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-paced-resume"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	r := newRecorder(8)
+	defer r.close()
+	chunks := makeChunks(3)
+
+	a.PauseStream(traceID)
+	for i := 0; i < 2; i++ {
+		if !a.GateSend(traceID, chunks[i], false, false, r.ch, ctx) {
+			t.Fatalf("buffer chunk %d: GateSend returned false", i)
+		}
+	}
+	if !a.ResumeStreamWithReplayInterval(traceID, 50*time.Millisecond) {
+		t.Fatal("ResumeStreamWithReplayInterval returned false, want paced resume armed")
+	}
+
+	sa := mustGet(t, a, traceID)
+	sa.mu.Lock()
+	stateBeforeFinal := sa.gateState
+	bufferedBeforeFinal := len(sa.gateReplayBuf)
+	pendingIntervalBeforeFinal := sa.gateReplayEventInterval
+	sa.mu.Unlock()
+	if stateBeforeFinal != StreamStatePaused || bufferedBeforeFinal != 2 || pendingIntervalBeforeFinal != 50*time.Millisecond {
+		t.Fatalf("before final: state=%v buffered=%d interval=%v, want Paused/2/50ms", stateBeforeFinal, bufferedBeforeFinal, pendingIntervalBeforeFinal)
+	}
+	if delivered, _ := r.snapshot(); len(delivered) != 0 {
+		t.Fatalf("delivered %d chunks before the in-flight final event reached GateSend", len(delivered))
+	}
+
+	start := time.Now()
+	if !a.GateSend(traceID, chunks[2], true, false, r.ch, ctx) {
+		t.Fatal("final chunk: GateSend returned false")
+	}
+	sa.WaitForFlusher()
+	if !r.waitFor(3, time.Second) {
+		t.Fatal("expected all paced chunks to be delivered")
+	}
+
+	delivered, stamps := r.snapshot()
+	if len(delivered) != len(chunks) {
+		t.Fatalf("delivered %d chunks, want %d", len(delivered), len(chunks))
+	}
+	for i := range chunks {
+		if delivered[i] != chunks[i] {
+			t.Fatalf("position %d: pointer mismatch", i)
+		}
+	}
+	if firstDelay := stamps[0].Sub(start); firstDelay > 100*time.Millisecond {
+		t.Fatalf("first paced chunk delay = %v, want immediate release", firstDelay)
+	}
+	for i := 1; i < len(stamps); i++ {
+		if gap := stamps[i].Sub(stamps[i-1]); gap < 40*time.Millisecond || gap > 500*time.Millisecond {
+			t.Fatalf("event gap %d = %v, want approximately 50ms", i, gap)
+		}
+	}
+	sa.mu.Lock()
+	stateAfterReplay := sa.gateState
+	replayIntervalAfterReplay := sa.gateReplayEventInterval
+	sa.mu.Unlock()
+	if stateAfterReplay != StreamStateEnded || replayIntervalAfterReplay != 0 {
+		t.Fatalf("after replay: state=%v interval=%v, want Ended/0", stateAfterReplay, replayIntervalAfterReplay)
+	}
+}
+
+// TestGate_ResumeWithReplayIntervalCancellationStopsWaiting verifies a disconnected
+// consumer promptly interrupts a pending replay interval and releases buffered memory.
+func TestGate_ResumeWithReplayIntervalCancellationStopsWaiting(t *testing.T) {
+	a := newTestAccumulator(t)
+	traceID := "trace-paced-cancel"
+	parent, cancel := context.WithCancel(context.Background())
+	ctx := schemas.NewBifrostContext(parent, time.Time{})
+	r := newRecorder(128)
+	defer r.close()
+	chunks := makeChunks(100)
+
+	a.PauseStream(traceID)
+	for i := 0; i < len(chunks)-1; i++ {
+		if !a.GateSend(traceID, chunks[i], false, false, r.ch, ctx) {
+			t.Fatalf("buffer chunk %d: GateSend returned false", i)
+		}
+	}
+	if !a.ResumeStreamWithReplayInterval(traceID, time.Second) {
+		t.Fatal("ResumeStreamWithReplayInterval returned false, want paced resume armed")
+	}
+	if !a.GateSend(traceID, chunks[len(chunks)-1], true, false, r.ch, ctx) {
+		t.Fatal("final chunk: GateSend returned false")
+	}
+	if !r.waitFor(1, time.Second) {
+		t.Fatal("first replay event was not delivered")
+	}
+
+	start := time.Now()
+	cancel()
+	sa := mustGet(t, a, traceID)
+	sa.WaitForFlusher()
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("canceled replay stopped after %v, want prompt termination", elapsed)
+	}
+	sa.mu.Lock()
+	buffered := len(sa.gateReplayBuf)
+	bufferedBytes := sa.gateReplayBufBytes
+	state := sa.gateState
+	sa.mu.Unlock()
+	if buffered != 0 || bufferedBytes != 0 || state != StreamStateEnded {
+		t.Fatalf("after cancellation: state=%v buffered=%d bytes=%d, want Ended/0/0", state, buffered, bufferedBytes)
+	}
+}
+
 // TestGate_ClearPausedStreamBufferDropsBufferedOriginals verifies cleared replay chunks are not delivered.
 func TestGate_ClearPausedStreamBufferDropsBufferedOriginals(t *testing.T) {
 	a := newTestAccumulator(t)

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -164,16 +164,17 @@ type StreamAccumulator struct {
 	// gatePendingTerminal is set when an isFinal or isHardErr chunk arrived
 	// while Paused. The flusher consumes this flag after Resume drains the
 	// buffer and transitions the gate to Ended.
-	gatePendingTerminal bool
-	gateSeq             int                              // monotonic, bumped on every GateSend
-	gateReplayBuf       []*schemas.BifrostStreamChunk    // wire-format chunks captured while paused
-	gateReplayBufBytes  int64                            // sum of MarshalJSON sizes of chunks in gateReplayBuf; capped by gateReplayBufMaxBytes
-	gateCond            *sync.Cond                       // wakes flusher on Resume / End / append-while-active
-	gateEndError        *schemas.BifrostError            // delivered as terminal chunk if EndStream(err) was called with non-nil
-	gateFlusherCh       chan *schemas.BifrostStreamChunk // captured on first GateSend; reused by flusher
-	gateFlusherCtx      *schemas.BifrostContext          // captured on first GateSend
-	gateFlusherOn       bool                             // flusher goroutine running
-	gateFlusherDone     chan struct{}                    // closed when the most recent flusher exits; nil when no flusher has ever started
+	gatePendingTerminal     bool
+	gateSeq                 int                              // monotonic, bumped on every GateSend
+	gateReplayBuf           []*schemas.BifrostStreamChunk    // wire-format chunks captured while paused
+	gateReplayBufBytes      int64                            // sum of MarshalJSON sizes of chunks in gateReplayBuf; capped by gateReplayBufMaxBytes
+	gateReplayEventInterval time.Duration                    // delay between buffered events after paced resume is armed
+	gateCond                *sync.Cond                       // wakes flusher on Resume / End / append-while-active
+	gateEndError            *schemas.BifrostError            // delivered as terminal chunk if EndStream(err) was called with non-nil
+	gateFlusherCh           chan *schemas.BifrostStreamChunk // captured on first GateSend; reused by flusher
+	gateFlusherCtx          *schemas.BifrostContext          // captured on first GateSend
+	gateFlusherOn           bool                             // flusher goroutine running
+	gateFlusherDone         chan struct{}                    // closed when the most recent flusher exits; nil when no flusher has ever started
 	// gatePendingCleanup is set by cleanupStreamAccumulator when the caller
 	// requested teardown but the gate is still busy (flusher running or
 	// Paused). The flusher's exit defer checks this flag and re-runs cleanup

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -476,6 +476,14 @@ func (t *Tracer) ResumeStream(traceID string) {
 	t.accumulator.ResumeStream(traceID)
 }
 
+// ResumeStreamWithReplayInterval arms fixed-interval replay after the in-flight chunk reaches the core gate.
+func (t *Tracer) ResumeStreamWithReplayInterval(traceID string, eventInterval time.Duration) bool {
+	if traceID == "" || t.accumulator == nil {
+		return false
+	}
+	return t.accumulator.ResumeStreamWithReplayInterval(traceID, eventInterval)
+}
+
 // ClearPausedStreamBuffer drops chunks buffered while traceID is paused.
 func (t *Tracer) ClearPausedStreamBuffer(traceID string) error {
 	if traceID == "" || t.accumulator == nil {

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -12,6 +12,8 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 - Added `bifrost.client.retainContentInObjectStorage` (default off, commented out) to keep full request/response content in object storage when content logging is disabled — via the global `disableContentLogging` setting or the `x-bf-disable-content-logging` header — instead of dropping it. The content is hidden: the database row stays metadata-only and the UI/API never fetch the payload back, so it is only readable with direct access to the bucket. Requires `storage.logsStore.objectStorage.enabled: true`; without it the content is dropped as before. Renders into `client.retain_content_in_object_storage`.
 
+- Added `bifrost.guardrails.rules[].stream_replay_event_interval_ms` to configure the delay between buffered events after block-capable output guardrails allow a streaming response; `0` keeps immediate delivery.
+
 ### 2.1.29
 
 - Added `bifrost.scim.config.provisioningToken` and `claimScimAttributes` to the Okta, Entra, SailPoint, and generic OIDC SCIM providers, so inbound SCIM provisioning can be seeded declaratively instead of via the dashboard. Both render into `scim_config.config`. Generate a token with `openssl rand -base64 32 | tr '+/' '-_' | tr -d '='` (supports `env.` prefix).

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -735,6 +735,7 @@ false
 {{- if .timeout }}{{- $_ := set $rule "timeout" .timeout }}{{- end }}
 {{- if hasKey . "max_turns_to_send" }}{{- $_ := set $rule "max_turns_to_send" .max_turns_to_send }}{{- end }}
 {{- if .evaluation_mode }}{{- $_ := set $rule "evaluation_mode" .evaluation_mode }}{{- end }}
+{{- if hasKey . "stream_replay_event_interval_ms" }}{{- $_ := set $rule "stream_replay_event_interval_ms" .stream_replay_event_interval_ms }}{{- end }}
 {{- if .provider_config_ids }}{{- $_ := set $rule "provider_config_ids" .provider_config_ids }}{{- end }}
 {{- $rules = append $rules $rule }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2929,6 +2929,13 @@
                     "default": "bundled",
                     "description": "How the rule's turns are sent to its guardrail providers. 'bundled' (default) concatenates all turns into one guardrail call. 'per_turn' sends each turn in its own call, evaluated in isolation, to avoid context-sensitive classifiers (e.g. Bedrock prompt-attack) combining unrelated turns into a false-positive block; this scans every turn but uses more provider calls."
                   },
+                  "stream_replay_event_interval_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1000,
+                    "default": 0,
+                    "description": "Delay in milliseconds between consecutive buffered events after block-capable streaming output guardrails allow the response. 0 sends the buffered events immediately."
+                  },
                   "provider_config_ids": {
                     "type": "array",
                     "items": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1079,6 +1079,7 @@ bifrost:
       #   timeout: 60        # Timeout in seconds for rule execution (default: 60)
       #   max_turns_to_send: 0
       #   evaluation_mode: "bundled"   # "bundled" (default) | "per_turn" (each turn scanned in isolation; avoids cross-turn false positives, more provider calls)
+      #   stream_replay_event_interval_ms: 25  # Delay between buffered events after an allowed response; 0 sends them immediately
     providers: []
       # - id: 1
       #   provider_name: "bedrock"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6139,6 +6139,13 @@
                 "default": "bundled",
                 "description": "How the rule's turns are sent to its guardrail providers. 'bundled' (default) concatenates all turns into one guardrail call. 'per_turn' sends each turn in its own call, evaluated in isolation, to avoid context-sensitive classifiers (e.g. Bedrock prompt-attack) combining unrelated turns into a false-positive block; this scans every turn but uses more provider calls."
               },
+              "stream_replay_event_interval_ms": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 1000,
+                "default": 0,
+                "description": "Delay in milliseconds between consecutive buffered events after block-capable streaming output guardrails allow the response. 0 sends the buffered events immediately."
+              },
               "provider_config_ids": {
                 "type": "array",
                 "items": {


### PR DESCRIPTION
## Summary

Adds a paced replay mode to the streaming gate that introduces a configurable inter-event delay when resuming a paused stream. Previously, resuming a paused stream would flush all buffered chunks immediately. `ResumeStreamWithReplayInterval` arms a deferred activation that waits until the next in-flight chunk joins the buffer before waking the flusher, ensuring the full buffered sequence is present before paced delivery begins.

## Changes

- Added `ResumeStreamWithReplayInterval(traceID string, eventInterval time.Duration) bool` to `Accumulator` and `Tracer`, which records the requested interval without immediately waking the flusher.
- Added `ResumeWithReplayInterval` on `StreamAccumulator` that stores `gateReplayEventInterval` and defers activation to the next `GateSend` call.
- Added `waitForReplayIntervalLocked` which sleeps between consecutive buffered chunk deliveries, releases the mutex while waiting, and exits early if the flusher context is cancelled.
- Cleared `gateReplayEventInterval` on `Pause`, plain `Resume`, `End`, buffer overflow, buffer clear, context cancellation, and orphan cleanup to prevent stale pacing state from carrying across stream lifecycle transitions.
- Extended `StreamAccumulator` with the `gateReplayEventInterval time.Duration` field.
- Added two tests covering: paced resume that includes the in-flight final chunk and verifies per-event timing, and context cancellation that promptly interrupts an in-progress replay and releases buffered memory.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/streaming/... -v -run TestGate_ResumeWithReplayInterval
go test ./framework/streaming/... ./framework/tracing/...
```

Expected: both new tests pass, existing gate tests remain green, and the cancellation test completes well under 250ms.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Paced replay operates entirely in-process on already-buffered chunks and introduces no new external inputs or data exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable