### PR TITLE
refactor: replace boolean switches with tri-state selects for deployment-level overrides

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 // Batch API form field for all providers
 function BatchAPIFormField({ control }: { control: Control<any>; form: UseFormReturn<any> }) {
-	return (	
+	return (
 		<FormField
 			control={control}
 			name={`key.use_for_batch_api`}
@@ -60,8 +60,8 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 	const isVLLM = effectiveProvider === "vllm";
 	const isOllama = effectiveProvider === "ollama";
 	const isSGL = effectiveProvider === "sgl";
-    const isDeepseek = effectiveProvider === "deepseek";
-    const isFireworks = effectiveProvider === "fireworks";
+	const isDeepseek = effectiveProvider === "deepseek";
+	const isFireworks = effectiveProvider === "fireworks";
 	const isKeylessProvider = isOllama || isSGL;
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(effectiveProvider);
 
@@ -777,12 +777,14 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							<FormItem className="flex flex-row items-center justify-between rounded-sm border p-2">
 								<div className="space-y-1.5">
 									<FormLabel htmlFor="use-anthropic-endpoints-alias-override-switch">Use Anthropic Endpoints</FormLabel>
-									<FormDescription>
-										Routes chat completions and responses requests through Anthropic-compatible endpoints.
-									</FormDescription>
+									<FormDescription>Routes chat completions and responses requests through Anthropic-compatible endpoints.</FormDescription>
 								</div>
 								<FormControl>
-									<Switch id="use-anthropic-endpoints-alias-override-switch" checked={field.value ?? false} onCheckedChange={field.onChange} />
+									<Switch
+										id="use-anthropic-endpoints-alias-override-switch"
+										checked={field.value ?? false}
+										onCheckedChange={field.onChange}
+									/>
 								</FormControl>
 							</FormItem>
 						)}

--- a/ui/app/workspace/providers/fragments/deploymentsTable.tsx
+++ b/ui/app/workspace/providers/fragments/deploymentsTable.tsx
@@ -10,7 +10,7 @@ import { AliasConfig, ModelFamily, ModelFamilyValues } from "@/lib/types/config"
 import { SecretVar } from "@/lib/types/schemas";
 import { cn } from "@/lib/utils";
 import { ChevronDown, ChevronRight, Trash } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 
 type DeploymentsValue = Record<string, AliasConfig> | undefined | null;
 
@@ -125,6 +125,51 @@ interface ProviderSectionProps {
 	disabled?: boolean;
 }
 
+// Three-way control for boolean overrides that inherit a key-level toggle when
+// unset: undefined = use the key's setting, true/false = explicit override. A
+// plain switch can't express "explicitly off while the key-level toggle is on".
+function TriStateOverrideRow({
+	label,
+	hint,
+	value,
+	onChange,
+	disabled,
+	testId,
+}: {
+	label: string;
+	hint: string;
+	value: boolean | undefined;
+	onChange: (next: boolean | undefined) => void;
+	disabled?: boolean;
+	testId?: string;
+}) {
+	const id = useId();
+	const hintId = `${id}-hint`;
+	const selectValue = value === undefined ? "inherit" : value ? "on" : "off";
+	return (
+		<div className="flex items-start justify-between gap-4 rounded-md border p-3">
+			<div className="space-y-0.5">
+				<label htmlFor={id} className="text-sm font-medium">
+					{label}
+				</label>
+				<p id={hintId} className="text-muted-foreground text-xs">
+					{hint}
+				</p>
+			</div>
+			<Select value={selectValue} onValueChange={(v) => onChange(v === "inherit" ? undefined : v === "on")} disabled={disabled}>
+				<SelectTrigger id={id} aria-describedby={hintId} className="w-fit min-w-44 shrink-0" data-testid={testId}>
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="inherit">Use key setting</SelectItem>
+					<SelectItem value="on">On</SelectItem>
+					<SelectItem value="off">Off</SelectItem>
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}
+
 function AzureSection({ config, onChange, disabled }: ProviderSectionProps) {
 	return (
 		<div className="space-y-4">
@@ -195,8 +240,7 @@ function VertexSection({ config, onChange, disabled }: ProviderSectionProps) {
 				<div className="space-y-0.5">
 					<label className="text-sm font-medium">Force single region</label>
 					<p className="text-muted-foreground text-xs">
-						Call the region above as-is and skip multi-region promotion of multi-region-only models. Use for provisioned
-						throughput.
+						Call the region above as-is and skip multi-region promotion of multi-region-only models. Use for provisioned throughput.
 					</p>
 				</div>
 				<Switch
@@ -232,7 +276,10 @@ function BedrockSection({ config, onChange, disabled }: ProviderSectionProps) {
 					disabled={disabled}
 				/>
 			</FieldRow>
-			<FieldRow label="Project ID" hint="Scope this deployment's Bedrock Mantle (gpt-*/Gemma) calls to a specific project via the OpenAI-Project header. Leave blank to use the key's project.">
+			<FieldRow
+				label="Project ID"
+				hint="Scope this deployment's Bedrock Mantle (gpt-*/Gemma) calls to a specific project via the OpenAI-Project header. Leave blank to use the key's project."
+			>
 				<SecretVarField
 					value={config.project_id}
 					onChange={(v) => onChange({ project_id: v })}
@@ -259,7 +306,10 @@ function BedrockMantleSection({ config, onChange, disabled }: ProviderSectionPro
 					disabled={disabled}
 				/>
 			</FieldRow>
-			<FieldRow label="Project ID" hint="Scope this deployment to a specific project via the OpenAI-Project / anthropic-workspace-id header. Leave blank to use the key's project.">
+			<FieldRow
+				label="Project ID"
+				hint="Scope this deployment to a specific project via the OpenAI-Project / anthropic-workspace-id header. Leave blank to use the key's project."
+			>
 				<SecretVarField
 					value={config.project_id}
 					onChange={(v) => onChange({ project_id: v })}
@@ -275,19 +325,14 @@ function ReplicateSection({ config, onChange, disabled }: ProviderSectionProps) 
 	return (
 		<div className="space-y-4">
 			<SectionHeader title="Replicate overrides" description="Override key-level Replicate defaults for this deployment." />
-			<div className="flex items-start justify-between gap-4 rounded-md border p-3">
-				<div className="space-y-0.5">
-					<label className="text-sm font-medium">Use deployments endpoint</label>
-					<p className="text-muted-foreground text-xs">
-						Route through Replicate&apos;s deployments endpoint instead of the models endpoint.
-					</p>
-				</div>
-				<Switch
-					checked={config.use_deployments_endpoint ?? false}
-					onCheckedChange={(checked) => onChange({ use_deployments_endpoint: checked ? true : undefined })}
-					disabled={disabled}
-				/>
-			</div>
+			<TriStateOverrideRow
+				label="Use deployments endpoint"
+				hint="Route through Replicate's deployments endpoint instead of the models endpoint."
+				value={config.use_deployments_endpoint}
+				onChange={(next) => onChange({ use_deployments_endpoint: next })}
+				disabled={disabled}
+				testId="deployment-use-deployments-endpoint"
+			/>
 		</div>
 	);
 }
@@ -296,20 +341,14 @@ function UseAnthropicEndpointsToggleSection({ config, onChange, disabled, provid
 	return (
 		<div className="space-y-4">
 			<SectionHeader title={`${providerName} overrides`} description={`Override key-level ${providerName} defaults for this deployment.`} />
-			<div className="flex items-start justify-between gap-4 rounded-md border p-3">
-				<div className="space-y-0.5">
-					<label htmlFor="use-anthropic-endpoints-switch" className="text-sm font-medium">Use Anthropic endpoints</label>
-					<p className="text-muted-foreground text-xs">
-						Route chat completions and responses requests through Anthropic-compatible endpoints.
-					</p>
-				</div>
-                <Switch
-                    id="use-anthropic-endpoints-switch"
-                    checked={config.use_anthropic_endpoints ?? false}
-                    onCheckedChange={(checked) => onChange({ use_anthropic_endpoints: checked ? true : undefined })}
-                    disabled={disabled}
-                />
-			</div>
+			<TriStateOverrideRow
+				label="Use Anthropic endpoints"
+				hint="Route chat completions and responses requests through Anthropic-compatible endpoints."
+				value={config.use_anthropic_endpoints}
+				onChange={(next) => onChange({ use_anthropic_endpoints: next })}
+				disabled={disabled}
+				testId="deployment-use-anthropic-endpoints"
+			/>
 		</div>
 	);
 }
@@ -328,11 +367,11 @@ function ProviderSection({ providerName, ...props }: ProviderSectionProps & { pr
 			return <ReplicateSection {...props} />;
 		case "sgl":
 			return <UseAnthropicEndpointsToggleSection providerName="SGLang" {...props} />;
-        case "deepseek":
+		case "deepseek":
 			return <UseAnthropicEndpointsToggleSection providerName="Deepseek" {...props} />;
-        case "fireworks":
+		case "fireworks":
 			return <UseAnthropicEndpointsToggleSection providerName="Fireworks" {...props} />;
-        case "vllm":
+		case "vllm":
 			return <UseAnthropicEndpointsToggleSection providerName="vLLM" {...props} />;
 		default:
 			return null;


### PR DESCRIPTION
## Summary

Replaces the binary on/off switches for deployment-level boolean overrides (Replicate's "use deployments endpoint" and the "use Anthropic endpoints" toggle for SGLang, Deepseek, Fireworks, and vLLM) with a three-way select control. Previously, a plain switch could not distinguish between "explicitly off" and "inherit from the key-level setting," meaning turning the switch off was indistinguishable from leaving it unset. The new `TriStateOverrideRow` component expresses three states: `undefined` (inherit the key's setting), `true` (explicitly on), and `false` (explicitly off).

## Changes

- Added a `TriStateOverrideRow` component that renders a select with "Use key setting", "On", and "Off" options, mapping to `undefined`, `true`, and `false` respectively.
- Replaced the `Switch`-based inline rows in `ReplicateSection` and `UseAnthropicEndpointsToggleSection` with `TriStateOverrideRow`, preserving the `onChange` contract but now passing the value through directly rather than coercing `false` to `undefined`.
- Fixed inconsistent indentation (spaces vs. tabs) in `apiKeysFormFragment.tsx` and `deploymentsTable.tsx`.
- Reformatted a few long JSX attribute lists and inline strings for readability.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open a provider that supports deployment-level overrides (e.g., Replicate, SGLang, Deepseek, Fireworks, vLLM).
2. Add or edit a deployment and locate the relevant override row.
3. Verify the control renders as a three-option select ("Use key setting", "On", "Off") rather than a toggle switch.
4. Set the value to "Off" and save. Confirm the deployment stores an explicit `false` rather than `undefined`.
5. Set the value to "Use key setting" and save. Confirm the field is stored as `undefined`/absent.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: A binary switch that could not express "explicitly off" — toggling it off was equivalent to leaving it unset.

After: A three-way select with "Use key setting" / "On" / "Off", allowing deployments to explicitly disable a toggle that is enabled at the key level.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable