### PR TITLE
fix: remove default api-version preview for GA azure responses endpoints

### DIFF
--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -542,7 +542,10 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
-	path := fmt.Sprintf("openai/v1/responses?api-version=%s", resolveAPIVersion(ctx, AzureAPIVersionPreview))
+	path := "openai/v1/responses"
+	if v := resolveAPIVersion(ctx, ""); v != "" {
+		path += "?api-version=" + v
+	}
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
@@ -611,7 +614,11 @@ func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, post
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/openai/v1/responses?api-version=%s", endpoint, resolveAPIVersion(ctx, AzureAPIVersionPreview))
+		path := "openai/v1/responses"
+		if v := resolveAPIVersion(ctx, ""); v != "" {
+			path += "?api-version=" + v
+		}
+		url = fmt.Sprintf("%s/%s", endpoint, path)
 
 		// Use shared streaming logic from OpenAI
 		return openai.HandleOpenAIResponsesStreaming(
@@ -2571,7 +2578,10 @@ func (provider *AzureProvider) Compaction(ctx *schemas.BifrostContext, key schem
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
-	path := fmt.Sprintf("openai/v1/responses/compact?api-version=%s", resolveAPIVersion(ctx, AzureAPIVersionPreview))
+	path := "openai/v1/responses/compact"
+	if v := resolveAPIVersion(ctx, ""); v != "" {
+		path += "?api-version=" + v
+	}
 	return openai.HandleOpenAICompactionRequest(
 		ctx,
 		provider.client,
@@ -3608,11 +3618,17 @@ func (provider *AzureProvider) buildPassthroughURL(ctx *schemas.BifrostContext, 
 			rawQuery = values.Encode()
 		}
 	case strings.Contains(path, "/openai/v1/responses"):
-		// Responses API requires api-version=preview.
-		values, _ := url.ParseQuery(rawQuery)
-		if values.Get("api-version") == "" {
-			values.Set("api-version", resolveAPIVersion(ctx, AzureAPIVersionPreview))
-			rawQuery = values.Encode()
+		// The versionless v1 API omits api-version by default — Azure OpenAI v1
+		// GA and Azure AI Foundry project endpoints reject it outright on /v1
+		// paths. Only attach it if the caller didn't already supply one and the
+		// user explicitly configured an override.
+		if values, err := url.ParseQuery(rawQuery); err == nil {
+			if values.Get("api-version") == "" {
+				if v := resolveAPIVersion(ctx, ""); v != "" {
+					values.Set("api-version", v)
+					rawQuery = values.Encode()
+				}
+			}
 		}
 	case strings.Contains(path, "/openai/deployments/"):
 		// Classic /deployments/ routes require api-version. Inject a default if absent.

--- a/core/providers/azure/azure_passthrough_test.go
+++ b/core/providers/azure/azure_passthrough_test.go
@@ -30,7 +30,7 @@ func TestBuildPassthroughURL(t *testing.T) {
 		{
 			name: "normalise /openai/responses to /openai/v1/responses",
 			path: "/openai/responses",
-			want: endpoint + "/openai/v1/responses?api-version=" + AzureAPIVersionPreview,
+			want: endpoint + "/openai/v1/responses",
 		},
 		{
 			name: "normalise /openai/videos to /openai/v1/videos",
@@ -57,17 +57,22 @@ func TestBuildPassthroughURL(t *testing.T) {
 			want:     endpoint + "/openai/deployments/gpt-4o/chat/completions?api-version=2024-06-01&foo=bar",
 		},
 
-		// --- /openai/v1/responses — inject api-version=preview when absent ---
+		// --- /openai/v1/responses — no api-version injected by default ---
 		{
-			name: "responses route: inject preview api-version when missing",
+			name: "responses route: no api-version injected when missing and no override configured",
 			path: "/openai/v1/responses",
-			want: endpoint + "/openai/v1/responses?api-version=" + AzureAPIVersionPreview,
+			want: endpoint + "/openai/v1/responses",
 		},
 		{
 			name:     "responses route: preserve caller-supplied api-version",
 			path:     "/openai/v1/responses",
 			rawQuery: "api-version=2025-01-01-preview",
 			want:     endpoint + "/openai/v1/responses?api-version=2025-01-01-preview",
+		},
+		{
+			name: "responses/compact route: no api-version injected when missing",
+			path: "/openai/v1/responses/compact",
+			want: endpoint + "/openai/v1/responses/compact",
 		},
 
 		// --- Anthropic routes — strip api-version ---
@@ -128,11 +133,12 @@ func TestBuildPassthroughURL(t *testing.T) {
 }
 
 // TestBuildPassthroughURL_AliasAPIVersionOverride verifies that when the
-// resolved alias carries an AzureAliasCfg.APIVersion override, it takes
-// precedence over the route default (DefaultAzureAPIVersion for /deployments/,
-// AzureAPIVersionPreview for /openai/v1/responses) — only in the path where
-// the caller did NOT supply api-version themselves. Caller-supplied wins over
-// alias override; alias override wins over route default.
+// resolved alias carries an AzureAliasCfg.APIVersion override, it is attached
+// to the request — as the route default for /deployments/ (DefaultAzureAPIVersion),
+// or as an explicit opt-in for /openai/v1/responses (which otherwise omits
+// api-version entirely) — only in the path where the caller did NOT supply
+// api-version themselves. Caller-supplied wins over alias override; alias
+// override wins over route default.
 func TestBuildPassthroughURL_AliasAPIVersionOverride(t *testing.T) {
 	t.Parallel()
 
@@ -165,7 +171,7 @@ func TestBuildPassthroughURL_AliasAPIVersionOverride(t *testing.T) {
 		}
 	})
 
-	t.Run("responses route: alias APIVersion overrides preview default", func(t *testing.T) {
+	t.Run("responses route: alias APIVersion is attached as explicit opt-in", func(t *testing.T) {
 		got, _ := provider.buildPassthroughURL(ctx, makeKey, "/openai/v1/responses", "")
 		want := endpoint + "/openai/v1/responses?api-version=" + overrideVer
 		if got != want {


### PR DESCRIPTION
## Summary

The Azure provider was unconditionally appending `api-version=preview` to all `/openai/v1/responses` and `/openai/v1/responses/compact` requests. Azure OpenAI v1 GA endpoints and Azure AI Foundry project endpoints reject requests on `/v1` paths that include an `api-version` query parameter, causing failures for users on those endpoint types. This PR makes `api-version` injection opt-in for the versionless v1 API — it is only attached when the caller explicitly configures an API version override.

## Changes

- Removed the automatic injection of `AzureAPIVersionPreview` for `Responses`, `ResponsesStream`, and `Compaction` endpoints; `api-version` is now only appended when a non-empty version is resolved from the caller's configuration.
- Updated `buildPassthroughURL` so that the `/openai/v1/responses` path branch no longer falls back to `AzureAPIVersionPreview` — it only sets `api-version` if the caller did not supply one and an explicit override is configured.
- Updated tests to reflect the new default behavior (no `api-version` injected when absent and no override is set) and added a test case for the `/openai/v1/responses/compact` route.
- Updated test descriptions and comments to accurately describe the opt-in semantics.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/azure/...
```

Validate that:

- Requests to `/openai/v1/responses` without a configured API version override do **not** include `api-version` in the query string.
- Requests with an explicit `AzureAliasCfg.APIVersion` override **do** include `api-version` in the query string.
- Caller-supplied `api-version` query parameters are always preserved as-is.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable