### PR TITLE
release notice

### DIFF
--- a/docs/changelogs/ent-v1.5.4.mdx
+++ b/docs/changelogs/ent-v1.5.4.mdx
@@ -6,6 +6,10 @@ description: "Enterprise v1.5.4 changelog - 2026-07-14"
 <Update label="Bifrost Enterprise" description="v1.5.4">
 
 
+<Warning>
+We have received some reports about JWT token is not workgin with 1.5.5 and 1.5.4. We are currently investigating the issue.
+</Warning>
+
 ## Changelog
 
 Release on `transports/v1.6.4`. Ships a full guardrails redaction engine (PII, secrets, and custom regex redaction with logs-only and reversible modes plus RBAC-gated reveal), a new alerting system with declarative channels and CEL-based rules, and a major SCIM/OIDC provisioning overhaul including SailPoint support, wildcard/glob role mappings, and transactional team/BU mapping ownership transfers. Also picks up the new Sarvam AI provider and durable background jobs from OSS.

--- a/docs/changelogs/ent-v1.5.5.mdx
+++ b/docs/changelogs/ent-v1.5.5.mdx
@@ -5,6 +5,10 @@ description: "Enterprise v1.5.5 changelog - 2026-07-21"
 
 <Update label="Bifrost Enterprise" description="v1.5.5">
 
+<Warning>
+We have received some reports about JWT token is not workgin with 1.5.5 and 1.5.4. We are currently investigating the issue.
+</Warning>
+
 ## Changelog
 
 Release on `transports/v1.6.5`. Ships identity-aware proxy authentication for inference (Cloudflare Access, AWS ALB, and generic JWKS proxies) with configurable dual-credential conflict handling, identity-scoped guardrail rules with streaming replay pacing, windowed audit log archival with S3 support, and cluster-wide async webhook delivery. Also picks up the new Wafer AI provider and reasoning token tracking from OSS.


### PR DESCRIPTION
## Summary

Adds a warning notice to the Enterprise v1.5.4 and v1.5.5 changelogs alerting users to a known issue where JWT tokens are not working correctly in those versions, and that the issue is currently under investigation.

## Changes

- Added a `<Warning>` block to both `ent-v1.5.4.mdx` and `ent-v1.5.5.mdx` notifying users of reported JWT token failures in versions 1.5.4 and 1.5.5

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the warning block renders correctly in the docs site on the v1.5.4 and v1.5.5 changelog pages.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Relates to the ongoing investigation into JWT token failures in Enterprise v1.5.4 and v1.5.5.

## Security considerations

This change documents a known authentication issue involving JWT tokens. The underlying bug being referenced may have security implications depending on how JWT validation is failing — the investigation should assess whether tokens are being incorrectly accepted or rejected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable