### PR TITLE
feat: add content disabled message on logs UI

### DIFF
--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -210,7 +210,7 @@ type Log struct {
 	IsLargePayloadRequest   bool      `gorm:"default:false" json:"is_large_payload_request"`
 	IsLargePayloadResponse  bool      `gorm:"default:false" json:"is_large_payload_response"`
 	HasObject               bool      `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
-	ContentHidden           bool      `gorm:"default:false" json:"content_hidden"` // True when the payload is retained in object storage but must never be served back through the API/UI
+	ContentHidden           bool      `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
 
 	RedactionData          *schemas.RedactionData        `gorm:"-" json:"-"`                           // Transient guardrail redaction data consumed by enterprise logstore wrappers
 	RedactionMapping       string                        `gorm:"type:text" json:"-"`                   // Reversible redaction mapping (encrypted when an encryption key is set), written by enterprise logstore wrappers; deleted with the row

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1392,7 +1392,9 @@ drainQueue:
 // Multiple entries per traceID are supported (e.g. fallback/retry attempts within the same trace).
 func (p *LoggerPlugin) storeOrEnqueueEntry(ctx *schemas.BifrostContext, entry *logstore.Log, callback func(entry *logstore.Log)) {
 	policy := p.resolveContentPolicy(ctx)
-	entry.ContentHidden = policy.hidden
+	// ContentHidden marks entries whose content the API/UI never serves back —
+	// both the retained-in-object-storage case and the dropped-entirely case.
+	entry.ContentHidden = !policy.visible()
 	// Redaction mappings exist to reveal redacted content on permitted UI
 	// reads; hidden entries serve no content back, so attach only when the
 	// content is actually visible.

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1691,7 +1691,12 @@ export function LogDetailView({
 				</TabsList>
 
 				<TabsContent value="messages" className="space-y-4">
-					<div className="flex justify-end">
+					{log.content_hidden && (
+						<div className="text-muted-foreground rounded-sm border border-dashed p-5 text-center text-sm">
+							Content logging has been disabled for this request.
+						</div>
+					)}
+					<div className={cn("flex justify-end", log.content_hidden && "hidden")}>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
 								<button

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -580,6 +580,7 @@ export interface LogEntry {
 	created_at: string; // ISO string format from Go time.Time - when the log was first created
 	raw_request?: string; // Raw provider request
 	raw_response?: string; // Raw provider response
+	content_hidden?: boolean; // true when content logging was disabled for this request, so no content is served back
 	is_large_payload_request?: boolean; // true if request used large payload streaming
 	is_large_payload_response?: boolean; // true if response used large payload streaming
 	passthrough_request_body?: string; // Raw passthrough request body (UTF-8)


### PR DESCRIPTION
## Summary

When content logging is disabled for a request, the `ContentHidden` flag should reflect that the payload was never retained — not just that it was retained but must be hidden. This PR corrects the semantics of `ContentHidden` to cover both cases (payload dropped entirely, or payload retained but never served back), and surfaces this state clearly in the UI.

## Changes

- Updated the `ContentHidden` field comment to accurately describe its meaning: it is `true` whenever content logging was disabled, regardless of whether the payload was stored in object storage or dropped entirely.
- Changed the assignment of `ContentHidden` from `policy.hidden` to `!policy.visible()` so the flag correctly captures all non-visible content states.
- Added `content_hidden` to the `LogEntry` TypeScript type.
- Added a UI banner in the log detail view's messages tab that displays when `content_hidden` is `true`, informing the user that content logging was disabled for the request. The copy/export controls are hidden in this state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a route or policy with content logging disabled.
2. Send a request through that route.
3. Open the log detail view for that request in the UI.
4. Verify the messages tab shows the "Content logging has been disabled for this request." banner and that the copy/export controls are not visible.
5. Confirm that logs for routes with content logging enabled are unaffected.

```sh
go test ./...

cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

**Before:** No indication in the UI that content logging was disabled; the messages tab appeared empty or showed no controls.

**After:** A clearly labeled banner with a `Ban` icon is shown in the messages tab when `content_hidden` is `true`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change ensures that when content logging is explicitly disabled, the UI never attempts to render or expose payload content, reducing the risk of inadvertently surfacing sensitive data through the log detail view.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable