### PR TITLE
`chore: remove WEBHOOK_EVENT_COLORS and sort events in webhook badges`

### DIFF
--- a/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookDetailsSheet.tsx
@@ -6,14 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { getErrorMessage, useGetWebhookDeliveriesQuery, useRedeliverWebhookDeliveryMutation } from "@/lib/store";
-import {
-	WEBHOOK_EVENT_COLORS,
-	WEBHOOK_TUNING_DEFAULTS,
-	WebhookDelivery,
-	WebhookDeliveryOutcome,
-	WebhookEndpoint,
-	WebhookEvent,
-} from "@/lib/types/webhooks";
+import { WEBHOOK_TUNING_DEFAULTS, WebhookDelivery, WebhookDeliveryOutcome, WebhookEndpoint, WebhookEvent } from "@/lib/types/webhooks";
 import { format, formatDistanceToNow } from "date-fns";
 import { ChevronDown, ChevronLeft, ChevronRight, Info, Loader2, RefreshCcw, Send } from "lucide-react";
 import { Fragment, useEffect, useMemo, useState } from "react";
@@ -227,7 +220,7 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 							value={
 								<div className="flex flex-wrap gap-1">
 									{endpoint?.events.map((event) => (
-										<Badge key={event} variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[event]}`}>
+										<Badge key={event} variant="outline" className="font-mono text-xs">
 											{event}
 										</Badge>
 									))}
@@ -401,7 +394,7 @@ export function WebhookDetailsSheet({ endpoint, isTesting, canManage, onTest, on
 													)}
 												</TableCell>
 												<TableCell className="whitespace-nowrap">
-													<Badge variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[latest.event]}`}>
+													<Badge variant="outline" className="font-mono text-xs">
 														{latest.event}
 													</Badge>
 												</TableCell>

--- a/ui/app/workspace/webhooks/views/webhooksView.tsx
+++ b/ui/app/workspace/webhooks/views/webhooksView.tsx
@@ -23,7 +23,7 @@ import {
 	useTestWebhookEndpointMutation,
 	useUpdateWebhookEndpointMutation,
 } from "@/lib/store";
-import { WEBHOOK_EVENT_COLORS, WEBHOOK_EVENTS, WebhookEndpoint, WebhookEndpointRequest, WebhookEvent } from "@/lib/types/webhooks";
+import { WEBHOOK_EVENTS, WebhookEndpoint, WebhookEndpointRequest, WebhookEvent } from "@/lib/types/webhooks";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { ChevronLeft, ChevronRight, MoreHorizontal, PencilIcon, Plus, RotateCcw, Trash2 } from "lucide-react";
@@ -381,8 +381,8 @@ export default function WebhooksView() {
 											</TableCell>
 											<TableCell>
 												<div className="flex flex-wrap gap-1">
-													{endpoint.events.map((event) => (
-														<Badge key={event} variant="outline" className={`font-mono text-xs ${WEBHOOK_EVENT_COLORS[event]}`}>
+													{[...endpoint.events].sort().map((event) => (
+														<Badge key={event} variant="outline" className="font-mono text-xs">
 															{event}
 														</Badge>
 													))}

--- a/ui/lib/types/webhooks.ts
+++ b/ui/lib/types/webhooks.ts
@@ -117,13 +117,6 @@ export interface RedeliverWebhookResponse {
 	webhook_id: string;
 }
 
-// Soft tints for event badges, matching the delivery-outcome color language
-// (green = completed/delivered, red = failed).
-export const WEBHOOK_EVENT_COLORS: Record<WebhookEvent, string> = {
-	"async_job.completed": "bg-green-100 text-green-800",
-	"async_job.failed": "bg-red-100 text-red-800",
-};
-
 // Delivery worker defaults, shown as placeholders for unset (0) knobs.
 export const WEBHOOK_TUNING_DEFAULTS = {
 	max_retries: 4,


### PR DESCRIPTION
## Summary

Removes color-coded styling from webhook event badges and replaces it with a uniform unstyled appearance. Previously, event badges used green/red tints to mirror delivery outcome colors, but this coupling was misleading and unnecessary.

## Changes

- Removed the `WEBHOOK_EVENT_COLORS` constant and its usage across the webhook details sheet and webhooks list view — event badges now render without background color tints
- Events in the webhooks list view are now sorted alphabetically before rendering for consistent display order

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Webhooks section of the workspace and verify:
1. Event badges on the webhook list view appear without green/red background tints and are sorted alphabetically
2. Event badges in the webhook details sheet (both the endpoint info section and the delivery history table) appear without color tints

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Event badges were tinted green (`bg-green-100 text-green-800`) or red (`bg-red-100 text-red-800`) based on event type.

After: All event badges render with a plain outline style regardless of event type.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable