### PR TITLE
docs: remove mermaid diagrams and simplify warnings in auth proxy docs

### DIFF
--- a/docs/enterprise/auth-proxy/cloudflare-ztna.mdx
+++ b/docs/enterprise/auth-proxy/cloudflare-ztna.mdx
@@ -15,15 +15,6 @@ This guide covers [Cloudflare Access](https://www.cloudflare.com/zero-trust/prod
 
 ## How it works
 
-```mermaid
-graph LR
-    U[User] --> CF[Cloudflare Access]
-    CF -->|validates identity<br/>against your IdP| CF
-    CF -->|Cf-Access-Jwt-Assertion header| B[Bifrost]
-    B -->|verify signature vs<br/>team-domain JWKS| B
-    B -->|authenticate + authorize| APP[Dashboard / Inference APIs]
-```
-
 1. A user requests a Bifrost URL protected by a Cloudflare Access application.
 2. Cloudflare authenticates the user against your configured identity provider and enforces your Access policies.
 3. Cloudflare forwards the request to Bifrost with the `Cf-Access-Jwt-Assertion` header — a short-lived RS256 JWT signed by your team domain.
@@ -32,7 +23,7 @@ graph LR
 Because Bifrost validates the proxy's token (not the IdP's), both the dashboard and the inference APIs are protected by the same upstream authentication layer.
 
 <Warning>
-  **Isolate the Bifrost origin.** When the proxy header is absent, Bifrost falls back to its normal bearer/cookie login — so if Bifrost is reachable directly (bypassing Cloudflare), a client can skip your Access policies. Restrict network access so Bifrost is only reachable through Cloudflare (e.g. via a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) or by allowlisting Cloudflare IPs), and ensure the proxy strips any client-supplied `Cf-Access-Jwt-Assertion` header before injecting its own.
+  When the proxy header is absent, Bifrost falls back to the IDP login - so if Bifrost is reachable directly (bypassing Cloudflare), a client can skip your Access policies. Restrict network access so Bifrost is only reachable through Cloudflare (e.g. via a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) or by allowlisting Cloudflare IPs), and ensure the proxy strips any client-supplied `Cf-Access-Jwt-Assertion` header before injecting its own.
 </Warning>
 
 ---

--- a/docs/enterprise/auth-proxy/generic-proxy.mdx
+++ b/docs/enterprise/auth-proxy/generic-proxy.mdx
@@ -13,15 +13,6 @@ Bifrost's identity-aware proxy support isn't limited to Cloudflare Access. Any u
 
 ## How it works
 
-```mermaid
-graph LR
-    U[User] --> P[OIDC proxy]
-    P -->|validates identity<br/>against your IdP| P
-    P -->|signed JWT in a<br/>configurable header| B[Bifrost]
-    B -->|verify signature vs<br/>JWKS / OIDC discovery| B
-    B -->|authenticate + authorize| APP[Dashboard / Inference APIs]
-```
-
 1. The proxy authenticates the user against your identity provider.
 2. It forwards the request to Bifrost with a signed OIDC JWT in a header you choose (e.g. `X-Forwarded-Assertion`).
 3. Bifrost validates the token's signature against the configured **JWKS URL**, or discovers it from the **issuer** via `<issuer>/.well-known/openid-configuration`.
@@ -30,7 +21,7 @@ graph LR
 The token is validated against the **proxy's** keys — not the IdP's — so both the dashboard and the inference APIs are protected by the same upstream layer.
 
 <Warning>
-  **Isolate the Bifrost origin.** When the configured header is absent, Bifrost falls back to its normal bearer/cookie login — so if Bifrost is reachable directly (bypassing the proxy), a client can skip the proxy's access policy. Restrict network access so Bifrost is only reachable through the proxy (private network, service mesh, or firewall allowlist), and configure the proxy to strip any client-supplied assertion header before injecting its own signed token.
+  When the configured header is absent, Bifrost falls back to the IDP login — so if Bifrost is reachable directly (bypassing the proxy), a client can skip the proxy's access policy. Restrict network access so Bifrost is only reachable through the proxy (private network, service mesh, or firewall allowlist), and configure the proxy to strip any client-supplied assertion header before injecting its own signed token.
 </Warning>
 
 ---


### PR DESCRIPTION
## Summary

Cleans up the auth proxy documentation for both Cloudflare ZTNA and the generic proxy guides by removing Mermaid flow diagrams and simplifying warning callouts.

## Changes

- Removed Mermaid `graph LR` diagrams from both `cloudflare-ztna.mdx` and `generic-proxy.mdx`, as the numbered steps below them already describe the flow clearly
- Simplified the `<Warning>` blocks by removing the bold "Isolate the Bifrost origin." lead-in and updating the fallback behavior description from "normal bearer/cookie login" to "IDP login" for consistency and clarity

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for `cloudflare-ztna` and `generic-proxy` to confirm the diagrams are gone, the warning text reads correctly, and the remaining content flows logically.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. The security guidance itself is preserved; only the formatting and phrasing of the warning was adjusted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable