### PR TITLE
docs: add `data.error` and `data.error_omitted` webhook fields and update `max_response_payload_kbs` description

### DIFF
--- a/docs/features/webhooks.mdx
+++ b/docs/features/webhooks.mdx
@@ -81,6 +81,8 @@ The body:
 | `data.result_url` | Relative path to fetch the full result. `GET` it through Bifrost with your usual auth, before `result_expires_at`. |
 | `data.response` | The full job response, inlined only when the endpoint sets `include_response` and the response fits `max_response_payload_kbs`. |
 | `data.response_omitted` | `true` when a response was too large to inline; fetch it via `result_url` instead. |
+| `data.error` | The job's error body, inlined only when the endpoint sets `include_response` and it fits `max_response_payload_kbs`. Present only for `async_job.failed`. |
+| `data.error_omitted` | `true` when an error was too large to inline; fetch it via `result_url` instead. |
 | `data.result_expired` | `true` when the job's result was already gone at delivery time — the outcome is known, but there is nothing left to fetch. |
 
 ---
@@ -230,7 +232,7 @@ Each endpoint exposes per-endpoint controls. All are optional and fall back to t
 | `retry_backoff_initial_seconds` | `30` | Delay before the first retry; each further retry doubles it. |
 | `retry_backoff_max_seconds` | `1800` | Cap on the per-retry delay. |
 | `attempt_timeout_seconds` | `10` | End-to-end bound for a single delivery attempt. |
-| `max_response_payload_kbs` | `256` | Cap for inlined responses when `include_response` is set. Oversized responses are omitted and flagged with `response_omitted`. |
+| `max_response_payload_kbs` | `256` | Cap for inlined response/error payloads when `include_response` is set. Oversized values are omitted and flagged with `response_omitted`/`error_omitted`. |
 | `max_concurrent_deliveries` | `10` | Concurrent in-flight deliveries to this endpoint, per node. |
 
 ---

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3636,7 +3636,7 @@
               "max_response_payload_kbs": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Cap for inlined response payloads in KB when include_response is set (default: 256). Oversized responses are omitted and flagged with response_omitted."
+                "description": "Cap for inlined response/error payloads in KB when include_response is set (default: 256). Oversized values are omitted and flagged with response_omitted/error_omitted."
               },
               "max_concurrent_deliveries": {
                 "type": "integer",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1359,7 +1359,7 @@
               "max_response_payload_kbs": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Cap for inlined response payloads in KB when include_response is set (default: 256). Oversized responses are omitted and flagged with response_omitted."
+                "description": "Cap for inlined response/error payloads in KB when include_response is set (default: 256). Oversized values are omitted and flagged with response_omitted/error_omitted."
               },
               "max_concurrent_deliveries": {
                 "type": "integer",


### PR DESCRIPTION
## Summary

Extends webhook payloads for `async_job.failed` events to include the job's error body inline, mirroring the existing `response`/`response_omitted` behavior for successful jobs.

## Changes

- Added `data.error` field to the webhook payload, which inlines the job's error body for `async_job.failed` events when `include_response` is set and the payload fits within `max_response_payload_kbs`.
- Added `data.error_omitted` field, set to `true` when the error body exceeds the size cap, directing consumers to fetch it via `result_url` instead.
- Updated `max_response_payload_kbs` descriptions in the docs, Helm chart schema, and transport config schema to reflect that the cap applies to both response and error payloads, and that oversized values are flagged with `response_omitted` or `error_omitted` accordingly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Trigger an async job that fails and verify the webhook payload delivered to the endpoint includes `data.error` when the error body is within `max_response_payload_kbs`, and `data.error_omitted: true` when it exceeds the cap.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Error bodies may contain sensitive information. Consumers should treat `data.error` with the same care as `data.response` and ensure webhook endpoints are appropriately secured.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable