### PR TITLE
framework test fixes

### DIFF
--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -28,9 +28,15 @@ import (
 // functions directly.
 var testMigrationLogger = bifrost.NewDefaultLogger(schemas.LogLevelInfo)
 
+// pgTestSchema is this package's dedicated Postgres schema. Test packages
+// (configstore, configstore/tables, logstore) run in parallel against the same
+// database, so each one works in its own schema to avoid clobbering the
+// others' tables and rows.
+const pgTestSchema = "configstore_test"
+
 // postgresDSN matches the postgres service in tests/docker-compose.yml and
 // framework/docker-compose.yml.
-const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable"
+const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable search_path=" + pgTestSchema
 
 // namedDB pairs a backend name with its GORM connection for use in subtests.
 type namedDB struct {
@@ -622,14 +628,17 @@ func trySetupPostgresDBWithoutStoreRawColumn(t *testing.T, testSuffix string) *g
 		return nil
 	}
 
+	// All objects live in this package's dedicated schema (via search_path in
+	// the DSN), isolated from other test packages sharing the same database.
+	if err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + pgTestSchema).Error; err != nil {
+		return nil
+	}
+
 	// Drop config_providers to start fresh (for this specific test).
 	// Use CASCADE to drop dependent objects (composite types, sequences, etc.).
 	db.Exec("DROP TABLE IF EXISTS config_providers CASCADE")
 
-	// Clear migration tracking without dropping the table — other test packages
-	// (e.g. logstore) may share this Postgres instance and use the same table
-	// concurrently.  CREATE IF NOT EXISTS is safe even if the table already
-	// exists from a previous test or a concurrent package.
+	// Clear migration tracking so the migration under test always runs.
 	db.Exec(`CREATE TABLE IF NOT EXISTS migrations (
 		id VARCHAR(255) PRIMARY KEY
 	)`)
@@ -662,8 +671,7 @@ func trySetupPostgresDBWithoutStoreRawColumn(t *testing.T, testSuffix string) *g
 		return nil
 	}
 
-	// Clean up after the test — drop config_providers but leave migrations
-	// intact for concurrent test packages.
+	// Clean up after the test so later tests in this package start fresh.
 	t.Cleanup(func() {
 		db.Exec("DELETE FROM migrations")
 		db.Exec("DROP TABLE IF EXISTS config_providers CASCADE")

--- a/framework/configstore/rdb_deadlock_postgres_test.go
+++ b/framework/configstore/rdb_deadlock_postgres_test.go
@@ -28,8 +28,10 @@ func setupPostgresDeadlockStore(t *testing.T) *RDBConfigStore {
 		t.Skipf("postgres not available: %v", err)
 	}
 
-	require.NoError(t, db.Exec("DROP SCHEMA public CASCADE").Error)
-	require.NoError(t, db.Exec("CREATE SCHEMA public").Error)
+	// Reset only this package's schema — other test packages share the same
+	// database and must not lose their tables.
+	require.NoError(t, db.Exec("DROP SCHEMA IF EXISTS "+pgTestSchema+" CASCADE").Error)
+	require.NoError(t, db.Exec("CREATE SCHEMA "+pgTestSchema).Error)
 	require.NoError(t, triggerMigrations(context.Background(), db, testMigrationLogger))
 
 	store := &RDBConfigStore{logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -1546,9 +1546,15 @@ func TestTableVectorStoreConfig_EncryptionDisabled_StoresPlaintext(t *testing.T)
 // Multi-backend helpers — run the same tests on SQLite and Postgres
 // ============================================================================
 
+// pgTestSchema is this package's dedicated Postgres schema. Test packages
+// (configstore, configstore/tables, logstore) run in parallel against the same
+// database, so each one works in its own schema to avoid clobbering the
+// others' tables and rows.
+const pgTestSchema = "configstore_tables_test"
+
 // postgresDSN matches the postgres service in tests/docker-compose.yml and
 // framework/docker-compose.yml.
-const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable"
+const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable search_path=" + pgTestSchema
 
 // namedDB pairs a backend name with its GORM connection for use in subtests.
 type namedDB struct {
@@ -1584,6 +1590,12 @@ func trySetupPostgresDB(t *testing.T) *gorm.DB {
 		return nil
 	}
 	if err := sqlDB.Ping(); err != nil {
+		return nil
+	}
+
+	// All objects live in this package's dedicated schema (via search_path in
+	// the DSN), isolated from other test packages sharing the same database.
+	if err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + pgTestSchema).Error; err != nil {
 		return nil
 	}
 

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -13,9 +13,15 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// pgTestSchema is this package's dedicated Postgres schema. Test packages
+// (configstore, configstore/tables, logstore) run in parallel against the same
+// database, so each one works in its own schema to avoid clobbering the
+// others' tables and rows.
+const pgTestSchema = "logstore_test"
+
 // postgresDSN matches the postgres service in tests/docker-compose.yml and
 // framework/docker-compose.yml.
-const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable"
+const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable search_path=" + pgTestSchema
 
 // trySetupPostgresDB attempts to connect to Postgres and returns the connection.
 // Returns nil if Postgres is unavailable.
@@ -34,6 +40,12 @@ func trySetupPostgresDB(t *testing.T) *gorm.DB {
 		return nil
 	}
 	if err := sqlDB.Ping(); err != nil {
+		return nil
+	}
+
+	// All objects live in this package's dedicated schema (via search_path in
+	// the DSN), isolated from other test packages sharing the same database.
+	if err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + pgTestSchema).Error; err != nil {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Test packages (`configstore`, `configstore/tables`, and `logstore`) run in parallel against the same Postgres database, which previously caused race conditions where one package's setup/teardown would clobber another's tables. This PR isolates each test package into its own dedicated Postgres schema so they can run concurrently without interfering with each other.

## Changes

- Each test package now defines a `pgTestSchema` constant with a unique schema name (`configstore_test`, `configstore_tables_test`, `logstore_test`) and appends `search_path=<schema>` to its DSN so all DDL and DML is scoped to that schema automatically.
- Each package's setup function now issues `CREATE SCHEMA IF NOT EXISTS <schema>` before running any migrations or table operations.
- The deadlock test in `configstore` was updated to drop and recreate only its own schema instead of the shared `public` schema, preventing it from destroying tables owned by other test packages.
- Cleanup logic and comments that previously worked around cross-package table sharing (e.g., leaving the `migrations` table intact for concurrent packages) were simplified now that each package has full ownership of its own schema.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Start the Postgres dependency
docker-compose -f framework/docker-compose.yml up -d postgres

# Run all affected test packages in parallel to confirm no cross-package interference
go test ./framework/configstore/... ./framework/logstore/... -v -count=1
```

Each package should complete without errors related to missing or unexpectedly modified tables.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are limited to test infrastructure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable