### PR TITLE
cherrypick anyOf, oneOf change back in dev

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,5 @@
+[fix]: OpenAI Responses - preserve JSON schema key order in structured-output requests [@georg-wolflein](https://github.com/georg-wolflein)
+  - breaking: a non-schema scalar (string/number/array) at the nested `text.format.schema.schema` position now fails request decode; boolean schemas (`"schema": true` / `"schema": false`) and objects still decode and are forwarded
 - feat: track Anthropic extended-thinking tokens as `ReasoningTokens` across chat, responses, and passthrough
 - feat: added Wafer AI provider
 - feat: added toggle for always retaining content in object storage

--- a/core/internal/llmtests/structured_outputs.go
+++ b/core/internal/llmtests/structured_outputs.go
@@ -441,7 +441,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 			typeStr := "object"
-			props := structuredOutputSchema["properties"].(map[string]interface{})
+			props := schemas.OrderedMapFromMap(structuredOutputSchema["properties"].(map[string]interface{}))
 			additionalProps := structuredOutputSchema["additionalProperties"].(bool)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
@@ -455,7 +455,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 							Name: bifrost.Ptr("decision_schema"),
 							JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 								Type:       &typeStr,
-								Properties: &props,
+								Properties: props,
 								Required:   structuredOutputSchema["required"].([]string),
 								AdditionalProperties: &schemas.AdditionalPropertiesStruct{
 									AdditionalPropertiesBool: &additionalProps,
@@ -572,7 +572,7 @@ func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifros
 		}
 
 		typeStr := "object"
-		props := structuredOutputSchema["properties"].(map[string]interface{})
+		props := schemas.OrderedMapFromMap(structuredOutputSchema["properties"].(map[string]interface{}))
 		additionalProps := structuredOutputSchema["additionalProperties"].(bool)
 		request := &schemas.BifrostResponsesRequest{
 			Provider: testConfig.Provider,
@@ -586,7 +586,7 @@ func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifros
 						Name: bifrost.Ptr("decision_schema"),
 						JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 							Type:       &typeStr,
-							Properties: &props,
+							Properties: props,
 							Required:   structuredOutputSchema["required"].([]string),
 							AdditionalProperties: &schemas.AdditionalPropertiesStruct{
 								AdditionalPropertiesBool: &additionalProps,

--- a/core/providers/anthropic/responses_test.go
+++ b/core/providers/anthropic/responses_test.go
@@ -20,7 +20,7 @@ func makeResponsesTextFormat(schemaName string) *schemas.ResponsesTextConfig {
 			Name: schemas.Ptr(schemaName),
 			JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 				Type:       schemas.Ptr("object"),
-				Properties: &properties,
+				Properties: schemas.OrderedMapFromMap(properties),
 				Required:   []string{"color", "animal"},
 			},
 		},

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -1926,10 +1927,11 @@ func convertChatResponseFormatToTool(ctx *schemas.BifrostContext, params *schema
 		toolName = "json_response"
 	}
 
-	schemaObj, ok := jsonSchemaObj["schema"].(map[string]interface{})
+	schemaOrdered, ok := schemas.SafeExtractOrderedMap(jsonSchemaObj["schema"])
 	if !ok {
 		return nil
 	}
+	schemaObj := schemaOrdered.ToMap() // shallow: nested OrderedMap values keep their order
 
 	// Extract description from schema if available
 	description := "Returns structured JSON output"
@@ -2897,88 +2899,153 @@ func normalizeSchemaForAnthropic(schema map[string]interface{}) map[string]inter
 	}
 
 	// Recursively normalize properties
-	if properties, ok := schema["properties"].(map[string]interface{}); ok {
+	switch properties := schema["properties"].(type) {
+	case map[string]interface{}:
 		newProps := make(map[string]interface{})
 		for key, prop := range properties {
-			if propMap, ok := prop.(map[string]interface{}); ok {
-				newProps[key] = normalizeSchemaForAnthropic(propMap)
-			} else {
-				newProps[key] = prop
-			}
+			newProps[key] = normalizeSchemaValueForAnthropic(prop)
 		}
+		normalized["properties"] = newProps
+	case *schemas.OrderedMap:
+		newProps := schemas.NewOrderedMapWithCapacity(properties.Len())
+		properties.Range(func(key string, prop interface{}) bool {
+			newProps.Set(key, normalizeSchemaValueForAnthropic(prop))
+			return true
+		})
+		normalized["properties"] = newProps
+	case schemas.OrderedMap:
+		newProps := schemas.NewOrderedMapWithCapacity(properties.Len())
+		properties.Range(func(key string, prop interface{}) bool {
+			newProps.Set(key, normalizeSchemaValueForAnthropic(prop))
+			return true
+		})
 		normalized["properties"] = newProps
 	}
 
 	// Recursively normalize items (for arrays)
-	if items, ok := schema["items"].(map[string]interface{}); ok {
-		normalized["items"] = normalizeSchemaForAnthropic(items)
+	switch schema["items"].(type) {
+	case map[string]interface{}, *schemas.OrderedMap, schemas.OrderedMap:
+		normalized["items"] = normalizeSchemaValueForAnthropic(schema["items"])
 	}
 
-	// Recursively normalize anyOf
-	if anyOf, ok := schema["anyOf"].([]interface{}); ok {
-		newAnyOf := make([]interface{}, 0, len(anyOf))
-		for _, item := range anyOf {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				newAnyOf = append(newAnyOf, normalizeSchemaForAnthropic(itemMap))
-			} else {
-				newAnyOf = append(newAnyOf, item)
-			}
+	// Recursively normalize composition fields (anyOf, oneOf, allOf), which may
+	// be []interface{} (JSON-decoded) or []schemas.OrderedMap (typed struct fields).
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		switch schema[key].(type) {
+		case []interface{}, []schemas.OrderedMap:
+			normalized[key] = normalizeSchemaValueForAnthropic(schema[key])
 		}
-		normalized["anyOf"] = newAnyOf
-	}
-
-	// Recursively normalize oneOf
-	if oneOf, ok := schema["oneOf"].([]interface{}); ok {
-		newOneOf := make([]interface{}, 0, len(oneOf))
-		for _, item := range oneOf {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				newOneOf = append(newOneOf, normalizeSchemaForAnthropic(itemMap))
-			} else {
-				newOneOf = append(newOneOf, item)
-			}
-		}
-		normalized["oneOf"] = newOneOf
-	}
-
-	// Recursively normalize allOf
-	if allOf, ok := schema["allOf"].([]interface{}); ok {
-		newAllOf := make([]interface{}, 0, len(allOf))
-		for _, item := range allOf {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				newAllOf = append(newAllOf, normalizeSchemaForAnthropic(itemMap))
-			} else {
-				newAllOf = append(newAllOf, item)
-			}
-		}
-		normalized["allOf"] = newAllOf
 	}
 
 	// Recursively normalize definitions/defs
-	if definitions, ok := schema["definitions"].(map[string]interface{}); ok {
+	switch definitions := schema["definitions"].(type) {
+	case map[string]interface{}:
 		newDefs := make(map[string]interface{})
 		for key, def := range definitions {
-			if defMap, ok := def.(map[string]interface{}); ok {
-				newDefs[key] = normalizeSchemaForAnthropic(defMap)
-			} else {
-				newDefs[key] = def
-			}
+			newDefs[key] = normalizeSchemaValueForAnthropic(def)
 		}
+		normalized["definitions"] = newDefs
+	case *schemas.OrderedMap:
+		newDefs := schemas.NewOrderedMapWithCapacity(definitions.Len())
+		definitions.Range(func(key string, def interface{}) bool {
+			newDefs.Set(key, normalizeSchemaValueForAnthropic(def))
+			return true
+		})
+		normalized["definitions"] = newDefs
+	case schemas.OrderedMap:
+		newDefs := schemas.NewOrderedMapWithCapacity(definitions.Len())
+		definitions.Range(func(key string, def interface{}) bool {
+			newDefs.Set(key, normalizeSchemaValueForAnthropic(def))
+			return true
+		})
 		normalized["definitions"] = newDefs
 	}
 
-	if defs, ok := schema["$defs"].(map[string]interface{}); ok {
+	switch defs := schema["$defs"].(type) {
+	case map[string]interface{}:
 		newDefs := make(map[string]interface{})
 		for key, def := range defs {
-			if defMap, ok := def.(map[string]interface{}); ok {
-				newDefs[key] = normalizeSchemaForAnthropic(defMap)
-			} else {
-				newDefs[key] = def
-			}
+			newDefs[key] = normalizeSchemaValueForAnthropic(def)
 		}
+		normalized["$defs"] = newDefs
+	case *schemas.OrderedMap:
+		newDefs := schemas.NewOrderedMapWithCapacity(defs.Len())
+		defs.Range(func(key string, def interface{}) bool {
+			newDefs.Set(key, normalizeSchemaValueForAnthropic(def))
+			return true
+		})
+		normalized["$defs"] = newDefs
+	case schemas.OrderedMap:
+		newDefs := schemas.NewOrderedMapWithCapacity(defs.Len())
+		defs.Range(func(key string, def interface{}) bool {
+			newDefs.Set(key, normalizeSchemaValueForAnthropic(def))
+			return true
+		})
 		normalized["$defs"] = newDefs
 	}
 
 	return normalized
+}
+
+// normalizeSchemaValueForAnthropic applies normalizeSchemaForAnthropic to a schema
+// value that may be a plain map or an order-preserving OrderedMap; other values
+// pass through unchanged.
+func normalizeSchemaValueForAnthropic(v interface{}) interface{} {
+	switch tv := v.(type) {
+	case []interface{}:
+		out := make([]interface{}, len(tv))
+		for i, item := range tv {
+			out[i] = normalizeSchemaValueForAnthropic(item)
+		}
+		return out
+	case []schemas.OrderedMap:
+		out := make([]schemas.OrderedMap, len(tv))
+		for i := range tv {
+			if normalized := normalizeOrderedSchemaForAnthropic(&tv[i]); normalized != nil {
+				out[i] = *normalized
+			} else {
+				out[i] = tv[i]
+			}
+		}
+		return out
+	case map[string]interface{}:
+		return normalizeSchemaForAnthropic(tv)
+	case *schemas.OrderedMap:
+		return normalizeOrderedSchemaForAnthropic(tv)
+	case schemas.OrderedMap:
+		if normalized := normalizeOrderedSchemaForAnthropic(&tv); normalized != nil {
+			return *normalized
+		}
+		return tv
+	}
+	return v
+}
+
+// normalizeOrderedSchemaForAnthropic runs normalizeSchemaForAnthropic over an
+// OrderedMap schema while preserving the original key order. Keys added by
+// normalization (e.g. anyOf replacing a union type) are appended after the
+// original keys in sorted order for determinism.
+func normalizeOrderedSchemaForAnthropic(om *schemas.OrderedMap) *schemas.OrderedMap {
+	if om == nil {
+		return nil
+	}
+	normalized := normalizeSchemaForAnthropic(om.ToMap())
+	out := schemas.NewOrderedMapWithCapacity(om.Len())
+	for _, key := range om.Keys() {
+		if value, ok := normalized[key]; ok {
+			out.Set(key, value)
+			delete(normalized, key)
+		}
+	}
+	added := make([]string, 0, len(normalized))
+	for key := range normalized {
+		added = append(added, key)
+	}
+	sort.Strings(added)
+	for _, key := range added {
+		out.Set(key, normalized[key])
+	}
+	return out
 }
 
 // convertChatResponseFormatToAnthropicOutputFormat converts OpenAI Chat Completions response_format
@@ -3031,10 +3098,9 @@ func convertChatResponseFormatToAnthropicOutputFormat(responseFormat *interface{
 		"type": formatType,
 	}
 
-	if schema, ok := jsonSchemaObj["schema"].(map[string]interface{}); ok {
+	if schema, ok := schemas.SafeExtractOrderedMap(jsonSchemaObj["schema"]); ok {
 		// Normalize the schema to handle type arrays like ["string", "null"]
-		normalizedSchema := normalizeSchemaForAnthropic(schema)
-		outputFormat["schema"] = normalizedSchema
+		outputFormat["schema"] = normalizeOrderedSchemaForAnthropic(schema)
 	}
 
 	result, err := providerUtils.MarshalSorted(outputFormat)
@@ -3149,11 +3215,13 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 		return nil
 	}
 
-	// Unmarshal to map
-	var formatMap map[string]interface{}
-	if err := sonic.Unmarshal(outputFormat, &formatMap); err != nil {
+	// Unmarshal into an OrderedMap so nested schema objects keep the client's
+	// key order (a plain map would lose it before it can be preserved).
+	var formatOrdered schemas.OrderedMap
+	if err := sonic.Unmarshal(outputFormat, &formatOrdered); err != nil {
 		return nil
 	}
+	formatMap := formatOrdered.ToMap() // shallow: nested values stay ordered
 
 	// Extract type
 	formatType, ok := formatMap["type"].(string)
@@ -3172,16 +3240,17 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 		format.Name = schemas.Ptr("output_format")
 	}
 
-	// Extract schema if present
-	if schemaMap, ok := formatMap["schema"].(map[string]interface{}); ok {
+	// Extract schema if present (an *OrderedMap after the ordered decode)
+	if schemaOrdered, ok := schemas.SafeExtractOrderedMap(formatMap["schema"]); ok {
+		schemaMap := schemaOrdered.ToMap() // shallow: nested values stay ordered
 		jsonSchema := &schemas.ResponsesTextConfigFormatJSONSchema{}
 
 		if schemaType, ok := schemaMap["type"].(string); ok {
 			jsonSchema.Type = &schemaType
 		}
 
-		if properties, ok := schemaMap["properties"].(map[string]interface{}); ok {
-			jsonSchema.Properties = &properties
+		if properties, ok := schemas.SafeExtractOrderedMap(schemaMap["properties"]); ok {
+			jsonSchema.Properties = properties
 		}
 
 		if required, ok := schemaMap["required"].([]interface{}); ok {
@@ -3214,13 +3283,13 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 		}
 
 		// Extract $defs (JSON Schema draft 2019-09+)
-		if defs, ok := schemaMap["$defs"].(map[string]interface{}); ok {
-			jsonSchema.Defs = &defs
+		if defs, ok := schemas.SafeExtractOrderedMap(schemaMap["$defs"]); ok {
+			jsonSchema.Defs = defs
 		}
 
 		// Extract definitions (legacy JSON Schema draft-07)
-		if definitions, ok := schemaMap["definitions"].(map[string]interface{}); ok {
-			jsonSchema.Definitions = &definitions
+		if definitions, ok := schemas.SafeExtractOrderedMap(schemaMap["definitions"]); ok {
+			jsonSchema.Definitions = definitions
 		}
 
 		// Extract $ref
@@ -3229,8 +3298,8 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 		}
 
 		// Extract items (array element schema)
-		if items, ok := schemaMap["items"].(map[string]interface{}); ok {
-			jsonSchema.Items = &items
+		if items, ok := schemas.SafeExtractOrderedMap(schemaMap["items"]); ok {
+			jsonSchema.Items = items
 		}
 
 		// Extract minItems
@@ -3245,10 +3314,10 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 
 		// Extract anyOf
 		if anyOf, ok := schemaMap["anyOf"].([]interface{}); ok {
-			anyOfMaps := make([]map[string]any, 0, len(anyOf))
+			anyOfMaps := make([]schemas.OrderedMap, 0, len(anyOf))
 			for _, item := range anyOf {
-				if m, ok := item.(map[string]interface{}); ok {
-					anyOfMaps = append(anyOfMaps, m)
+				if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+					anyOfMaps = append(anyOfMaps, *om)
 				}
 			}
 			if len(anyOfMaps) > 0 {
@@ -3258,10 +3327,10 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 
 		// Extract oneOf
 		if oneOf, ok := schemaMap["oneOf"].([]interface{}); ok {
-			oneOfMaps := make([]map[string]any, 0, len(oneOf))
+			oneOfMaps := make([]schemas.OrderedMap, 0, len(oneOf))
 			for _, item := range oneOf {
-				if m, ok := item.(map[string]interface{}); ok {
-					oneOfMaps = append(oneOfMaps, m)
+				if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+					oneOfMaps = append(oneOfMaps, *om)
 				}
 			}
 			if len(oneOfMaps) > 0 {
@@ -3271,10 +3340,10 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat json.RawMess
 
 		// Extract allOf
 		if allOf, ok := schemaMap["allOf"].([]interface{}); ok {
-			allOfMaps := make([]map[string]any, 0, len(allOf))
+			allOfMaps := make([]schemas.OrderedMap, 0, len(allOf))
 			for _, item := range allOf {
-				if m, ok := item.(map[string]interface{}); ok {
-					allOfMaps = append(allOfMaps, m)
+				if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+					allOfMaps = append(allOfMaps, *om)
 				}
 			}
 			if len(allOfMaps) > 0 {

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -614,9 +614,9 @@ func TestConvertResponsesTextConfigToAnthropicOutputFormatPreservesSchemaRefs(t 
 			Type: "json_schema",
 			JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 				Type:       &schemaType,
-				Properties: &properties,
+				Properties: schemas.OrderedMapFromMap(properties),
 				Required:   []string{"record"},
-				Defs:       &defs,
+				Defs:       schemas.OrderedMapFromMap(defs),
 			},
 		},
 	})
@@ -679,9 +679,9 @@ func TestConvertResponsesTextConfigToAnthropicOutputFormatPreservesLegacyDefinit
 			Type: "json_schema",
 			JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 				Type:        &schemaType,
-				Properties:  &properties,
+				Properties:  schemas.OrderedMapFromMap(properties),
 				Required:    []string{"record"},
-				Definitions: &definitions,
+				Definitions: schemas.OrderedMapFromMap(definitions),
 			},
 		},
 	})
@@ -3951,5 +3951,56 @@ func TestResponsesStream_TerminalChunkCarriesServedModifiers(t *testing.T) {
 	}
 	if finalResp.Usage.InputTokensDetails == nil || finalResp.Usage.InputTokensDetails.CachedWriteTokens != 44667 {
 		t.Fatal("terminal billed chunk missing cache-creation tokens")
+	}
+}
+
+// TestConvertChatResponseFormatToTool_OrderedMapSchema verifies the
+// Responses→Chat fallback path: mux's ToChatRequest builds response_format with
+// OrderedMap-valued schema fields (order-preserving), and the structured-output
+// tool conversion must handle them rather than silently dropping the schema.
+func TestConvertChatResponseFormatToTool_OrderedMapSchema(t *testing.T) {
+	props := schemas.NewOrderedMapFromPairs(
+		schemas.KV("type", map[string]interface{}{"const": "text"}),
+		schemas.KV("text", map[string]interface{}{"type": []interface{}{"string", "integer"}}),
+	)
+	// The schema arrives as an OrderedMap (mux's ToChatRequest emits the
+	// order-preserving form of the client's Responses schema).
+	schemaOM := schemas.NewOrderedMapFromPairs(
+		schemas.KV("type", "object"),
+		schemas.KV("properties", props),
+		schemas.KV("required", []string{"type", "text"}),
+	)
+	var responseFormat interface{} = map[string]interface{}{
+		"type": "json_schema",
+		"json_schema": map[string]interface{}{
+			"name":   "reply",
+			"schema": schemaOM,
+		},
+	}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	tool := convertChatResponseFormatToTool(ctx, &schemas.ChatParameters{ResponseFormat: &responseFormat})
+	if tool == nil {
+		t.Fatal("OrderedMap-valued schema must not be dropped")
+	}
+	if tool.InputSchema == nil || tool.InputSchema.Properties == nil {
+		t.Fatal("expected input schema with properties")
+	}
+	keys := tool.InputSchema.Properties.Keys()
+	if !reflect.DeepEqual(keys, []string{"type", "text"}) {
+		t.Fatalf("property order must be preserved through the fallback conversion, got %v", keys)
+	}
+
+	// The recursion must descend into OrderedMap values: Anthropic does not
+	// accept multi-type arrays, so ["string","integer"] must become anyOf.
+	textProp, ok := tool.InputSchema.Properties.Get("text")
+	if !ok {
+		t.Fatal("text property missing")
+	}
+	normalizedText, ok := schemas.SafeExtractOrderedMap(textProp)
+	if !ok {
+		t.Fatalf("text property should be a schema object, got %T", textProp)
+	}
+	if _, hasAnyOf := normalizedText.Get("anyOf"); !hasAnyOf {
+		t.Fatal("nested multi-type union must be normalized to anyOf (recursion must descend into OrderedMap values)")
 	}
 }

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -2640,7 +2640,7 @@ func TestGuardrailTraceResponseRoundTrip(t *testing.T) {
 }
 
 func TestToBedrockResponsesRequest_AnthropicTextFormatUsesOutputConfig(t *testing.T) {
-	schemaObj := any(schemas.NewOrderedMapFromPairs(
+	schemaObj := schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),
 		schemas.KV("properties", schemas.NewOrderedMapFromPairs(
 			schemas.KV("topic", schemas.NewOrderedMapFromPairs(
@@ -2648,7 +2648,7 @@ func TestToBedrockResponsesRequest_AnthropicTextFormatUsesOutputConfig(t *testin
 			)),
 		)),
 		schemas.KV("required", []string{"topic"}),
-	))
+	)
 
 	req := &schemas.BifrostResponsesRequest{
 		Model: "bedrock/anthropic.claude-3-sonnet-20240229-v1:0",
@@ -2658,7 +2658,7 @@ func TestToBedrockResponsesRequest_AnthropicTextFormatUsesOutputConfig(t *testin
 					Type: "json_schema",
 					Name: schemas.Ptr("classification"),
 					JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-						Schema: &schemaObj,
+						Schema: &schemas.JSONSchemaOrBool{SchemaMap: schemaObj},
 					},
 				},
 			},
@@ -2686,7 +2686,7 @@ func TestToBedrockResponsesRequest_AnthropicTextFormatUsesOutputConfig(t *testin
 }
 
 func TestToBedrockResponsesRequest_NonAnthropicTextFormatStillUsesToolConversion(t *testing.T) {
-	schemaObj := any(schemas.NewOrderedMapFromPairs(
+	schemaObj := schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),
 		schemas.KV("properties", schemas.NewOrderedMapFromPairs(
 			schemas.KV("topic", schemas.NewOrderedMapFromPairs(
@@ -2694,7 +2694,7 @@ func TestToBedrockResponsesRequest_NonAnthropicTextFormatStillUsesToolConversion
 			)),
 		)),
 		schemas.KV("required", []string{"topic"}),
-	))
+	)
 
 	req := &schemas.BifrostResponsesRequest{
 		Model: "bedrock/amazon.nova-pro-v1:0",
@@ -2704,7 +2704,7 @@ func TestToBedrockResponsesRequest_NonAnthropicTextFormatStillUsesToolConversion
 					Type: "json_schema",
 					Name: schemas.Ptr("classification"),
 					JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-						Schema: &schemaObj,
+						Schema: &schemas.JSONSchemaOrBool{SchemaMap: schemaObj},
 					},
 				},
 			},
@@ -2729,7 +2729,7 @@ func TestToBedrockResponsesRequest_NonAnthropicTextFormatStillUsesToolConversion
 }
 
 func TestToBedrockResponsesRequest_NonAnthropicTextFormatPreservedWithUserTools(t *testing.T) {
-	schemaObj := any(schemas.NewOrderedMapFromPairs(
+	schemaObj := schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),
 		schemas.KV("properties", schemas.NewOrderedMapFromPairs(
 			schemas.KV("topic", schemas.NewOrderedMapFromPairs(
@@ -2737,7 +2737,7 @@ func TestToBedrockResponsesRequest_NonAnthropicTextFormatPreservedWithUserTools(
 			)),
 		)),
 		schemas.KV("required", []string{"topic"}),
-	))
+	)
 
 	toolParams := schemas.ToolFunctionParameters{
 		Type: "object",
@@ -2756,7 +2756,7 @@ func TestToBedrockResponsesRequest_NonAnthropicTextFormatPreservedWithUserTools(
 					Type: "json_schema",
 					Name: schemas.Ptr("classification"),
 					JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-						Schema: &schemaObj,
+						Schema: &schemas.JSONSchemaOrBool{SchemaMap: schemaObj},
 					},
 				},
 			},
@@ -3849,7 +3849,7 @@ func TestBedrockAnthropicChatStructuredOutputUsesSyntheticTool(t *testing.T) {
 // (`client.messages.create`), routed via /v1/messages -> ToBifrostResponsesRequest
 // -> ToBedrockResponsesRequest with Params.Text.Format set.
 func TestToBedrockResponsesRequest_AnthropicStructuredOutputUsesSyntheticTool(t *testing.T) {
-	schemaObj := any(schemas.NewOrderedMapFromPairs(
+	schemaObj := schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),
 		schemas.KV("properties", schemas.NewOrderedMapFromPairs(
 			schemas.KV("isNewTopic", schemas.NewOrderedMapFromPairs(schemas.KV("type", "boolean"))),
@@ -3857,7 +3857,7 @@ func TestToBedrockResponsesRequest_AnthropicStructuredOutputUsesSyntheticTool(t 
 			schemas.KV("result", schemas.NewOrderedMapFromPairs(schemas.KV("type", "number"))),
 		)),
 		schemas.KV("required", []string{"isNewTopic", "title", "result"}),
-	))
+	)
 
 	req := &schemas.BifrostResponsesRequest{
 		Model: "anthropic.claude-opus-4-7-v1:0",
@@ -3867,7 +3867,7 @@ func TestToBedrockResponsesRequest_AnthropicStructuredOutputUsesSyntheticTool(t 
 					Type: "json_schema",
 					Name: schemas.Ptr("classification"),
 					JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-						Schema: &schemaObj,
+						Schema: &schemas.JSONSchemaOrBool{SchemaMap: schemaObj},
 					},
 				},
 			},
@@ -5446,13 +5446,13 @@ func TestBedrockNonLlamaChatStructuredOutputForcesToolChoice(t *testing.T) {
 // rather than Params.ResponseFormat, but lands at the same Bedrock Converse
 // constraint: toolChoice.tool is rejected on Llama.
 func TestToBedrockResponsesRequest_LlamaStructuredOutputOmitsForcedToolChoice(t *testing.T) {
-	schemaObj := any(schemas.NewOrderedMapFromPairs(
+	schemaObj := schemas.NewOrderedMapFromPairs(
 		schemas.KV("type", "object"),
 		schemas.KV("properties", schemas.NewOrderedMapFromPairs(
 			schemas.KV("intent", schemas.NewOrderedMapFromPairs(schemas.KV("type", "string"))),
 		)),
 		schemas.KV("required", []string{"intent"}),
-	))
+	)
 
 	req := &schemas.BifrostResponsesRequest{
 		Model: "us.meta.llama4-maverick-17b-instruct-v1:0",
@@ -5462,7 +5462,7 @@ func TestToBedrockResponsesRequest_LlamaStructuredOutputOmitsForcedToolChoice(t 
 					Type: "json_schema",
 					Name: schemas.Ptr("PlannerOutput"),
 					JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
-						Schema: &schemaObj,
+						Schema: &schemas.JSONSchemaOrBool{SchemaMap: schemaObj},
 					},
 				},
 			},

--- a/core/providers/cohere/utils.go
+++ b/core/providers/cohere/utils.go
@@ -260,7 +260,9 @@ func convertResponseFormatToCohere(responseFormat *interface{}) *CohereResponseF
 		// Extract the nested schema
 		// OpenAI format: { type: "json_schema", json_schema: { name: "X", strict: true, schema: {...} } }
 		if jsonSchemaWrapper, ok := formatMap["json_schema"].(map[string]interface{}); ok {
-			if schema, ok := jsonSchemaWrapper["schema"].(map[string]interface{}); ok {
+			// The schema may be a plain map or an order-preserving OrderedMap
+			// (e.g. when built from a Responses request).
+			if schema, ok := schemas.SafeExtractOrderedMap(jsonSchemaWrapper["schema"]); ok {
 				var schemaInterface interface{} = schema
 				cohereFormat.JSONSchema = &schemaInterface
 			}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -1378,10 +1378,12 @@ func TestStructuredOutputConversion(t *testing.T) {
 				require.Len(t, anyOfSlice, 2, "anyOf should have 2 branches for string and integer")
 
 				// Verify the anyOf branches
-				stringBranch := anyOfSlice[0].(map[string]interface{})
+				stringBranch, ok := asPlainMap(t, anyOfSlice[0])
+				require.True(t, ok, "anyOf branch should be a map")
 				assert.Equal(t, "string", stringBranch["type"])
 
-				integerBranch := anyOfSlice[1].(map[string]interface{})
+				integerBranch, ok := asPlainMap(t, anyOfSlice[1])
+				require.True(t, ok, "anyOf branch should be a map")
 				assert.Equal(t, "integer", integerBranch["type"])
 
 				// Validate status property - should remain unchanged
@@ -1422,9 +1424,12 @@ func TestStructuredOutputConversion(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
-				schemaMap := result.GenerationConfig.ResponseJSONSchema.(map[string]interface{})
-				properties := schemaMap["properties"].(map[string]interface{})
-				name := properties["name"].(map[string]interface{})
+				schemaMap, ok := asPlainMap(t, result.GenerationConfig.ResponseJSONSchema)
+				require.True(t, ok, "ResponseJSONSchema should be a map")
+				properties, ok := asPlainMap(t, schemaMap["properties"])
+				require.True(t, ok, "properties should be a map")
+				name, ok := asPlainMap(t, properties["name"])
+				require.True(t, ok, "name should be a map")
 
 				// Nullable types should be kept as array (Gemini supports this)
 				typeVal := name["type"]
@@ -1667,6 +1672,25 @@ func TestStructuredOutputWithToolsConflict(t *testing.T) {
 }
 
 // TestResponsesStructuredOutputConversion tests that Responses API text config with union types is properly handled
+
+// asPlainMap normalizes schema objects that may be either plain maps or
+// order-preserving OrderedMaps (schema fields preserve client key order).
+func asPlainMap(t *testing.T, v interface{}) (map[string]interface{}, bool) {
+	t.Helper()
+	switch m := v.(type) {
+	case map[string]interface{}:
+		return m, true
+	case *schemas.OrderedMap:
+		if m == nil {
+			return nil, false
+		}
+		return m.ToMap(), true
+	case schemas.OrderedMap:
+		return m.ToMap(), true
+	}
+	return nil, false
+}
+
 func TestResponsesStructuredOutputConversion(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1694,7 +1718,7 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 							Name: schemas.Ptr("UserInfo"),
 							JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 								Type: schemas.Ptr("object"),
-								Properties: &map[string]interface{}{
+								Properties: schemas.OrderedMapFromMap(map[string]interface{}{
 									"user_id": map[string]interface{}{
 										"type":        []interface{}{"string", "integer"},
 										"description": "User ID as string or integer",
@@ -1703,7 +1727,7 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 										"type": "string",
 										"enum": []interface{}{"active", "inactive"},
 									},
-								},
+								}),
 								Required: []string{"user_id", "status"},
 								AdditionalProperties: &schemas.AdditionalPropertiesStruct{
 									AdditionalPropertiesBool: schemas.Ptr(false),
@@ -1719,14 +1743,14 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 				assert.NotNil(t, result.GenerationConfig.ResponseJSONSchema)
 
 				// Validate the schema structure
-				schemaMap, ok := result.GenerationConfig.ResponseJSONSchema.(map[string]interface{})
+				schemaMap, ok := asPlainMap(t, result.GenerationConfig.ResponseJSONSchema)
 				require.True(t, ok, "ResponseJSONSchema should be a map")
 
-				properties, ok := schemaMap["properties"].(map[string]interface{})
+				properties, ok := asPlainMap(t, schemaMap["properties"])
 				require.True(t, ok, "properties should be a map")
 
 				// Validate user_id property - should be converted to anyOf
-				userID, ok := properties["user_id"].(map[string]interface{})
+				userID, ok := asPlainMap(t, properties["user_id"])
 				require.True(t, ok, "user_id should exist in properties")
 
 				// user_id should have anyOf instead of type array
@@ -1738,10 +1762,12 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 				require.Len(t, anyOfSlice, 2, "anyOf should have 2 branches for string and integer")
 
 				// Verify the anyOf branches
-				stringBranch := anyOfSlice[0].(map[string]interface{})
+				stringBranch, ok := asPlainMap(t, anyOfSlice[0])
+				require.True(t, ok, "anyOf branch should be a map")
 				assert.Equal(t, "string", stringBranch["type"])
 
-				integerBranch := anyOfSlice[1].(map[string]interface{})
+				integerBranch, ok := asPlainMap(t, anyOfSlice[1])
+				require.True(t, ok, "anyOf branch should be a map")
 				assert.Equal(t, "integer", integerBranch["type"])
 			},
 		},
@@ -1766,20 +1792,23 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 							Name: schemas.Ptr("NullableData"),
 							JSONSchema: &schemas.ResponsesTextConfigFormatJSONSchema{
 								Type: schemas.Ptr("object"),
-								Properties: &map[string]interface{}{
+								Properties: schemas.OrderedMapFromMap(map[string]interface{}{
 									"name": map[string]interface{}{
 										"type": []interface{}{"string", "null"},
 									},
-								},
+								}),
 							},
 						},
 					},
 				},
 			},
 			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
-				schemaMap := result.GenerationConfig.ResponseJSONSchema.(map[string]interface{})
-				properties := schemaMap["properties"].(map[string]interface{})
-				name := properties["name"].(map[string]interface{})
+				schemaMap, ok := asPlainMap(t, result.GenerationConfig.ResponseJSONSchema)
+				require.True(t, ok, "ResponseJSONSchema should be a map")
+				properties, ok := asPlainMap(t, schemaMap["properties"])
+				require.True(t, ok, "properties should be a map")
+				name, ok := asPlainMap(t, properties["name"])
+				require.True(t, ok, "name should be a map")
 
 				// Nullable types should be kept as array (Gemini supports this)
 				typeVal := name["type"]

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2786,55 +2786,50 @@ func convertTextConfigToGenerationConfig(textConfig *schemas.ResponsesTextConfig
 
 // reconstructSchemaFromJSONSchema rebuilds a schema map from ResponsesTextConfigFormatJSONSchema
 func reconstructSchemaFromJSONSchema(jsonSchema *schemas.ResponsesTextConfigFormatJSONSchema) interface{} {
-	var schema map[string]interface{}
-
 	if jsonSchema.Schema != nil {
-		// If Schema field is set, use it directly
-		schemaMap, ok := (*jsonSchema.Schema).(map[string]interface{})
-		if !ok {
-			return *jsonSchema.Schema
-		}
-		schema = schemaMap
-	} else {
-		// New format: Schema is spread across individual fields
-		schema = make(map[string]interface{})
+		// If Schema field is set, use it directly. Normalize via the
+		// OrderedMap-aware path so the client's key order survives end-to-end.
+		return normalizeSchemaValueForGemini(jsonSchema.Schema)
+	}
 
-		if jsonSchema.Defs != nil {
-			schema["$defs"] = *jsonSchema.Defs
-		}
+	// New format: Schema is spread across individual fields
+	schema := make(map[string]interface{})
 
-		if jsonSchema.Type != nil {
-			schema["type"] = *jsonSchema.Type
-		}
+	if jsonSchema.Defs != nil {
+		schema["$defs"] = *jsonSchema.Defs
+	}
 
-		if jsonSchema.Properties != nil {
-			schema["properties"] = *jsonSchema.Properties
-		}
+	if jsonSchema.Type != nil {
+		schema["type"] = *jsonSchema.Type
+	}
 
-		if len(jsonSchema.Required) > 0 {
-			schema["required"] = jsonSchema.Required
-		}
+	if jsonSchema.Properties != nil {
+		schema["properties"] = *jsonSchema.Properties
+	}
 
-		if jsonSchema.Description != nil {
-			schema["description"] = *jsonSchema.Description
-		}
+	if len(jsonSchema.Required) > 0 {
+		schema["required"] = jsonSchema.Required
+	}
 
-		if jsonSchema.AdditionalProperties != nil {
-			schema["additionalProperties"] = *jsonSchema.AdditionalProperties
-		}
+	if jsonSchema.Description != nil {
+		schema["description"] = *jsonSchema.Description
+	}
 
-		if jsonSchema.Name != nil {
-			schema["title"] = *jsonSchema.Name
-		}
+	if jsonSchema.AdditionalProperties != nil {
+		schema["additionalProperties"] = *jsonSchema.AdditionalProperties
+	}
 
-		if len(jsonSchema.PropertyOrdering) > 0 {
-			schema["propertyOrdering"] = jsonSchema.PropertyOrdering
-		}
+	if jsonSchema.Name != nil {
+		schema["title"] = *jsonSchema.Name
+	}
 
-		// Return nil if no fields were populated
-		if len(schema) == 0 {
-			return nil
-		}
+	if len(jsonSchema.PropertyOrdering) > 0 {
+		schema["propertyOrdering"] = jsonSchema.PropertyOrdering
+	}
+
+	// Return nil if no fields were populated
+	if len(schema) == 0 {
+		return nil
 	}
 
 	// Normalize the schema for Gemini compatibility (handle union types, etc.)

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -2286,8 +2287,8 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 	}
 
 	// Extract properties
-	if properties, ok := normalizedSchemaMap["properties"].(map[string]interface{}); ok {
-		jsonSchema.Properties = &properties
+	if properties, ok := schemas.SafeExtractOrderedMap(normalizedSchemaMap["properties"]); ok {
+		jsonSchema.Properties = properties
 	}
 
 	// Extract required fields
@@ -2331,13 +2332,13 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 	}
 
 	// Extract $defs (JSON Schema draft 2019-09+)
-	if defs, ok := normalizedSchemaMap["$defs"].(map[string]interface{}); ok {
-		jsonSchema.Defs = &defs
+	if defs, ok := schemas.SafeExtractOrderedMap(normalizedSchemaMap["$defs"]); ok {
+		jsonSchema.Defs = defs
 	}
 
 	// Extract definitions (legacy JSON Schema draft-07)
-	if definitions, ok := normalizedSchemaMap["definitions"].(map[string]interface{}); ok {
-		jsonSchema.Definitions = &definitions
+	if definitions, ok := schemas.SafeExtractOrderedMap(normalizedSchemaMap["definitions"]); ok {
+		jsonSchema.Definitions = definitions
 	}
 
 	// Extract $ref
@@ -2346,8 +2347,8 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 	}
 
 	// Extract items (array element schema)
-	if items, ok := normalizedSchemaMap["items"].(map[string]interface{}); ok {
-		jsonSchema.Items = &items
+	if items, ok := schemas.SafeExtractOrderedMap(normalizedSchemaMap["items"]); ok {
+		jsonSchema.Items = items
 	}
 
 	// Extract minItems
@@ -2362,10 +2363,10 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 
 	// Extract anyOf
 	if anyOf, ok := normalizedSchemaMap["anyOf"].([]interface{}); ok {
-		anyOfMaps := make([]map[string]any, 0, len(anyOf))
+		anyOfMaps := make([]schemas.OrderedMap, 0, len(anyOf))
 		for _, item := range anyOf {
-			if m, ok := item.(map[string]interface{}); ok {
-				anyOfMaps = append(anyOfMaps, m)
+			if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+				anyOfMaps = append(anyOfMaps, *om)
 			}
 		}
 		if len(anyOfMaps) > 0 {
@@ -2375,10 +2376,10 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 
 	// Extract oneOf
 	if oneOf, ok := normalizedSchemaMap["oneOf"].([]interface{}); ok {
-		oneOfMaps := make([]map[string]any, 0, len(oneOf))
+		oneOfMaps := make([]schemas.OrderedMap, 0, len(oneOf))
 		for _, item := range oneOf {
-			if m, ok := item.(map[string]interface{}); ok {
-				oneOfMaps = append(oneOfMaps, m)
+			if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+				oneOfMaps = append(oneOfMaps, *om)
 			}
 		}
 		if len(oneOfMaps) > 0 {
@@ -2388,10 +2389,10 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 
 	// Extract allOf
 	if allOf, ok := normalizedSchemaMap["allOf"].([]interface{}); ok {
-		allOfMaps := make([]map[string]any, 0, len(allOf))
+		allOfMaps := make([]schemas.OrderedMap, 0, len(allOf))
 		for _, item := range allOf {
-			if m, ok := item.(map[string]interface{}); ok {
-				allOfMaps = append(allOfMaps, m)
+			if om, ok := schemas.SafeExtractOrderedMap(item); ok {
+				allOfMaps = append(allOfMaps, *om)
 			}
 		}
 		if len(allOfMaps) > 0 {
@@ -2481,11 +2482,20 @@ func buildOpenAIResponseFormat(responseJsonSchema interface{}, responseSchema *S
 
 	// Try to use responseJsonSchema first
 	if responseJsonSchema != nil {
-		// Use responseJsonSchema directly if it's a map
-		var ok bool
-		schemaMap, ok = responseJsonSchema.(map[string]interface{})
-		if !ok {
-			// If not a map, fall back to json_object mode
+		// The schema may be a plain map or an order-preserving OrderedMap
+		// (e.g. when extracted from a Responses request).
+		switch tv := responseJsonSchema.(type) {
+		case map[string]interface{}:
+			schemaMap = tv
+		case *schemas.OrderedMap:
+			if tv != nil {
+				schemaMap = tv.ToMap() // shallow: nested OrderedMap values keep their order
+			}
+		case schemas.OrderedMap:
+			schemaMap = tv.ToMap()
+		}
+		if schemaMap == nil {
+			// Unsupported shape - fall back to json_object mode
 			return &schemas.ResponsesTextConfig{
 				Format: &schemas.ResponsesTextConfigFormat{
 					Type: "json_object",
@@ -2639,55 +2649,112 @@ func normalizeSchemaForGemini(schema map[string]interface{}) map[string]interfac
 	}
 
 	// Recursively normalize properties
-	if properties, ok := schema["properties"].(map[string]interface{}); ok {
+	switch properties := schema["properties"].(type) {
+	case map[string]interface{}:
 		newProps := make(map[string]interface{})
 		for key, prop := range properties {
-			if propMap, ok := prop.(map[string]interface{}); ok {
-				newProps[key] = normalizeSchemaForGemini(propMap)
-			} else {
-				newProps[key] = prop
-			}
+			newProps[key] = normalizeSchemaValueForGemini(prop)
 		}
+		normalized["properties"] = newProps
+	case *schemas.OrderedMap:
+		newProps := schemas.NewOrderedMapWithCapacity(properties.Len())
+		properties.Range(func(key string, prop interface{}) bool {
+			newProps.Set(key, normalizeSchemaValueForGemini(prop))
+			return true
+		})
+		normalized["properties"] = newProps
+	case schemas.OrderedMap:
+		newProps := schemas.NewOrderedMapWithCapacity(properties.Len())
+		properties.Range(func(key string, prop interface{}) bool {
+			newProps.Set(key, normalizeSchemaValueForGemini(prop))
+			return true
+		})
 		normalized["properties"] = newProps
 	}
 
 	// Recursively normalize items (for arrays)
-	if items, ok := schema["items"].(map[string]interface{}); ok {
-		normalized["items"] = normalizeSchemaForGemini(items)
+	switch schema["items"].(type) {
+	case map[string]interface{}, *schemas.OrderedMap, schemas.OrderedMap:
+		normalized["items"] = normalizeSchemaValueForGemini(schema["items"])
 	}
 
-	// Recursively normalize anyOf
-	if anyOf, ok := schema["anyOf"].([]interface{}); ok {
-		newAnyOf := make([]interface{}, 0, len(anyOf))
-		for _, item := range anyOf {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				newAnyOf = append(newAnyOf, normalizeSchemaForGemini(itemMap))
-			} else {
-				newAnyOf = append(newAnyOf, item)
-			}
+	// Recursively normalize composition fields (anyOf, oneOf, allOf), which may
+	// be []interface{} (JSON-decoded) or []schemas.OrderedMap (typed struct fields).
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		switch schema[key].(type) {
+		case []interface{}, []schemas.OrderedMap:
+			normalized[key] = normalizeSchemaValueForGemini(schema[key])
 		}
-		normalized["anyOf"] = newAnyOf
-	}
-
-	// Recursively normalize oneOf
-	if oneOf, ok := schema["oneOf"].([]interface{}); ok {
-		newOneOf := make([]interface{}, 0, len(oneOf))
-		for _, item := range oneOf {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				newOneOf = append(newOneOf, normalizeSchemaForGemini(itemMap))
-			} else {
-				newOneOf = append(newOneOf, item)
-			}
-		}
-		normalized["oneOf"] = newOneOf
 	}
 
 	return normalized
 }
 
-// extractSchemaMapFromResponseFormat extracts the JSON schema map from OpenAI's response_format structure
-// This returns the raw schema map to be used with ResponseJSONSchema
-func extractSchemaMapFromResponseFormat(responseFormat *interface{}) map[string]interface{} {
+// normalizeSchemaValueForGemini applies normalizeSchemaForGemini to a schema
+// value that may be a plain map or an order-preserving OrderedMap; other values
+// pass through unchanged.
+func normalizeSchemaValueForGemini(v interface{}) interface{} {
+	switch tv := v.(type) {
+	case []interface{}:
+		out := make([]interface{}, len(tv))
+		for i, item := range tv {
+			out[i] = normalizeSchemaValueForGemini(item)
+		}
+		return out
+	case []schemas.OrderedMap:
+		out := make([]schemas.OrderedMap, len(tv))
+		for i := range tv {
+			if normalized := normalizeOrderedSchemaForGemini(&tv[i]); normalized != nil {
+				out[i] = *normalized
+			} else {
+				out[i] = tv[i]
+			}
+		}
+		return out
+	case map[string]interface{}:
+		return normalizeSchemaForGemini(tv)
+	case *schemas.OrderedMap:
+		return normalizeOrderedSchemaForGemini(tv)
+	case schemas.OrderedMap:
+		if normalized := normalizeOrderedSchemaForGemini(&tv); normalized != nil {
+			return *normalized
+		}
+		return tv
+	}
+	return v
+}
+
+// normalizeOrderedSchemaForGemini runs normalizeSchemaForGemini over an
+// OrderedMap schema while preserving the original key order. Keys added by
+// normalization (e.g. anyOf replacing a union type) are appended after the
+// original keys in sorted order for determinism.
+func normalizeOrderedSchemaForGemini(om *schemas.OrderedMap) *schemas.OrderedMap {
+	if om == nil {
+		return nil
+	}
+	normalized := normalizeSchemaForGemini(om.ToMap())
+	out := schemas.NewOrderedMapWithCapacity(om.Len())
+	for _, key := range om.Keys() {
+		if value, ok := normalized[key]; ok {
+			out.Set(key, value)
+			delete(normalized, key)
+		}
+	}
+	added := make([]string, 0, len(normalized))
+	for key := range normalized {
+		added = append(added, key)
+	}
+	sort.Strings(added)
+	for _, key := range added {
+		out.Set(key, normalized[key])
+	}
+	return out
+}
+
+// extractSchemaMapFromResponseFormat extracts the JSON schema from OpenAI's response_format
+// structure. The schema may be a plain map or an order-preserving OrderedMap (e.g. when built
+// from a Responses request); the result is used with ResponseJSONSchema.
+func extractSchemaMapFromResponseFormat(responseFormat *interface{}) interface{} {
 	formatMap, ok := (*responseFormat).(map[string]interface{})
 	if !ok {
 		return nil
@@ -2708,13 +2775,12 @@ func extractSchemaMapFromResponseFormat(responseFormat *interface{}) map[string]
 		return nil
 	}
 
-	schemaMap, ok := schemaObj.(map[string]interface{})
-	if !ok {
-		return nil
+	switch schemaObj.(type) {
+	case map[string]interface{}, *schemas.OrderedMap, schemas.OrderedMap:
+		// Normalize the schema for Gemini compatibility
+		return normalizeSchemaValueForGemini(schemaObj)
 	}
-
-	// Normalize the schema for Gemini compatibility
-	return normalizeSchemaForGemini(schemaMap)
+	return nil
 }
 
 // extractFunctionResponseOutput extracts the output text from a FunctionResponse.

--- a/core/providers/openai/payload_ordering_test.go
+++ b/core/providers/openai/payload_ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"mime/multipart"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -119,3 +120,44 @@ func TestParseImageVariationFormDataBodyFromRequest_OrdersMetadataBeforeFile(t *
 	)
 }
 
+
+// TestPayloadOrdering_ResponsesTextFormatJSONSchema guards against JSON-schema
+// key reordering on the Responses passthrough path. Structured-output generation
+// is sensitive to the literal property order of `text.format.schema`: OpenAI
+// models fill fields / pick union branches following schema key order, so
+// decoding schema objects into plain Go maps and re-marshaling them sorted
+// (alphabetized) measurably degrades output quality (e.g. union-of-parts outputs
+// collapsing to citation-only responses).
+//
+// The schema's top-level keys map to typed struct fields (emitted in struct
+// field order); everything nested — properties, $defs, items, anyOf bodies,
+// i.e. where property order actually shapes generation — must round-trip in
+// the client's original key order via OrderedMap.
+func TestPayloadOrdering_ResponsesTextFormatJSONSchema(t *testing.T) {
+	// Deliberately non-alphabetical key order everywhere: "type" precedes
+	// "text"/"url"/"items" etc. — alphabetical sorting would reorder all of them.
+	schemaJSON := `{"type":"object","properties":{"parts":{"type":"array","items":{"anyOf":[{"$ref":"#/$defs/TextPart"},{"$ref":"#/$defs/WebCitation"}]}}},"required":["parts"],"additionalProperties":false,"$defs":{"TextPart":{"type":"object","properties":{"type":{"const":"text"},"text":{"type":"string"}},"required":["type","text"],"additionalProperties":false},"WebCitation":{"type":"object","properties":{"type":{"const":"cite:web"},"url":{"type":"string"}},"required":["type","url"],"additionalProperties":false}}}`
+	rawBody := `{"model":"gpt-4o","input":"hi","text":{"format":{"type":"json_schema","name":"final_output","schema":` + schemaJSON + `,"strict":true}}}`
+
+	var req OpenAIResponsesRequest
+	require.NoError(t, sonic.Unmarshal([]byte(rawBody), &req), "decode request")
+	require.NotNil(t, req.Text)
+	require.NotNil(t, req.Text.Format)
+	require.NotNil(t, req.Text.Format.JSONSchema)
+
+	marshaled, err := providerUtils.MarshalSorted(&req)
+	require.NoError(t, err)
+
+	// Top-level schema keys re-serialize in struct field order; all nested
+	// objects must keep the client's original (non-alphabetical) key order.
+	goldenSchema := `{"additionalProperties":false,"properties":{"parts":{"type":"array","items":{"anyOf":[{"$ref":"#/$defs/TextPart"},{"$ref":"#/$defs/WebCitation"}]}}},"required":["parts"],"type":"object","$defs":{"TextPart":{"type":"object","properties":{"type":{"const":"text"},"text":{"type":"string"}},"required":["type","text"],"additionalProperties":false},"WebCitation":{"type":"object","properties":{"type":{"const":"cite:web"},"url":{"type":"string"}},"required":["type","url"],"additionalProperties":false}}}`
+	assert.Contains(t, string(marshaled), `"schema":`+goldenSchema,
+		"nested schema key order changed — if intentional, update the golden string")
+
+	// Determinism: repeated marshals must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(&req)
+		require.NoError(t, err)
+		assert.Equal(t, string(marshaled), string(iter), "non-deterministic marshal on iteration %d", i)
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -140,6 +140,39 @@ func GetJSONField(data []byte, path string) gjson.Result {
 	return gjson.GetBytes(data, path)
 }
 
+// GetJSONSubtree extracts a JSON sub-tree as raw bytes by gjson path, without parsing the
+// entire document. Returns nil if the path does not exist. The returned slice is a copy
+// of the matched sub-tree bytes — safe to retain after the input is mutated or released.
+func GetJSONSubtree(data []byte, path string) []byte {
+	res := gjson.GetBytes(data, path)
+	if !res.Exists() {
+		return nil
+	}
+	raw := res.Raw
+	if raw == "" {
+		return nil
+	}
+	out := make([]byte, len(raw))
+	copy(out, raw)
+	return out
+}
+
+// UnmarshalOrdered decodes JSON bytes into a *schemas.OrderedMap, preserving the key order
+// of the source document. Use this in preference to sonic.Unmarshal into a map[string]any
+// whenever the caller cares about field order (e.g., LLM prompt-cache keying or property
+// ordering surfaced to users).
+//
+// Note: the decoder under the hood is encoding/json (not sonic), because token-by-token
+// decoding is required to preserve key order. Outer dispatch goes through sonic, which
+// invokes OrderedMap's custom UnmarshalJSON.
+func UnmarshalOrdered(data []byte) (*schemas.OrderedMap, error) {
+	om := schemas.NewOrderedMap()
+	if err := sonic.Unmarshal(data, om); err != nil {
+		return nil, err
+	}
+	return om, nil
+}
+
 // logger is the global logger for the provider utils (thread-safe via atomic.Pointer).
 var logger atomic.Pointer[schemas.Logger]
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -976,10 +976,12 @@ func TestToResponsesRequest_NoResponseFormat(t *testing.T) {
 }
 
 func TestToChatRequest_TextFormat_JSONSchema(t *testing.T) {
-	schema := map[string]interface{}{
-		"type":     "object",
-		"required": []interface{}{"country"},
-	}
+	// "type" before "required" is non-alphabetical on purpose: a regression to
+	// sorted marshaling would reorder them and fail the exact-bytes assertion below.
+	schema := NewOrderedMapFromPairs(
+		KV("type", "object"),
+		KV("required", []interface{}{"country"}),
+	)
 	rr := &BifrostResponsesRequest{
 		Params: &ResponsesParameters{
 			Text: &ResponsesTextConfig{
@@ -988,7 +990,7 @@ func TestToChatRequest_TextFormat_JSONSchema(t *testing.T) {
 					Name:        Ptr("CityInfo"),
 					Description: Ptr("City schema"),
 					Strict:      Ptr(true),
-					JSONSchema:  &ResponsesTextConfigFormatJSONSchema{Schema: func() *any { v := any(schema); return &v }()},
+					JSONSchema:  &ResponsesTextConfigFormatJSONSchema{Schema: &JSONSchemaOrBool{SchemaMap: schema}},
 				},
 			},
 		},
@@ -1020,6 +1022,13 @@ func TestToChatRequest_TextFormat_JSONSchema(t *testing.T) {
 	}
 	if jsObj["schema"] == nil {
 		t.Fatal("expected schema to be set")
+	}
+	schemaBytes, err := MarshalSorted(jsObj["schema"])
+	if err != nil {
+		t.Fatalf("failed to marshal schema: %v", err)
+	}
+	if want := `{"type":"object","required":["country"]}`; string(schemaBytes) != want {
+		t.Fatalf("schema key order not preserved: want %s, got %s", want, string(schemaBytes))
 	}
 }
 
@@ -1156,7 +1165,12 @@ func TestToResponsesRequest_JSONSchema_NoDoubleNesting(t *testing.T) {
 // ResponsesTextConfigFormatJSONSchema (Schema==nil), ToChatRequest still
 // produces a valid response_format with a non-empty json_schema.schema body.
 func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
-	props := map[string]any{"name": map[string]any{"type": "string"}}
+	// "zip" before "age" is non-alphabetical on purpose: a regression to sorted
+	// marshaling would reorder them and fail the exact-bytes assertion below.
+	props := NewOrderedMapFromPairs(
+		KV("zip", map[string]any{"type": "string"}),
+		KV("age", map[string]any{"type": "integer"}),
+	)
 	rr := &BifrostResponsesRequest{
 		Params: &ResponsesParameters{
 			Text: &ResponsesTextConfig{
@@ -1167,9 +1181,9 @@ func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
 					// Schema is nil — fields are spread across typed fields (direct client path)
 					JSONSchema: &ResponsesTextConfigFormatJSONSchema{
 						Type:       Ptr("object"),
-						Properties: &props,
-						Required:   []string{"name"},
-						// Schema *any is intentionally nil here
+						Properties: props,
+						Required:   []string{"zip", "age"},
+						// Schema is intentionally nil here
 					},
 				},
 			},
@@ -1203,6 +1217,13 @@ func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
 	}
 	if schemaMap["type"] != "object" {
 		t.Fatalf("expected schema.type=object, got %v", schemaMap["type"])
+	}
+	propsBytes, err := MarshalSorted(schemaMap["properties"])
+	if err != nil {
+		t.Fatalf("failed to marshal properties: %v", err)
+	}
+	if want := `{"zip":{"type":"string"},"age":{"type":"integer"}}`; string(propsBytes) != want {
+		t.Fatalf("properties key order not preserved: want %s, got %s", want, string(propsBytes))
 	}
 }
 

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1,6 +1,7 @@
 package schemas
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -537,30 +538,34 @@ type ResponsesTextConfigFormat struct {
 
 // ResponsesTextConfigFormatJSONSchema represents a JSON schema specification
 // It supports JSON Schema fields used by various providers for structured outputs.
+// Schema-bearing fields use OrderedMap (mirroring ToolFunctionParameters) because
+// structured-output generation is sensitive to JSON schema property order: providers
+// like OpenAI follow the literal key order of the schema, so decoding into plain Go
+// maps (and re-marshaling them sorted) degrades output quality.
 type ResponsesTextConfigFormatJSONSchema struct {
 	Name                 *string                     `json:"name,omitempty"`
-	Schema               *any                        `json:"schema,omitempty"`
+	Schema               *JSONSchemaOrBool           `json:"schema,omitempty"`
 	Description          *string                     `json:"description,omitempty"`
 	Strict               *bool                       `json:"strict,omitempty"`
 	AdditionalProperties *AdditionalPropertiesStruct `json:"additionalProperties,omitempty"`
-	Properties           *map[string]any             `json:"properties,omitempty"`
+	Properties           *OrderedMap                 `json:"properties,omitempty"`
 	Required             []string                    `json:"required,omitempty"`
 	Type                 *string                     `json:"type,omitempty"`
 
 	// JSON Schema definition fields
-	Defs        *map[string]any `json:"$defs,omitempty"`       // JSON Schema draft 2019-09+ definitions
-	Definitions *map[string]any `json:"definitions,omitempty"` // Legacy JSON Schema draft-07 definitions
-	Ref         *string         `json:"$ref,omitempty"`        // Reference to definition
+	Defs        *OrderedMap `json:"$defs,omitempty"`       // JSON Schema draft 2019-09+ definitions
+	Definitions *OrderedMap `json:"definitions,omitempty"` // Legacy JSON Schema draft-07 definitions
+	Ref         *string     `json:"$ref,omitempty"`        // Reference to definition
 
 	// Array schema fields
-	Items    *map[string]any `json:"items,omitempty"`    // Array element schema
-	MinItems *int64          `json:"minItems,omitempty"` // Minimum array length
-	MaxItems *int64          `json:"maxItems,omitempty"` // Maximum array length
+	Items    *OrderedMap `json:"items,omitempty"`    // Array element schema
+	MinItems *int64      `json:"minItems,omitempty"` // Minimum array length
+	MaxItems *int64      `json:"maxItems,omitempty"` // Maximum array length
 
 	// Composition fields (union types)
-	AnyOf []map[string]any `json:"anyOf,omitempty"` // Union types (any of these schemas)
-	OneOf []map[string]any `json:"oneOf,omitempty"` // Exclusive union types (exactly one of these)
-	AllOf []map[string]any `json:"allOf,omitempty"` // Schema intersection (all of these)
+	AnyOf []OrderedMap `json:"anyOf,omitempty"` // Union types (any of these schemas)
+	OneOf []OrderedMap `json:"oneOf,omitempty"` // Exclusive union types (exactly one of these)
+	AllOf []OrderedMap `json:"allOf,omitempty"` // Schema intersection (all of these)
 
 	// String validation fields
 	Format    *string `json:"format,omitempty"`    // String format (email, date, uri, etc.)
@@ -580,19 +585,77 @@ type ResponsesTextConfigFormatJSONSchema struct {
 	PropertyOrdering []string    `json:"propertyOrdering,omitempty"` // Ordering of properties, specific to Gemini
 }
 
+// JSONSchemaOrBool holds a JSON Schema value that is either a boolean schema
+// (true/false, valid per JSON Schema draft 6+) or an object schema with key
+// order preserved. Mirrors AdditionalPropertiesStruct.
+type JSONSchemaOrBool struct {
+	SchemaBool *bool
+	SchemaMap  *OrderedMap
+}
+
+// MarshalJSON implements custom JSON marshalling for JSONSchemaOrBool.
+// It marshals either SchemaBool or SchemaMap based on which is set.
+func (s JSONSchemaOrBool) MarshalJSON() ([]byte, error) {
+	if s.SchemaBool != nil && s.SchemaMap != nil {
+		return nil, fmt.Errorf("both SchemaBool and SchemaMap are set; only one should be non-nil")
+	}
+	if s.SchemaBool != nil {
+		return MarshalSorted(*s.SchemaBool)
+	}
+	if s.SchemaMap != nil {
+		return MarshalSorted(s.SchemaMap)
+	}
+	return nil, fmt.Errorf("schema cannot be null; omit the field instead")
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for JSONSchemaOrBool.
+// It handles both boolean and object JSON Schemas.
+func (s *JSONSchemaOrBool) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		s.SchemaBool = nil
+		s.SchemaMap = nil
+		return nil
+	}
+
+	var boolValue bool
+	if err := Unmarshal(data, &boolValue); err == nil {
+		s.SchemaMap = nil
+		s.SchemaBool = &boolValue
+		return nil
+	}
+
+	var mapValue OrderedMap
+	if err := Unmarshal(data, &mapValue); err == nil {
+		s.SchemaBool = nil
+		s.SchemaMap = &mapValue
+		return nil
+	}
+
+	return fmt.Errorf("schema must be either a boolean or an object")
+}
+
 // JSONSchemaFromMap builds a ResponsesTextConfigFormatJSONSchema from a raw interface{}
 func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
-	m, ok := v.(map[string]interface{})
-	if !ok {
+	var m map[string]interface{}
+	switch src := v.(type) {
+	case map[string]interface{}:
+		m = src
+	case *OrderedMap:
+		if src == nil {
+			return nil
+		}
+		m = src.ToMap() // shallow: nested *OrderedMap values keep their order
+	case OrderedMap:
+		m = src.ToMap()
+	default:
 		return nil
 	}
 	s := &ResponsesTextConfigFormatJSONSchema{}
 	if t, ok := m["type"].(string); ok {
 		s.Type = Ptr(t)
 	}
-	if props, ok := m["properties"].(map[string]interface{}); ok {
-		p := map[string]any(props)
-		s.Properties = &p
+	if props, ok := SafeExtractOrderedMap(m["properties"]); ok {
+		s.Properties = props
 	}
 	if req, ok := m["required"].([]interface{}); ok {
 		strs := make([]string, 0, len(req))
@@ -614,22 +677,19 @@ func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
 	if ref, ok := m["$ref"].(string); ok {
 		s.Ref = Ptr(ref)
 	}
-	if defs, ok := m["$defs"].(map[string]interface{}); ok {
-		d := map[string]any(defs)
-		s.Defs = &d
+	if defs, ok := SafeExtractOrderedMap(m["$defs"]); ok {
+		s.Defs = defs
 	}
-	if defs, ok := m["definitions"].(map[string]interface{}); ok {
-		d := map[string]any(defs)
-		s.Definitions = &d
+	if defs, ok := SafeExtractOrderedMap(m["definitions"]); ok {
+		s.Definitions = defs
 	}
-	if items, ok := m["items"].(map[string]interface{}); ok {
-		it := map[string]any(items)
-		s.Items = &it
+	if items, ok := SafeExtractOrderedMap(m["items"]); ok {
+		s.Items = items
 	}
 	if b, ok := m["additionalProperties"].(bool); ok {
 		s.AdditionalProperties = &AdditionalPropertiesStruct{AdditionalPropertiesBool: Ptr(b)}
-	} else if ap, ok := m["additionalProperties"].(map[string]interface{}); ok {
-		s.AdditionalProperties = &AdditionalPropertiesStruct{AdditionalPropertiesMap: OrderedMapFromMap(ap)}
+	} else if ap, ok := SafeExtractOrderedMap(m["additionalProperties"]); ok {
+		s.AdditionalProperties = &AdditionalPropertiesStruct{AdditionalPropertiesMap: ap}
 	}
 	if f, ok := m["format"].(string); ok {
 		s.Format = Ptr(f)
@@ -649,18 +709,20 @@ func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
 	if n, ok := m["nullable"].(bool); ok {
 		s.Nullable = Ptr(n)
 	}
-	if extractSliceOfMaps := func(key string) []map[string]any {
-		raw, ok := m[key].([]interface{})
-		if !ok {
-			return nil
-		}
-		out := make([]map[string]any, 0, len(raw))
-		for _, item := range raw {
-			if mp, ok := item.(map[string]interface{}); ok {
-				out = append(out, mp)
+	if extractSliceOfMaps := func(key string) []OrderedMap {
+		switch raw := m[key].(type) {
+		case []interface{}:
+			out := make([]OrderedMap, 0, len(raw))
+			for _, item := range raw {
+				if om, ok := SafeExtractOrderedMap(item); ok {
+					out = append(out, *om)
+				}
 			}
+			return out
+		case []OrderedMap:
+			return raw
 		}
-		return out
+		return nil
 	}; true {
 		if ao := extractSliceOfMaps("anyOf"); len(ao) > 0 {
 			s.AnyOf = ao
@@ -716,14 +778,19 @@ func (s *ResponsesTextConfigFormatJSONSchema) ToMap() interface{} {
 		return nil
 	}
 	if s.Schema != nil {
-		return *s.Schema
+		if s.Schema.SchemaMap != nil {
+			return s.Schema.SchemaMap
+		}
+		if s.Schema.SchemaBool != nil {
+			return *s.Schema.SchemaBool
+		}
 	}
 	m := make(map[string]interface{})
 	if s.Type != nil {
 		m["type"] = *s.Type
 	}
 	if s.Properties != nil {
-		m["properties"] = *s.Properties
+		m["properties"] = s.Properties
 	}
 	if len(s.Required) > 0 {
 		m["required"] = s.Required
@@ -738,13 +805,13 @@ func (s *ResponsesTextConfigFormatJSONSchema) ToMap() interface{} {
 		m["$ref"] = *s.Ref
 	}
 	if s.Defs != nil {
-		m["$defs"] = *s.Defs
+		m["$defs"] = s.Defs
 	}
 	if s.Definitions != nil {
-		m["definitions"] = *s.Definitions
+		m["definitions"] = s.Definitions
 	}
 	if s.Items != nil {
-		m["items"] = *s.Items
+		m["items"] = s.Items
 	}
 	if s.AdditionalProperties != nil {
 		if s.AdditionalProperties.AdditionalPropertiesBool != nil {

--- a/plugins/compat/changelog.md
+++ b/plugins/compat/changelog.md
@@ -1,3 +1,4 @@
+[fix]: deep-copy OrderedMap schema fields when cloning Responses text config [@georg-wolflein](https://github.com/georg-wolflein)
 - fix: drop unsupported reasoning summary values for Azure model router
 - fix: use Anthropic endpoints in chat completion and responses for DeepSeek
 - chore: upgraded core to v1.7.2 and framework to v1.5.2

--- a/plugins/compat/requestcopy.go
+++ b/plugins/compat/requestcopy.go
@@ -217,36 +217,36 @@ func cloneResponsesTextConfig(text *schemas.ResponsesTextConfig) *schemas.Respon
 		if text.Format.JSONSchema != nil {
 			jsonSchema := *text.Format.JSONSchema
 			if text.Format.JSONSchema.Schema != nil {
-				schema := cloneAnyValue(*text.Format.JSONSchema.Schema)
-				jsonSchema.Schema = &schema
+				schemaCopy := *text.Format.JSONSchema.Schema
+				if schemaCopy.SchemaBool != nil {
+					schemaCopy.SchemaBool = schemas.Ptr(*schemaCopy.SchemaBool)
+				}
+				schemaCopy.SchemaMap = cloneOrderedMap(schemaCopy.SchemaMap)
+				jsonSchema.Schema = &schemaCopy
 			}
 			if text.Format.JSONSchema.Properties != nil {
-				properties := cloneAnyMap(*text.Format.JSONSchema.Properties)
-				jsonSchema.Properties = &properties
+				jsonSchema.Properties = cloneOrderedMap(text.Format.JSONSchema.Properties)
 			}
 			if text.Format.JSONSchema.Required != nil {
 				jsonSchema.Required = slices.Clone(text.Format.JSONSchema.Required)
 			}
 			if text.Format.JSONSchema.Defs != nil {
-				defs := cloneAnyMap(*text.Format.JSONSchema.Defs)
-				jsonSchema.Defs = &defs
+				jsonSchema.Defs = cloneOrderedMap(text.Format.JSONSchema.Defs)
 			}
 			if text.Format.JSONSchema.Definitions != nil {
-				definitions := cloneAnyMap(*text.Format.JSONSchema.Definitions)
-				jsonSchema.Definitions = &definitions
+				jsonSchema.Definitions = cloneOrderedMap(text.Format.JSONSchema.Definitions)
 			}
 			if text.Format.JSONSchema.Items != nil {
-				items := cloneAnyMap(*text.Format.JSONSchema.Items)
-				jsonSchema.Items = &items
+				jsonSchema.Items = cloneOrderedMap(text.Format.JSONSchema.Items)
 			}
 			if text.Format.JSONSchema.AnyOf != nil {
-				jsonSchema.AnyOf = cloneAnyMapSlice(text.Format.JSONSchema.AnyOf)
+				jsonSchema.AnyOf = cloneOrderedMapSlice(text.Format.JSONSchema.AnyOf)
 			}
 			if text.Format.JSONSchema.OneOf != nil {
-				jsonSchema.OneOf = cloneAnyMapSlice(text.Format.JSONSchema.OneOf)
+				jsonSchema.OneOf = cloneOrderedMapSlice(text.Format.JSONSchema.OneOf)
 			}
 			if text.Format.JSONSchema.AllOf != nil {
-				jsonSchema.AllOf = cloneAnyMapSlice(text.Format.JSONSchema.AllOf)
+				jsonSchema.AllOf = cloneOrderedMapSlice(text.Format.JSONSchema.AllOf)
 			}
 			if text.Format.JSONSchema.Default != nil {
 				jsonSchema.Default = cloneAnyValue(text.Format.JSONSchema.Default)
@@ -358,7 +358,45 @@ func cloneAnyValue(value any) any {
 		cloned := make(map[string]string, len(typed))
 		maps.Copy(cloned, typed)
 		return cloned
+	case *schemas.OrderedMap:
+		return cloneOrderedMap(typed)
+	case schemas.OrderedMap:
+		if cloned := cloneOrderedMap(&typed); cloned != nil {
+			return *cloned
+		}
+		return typed
+	case []schemas.OrderedMap:
+		return cloneOrderedMapSlice(typed)
 	default:
 		return typed
 	}
+}
+
+// cloneOrderedMap deep-copies an OrderedMap, preserving key order and
+// recursively cloning nested values (including nested *OrderedMap).
+func cloneOrderedMap(input *schemas.OrderedMap) *schemas.OrderedMap {
+	if input == nil {
+		return nil
+	}
+
+	cloned := schemas.NewOrderedMapWithCapacity(input.Len())
+	input.Range(func(key string, value any) bool {
+		cloned.Set(key, cloneAnyValue(value))
+		return true
+	})
+	return cloned
+}
+
+func cloneOrderedMapSlice(input []schemas.OrderedMap) []schemas.OrderedMap {
+	if input == nil {
+		return nil
+	}
+
+	cloned := make([]schemas.OrderedMap, len(input))
+	for i := range input {
+		if c := cloneOrderedMap(&input[i]); c != nil {
+			cloned[i] = *c
+		}
+	}
+	return cloned
 }

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -10129,7 +10129,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"contents\": [{\"parts\":[{\"text\":\"What was announced at Google I/O 2026?\"}]}],\n  \"tools\": [{ \"googleSearch\": {} }]\n}"
+                  "raw": "{\n  \"contents\": [{\"parts\":[{\"text\":\"What is the current population of Tokyo? Answer briefly using Google Search.\"}]}],\n  \"tools\": [{ \"googleSearch\": {} }]\n}"
                 },
                 "url": {
                   "raw": "{{baseUrl}}/genai/v1beta/models/{{genaiModel}}:generateContent",
@@ -40082,7 +40082,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"max_tokens\": 300\n}"
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"max_tokens\": 2000\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/chat/completions",
@@ -40135,7 +40135,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"stream\": true,\n  \"max_tokens\": 300\n}"
+              "raw": "{\n  \"model\": \"gemini/gemini-2.5-flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What was a major world news headline this week? Answer in one short sentence, using Google Search for current information.\"\n    }\n  ],\n  \"web_search_options\": {},\n  \"stream\": true,\n  \"max_tokens\": 2000\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/chat/completions",

--- a/tests/e2e/api/runners/run-stream-cancellation.mjs
+++ b/tests/e2e/api/runners/run-stream-cancellation.mjs
@@ -115,11 +115,12 @@ function expectedCost(entry, row) {
   return nonCached * input + cachedRead * cr + cachedWrite * cw + completion * output;
 }
 
-// A streaming cancel is always logged status=error; a non-streaming cancel may finish
-// server-side and log success — accept either for non-stream.
+// A streaming cancel logs status=cancelled (dedicated state since #4831; status=error
+// on older builds); a non-streaming cancel may instead finish server-side and log
+// success — accept any of these for non-stream.
 function statusIsCancelOutcome(status, nonStream) {
-  if (nonStream) return status === "error" || status === "success";
-  return status === "error";
+  if (nonStream) return status === "error" || status === "success" || status === "cancelled";
+  return status === "error" || status === "cancelled";
 }
 
 // Compare the logged cost against the datasheet-recomputed cost. Returns
@@ -397,10 +398,10 @@ if (skipCostCheck) {
         if (!row) {
           r.costCheck = "FAIL"; r.costDetail = `no log row for ${r.requestId}`; costFailures++;
         } else if (!statusIsCancelOutcome(row.status, r.nonStream)) {
-          // A streaming cancel is always logged status=error. A non-streaming cancel may
-          // instead finish the upstream call server-side and log success — either way it
-          // must be billed, so we accept both for non-stream and key the cost rules off
-          // the provider, not the status.
+          // A streaming cancel logs status=cancelled (#4831; error on older builds).
+          // A non-streaming cancel may instead finish the upstream call server-side and
+          // log success — either way it must be billed, so we accept all of these for
+          // non-stream and key the cost rules off the provider, not the status.
           r.costCheck = "FAIL"; r.costDetail = `status=${row.status}, unexpected for ${kind} cancel`; costFailures++;
         } else {
           const cost = Number(row.cost || 0), tokens = Number(row.total_tokens || 0);


### PR DESCRIPTION
## Summary

Schema fields that previously used `*map[string]any` (and `[]map[string]any`) for `Properties`, `Defs`, `Definitions`, `Items`, `AnyOf`, `OneOf`, and `AllOf` on `ResponsesTextConfigFormatJSONSchema` now use `*OrderedMap` and `[]OrderedMap`. This ensures JSON Schema documents are serialized with a deterministic, insertion-order-preserving key order end-to-end — from user input through provider-specific transformations to the wire — rather than the non-deterministic order produced by Go's built-in map type. Closes #5148

## Changes

- `ResponsesTextConfigFormatJSONSchema` fields `Properties`, `Defs`, `Definitions`, and `Items` changed from `*map[string]any` to `*OrderedMap`; `AnyOf`, `OneOf`, and `AllOf` changed from `[]map[string]any` to `[]OrderedMap`.
- All construction sites (tests, `JSONSchemaFromMap`, Anthropic/Gemini utils, compat plugin clone helpers) updated to use `OrderedMapFromMap(...)` or `NewOrderedMap()` instead of bare map literals or pointer-to-map.
- `reconstructSchemaFromJSONSchema` (Gemini responses) rewritten to build an `*OrderedMap` directly, covering all schema fields including previously missing ones (`Definitions`, `Items`, `AnyOf`/`OneOf`/`AllOf`, numeric constraints, `nullable`, `enum`, `propertyOrdering`, etc.).
- `normalizeSchemaForGemini`, `normalizeSchemaTypes`, `buildJSONSchemaFromMap` (renamed to `buildJSONSchemaFromOrderedMap`), `convertPropertyToSchema`, `buildOpenAIResponseFormat`, `extractSchemaMapFromResponseFormat`, and `convertTypeToLowerCase` all updated to operate on `*OrderedMap` instead of `map[string]interface{}`, eliminating JSON round-trips that were silently discarding key order.
- `convertSchemaToOrderedMap` and the new `buildPropertiesOrderedMap` (replacing `convertSchemaToMap`) honor `schema.PropertyOrdering` first, then append remaining keys alphabetically for determinism, with no Marshal/Unmarshal detour.
- `anthropicCollectOrderedMapSlice` and `collectOrderedMapSlice` helpers added to convert `anyOf`/`oneOf`/`allOf` slices into `[]OrderedMap`.
- `asOrderedMap` helper centralizes coercion of `*OrderedMap`, value-form `OrderedMap`, and legacy `map[string]interface{}` into `*OrderedMap`.
- `readResponseFormatType` added to cheaply read the top-level `"type"` field from any supported input form without a full parse.
- `GetJSONSubtree` and `UnmarshalOrdered` added to `providers/utils` for gjson-based sub-tree extraction and order-preserving JSON decoding respectively.
- Gemini tests updated to validate `ResponseJSONSchema` via a Marshal/Unmarshal round-trip rather than a direct type assertion to `map[string]interface{}`, since the value is now `*OrderedMap`.
- `cloneOrderedMap` and `cloneOrderedMapSlice` added to the compat plugin's clone helpers; `cloneAnyValue` extended to handle `*OrderedMap` and value-form `OrderedMap`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
go test ./plugins/...
```

Structured output integration tests (`RunStructuredOutputResponsesTest`, `RunStructuredOutputResponsesStreamTest`) exercise the full path from user-supplied schema through provider serialization. Gemini unit tests (`TestStructuredOutputConversion`, `TestResponsesStructuredOutputConversion`) validate that `ResponseJSONSchema` serializes to the expected JSON object. Anthropic utils tests (`TestConvertResponsesTextConfigToAnthropicOutputFormatPreservesSchemaRefs`, `TestConvertResponsesTextConfigToAnthropicOutputFormatPreservesLegacyDefinitions`) confirm `$defs` and `definitions` round-trip correctly.

## Breaking changes

- [x] Yes
- [ ] No

Any code outside this repository that constructs `ResponsesTextConfigFormatJSONSchema` with `Properties`, `Defs`, `Definitions`, `Items`, `AnyOf`, `OneOf`, or `AllOf` using the old `*map[string]any` / `[]map[string]any` types will need to be updated to use `*OrderedMap` / `[]OrderedMap`. Use `schemas.OrderedMapFromMap(m)` to wrap an existing `map[string]interface{}`.

## Related issues

Prerequisite for stable prompt-cache keying and user-visible property ordering in structured output schemas.

## Security considerations

None. This change affects serialization order only; no auth, secrets, or PII handling is modified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable