### PR TITLE
fix(core): carry tool-result is_error through chat completions

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: carry tool-result `is_error` through the chat completions surface so Anthropic replay and Bedrock Converse status reflect failed tool calls [@AidanAllchin](https://github.com/AidanAllchin)
 - fix: preserve encrypted reasoning as a Bedrock replay signature when translating Responses history [@zachgersh](https://github.com/zachgersh)
 - feat: add proxy support for WebSocket-based realtime calls, mirroring existing HTTP proxy configuration (#5788)
 - feat: add `WithFasthttpBufferSizes` option to `HTTPClientFactory` for configurable SCIM read/write buffers, fixing failures when IdP token endpoints return headers larger than the 4KB default (#5808)

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -768,6 +768,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					toolResult := AnthropicContentBlock{
 						Type:      AnthropicContentBlockTypeToolResult,
 						ToolUseID: &sanitizedToolUseID,
+						IsError:   toolMsg.ChatToolMessage.IsError,
 					}
 
 					// Convert tool result content

--- a/core/providers/anthropic/toolresultiserror_test.go
+++ b/core/providers/anthropic/toolresultiserror_test.go
@@ -1,0 +1,81 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestToolResultIsErrorReachesAnthropicWire verifies that a tool message
+// carrying IsError converts to an Anthropic tool_result block with is_error
+// set. Claude is trained to treat errored tool results differently, so
+// dropping the marker silently changes model behavior on replayed histories.
+func TestToolResultIsErrorReachesAnthropicWire(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-sonnet-4-5",
+		Input: []schemas.ChatMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("run the tool")},
+			},
+			{
+				Role: schemas.ChatMessageRoleAssistant,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: []schemas.ChatAssistantMessageToolCall{
+						{
+							ID:       schemas.Ptr("toolu_failed"),
+							Function: schemas.ChatAssistantMessageToolCallFunction{Name: schemas.Ptr("run"), Arguments: "{}"},
+						},
+						{
+							ID:       schemas.Ptr("toolu_ok"),
+							Function: schemas.ChatAssistantMessageToolCallFunction{Name: schemas.Ptr("run"), Arguments: "{}"},
+						},
+					},
+				},
+			},
+			{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_failed"), IsError: schemas.Ptr(true)},
+				Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("command exited with code 1")},
+			},
+			{
+				Role:            schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_ok")},
+				Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("done")},
+			},
+		},
+	}
+
+	result, err := ToAnthropicChatRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("convert to Anthropic request: %v", err)
+	}
+
+	var toolResults []AnthropicContentBlock
+	for _, msg := range result.Messages {
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Type == AnthropicContentBlockTypeToolResult {
+				toolResults = append(toolResults, block)
+			}
+		}
+	}
+	if len(toolResults) != 2 {
+		t.Fatalf("expected 2 tool_result blocks, got %d", len(toolResults))
+	}
+
+	failed := toolResults[0]
+	if failed.ToolUseID == nil || *failed.ToolUseID != "toolu_failed" {
+		t.Fatalf("expected first tool_result for toolu_failed, got %v", failed.ToolUseID)
+	}
+	if failed.IsError == nil || !*failed.IsError {
+		t.Fatal("tool_result for the failed call must carry is_error: true")
+	}
+
+	ok := toolResults[1]
+	if ok.IsError != nil {
+		t.Fatalf("tool_result without IsError must omit is_error, got %v", *ok.IsError)
+	}
+}

--- a/core/providers/bedrock/toolresultstatus_test.go
+++ b/core/providers/bedrock/toolresultstatus_test.go
@@ -1,0 +1,53 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestToolResultStatusFromIsError verifies that a tool message carrying
+// IsError converts to a Converse toolResult with status "error", and that
+// non-error results keep the "success" default. Before IsError existed on
+// ChatToolMessage the status was hard-coded to "success", so failed tool
+// calls replayed through Bedrock looked successful to the model.
+func TestToolResultStatusFromIsError(t *testing.T) {
+	msgs := []schemas.ChatMessage{
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_failed"), IsError: schemas.Ptr(true)},
+			Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("command exited with code 1")},
+		},
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: schemas.Ptr("toolu_ok")},
+			Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("done")},
+		},
+	}
+
+	converted, err := convertToolMessages(context.Background(), msgs)
+	if err != nil {
+		t.Fatalf("convert tool messages: %v", err)
+	}
+
+	var results []*BedrockToolResult
+	for _, block := range converted.Content {
+		if block.ToolResult != nil {
+			results = append(results, block.ToolResult)
+		}
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 toolResult blocks, got %d", len(results))
+	}
+
+	if results[0].ToolUseID != "toolu_failed" {
+		t.Fatalf("expected first toolResult for toolu_failed, got %s", results[0].ToolUseID)
+	}
+	if results[0].Status == nil || *results[0].Status != "error" {
+		t.Fatalf("failed tool call must map to status \"error\", got %v", results[0].Status)
+	}
+	if results[1].Status == nil || *results[1].Status != "success" {
+		t.Fatalf("non-error tool call must keep status \"success\", got %v", results[1].Status)
+	}
+}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1079,11 +1079,15 @@ func convertToolMessages(ctx context.Context, msgs []schemas.ChatMessage) (Bedro
 		}
 
 		// Create tool result content block for this tool message
+		status := "success"
+		if msg.ChatToolMessage.IsError != nil && *msg.ChatToolMessage.IsError {
+			status = "error"
+		}
 		toolResultBlock := BedrockContentBlock{
 			ToolResult: &BedrockToolResult{
 				ToolUseID: *msg.ChatToolMessage.ToolCallID,
 				Content:   toolResultContent,
-				Status:    schemas.Ptr("success"), // Default to success
+				Status:    schemas.Ptr(status),
 			},
 		}
 

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -23,6 +23,13 @@ func sanitizeMessagesForHuggingFace(messages []schemas.ChatMessage) []schemas.Ch
 			Content:         msg.Content,
 			ChatToolMessage: msg.ChatToolMessage,
 		}
+		// The OpenAI-compatible wire has no tool-error field; strip is_error.
+		// Clone first — ChatToolMessage is shared with the caller's input.
+		if msg.ChatToolMessage != nil && msg.ChatToolMessage.IsError != nil {
+			toolMsgCopy := *msg.ChatToolMessage
+			toolMsgCopy.IsError = nil
+			sanitized[i].ChatToolMessage = &toolMsgCopy
+		}
 		// Only preserve ToolCalls from ChatAssistantMessage
 		if msg.ChatAssistantMessage != nil && len(msg.ChatAssistantMessage.ToolCalls) > 0 {
 			sanitized[i].ChatAssistantMessage = &schemas.ChatAssistantMessage{

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -10,10 +10,11 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
-// sanitizeMessagesForHuggingFace removes unsupported ChatAssistantMessage fields
-// from chat messages. HuggingFace's OpenAI-compatible API doesn't support fields
+// sanitizeMessagesForHuggingFace removes unsupported fields from chat messages.
+// HuggingFace's OpenAI-compatible API doesn't support ChatAssistantMessage fields
 // like reasoning_details, reasoning, annotations, audio, and refusal.
 // Only ToolCalls is preserved from ChatAssistantMessage.
+// Tool messages also lose is_error, which has no OpenAI-wire equivalent.
 func sanitizeMessagesForHuggingFace(messages []schemas.ChatMessage) []schemas.ChatMessage {
 	sanitized := make([]schemas.ChatMessage, len(messages))
 	for i, msg := range messages {

--- a/core/providers/openai/toolresultiserror_test.go
+++ b/core/providers/openai/toolresultiserror_test.go
@@ -1,0 +1,54 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestToolResultIsErrorStrippedFromOpenAIWire verifies that IsError — an
+// Anthropic-family marker with no OpenAI wire equivalent — never serializes
+// into an OpenAI message. OpenAI-compatible providers reject unknown message
+// parameters (see the Responses-path incident with `input[N].error`), so the
+// converter must strip it rather than forward it.
+func TestToolResultIsErrorStrippedFromOpenAIWire(t *testing.T) {
+	original := &schemas.ChatToolMessage{
+		ToolCallID: schemas.Ptr("call_1"),
+		IsError:    schemas.Ptr(true),
+	}
+	messages := []schemas.ChatMessage{
+		{
+			Role:            schemas.ChatMessageRoleTool,
+			ChatToolMessage: original,
+			Content:         &schemas.ChatMessageContent{ContentStr: schemas.Ptr("command exited with code 1")},
+		},
+	}
+
+	converted := ConvertBifrostMessagesToOpenAIMessages(messages)
+	if len(converted) != 1 {
+		t.Fatalf("expected 1 converted message, got %d", len(converted))
+	}
+	if converted[0].ChatToolMessage == nil {
+		t.Fatal("expected tool message fields to survive conversion")
+	}
+	if converted[0].ChatToolMessage.IsError != nil {
+		t.Fatal("IsError must be stripped from the OpenAI-wire message")
+	}
+	if converted[0].ChatToolMessage.ToolCallID == nil || *converted[0].ChatToolMessage.ToolCallID != "call_1" {
+		t.Fatal("tool_call_id must survive the strip")
+	}
+
+	wire, err := schemas.MarshalSorted(converted[0])
+	if err != nil {
+		t.Fatalf("marshal converted message: %v", err)
+	}
+	if strings.Contains(string(wire), "is_error") {
+		t.Fatalf("serialized OpenAI message must not contain is_error, got: %s", wire)
+	}
+
+	// The caller's input is shared; the strip must clone, never mutate.
+	if original.IsError == nil || !*original.IsError {
+		t.Fatal("caller's ChatToolMessage must not be mutated by the strip")
+	}
+}

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -53,6 +53,14 @@ func ConvertBifrostMessagesToOpenAIMessages(messages []schemas.ChatMessage) []Op
 				openaiMessages[i].ChatToolMessage = &toolMsgCopy
 			}
 		}
+		// The OpenAI wire format has no tool-error field; strip is_error so
+		// providers that reject unknown message parameters never see it. Clone
+		// first — ChatToolMessage is shared with the caller's input.
+		if openaiMessages[i].ChatToolMessage != nil && openaiMessages[i].ChatToolMessage.IsError != nil {
+			toolMsgCopy := *openaiMessages[i].ChatToolMessage
+			toolMsgCopy.IsError = nil
+			openaiMessages[i].ChatToolMessage = &toolMsgCopy
+		}
 		if message.ChatAssistantMessage != nil {
 			// Strip the same embedded signature from over-long assistant tool call IDs. Clone the
 			// slice only when a strip is actually needed so the caller's input is never mutated.

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -32,6 +32,12 @@ func ConvertOpenAIMessagesToBifrostMessages(messages []OpenAIMessage) []schemas.
 	return bifrostMessages
 }
 
+// ConvertBifrostMessagesToOpenAIMessages converts Bifrost chat messages to the
+// OpenAI wire format, dropping neutral-format fields the OpenAI wire has no
+// carrier for. Over-long tool call IDs are stripped of embedded provider
+// reasoning signatures, and tool messages lose is_error so providers that reject
+// unknown message parameters never see it.
+// The caller's messages are never mutated: shared pointers are cloned before edit.
 func ConvertBifrostMessagesToOpenAIMessages(messages []schemas.ChatMessage) []OpenAIMessage {
 	openaiMessages := make([]OpenAIMessage, len(messages))
 	for i, message := range messages {

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1388,6 +1388,12 @@ type ChatInputFile struct {
 // ChatToolMessage represents a tool message in a chat conversation.
 type ChatToolMessage struct {
 	ToolCallID *string `json:"tool_call_id,omitempty"`
+	// IsError marks the tool execution as failed. Not part of the OpenAI wire
+	// format — converters for providers whose wire supports an error marker map
+	// it (Anthropic tool_result.is_error, Bedrock toolResult.status), and
+	// OpenAI-wire converters strip it before serialization so providers that
+	// reject unknown message parameters never see it.
+	IsError *bool `json:"is_error,omitempty"`
 }
 
 // ChatAssistantMessage represents a message in a chat conversation.

--- a/core/schemas/toolmessageiserror_test.go
+++ b/core/schemas/toolmessageiserror_test.go
@@ -1,0 +1,46 @@
+package schemas
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestChatMessageIsErrorRoundTrip verifies is_error on a tool message survives
+// the ChatMessage JSON round trip — ChatMessage has a custom UnmarshalJSON
+// that reattaches ChatToolMessage, so a new field silently dropping there
+// would lose the marker for every HTTP-transport caller.
+func TestChatMessageIsErrorRoundTrip(t *testing.T) {
+	in := `{"role":"tool","tool_call_id":"call_1","content":"command exited with code 1","is_error":true}`
+
+	var msg ChatMessage
+	if err := Unmarshal([]byte(in), &msg); err != nil {
+		t.Fatalf("unmarshal tool message: %v", err)
+	}
+	if msg.ChatToolMessage == nil {
+		t.Fatal("expected ChatToolMessage to be attached")
+	}
+	if msg.ChatToolMessage.IsError == nil || !*msg.ChatToolMessage.IsError {
+		t.Fatal("is_error must survive unmarshal")
+	}
+
+	out, err := MarshalSorted(msg)
+	if err != nil {
+		t.Fatalf("marshal tool message: %v", err)
+	}
+	if !strings.Contains(string(out), `"is_error":true`) {
+		t.Fatalf("is_error must survive marshal, got: %s", out)
+	}
+
+	// Absent is_error must stay absent — omitempty, never a false literal.
+	var clean ChatMessage
+	if err := Unmarshal([]byte(`{"role":"tool","tool_call_id":"call_2","content":"ok"}`), &clean); err != nil {
+		t.Fatalf("unmarshal clean tool message: %v", err)
+	}
+	out, err = MarshalSorted(clean)
+	if err != nil {
+		t.Fatalf("marshal clean tool message: %v", err)
+	}
+	if strings.Contains(string(out), "is_error") {
+		t.Fatalf("absent is_error must not serialize, got: %s", out)
+	}
+}

--- a/core/schemas/toolmessageiserror_test.go
+++ b/core/schemas/toolmessageiserror_test.go
@@ -43,4 +43,25 @@ func TestChatMessageIsErrorRoundTrip(t *testing.T) {
 	if strings.Contains(string(out), "is_error") {
 		t.Fatalf("absent is_error must not serialize, got: %s", out)
 	}
+
+	// Explicit false is distinct from absent: a caller that marks a tool result
+	// as succeeded must not have that collapse into "unspecified", which the
+	// Bedrock converter would read as the same thing but Anthropic would not.
+	var notError ChatMessage
+	if err := Unmarshal([]byte(`{"role":"tool","tool_call_id":"call_3","content":"ok","is_error":false}`), &notError); err != nil {
+		t.Fatalf("unmarshal false tool message: %v", err)
+	}
+	if notError.ChatToolMessage == nil {
+		t.Fatal("expected ChatToolMessage to be attached")
+	}
+	if notError.ChatToolMessage.IsError == nil || *notError.ChatToolMessage.IsError {
+		t.Fatal("explicit is_error:false must survive unmarshal as a non-nil false")
+	}
+	out, err = MarshalSorted(notError)
+	if err != nil {
+		t.Fatalf("marshal false tool message: %v", err)
+	}
+	if !strings.Contains(string(out), `"is_error":false`) {
+		t.Fatalf("explicit is_error:false must survive marshal, got: %s", out)
+	}
 }


### PR DESCRIPTION
## Summary

The Chat Completions neutral format has no carrier for a failed tool execution: `ChatToolMessage` holds only `tool_call_id`, so an Anthropic `tool_result`'s `is_error` is silently dropped when a conversation is replayed through bifrost — and the model genuinely treats errored tool results differently, so the loss changes behavior rather than just cosmetics. The gap was acknowledged in #190 ("we are dropping the `is_error` field from Anthropic which I guess we can include in the ToolMessage struct as an optional pointer if necessary") but never landed. The sibling Responses surface already preserves the marker (`ResponsesToolMessage.Error` / `status: "incomplete"`, refined in #1580); this PR brings the chat surface to parity.

A second concrete symptom: the Bedrock Converse converter hard-codes every `toolResult` to `status: "success"` (`// Default to success`), so failed tool calls replayed via Bedrock look successful to the model.

<details>
<summary>Verification that the flag is actually model-visible (not just API bookkeeping)</summary>

Probe against the live Anthropic API: a tool_result whose content looks like a perfectly successful value (`"42"`), with only `is_error` flipped, then ask the model whether the call succeeded.

| Model | `is_error` | Response |
|---|---|---|
| claude-sonnet-4-5 | absent | "The tool call **SUCCEEDED**. The value returned was: **42**" |
| claude-sonnet-4-5 | `true` | "The tool call **FAILED**. What was returned: An error with the value `42`." |
| claude-sonnet-5 | absent | "The tool call **SUCCEEDED**. It returned the value: **42**" |
| claude-sonnet-5 | `true` | "The tool call **FAILED**. … instead of a valid value, the system returned an error, with the error content being: `42`" |

Identical content, flag alone flips the model's success/failure judgment on both generations. So dropping the marker on replay changes behavior specifically in the failure-judgment path (retry vs. proceed) while looking harmless in the happy path.

</details>

## Changes

- **`schemas`**: add `IsError *bool` (`is_error,omitempty`) to `ChatToolMessage`, with a doc comment stating the strip contract for OpenAI-wire converters. Round-trip covered in `toolmessageiserror_test.go` (the custom `ChatMessage.UnmarshalJSON` reattach path is the risky spot).
- **`providers/anthropic`**: map `IsError` onto the `tool_result` block (`AnthropicContentBlock.IsError` already existed but was never populated from the chat-neutral form). Nil stays absent; tri-state preserved.
- **`providers/bedrock`**: derive Converse `toolResult.status` (`"error"`/`"success"`) from `IsError` instead of hard-coding `"success"`.
- **`providers/openai`**: strip `is_error` in `ConvertBifrostMessagesToOpenAIMessages` (clone-first, same pattern as the thought-signature strip directly above it) — the OpenAI wire has no such field and OpenAI-compatible providers reject unknown message parameters (same failure class as the Responses-path `input[N].error` incident #1580 fixed).
- **`providers/huggingface`**: same strip in `sanitizeMessagesForHuggingFace`, which forwards `ChatToolMessage` by pointer.
- Cohere/Gemini and the other converters build their wire structs by explicit field mapping, so no strip is needed there. Bedrock ingress (Converse `status` → neutral `IsError`) is not wired here — happy to add if wanted.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```bash
cd core
go test ./schemas/ -run TestChatMessageIsErrorRoundTrip -count=1
go test ./providers/anthropic/ -run TestToolResultIsErrorReachesAnthropicWire -count=1
go test ./providers/openai/ -run TestToolResultIsErrorStrippedFromOpenAIWire -count=1
go test ./providers/bedrock/ -run TestToolResultStatusFromIsError -count=1
```

All four pass; full unit suites for the touched packages (`schemas`, `anthropic`, `bedrock`, `huggingface`) are green. `providers/openai` has one pre-existing failure on the base commit, unrelated to this change (`TestToOpenAIResponsesRequest_GPTOSS_SummaryToContentBlocks` — fails identically with this diff stashed).

Let me know if you want a different placement for the OpenAI-wire strip (e.g. centralizing it in `filterOpenAISpecificParameters`) or want Bedrock ingress mapping included.
