### PR TITLE
fix: handle input images in image gen for replicate

### DIFF
--- a/core/providers/replicate/images.go
+++ b/core/providers/replicate/images.go
@@ -1,6 +1,7 @@
 package replicate
 
 import (
+	"fmt"
 	"strings"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -28,9 +29,9 @@ var modelInputImageFieldMap = map[string]string{
 }
 
 // ToReplicateImageGenerationInput converts a Bifrost image generation request to Replicate prediction input
-func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationRequest) *ReplicatePredictionRequest {
+func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationRequest) (*ReplicatePredictionRequest, error) {
 	if bifrostReq == nil || bifrostReq.Input == nil {
-		return nil
+		return nil, nil
 	}
 
 	input := &ReplicatePredictionRequestInput{
@@ -40,6 +41,19 @@ func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationR
 	// Map parameters if available
 	if bifrostReq.Params != nil {
 		params := bifrostReq.Params
+
+		// Map input images to the field name the target model expects
+		if len(params.InputImages) > 0 {
+			images := make([]string, 0, len(params.InputImages))
+			for _, img := range params.InputImages {
+				sanitizedURL, err := schemas.SanitizeImageURL(img)
+				if err != nil {
+					return nil, fmt.Errorf("invalid input image: %w", err)
+				}
+				images = append(images, sanitizedURL)
+			}
+			setInputImageField(input, bifrostReq.Model, images)
+		}
 
 		if bifrostReq.Params.N != nil {
 			input.NumberOfImages = bifrostReq.Params.N
@@ -111,7 +125,7 @@ func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationR
 		}
 	}
 
-	return request
+	return request, nil
 }
 
 // ToBifrostImageGenerationResponse converts a Replicate prediction response to Bifrost format
@@ -187,6 +201,28 @@ func getInputImageFieldName(model string) string {
 	return "input_images"
 }
 
+// setInputImageField assigns images to the input field the model expects.
+// Shared by the generation and edit paths so both stay in sync.
+func setInputImageField(input *ReplicatePredictionRequestInput, model string, images []string) {
+	switch getInputImageFieldName(model) {
+	case "image_prompt":
+		// For flux-1.1-pro variants: use first image as image_prompt
+		input.ImagePrompt = &images[0]
+
+	case "input_image":
+		// For flux-kontext variants: use first image as input_image
+		input.InputImage = &images[0]
+
+	case "image":
+		// For flux-dev variants: use first image as image field
+		input.Image = &images[0]
+
+	case "input_images":
+		// For all other models: use input_images array (preserves multi-image support)
+		input.InputImages = images
+	}
+}
+
 // ToReplicateImageEditInput converts a Bifrost image edit request to Replicate prediction input
 func ToReplicateImageEditInput(bifrostReq *schemas.BifrostImageEditRequest) *ReplicatePredictionRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
@@ -207,26 +243,7 @@ func ToReplicateImageEditInput(bifrostReq *schemas.BifrostImageEditRequest) *Rep
 		}
 
 		if len(images) > 0 {
-			// Determine the appropriate field based on model
-			fieldName := getInputImageFieldName(bifrostReq.Model)
-
-			switch fieldName {
-			case "image_prompt":
-				// For flux-1.1-pro variants: use first image as image_prompt
-				input.ImagePrompt = &images[0]
-
-			case "input_image":
-				// For flux-kontext variants: use first image as input_image
-				input.InputImage = &images[0]
-
-			case "image":
-				// For flux-dev variants: use first image as image field
-				input.Image = &images[0]
-
-			case "input_images":
-				// For all other models: use input_images array (preserves multi-image support)
-				input.InputImages = images
-			}
+			setInputImageField(input, bifrostReq.Model, images)
 		}
 	}
 

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -1744,7 +1744,7 @@ func (provider *ReplicateProvider) ImageGeneration(ctx *schemas.BifrostContext, 
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToReplicateImageGenerationInput(request), nil
+			return ToReplicateImageGenerationInput(request)
 		})
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1839,7 +1839,10 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			replicateReq := ToReplicateImageGenerationInput(request)
+			replicateReq, err := ToReplicateImageGenerationInput(request)
+			if err != nil {
+				return nil, err
+			}
 			replicateReq.Stream = schemas.Ptr(true)
 			return replicateReq, nil
 		})

--- a/core/providers/replicate/replicate_test.go
+++ b/core/providers/replicate/replicate_test.go
@@ -607,6 +607,60 @@ func TestBifrostToReplicateImageGenerationConversion(t *testing.T) {
 			},
 		},
 		{
+			name: "InputImages_SingleImageField",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-kontext-pro",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/a.png", "https://example.com/b.png"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				require.NotNil(t, result.Input.InputImage)
+				assert.Equal(t, "https://example.com/a.png", *result.Input.InputImage)
+				assert.Nil(t, result.Input.InputImages)
+				assert.Nil(t, result.Input.ImagePrompt)
+				assert.Nil(t, result.Input.Image)
+			},
+		},
+		{
+			name: "InputImages_ArrayFieldWithBase64Normalization",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "some-owner/some-model",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"iVBORw0KGgoAAAANSUhEUg", "https://example.com/b.png"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				require.Len(t, result.Input.InputImages, 2)
+				assert.Equal(t, "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg", result.Input.InputImages[0])
+				assert.Equal(t, "https://example.com/b.png", result.Input.InputImages[1])
+				assert.Nil(t, result.Input.InputImage)
+			},
+		},
+		{
+			name: "InputImages_InvalidURL",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-dev",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"file:///etc/passwd"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name:    "NilRequest",
 			input:   nil,
 			wantErr: false, // Function returns nil, not error
@@ -629,10 +683,12 @@ func TestBifrostToReplicateImageGenerationConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := replicate.ToReplicateImageGenerationInput(tt.input)
+			actual, err := replicate.ToReplicateImageGenerationInput(tt.input)
 			if tt.wantErr {
+				assert.Error(t, err)
 				assert.Nil(t, actual)
 			} else {
+				require.NoError(t, err)
 				if tt.validate != nil {
 					tt.validate(t, actual)
 				}

--- a/docs/providers/supported-providers/replicate.mdx
+++ b/docs/providers/supported-providers/replicate.mdx
@@ -770,7 +770,6 @@ Each Replicate model has unique parameters. To find available parameters:
 **Behavior**: Not all models support `system_prompt` field. For unsupported models, system prompt is prepended to conversation prompt.
 **Impact**: Prompt structure differs between models
 **Models Affected**: `meta/meta-llama-3-8b`, `meta/llama-2-70b`, `openai/gpt-oss-20b`, `openai/o1-mini`, `xai/grok-4`, and all `deepseek-ai/deepseek*` models
-**Code**: `chat.go:300-318`
 </Accordion>
 
 <Accordion title="Input Image Field Mapping">
@@ -778,14 +777,12 @@ Each Replicate model has unique parameters. To find available parameters:
 **Behavior**: Different models expect input images in different fields (`image_prompt`, `input_image`, `image`, `input_images`)
 **Impact**: Bifrost automatically maps to correct field based on model
 **Models Affected**: Flux family models (see Input Image Field Mapping table)
-**Code**: `images.go:192-209`
 </Accordion>
 
 <Accordion title="Image Content in Chat">
 **Severity**: Low
 **Behavior**: Only non-base64 image URLs from message content blocks are extracted to `image_input`
 **Impact**: Base64-encoded images in messages are ignored
-**Code**: `chat.go:58-63`
 </Accordion>
 
 <Accordion title="Model-Specific Parameters">


### PR DESCRIPTION
## Summary

`ToReplicateImageGenerationInput` previously ignored `InputImages` entirely and could not surface validation errors to callers. This PR adds input image support to the image generation path (mirroring what already existed for image edits) and propagates URL sanitization errors instead of silently dropping them.

## Changes

- Changed `ToReplicateImageGenerationInput` to return `(*ReplicatePredictionRequest, error)` so URL validation errors can be surfaced to callers.
- Added `InputImages` handling in the generation path: each image URL is sanitized via `schemas.SanitizeImageURL`, and the resulting slice is routed to the correct model-specific field using the new shared helper.
- Extracted the model-to-field dispatch logic (`image_prompt`, `input_image`, `image`, `input_images`) into a `setInputImageField` helper, eliminating the duplicated switch block that previously existed only in the edit path.
- Updated both `ImageGeneration` and `ImageGenerationStream` call sites to handle the new error return.
- Removed stale line-number references from the Replicate provider docs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/replicate/...
```

New test cases cover:
- `InputImages_SingleImageField` — verifies that a kontext-pro model receives the first image in `input_image` and no other image fields are set.
- `InputImages_ArrayFieldWithBase64Normalization` — verifies that a generic model receives all images in `input_images` and that bare base64 strings are prefixed with the `data:image/png;base64,` URI scheme.
- `InputImages_InvalidURL` — verifies that a `file://` URI causes an error return and a `nil` result.

## Breaking changes

- [x] Yes
- [ ] No

`ToReplicateImageGenerationInput` now returns `(*ReplicatePredictionRequest, error)` instead of `*ReplicatePredictionRequest`. Any external callers must be updated to handle the additional return value.

## Related issues

## Security considerations

Input images are now validated through `schemas.SanitizeImageURL` before being forwarded to Replicate. This prevents schemes such as `file://` from being passed through to the provider.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable