### PR TITLE
chore: disable Docker Hub Helm chart push step

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -158,8 +158,8 @@ jobs:
         run: |
           helm push helm-charts/bifrost-${{ steps.chart-version.outputs.version }}.tgz oci://ghcr.io/maximhq/helm-charts
 
-      - name: Push Helm chart as OCI artifact to Docker Hub
-        if: steps.check-release.outputs.exists == 'false'
-        continue-on-error: true
-        run: |
-          helm push helm-charts/bifrost-${{ steps.chart-version.outputs.version }}.tgz oci://registry-1.docker.io/maximhq
+      # - name: Push Helm chart as OCI artifact to Docker Hub
+      #   if: steps.check-release.outputs.exists == 'false'
+      #   continue-on-error: true
+      #   run: |
+      #     helm push helm-charts/bifrost-${{ steps.chart-version.outputs.version }}.tgz oci://registry-1.docker.io/maximhq


### PR DESCRIPTION
## Summary

Disables the Helm chart push step targeting Docker Hub by commenting it out, as it is no longer needed or is causing issues in the release pipeline.

## Changes

- Commented out the "Push Helm chart as OCI artifact to Docker Hub" step in the Helm release workflow, leaving only the GitHub Container Registry (GHCR) push active.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a Helm release and verify the chart is pushed only to `ghcr.io/maximhq/helm-charts` and that no attempt is made to push to Docker Hub.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable