### PR TITLE
vk budget overrides: APIs

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4473,6 +4473,45 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 	return nil
 }
 
+// UpdateBudgetOverride atomically updates only override columns so concurrent usage changes are preserved.
+func (s *RDBConfigStore) UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesRemaining int, tx ...*gorm.DB) (*tables.TableBudget, error) {
+	if len(tx) == 0 {
+		var updated *tables.TableBudget
+		err := s.DB().WithContext(ctx).Transaction(func(transaction *gorm.DB) error {
+			var err error
+			updated, err = s.UpdateBudgetOverride(ctx, id, amount, mode, cyclesRemaining, transaction)
+			return err
+		})
+		return updated, err
+	}
+
+	txDB := tx[0].WithContext(ctx)
+	var budget tables.TableBudget
+	if err := dbForUpdate(txDB).First(&budget, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if err := budget.SetOverride(amount, mode, cyclesRemaining); err != nil {
+		return nil, err
+	}
+	if err := txDB.Session(&gorm.Session{SkipHooks: true}).Model(&tables.TableBudget{}).
+		Where("id = ?", id).
+		Updates(map[string]any{
+			"override_amount":           budget.OverrideAmount,
+			"override_mode":             budget.OverrideMode,
+			"override_cycles_remaining": budget.OverrideCyclesRemaining,
+			"updated_at":                time.Now(),
+		}).Error; err != nil {
+		return nil, s.parseGormError(err)
+	}
+	if err := txDB.First(&budget, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &budget, nil
+}
+
 // DeleteBudget deletes a budget from the database.
 func (s *RDBConfigStore) DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error {
 	if len(tx) == 0 {

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -780,6 +780,36 @@ func TestCreateBudgetWithOverride(t *testing.T) {
 	}
 }
 
+// TestUpdateBudgetOverridePreservesBudgetState verifies the partial update cannot clobber usage or base configuration.
+func TestUpdateBudgetOverridePreservesBudgetState(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	budget := &tables.TableBudget{
+		ID:            "budget-override-partial-update",
+		MaxLimit:      100,
+		ResetDuration: "1d",
+		CurrentUsage:  40,
+	}
+	require.NoError(t, store.CreateBudget(ctx, budget))
+
+	updated, err := store.UpdateBudgetOverride(ctx, budget.ID, 25, tables.BudgetOverrideModeCycles, 4)
+	require.NoError(t, err)
+	assert.Equal(t, 100.0, updated.MaxLimit)
+	assert.Equal(t, "1d", updated.ResetDuration)
+	assert.Equal(t, 40.0, updated.CurrentUsage)
+	assert.Equal(t, 25.0, updated.OverrideAmount)
+	assert.Equal(t, tables.BudgetOverrideModeCycles, updated.OverrideMode)
+	assert.Equal(t, 4, updated.OverrideCyclesRemaining)
+
+	cleared, err := store.UpdateBudgetOverride(ctx, budget.ID, 0, "", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 100.0, cleared.MaxLimit)
+	assert.Equal(t, 40.0, cleared.CurrentUsage)
+	assert.Zero(t, cleared.OverrideAmount)
+	assert.Empty(t, cleared.OverrideMode)
+	assert.Zero(t, cleared.OverrideCyclesRemaining)
+}
+
 func TestGetBudgets(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -353,6 +353,8 @@ type ConfigStore interface {
 	GetBudget(ctx context.Context, id string, tx ...*gorm.DB) (*tables.TableBudget, error)
 	CreateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	UpdateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
+	// UpdateBudgetOverride updates only the override state and returns the refreshed budget.
+	UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesRemaining int, tx ...*gorm.DB) (*tables.TableBudget, error)
 	UpdateBudgets(ctx context.Context, budgets []*tables.TableBudget, tx ...*gorm.DB) error
 	DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error
 	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -64,6 +64,56 @@ type TableBudget struct {
 // TableName sets the table name for each model
 func (TableBudget) TableName() string { return "governance_budgets" }
 
+// HasActiveOverride reports whether the budget currently has a valid configured override.
+func (b *TableBudget) HasActiveOverride() bool {
+	if b == nil || b.OverrideAmount <= 0 {
+		return false
+	}
+	return b.OverrideMode == BudgetOverrideModeForever ||
+		(b.OverrideMode == BudgetOverrideModeCycles && b.OverrideCyclesRemaining > 0)
+}
+
+// EffectiveMaxLimit returns the base limit plus any active override amount.
+func (b *TableBudget) EffectiveMaxLimit() float64 {
+	if b == nil {
+		return 0
+	}
+	if !b.HasActiveOverride() {
+		return b.MaxLimit
+	}
+	return b.MaxLimit + b.OverrideAmount
+}
+
+// SetOverride replaces the budget's current override after validating the complete state.
+func (b *TableBudget) SetOverride(amount float64, mode BudgetOverrideMode, cyclesRemaining int) error {
+	if b == nil {
+		return fmt.Errorf("budget is required")
+	}
+	previousAmount := b.OverrideAmount
+	previousMode := b.OverrideMode
+	previousCyclesRemaining := b.OverrideCyclesRemaining
+	b.OverrideAmount = amount
+	b.OverrideMode = mode
+	b.OverrideCyclesRemaining = cyclesRemaining
+	if err := b.validateOverride(); err != nil {
+		b.OverrideAmount = previousAmount
+		b.OverrideMode = previousMode
+		b.OverrideCyclesRemaining = previousCyclesRemaining
+		return err
+	}
+	return nil
+}
+
+// ClearOverride removes any finite or permanent override from the budget.
+func (b *TableBudget) ClearOverride() {
+	if b == nil {
+		return
+	}
+	b.OverrideAmount = 0
+	b.OverrideMode = ""
+	b.OverrideCyclesRemaining = 0
+}
+
 // validateOverride checks that the persisted override fields form one unambiguous state.
 func (b *TableBudget) validateOverride() error {
 	if math.IsNaN(b.OverrideAmount) || math.IsInf(b.OverrideAmount, 0) {

--- a/framework/configstore/tables/budget_test.go
+++ b/framework/configstore/tables/budget_test.go
@@ -4,8 +4,41 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestTableBudgetOverrideLifecycle verifies replacement, effective-limit, and clear behavior.
+func TestTableBudgetOverrideLifecycle(t *testing.T) {
+	budget := &TableBudget{MaxLimit: 100}
+	require.NoError(t, budget.SetOverride(25, BudgetOverrideModeCycles, 4))
+	assert.True(t, budget.HasActiveOverride())
+	assert.Equal(t, 125.0, budget.EffectiveMaxLimit())
+	assert.Equal(t, 4, budget.OverrideCyclesRemaining)
+
+	require.NoError(t, budget.SetOverride(50, BudgetOverrideModeForever, 0))
+	assert.True(t, budget.HasActiveOverride())
+	assert.Equal(t, 150.0, budget.EffectiveMaxLimit())
+	assert.Equal(t, BudgetOverrideModeForever, budget.OverrideMode)
+
+	budget.ClearOverride()
+	assert.False(t, budget.HasActiveOverride())
+	assert.Equal(t, 100.0, budget.EffectiveMaxLimit())
+	assert.Zero(t, budget.OverrideAmount)
+	assert.Empty(t, budget.OverrideMode)
+	assert.Zero(t, budget.OverrideCyclesRemaining)
+}
+
+// TestTableBudgetSetOverrideRestoresPreviousState verifies invalid replacements are non-mutating.
+func TestTableBudgetSetOverrideRestoresPreviousState(t *testing.T) {
+	budget := &TableBudget{MaxLimit: 100}
+	require.NoError(t, budget.SetOverride(25, BudgetOverrideModeCycles, 2))
+
+	require.Error(t, budget.SetOverride(50, BudgetOverrideModeCycles, 0))
+	assert.Equal(t, 25.0, budget.OverrideAmount)
+	assert.Equal(t, BudgetOverrideModeCycles, budget.OverrideMode)
+	assert.Equal(t, 2, budget.OverrideCyclesRemaining)
+}
 
 // TestTableBudgetValidateOverride verifies that persisted override fields cannot form an ambiguous state.
 func TestTableBudgetValidateOverride(t *testing.T) {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -265,6 +265,19 @@ type UpdateBudgetRequest struct {
 	ResetDuration *string  `json:"reset_duration,omitempty"`
 }
 
+// BudgetOverrideRequest replaces the active override on one budget.
+type BudgetOverrideRequest struct {
+	Amount float64                              `json:"amount"`
+	Mode   configstoreTables.BudgetOverrideMode `json:"mode"`
+	Cycles int                                  `json:"cycles,omitempty"`
+}
+
+// BudgetOverrideResponse returns the persisted budget and its additive effective limit.
+type BudgetOverrideResponse struct {
+	Budget            *configstoreTables.TableBudget `json:"budget"`
+	EffectiveMaxLimit float64                        `json:"effective_max_limit"`
+}
+
 // RoutingTarget represents a single weighted routing target within a rule.
 // All fields except Weight are optional; nil means "use the incoming request's value".
 // Weights across all targets in a rule must sum to 1 (e.g. 0.7 + 0.3 = 1.0).
@@ -997,6 +1010,8 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 	r.GET("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.getVirtualKey, middlewares...))
 	r.PUT("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.updateVirtualKey, middlewares...))
 	r.POST("/api/governance/virtual-keys/{vk_id}/rotate", lib.ChainMiddlewares(h.rotateVirtualKey, middlewares...))
+	r.PUT("/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override", lib.ChainMiddlewares(h.updateVirtualKeyBudgetOverride, middlewares...))
+	r.DELETE("/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override", lib.ChainMiddlewares(h.deleteVirtualKeyBudgetOverride, middlewares...))
 	r.DELETE("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.deleteVirtualKey, middlewares...))
 
 	// Team CRUD operations
@@ -1512,6 +1527,94 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_key": vk,
+	})
+}
+
+// loadVirtualKeyBudget resolves only budgets owned by the virtual key's scoped model configs.
+func (h *GovernanceHandler) loadVirtualKeyBudget(ctx context.Context, vkID, budgetID string) (*configstoreTables.TableBudget, error) {
+	if _, err := h.configStore.GetVirtualKey(ctx, vkID); err != nil {
+		return nil, err
+	}
+	modelConfigs, err := h.configStore.GetModelConfigsByScopeAndScopeIDs(
+		ctx,
+		configstoreTables.ModelConfigScopeVirtualKey,
+		[]string{vkID},
+	)
+	if err != nil {
+		return nil, err
+	}
+	for i := range modelConfigs {
+		for j := range modelConfigs[i].Budgets {
+			if modelConfigs[i].Budgets[j].ID == budgetID {
+				return &modelConfigs[i].Budgets[j], nil
+			}
+		}
+	}
+	return nil, configstore.ErrNotFound
+}
+
+// updateVirtualKeyBudgetOverride handles PUT for a standalone virtual-key budget override.
+func (h *GovernanceHandler) updateVirtualKeyBudgetOverride(ctx *fasthttp.RequestCtx) {
+	h.mutateVirtualKeyBudgetOverride(ctx, false)
+}
+
+// deleteVirtualKeyBudgetOverride handles DELETE for a standalone virtual-key budget override.
+func (h *GovernanceHandler) deleteVirtualKeyBudgetOverride(ctx *fasthttp.RequestCtx) {
+	h.mutateVirtualKeyBudgetOverride(ctx, true)
+}
+
+// mutateVirtualKeyBudgetOverride replaces or clears an override without changing base budget configuration or usage.
+func (h *GovernanceHandler) mutateVirtualKeyBudgetOverride(ctx *fasthttp.RequestCtx, clear bool) {
+	vkID := ctx.UserValue("vk_id").(string)
+	budgetID := ctx.UserValue("budget_id").(string)
+	budget, err := h.loadVirtualKeyBudget(ctx, vkID, budgetID)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "virtual key or budget not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to retrieve virtual key budget")
+		return
+	}
+
+	if clear {
+		budget.ClearOverride()
+	} else {
+		var req BudgetOverrideRequest
+		if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+			return
+		}
+		if err := budget.SetOverride(req.Amount, req.Mode, req.Cycles); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	budget, err = h.configStore.UpdateBudgetOverride(
+		ctx,
+		budget.ID,
+		budget.OverrideAmount,
+		budget.OverrideMode,
+		budget.OverrideCyclesRemaining,
+	)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "budget not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, "failed to update budget override")
+		return
+	}
+	if _, err := h.governanceManager.ReloadVirtualKey(ctx, vkID); err != nil {
+		logger.Error("failed to reload virtual key after budget override: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "budget override saved but virtual key reload failed")
+		return
+	}
+
+	SendJSON(ctx, BudgetOverrideResponse{
+		Budget:            budget,
+		EffectiveMaxLimit: budget.EffectiveMaxLimit(),
 	})
 }
 

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -120,12 +120,147 @@ type mockRotateGovernanceManager struct {
 	reloadErr error
 }
 
+// budgetOverrideTestGovernanceManager records reloads after budget override mutations.
+type budgetOverrideTestGovernanceManager struct {
+	GovernanceManager
+	store     configstore.ConfigStore
+	reloadIDs []string
+}
+
+// ReloadVirtualKey records the reload and returns the current persisted virtual key.
+func (m *budgetOverrideTestGovernanceManager) ReloadVirtualKey(ctx context.Context, id string) (*configstoreTables.TableVirtualKey, error) {
+	m.reloadIDs = append(m.reloadIDs, id)
+	return m.store.GetVirtualKey(ctx, id)
+}
+
 func (m *mockRotateGovernanceManager) ReloadVirtualKey(ctx context.Context, id string) (*configstoreTables.TableVirtualKey, error) {
 	m.reloadIDs = append(m.reloadIDs, id)
 	if m.reloadErr != nil {
 		return nil, m.reloadErr
 	}
 	return m.store.GetVirtualKey(ctx, id)
+}
+
+// TestVirtualKeyBudgetOverrideLifecycle verifies finite, replacement, and clear mutations preserve base budget state.
+func TestVirtualKeyBudgetOverrideLifecycle(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := setupPricingOverrideHandlerStore(t)
+	manager := &budgetOverrideTestGovernanceManager{store: store}
+	handler := &GovernanceHandler{configStore: store, governanceManager: manager}
+	ctx := context.Background()
+
+	active := true
+	vk := &configstoreTables.TableVirtualKey{
+		ID:       "vk-budget-override",
+		Name:     "override-test",
+		Value:    *schemas.NewSecretVar("sk-bf-override-test"),
+		IsActive: &active,
+	}
+	if err := store.CreateVirtualKey(ctx, vk); err != nil {
+		t.Fatalf("create virtual key: %v", err)
+	}
+	scopeID := vk.ID
+	modelConfig := &configstoreTables.TableModelConfig{
+		ID:        "mc-budget-override",
+		ModelName: configstoreTables.ModelConfigAllModels,
+		Scope:     configstoreTables.ModelConfigScopeVirtualKey,
+		ScopeID:   &scopeID,
+		Budgets: []configstoreTables.TableBudget{{
+			ID:            "budget-override",
+			MaxLimit:      100,
+			CurrentUsage:  40,
+			ResetDuration: "1d",
+		}},
+	}
+	if err := store.CreateModelConfig(ctx, modelConfig); err != nil {
+		t.Fatalf("create model config: %v", err)
+	}
+
+	putCtx := newTestRequestCtx(`{"amount":25,"mode":"cycles","cycles":4}`)
+	putCtx.SetUserValue("vk_id", vk.ID)
+	putCtx.SetUserValue("budget_id", "budget-override")
+	handler.updateVirtualKeyBudgetOverride(putCtx)
+	if putCtx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("finite override status=%d body=%s", putCtx.Response.StatusCode(), putCtx.Response.Body())
+	}
+
+	budget, err := store.GetBudget(ctx, "budget-override")
+	if err != nil {
+		t.Fatalf("get finite override budget: %v", err)
+	}
+	if budget.MaxLimit != 100 || budget.CurrentUsage != 40 || budget.OverrideAmount != 25 || budget.OverrideMode != configstoreTables.BudgetOverrideModeCycles || budget.OverrideCyclesRemaining != 4 {
+		t.Fatalf("unexpected finite override budget: %+v", budget)
+	}
+
+	replaceCtx := newTestRequestCtx(`{"amount":50,"mode":"forever"}`)
+	replaceCtx.SetUserValue("vk_id", vk.ID)
+	replaceCtx.SetUserValue("budget_id", "budget-override")
+	handler.updateVirtualKeyBudgetOverride(replaceCtx)
+	if replaceCtx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("forever override status=%d body=%s", replaceCtx.Response.StatusCode(), replaceCtx.Response.Body())
+	}
+
+	deleteCtx := newTestRequestCtx("")
+	deleteCtx.SetUserValue("vk_id", vk.ID)
+	deleteCtx.SetUserValue("budget_id", "budget-override")
+	handler.deleteVirtualKeyBudgetOverride(deleteCtx)
+	if deleteCtx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("clear override status=%d body=%s", deleteCtx.Response.StatusCode(), deleteCtx.Response.Body())
+	}
+	budget, err = store.GetBudget(ctx, "budget-override")
+	if err != nil {
+		t.Fatalf("get cleared override budget: %v", err)
+	}
+	if budget.OverrideAmount != 0 || budget.OverrideMode != "" || budget.OverrideCyclesRemaining != 0 {
+		t.Fatalf("override was not cleared: %+v", budget)
+	}
+	if len(manager.reloadIDs) != 3 {
+		t.Fatalf("reload calls=%d, want 3", len(manager.reloadIDs))
+	}
+}
+
+// TestVirtualKeyBudgetOverrideRejectsDirectMirrorBudget verifies AP-style direct VK budgets cannot be overridden through the OSS endpoint.
+func TestVirtualKeyBudgetOverrideRejectsDirectMirrorBudget(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := setupPricingOverrideHandlerStore(t)
+	manager := &budgetOverrideTestGovernanceManager{store: store}
+	handler := &GovernanceHandler{configStore: store, governanceManager: manager}
+	ctx := context.Background()
+
+	active := true
+	vk := &configstoreTables.TableVirtualKey{
+		ID:       "vk-ap-managed",
+		Name:     "ap-managed",
+		Value:    *schemas.NewSecretVar("sk-bf-ap-managed"),
+		IsActive: &active,
+	}
+	if err := store.CreateVirtualKey(ctx, vk); err != nil {
+		t.Fatalf("create virtual key: %v", err)
+	}
+	directBudget := &configstoreTables.TableBudget{
+		ID:            "ap-mirror-budget",
+		MaxLimit:      100,
+		ResetDuration: "1d",
+		VirtualKeyID:  &vk.ID,
+	}
+	if err := store.CreateBudget(ctx, directBudget); err != nil {
+		t.Fatalf("create direct budget: %v", err)
+	}
+
+	putCtx := newTestRequestCtx(`{"amount":25,"mode":"forever"}`)
+	putCtx.SetUserValue("vk_id", vk.ID)
+	putCtx.SetUserValue("budget_id", directBudget.ID)
+	handler.updateVirtualKeyBudgetOverride(putCtx)
+	if putCtx.Response.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("status=%d, want 404; body=%s", putCtx.Response.StatusCode(), putCtx.Response.Body())
+	}
+	stored, err := store.GetBudget(ctx, directBudget.ID)
+	if err != nil {
+		t.Fatalf("get direct budget: %v", err)
+	}
+	if stored.OverrideMode != "" {
+		t.Fatalf("direct mirror override changed unexpectedly: %+v", stored)
+	}
 }
 
 type mockComplexityGovernanceManager struct {


### PR DESCRIPTION
## Summary

Adds a dedicated `UpdateBudgetOverride` operation that atomically replaces or clears only the override fields on a budget, ensuring concurrent usage changes and base configuration are never clobbered. Exposes this via two new HTTP endpoints (`PUT` and `DELETE`) scoped to virtual-key budgets.

## Changes

- Added `UpdateBudgetOverride` to `RDBConfigStore` and the `ConfigStore` interface. The method locks the row, validates the new override state via `SetOverride`, and updates only `override_amount`, `override_mode`, `override_cycles_remaining`, and `updated_at`, leaving `current_usage`, `max_limit`, and `reset_duration` untouched.
- Added `HasActiveOverride`, `EffectiveMaxLimit`, `SetOverride`, and `ClearOverride` helpers to `TableBudget`. `SetOverride` rolls back to the previous state if validation fails, making it non-mutating on error.
- Registered `PUT /api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override` and `DELETE /api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override` in the governance HTTP handler. Both routes resolve the budget only through model configs scoped to the virtual key, so AP-managed direct mirror budgets are unreachable (404) through this endpoint.
- After a successful override mutation the handler reloads the virtual key in the governance manager so in-memory state stays consistent.
- Added `BudgetOverrideRequest` and `BudgetOverrideResponse` HTTP types; the response includes the refreshed budget and its computed `effective_max_limit`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/handlers/...
```

Key scenarios covered by the new tests:

- `TestUpdateBudgetOverridePreservesBudgetState` — confirms `max_limit`, `reset_duration`, and `current_usage` are unchanged after a partial override update and after clearing.
- `TestTableBudgetOverrideLifecycle` — verifies finite-cycle, forever, and cleared override transitions on the model directly.
- `TestTableBudgetSetOverrideRestoresPreviousState` — confirms an invalid `SetOverride` call leaves the budget unchanged.
- `TestVirtualKeyBudgetOverrideLifecycle` — end-to-end HTTP test covering finite override, replacement, clear, and virtual key reload (expects 3 reload calls).
- `TestVirtualKeyBudgetOverrideRejectsDirectMirrorBudget` — confirms AP-managed budgets attached directly to a virtual key return 404 and are not mutated.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The override endpoints resolve budgets exclusively through model configs owned by the target virtual key. Budgets attached directly via `virtual_key_id` (AP mirror budgets) are not reachable, preventing unintended cross-scope mutations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable