### PR TITLE
feat: add rotation grace-period columns to governance_virtual_keys

### DIFF
--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -431,6 +431,37 @@ func TestEncryptPlaintextVirtualKeys_EncryptsAndDecryptsCorrectly(t *testing.T) 
 	assert.Equal(t, "vk-batch-secret", found.Value.GetValue())
 }
 
+func TestVirtualKeyPreviousValue_EncryptsAndDecryptsCorrectly(t *testing.T) {
+	_, db := setupEncryptionTestStore(t)
+	now := time.Now().UTC()
+	exp := now.Add(10 * time.Minute)
+
+	vk := &tables.TableVirtualKey{
+		ID:                     "vk-prev-enc",
+		Name:                   "prev-enc-vk",
+		Value:                  *schemas.NewSecretVar("vk-current-secret"),
+		IsActive:               schemas.Ptr(true),
+		PreviousValue:          *schemas.NewSecretVar("vk-previous-secret"),
+		PreviousValueExpiresAt: &exp,
+		RotatedAt:              &now,
+	}
+	require.NoError(t, db.Create(vk).Error)
+
+	// Raw DB must hold the previous value encrypted, with its hash computed.
+	var raw map[string]any
+	db.Table("governance_virtual_keys").Where("id = ?", "vk-prev-enc").Take(&raw)
+	assert.Equal(t, "encrypted", raw["encryption_status"])
+	assert.NotEqual(t, "vk-previous-secret", raw["previous_value"])
+	assert.NotEmpty(t, raw["previous_value_hash"])
+
+	// GORM hooks should decrypt both values on read.
+	var found tables.TableVirtualKey
+	require.NoError(t, db.Where("id = ?", "vk-prev-enc").First(&found).Error)
+	assert.Equal(t, "vk-current-secret", found.Value.GetValue())
+	assert.Equal(t, "vk-previous-secret", found.PreviousValue.GetValue())
+	assert.True(t, found.HasActivePreviousValue(now))
+}
+
 func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T) {
 	store, db := setupEncryptionTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -475,6 +475,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_ultrafast_pricing_columns"}, run: migrationAddUltrafastPricingColumns},
 	{IDs: []string{"add_image_size_quality_pricing_columns"}, run: migrationAddImageSizeQualityPricingColumns},
 	{IDs: []string{"add_batch_jobs_attribution_columns"}, run: migrationAddBatchJobsAttributionColumns},
+	{IDs: []string{"add_vk_rotation_cooldown_columns"}, run: migrationAddVKRotationCooldownColumns},
 }
 
 // migrationAddBatchJobsAttributionColumns adds the requester-identity columns to
@@ -10982,6 +10983,55 @@ func migrationAddSidekiqPartitioningKeyColumn(ctx context.Context, db *gorm.DB, 
 
 // migrationAddVirtualKeyExpiresAtColumn adds nullable expires_at to governance_virtual_keys.
 // No index: expiry is checked in-memory from the already-loaded VK, never queried by column.
+// migrationAddVKRotationCooldownColumns adds the rotation grace-period columns to
+// governance_virtual_keys: previous_value, previous_value_hash,
+// previous_value_expires_at, and rotated_at. All nullable and additive, no
+// backfill (NULL = no previous value = pre-cooldown behavior), so the migration
+// is safe during rolling upgrades; pgx cached-plan invalidation (0A000) after
+// ADD COLUMN is handled by the postgresconn retry pool.
+func migrationAddVKRotationCooldownColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_vk_rotation_cooldown_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	columns := []string{"previous_value", "previous_value_hash", "previous_value_expires_at", "rotated_at"}
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range columns {
+				if err := addColumnIfNotExists(tx, logger, &tables.TableVirtualKey{}, column); err != nil {
+					return err
+				}
+			}
+			// AddColumn doesn't create indexes from struct tags; grace-period
+			// auth looks keys up by previous_value_hash, so upgraded databases
+			// need the index created explicitly. CreateIndex reads the struct
+			// tags so it is dialect-safe.
+			mg := tx.Migrator()
+			if !mg.HasIndex(&tables.TableVirtualKey{}, "idx_virtual_key_previous_value_hash") {
+				logger.Info("[configstore] %s: creating index PreviousValueHash on TableVirtualKey", migrationName)
+				if err := mg.CreateIndex(&tables.TableVirtualKey{}, "PreviousValueHash"); err != nil {
+					return fmt.Errorf("failed to create index on governance_virtual_keys.previous_value_hash: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			for _, column := range columns {
+				if err := dropColumnIfExists(tx, logger, &tables.TableVirtualKey{}, column); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}
+
 func migrationAddVirtualKeyExpiresAtColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
 	migrationName := "add_virtual_key_expires_at_column"
 	logger.Info("[configstore] starting migration %s", migrationName)

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -691,6 +691,62 @@ func forEachProviderMigrationDB(t *testing.T, testSuffix string) []namedDB {
 	return dbs
 }
 
+// setupVKTestDBWithoutRotationColumns creates an in-memory SQLite database with
+// governance_virtual_keys in its pre-rotation-migration shape: none of the
+// previous_value*/rotated_at columns and no idx_virtual_key_previous_value_hash
+// index, simulating an upgraded (not fresh) installation.
+func setupVKTestDBWithoutRotationColumns(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err, "Failed to create test database")
+
+	err = db.Exec(`
+		CREATE TABLE governance_virtual_keys (
+			id VARCHAR(255) PRIMARY KEY,
+			name VARCHAR(255) NOT NULL,
+			value TEXT,
+			value_hash VARCHAR(64),
+			encryption_status VARCHAR(20) DEFAULT 'plain_text',
+			config_hash VARCHAR(255),
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create governance_virtual_keys table")
+
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS migrations (
+			id VARCHAR(255) PRIMARY KEY
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create migrations table")
+
+	return db
+}
+
+func TestMigrationAddVKRotationCooldownColumns_CreatesIndex(t *testing.T) {
+	db := setupVKTestDBWithoutRotationColumns(t)
+	ctx := context.Background()
+	mg := db.Migrator()
+
+	require.False(t, mg.HasColumn(&tables.TableVirtualKey{}, "previous_value_hash"),
+		"previous_value_hash column must not exist before migration")
+	require.False(t, mg.HasIndex(&tables.TableVirtualKey{}, "idx_virtual_key_previous_value_hash"),
+		"previous_value_hash index must not exist before migration")
+
+	require.NoError(t, migrationAddVKRotationCooldownColumns(ctx, db, testMigrationLogger))
+
+	for _, column := range []string{"previous_value", "previous_value_hash", "previous_value_expires_at", "rotated_at"} {
+		assert.True(t, mg.HasColumn(&tables.TableVirtualKey{}, column),
+			"%s column should exist after migration", column)
+	}
+	assert.True(t, mg.HasIndex(&tables.TableVirtualKey{}, "idx_virtual_key_previous_value_hash"),
+		"upgrade path must create the previous_value_hash index declared in struct tags")
+
+	// Idempotent: a re-run with the index already present must not fail.
+	require.NoError(t, db.Exec("DELETE FROM migrations WHERE id = ?", "add_vk_rotation_cooldown_columns").Error)
+	require.NoError(t, migrationAddVKRotationCooldownColumns(ctx, db, testMigrationLogger))
+}
+
 func TestMigrationAddStoreRawRequestResponseColumn(t *testing.T) {
 	tests := []struct {
 		name                            string

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3779,8 +3779,18 @@ func (s *RDBConfigStore) UpdateVirtualKey(ctx context.Context, virtualKey *table
 		}
 	} else {
 		virtualKey.ID = existing.ID
+		// Rotation grace-period state travels with the row: unless the caller is
+		// itself performing a rotation (RotatedAt set), preserve the stored
+		// previous-value fields so a plain update cannot wipe an in-flight grace
+		// window (the Select below writes zero values).
+		if virtualKey.RotatedAt == nil {
+			virtualKey.PreviousValue = existing.PreviousValue
+			virtualKey.PreviousValueHash = existing.PreviousValueHash
+			virtualKey.PreviousValueExpiresAt = existing.PreviousValueExpiresAt
+			virtualKey.RotatedAt = existing.RotatedAt
+		}
 		if err := txDB.WithContext(ctx).
-			Select("name", "description", "value", "is_active", "expires_at", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "config_hash", "updated_at", "encryption_status", "value_hash").
+			Select("name", "description", "value", "is_active", "expires_at", "team_id", "customer_id", "rate_limit_id", "calendar_aligned", "config_hash", "updated_at", "encryption_status", "value_hash", "previous_value", "previous_value_hash", "previous_value_expires_at", "rotated_at").
 			Updates(virtualKey).Error; err != nil {
 			return s.parseGormError(err)
 		}

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -1336,6 +1336,140 @@ func TestUpdateVirtualKey(t *testing.T) {
 	assert.False(t, result.IsActiveValue())
 }
 
+func TestUpdateVirtualKey_PreservesRotationStateOnPlainUpdate(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	vk := &tables.TableVirtualKey{
+		ID:       "vk-grace",
+		Name:     "Grace Key",
+		Value:    *schemas.NewSecretVar("vk-old-value"),
+		IsActive: schemas.Ptr(true),
+	}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	// Rotation: RotatedAt set makes the grace-period fields authoritative.
+	now := time.Now().UTC()
+	exp := now.Add(5 * time.Minute)
+	vk.Value = *schemas.NewSecretVar("vk-new-value")
+	vk.PreviousValue = *schemas.NewSecretVar("vk-old-value")
+	vk.PreviousValueExpiresAt = &exp
+	vk.RotatedAt = &now
+	require.NoError(t, store.UpdateVirtualKey(ctx, vk))
+
+	stored, err := store.GetVirtualKey(ctx, "vk-grace")
+	require.NoError(t, err)
+	assert.Equal(t, "vk-new-value", stored.Value.GetValue())
+	assert.Equal(t, "vk-old-value", stored.PreviousValue.GetValue())
+	assert.NotEmpty(t, stored.PreviousValueHash)
+	require.NotNil(t, stored.PreviousValueExpiresAt)
+	require.NotNil(t, stored.RotatedAt)
+	assert.True(t, stored.HasActivePreviousValue(now))
+
+	// Plain update (RotatedAt nil) must not wipe the in-flight grace window.
+	plain := &tables.TableVirtualKey{
+		ID:       "vk-grace",
+		Name:     "Grace Key Renamed",
+		Value:    *schemas.NewSecretVar("vk-new-value"),
+		IsActive: schemas.Ptr(true),
+	}
+	require.NoError(t, store.UpdateVirtualKey(ctx, plain))
+
+	stored, err = store.GetVirtualKey(ctx, "vk-grace")
+	require.NoError(t, err)
+	assert.Equal(t, "Grace Key Renamed", stored.Name)
+	assert.Equal(t, "vk-old-value", stored.PreviousValue.GetValue())
+	require.NotNil(t, stored.PreviousValueExpiresAt)
+	require.NotNil(t, stored.RotatedAt)
+}
+
+func TestUpdateVirtualKey_RotationWithoutCooldownClearsPreviousValue(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	vk := &tables.TableVirtualKey{
+		ID:       "vk-nograce",
+		Name:     "No Grace Key",
+		Value:    *schemas.NewSecretVar("vk-first-value"),
+		IsActive: schemas.Ptr(true),
+	}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	// First rotation with a grace window.
+	now := time.Now().UTC()
+	exp := now.Add(5 * time.Minute)
+	vk.Value = *schemas.NewSecretVar("vk-second-value")
+	vk.PreviousValue = *schemas.NewSecretVar("vk-first-value")
+	vk.PreviousValueExpiresAt = &exp
+	vk.RotatedAt = &now
+	require.NoError(t, store.UpdateVirtualKey(ctx, vk))
+
+	// Second rotation with cooldown disabled clears the grace state.
+	later := now.Add(time.Minute)
+	second := &tables.TableVirtualKey{
+		ID:        "vk-nograce",
+		Name:      "No Grace Key",
+		Value:     *schemas.NewSecretVar("vk-third-value"),
+		IsActive:  schemas.Ptr(true),
+		RotatedAt: &later,
+	}
+	second.ClearPreviousValue()
+	require.NoError(t, store.UpdateVirtualKey(ctx, second))
+
+	stored, err := store.GetVirtualKey(ctx, "vk-nograce")
+	require.NoError(t, err)
+	assert.Equal(t, "vk-third-value", stored.Value.GetValue())
+	assert.False(t, stored.PreviousValue.IsSet())
+	assert.Empty(t, stored.PreviousValueHash)
+	assert.Nil(t, stored.PreviousValueExpiresAt)
+	assert.False(t, stored.HasActivePreviousValue(later))
+}
+
+func TestUpdateVirtualKey_UnresolvablePreviousValueRejected(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	vk := &tables.TableVirtualKey{
+		ID:       "vk-badprev",
+		Name:     "Bad Prev Key",
+		Value:    *schemas.NewSecretVar("vk-current-value"),
+		IsActive: schemas.Ptr(true),
+	}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	// A set-but-unresolvable PreviousValue must fail the save, mirroring the
+	// Value validation: persisting it would leave an empty hash that
+	// grace-period authentication can never match.
+	now := time.Now().UTC()
+	exp := now.Add(5 * time.Minute)
+	vk.Value = *schemas.NewSecretVar("vk-rotated-value")
+	vk.PreviousValue = *schemas.NewSecretVar("env.BIFROST_TEST_UNSET_PREVIOUS_VALUE")
+	vk.PreviousValueExpiresAt = &exp
+	vk.RotatedAt = &now
+	err := store.UpdateVirtualKey(ctx, vk)
+	require.Error(t, err, "unresolvable previous value must not persist")
+	assert.Contains(t, err.Error(), "could not be resolved")
+}
+
+func TestVirtualKeyHasActivePreviousValue(t *testing.T) {
+	now := time.Now().UTC()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+
+	vk := &tables.TableVirtualKey{}
+	assert.False(t, vk.HasActivePreviousValue(now), "no previous value")
+
+	vk.PreviousValue = *schemas.NewSecretVar("vk-prev")
+	assert.False(t, vk.HasActivePreviousValue(now), "no expiry set")
+
+	vk.PreviousValueExpiresAt = &future
+	assert.True(t, vk.HasActivePreviousValue(now), "inside grace window")
+	assert.False(t, vk.HasActivePreviousValue(future), "now == expiry is expired")
+
+	vk.PreviousValueExpiresAt = &past
+	assert.False(t, vk.HasActivePreviousValue(now), "past expiry")
+}
+
 func TestDeleteVirtualKey(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -264,6 +264,17 @@ type TableVirtualKey struct {
 	EncryptionStatus string `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
 	ValueHash        string `gorm:"type:varchar(64);index:idx_virtual_key_value_hash,unique" json:"-"`
 
+	// Rotation grace-period state. When a VK is rotated with a non-zero
+	// vk_rotation_cooldown, the retired value is kept here and keeps
+	// authenticating until PreviousValueExpiresAt. Runtime state only: these
+	// fields are excluded from GenerateVirtualKeyHash so config.json sync never
+	// sees rotation as drift. The hash index is intentionally non-unique - a
+	// retiring value cannot reserve uniqueness against live values.
+	PreviousValue          schemas.SecretVar `gorm:"type:text" json:"-"`
+	PreviousValueHash      string            `gorm:"type:varchar(64);index:idx_virtual_key_previous_value_hash" json:"-"`
+	PreviousValueExpiresAt *time.Time        `gorm:"type:timestamp;null" json:"previous_value_expires_at,omitempty"`
+	RotatedAt              *time.Time        `gorm:"type:timestamp;null" json:"rotated_at,omitempty"`
+
 	CreatedByUserID *string `gorm:"type:varchar(255);index:idx_virtual_key_created_by" json:"created_by_user_id,omitempty"`
 
 	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
@@ -306,6 +317,22 @@ func (vk TableVirtualKey) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// HasActivePreviousValue reports whether the VK carries a rotated-out value
+// that is still inside its grace window. now == expiry is treated as expired.
+func (vk *TableVirtualKey) HasActivePreviousValue(now time.Time) bool {
+	if vk == nil || !vk.PreviousValue.IsSet() || vk.PreviousValueExpiresAt == nil {
+		return false
+	}
+	return now.UTC().Before(vk.PreviousValueExpiresAt.UTC())
+}
+
+// ClearPreviousValue drops the grace-period state, leaving only the current value.
+func (vk *TableVirtualKey) ClearPreviousValue() {
+	vk.PreviousValue = schemas.SecretVar{}
+	vk.PreviousValueHash = ""
+	vk.PreviousValueExpiresAt = nil
+}
+
 // IsExpiredAt reports whether the virtual key has passed its expiry.
 // now == expires_at is treated as expired; nil ExpiresAt means never expires.
 func (vk *TableVirtualKey) IsExpiredAt(now time.Time) bool {
@@ -332,6 +359,16 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 		}
 		vk.ValueHash = encrypt.HashSHA256(resolved)
 	}
+	// PreviousValue is always a plain retired value (never an env/vault ref at
+	// this point), but guard resolution anyway: persisting a set-but-unresolved
+	// value would leave an empty hash that grace-period auth can never match.
+	if vk.PreviousValue.IsSet() {
+		resolved := vk.PreviousValue.GetValue()
+		if resolved == "" {
+			return fmt.Errorf("virtual key %s: previous env/vault ref %q could not be resolved", vk.ID, vk.PreviousValue.GetRawRef())
+		}
+		vk.PreviousValueHash = encrypt.HashSHA256(resolved)
+	}
 	// Store plaintext SecretVar into vault and rewrite to vault ref before encrypting.
 	if schemas.VaultStoreWriteEnabled() {
 		base := schemas.VaultBasePath(vk.TableName(), vk.VaultPathKey())
@@ -344,6 +381,11 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 			return fmt.Errorf("failed to encrypt virtual key value: %w", err)
 		}
 		vk.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	if encrypt.IsEnabled() && vk.PreviousValue.IsSet() {
+		if err := encryptSecretVar(&vk.PreviousValue); err != nil {
+			return fmt.Errorf("failed to encrypt virtual key previous value: %w", err)
+		}
 	}
 	return nil
 }
@@ -358,6 +400,11 @@ func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	case EncryptionStatusEncrypted:
 		if err := decryptSecretVar(&vk.Value); err != nil {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
+		}
+		if vk.PreviousValue.IsSet() {
+			if err := decryptSecretVar(&vk.PreviousValue); err != nil {
+				return fmt.Errorf("failed to decrypt virtual key previous value: %w", err)
+			}
 		}
 	}
 	StampCalendarAlignment(vk.CalendarAligned, vk.Budgets, vk.RateLimit)


### PR DESCRIPTION
## Summary

Adds rotation grace-period (cooldown) support to virtual keys. When a virtual key is rotated, the retired value can be preserved alongside the new one and continue authenticating requests until a configurable expiry (`PreviousValueExpiresAt`). This allows clients using the old key to continue working during a transition window without immediate hard failures.

## Changes

- Added four new nullable columns to `governance_virtual_keys` via a new additive migration (`add_vk_rotation_cooldown_columns`): `previous_value`, `previous_value_hash`, `previous_value_expires_at`, and `rotated_at`. NULL values preserve pre-cooldown behavior, making the migration safe for rolling upgrades.
- Extended `TableVirtualKey` with the corresponding struct fields and two helper methods:
  - `HasActivePreviousValue(now time.Time) bool` — reports whether the retired value is still within its grace window (now == expiry is treated as expired).
  - `ClearPreviousValue()` — drops all grace-period state when rotating without a cooldown.
- `BeforeSave` now computes `PreviousValueHash` and encrypts `PreviousValue` when encryption is enabled. `AfterFind` decrypts `PreviousValue` on read.
- `UpdateVirtualKey` preserves existing grace-period fields on plain (non-rotation) updates so that a rename or flag change cannot silently wipe an in-flight grace window. When `RotatedAt` is set on the incoming record, the caller's values are treated as authoritative.
- Grace-period fields are intentionally excluded from `GenerateVirtualKeyHash` so config.json sync never treats rotation state as configuration drift. The `previous_value_hash` index is non-unique by design — a retiring value must not block uniqueness for live values.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

Key test cases added:
- `TestVirtualKeyPreviousValue_EncryptsAndDecryptsCorrectly` — verifies the previous value is stored encrypted and decrypted correctly on read.
- `TestUpdateVirtualKey_PreservesRotationStateOnPlainUpdate` — verifies a plain update does not wipe an in-flight grace window.
- `TestUpdateVirtualKey_RotationWithoutCooldownClearsPreviousValue` — verifies that a rotation with cooldown disabled explicitly clears previous-value state.
- `TestVirtualKeyHasActivePreviousValue` — unit tests the grace-window boundary conditions (no value, no expiry, inside window, at expiry, past expiry).

## Breaking changes

- [ ] Yes
- [x] No

The migration is fully additive. Existing rows with NULL grace-period columns behave identically to pre-feature behavior.

## Security considerations

- `PreviousValue` is encrypted at rest using the same mechanism as the primary `Value` field and is never exposed in JSON output (`json:"-"`).
- `PreviousValueHash` uses SHA-256, consistent with `ValueHash`, and is stored in a non-unique index to avoid leaking uniqueness constraints across live and retiring values.
- Grace-period fields are excluded from config hash computation to prevent rotation metadata from being treated as a secret configuration change.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)