### PR TITLE
fix: bill rerank per query at the cost layer

### DIFF
--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -154,8 +154,10 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 		return input.usage.Cost.TotalCost
 	}
 
-	// If no usage data at all, nothing to price
-	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
+	// If no usage data at all, nothing to price. Rerank is exempt: providers
+	// like Vertex return no usage payload at all, yet every rerank request is
+	// one billable query priced from the datasheet (see computeRerankCost).
+	if requestType != schemas.RerankRequest && input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
 		return 0
 	}
 
@@ -513,17 +515,24 @@ func computeEmbeddingCost(pricing *configstoreTables.TableModelPricing, usage *s
 
 // computeRerankCost handles rerank requests.
 func computeRerankCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, tier serviceTier) float64 {
+	// Rerank providers bill per query, and every Bifrost rerank request carries
+	// exactly one query, so the billable count defaults to 1. Provider-reported
+	// counts (e.g. Cohere search units) override the default; nothing is ever
+	// written back onto the response payload.
+	queries := 1
+	if usage != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil && *usage.CompletionTokensDetails.NumSearchQueries > 0 {
+		queries = *usage.CompletionTokensDetails.NumSearchQueries
+	}
+	searchCost := 0.0
+	if pricing.SearchContextCostPerQuery != nil {
+		searchCost = float64(queries) * *pricing.SearchContextCostPerQuery
+	}
 	if usage == nil {
-		return 0
+		return searchCost
 	}
 	tierTokens := usage.PromptTokens
 	inputCost := float64(usage.PromptTokens) * tieredInputRate(pricing, tierTokens, tier)
 	outputCost := float64(usage.CompletionTokens) * tieredOutputRate(pricing, tierTokens, tier)
-
-	searchCost := 0.0
-	if pricing.SearchContextCostPerQuery != nil && usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.NumSearchQueries != nil {
-		searchCost = float64(*usage.CompletionTokensDetails.NumSearchQueries) * *pricing.SearchContextCostPerQuery
-	}
 
 	return inputCost + outputCost + searchCost
 }
@@ -1286,6 +1295,27 @@ func (s *Store) getBasePricing(model, provider string, requestType schemas.Reque
 	}
 
 	if provider == string(schemas.Bedrock) {
+		// Bedrock rerank models are addressed by full ARN
+		// ("arn:aws:bedrock:<region>:<account>:foundation-model/<model-id>");
+		// datasheet rows are keyed by the bare model ID, so retry with the
+		// resource ID extracted from the ARN.
+		if strings.HasPrefix(model, "arn:") {
+			if idx := strings.LastIndex(model, "/"); idx >= 0 && idx < len(model)-1 {
+				arnModel := model[idx+1:]
+				s.logger.Debug("primary lookup failed, trying bare model ID %s extracted from ARN", arnModel)
+				pricing, ok = s.pricingData[makeKey(arnModel, provider, mode)]
+				if ok {
+					return &pricing, true
+				}
+				if hasFallbackMode {
+					pricing, ok = s.pricingData[makeKey(arnModel, provider, fallbackMode)]
+					if ok {
+						return &pricing, true
+					}
+				}
+			}
+		}
+
 		// Bedrock model IDs carry a vendor namespace ("anthropic.claude-*",
 		// "openai.gpt-oss-*", "google.gemma-*", "xai.grok-*"). When the caller
 		// sends the bare model name, retry with the namespace inferred from

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -3824,3 +3824,76 @@ func TestCalculateCostForUsage_NoServerSideFallback_Unchanged(t *testing.T) {
 	assert.InDelta(t, 38*(10.0/1_000_000)+345*(50.0/1_000_000),
 		s.CalculateCostForUsage(usage, schemas.Anthropic, "claude-fable-5", schemas.ResponsesRequest, nil), 1e-12)
 }
+
+// TestComputeRerankCost_DefaultsToOneQuery verifies rerank bills one query per
+// request when the provider reports no usage at all (e.g. Vertex).
+func TestComputeRerankCost_DefaultsToOneQuery(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		SearchContextCostPerQuery: bifrost.Ptr(0.001),
+	}
+	assert.InDelta(t, 0.001, computeRerankCost(&p, nil, serviceTier{}), 1e-12)
+
+	// No per-query rate configured → nothing to bill.
+	empty := configstoreTables.TableModelPricing{}
+	assert.Equal(t, 0.0, computeRerankCost(&empty, nil, serviceTier{}))
+}
+
+// TestComputeRerankCost_TokenOnlyUsageDefaultsToOneQuery verifies a usage that
+// carries only token counts (e.g. Bedrock's header-derived input tokens) still
+// bills the default single query at the per-query rate.
+func TestComputeRerankCost_TokenOnlyUsageDefaultsToOneQuery(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		SearchContextCostPerQuery: bifrost.Ptr(0.002),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 500,
+		TotalTokens:  500,
+	}
+	assert.InDelta(t, 0.002, computeRerankCost(&p, usage, serviceTier{}), 1e-12)
+}
+
+// TestCalculateCost_RerankNoUsageBillsPerQuery verifies the end-to-end path: a
+// rerank response with nil usage passes the no-usage gate and bills per query.
+func TestCalculateCost_RerankNoUsageBillsPerQuery(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("semantic-ranker-default@latest", "vertex", "rerank"): {
+			Model: "semantic-ranker-default@latest", Provider: "vertex", Mode: "rerank",
+			SearchContextCostPerQuery: bifrost.Ptr(0.001),
+		},
+	})
+
+	resp := makeRerankResponse(schemas.Vertex, "semantic-ranker-default@latest", nil)
+
+	assert.InDelta(t, 0.001, s.CalculateCost(resp, nil), 1e-12)
+}
+
+// TestCalculateCost_BedrockRerankARNResolvesPricing verifies a Bedrock rerank
+// request addressed by full ARN resolves the datasheet row keyed by the bare
+// model ID.
+func TestCalculateCost_BedrockRerankARNResolvesPricing(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("cohere.rerank-v3-5:0", "bedrock", "rerank"): {
+			Model: "cohere.rerank-v3-5:0", Provider: "bedrock", Mode: "rerank",
+			SearchContextCostPerQuery: bifrost.Ptr(0.002),
+		},
+	})
+
+	resp := makeRerankResponse(schemas.Bedrock, "arn:aws:bedrock:us-east-1::foundation-model/cohere.rerank-v3-5:0", nil)
+
+	assert.InDelta(t, 0.002, s.CalculateCost(resp, nil), 1e-12)
+}
+
+// TestComputeRerankCost_NonPositiveReportedQueriesDefaultsToOne verifies a
+// zero (or negative) provider-reported query count does not zero out billing —
+// a successful rerank request is always at least one billable query.
+func TestComputeRerankCost_NonPositiveReportedQueriesDefaultsToOne(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		SearchContextCostPerQuery: bifrost.Ptr(0.002),
+	}
+	usage := &schemas.BifrostLLMUsage{
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+			NumSearchQueries: bifrost.Ptr(0),
+		},
+	}
+	assert.InDelta(t, 0.002, computeRerankCost(&p, usage, serviceTier{}), 1e-12)
+}


### PR DESCRIPTION
## Summary

Follow-up to the reverted #4322, redone per review direction: no usage is
synthesized on the client-facing response. Bedrock and Vertex bill rerank per
query but return no usage payload, so rerank cost always computed to 0 —
Vertex responses (nil usage) were dropped at the no-usage gate before pricing
was even resolved, and Bedrock's header-derived token usage carried no query
count. This PR moves the per-query knowledge into the cost engine instead:
every Bifrost rerank request carries exactly one query, so the billable count
defaults to 1 there, and response payloads are never touched.

## Changes

- `calculateBaseCost` exempts rerank from the "no usage data at all" early
  return (mirroring the container flat-cost precedent), so usage-less rerank
  responses reach pricing resolution.
- `computeRerankCost` defaults the billable query count to 1; provider-reported
  counts (e.g. Cohere's search units, once mapped) still override. With nil
  usage only the per-query term is billed; token-bearing usage (Bedrock's
  header-derived input tokens, #3917) keeps the existing token + search sum.
- Bedrock pricing lookup resolves full ARNs
  (`arn:aws:bedrock:...:foundation-model/<model-id>`) to their bare model IDs,
  since rerank models are addressed by ARN and would never match a datasheet
  key otherwise.
- Regression tests: nil-usage default billing (unit + end-to-end through
  `CalculateCost`), token-only usage (Bedrock shape), and ARN→datasheet-key
  resolution.

Notes for reviewers:
- Billing activates once datasheet rows exist for the rerank models (e.g.
  `cohere.rerank-v3-5:0` / `amazon.rerank-v1:0` under provider `bedrock`,
  `semantic-ranker-default@latest` under `vertex`) carrying the per-query rate
  with no token rates — that's on the hosted datasheet side.
- This composes with #4277 (which wires `input_cost_per_query` as a
  first-class field and maps Cohere's reported search units); until then the
  per-query rate is read from the existing `search_context_cost_per_query`
  field.
- Passthrough rerank is out of scope (it is not typed as a rerank request).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run:

```sh
- go test ./framework/modelcatalog/datasheet/... -run "DefaultsToOneQuery|TokenOnlyUsage|NoUsageBillsPerQuery|ARNResolvesPricing" -v
- go test ./framework/modelcatalog/datasheet/...
```

Expected: the four new tests pass and the full datasheet suite passes —
existing rerank tests are unaffected (token-only pricing rows still bill 0 for
the default query since no per-query rate is configured).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Supersedes the reverted #4322.

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable