### PR TITLE
feat: track Anthropic extended-thinking tokens as `ReasoningTokens` across chat, responses, and passthrough

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -641,6 +641,26 @@ func accumulateAnthropicResponsesUsage(usage *schemas.ResponsesResponseUsage, bi
 			}
 		}
 	}
+	// Extended-thinking tokens. Max-merged (per-request total, not per-event
+	// increment) and mirrored onto the billing handle so a mid-stream cancel or
+	// timeout still reports the reasoning breakdown.
+	if usageToProcess.OutputTokensDetails != nil && usageToProcess.OutputTokensDetails.ThinkingTokens > 0 {
+		t := usageToProcess.OutputTokensDetails.ThinkingTokens
+		if usage.OutputTokensDetails == nil {
+			usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{}
+		}
+		if t > usage.OutputTokensDetails.ReasoningTokens {
+			usage.OutputTokensDetails.ReasoningTokens = t
+		}
+		if billedUsage != nil {
+			if billedUsage.CompletionTokensDetails == nil {
+				billedUsage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+			}
+			if t > billedUsage.CompletionTokensDetails.ReasoningTokens {
+				billedUsage.CompletionTokensDetails.ReasoningTokens = t
+			}
+		}
+	}
 	if usageToProcess.InputTokens > usage.InputTokens {
 		usage.InputTokens = usageToProcess.InputTokens
 		if billedUsage != nil {
@@ -974,6 +994,17 @@ func HandleAnthropicChatCompletionStreaming(
 					}
 					if n := usageToProcess.ServerToolUse.WebSearchRequests; usage.CompletionTokensDetails.NumSearchQueries == nil || n > *usage.CompletionTokensDetails.NumSearchQueries {
 						usage.CompletionTokensDetails.NumSearchQueries = &n
+					}
+				}
+				// Extended-thinking tokens. Max-merged like the other counters because usage
+				// arrives split across message_start and message_delta; the value is a
+				// per-request total, not a per-event increment, so summing would inflate it.
+				if usageToProcess.OutputTokensDetails != nil && usageToProcess.OutputTokensDetails.ThinkingTokens > 0 {
+					if usage.CompletionTokensDetails == nil {
+						usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+					}
+					if t := usageToProcess.OutputTokensDetails.ThinkingTokens; t > usage.CompletionTokensDetails.ReasoningTokens {
+						usage.CompletionTokensDetails.ReasoningTokens = t
 					}
 				}
 				// Capture served fast mode + inference geography (top-level response fields).

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1087,6 +1087,15 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 				NumSearchQueries: &n,
 			}
 		}
+		// Extended-thinking token count. Already a subset of OutputTokens (see
+		// AnthropicOutputTokensDetails), which matches the Bifrost invariant that
+		// ReasoningTokens <= CompletionTokens — so no folding is required here.
+		if response.Usage.OutputTokensDetails != nil && response.Usage.OutputTokensDetails.ThinkingTokens > 0 {
+			if bifrostResponse.Usage.CompletionTokensDetails == nil {
+				bifrostResponse.Usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+			}
+			bifrostResponse.Usage.CompletionTokensDetails.ReasoningTokens = response.Usage.OutputTokensDetails.ThinkingTokens
+		}
 		bifrostResponse.Usage.TotalTokens = bifrostResponse.Usage.PromptTokens + bifrostResponse.Usage.CompletionTokens
 		// Forward service tier from usage to response
 		if response.Usage.ServiceTier != nil {

--- a/core/providers/anthropic/passthrough_usage.go
+++ b/core/providers/anthropic/passthrough_usage.go
@@ -69,6 +69,15 @@ func buildAnthropicPassthroughUsage(au *AnthropicUsage) *schemas.BifrostPassthro
 		}
 	}
 
+	// Extended-thinking tokens are already inside au.OutputTokens, so CompletionTokens
+	// and TotalTokens above stay as-is.
+	if au.OutputTokensDetails != nil && au.OutputTokensDetails.ThinkingTokens > 0 {
+		if usage.CompletionTokensDetails == nil {
+			usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+		}
+		usage.CompletionTokensDetails.ReasoningTokens = au.OutputTokensDetails.ThinkingTokens
+	}
+
 	u := &schemas.BifrostPassthroughUsage{LLMUsage: usage}
 	if au.ServiceTier != nil {
 		t := MapAnthropicServiceTierToBifrost(*au.ServiceTier)
@@ -137,6 +146,14 @@ func (a *AnthropicPassthroughStreamUsage) ObserveEvent(event []byte) *schemas.Bi
 		}
 		if u.ServerToolUse.WebSearchRequests > c.ServerToolUse.WebSearchRequests {
 			c.ServerToolUse.WebSearchRequests = u.ServerToolUse.WebSearchRequests
+		}
+	}
+	if u.OutputTokensDetails != nil {
+		if c.OutputTokensDetails == nil {
+			c.OutputTokensDetails = &AnthropicOutputTokensDetails{}
+		}
+		if u.OutputTokensDetails.ThinkingTokens > c.OutputTokensDetails.ThinkingTokens {
+			c.OutputTokensDetails.ThinkingTokens = u.OutputTokensDetails.ThinkingTokens
 		}
 	}
 	if u.ServiceTier != nil {

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3955,6 +3955,15 @@ func ConvertAnthropicUsageToBifrostUsage(anthropicUsage *AnthropicUsage) *schema
 		bifrostUsage.OutputTokensDetails.NumSearchQueries = schemas.Ptr(anthropicUsage.ServerToolUse.WebSearchRequests)
 	}
 
+	// Extended-thinking token count. Already a subset of OutputTokens upstream, so it
+	// carries across unchanged and OutputTokens/TotalTokens are left alone.
+	if anthropicUsage.OutputTokensDetails != nil && anthropicUsage.OutputTokensDetails.ThinkingTokens > 0 {
+		if bifrostUsage.OutputTokensDetails == nil {
+			bifrostUsage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{}
+		}
+		bifrostUsage.OutputTokensDetails.ReasoningTokens = anthropicUsage.OutputTokensDetails.ThinkingTokens
+	}
+
 	// Recursively convert iterations
 	if len(anthropicUsage.Iterations) > 0 {
 		bifrostUsage.Iterations = make([]schemas.ResponsesResponseUsage, len(anthropicUsage.Iterations))
@@ -4004,6 +4013,15 @@ func ConvertBifrostUsageToAnthropicUsage(bifrostUsage *schemas.ResponsesResponse
 	if bifrostUsage.OutputTokensDetails != nil && bifrostUsage.OutputTokensDetails.NumSearchQueries != nil && *bifrostUsage.OutputTokensDetails.NumSearchQueries > 0 {
 		anthropicUsage.ServerToolUse = &AnthropicServerToolUseUsage{
 			WebSearchRequests: *bifrostUsage.OutputTokensDetails.NumSearchQueries,
+		}
+	}
+
+	// Reasoning tokens map back to Anthropic's thinking-token breakdown. Unlike the
+	// cache counters above, OutputTokens is not adjusted: thinking tokens are already
+	// inside it on both sides.
+	if bifrostUsage.OutputTokensDetails != nil && bifrostUsage.OutputTokensDetails.ReasoningTokens > 0 {
+		anthropicUsage.OutputTokensDetails = &AnthropicOutputTokensDetails{
+			ThinkingTokens: bifrostUsage.OutputTokensDetails.ReasoningTokens,
 		}
 	}
 

--- a/core/providers/anthropic/thinking_tokens_test.go
+++ b/core/providers/anthropic/thinking_tokens_test.go
@@ -1,0 +1,157 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// realThinkingUsage is a verbatim usage block from a Claude extended-thinking
+// response. Note thinking_tokens (39) is a SUBSET of output_tokens (87) — the two
+// must never be summed.
+const realThinkingUsage = `{
+  "input_tokens": 23,
+  "cache_creation_input_tokens": 0,
+  "cache_read_input_tokens": 0,
+  "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
+  "output_tokens": 87,
+  "output_tokens_details": {"thinking_tokens": 39}
+}`
+
+func mustParseUsage(t *testing.T, raw string) *AnthropicUsage {
+	t.Helper()
+	var u AnthropicUsage
+	if err := sonic.Unmarshal([]byte(raw), &u); err != nil {
+		t.Fatalf("unmarshal usage: %v", err)
+	}
+	return &u
+}
+
+func TestAnthropicUsage_UnmarshalsThinkingTokens(t *testing.T) {
+	u := mustParseUsage(t, realThinkingUsage)
+	if u.OutputTokensDetails == nil {
+		t.Fatal("OutputTokensDetails is nil; thinking_tokens was dropped at unmarshal")
+	}
+	if got := u.OutputTokensDetails.ThinkingTokens; got != 39 {
+		t.Errorf("ThinkingTokens = %d, want 39", got)
+	}
+}
+
+func TestChatConversion_ThinkingTokensAreSubsetOfCompletion(t *testing.T) {
+	resp := &AnthropicMessageResponse{Usage: mustParseUsage(t, realThinkingUsage)}
+	got := resp.ToBifrostChatResponse(nil)
+
+	if got.Usage == nil || got.Usage.CompletionTokensDetails == nil {
+		t.Fatal("CompletionTokensDetails is nil; reasoning tokens were dropped")
+	}
+	if r := got.Usage.CompletionTokensDetails.ReasoningTokens; r != 39 {
+		t.Errorf("ReasoningTokens = %d, want 39", r)
+	}
+	// The invariant: reasoning is inside completion, not added to it.
+	if got.Usage.CompletionTokens != 87 {
+		t.Errorf("CompletionTokens = %d, want 87 (thinking must not be added)", got.Usage.CompletionTokens)
+	}
+	if got.Usage.CompletionTokensDetails.ReasoningTokens > got.Usage.CompletionTokens {
+		t.Error("invariant violated: ReasoningTokens > CompletionTokens")
+	}
+	if got.Usage.TotalTokens != got.Usage.PromptTokens+got.Usage.CompletionTokens {
+		t.Errorf("TotalTokens = %d, want PromptTokens+CompletionTokens = %d",
+			got.Usage.TotalTokens, got.Usage.PromptTokens+got.Usage.CompletionTokens)
+	}
+}
+
+func TestChatConversion_NoThinkingLeavesReasoningZero(t *testing.T) {
+	resp := &AnthropicMessageResponse{
+		Usage: mustParseUsage(t, `{"input_tokens": 10, "output_tokens": 5}`),
+	}
+	got := resp.ToBifrostChatResponse(nil)
+	if got.Usage.CompletionTokensDetails != nil &&
+		got.Usage.CompletionTokensDetails.ReasoningTokens != 0 {
+		t.Errorf("ReasoningTokens = %d on a non-thinking response, want 0",
+			got.Usage.CompletionTokensDetails.ReasoningTokens)
+	}
+}
+
+func TestResponsesConversion_CarriesThinkingTokens(t *testing.T) {
+	got := ConvertAnthropicUsageToBifrostUsage(mustParseUsage(t, realThinkingUsage))
+	if got == nil || got.OutputTokensDetails == nil {
+		t.Fatal("OutputTokensDetails is nil; reasoning tokens were dropped")
+	}
+	if r := got.OutputTokensDetails.ReasoningTokens; r != 39 {
+		t.Errorf("ReasoningTokens = %d, want 39", r)
+	}
+	if got.OutputTokens != 87 {
+		t.Errorf("OutputTokens = %d, want 87 (thinking must not be added)", got.OutputTokens)
+	}
+}
+
+func TestUsageRoundTrip_PreservesThinkingTokens(t *testing.T) {
+	original := mustParseUsage(t, realThinkingUsage)
+	back := ConvertBifrostUsageToAnthropicUsage(ConvertAnthropicUsageToBifrostUsage(original))
+
+	if back == nil || back.OutputTokensDetails == nil {
+		t.Fatal("thinking tokens lost on Anthropic->Bifrost->Anthropic round trip")
+	}
+	if back.OutputTokensDetails.ThinkingTokens != original.OutputTokensDetails.ThinkingTokens {
+		t.Errorf("ThinkingTokens = %d after round trip, want %d",
+			back.OutputTokensDetails.ThinkingTokens, original.OutputTokensDetails.ThinkingTokens)
+	}
+	if back.OutputTokens != original.OutputTokens {
+		t.Errorf("OutputTokens = %d after round trip, want %d", back.OutputTokens, original.OutputTokens)
+	}
+}
+
+// Anthropic reports thinking tokens as a running per-request total across
+// message_start and message_delta. The accumulator must max-merge, not sum.
+func TestResponsesAccumulator_MaxMergesRatherThanSums(t *testing.T) {
+	usage := &schemas.ResponsesResponseUsage{}
+	billed := &schemas.BifrostLLMUsage{}
+
+	for _, raw := range []string{
+		`{"input_tokens": 23, "output_tokens": 20, "output_tokens_details": {"thinking_tokens": 20}}`,
+		`{"input_tokens": 23, "output_tokens": 87, "output_tokens_details": {"thinking_tokens": 39}}`,
+		// Out-of-order/stale event must not regress the accumulated value.
+		`{"input_tokens": 23, "output_tokens": 50, "output_tokens_details": {"thinking_tokens": 30}}`,
+	} {
+		accumulateAnthropicResponsesUsage(usage, billed, mustParseUsage(t, raw))
+	}
+
+	if usage.OutputTokensDetails == nil {
+		t.Fatal("OutputTokensDetails is nil after accumulation")
+	}
+	if r := usage.OutputTokensDetails.ReasoningTokens; r != 39 {
+		t.Errorf("ReasoningTokens = %d, want 39 (max, not sum of 20+39+30=89)", r)
+	}
+	if billed.CompletionTokensDetails == nil {
+		t.Fatal("billed usage did not receive reasoning tokens")
+	}
+	if r := billed.CompletionTokensDetails.ReasoningTokens; r != 39 {
+		t.Errorf("billed ReasoningTokens = %d, want 39", r)
+	}
+	if usage.OutputTokensDetails.ReasoningTokens > usage.OutputTokens {
+		t.Error("invariant violated: ReasoningTokens > OutputTokens")
+	}
+}
+
+func TestPassthroughStream_MergesThinkingTokensAcrossEvents(t *testing.T) {
+	var acc AnthropicPassthroughStreamUsage
+
+	// message_start nests usage under message.usage and has no output counts yet.
+	acc.ObserveEvent([]byte(`{"type":"message_start","message":{"usage":{"input_tokens":23,"output_tokens":0}}}`))
+	// message_delta carries usage at the top level, including the thinking breakdown.
+	got := acc.ObserveEvent([]byte(`{"type":"message_delta","usage":{"input_tokens":23,"output_tokens":87,"output_tokens_details":{"thinking_tokens":39}}}`))
+
+	if got == nil || got.LLMUsage == nil {
+		t.Fatal("no usage assembled from stream")
+	}
+	if got.LLMUsage.CompletionTokensDetails == nil {
+		t.Fatal("CompletionTokensDetails is nil; reasoning tokens were dropped in streaming passthrough")
+	}
+	if r := got.LLMUsage.CompletionTokensDetails.ReasoningTokens; r != 39 {
+		t.Errorf("ReasoningTokens = %d, want 39", r)
+	}
+	if got.LLMUsage.CompletionTokens != 87 {
+		t.Errorf("CompletionTokens = %d, want 87", got.LLMUsage.CompletionTokens)
+	}
+}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1780,16 +1780,34 @@ type AnthropicUsage struct {
 	Type  *string `json:"type,omitempty"`
 	Model *string `json:"model,omitempty"` // model that produced this (iteration) attempt; sent on usage.iterations[] for server-side fallback
 	// Unlike OpenAI models, Anthropic (claude) models separately track cache creation and cache read tokens, and its not included in the input_tokens field.
-	InputTokens              int                          `json:"input_tokens"`
-	CacheCreationInputTokens int                          `json:"cache_creation_input_tokens"`
-	CacheReadInputTokens     int                          `json:"cache_read_input_tokens"`
-	CacheCreation            AnthropicUsageCacheCreation  `json:"cache_creation"`
-	OutputTokens             int                          `json:"output_tokens"`
-	ServerToolUse            *AnthropicServerToolUseUsage `json:"server_tool_use,omitempty"` // Server tool use statistics (e.g., web search)
-	ServiceTier              *string                      `json:"service_tier,omitempty"`    // "standard", "priority", or "batch"
-	Speed                    *string                      `json:"speed,omitempty"`           // "fast" or "standard" — which speed was actually served (fast mode research preview)
-	InferenceGeo             *string                      `json:"inference_geo,omitempty"`   // the geographic region for inference processing. If not specified, the workspace's default_inference_geo is used.
-	Iterations               []AnthropicUsage             `json:"iterations,omitempty"`      // Iterations statistics
+	InputTokens              int                           `json:"input_tokens"`
+	CacheCreationInputTokens int                           `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int                           `json:"cache_read_input_tokens"`
+	CacheCreation            AnthropicUsageCacheCreation   `json:"cache_creation"`
+	OutputTokens             int                           `json:"output_tokens"`
+	OutputTokensDetails      *AnthropicOutputTokensDetails `json:"output_tokens_details,omitempty"` // Breakdown of output_tokens (extended thinking). Absent on non-thinking responses.
+	ServerToolUse            *AnthropicServerToolUseUsage  `json:"server_tool_use,omitempty"`       // Server tool use statistics (e.g., web search)
+	ServiceTier              *string                       `json:"service_tier,omitempty"`          // "standard", "priority", or "batch"
+	Speed                    *string                       `json:"speed,omitempty"`                 // "fast" or "standard" — which speed was actually served (fast mode research preview)
+	InferenceGeo             *string                       `json:"inference_geo,omitempty"`         // the geographic region for inference processing. If not specified, the workspace's default_inference_geo is used.
+	Iterations               []AnthropicUsage              `json:"iterations,omitempty"`            // Iterations statistics
+}
+
+// AnthropicOutputTokensDetails breaks down output_tokens for extended-thinking responses.
+//
+// ThinkingTokens is a SUBSET of AnthropicUsage.OutputTokens, never additive: Anthropic
+// documents it as "always <= output_tokens", with output_tokens remaining the inclusive,
+// authoritative total used for billing. Do not add it to OutputTokens — non-reasoning
+// output is OutputTokens - ThinkingTokens.
+//
+// Note this is the opposite convention from the input side of the same object, where
+// InputTokens excludes the cache counters and must be summed with them.
+//
+// Observability-grade, not billing-grade: Anthropic computes it by re-tokenizing the raw
+// reasoning text, so it may differ from the model's exact generation count by a few tokens.
+// It reflects raw reasoning, not the shorter visible summary.
+type AnthropicOutputTokensDetails struct {
+	ThinkingTokens int `json:"thinking_tokens"`
 }
 
 // AnthropicUsageIterationTypeFallbackMessage marks the usage.iterations entry for


### PR DESCRIPTION
## Summary

Anthropic's extended-thinking (Claude reasoning) responses include an `output_tokens_details.thinking_tokens` field that was previously being silently dropped. This PR surfaces that value as `ReasoningTokens` in Bifrost's usage schemas across all response paths — non-streaming chat, streaming chat, Responses API, and passthrough — while preserving the invariant that thinking tokens are a **subset** of output tokens, not additive to them.

## Changes

- Added `AnthropicOutputTokensDetails` struct with `ThinkingTokens` field and attached it to `AnthropicUsage` as `OutputTokensDetails`.
- Mapped `ThinkingTokens` → `ReasoningTokens` in `ToBifrostChatResponse`, `ConvertAnthropicUsageToBifrostUsage`, `buildAnthropicPassthroughUsage`, and the streaming accumulator `accumulateAnthropicResponsesUsage`.
- Implemented `ConvertBifrostUsageToAnthropicUsage` round-trip support so `ReasoningTokens` maps back to `ThinkingTokens` without touching `OutputTokens`.
- Used max-merge (rather than summation) when accumulating thinking tokens across streaming events, because Anthropic reports a running per-request total across `message_start` and `message_delta` — summing would inflate the count.
- Mirrored reasoning tokens onto the billing usage handle so mid-stream cancels or timeouts still report the reasoning breakdown.
- Added `thinking_tokens_test.go` covering unmarshal correctness, the subset invariant, round-trip fidelity, max-merge accumulation behavior, and streaming passthrough assembly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestAnthropicUsage_UnmarshalsThinkingTokens
go test ./core/providers/anthropic/... -run TestChatConversion_ThinkingTokensAreSubsetOfCompletion
go test ./core/providers/anthropic/... -run TestResponsesAccumulator_MaxMergesRatherThanSums
go test ./core/providers/anthropic/... -run TestPassthroughStream_MergesThinkingTokensAcrossEvents
go test ./core/providers/anthropic/... -run TestUsageRoundTrip_PreservesThinkingTokens
go test ./...
```

To validate end-to-end, send a request to a Claude model with extended thinking enabled and confirm that `completion_tokens_details.reasoning_tokens` is populated in the response usage and that `completion_tokens` is unchanged (thinking tokens must not be added to it).

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing implications. Usage fields are observability-grade metadata only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable