### PR TITLE
fix: support RFC3339 timestamps in `parseTrialExpiry` and update banner background colors

### DIFF
--- a/ui/components/trialExpiryBanner.tsx
+++ b/ui/components/trialExpiryBanner.tsx
@@ -19,7 +19,7 @@ export default function TrialExpiryBanner() {
 			id="trial-notification-banner"
 			className={cn(
 				"sticky top-0 z-10 flex w-full items-center justify-center gap-2 rounded-tl-md rounded-tr-md px-4 py-2 text-xs font-medium",
-				expired || critical ? "bg-red-500/10 text-red-700 dark:text-red-400" : "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+				expired || critical ? "bg-[#ffebea] text-red-700 dark:text-red-400" : "bg-[#fff4e4] text-amber-700 dark:text-amber-400",
 			)}
 			role="status"
 		>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -2,17 +2,27 @@ import { BaseProvider, ConcurrencyAndBufferSize, NetworkConfig } from "@/lib/typ
 import { ProviderName } from "./logs";
 
 /**
- * Parse a date string in YYYY-MM-DD format with strict validation.
- * Returns null if the string is empty, malformed, or represents an invalid date.
+ * Parse a trial expiry string with strict validation.
+ * Accepts either a bare date (YYYY-MM-DD) or a full RFC3339 timestamp
+ * (YYYY-MM-DDTHH:mm:ssZ) — the Docker build injects the latter, since the Go
+ * side needs an RFC3339 value. Only the calendar date is significant for the
+ * banner, so any time component is ignored and the date is taken at local
+ * midnight. Returns null if the string is empty, malformed, or represents an
+ * invalid date.
  */
 function parseTrialExpiry(dateStr: string | undefined): Date | null {
 	if (!dateStr || !dateStr.trim()) return null;
 
-	// Strict format check: YYYY-MM-DD
-	const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-	if (!dateRegex.test(dateStr)) return null;
+	// Accept YYYY-MM-DD optionally followed by a time component (e.g. the
+	// RFC3339 "T00:00:00Z" suffix), and capture just the date part.
+	const dateRegex = /^(\d{4})-(\d{2})-(\d{2})(?:[T ].*)?$/;
+	const match = dateRegex.exec(dateStr.trim());
+	if (!match) return null;
 
-	const [year, month, day] = dateStr.split("-").map(Number);
+	const [, yearStr, monthStr, dayStr] = match;
+	const year = Number(yearStr);
+	const month = Number(monthStr);
+	const day = Number(dayStr);
 	const date = new Date(year, month - 1, day);
 
 	// Validate the date components match (catches invalid dates like 2024-02-30)


### PR DESCRIPTION
## Summary

Fixes two issues with the trial expiry banner: the background colours were using Tailwind opacity-modifier classes that didn't render correctly, and the trial expiry date parser rejected RFC3339 timestamps (e.g. `2024-06-01T00:00:00Z`) injected by the Docker build, causing the banner to silently disappear.

## Changes

- Replaced `bg-red-500/10` and `bg-amber-500/10` with explicit hex values (`#ffebea` and `#fff4e4`) to ensure the banner background renders as intended in both expired/critical and warning states.
- Updated `parseTrialExpiry` to accept both bare `YYYY-MM-DD` dates and full RFC3339 timestamps. Only the calendar date portion is used (interpreted at local midnight), so the time component is stripped before parsing.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Set `TRIAL_EXPIRY_DATE` to an RFC3339 value such as `2024-06-01T00:00:00Z` and confirm the banner appears with the correct background colour.
2. Set it to a bare date such as `2024-06-01` and confirm the banner still renders correctly.
3. Set it to a date within the warning window and confirm the amber (`#fff4e4`) background is shown.
4. Set it to an expired or critical date and confirm the red (`#ffebea`) background is shown.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: banner background was invisible due to unresolved Tailwind opacity-modifier classes.  
After: banner displays the correct solid tinted background in both warning and expired/critical states.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable