### PR TITLE
fix: use the central method for content attribute check in OTEL

### DIFF
--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -33,11 +33,19 @@ A larger pool reduces latency spikes under burst load at the cost of higher base
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enable_logging` | boolean | - | Log all LLM requests and responses |
-| `disable_content_logging` | boolean | `false` | Strip message content from logs (keeps metadata only) |
+| `disable_content_logging` | boolean | `false` | Strip message content from the **Bifrost log store** (keeps metadata only) |
+| `retain_content_in_object_storage` | boolean | `false` | When content logging is disabled, offload the full content to object storage as hidden instead of dropping it. Never served back through the UI or API. Requires object storage on the logs store. See [Content Logging](/features/observability/content-logging#retaining-content-in-object-storage) |
+| `allow_per_request_content_storage_override` | boolean | `false` | Allow individual requests to override content storage via the `x-bf-disable-content-logging` header or its context key, and to opt in to raw-byte persistence via `x-bf-store-raw-request-response`. When `false`, the global `disable_content_logging` setting is authoritative and per-request overrides are ignored. See [Request Options](/providers/request-options#disable-content-logging-per-request) |
 | `log_retention_days` | integer | `365` | Days to retain log entries in the store |
 | `logging_headers` | array of strings | `[]` | HTTP request headers to capture in log metadata |
 
 Set `disable_content_logging: true` for HIPAA / PCI compliance workloads where message content must not be persisted.
+
+<Warning>
+**This setting does not apply to observability connectors.** Each connector (BigQuery, Kafka, Pub/Sub, OpenTelemetry, Datadog) has its **own** `disable_content_logging` flag that defaults to `false` and is read independently of this one. Setting the client flag alone still exports full message content to every configured connector.
+
+For a compliance workload where content must not leave the deployment, set `disable_content_logging: true` **on every configured connector as well**. See [Content Logging](/features/observability/content-logging) for how the layers compose, and for `retain_content_in_object_storage`, which keeps content in your storage bucket while hiding it from the UI and API.
+</Warning>
 
 ```json
 {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -558,6 +558,7 @@
             "icon": "binoculars",
             "pages": [
               "features/observability/default",
+              "features/observability/content-logging",
               "features/observability/maxim",
               "features/observability/otel",
               "features/observability/prometheus",

--- a/docs/enterprise/datadog-connector.mdx
+++ b/docs/enterprise/datadog-connector.mdx
@@ -78,6 +78,8 @@ Datadog officially supports agentless submission for [LLM Observability](https:/
 | `enable_traces` | `bool` | No | `true` | Enable APM traces |
 | `enable_llm_obs` | `bool` | No | `true` | Enable LLM Observability |
 | `group_traces_by_session` | `bool` | No | `false` | Group requests sharing the same `x-bf-session-id` into one APM trace (agent mode only). See [Grouping APM Traces by Session](#grouping-apm-traces-by-session) |
+| `disable_content_logging` | `bool` | No | `false` | Drop message content from APM spans and LLM Observability payloads. See [Controlling Exported Content](#controlling-exported-content) |
+| `request_headers` | `string[]` | No | - | Request-header name patterns to capture and attach to spans. Supports exact names and wildcards (`x-custom-*`, `*`) |
 | `agentless` | `bool` | No | `false` | Use agentless mode (direct API) |
 | `api_key` | `string` | Agentless only | - | Datadog API key (supports `env.VAR_NAME`) |
 | `site` | `string` | No | `datadoghq.com` | Datadog site/region |
@@ -473,6 +475,28 @@ Each APM trace includes comprehensive LLM operation metadata:
 - Reasoning and refusal content (when present)
 
 When Enterprise guardrail redaction is enabled, Bifrost applies trace redaction replacements before exporting completed traces to Datadog. Exported span content receives the redacted or placeholderized value, but reversible reveal mappings are not exported. For the full mode matrix, see [Guardrail Redaction](/enterprise/guardrails/redaction).
+
+### Controlling Exported Content
+
+Set `disable_content_logging: true` to stop message content from reaching Datadog. Input and output messages, prompt and instructions, embedding inputs, model reasoning, and tool definitions, calls, and results are dropped from both APM spans and LLM Observability payloads. Metadata is still exported, including model, provider, tokens, cost, latency, status, and governance attribution, so metrics and dashboards are unaffected.
+
+```json
+{
+  "name": "datadog",
+  "config": {
+    "agent_addr": "localhost:8126",
+    "disable_content_logging": true
+  }
+}
+```
+
+<Warning>
+This flag is **independent** of the global `client.disable_content_logging`, which governs the Bifrost log store only. Setting the client flag does not stop content from reaching Datadog. Set `disable_content_logging` on the Datadog connector as well.
+
+It also does **not** cover attribution identifiers. Metric tags continue to include `user_id`, `user_name`, `team_ids`, `team_names`, `customer_ids`, `customer_names`, `business_unit_ids`, and `business_unit_names`. If end-user identifiers are sensitive in your deployment, treat that as a separate concern from content logging.
+
+Values captured via `request_headers` are attached to spans regardless of this flag. Only enable header capture for headers you intend to export.
+</Warning>
 
 ### Performance Metrics
 

--- a/docs/features/observability/bigquery.mdx
+++ b/docs/features/observability/bigquery.mdx
@@ -202,8 +202,12 @@ Each row corresponds to one trace — one full LLM request lifecycle. The column
 |--------|------|-------------|
 | `input_history` | `STRING` | JSON of input messages. Omitted when `disable_content_logging` is `true`. |
 | `output_message` | `STRING` | JSON of output messages. Omitted when `disable_content_logging` is `true`. |
-| `params` | `STRING` | JSON of request parameters. |
-| `tools` | `STRING` | JSON of tool definitions. |
+| `params` | `STRING` | JSON of request parameters. **Written regardless of `disable_content_logging`.** |
+| `tools` | `STRING` | JSON of tool definitions, including tool names, descriptions, and parameter schemas. **Written regardless of `disable_content_logging`.** |
+
+<Warning>
+`disable_content_logging` gates `input_history` and `output_message` only. `params` and `tools` are always written. Tool definitions frequently describe internal APIs and business logic. If that is sensitive in your deployment, do not rely on this flag alone.
+</Warning>
 
 </Accordion>
 

--- a/docs/features/observability/content-logging.mdx
+++ b/docs/features/observability/content-logging.mdx
@@ -1,0 +1,151 @@
+---
+title: "Content Logging"
+description: "Control which parts of a request and response are persisted, where they land, and who can read them back"
+icon: "eye-slash"
+---
+
+## Overview
+
+Bifrost records two kinds of information about every request. **Metadata** covers model, provider, token counts, cost, latency, status, and governance attribution. **Content** is the actual prompts, completions, and tool traffic.
+
+Metadata is what dashboards, budgets, and alerts run on. Content is what makes a log useful for debugging, and what compliance regimes care about. Bifrost lets you keep the first without the second.
+
+<Note>
+There is no single switch. Content is stripped **independently at each destination**, from that destination's own setting. A log store with content disabled says nothing about what your BigQuery table or Datadog spans contain. This page covers how the layers compose.
+</Note>
+
+---
+
+## What counts as content
+
+Broadly, anything derived from the request or response body:
+
+| Category | Examples |
+|----------|----------|
+| **Messages** | Chat history, prompt text for completions, response messages with role attribution |
+| **Tool traffic** | Tool definitions (names, descriptions, parameter schemas), tool call arguments, tool results |
+| **Parameters** | Temperature, `max_tokens`, stop sequences, and other request parameters |
+| **Modality payloads** | Embedding inputs, transcription audio, speech text, image prompts |
+| **Reasoning** | Reasoning traces and refusal content, when the provider returns them |
+| **Raw bytes** | Verbatim provider request/response bodies, when `x-bf-store-raw-request-response` is used |
+
+<Warning>
+The categories each destination actually strips are **not identical**. A setting that removes messages may leave tool definitions or request parameters in place. Check the destination-specific notes below before treating a flag as a guarantee.
+</Warning>
+
+Attribution identifiers (user ID, team, customer, business unit, virtual key) are **metadata**, not content. They are never removed by a content setting. If end-user identifiers are sensitive in your deployment, treat that as a separate concern.
+
+---
+
+## Where content can land
+
+| Destination | Governed by |
+|-------------|-------------|
+| **Log store** (Postgres / SQLite / ClickHouse row) | `client.disable_content_logging` |
+| **Object storage** (offloaded log payloads) | `client.disable_content_logging` + `client.retain_content_in_object_storage` |
+| **Logs UI and Logs API** | Whatever the log store holds, plus the hidden-content gate |
+| **Observability connectors** (BigQuery, Kafka, Pub/Sub, OpenTelemetry, Datadog) | Each connector's own `disable_content_logging` |
+| **Metrics** (Prometheus, Datadog metrics, OTLP metrics) | Never carry content. Counters, histograms, and dimension tags only |
+
+---
+
+## The control layers
+
+### 1. Global: `client.disable_content_logging`
+
+The default for the Bifrost log store. Set it to `true` and log rows keep metadata only.
+
+```json
+{
+  "client": {
+    "enable_logging": true,
+    "disable_content_logging": true
+  }
+}
+```
+
+This governs **the log store only**. It has no effect on observability connectors.
+
+### 2. Per-request: `x-bf-disable-content-logging`
+
+Overrides the global setting for a single request, in either direction: `true` suppresses content for a request that would otherwise be logged, `false` captures content while the global setting is `true`.
+
+Per-request overrides are **off by default**. Enable `client.allow_per_request_content_storage_override` first. While it is off, the header is ignored and the global setting is authoritative.
+
+See [Request Options](/providers/request-options#disable-content-logging-per-request) for headers, context keys, and SDK examples.
+
+### 3. Per-connector: each connector's own flag
+
+Every observability connector has an independent `disable_content_logging`, defaulting to `false`. It is **not** inherited from the client setting.
+
+| Connector | Flag | Notes |
+|-----------|------|-------|
+| [BigQuery](/features/observability/bigquery) | `disable_content_logging` | Gates `input_history` and `output_message`. **`params` and `tools` are written either way.** |
+| [Kafka](/features/observability/kafka) | `disable_content_logging` | Strips `gen_ai.input.*` and `gen_ai.output.*` from all spans |
+| [Pub/Sub](/features/observability/pubsub) | `disable_content_logging` | Same as Kafka |
+| [OpenTelemetry](/features/observability/otel) | `disable_content_logging`, `disable_root_span_content` | The second drops content from the root span only |
+| [Datadog](/enterprise/datadog-connector) | `disable_content_logging` | Covers APM spans and LLM Observability payloads |
+
+Captured request headers (`request_headers` on a connector, `client.logging_headers` on the log store) are exported **regardless** of any content flag. Only capture headers you intend to export.
+
+<Warning>
+For a workload where content must not leave the deployment, set `disable_content_logging: true` on the client **and on every configured connector**. Setting only the client flag still exports full content everywhere.
+</Warning>
+
+---
+
+## Retaining content in object storage
+
+Disabling content logging normally drops content permanently. `client.retain_content_in_object_storage` offers a middle ground: content is **kept in the object storage bucket but never served back**.
+
+```json
+{
+  "client": {
+    "enable_logging": true,
+    "disable_content_logging": true,
+    "retain_content_in_object_storage": true
+  }
+}
+```
+
+In the UI this is **Retain Content in Object Storage**, under **Logs Settings**. The toggle is disabled unless object storage is configured on the logs store.
+
+When it is on and a request has content logging disabled, either by the global setting or by the `x-bf-disable-content-logging` header, Bifrost:
+
+- writes a **metadata-only database row**, with payload fields and the content preview cleared,
+- offloads the **complete payload** to object storage, marked hidden,
+- and **never hydrates that payload back** on reads. The Logs UI and the Logs API show metadata only.
+
+The content is readable only by someone with direct access to the storage bucket. That is a different access path, typically governed by your cloud IAM rather than by Bifrost roles. The result is that *retention* and *visibility* become separate decisions.
+
+### Requirements and behavior
+
+| Condition | Result |
+|-----------|--------|
+| Content logging enabled | Normal behavior; the toggle has no effect |
+| Content logging disabled, toggle **off** | Content is dropped entirely |
+| Content logging disabled, toggle **on**, object storage configured | Content retained in the bucket, hidden from UI and API |
+| Content logging disabled, toggle **on**, **no** object storage | Content is dropped entirely, and Bifrost logs a warning at startup |
+
+
+---
+
+## Interaction with other features
+
+**Raw byte storage.** `x-bf-store-raw-request-response` only persists raw provider bodies when content logging is on for that request. With content logging off, raw bytes are dropped from the log row even if the header is set.
+
+**Guardrail redaction.** When Enterprise redaction is enabled, redaction runs before persistence and before export, so connectors and object storage receive the redacted or placeholderized values. Reveal mappings stay on the Bifrost log row and are never exported. With `disable_content_logging` enabled, no reveal data is persisted at all. See [Guardrail Redaction](/enterprise/guardrails/redaction).
+
+**Log exports.** Offloaded payloads carry the same fields the log row would have carried. See [Log Exports](/enterprise/log-exports).
+
+---
+
+## Choosing a configuration
+
+**Metadata only, everywhere.** Set `disable_content_logging: true` on the client and on every connector. Confirm no connector is capturing headers you did not intend to export.
+
+**Metadata in Bifrost, content retained for security review.** Set `disable_content_logging: true` and `retain_content_in_object_storage: true`, with object storage configured. Restrict bucket access to the reviewing team.
+
+**Content on by default, suppressed for sensitive traffic.** Leave `disable_content_logging: false`, enable `allow_per_request_content_storage_override`, and send `x-bf-disable-content-logging: true` on the requests that need it.
+
+**Content in Bifrost, not in third-party tools.** Leave the client setting off and set `disable_content_logging: true` on each connector.

--- a/docs/features/observability/kafka.mdx
+++ b/docs/features/observability/kafka.mdx
@@ -171,6 +171,10 @@ When `disable_content_logging` is `true`, the connector removes all input and ou
 
 This is useful when downstream consumers should not have access to the actual prompt and completion text for compliance or access-control reasons.
 
+<Note>
+This flag is independent of the global `client.disable_content_logging`, which governs the Bifrost log store only. Set both if content must be suppressed everywhere.
+</Note>
+
 ### Capturing request headers
 
 By default, no request headers are embedded in the trace payload. Set `request_headers` to a list of header name patterns to include:

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -41,6 +41,9 @@ The plugin supports multiple trace formats to match your observability platform:
 | `headers` | `object` | ❌ No | Custom headers for authentication — values support `env.VAR_NAME` |
 | `tls_ca_cert` | `string` | ❌ No | File path to client CA certificate for TLS. Optional. Works with both gRPC and HTTP protocol |
 | `group_traces_by_session` | `boolean` | ❌ No | Group requests sharing the same `x-bf-session-id` into one trace (default: `false`). See [Grouping Traces by Session](#grouping-traces-by-session) |
+| `disable_content_logging` | `boolean` | ❌ No | Drop message content from exported spans (default: `false`). See [Controlling Exported Content](#controlling-exported-content) |
+| `disable_root_span_content` | `boolean` | ❌ No | Drop content from the **root span only**, keeping it on child spans (default: `false`). Overridden by `disable_content_logging`, which drops content from every span. See [Controlling Exported Content](#controlling-exported-content) |
+| `request_headers` | `string[]` | ❌ No | Request-header name patterns whose values are attached to the root span as `http.request.header.*` attributes. Supports exact names and wildcards (`x-custom-*`, `*`) |
 
 ### Environment Variable Substitution
 
@@ -746,6 +749,33 @@ Each trace includes comprehensive LLM operation metadata following OpenTelemetry
 - Tool calls and results
 
 When Enterprise guardrail redaction is enabled, Bifrost applies trace redaction replacements before exporting completed traces to OTel. Exported span content receives the redacted or placeholderized value, but reversible reveal mappings are not exported. For the full mode matrix, see [Guardrail Redaction](/enterprise/guardrails/redaction).
+
+### Controlling Exported Content
+
+Two profile-level flags control how much message content leaves Bifrost:
+
+| Flag | Effect |
+|------|--------|
+| `disable_content_logging` | Drops input/output message content, prompt and instructions, model reasoning, tool definitions, and tool call arguments/results from **every** exported span. Metadata is still exported, including model, provider, tokens, cost, latency, status, and governance attribution. |
+| `disable_root_span_content` | When used alone, drops content from the **root span only**. Bifrost duplicates input/output onto the root span for trace-level display; this removes that duplication while child spans keep full content. Useful when your backend indexes root-span attributes and you want to limit the blast radius without losing detail. `disable_content_logging` takes precedence: when it is enabled, child spans lose their content too. |
+
+```json
+{
+  "name": "otel",
+  "config": {
+    "collector_url": "http://localhost:4318",
+    "trace_type": "genai_extension",
+    "protocol": "http",
+    "disable_content_logging": true
+  }
+}
+```
+
+<Warning>
+These flags are **independent** of the global `client.disable_content_logging`, which governs the Bifrost log store only. Setting the client flag does not stop content from being exported to your OTLP collector. Set `disable_content_logging` on the OTel profile as well.
+
+Values captured via `request_headers` are attached to the root span **regardless** of either flag. Only enable header capture for headers you intend to export.
+</Warning>
 
 ### Performance Metrics
 

--- a/docs/features/observability/pubsub.mdx
+++ b/docs/features/observability/pubsub.mdx
@@ -147,6 +147,10 @@ When `disable_content_logging` is `true`, the connector removes all input and ou
 
 This is useful when downstream subscribers should not have access to the actual prompt and completion text for compliance or access-control reasons.
 
+<Note>
+This flag is independent of the global `client.disable_content_logging`, which governs the Bifrost log store only. Set both if content must be suppressed everywhere.
+</Note>
+
 ### Capturing request headers
 
 By default, no request headers are embedded in the trace payload. Set `request_headers` to a list of header name patterns to include:

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -222,7 +222,7 @@ func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bo
 	}
 	kvs := make([]*KeyValue, 0, len(attrs))
 	for k, v := range attrs {
-		if disableContentLogging && isContentAttribute(k) {
+		if disableContentLogging && schemas.IsContentAttribute(k) {
 			continue
 		}
 		kv := anyToKeyValue(k, v)
@@ -231,26 +231,6 @@ func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bo
 		}
 	}
 	return kvs
-}
-
-// isContentAttribute returns true if the attribute key contains message/input/output content
-// or tool definitions/arguments/results that should be filtered when content logging is disabled.
-func isContentAttribute(key string) bool {
-	switch key {
-	case schemas.AttrInputMessages, schemas.AttrOutputMessages,
-		schemas.AttrInputText, schemas.AttrInputSpeech,
-		schemas.AttrInputEmbedding:
-		return true
-	case schemas.AttrTools, schemas.AttrRespTools,
-		schemas.AttrToolName, schemas.AttrToolCallID,
-		schemas.AttrToolCallArguments, schemas.AttrToolCallResult,
-		schemas.AttrToolType,
-		schemas.AttrToolChoiceType, schemas.AttrToolChoiceName,
-		schemas.AttrRespToolChoiceType, schemas.AttrRespToolChoiceName:
-		return true
-	default:
-		return false
-	}
 }
 
 // anyToKeyValue converts any Go value to OTEL KeyValue

--- a/plugins/otel/mapping_test.go
+++ b/plugins/otel/mapping_test.go
@@ -10,51 +10,42 @@ import (
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
-// contentAttrKeysWant is the canonical set of content-bearing attribute keys — the
-// "Input/Output Attributes" block in core/schemas/trace.go. Every pass-through connector
-// must strip exactly these when content logging is disabled; this local copy is the drift
-// mirror. When core adds a content attribute, TestIsContentAttributeCoversCanonicalSet
-// fails here until isContentAttribute (and this list) are updated in lockstep.
-//
-// NOTE: OTEL's isContentAttribute intentionally strips a *superset* — it also drops tool
-// definitions/arguments/results (see converter.go). This list is only the canonical content
-// floor that every connector shares; the tool keys are asserted separately below.
+// contentAttrKeysWant is the set of content-bearing attribute keys the OTEL exporter must
+// strip when content logging is disabled. The exporter delegates to schemas.IsContentAttribute
+// so there is no local list to drift; this fixture asserts the classification the exporter
+// depends on, including the keys a hand-maintained mirror previously missed
+// (prompt, instructions, reasoning).
 var contentAttrKeysWant = []string{
 	schemas.AttrInputText,
 	schemas.AttrInputMessages,
 	schemas.AttrInputSpeech,
 	schemas.AttrInputEmbedding,
 	schemas.AttrOutputMessages,
+	schemas.AttrPrompt,
+	schemas.AttrInstructions,
+	schemas.AttrRespReasoningText,
+	schemas.AttrTools, schemas.AttrRespTools,
+	schemas.AttrToolName, schemas.AttrToolCallID,
+	schemas.AttrToolCallArguments, schemas.AttrToolCallResult, schemas.AttrToolType,
+	schemas.AttrToolChoiceType, schemas.AttrToolChoiceName,
+	schemas.AttrRespToolChoiceType, schemas.AttrRespToolChoiceName,
 }
 
-// TestIsContentAttributeCoversCanonicalSet is the A5 drift guard: every canonical content
-// key must be classified as content (and thus stripped) by isContentAttribute, and a
-// representative non-content metadata key must not be. If core introduces a new content
-// attribute without OTEL learning to strip it, this fails.
+// TestIsContentAttributeCoversCanonicalSet is the A5 drift guard: every content key must be
+// classified as content (and thus stripped) on export, and representative metadata keys must
+// not be. The exporter shares core's classifier, so a new content attribute in core is stripped
+// by OTEL automatically; this test pins the keys that must never regress to metadata.
 func TestIsContentAttributeCoversCanonicalSet(t *testing.T) {
 	for _, key := range contentAttrKeysWant {
-		if !isContentAttribute(key) {
-			t.Errorf("isContentAttribute(%q) = false, want true — canonical content key not stripped", key)
-		}
-	}
-
-	// The tool superset OTEL additionally strips must also be classified as content.
-	for _, key := range []string{
-		schemas.AttrTools, schemas.AttrRespTools,
-		schemas.AttrToolName, schemas.AttrToolCallID,
-		schemas.AttrToolCallArguments, schemas.AttrToolCallResult, schemas.AttrToolType,
-		schemas.AttrToolChoiceType, schemas.AttrToolChoiceName,
-		schemas.AttrRespToolChoiceType, schemas.AttrRespToolChoiceName,
-	} {
-		if !isContentAttribute(key) {
-			t.Errorf("isContentAttribute(%q) = false, want true — OTEL tool-content key not stripped", key)
+		if !schemas.IsContentAttribute(key) {
+			t.Errorf("IsContentAttribute(%q) = false, want true — content key not stripped on export", key)
 		}
 	}
 
 	// Metadata must survive.
 	for _, key := range []string{schemas.AttrRequestModel, schemas.AttrProviderName, schemas.AttrTotalTokens} {
-		if isContentAttribute(key) {
-			t.Errorf("isContentAttribute(%q) = true, want false — metadata must not be stripped as content", key)
+		if schemas.IsContentAttribute(key) {
+			t.Errorf("IsContentAttribute(%q) = true, want false — metadata must not be stripped as content", key)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The OTEL exporter previously maintained its own local `isContentAttribute` function to decide which span attributes to strip when content logging is disabled. This local copy was missing several content keys (`AttrPrompt`, `AttrInstructions`, `AttrRespReasoningText`) and was prone to drifting from the canonical definition in `core/schemas`. This PR removes the local function and delegates directly to `schemas.IsContentAttribute`, ensuring the OTEL exporter always strips exactly what core defines as content.

## Changes

- Removed the local `isContentAttribute` function from `converter.go` and replaced all call sites with `schemas.IsContentAttribute`.
- Consolidated the test fixture `contentAttrKeysWant` to include tool keys and the previously missing content keys (`AttrPrompt`, `AttrInstructions`, `AttrRespReasoningText`), since these are now covered by the shared classifier rather than a separate OTEL-only superset.
- Simplified the drift-guard test (`TestIsContentAttributeCoversCanonicalSet`) to reflect that there is no longer a local list to keep in sync — new content attributes added to core are automatically stripped by the OTEL exporter.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/otel/...
```

The drift-guard test `TestIsContentAttributeCoversCanonicalSet` will fail if any key in `contentAttrKeysWant` is not classified as content by `schemas.IsContentAttribute`, and will fail if any metadata key is incorrectly classified as content.

## Breaking changes

- [x] No

## Security considerations

This change ensures that content attributes (`prompt`, `instructions`, `reasoning`) that were previously leaking through the OTEL exporter when content logging was disabled are now correctly stripped. This is a privacy/PII fix — spans exported with `disableContentLogging=true` will no longer inadvertently include these fields.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable