### PR TITLE
feat: inline `error`/`error_omitted` fields in webhook payloads for failed async jobs

### DIFF
--- a/examples/webhooks/main.go
+++ b/examples/webhooks/main.go
@@ -65,6 +65,8 @@ type eventEnvelope struct {
 		ResultExpiresAt *time.Time      `json:"result_expires_at,omitempty"` // after which result_url is dead
 		Response        json.RawMessage `json:"response,omitempty"`          // inlined only if the endpoint opted in
 		ResponseOmitted bool            `json:"response_omitted,omitempty"`  // response too large to inline; fetch it
+		Error           json.RawMessage `json:"error,omitempty"`             // inlined only if the endpoint opted in (failed jobs)
+		ErrorOmitted    bool            `json:"error_omitted,omitempty"`     // error too large to inline; fetch it
 		ResultExpired   bool            `json:"result_expired,omitempty"`    // result gone before delivery; nothing to fetch
 	} `json:"data"`
 }

--- a/framework/webhooks/payload.go
+++ b/framework/webhooks/payload.go
@@ -30,6 +30,8 @@ type eventData struct {
 	ResultExpiresAt *time.Time             `json:"result_expires_at,omitempty"`
 	Response        json.RawMessage        `json:"response,omitempty"`
 	ResponseOmitted bool                   `json:"response_omitted,omitempty"`
+	Error           json.RawMessage        `json:"error,omitempty"`
+	ErrorOmitted    bool                   `json:"error_omitted,omitempty"`
 	ResultExpired   bool                   `json:"result_expired,omitempty"`
 }
 
@@ -85,9 +87,10 @@ func statusForEvent(event tables.WebhookEvent) schemas.AsyncJobStatus {
 }
 
 // renderPayload builds the delivery body for a live async job row. The
-// response is inlined only when the endpoint opted in and the stored response
-// fits within maxResponseBytes; an oversized response is dropped and flagged
-// with response_omitted so the receiver knows to fetch it instead.
+// job's response (on completion) or error (on failure) is inlined only when
+// the endpoint opted in and the stored value fits within maxResponseBytes;
+// an oversized value is dropped and flagged with response_omitted/
+// error_omitted so the receiver knows to fetch it instead.
 func renderPayload(job *logstore.AsyncJob, event tables.WebhookEvent, includeResponse bool, maxResponseBytes int, now time.Time) ([]byte, error) {
 	data := eventData{
 		JobID:           job.ID,
@@ -106,6 +109,13 @@ func renderPayload(job *logstore.AsyncJob, event tables.WebhookEvent, includeRes
 			data.Response = json.RawMessage(job.Response)
 		} else {
 			data.ResponseOmitted = true
+		}
+	}
+	if includeResponse && job.Error != "" {
+		if len(job.Error) <= maxResponseBytes {
+			data.Error = json.RawMessage(job.Error)
+		} else {
+			data.ErrorOmitted = true
 		}
 	}
 	return json.Marshal(eventEnvelope{Event: event, CreatedAt: now, Data: data})

--- a/framework/webhooks/payload_test.go
+++ b/framework/webhooks/payload_test.go
@@ -29,6 +29,22 @@ func testAsyncJob() *logstore.AsyncJob {
 	}
 }
 
+func testFailedAsyncJob() *logstore.AsyncJob {
+	created := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	completed := created.Add(time.Minute)
+	expires := completed.Add(time.Hour)
+	return &logstore.AsyncJob{
+		ID:          "job-1",
+		Status:      schemas.AsyncJobStatusFailed,
+		RequestType: schemas.ChatCompletionRequest,
+		Error:       `{"error":{"message":"upstream timed out"}}`,
+		StatusCode:  500,
+		CreatedAt:   created,
+		CompletedAt: &completed,
+		ExpiresAt:   &expires,
+	}
+}
+
 func decodeEnvelope(t *testing.T, body []byte) map[string]any {
 	t.Helper()
 	var envelope map[string]any
@@ -52,6 +68,8 @@ func TestRenderPayloadThin(t *testing.T) {
 	assert.Contains(t, data, "result_expires_at")
 	assert.NotContains(t, data, "response")
 	assert.NotContains(t, data, "response_omitted")
+	assert.NotContains(t, data, "error")
+	assert.NotContains(t, data, "error_omitted")
 	assert.NotContains(t, data, "result_expired")
 }
 
@@ -72,6 +90,34 @@ func TestRenderPayloadIncludeResponse(t *testing.T) {
 	data = decodeEnvelope(t, body)["data"].(map[string]any)
 	assert.NotContains(t, data, "response")
 	assert.Equal(t, true, data["response_omitted"])
+}
+
+func TestRenderPayloadIncludeError(t *testing.T) {
+	now := time.Now().UTC()
+	job := testFailedAsyncJob()
+
+	// A failed job's error is inlined the same way a completed job's
+	// response is, gated by the same includeResponse toggle.
+	body, err := renderPayload(job, tables.WebhookEventAsyncJobFailed, true, 256*1024, now)
+	require.NoError(t, err)
+	data := decodeEnvelope(t, body)["data"].(map[string]any)
+	require.Contains(t, data, "error")
+	assert.NotContains(t, data, "error_omitted")
+	assert.NotContains(t, data, "response")
+
+	// The toggle gates the error the same way it gates the response.
+	body, err = renderPayload(job, tables.WebhookEventAsyncJobFailed, false, 256*1024, now)
+	require.NoError(t, err)
+	data = decodeEnvelope(t, body)["data"].(map[string]any)
+	assert.NotContains(t, data, "error")
+
+	// An oversized error is dropped and flagged instead of inlined.
+	job.Error = `{"error":{"message":"` + strings.Repeat("x", 2048) + `"}}`
+	body, err = renderPayload(job, tables.WebhookEventAsyncJobFailed, true, 1024, now)
+	require.NoError(t, err)
+	data = decodeEnvelope(t, body)["data"].(map[string]any)
+	assert.NotContains(t, data, "error")
+	assert.Equal(t, true, data["error_omitted"])
 }
 
 func TestRenderExpiredPayload(t *testing.T) {


### PR DESCRIPTION
## Summary

Webhook payloads for failed async jobs now include an inlined `error` field, mirroring the existing `response` inlining behavior for completed jobs. Previously, failed job webhooks had no way to deliver error details inline to subscribers.

## Changes

- Added `error` and `error_omitted` fields to the webhook `eventData` struct and the example envelope struct, following the same pattern as `response`/`response_omitted`.
- `renderPayload` now checks `job.Error` when `includeResponse` is enabled: if the error fits within `maxResponseBytes` it is inlined as `error`; if it exceeds the limit, `error_omitted` is set to `true` so the receiver knows to fetch it separately.
- Added a `testFailedAsyncJob` helper and `TestRenderPayloadIncludeError` test covering inline delivery, the `includeResponse` toggle gate, and oversized error truncation behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/webhooks/...
```

Verify that a webhook endpoint configured with response inlining enabled receives an `error` field in the payload when a job fails, and that `error_omitted` is set instead when the error body exceeds the configured size limit.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Error bodies may contain upstream provider messages or internal details. The existing `includeResponse` opt-in gate and `maxResponseBytes` size cap apply equally to the new `error` field, limiting unintended exposure of large or sensitive error payloads.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable