### PR TITLE
docs: clarify `x-bf-async-webhook` opt-in delivery and update async/webhook docs and OpenAPI spec

### DIFF
--- a/docs/features/async-inference.mdx
+++ b/docs/features/async-inference.mdx
@@ -13,7 +13,7 @@ This is a gateway-only feature and is not available in the Go SDK and requires a
 </Note>
 
 <Tip>
-Prefer to be notified instead of polling? Register a [Webhook](/features/webhooks) and Bifrost delivers a signed callback the moment a job completes or fails.
+Prefer to be notified instead of polling? Register a [Webhook](/features/webhooks) endpoint, then name it in the `x-bf-async-webhook` header on submit and Bifrost delivers a signed callback the moment that job completes or fails.
 </Tip>
 
 ## How It Works
@@ -66,6 +66,7 @@ curl -X POST http://localhost:8080/v1/async/chat/completions \
   -H "Content-Type: application/json" \
   -H "x-bf-vk: sk-bf-your-virtual-key" \
   -H "x-bf-async-job-result-ttl: 3600" \
+  -H "x-bf-async-webhook: order-events" \
   -d '{
     "model": "openai/gpt-4o-mini",
     "messages": [
@@ -164,6 +165,15 @@ curl -X GET http://localhost:8080/v1/async/chat/completions/1e89b165-d4fe-49e8-b
 - If the header is invalid or `<= 0`, Bifrost falls back to the default TTL.
 - Expired jobs return `404 Job not found or expired`.
 - Expired async jobs are cleaned up every minute.
+
+## Webhook Notifications
+
+No webhook fires by default, even if you have endpoints registered. Delivery is opt-in per request:
+
+- Pass `x-bf-async-webhook: <endpoint-name>` on the submit request, naming a [Webhook](/features/webhooks) endpoint you already created.
+- The name must resolve to an existing, enabled endpoint, otherwise the submit request itself fails.
+- The endpoint must also be subscribed to `async_job.completed`/`async_job.failed` at the time the job finishes. If it isn't, the submit request still succeeds, but no delivery happens.
+- The header only affects submission; it has no effect on the poll (`GET`) request.
 
 ## Virtual Key Authorization
 

--- a/docs/features/webhooks.mdx
+++ b/docs/features/webhooks.mdx
@@ -6,7 +6,7 @@ icon: "webhook"
 
 ## Overview
 
-Webhooks are the push half of [Async Inference](/features/async-inference). Instead of polling `GET /v1/async/.../{job_id}` until a job reaches a terminal state, register an endpoint once and Bifrost delivers a signed HTTP `POST` the moment the job completes or fails.
+Webhooks are the push half of [Async Inference](/features/async-inference). Instead of polling `GET /v1/async/.../{job_id}` until a job reaches a terminal state, register an endpoint and name it on submit, and Bifrost delivers a signed HTTP `POST` the moment that job completes or fails.
 
 Every delivery is signed in the [Standard Webhooks](https://www.standardwebhooks.com/) format so your receiver can verify it came from your Bifrost instance and was not altered in transit.
 
@@ -43,6 +43,26 @@ sequenceDiagram
 ```
 
 Delivery is **at-least-once**: a failed attempt is retried with exponential backoff, and every attempt for the same event reuses the same `webhook-id`. Your receiver must be idempotent — dedupe on `webhook-id`.
+
+---
+
+## Triggering a Delivery
+
+Registering an endpoint does not, by itself, cause any deliveries. Delivery is opt-in per async job: the submit request must carry an `x-bf-async-webhook` header naming the endpoint to notify.
+
+```bash
+curl -X POST http://localhost:8080/v1/async/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-bf-vk: sk-bf-your-virtual-key" \
+  -H "x-bf-async-webhook: order-events" \
+  -d '{ "model": "openai/gpt-4o-mini", "messages": [...] }'
+```
+
+- The name must resolve to an existing, enabled endpoint. If it doesn't, the submit request itself fails, rather than accepting the job and silently dropping the notification.
+- The endpoint must still be enabled and subscribed to the resulting event (`async_job.completed` or `async_job.failed`) when the job finishes. If it isn't, the job completes normally but no delivery is enqueued.
+- Jobs submitted without the header never trigger a webhook, regardless of how many endpoints are registered.
+
+See [Async Inference](/features/async-inference#webhook-notifications) for the full submit flow.
 
 ---
 

--- a/docs/openapi/paths/inference/async.yaml
+++ b/docs/openapi/paths/inference/async.yaml
@@ -747,9 +747,10 @@ components:
       required: false
       description: |
         Name of a registered webhook endpoint to notify when this job reaches a terminal
-        state (`completed` or `failed`). The endpoint must already exist and be enabled, and
-        must be subscribed to the resulting event; otherwise the submission is rejected with
-        HTTP 400. When omitted, no webhook is sent for the job and results are retrieved by
-        polling. See the Webhooks management API to register endpoints.
+        state (`completed` or `failed`). The endpoint must already exist and be enabled;
+        otherwise the submission is rejected with HTTP 400. If the endpoint is not subscribed
+        to the resulting event, the job still completes normally but no delivery is enqueued.
+        When omitted, no webhook is sent for the job and results are retrieved by polling.
+        See the Webhooks management API to register endpoints.
       schema:
         type: string


### PR DESCRIPTION
## Summary

Clarifies that webhook delivery for async jobs is opt-in per request, not automatic. Previously, the docs implied that registering an endpoint was sufficient for delivery to occur. This PR corrects that by documenting the `x-bf-async-webhook` header as the explicit trigger, and refines the behavior around subscription validation timing.

## Changes

- Updated the async inference tip and webhook overview to state that the endpoint must be named via `x-bf-async-webhook` on the submit request for delivery to occur.
- Added a new "Webhook Notifications" section to `async-inference.mdx` detailing opt-in behavior, validation rules, and header scope.
- Added a new "Triggering a Delivery" section to `webhooks.mdx` with a curl example and clarifying bullet points.
- Corrected the OpenAPI description for `x-bf-async-webhook` to reflect that subscription validation happens at job completion time, not at submission — meaning a missing subscription no longer causes the submit to be rejected, but silently skips delivery instead.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:

1. The async inference page includes the "Webhook Notifications" section with accurate opt-in behavior.
2. The webhooks page includes the "Triggering a Delivery" section with a working curl example.
3. The OpenAPI spec correctly reflects that subscription absence at job completion skips delivery rather than rejecting the submit.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No changes to auth, secrets, or delivery signing behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable