### PR TITLE
fix: resolve model aliases in Azure passthrough requests

### DIFF
--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -3439,7 +3439,8 @@ func (provider *AzureProvider) Passthrough(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	url, err := provider.buildPassthroughURL(ctx, key, req.Path, req.RawQuery)
+	path, body := resolvePassthroughAlias(ctx, req.Path, req.Body)
+	url, err := provider.buildPassthroughURL(ctx, key, path, req.RawQuery)
 	if err != nil {
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("failed to build passthrough URL: %s", err.Error()))
 	}
@@ -3466,7 +3467,7 @@ func (provider *AzureProvider) Passthrough(
 		fasthttpReq.Header.Set(k, v)
 	}
 
-	fasthttpReq.SetBody(req.Body)
+	fasthttpReq.SetBody(body)
 
 	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
 	defer wait()
@@ -3477,20 +3478,20 @@ func (provider *AzureProvider) Passthrough(
 	headers := providerUtils.ExtractPassthroughProviderResponseHeaders(resp)
 	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
-	body, err := providerUtils.CheckAndDecodeBody(resp)
+	respBody, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
 
 	var passthroughUsage *schemas.BifrostPassthroughUsage
 	if resp.StatusCode() >= 200 && resp.StatusCode() < 300 {
-		passthroughUsage = extractAzurePassthroughUsage(req.Method, req.Path, req.Body, body, req.Model)
+		passthroughUsage = extractAzurePassthroughUsage(req.Method, req.Path, req.Body, respBody, req.Model)
 	}
 
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
-		Body:       body,
+		Body:       respBody,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
 			ProviderResponseHeaders: headers,
@@ -3511,7 +3512,8 @@ func (provider *AzureProvider) PassthroughStream(
 	key schemas.Key,
 	req *schemas.BifrostPassthroughRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	url, err := provider.buildPassthroughURL(ctx, key, req.Path, req.RawQuery)
+	path, body := resolvePassthroughAlias(ctx, req.Path, req.Body)
+	url, err := provider.buildPassthroughURL(ctx, key, path, req.RawQuery)
 	if err != nil {
 		return nil, providerUtils.NewConfigurationError(fmt.Sprintf("failed to build passthrough URL: %s", err.Error()))
 	}
@@ -3540,7 +3542,7 @@ func (provider *AzureProvider) PassthroughStream(
 		fasthttpReq.Header.Set(k, v)
 	}
 
-	fasthttpReq.SetBody(req.Body)
+	fasthttpReq.SetBody(body)
 
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
 	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, provider.networkConfig.StreamIdleTimeoutInSeconds)

--- a/core/providers/azure/azure_passthrough_test.go
+++ b/core/providers/azure/azure_passthrough_test.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -252,6 +253,145 @@ func TestResolveAzureEndpoint_AliasOverride(t *testing.T) {
 	if got := resolveAzureEndpoint(ctx2, key); got != keyEndpoint {
 		t.Errorf("empty alias endpoint should fall through: got %q, want %q", got, keyEndpoint)
 	}
+}
+
+// TestResolvePassthroughAlias verifies that the user-facing alias name is
+// replaced by the key's wire deployment (alias model_id) in both the
+// /deployments/{name} path segment and the top-level "model" body field, so
+// aliased models work through /azure_passthrough. Each retry attempt carries
+// its own key's ResolvedAlias in ctx, which is what lets multiple keys that
+// share an alias load-balance to their own deployments.
+func TestResolvePassthroughAlias(t *testing.T) {
+	t.Parallel()
+
+	const alias = "mistral-ocr-3-0"
+	const deployment = "mistral-document-ai-2512-1-swedencentral-14"
+
+	aliasCtx := func() *schemas.BifrostContext {
+		ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+			Key:    alias,
+			Config: &schemas.AliasConfig{ModelID: deployment},
+		})
+		return ctx
+	}
+
+	t.Run("no resolved alias: path and body unchanged", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"model":"` + alias + `"}`)
+		gotPath, gotBody := resolvePassthroughAlias(nil, "/openai/deployments/"+alias+"/chat/completions", body)
+		if gotPath != "/openai/deployments/"+alias+"/chat/completions" || string(gotBody) != string(body) {
+			t.Errorf("expected no-op, got path=%q body=%s", gotPath, gotBody)
+		}
+		emptyCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		gotPath, gotBody = resolvePassthroughAlias(emptyCtx, "/openai/deployments/"+alias+"/chat/completions", body)
+		if gotPath != "/openai/deployments/"+alias+"/chat/completions" || string(gotBody) != string(body) {
+			t.Errorf("expected no-op with empty ctx, got path=%q body=%s", gotPath, gotBody)
+		}
+	})
+
+	t.Run("deployments path segment rewritten", func(t *testing.T) {
+		t.Parallel()
+		gotPath, _ := resolvePassthroughAlias(aliasCtx(), "/openai/deployments/"+alias+"/chat/completions", nil)
+		want := "/openai/deployments/" + deployment + "/chat/completions"
+		if gotPath != want {
+			t.Errorf("\ngot:  %s\nwant: %s", gotPath, want)
+		}
+	})
+
+	t.Run("deployments segment at end of path rewritten", func(t *testing.T) {
+		t.Parallel()
+		gotPath, _ := resolvePassthroughAlias(aliasCtx(), "/openai/deployments/"+alias, nil)
+		if want := "/openai/deployments/" + deployment; gotPath != want {
+			t.Errorf("\ngot:  %s\nwant: %s", gotPath, want)
+		}
+	})
+
+	t.Run("deployments segment case-insensitive match", func(t *testing.T) {
+		t.Parallel()
+		gotPath, _ := resolvePassthroughAlias(aliasCtx(), "/openai/deployments/Mistral-OCR-3-0/embeddings", nil)
+		if want := "/openai/deployments/" + deployment + "/embeddings"; gotPath != want {
+			t.Errorf("\ngot:  %s\nwant: %s", gotPath, want)
+		}
+	})
+
+	t.Run("path with different deployment untouched", func(t *testing.T) {
+		t.Parallel()
+		path := "/openai/deployments/gpt-4o/chat/completions"
+		gotPath, _ := resolvePassthroughAlias(aliasCtx(), path, nil)
+		if gotPath != path {
+			t.Errorf("got %q, want unchanged %q", gotPath, path)
+		}
+	})
+
+	t.Run("body model field rewritten, other fields preserved", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"model":"` + alias + `","document":{"type":"document_url","document_url":"data:application/pdf;base64,AAAA"}}`)
+		_, gotBody := resolvePassthroughAlias(aliasCtx(), "/providers/mistral/azure/ocr", body)
+		var parsed struct {
+			Model    string `json:"model"`
+			Document struct {
+				Type        string `json:"type"`
+				DocumentURL string `json:"document_url"`
+			} `json:"document"`
+		}
+		if err := json.Unmarshal(gotBody, &parsed); err != nil {
+			t.Fatalf("rewritten body is not valid JSON: %v", err)
+		}
+		if parsed.Model != deployment {
+			t.Errorf("model = %q, want %q", parsed.Model, deployment)
+		}
+		if parsed.Document.Type != "document_url" || parsed.Document.DocumentURL != "data:application/pdf;base64,AAAA" {
+			t.Errorf("sibling fields not preserved: %+v", parsed.Document)
+		}
+	})
+
+	t.Run("body with different model untouched", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"model":"gpt-4o"}`)
+		_, gotBody := resolvePassthroughAlias(aliasCtx(), "/openai/v1/chat/completions", body)
+		if string(gotBody) != string(body) {
+			t.Errorf("got %s, want unchanged %s", gotBody, body)
+		}
+	})
+
+	t.Run("body without model field untouched", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"input":"hello"}`)
+		_, gotBody := resolvePassthroughAlias(aliasCtx(), "/openai/v1/embeddings", body)
+		if string(gotBody) != string(body) {
+			t.Errorf("got %s, want unchanged %s", gotBody, body)
+		}
+	})
+
+	t.Run("non-JSON body untouched", func(t *testing.T) {
+		t.Parallel()
+		body := []byte("--boundary\r\nnot json\r\n--boundary--")
+		_, gotBody := resolvePassthroughAlias(aliasCtx(), "/openai/deployments/"+alias+"/audio/transcriptions", body)
+		if string(gotBody) != string(body) {
+			t.Errorf("got %s, want unchanged %s", gotBody, body)
+		}
+	})
+
+	t.Run("per-key aliases resolve to their own deployments", func(t *testing.T) {
+		t.Parallel()
+		// Two keys sharing the alias map it to different regional deployments —
+		// the ctx carries the attempt's own resolution, so rotation load-balances.
+		for _, dep := range []string{"mistral-doc-ai-swedencentral", "mistral-doc-ai-eastus"} {
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+				Key:    alias,
+				Config: &schemas.AliasConfig{ModelID: dep},
+			})
+			_, gotBody := resolvePassthroughAlias(ctx, "/providers/mistral/azure/ocr", []byte(`{"model":"`+alias+`"}`))
+			var parsed struct {
+				Model string `json:"model"`
+			}
+			if err := json.Unmarshal(gotBody, &parsed); err != nil || parsed.Model != dep {
+				t.Errorf("model = %q (err=%v), want %q", parsed.Model, err, dep)
+			}
+		}
+	})
 }
 
 // TestResolveAnthropicVersion_AliasOverride verifies the AnthropicVersion

--- a/core/providers/azure/azure_passthrough_test.go
+++ b/core/providers/azure/azure_passthrough_test.go
@@ -364,9 +364,13 @@ func TestResolvePassthroughAlias(t *testing.T) {
 		}
 	})
 
-	t.Run("non-JSON body untouched", func(t *testing.T) {
+	// Multipart bodies must not reach sjson.SetBytes: given a non-JSON input it
+	// discards the body and returns a bare {"model":...} object, which would
+	// destroy the uploaded file. The leading-'{' guard is what prevents that.
+	t.Run("multipart body with model form field untouched", func(t *testing.T) {
 		t.Parallel()
-		body := []byte("--boundary\r\nnot json\r\n--boundary--")
+		body := []byte("--b\r\nContent-Disposition: form-data; name=\"model\"\r\n\r\n" +
+			alias + "\r\n--b\r\nContent-Disposition: form-data; name=\"file\"; filename=\"a.mp3\"\r\n\r\nBINARY\r\n--b--")
 		_, gotBody := resolvePassthroughAlias(aliasCtx(), "/openai/deployments/"+alias+"/audio/transcriptions", body)
 		if string(gotBody) != string(body) {
 			t.Errorf("got %s, want unchanged %s", gotBody, body)

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -1,11 +1,12 @@
 package azure
 
 import (
-	"encoding/json"
+	"bytes"
 	"strings"
 
-	"github.com/bytedance/sonic"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // getAzureScopes returns the configured scopes or the default scope if none are valid.
@@ -106,24 +107,16 @@ func rewriteDeploymentSegment(path, alias, modelID string) string {
 // untouched. ponytail: top-level JSON only — multipart passthrough routes
 // carry the deployment in the path, not the body.
 func rewriteBodyModel(body []byte, alias, modelID string) []byte {
-	if len(body) == 0 {
+	// JSON objects only: gjson/sjson do not validate, and a multipart body
+	// carrying a "model" form field would otherwise get corrupted.
+	if trimmed := bytes.TrimLeft(body, " \t\r\n"); len(trimmed) == 0 || trimmed[0] != '{' {
 		return body
 	}
-	var m map[string]json.RawMessage
-	if err := sonic.Unmarshal(body, &m); err != nil {
+	current := gjson.GetBytes(body, "model")
+	if current.Type != gjson.String || !strings.EqualFold(current.Str, alias) {
 		return body
 	}
-	var current string
-	raw, ok := m["model"]
-	if !ok || sonic.Unmarshal(raw, &current) != nil || !strings.EqualFold(current, alias) {
-		return body
-	}
-	quoted, err := sonic.Marshal(modelID)
-	if err != nil {
-		return body
-	}
-	m["model"] = quoted
-	out, err := sonic.Marshal(m)
+	out, err := sjson.SetBytes(body, "model", modelID)
 	if err != nil {
 		return body
 	}

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -1,8 +1,10 @@
 package azure
 
 import (
+	"encoding/json"
 	"strings"
 
+	"github.com/bytedance/sonic"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -64,4 +66,66 @@ func resolveAzureEndpoint(ctx *schemas.BifrostContext, key schemas.Key) string {
 		return key.AzureKeyConfig.Endpoint.GetValue()
 	}
 	return ""
+}
+
+// resolvePassthroughAlias rewrites a passthrough path and body so the
+// user-facing alias name is replaced by the wire deployment (alias model_id)
+// resolved for this attempt's key. Azure resolves the deployment from either
+// the /openai/deployments/{name} path segment or the top-level "model" body
+// field, so both are rewritten. No-op when no alias matched.
+func resolvePassthroughAlias(ctx *schemas.BifrostContext, path string, body []byte) (string, []byte) {
+	ra := schemas.GetResolvedAlias(ctx)
+	if ra == nil || ra.Config == nil || ra.Key == "" || ra.Config.ModelID == "" || ra.Config.ModelID == ra.Key {
+		return path, body
+	}
+	return rewriteDeploymentSegment(path, ra.Key, ra.Config.ModelID),
+		rewriteBodyModel(body, ra.Key, ra.Config.ModelID)
+}
+
+// rewriteDeploymentSegment replaces the path segment after "/deployments/"
+// when it equals the alias (case-insensitive, matching KeyAliases.ResolveConfig).
+func rewriteDeploymentSegment(path, alias, modelID string) string {
+	const seg = "/deployments/"
+	i := strings.Index(path, seg)
+	if i == -1 {
+		return path
+	}
+	name := path[i+len(seg):]
+	tail := ""
+	if j := strings.IndexByte(name, '/'); j != -1 {
+		name, tail = name[:j], name[j:]
+	}
+	if !strings.EqualFold(name, alias) {
+		return path
+	}
+	return path[:i+len(seg)] + modelID + tail
+}
+
+// rewriteBodyModel replaces the top-level "model" JSON field when it equals
+// the alias (case-insensitive). Non-JSON and modelless bodies pass through
+// untouched. ponytail: top-level JSON only — multipart passthrough routes
+// carry the deployment in the path, not the body.
+func rewriteBodyModel(body []byte, alias, modelID string) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	var m map[string]json.RawMessage
+	if err := sonic.Unmarshal(body, &m); err != nil {
+		return body
+	}
+	var current string
+	raw, ok := m["model"]
+	if !ok || sonic.Unmarshal(raw, &current) != nil || !strings.EqualFold(current, alias) {
+		return body
+	}
+	quoted, err := sonic.Marshal(modelID)
+	if err != nil {
+		return body
+	}
+	m["model"] = quoted
+	out, err := sonic.Marshal(m)
+	if err != nil {
+		return body
+	}
+	return out
 }


### PR DESCRIPTION
## Problem

Given an Azure key config with aliases:

```yaml
providers:
  azure:
    keys:
      - name: foundry-swedencentral-1
        value: env.AZURE_KEY
        models:
          - mistral-document-ai-2512-1-swedencentral-14
          - mistral-ocr-3-0
        aliases:
          mistral-ocr-3-0: mistral-document-ai-2512-1-swedencentral-14
```

calling `/azure_passthrough` with the alias name fails:

```
POST /azure_passthrough/providers/mistral/azure/ocr?api-version=2025-03-01-preview
→ 404 DeploymentNotFound: "mistral-ocr-3-0 does not exist"
```

`AzureProvider.Passthrough`/`PassthroughStream` forward `req.Path` and `req.Body` verbatim, so the user-facing alias name (in the `/openai/deployments/{name}` path segment or the top-level `"model"` body field) reaches Azure unresolved. Core already resolves each attempt's key alias into the request context (`ResolvedAlias`) and rotates the key pool for passthrough requests — the provider just never applied it to the wire request.


Same problem is described in #5458 

## Fix

New `resolvePassthroughAlias(ctx, path, body)` in `core/providers/azure/utils.go`, called from both `Passthrough` and `PassthroughStream`:

- rewrites the `/deployments/{alias}` path segment to the alias `model_id` (case-insensitive, matching `KeyAliases.ResolveConfig` semantics)
- rewrites the top-level `"model"` JSON body field when it equals the alias

It follows the same ctx-based pattern as the existing `resolveAzureEndpoint` / `resolveAPIVersion` per-alias overrides, which the passthrough path already honors. No-op when no alias matched — clients sending real deployment names get untouched requests. Non-JSON/multipart bodies pass through unchanged (those routes carry the deployment in the path). Usage extraction and logging still see the user-facing model name.

## Load balancing

This also makes load balancing work for aliased models through passthrough: the key pool already filters by the requested name against each key's `models` list and rotates with weights. Since the `ResolvedAlias` in ctx is refreshed per attempt for the selected key, multiple keys sharing an alias (e.g. `mistral-ocr-3-0` on Sweden Central and East US resources) each rewrite to their own regional deployment — including on rate-limit retries.

## Tests

`TestResolvePassthroughAlias` (10 subtests): path rewrite mid-path / end-of-path / case-insensitive, body rewrite preserving sibling fields, no-op guards (no alias, different model, no model field, non-JSON body), and per-key resolution to distinct regional deployments.

Full `core/providers/azure` suite passes; `go build ./...` and `go vet` clean.

Note: the OpenAI, Anthropic, and Gemini passthrough endpoints share this bug class (model in body for OpenAI/Anthropic, in path for Gemini). Kept out of scope here since each needs its own verification (multipart model field for OpenAI audio, `:action` suffix for Gemini) — happy to follow up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)