### PR TITLE
budget override: governance store updates

### DIFF
--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -114,6 +114,18 @@ func (b *TableBudget) ClearOverride() {
 	b.OverrideCyclesRemaining = 0
 }
 
+// ConsumeOverrideCycle advances a finite override by one completed budget reset cycle.
+func (b *TableBudget) ConsumeOverrideCycle() {
+	if b == nil || b.OverrideMode != BudgetOverrideModeCycles || !b.HasActiveOverride() {
+		return
+	}
+	if b.OverrideCyclesRemaining == 1 {
+		b.ClearOverride()
+		return
+	}
+	b.OverrideCyclesRemaining--
+}
+
 // validateOverride checks that the persisted override fields form one unambiguous state.
 func (b *TableBudget) validateOverride() error {
 	if math.IsNaN(b.OverrideAmount) || math.IsInf(b.OverrideAmount, 0) {

--- a/framework/configstore/tables/budget_test.go
+++ b/framework/configstore/tables/budget_test.go
@@ -40,6 +40,26 @@ func TestTableBudgetSetOverrideRestoresPreviousState(t *testing.T) {
 	assert.Equal(t, 2, budget.OverrideCyclesRemaining)
 }
 
+// TestTableBudgetConsumeOverrideCycle verifies finite overrides expire while permanent overrides survive resets.
+func TestTableBudgetConsumeOverrideCycle(t *testing.T) {
+	finite := &TableBudget{MaxLimit: 100}
+	require.NoError(t, finite.SetOverride(25, BudgetOverrideModeCycles, 2))
+
+	finite.ConsumeOverrideCycle()
+	assert.Equal(t, 1, finite.OverrideCyclesRemaining)
+	assert.Equal(t, 125.0, finite.EffectiveMaxLimit())
+
+	finite.ConsumeOverrideCycle()
+	assert.False(t, finite.HasActiveOverride())
+	assert.Equal(t, 100.0, finite.EffectiveMaxLimit())
+
+	permanent := &TableBudget{MaxLimit: 100}
+	require.NoError(t, permanent.SetOverride(50, BudgetOverrideModeForever, 0))
+	permanent.ConsumeOverrideCycle()
+	assert.True(t, permanent.HasActiveOverride())
+	assert.Equal(t, 150.0, permanent.EffectiveMaxLimit())
+}
+
 // TestTableBudgetValidateOverride verifies that persisted override fields cannot form an ambiguous state.
 func TestTableBudgetValidateOverride(t *testing.T) {
 	tests := []struct {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -448,6 +448,7 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 			gs.logger.Error("budget %s reset target not converging after %d resets; applying inline reset to avoid request-path spin", budgetID, resetAttempts)
 			clone.CurrentUsage = 0
 			clone.LastReset = *target
+			clone.ConsumeOverrideCycle()
 			gs.LastDBUsagesBudgetsMu.Lock()
 			gs.LastDBUsagesBudgets[budgetID] = 0
 			gs.LastDBUsagesBudgetsMu.Unlock()
@@ -574,6 +575,7 @@ func (gs *LocalGovernanceStore) ResetBudgetAt(ctx context.Context, budgetID stri
 		clone := *old
 		clone.CurrentUsage = 0
 		clone.LastReset = newLastReset
+		clone.ConsumeOverrideCycle()
 		if gs.budgets.CompareAndSwap(budgetID, raw, &clone) {
 			return &clone, true
 		}
@@ -1069,13 +1071,14 @@ func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudge
 			if !exists {
 				baseline = 0
 			}
+			effectiveMaxLimit := budget.EffectiveMaxLimit()
 			gs.logger.Debug("LocalStore CheckBudget: Checking %s budget %s: local=%.4f, remote=%.4f, total=%.4f, limit=%.4f",
-				entity, budget.ID, budget.CurrentUsage, baseline, budget.CurrentUsage+baseline, budget.MaxLimit)
+				entity, budget.ID, budget.CurrentUsage, baseline, budget.CurrentUsage+baseline, effectiveMaxLimit)
 			// Check if current usage (local + remote baseline) exceeds budget limit
-			if budget.CurrentUsage+baseline >= budget.MaxLimit {
+			if budget.CurrentUsage+baseline >= effectiveMaxLimit {
 				gs.logger.Debug("LocalStore CheckBudget: Budget %s EXCEEDED", budget.ID)
 				return DecisionBudgetExceeded, fmt.Errorf("%s budget exceeded: %.4f >= %.4f dollars",
-					entity, budget.CurrentUsage+baseline, budget.MaxLimit)
+					entity, budget.CurrentUsage+baseline, effectiveMaxLimit)
 			}
 		}
 	}
@@ -2037,6 +2040,28 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgets(ctx context.Context, resetBu
 	if len(resetBudgets) > 0 && gs.configStore != nil {
 		if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 			for _, budget := range resetBudgets {
+				// Persist the finite-override lifecycle first, guarded on last_reset:
+				// a snapshot that lost the persistence race to a newer reset must not
+				// restore older lifecycle state (extra override cycles would survive a
+				// restart otherwise). This must run BEFORE the usage write below, which
+				// advances last_reset and would close the guard within this transaction.
+				overrideResult := tx.WithContext(ctx).
+					Session(&gorm.Session{SkipHooks: true}).
+					Model(&configstoreTables.TableBudget{}).
+					Where("id = ? AND last_reset < ?", budget.ID, budget.LastReset).
+					Updates(map[string]interface{}{
+						"override_amount":           budget.OverrideAmount,
+						"override_mode":             budget.OverrideMode,
+						"override_cycles_remaining": budget.OverrideCyclesRemaining,
+					})
+
+				if overrideResult.Error != nil {
+					return fmt.Errorf("failed to reset budget override lifecycle %s: %w", budget.ID, overrideResult.Error)
+				}
+				if overrideResult.RowsAffected == 0 {
+					gs.logger.Debug("skipping stale override reset persistence for budget %s: database already holds newer reset state", budget.ID)
+				}
+
 				// Direct UPDATE only resets current_usage and last_reset
 				// This prevents overwriting max_limit or reset_duration that may have been changed by other nodes/requests
 				result := tx.WithContext(ctx).
@@ -2226,6 +2251,27 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 				newUsage := inMemoryBudget.CurrentUsage
 				if baseline, exists := baselines[inMemoryBudget.ID]; exists {
 					newUsage += baseline
+				}
+
+				// The override trio mutated by ConsumeOverrideCycle is flushed first
+				// under a monotonic last_reset guard: it only fires when this node
+				// performed a reset the database has not seen, which is exactly when
+				// its override snapshot is authoritative. An unguarded write would let
+				// a node with a stale in-memory override clobber a newer admin update
+				// every dump cycle. This must run BEFORE the usage write below, which
+				// advances last_reset and would close the guard within this transaction.
+				overrideResult := tx.WithContext(ctx).
+					Session(&gorm.Session{SkipHooks: true}).
+					Model(&configstoreTables.TableBudget{}).
+					Where("id = ? AND last_reset < ?", inMemoryBudget.ID, inMemoryBudget.LastReset).
+					Updates(map[string]interface{}{
+						"override_amount":           inMemoryBudget.OverrideAmount,
+						"override_mode":             inMemoryBudget.OverrideMode,
+						"override_cycles_remaining": inMemoryBudget.OverrideCyclesRemaining,
+					})
+
+				if overrideResult.Error != nil {
+					return fmt.Errorf("failed to update budget override lifecycle %s: %w", inMemoryBudget.ID, overrideResult.Error)
 				}
 
 				// Direct UPDATE avoids read-then-write lock escalation that causes deadlocks
@@ -4126,8 +4172,8 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 		for bi := range modelConfig.Budgets {
 			if budgetValue, ok := gs.budgets.Load(modelConfig.Budgets[bi].ID); ok && budgetValue != nil {
 				if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-					if budget.MaxLimit > 0 {
-						budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / budget.MaxLimit * 100
+					if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
+						budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
 						if budgetPercent > result.BudgetPercentUsed {
 							result.BudgetPercentUsed = budgetPercent
 						}
@@ -4185,8 +4231,8 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 			if providerTable.BudgetID != nil {
 				if budgetValue, ok := gs.budgets.Load(*providerTable.BudgetID); ok && budgetValue != nil {
 					if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-						if budget.MaxLimit > 0 {
-							budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / budget.MaxLimit * 100
+						if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
+							budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
 							if budgetPercent > result.BudgetPercentUsed {
 								result.BudgetPercentUsed = budgetPercent
 							}
@@ -4229,8 +4275,8 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context,
 					for _, b := range pc.Budgets {
 						if budgetValue, ok := gs.budgets.Load(b.ID); ok && budgetValue != nil {
 							if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
-								if budget.MaxLimit > 0 {
-									budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / budget.MaxLimit * 100
+								if effectiveMaxLimit := budget.EffectiveMaxLimit(); effectiveMaxLimit > 0 {
+									budgetPercent := float64(budget.CurrentUsage+budgetBaselines[budget.ID]) / effectiveMaxLimit * 100
 									if budgetPercent > result.BudgetPercentUsed {
 										result.BudgetPercentUsed = budgetPercent
 									}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -163,6 +163,23 @@ func TestGovernanceStore_CheckBudget_SingleBudget(t *testing.T) {
 	}
 }
 
+// TestGovernanceStoreCheckBudgetUsesOverride verifies enforcement reads the additive effective limit.
+func TestGovernanceStoreCheckBudgetUsesOverride(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+	budget := buildBudgetWithUsage("override-budget", 100, 110, "1d")
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 2))
+
+	decision, err := store.CheckBudget(context.Background(), EntityWiseBudgets{"VirtualKey": {budget}}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, DecisionAllow, decision)
+
+	decision, err = store.CheckBudget(context.Background(), EntityWiseBudgets{"VirtualKey": {budget}}, map[string]float64{budget.ID: 15})
+	require.Error(t, err)
+	assert.Equal(t, DecisionBudgetExceeded, decision)
+	assert.Contains(t, err.Error(), "125.0000 dollars")
+}
+
 // TestGovernanceStore_CheckBudget_HierarchyValidation tests multi-level budget hierarchy
 func TestGovernanceStore_CheckBudget_HierarchyValidation(t *testing.T) {
 	logger := NewMockLogger()
@@ -783,6 +800,88 @@ func TestGovernanceStore_ResetExpiredBudgets(t *testing.T) {
 	require.True(t, len(updatedVK.Budgets) > 0, "VK should have budgets")
 
 	assert.Equal(t, 0.0, updatedVK.Budgets[0].CurrentUsage, "Budget usage should be reset")
+}
+
+// TestGovernanceStoreResetBudgetAdvancesOverride verifies each existing reset consumes one finite cycle.
+func TestGovernanceStoreResetBudgetAdvancesOverride(t *testing.T) {
+	store := newStandaloneStore(t)
+	finite := buildBudgetWithUsage("finite-override", 100, 75, "1d")
+	require.NoError(t, finite.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 2))
+	store.budgets.Store(finite.ID, finite)
+
+	firstReset := finite.LastReset.Add(24 * time.Hour)
+	reset, ok := store.ResetBudgetAt(context.Background(), finite.ID, firstReset)
+	require.True(t, ok)
+	assert.Zero(t, reset.CurrentUsage)
+	assert.Equal(t, 1, reset.OverrideCyclesRemaining)
+	assert.Equal(t, 125.0, reset.EffectiveMaxLimit())
+
+	secondReset := firstReset.Add(24 * time.Hour)
+	reset, ok = store.ResetBudgetAt(context.Background(), finite.ID, secondReset)
+	require.True(t, ok)
+	assert.False(t, reset.HasActiveOverride())
+	assert.Equal(t, 100.0, reset.EffectiveMaxLimit())
+
+	permanent := buildBudgetWithUsage("forever-override", 100, 75, "1d")
+	require.NoError(t, permanent.SetOverride(50, configstoreTables.BudgetOverrideModeForever, 0))
+	store.budgets.Store(permanent.ID, permanent)
+	reset, ok = store.ResetBudgetAt(context.Background(), permanent.ID, permanent.LastReset.Add(24*time.Hour))
+	require.True(t, ok)
+	assert.True(t, reset.HasActiveOverride())
+	assert.Equal(t, 150.0, reset.EffectiveMaxLimit())
+}
+
+// TestGovernanceStoreUpsertBudgetConfigRefreshesOverride verifies cache refreshes config without clobbering runtime counters.
+func TestGovernanceStoreUpsertBudgetConfigRefreshesOverride(t *testing.T) {
+	store := newStandaloneStore(t)
+	lastReset := time.Now().Add(-30 * time.Minute)
+	live := buildBudgetWithUsage("cache-override", 100, 40, "1h")
+	live.LastReset = lastReset
+	store.budgets.Store(live.ID, live)
+
+	refreshed := buildBudgetWithUsage(live.ID, 120, 0, "2h")
+	require.NoError(t, refreshed.SetOverride(30, configstoreTables.BudgetOverrideModeCycles, 3))
+	store.UpsertBudgetConfig(context.Background(), live.ID, refreshed)
+
+	got := store.LoadBudget(context.Background(), live.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, 40.0, got.CurrentUsage)
+	assert.True(t, got.LastReset.Equal(lastReset))
+	assert.Equal(t, 120.0, got.MaxLimit)
+	assert.Equal(t, "2h", got.ResetDuration)
+	assert.Equal(t, 30.0, got.OverrideAmount)
+	assert.Equal(t, configstoreTables.BudgetOverrideModeCycles, got.OverrideMode)
+	assert.Equal(t, 3, got.OverrideCyclesRemaining)
+}
+
+// TestGovernanceStoreResetPersistsOverrideLifecycle verifies the existing reset write stores the decremented cycle state.
+func TestGovernanceStoreResetPersistsOverrideLifecycle(t *testing.T) {
+	ctx := context.Background()
+	logger := NewMockLogger()
+	configStore, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: t.TempDir() + "/governance.db"},
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, configStore.Close(ctx)) })
+
+	budget := buildBudgetWithUsage("persisted-override", 100, 75, "1d")
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 2))
+	require.NoError(t, configStore.CreateBudget(ctx, budget))
+
+	store, err := NewLocalGovernanceStore(ctx, logger, configStore, nil, nil)
+	require.NoError(t, err)
+	reset, ok := store.ResetBudgetAt(ctx, budget.ID, budget.LastReset.Add(24*time.Hour))
+	require.True(t, ok)
+	require.NoError(t, store.ResetExpiredBudgets(ctx, []*configstoreTables.TableBudget{reset}))
+
+	persisted, err := configStore.GetBudget(ctx, budget.ID)
+	require.NoError(t, err)
+	assert.Zero(t, persisted.CurrentUsage)
+	assert.Equal(t, 25.0, persisted.OverrideAmount)
+	assert.Equal(t, configstoreTables.BudgetOverrideModeCycles, persisted.OverrideMode)
+	assert.Equal(t, 1, persisted.OverrideCyclesRemaining)
 }
 
 // TestGovernanceStore_GetAllBudgets tests retrieving all budgets

--- a/plugins/governance/storeconcurrency_test.go
+++ b/plugins/governance/storeconcurrency_test.go
@@ -97,6 +97,9 @@ func TestResetBudgetAt_ConcurrentResettersCollapse(t *testing.T) {
 	old := buildBudget(budgetID, 1000, "1h")
 	old.LastReset = time.Now().Add(-2 * time.Hour)
 	old.CurrentUsage = 999
+	old.OverrideAmount = 25
+	old.OverrideMode = "cycles"
+	old.OverrideCyclesRemaining = 5
 	store.budgets.Store(budgetID, old)
 
 	const goroutines = 128
@@ -120,4 +123,5 @@ func TestResetBudgetAt_ConcurrentResettersCollapse(t *testing.T) {
 	require.NotNil(t, final)
 	assert.Equal(t, 0.0, final.CurrentUsage)
 	assert.True(t, final.LastReset.Equal(newLastReset))
+	assert.Equal(t, 4, final.OverrideCyclesRemaining, "the single winning reset should consume exactly one override cycle")
 }


### PR DESCRIPTION
## Summary

Budget overrides with a finite cycle count were not being decremented or expired as budget reset cycles completed. This meant a temporary spending override would remain active indefinitely rather than expiring after the configured number of resets. This PR wires the override lifecycle into the reset path so finite overrides count down and clear themselves automatically.

## Changes

- Added `ConsumeOverrideCycle()` to `TableBudget`, which decrements `OverrideCyclesRemaining` by one per reset cycle and calls `ClearOverride()` when the last cycle is consumed. Permanent (`BudgetOverrideModeForever`) overrides are left untouched.
- Called `ConsumeOverrideCycle()` in both the normal `ResetBudgetAt` path and the inline reset fallback inside `BumpBudgetUsage`, ensuring the cycle counter advances regardless of which reset code path fires.
- Updated `ResetExpiredBudgets` to persist the three override fields (`override_amount`, `override_mode`, `override_cycles_remaining`) alongside `current_usage` and `last_reset` so the decremented state is durably written to the database.
- Replaced direct `budget.MaxLimit` reads in `CheckBudget` and `GetBudgetAndRateLimitStatus` with `budget.EffectiveMaxLimit()` so enforcement and status reporting both reflect the active additive override rather than the bare base limit.
- The concurrent reset test was extended to assert that exactly one override cycle is consumed when multiple goroutines race to reset the same budget.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/tables/... -run TestTableBudgetConsumeOverrideCycle -v
go test ./plugins/governance/... -run TestGovernanceStoreCheckBudgetUsesOverride -v
go test ./plugins/governance/... -run TestGovernanceStoreResetBudgetAdvancesOverride -v
go test ./plugins/governance/... -run TestGovernanceStoreResetPersistsOverrideLifecycle -v
go test ./plugins/governance/... -run TestResetBudgetAt_ConcurrentResettersCollapse -v
go test ./plugins/governance/... -v
```

Expected: all tests pass; finite overrides expire after the configured number of reset cycles, permanent overrides survive resets, and the decremented cycle count is persisted to the database.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Override amounts are operator-configured values already validated on write; no new inputs or privilege boundaries are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable