### PR TITLE
feat: adds bifrost latency data to connectors

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4950,7 +4950,7 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 // It handles plugin hooks, request validation, response processing, and fallback providers.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
 // It is the wrapper for all non-streaming public API methods.
-func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) {
 	defer bifrost.releaseBifrostRequest(req)
 	provider, model, fallbacks := req.GetRequestFields()
 
@@ -4958,6 +4958,14 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	if ctx == nil {
 		ctx = bifrost.ctx
 	}
+
+	// Reset first: bifrost.ctx is shared across every nil-ctx caller.
+	ctx.ResetUpstreamLatency()
+	// Stamp on the way out, after every attempt and fallback.
+	defer func() {
+		ctx.StampUpstreamLatency()
+		resp.PopulateUpstreamLatency(ctx)
+	}()
 
 	// Try the primary provider first
 	ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
@@ -5088,6 +5096,8 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	if ctx == nil {
 		ctx = bifrost.ctx
 	}
+
+	ctx.ResetUpstreamLatency()
 
 	// Try the primary provider first
 	ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -708,7 +708,9 @@ func (m *ToolsManager) executeToolInternal(
 		},
 	}
 
+	toolCallStart := time.Now()
 	toolResponse, callErr := clientConn.CallTool(toolCtx, callRequest)
+	schemas.AddUpstreamLatency(ctx, time.Since(toolCallStart))
 	if callErr != nil {
 		// Sentinel-wrapped so the gate can classify error.type (timeout vs tool_error).
 		if toolCtx.Err() == context.DeadlineExceeded {

--- a/core/overhead_e2e_test.go
+++ b/core/overhead_e2e_test.go
@@ -1,0 +1,388 @@
+package bifrost
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// chatCompletionBody is a minimal well-formed OpenAI chat completion response.
+const chatCompletionBody = `{
+  "id": "chatcmpl-overhead-test",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "gpt-4o-mini",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+}`
+
+// recordingTracer captures attributes stamped on the root span. Everything not
+// overridden falls through to NoOpTracer, so a request runs normally.
+type recordingTracer struct {
+	*schemas.NoOpTracer
+	mu    sync.Mutex
+	attrs map[string]any
+}
+
+func newRecordingTracer() *recordingTracer {
+	return &recordingTracer{NoOpTracer: &schemas.NoOpTracer{}, attrs: map[string]any{}}
+}
+
+// NoOpTracer returns an empty trace ID, which the stamp treats as "no trace".
+func (r *recordingTracer) CreateTrace(_ string, _ ...string) string {
+	return "trace-overhead-test"
+}
+
+// A non-nil handle is required for StampUpstreamLatency to proceed.
+func (r *recordingTracer) GetSpanHandleByID(_ string, _ *string) schemas.SpanHandle {
+	return "root-span"
+}
+
+func (r *recordingTracer) SetAttribute(_ schemas.SpanHandle, key string, value any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.attrs[key] = value
+}
+
+func (r *recordingTracer) get(key string) (any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	v, ok := r.attrs[key]
+	return v, ok
+}
+
+// newBifrostWithMockProvider wires a real Bifrost against an httptest server
+// that stalls for providerDelay before answering.
+func newBifrostWithMockProvider(t *testing.T, providerDelay time.Duration) (*Bifrost, *httptest.Server, *int32) {
+	t.Helper()
+
+	var calls int32
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(providerDelay)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, chatCompletionBody)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: mockAccountFor(server.URL),
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(client.Shutdown)
+
+	return client, server, &calls
+}
+
+// mockAccountFor builds an account whose single OpenAI key explicitly supports
+// the test model — key selection rejects keys with no matching model.
+func mockAccountFor(baseURL string) *MockAccount {
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 5, 100, baseURL)
+	account.mu.Lock()
+	defer account.mu.Unlock()
+	for i := range account.keys[schemas.OpenAI] {
+		account.keys[schemas.OpenAI][i].Models = []string{testChatModel}
+	}
+	return account
+}
+
+const testChatModel = "gpt-4o-mini"
+
+func chatRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    testChatModel,
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+	}
+}
+
+// The whole feature, end to end: a real request through a real Bifrost against a
+// provider that takes a known amount of time. The accumulated upstream figure
+// must track the provider's delay, and the remainder is Bifrost's own cost.
+func TestOverheadEndToEndUnary(t *testing.T) {
+	const providerDelay = 200 * time.Millisecond
+	client, _, calls := newBifrostWithMockProvider(t, providerDelay)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	start := time.Now()
+	resp, bifrostErr := client.ChatCompletionRequest(ctx, chatRequest())
+	total := time.Since(start)
+
+	if bifrostErr != nil {
+		t.Fatalf("request failed: %v", bifrostErr.Error.Message)
+	}
+	if resp == nil {
+		t.Fatal("nil response")
+	}
+	if *calls != 1 {
+		t.Fatalf("provider called %d times, want 1", *calls)
+	}
+
+	upstream, ok := schemas.GetUpstreamLatency(ctx)
+	if !ok {
+		t.Fatal("no upstream accumulator on the context after a full request")
+	}
+
+	// Upstream must cover the provider's stall...
+	if upstream < providerDelay {
+		t.Fatalf("upstream = %v, want >= %v (the provider's own delay)", upstream, providerDelay)
+	}
+	// ...but must not swallow the whole request; that would mean overhead is
+	// structurally zero and the metric is worthless.
+	if upstream > total {
+		t.Fatalf("upstream = %v exceeds total %v", upstream, total)
+	}
+
+	overhead, ok := schemas.CalculateOverhead(ctx, total)
+	if !ok {
+		t.Fatal("overhead not derivable")
+	}
+	if overhead <= 0 {
+		t.Fatalf("overhead = %v, want > 0 — marshalling and pipeline work are never free", overhead)
+	}
+	// Sanity bound: a mock provider on loopback should not make Bifrost look slow.
+	if overhead > total/2 {
+		t.Fatalf("overhead = %v is more than half of total %v — instrumentation likely missing a wire segment", overhead, total)
+	}
+
+	// The body carrier has to agree with the context, since it is the only one
+	// that survives a proxy hop between gateway nodes.
+	body := resp.ExtraFields.UpstreamLatency
+	if body == nil {
+		t.Fatal("ExtraFields.UpstreamLatency not populated on the response")
+	}
+	if want := upstream.Milliseconds(); *body != want {
+		t.Fatalf("ExtraFields.UpstreamLatency = %dms, want %dms (context total)", *body, want)
+	}
+
+	t.Logf("total=%v upstream=%v overhead=%v (%.1f%%)",
+		total, upstream, overhead, 100*float64(overhead)/float64(total))
+}
+
+// Retries must sum, not overwrite. This is the case ExtraFields.Latency gets
+// wrong today: it holds only the last attempt, so earlier attempts would be
+// misreported as Bifrost overhead.
+func TestOverheadEndToEndAccumulatesAcrossRetries(t *testing.T) {
+	const providerDelay = 100 * time.Millisecond
+
+	var mu sync.Mutex
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		attempt := calls
+		mu.Unlock()
+
+		time.Sleep(providerDelay)
+		// Fail the first two attempts with a retriable status.
+		if attempt <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"error":{"message":"transient","type":"server_error"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, chatCompletionBody)
+	}))
+	defer server.Close()
+
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: mockAccountFor(server.URL),
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer client.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	if _, bifrostErr := client.ChatCompletionRequest(ctx, chatRequest()); bifrostErr != nil {
+		t.Fatalf("request failed after retries: %v", bifrostErr.Error.Message)
+	}
+
+	mu.Lock()
+	attempts := calls
+	mu.Unlock()
+	if attempts < 3 {
+		t.Fatalf("provider called %d times, want 3 (two failures then success)", attempts)
+	}
+
+	upstream, ok := schemas.GetUpstreamLatency(ctx)
+	if !ok {
+		t.Fatal("no upstream accumulator")
+	}
+	// All three attempts must be represented. Anything near a single delay means
+	// the counter is being overwritten rather than accumulated.
+	if want := time.Duration(attempts) * providerDelay; upstream < want {
+		t.Fatalf("upstream = %v, want >= %v (%d attempts x %v)", upstream, want, attempts, providerDelay)
+	}
+
+	t.Logf("attempts=%d upstream=%v", attempts, upstream)
+}
+
+// The number has to reach the root span, or the trace-based connectors never see it.
+func TestOverheadStampedOnRootSpan(t *testing.T) {
+	client, _, _ := newBifrostWithMockProvider(t, 150*time.Millisecond)
+
+	// Must go on the instance: core overwrites the context's tracer key with
+	// bifrost.getTracer() at the start of every request.
+	tracer := newRecordingTracer()
+	client.SetTracer(tracer)
+
+	// Stands in for the HTTP transport's tracing middleware, which is what
+	// creates the trace and root span on a real request. The pure SDK path has
+	// neither, so nothing would be stamped.
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyTraceID, "trace-overhead-test")
+
+	if _, bifrostErr := client.ChatCompletionRequest(ctx, chatRequest()); bifrostErr != nil {
+		t.Fatalf("request failed: %v", bifrostErr.Error.Message)
+	}
+
+	raw, ok := tracer.get(schemas.AttrBifrostUpstreamDurationMs)
+	if !ok {
+		t.Fatalf("%s was never stamped on the root span", schemas.AttrBifrostUpstreamDurationMs)
+	}
+	ms, ok := raw.(float64)
+	if !ok {
+		t.Fatalf("%s is %T, want float64", schemas.AttrBifrostUpstreamDurationMs, raw)
+	}
+	if ms < 150 {
+		t.Fatalf("stamped upstream = %vms, want >= 150ms", ms)
+	}
+
+	t.Logf("stamped %s = %.2fms", schemas.AttrBifrostUpstreamDurationMs, ms)
+}
+
+// Two requests sharing one process-global context (the nil-ctx SDK path) must not
+// inherit each other's totals.
+func TestOverheadResetBetweenRequests(t *testing.T) {
+	const providerDelay = 120 * time.Millisecond
+	client, _, _ := newBifrostWithMockProvider(t, providerDelay)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	for i := range 3 {
+		if _, bifrostErr := client.ChatCompletionRequest(ctx, chatRequest()); bifrostErr != nil {
+			t.Fatalf("request %d failed: %v", i, bifrostErr.Error.Message)
+		}
+		upstream, ok := schemas.GetUpstreamLatency(ctx)
+		if !ok {
+			t.Fatalf("request %d: no accumulator", i)
+		}
+		// Each request re-zeroes the counter, so this stays near one delay
+		// regardless of how many requests came before.
+		if upstream > 2*providerDelay {
+			t.Fatalf("request %d: upstream = %v, want ~%v — counter leaked across requests",
+				i, upstream, providerDelay)
+		}
+	}
+}
+
+// Streaming is where the old measurement was worst: fasthttp returns as soon as
+// headers arrive, so the only provider time ever recorded was TTFB and the whole
+// token-generation window looked like Bifrost overhead. This asserts the
+// generation window is now counted as upstream.
+func TestOverheadEndToEndStreaming(t *testing.T) {
+	const (
+		ttfb       = 100 * time.Millisecond
+		perChunk   = 60 * time.Millisecond
+		chunkCount = 5
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server cannot flush; SSE simulation impossible")
+			return
+		}
+
+		// Stall before the first byte of the body.
+		time.Sleep(ttfb)
+		for i := range chunkCount {
+			fmt.Fprintf(w, "data: {\"id\":\"c\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":%q,"+
+				"\"choices\":[{\"index\":0,\"delta\":{\"content\":\"tok%d\"}}]}\n\n", testChatModel, i)
+			flusher.Flush()
+			time.Sleep(perChunk)
+		}
+		fmt.Fprint(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: mockAccountFor(server.URL),
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	defer client.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	start := time.Now()
+	stream, bifrostErr := client.ChatCompletionStreamRequest(ctx, chatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream request failed: %v", bifrostErr.Error.Message)
+	}
+
+	received := 0
+	for chunk := range stream {
+		if chunk != nil {
+			received++
+		}
+	}
+	total := time.Since(start)
+
+	if received == 0 {
+		t.Fatal("no chunks received")
+	}
+
+	upstream, ok := schemas.GetUpstreamLatency(ctx)
+	if !ok {
+		t.Fatal("no upstream accumulator after streaming")
+	}
+
+	// The generation window alone is ~chunkCount*perChunk. If only TTFB were
+	// measured (the old behaviour) this would sit near 100ms and fail.
+	generation := time.Duration(chunkCount) * perChunk
+	if upstream < ttfb+generation/2 {
+		t.Fatalf("upstream = %v, want >= %v — generation window not counted, "+
+			"only TTFB is being measured", upstream, ttfb+generation/2)
+	}
+	if upstream > total {
+		t.Fatalf("upstream = %v exceeds total %v", upstream, total)
+	}
+
+	overhead, ok := schemas.CalculateOverhead(ctx, total)
+	if !ok {
+		t.Fatal("overhead not derivable")
+	}
+	// The decisive assertion: Bifrost's share of a stream must stay small. Before
+	// this work it would have been essentially the entire generation window.
+	if overhead > generation/2 {
+		t.Fatalf("overhead = %v of total %v — generation time is leaking into overhead", overhead, total)
+	}
+
+	t.Logf("chunks=%d total=%v upstream=%v overhead=%v (%.1f%%)",
+		received, total, upstream, overhead, 100*float64(overhead)/float64(total))
+}

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -809,7 +809,7 @@ func HandleAnthropicChatCompletionStreaming(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -1428,7 +1428,7 @@ func HandleAnthropicResponsesStream(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -3058,7 +3058,7 @@ func (provider *AnthropicProvider) PassthroughStream(
 	fasthttpReq.SetBody(req.Body)
 
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
-	err := activeClient.Do(fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -777,7 +777,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 
 	startTime := time.Now()
 	// Make the request
-	requestErr := provider.client.Do(req, resp)
+	requestErr := providerUtils.DoStreamingRequest(ctx, provider.client, req, resp)
 	latency := time.Since(startTime)
 	if requestErr != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -3524,7 +3524,7 @@ func (provider *AzureProvider) PassthroughStream(
 
 	startTime := time.Now()
 
-	err = activeClient.Do(fasthttpReq, resp)
+	err = providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -310,7 +310,7 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 func (provider *BedrockProvider) executeBedrockRequest(req *http.Request) ([]byte, time.Duration, map[string]string, *schemas.BifrostError) {
 	// Execute the request and measure latency
 	startTime := time.Now()
-	resp, err := provider.client.Do(req)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, req)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -407,7 +407,7 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 	}
 
 	startTime := time.Now()
-	resp, err := provider.client.Do(req)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, req)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -509,7 +509,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 
 	// Make the request
 	startTime := time.Now()
-	resp, respErr := provider.streamingClient.Do(req)
+	resp, respErr := providerUtils.DoHTTPRequest(provider.streamingClient, req)
 	latency := time.Since(startTime)
 	if respErr != nil {
 		if errors.Is(respErr, context.Canceled) {
@@ -731,7 +731,7 @@ func (provider *BedrockProvider) listMantleModels(ctx *schemas.BifrostContext, k
 		return nil
 	}
 
-	resp, err := provider.client.Do(req)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, req)
 	if err != nil {
 		provider.logger.Warn("mantle list-models request failed: %v", err)
 		return nil
@@ -812,7 +812,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	startTime := time.Now()
 
 	// Execute the request
-	resp, err := provider.client.Do(req)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, req)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -2480,7 +2480,7 @@ func (provider *BedrockProvider) FileUpload(ctx *schemas.BifrostContext, key sch
 
 	// Execute request
 	startTime := time.Now()
-	resp, err := provider.client.Do(httpReq)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -2609,7 +2609,7 @@ func (provider *BedrockProvider) FileList(ctx *schemas.BifrostContext, keys []sc
 
 	// Execute request
 	startTime := time.Now()
-	resp, err := provider.client.Do(httpReq)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -2721,7 +2721,7 @@ func (provider *BedrockProvider) FileRetrieve(ctx *schemas.BifrostContext, keys 
 
 		// Execute request
 		startTime := time.Now()
-		resp, err := provider.client.Do(httpReq)
+		resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 		latency := time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -2819,7 +2819,7 @@ func (provider *BedrockProvider) FileDelete(ctx *schemas.BifrostContext, keys []
 
 		// Execute request
 		startTime := time.Now()
-		resp, err := provider.client.Do(httpReq)
+		resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 		latency := time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -2900,7 +2900,7 @@ func (provider *BedrockProvider) FileContent(ctx *schemas.BifrostContext, keys [
 
 		// Execute request
 		startTime := time.Now()
-		resp, err := provider.client.Do(httpReq)
+		resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 		latency := time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -3105,7 +3105,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 
 	// Execute request
 	startTime := time.Now()
-	resp, err := provider.client.Do(httpReq)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -3230,7 +3230,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 
 	// Execute request
 	startTime := time.Now()
-	resp, err := provider.client.Do(httpReq)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -3348,7 +3348,7 @@ func (provider *BedrockProvider) fetchBatchManifest(ctx *schemas.BifrostContext,
 		return nil
 	}
 
-	resp, err := provider.client.Do(httpReq)
+	resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 	if err != nil {
 		provider.logger.Error("failed to fetch manifest: %v", err)
 		return nil
@@ -3410,7 +3410,7 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 
 		// Execute request
 		startTime := time.Now()
-		resp, err := provider.client.Do(httpReq)
+		resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 		latency := time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -3554,7 +3554,7 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 
 		// Execute request
 		startTime := time.Now()
-		resp, err := provider.client.Do(httpReq)
+		resp, err := providerUtils.DoHTTPRequest(provider.client, httpReq)
 		latency := time.Since(startTime)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -456,7 +456,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)
@@ -737,7 +737,7 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if usedLargePayloadBody {
 		providerUtils.DrainLargePayloadRemainder(ctx)

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -357,7 +357,7 @@ func (provider *ElevenlabsProvider) SpeechStream(ctx *schemas.BifrostContext, po
 
 	// Make request
 	startTime := time.Now()
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -429,7 +429,7 @@ func HandleGeminiChatCompletionStream(
 
 	startTime := time.Now()
 	// Make the request — caller is responsible for passing a streaming-configured client.
-	doErr := client.Do(req, resp)
+	doErr := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if doErr != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -934,7 +934,7 @@ func HandleGeminiResponsesStream(
 
 	startTime := time.Now()
 	// Make the request — caller is responsible for passing a streaming-configured client.
-	doErr := client.Do(req, resp)
+	doErr := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if doErr != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -1426,7 +1426,7 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -1714,7 +1714,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -4162,7 +4162,7 @@ func (provider *GeminiProvider) PassthroughStream(
 	fasthttpReq.SetBody(req.Body)
 
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
-	err := activeClient.Do(fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -1058,7 +1058,7 @@ func (provider *HuggingFaceProvider) ImageGenerationStream(ctx *schemas.BifrostC
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -1442,7 +1442,7 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -423,7 +423,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 
 	startTime := time.Now()
 	// Make the request
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -497,7 +497,7 @@ func HandleOpenAITextCompletionStreaming(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
 		latency := time.Since(startTime)
@@ -1078,7 +1078,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -1762,7 +1762,7 @@ func HandleOpenAIResponsesStreaming(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -2393,7 +2393,7 @@ func HandleOpenAISpeechStreamRequest(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -2901,7 +2901,7 @@ func HandleOpenAITranscriptionStreamRequest(
 
 	startTime := time.Now()
 	// Make the request
-	err := client.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -3343,7 +3343,7 @@ func HandleOpenAIImageGenerationStreaming(
 
 	startTime := time.Now()
 	// Make the request
-	err := activeClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -4829,7 +4829,7 @@ func HandleOpenAIImageEditStreamRequest(
 
 	startTime := time.Now()
 	// Make the request
-	err := client.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)
@@ -7460,7 +7460,7 @@ func (provider *OpenAIProvider) PassthroughStream(
 
 	startTime := time.Now()
 
-	err := activeClient.Do(fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -1287,7 +1287,7 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 
 	// Make the streaming request
 	startTime = time.Now()
-	streamErr := provider.streamingClient.Do(req, resp)
+	streamErr := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency = time.Since(startTime)
 	if streamErr != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/replicate/utils.go
+++ b/core/providers/replicate/utils.go
@@ -108,7 +108,7 @@ func listenToReplicateStreamURL(
 
 	// Make request
 	startTime := time.Now()
-	err := client.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, client, req, resp)
 	latency := time.Since(startTime)
 	fasthttp.ReleaseRequest(req)
 

--- a/core/providers/sarvam/sarvam.go
+++ b/core/providers/sarvam/sarvam.go
@@ -299,7 +299,7 @@ func (provider *SarvamProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 	req.SetBody(jsonBody)
 
 	startTime := time.Now()
-	err := provider.streamingClient.Do(req, resp)
+	err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/utils/fetch.go
+++ b/core/providers/utils/fetch.go
@@ -60,7 +60,7 @@ func FetchAndEncodeURL(ctx context.Context, resourceURL string) (mediaType strin
 	}
 	req.Header.Set("User-Agent", "bifrost-fetch/1")
 
-	resp, err := client.Do(req)
+	resp, err := DoHTTPRequest(client, req)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch from %q: %w", resourceURL, err)
 	}

--- a/core/providers/utils/upstream_latency_test.go
+++ b/core/providers/utils/upstream_latency_test.go
@@ -1,0 +1,256 @@
+package utils
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func accumCtx() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.ResetUpstreamLatency()
+	return ctx
+}
+
+func upstream(t *testing.T, ctx *schemas.BifrostContext) time.Duration {
+	t.Helper()
+	d, ok := schemas.GetUpstreamLatency(ctx)
+	if !ok {
+		t.Fatal("no accumulator on context")
+	}
+	return d
+}
+
+// The unary choke point every non-streaming provider call funnels through.
+func TestMakeRequestWithDoFuncAccumulates(t *testing.T) {
+	ctx := accumCtx()
+
+	_, bifrostErr, wait := makeRequestWithDoFunc(ctx, func() error {
+		time.Sleep(60 * time.Millisecond)
+		return nil
+	})
+	wait()
+
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+	if got := upstream(t, ctx); got < 50*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 50ms", got)
+	}
+}
+
+// A cancelled request still spent real time on the socket; that time belongs to
+// upstream, not to Bifrost.
+func TestMakeRequestWithDoFuncAccumulatesOnCancel(t *testing.T) {
+	base := accumCtx()
+	cancellable, cancel := context.WithCancel(base)
+	defer cancel()
+
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan struct{})
+	_, bifrostErr, wait := makeRequestWithDoFunc(cancellable, func() error {
+		<-done
+		return nil
+	})
+	if bifrostErr == nil {
+		t.Fatal("expected a cancellation error")
+	}
+	close(done)
+	wait()
+
+	// The accumulator lives on base; the cancellable context reads through to it.
+	if got := upstream(t, base); got < 30*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 30ms on the cancel path", got)
+	}
+}
+
+// Retries and fallbacks reuse one context, so their provider time must sum
+// rather than overwrite — this is what ExtraFields.Latency cannot express.
+func TestUnaryAccumulatesAcrossAttempts(t *testing.T) {
+	ctx := accumCtx()
+
+	for range 3 {
+		_, _, wait := makeRequestWithDoFunc(ctx, func() error {
+			time.Sleep(30 * time.Millisecond)
+			return nil
+		})
+		wait()
+	}
+
+	if got := upstream(t, ctx); got < 80*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 80ms across 3 attempts", got)
+	}
+}
+
+// The net/http path used by Bedrock and the media fetcher. Attribution runs off
+// req.Context(), so no explicit context argument is threaded through.
+func TestDoHTTPRequestAccumulates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx := accumCtx()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	resp, err := DoHTTPRequest(server.Client(), req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := upstream(t, ctx); got < 40*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 40ms", got)
+	}
+}
+
+// client.Do returns at response headers; draining the body is still socket
+// time. The wrapped body must attribute it to upstream, not Bifrost.
+func TestDoHTTPRequestAccumulatesBodyReadTime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush() // headers out immediately; the wait below is body-only
+		time.Sleep(60 * time.Millisecond)
+		w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	ctx := accumCtx()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+
+	resp, err := DoHTTPRequest(server.Client(), req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	afterHeaders := upstream(t, ctx)
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+
+	if got := upstream(t, ctx) - afterHeaders; got < 50*time.Millisecond {
+		t.Fatalf("body read added %v to upstream, want >= 50ms", got)
+	}
+}
+
+// Streaming consumes a DoHTTPRequest body through NewIdleTimeoutReader, which
+// does its own per-chunk timing — the timed wrapper must be unwrapped there or
+// every chunk counts twice.
+func TestIdleTimeoutReaderUnwrapsTimedBody(t *testing.T) {
+	ctx := accumCtx()
+
+	timed := &upstreamTimingBody{inner: io.NopCloser(strings.NewReader("payload")), ctx: ctx}
+	reader, stop := NewIdleTimeoutReader(timed, timed, 5*time.Second, ctx)
+	defer stop()
+
+	itr := reader.(*idleTimeoutReader)
+	if _, ok := itr.reader.(*upstreamTimingBody); ok {
+		t.Fatal("reader not unwrapped — chunk reads would be double-counted")
+	}
+	if _, ok := itr.bodyStream.(*upstreamTimingBody); ok {
+		t.Fatal("bodyStream not unwrapped")
+	}
+}
+
+// slowReader blocks before returning each chunk, standing in for a provider
+// generating tokens.
+type slowReader struct {
+	chunks []string
+	delay  time.Duration
+	idx    int
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.idx >= len(s.chunks) {
+		return 0, io.EOF
+	}
+	time.Sleep(s.delay)
+	n := copy(p, s.chunks[s.idx])
+	s.idx++
+	return n, nil
+}
+
+// The streaming seam. Time blocked inside the wrapped Read is the provider
+// generating; everything else in that goroutine is Bifrost's own cost. Without
+// this, the whole generation window would be reported as Bifrost overhead.
+func TestIdleTimeoutReaderAccumulatesReadTime(t *testing.T) {
+	ctx := accumCtx()
+
+	src := &slowReader{chunks: []string{"a", "b", "c"}, delay: 30 * time.Millisecond}
+	reader, stop := NewIdleTimeoutReader(src, src, 5*time.Second, ctx)
+	defer stop()
+
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+
+	// Three 30ms chunk waits, minus scheduler slop.
+	if got := upstream(t, ctx); got < 80*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 80ms across 3 chunks", got)
+	}
+}
+
+// Parsing between reads is Bifrost's cost and must stay out of the total.
+func TestIdleTimeoutReaderExcludesProcessingTime(t *testing.T) {
+	ctx := accumCtx()
+
+	src := &slowReader{chunks: []string{"x", "y"}, delay: 20 * time.Millisecond}
+	reader, stop := NewIdleTimeoutReader(src, src, 5*time.Second, ctx)
+	defer stop()
+
+	buf := make([]byte, 8)
+	for {
+		_, err := reader.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		// Stand-in for SSE parsing and schema transformation.
+		time.Sleep(60 * time.Millisecond)
+	}
+
+	got := upstream(t, ctx)
+	if got < 30*time.Millisecond {
+		t.Fatalf("upstream = %v, want >= 30ms of genuine read time", got)
+	}
+	// Two reads (~40ms) plus two sleeps (~120ms) is ~160ms wall clock. If the
+	// simulated processing leaked in, this would be well over 100ms.
+	if got > 100*time.Millisecond {
+		t.Fatalf("upstream = %v, want < 100ms — processing time leaked into upstream", got)
+	}
+}
+
+// A reader with no accumulator on its context must not panic or misreport.
+func TestIdleTimeoutReaderWithoutAccumulator(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	reader, stop := NewIdleTimeoutReader(strings.NewReader("payload"), nil, 5*time.Second, ctx)
+	defer stop()
+
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	if _, ok := schemas.GetUpstreamLatency(ctx); ok {
+		t.Fatal("accumulator appeared without a reset")
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -248,6 +248,8 @@ func makeRequestWithDoFunc(ctx context.Context, do func() error) (time.Duration,
 		// Context was cancelled (e.g., deadline exceeded or manual cancellation).
 		// Calculate latency even for cancelled requests.
 		latency := time.Since(startTime)
+		// Socket wait is upstream even when it ends in cancellation.
+		schemas.AddUpstreamLatency(ctx, latency)
 		// Return a wait function that blocks until the background goroutine finishes.
 		// The caller MUST invoke this (via defer) before releasing req/resp to avoid
 		// a data race with the still-running goroutine.
@@ -281,6 +283,8 @@ func makeRequestWithDoFunc(ctx context.Context, do func() error) (time.Duration,
 		// The do() call completed.
 		// Calculate latency for both successful and failed requests.
 		latency := time.Since(startTime)
+		// Single accumulation point for every unary provider call.
+		schemas.AddUpstreamLatency(ctx, latency)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				return latency, &schemas.BifrostError{
@@ -332,6 +336,64 @@ func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *f
 func MakeRequestWithContextFollowRedirects(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response, maxRedirects int) (time.Duration, *schemas.BifrostError, func()) {
 	latency, bifrostErr, wait := makeRequestWithDoFunc(ctx, func() error { return client.DoRedirects(req, resp, maxRedirects) })
 	return latency, bifrostErr, wait
+}
+
+// DoStreamingRequest performs the initial client.Do for a streaming request and
+// records the wait as upstream latency.
+//
+// Streaming cannot use MakeRequestWithContext: for a streamed response fasthttp
+// returns as soon as the headers arrive, and the body is consumed lazily
+// afterwards. So this measures time-to-first-byte only — the generation window
+// is measured separately, inside idleTimeoutReader.Read. Both are needed;
+// counting only one attributes the other to Bifrost.
+//
+// Returns client.Do's error untouched so callers keep their own error
+// classification and latency bookkeeping.
+func DoStreamingRequest(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) error {
+	startTime := time.Now()
+	err := client.Do(req, resp)
+	schemas.AddUpstreamLatency(ctx, time.Since(startTime))
+	return err
+}
+
+// upstreamTimingBody wraps a response body so time blocked reading it counts as
+// upstream latency. net/http's client.Do returns at response headers; the body
+// still streams from the provider's socket, and an untimed io.ReadAll would
+// misattribute that wait to Bifrost overhead.
+type upstreamTimingBody struct {
+	inner io.ReadCloser
+	ctx   context.Context
+}
+
+func (b *upstreamTimingBody) Read(p []byte) (int, error) {
+	start := time.Now()
+	n, err := b.inner.Read(p)
+	schemas.AddUpstreamLatency(b.ctx, time.Since(start))
+	return n, err
+}
+
+func (b *upstreamTimingBody) Close() error { return b.inner.Close() }
+
+// DoHTTPRequest performs a net/http request and records the wait as upstream
+// latency. Used by the paths that don't go through fasthttp — Bedrock, which
+// builds and signs its own requests, and the media fetcher.
+//
+// The duration is attributed via req.Context() rather than an explicit ctx
+// parameter, so callers that no longer hold the context (Bedrock's
+// executeBedrockRequest) need no signature change. Every such request is built
+// with http.NewRequestWithContext, so the accumulator is always reachable.
+//
+// client.Do covers headers only, so the returned body is wrapped to time the
+// reads that drain it. Streamed responses consumed through NewIdleTimeoutReader
+// are unwrapped there — the idle reader does its own per-chunk timing.
+func DoHTTPRequest(client *http.Client, req *http.Request) (*http.Response, error) {
+	startTime := time.Now()
+	resp, err := client.Do(req)
+	schemas.AddUpstreamLatency(req.Context(), time.Since(startTime))
+	if err == nil && resp != nil && resp.Body != nil {
+		resp.Body = &upstreamTimingBody{inner: resp.Body, ctx: req.Context()}
+	}
+	return resp, err
 }
 
 // Deprecated: ConfigureRetry is now handled internally by ConfigureDialer.
@@ -2492,6 +2554,14 @@ func NewIdleTimeoutReader(reader io.Reader, bodyStream io.Reader, timeout time.D
 	if timeout <= 0 {
 		timeout = DefaultStreamIdleTimeout
 	}
+	// A body wrapped by DoHTTPRequest times its own reads; unwrap so the
+	// per-chunk timing in Read below isn't counted twice.
+	if tb, ok := reader.(*upstreamTimingBody); ok {
+		reader = tb.inner
+	}
+	if tb, ok := bodyStream.(*upstreamTimingBody); ok {
+		bodyStream = tb.inner
+	}
 	r := &idleTimeoutReader{
 		ctx:        ctx,
 		reader:     reader,
@@ -2576,7 +2646,11 @@ func (r *idleTimeoutReader) Read(p []byte) (n int, err error) {
 	if r.connectionClosed() {
 		return 0, r.closedReadError()
 	}
+	readStart := time.Now()
 	n, err = r.reader.Read(p)
+	if r.ctx != nil {
+		schemas.AddUpstreamLatency(r.ctx, time.Since(readStart))
+	}
 	if n > 0 {
 		r.timer.Reset(r.timeout)
 	}
@@ -3285,6 +3359,10 @@ func completeDeferredSpan(ctx *schemas.BifrostContext, result *schemas.BifrostRe
 	if !ok || tracer == nil {
 		return
 	}
+
+	// Stamp now the stream has drained; the handler returned long ago. Before the
+	// guard below so it still runs when there is no deferred span.
+	ctx.StampUpstreamLatency()
 
 	// Get the deferred span handle from TraceStore using trace ID
 	handle := tracer.GetDeferredSpanHandle(traceID)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -4526,7 +4526,7 @@ func (provider *VertexProvider) PassthroughStream(
 
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.streamingClient, resp)
 	startTime := time.Now()
-	err := activeClient.Do(fasthttpReq, resp)
+	err := providerUtils.DoStreamingRequest(ctx, activeClient, fasthttpReq, resp)
 	latency := time.Since(startTime)
 	if err != nil {
 		providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -623,7 +623,7 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 
 		startTime := time.Now()
 		// Make the request
-		err := provider.streamingClient.Do(req, resp)
+		err := providerUtils.DoStreamingRequest(ctx, provider.streamingClient, req, resp)
 		latency := time.Since(startTime)
 		if err != nil {
 			defer providerUtils.ReleaseStreamingResponse(ctx, resp)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -382,6 +382,7 @@ const (
 	BifrostContextKeyTempTokenScope                      BifrostContextKey = "bifrost-temp-token-scope"       // string (set by auth middleware when a temp token authorized the request - names the scope from the temptoken registry)
 	BifrostContextKeyTempTokenResourceID                 BifrostContextKey = "bifrost-temp-token-resource-id" // string (set by auth middleware alongside the scope - the resource_id the token is bound to, e.g. an OAuth flow ID for mcp_auth)
 	BifrostContextKeyAsyncWebhookEndpoint                BifrostContextKey = "bifrost-async-webhook-endpoint" // string (webhook endpoint name to notify when an async job finishes - carried as-is from the x-bf-async-webhook header; the submit path resolves and validates it before the job is created)
+	BifrostContextKeyUpstreamLatency                     BifrostContextKey = "bifrost-upstream-latency"       // *atomic.Int64 nanoseconds (set by bifrost - DO NOT SET THIS MANUALLY) - cumulative time blocked on provider sockets across every attempt; subtract from total to get Bifrost overhead
 )
 
 const (
@@ -1678,6 +1679,11 @@ type BifrostResponseExtraFields struct {
 	// consumers should read from RoutingInfo.
 	ResolvedModelUsed         string             `json:"resolved_model_used,omitempty"`
 	Latency                   int64              `json:"latency"`     // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
+	// UpstreamLatency is the total time spent blocked on upstream sockets across
+	// every attempt, in milliseconds. Unlike Latency it survives retries and
+	// fallbacks, so total-UpstreamLatency is Bifrost's own cost. Nil when the
+	// request never accumulated one; nil means unknown, not zero.
+	UpstreamLatency           *int64             `json:"upstream_latency,omitempty"`
 	ChunkIndex                int                `json:"chunk_index"` // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
 	RawRequest                interface{}        `json:"raw_request,omitempty"`
 	RawResponse               interface{}        `json:"raw_response,omitempty"`

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -29,6 +29,7 @@ var reservedKeys = []any{
 	BifrostContextKeyAttemptTrail,
 	BifrostContextKeyStreamGated,
 	BifrostContextKeyMCPHealthCheckRequest,
+	BifrostContextKeyUpstreamLatency,
 }
 
 // pluginLogStore holds plugin log entries accumulated during request processing.

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -202,6 +202,52 @@ func (t *Trace) SnapshotForExport() *Trace {
 	return clone
 }
 
+// StampOverheadDuration writes Bifrost's own cost onto the root span as
+// AttrBifrostOverheadDurationMs: the root span's wall time minus the upstream
+// total stamped on it. This is the single definition of the overhead number —
+// every trace connector reads the attribute rather than re-deriving it, so the
+// span and the overhead metric can never disagree.
+//
+// Call this on the export snapshot after SnapshotForExport, never on the pooled
+// trace: the root span's duration is only known once it has ended, and mutating
+// a pooled span at flush time races the late writers the snapshot exists to
+// isolate. The snapshot's attribute maps are private clones, so the write here
+// is safe on the single flush goroutine before any connector reads them.
+//
+// No-op when the root span never ended or carried no upstream measurement;
+// absent overhead must not be reported as zero.
+func (t *Trace) StampOverheadDuration() {
+	if t == nil || t.RootSpan == nil {
+		return
+	}
+	root := t.RootSpan
+	if root.StartTime.IsZero() || root.EndTime.IsZero() || root.Attributes == nil {
+		return
+	}
+	raw, ok := root.Attributes[AttrBifrostUpstreamDurationMs]
+	if !ok {
+		return
+	}
+	var upstreamMs float64
+	switch v := raw.(type) {
+	case float64:
+		upstreamMs = v
+	case int64:
+		upstreamMs = float64(v)
+	case int:
+		upstreamMs = float64(v)
+	default:
+		return
+	}
+	overheadMs := float64(root.EndTime.Sub(root.StartTime))/float64(time.Millisecond) - upstreamMs
+	// Different clocks: a request that is almost entirely upstream can round
+	// slightly negative, which is meaningless and would poison a histogram.
+	if overheadMs < 0 {
+		overheadMs = 0
+	}
+	root.Attributes[AttrBifrostOverheadDurationMs] = overheadMs
+}
+
 // Reset clears the trace for reuse from pool
 func (t *Trace) Reset() {
 	t.mu.Lock()
@@ -708,6 +754,20 @@ const (
 	// The corresponding legacy gen_ai.* emissions are tagged "// legacy:" at their
 	// call sites and will be removed once dashboards migrate over.
 	// =====================================================================
+	// Cumulative time (float64 ms) the request spent blocked on sockets outside
+	// Bifrost — every provider attempt, plus MCP tool calls and media fetches.
+	// Stamped on the ROOT span once per request, so connectors derive Bifrost's
+	// own cost as (root span duration - this). Deliberately not a per-attempt
+	// value: retries and fallbacks all contribute to the same total.
+	AttrBifrostUpstreamDurationMs = "bifrost.upstream.duration_ms"
+
+	// Bifrost's own cost (float64 ms): root span duration minus the upstream
+	// total above. Stamped on the ROOT span at export time, since the root's
+	// duration is not known while the request is still running. Connectors read
+	// this rather than re-deriving it, so the span and the overhead metric can
+	// never disagree.
+	AttrBifrostOverheadDurationMs = "bifrost.overhead.duration_ms"
+
 	AttrBifrostProviderName        = "bifrost.provider.name"
 	AttrBifrostRequestID           = "bifrost.request.id"
 	AttrBifrostVirtualKeyID        = "bifrost.virtual_key.id"
@@ -733,8 +793,8 @@ const (
 	AttrBifrostUserEmail           = "bifrost.user.email"
 	AttrBifrostRetries             = "bifrost.retries"
 	AttrBifrostFallbackIndex       = "bifrost.fallback_index"
-	AttrBifrostAlias               = "bifrost.alias"                // original requested model when it differs from the resolved model
-	AttrBifrostRoutingEngineUsed   = "bifrost.routing_engine_used"  // comma-joined routing engines that handled the request
+	AttrBifrostAlias               = "bifrost.alias"               // original requested model when it differs from the resolved model
+	AttrBifrostRoutingEngineUsed   = "bifrost.routing_engine_used" // comma-joined routing engines that handled the request
 	AttrBifrostStopSequencesJoined = "bifrost.request.stop_sequences"
 
 	// OTel general semconv (no gen_ai prefix). Emitted alongside the legacy

--- a/core/schemas/upstream_latency_test.go
+++ b/core/schemas/upstream_latency_test.go
@@ -1,0 +1,239 @@
+package schemas
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestCtx() *BifrostContext {
+	return NewBifrostContext(context.Background(), NoDeadline)
+}
+
+func TestUpstreamLatencyAccumulates(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+
+	AddUpstreamLatency(ctx, 100*time.Millisecond)
+	AddUpstreamLatency(ctx, 50*time.Millisecond)
+
+	got, ok := GetUpstreamLatency(ctx)
+	if !ok {
+		t.Fatal("accumulator missing after reset")
+	}
+	if got != 150*time.Millisecond {
+		t.Fatalf("upstream = %v, want 150ms", got)
+	}
+}
+
+// Absent and zero must stay distinguishable: a request that never measured
+// upstream time is "unknown", not "100% overhead".
+func TestUpstreamLatencyAbsentWithoutReset(t *testing.T) {
+	ctx := newTestCtx()
+
+	if _, ok := GetUpstreamLatency(ctx); ok {
+		t.Fatal("accumulator reported present before reset")
+	}
+	// Must not panic — provider code calls this unconditionally.
+	AddUpstreamLatency(ctx, time.Second)
+
+	if _, ok := CalculateOverhead(ctx, time.Second); ok {
+		t.Fatal("overhead reported without an accumulator")
+	}
+}
+
+func TestUpstreamLatencyZeroIsPresent(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+
+	got, ok := GetUpstreamLatency(ctx)
+	if !ok || got != 0 {
+		t.Fatalf("got (%v, %v), want (0, true)", got, ok)
+	}
+
+	// A cache hit does zero upstream work, so all of the elapsed time is Bifrost's.
+	overhead, ok := CalculateOverhead(ctx, 40*time.Millisecond)
+	if !ok || overhead != 40*time.Millisecond {
+		t.Fatalf("overhead = (%v, %v), want (40ms, true)", overhead, ok)
+	}
+}
+
+// The reset is what keeps the process-global bifrost.ctx (used for every
+// nil-context SDK call) from accumulating across unrelated requests.
+func TestUpstreamLatencyResetClearsPreviousRequest(t *testing.T) {
+	ctx := newTestCtx()
+
+	ctx.ResetUpstreamLatency()
+	AddUpstreamLatency(ctx, 900*time.Millisecond)
+
+	ctx.ResetUpstreamLatency()
+	AddUpstreamLatency(ctx, 10*time.Millisecond)
+
+	got, _ := GetUpstreamLatency(ctx)
+	if got != 10*time.Millisecond {
+		t.Fatalf("upstream = %v, want 10ms — previous request leaked", got)
+	}
+}
+
+func TestCalculateOverheadClampsNegative(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+	AddUpstreamLatency(ctx, 200*time.Millisecond)
+
+	// Upstream exceeding total is possible: the two are measured by different
+	// clocks started at different instants.
+	overhead, ok := CalculateOverhead(ctx, 150*time.Millisecond)
+	if !ok {
+		t.Fatal("overhead not reported")
+	}
+	if overhead != 0 {
+		t.Fatalf("overhead = %v, want 0 (clamped)", overhead)
+	}
+}
+
+func TestCalculateOverheadSubtracts(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+	AddUpstreamLatency(ctx, 700*time.Millisecond)
+
+	overhead, ok := CalculateOverhead(ctx, time.Second)
+	if !ok || overhead != 300*time.Millisecond {
+		t.Fatalf("overhead = (%v, %v), want (300ms, true)", overhead, ok)
+	}
+}
+
+// A scoped plugin context delegates values to its root, so adds made from a
+// plugin must land on the same accumulator the request reads at the end.
+func TestUpstreamLatencyThroughScopedContext(t *testing.T) {
+	root := newTestCtx()
+	root.ResetUpstreamLatency()
+
+	pluginName := "test-plugin"
+	scoped := root.WithPluginScope(&pluginName)
+	AddUpstreamLatency(scoped, 25*time.Millisecond)
+
+	got, ok := GetUpstreamLatency(root)
+	if !ok {
+		t.Fatal("accumulator missing on root")
+	}
+	if got != 25*time.Millisecond {
+		t.Fatalf("root upstream = %v, want 25ms — scoped add did not reach root", got)
+	}
+}
+
+// Streaming keeps adding from the provider goroutine after the handler returns,
+// concurrently with the transport reading. Run under -race.
+func TestUpstreamLatencyConcurrentAdds(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+
+	const writers, addsEach = 8, 500
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for range writers {
+		go func() {
+			defer wg.Done()
+			for range addsEach {
+				AddUpstreamLatency(ctx, time.Microsecond)
+			}
+		}()
+	}
+
+	// Concurrent reader, mirroring a connector sampling mid-stream.
+	stop := make(chan struct{})
+	var readerWG sync.WaitGroup
+	readerWG.Add(1)
+	go func() {
+		defer readerWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				GetUpstreamLatency(ctx)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	readerWG.Wait()
+
+	got, _ := GetUpstreamLatency(ctx)
+	want := time.Duration(writers*addsEach) * time.Microsecond
+	// Exact equality is the point: a lost update here is the bug this design exists
+	// to avoid (the context has no atomic read-modify-write).
+	if got != want {
+		t.Fatalf("upstream = %v, want %v — lost update", got, want)
+	}
+}
+
+func TestAddUpstreamLatencyIgnoresNonPositive(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+
+	AddUpstreamLatency(ctx, 0)
+	AddUpstreamLatency(ctx, -5*time.Second)
+
+	if got, _ := GetUpstreamLatency(ctx); got != 0 {
+		t.Fatalf("upstream = %v, want 0", got)
+	}
+}
+
+// The body copy is what survives a proxy hop, so it has to carry the same total
+// the header does — and stay absent, not zero, when nothing was measured.
+func TestPopulateUpstreamLatencyOnResponse(t *testing.T) {
+	ctx := newTestCtx()
+	ctx.ResetUpstreamLatency()
+	AddUpstreamLatency(ctx, 120*time.Millisecond)
+	AddUpstreamLatency(ctx, 80*time.Millisecond)
+
+	resp := &BifrostResponse{ChatResponse: &BifrostChatResponse{}}
+	resp.PopulateUpstreamLatency(ctx)
+
+	got := resp.GetExtraFields().UpstreamLatency
+	if got == nil {
+		t.Fatal("UpstreamLatency not populated")
+	}
+	if *got != 200 {
+		t.Fatalf("UpstreamLatency = %dms, want 200ms", *got)
+	}
+}
+
+func TestPopulateUpstreamLatencyAbsentWithoutAccumulator(t *testing.T) {
+	ctx := newTestCtx()
+
+	resp := &BifrostResponse{ChatResponse: &BifrostChatResponse{}}
+	resp.PopulateUpstreamLatency(ctx)
+
+	if got := resp.GetExtraFields().UpstreamLatency; got != nil {
+		t.Fatalf("UpstreamLatency = %dms, want nil — unmeasured must not read as zero", *got)
+	}
+
+	// Must not panic on a nil response; handleRequest calls this on its error paths.
+	var nilResp *BifrostResponse
+	nilResp.PopulateUpstreamLatency(ctx)
+}
+
+func TestUpstreamLatencyNilSafe(t *testing.T) {
+	var ctx *BifrostContext
+
+	// None of these may panic — they run on every request. The typed-nil cases
+	// matter most: a nil *BifrostContext boxed into a context.Context interface is
+	// not == nil, so a naive guard would let it through to a panicking Value call.
+	ctx.ResetUpstreamLatency()
+	ctx.StampUpstreamLatency()
+	AddUpstreamLatency(ctx, time.Second)
+
+	if _, ok := GetUpstreamLatency(ctx); ok {
+		t.Fatal("typed-nil context reported an accumulator")
+	}
+
+	var untyped context.Context
+	AddUpstreamLatency(untyped, time.Second)
+	if _, ok := GetUpstreamLatency(untyped); ok {
+		t.Fatal("nil context reported an accumulator")
+	}
+}

--- a/core/schemas/upstreamlatency.go
+++ b/core/schemas/upstreamlatency.go
@@ -1,0 +1,156 @@
+package schemas
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+// Upstream-latency accumulation.
+//
+// Bifrost's "overhead" is the time a request spends inside Bifrost rather than
+// blocked on a provider socket:
+//
+//	overhead = total_wall_time - upstream_latency
+//
+// The subtrahend has to be a running total, not a single measurement. A request
+// can hit the network many times over its lifetime (retries, fallbacks, media
+// fetches, cached-content lookups), and ExtraFields.Latency only ever holds the
+// last attempt. So every site that blocks on a provider socket adds its own
+// duration here, and the sum is read once at request end.
+//
+// The value is an *atomic.Int64 (nanoseconds) stored on the context. The pointer
+// is installed once per request and only ever dereferenced afterwards, so
+// concurrent adds never touch the context's value map. This matters: streaming
+// keeps writing from the provider goroutine long after the request handler has
+// returned, and there is no atomic read-modify-write on BifrostContext —
+// GetAndSetValue is a swap, not an add.
+
+// ResetUpstreamLatency installs a fresh accumulator on ctx. Call once at request
+// entry, before any provider call.
+//
+// The reset is not optional. Bifrost falls back to a single process-global
+// context when an SDK caller passes nil, so without this the counter would grow
+// without bound across every such request and overhead would go negative.
+func (bc *BifrostContext) ResetUpstreamLatency() {
+	if bc == nil {
+		return
+	}
+	bc.setReservedValue(BifrostContextKeyUpstreamLatency, &atomic.Int64{})
+}
+
+// AddUpstreamLatency adds d to the request's upstream total.
+//
+// Takes a plain context.Context so provider code can call it without knowing
+// whether it holds a *BifrostContext or a derived one — Value traverses either
+// way. A context with no accumulator (internal calls, tests, SDK callers on a
+// path that never reset) is silently ignored: this is telemetry, and a missing
+// counter must never break a request.
+func AddUpstreamLatency(ctx context.Context, d time.Duration) {
+	if d <= 0 || isNilContext(ctx) {
+		return
+	}
+	if acc, ok := ctx.Value(BifrostContextKeyUpstreamLatency).(*atomic.Int64); ok && acc != nil {
+		acc.Add(int64(d))
+	}
+}
+
+// isNilContext reports whether ctx carries nothing readable.
+//
+// A plain ctx == nil check is not enough: a nil *BifrostContext stored in a
+// context.Context interface is itself non-nil, and calling Value on it would
+// panic. Provider code passes its context straight through to the helpers here,
+// so that case has to be absorbed rather than crash a live request.
+func isNilContext(ctx context.Context) bool {
+	if ctx == nil {
+		return true
+	}
+	bc, ok := ctx.(*BifrostContext)
+	return ok && bc == nil
+}
+
+// GetUpstreamLatency returns the accumulated upstream total and whether an
+// accumulator was present. Callers must treat !ok as "unknown", not as zero —
+// reporting zero upstream time would attribute the entire request to Bifrost.
+func GetUpstreamLatency(ctx context.Context) (time.Duration, bool) {
+	if isNilContext(ctx) {
+		return 0, false
+	}
+	if acc, ok := ctx.Value(BifrostContextKeyUpstreamLatency).(*atomic.Int64); ok && acc != nil {
+		return time.Duration(acc.Load()), true
+	}
+	return 0, false
+}
+
+// StampUpstreamLatency writes the accumulated total onto the request's root span
+// so trace-based connectors (OTEL, Datadog) can derive overhead at export time.
+//
+// It stamps the ROOT span, not the llm.call span: the root is the only one whose
+// duration covers the whole request, and the accumulator spans every attempt.
+// Only upstream is stamped, never overhead itself — each connector already knows
+// its own notion of "total" and subtracting at export keeps the two consistent.
+//
+// Call as late as possible: at handler return for unary, and at stream
+// completion for streaming, since a stream keeps accumulating until it drains.
+// Every lookup is best-effort; a request with no tracer simply isn't stamped.
+func (bc *BifrostContext) StampUpstreamLatency() {
+	if bc == nil {
+		return
+	}
+	upstream, ok := GetUpstreamLatency(bc)
+	if !ok {
+		return
+	}
+	traceID, _ := bc.Value(BifrostContextKeyTraceID).(string)
+	if traceID == "" {
+		return
+	}
+	tracer, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
+	if tracer == nil {
+		return
+	}
+	// nil spanID selects the root span.
+	handle := tracer.GetSpanHandleByID(traceID, nil)
+	if handle == nil {
+		return
+	}
+	tracer.SetAttribute(handle, AttrBifrostUpstreamDurationMs, float64(upstream)/float64(time.Millisecond))
+}
+
+// PopulateUpstreamLatency copies the accumulated total onto the response's
+// ExtraFields so callers can derive overhead from the body alone.
+//
+// The response body is the only carrier that survives a proxy hop — response
+// headers set by one node are not forwarded when another serves the request.
+// Left nil when no accumulator is present, so absent stays distinguishable from
+// zero.
+func (r *BifrostResponse) PopulateUpstreamLatency(ctx context.Context) {
+	if r == nil {
+		return
+	}
+	upstream, ok := GetUpstreamLatency(ctx)
+	if !ok {
+		return
+	}
+	if ef := r.GetExtraFields(); ef != nil {
+		ms := int64(upstream / time.Millisecond)
+		ef.UpstreamLatency = &ms
+	}
+}
+
+// CalculateOverhead derives Bifrost's own cost from a total wall-clock duration.
+//
+// Clamps at zero. The two measurements come from different clocks started at
+// different instants, so a fast request with a slow-to-observe total can round
+// negative; a negative "overhead" is meaningless and would poison a histogram.
+func CalculateOverhead(ctx context.Context, total time.Duration) (time.Duration, bool) {
+	upstream, ok := GetUpstreamLatency(ctx)
+	if !ok {
+		return 0, false
+	}
+	overhead := total - upstream
+	if overhead < 0 {
+		overhead = 0
+	}
+	return overhead, true
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -734,6 +734,11 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// here covers all connectors.
 		exportTrace := completedTrace.SnapshotForExport()
 
+		// Stamp Bifrost's overhead onto the snapshot's root span now that it has
+		// ended. Done here — one write, before any connector reads the snapshot —
+		// so every trace connector sees the same value on the root span.
+		exportTrace.StampOverheadDuration()
+
 		var obsPlugins []schemas.ObservabilityPlugin
 		if loaded := t.obsPlugins.Load(); loaded != nil {
 			obsPlugins = *loaded

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -150,6 +150,8 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 					kvStr(schemas.AttrBifrostRequestID, requestID),
 				)
 			}
+			// Overhead is stamped on the snapshot's root span by the tracer, so it
+			// flows through convertAttributesToKeyValues above like any other attr.
 			if len(p.instanceAttrs) > 0 {
 				otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
 			}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -747,6 +747,41 @@ func getFloat64Attr(attrs map[string]any, key string) float64 {
 	return 0
 }
 
+// getFloat64AttrOK is getFloat64Attr with presence reporting. Needed where zero
+// is a meaningful value distinct from "absent" — an upstream total of 0 (a cache
+// hit, or a request rejected before any provider call) means all of the elapsed
+// time was Bifrost's, whereas a missing attribute means it was never measured.
+// overheadSecondsFromTrace reads Bifrost's own cost off the root span, where the
+// tracer stamps it as AttrBifrostOverheadDurationMs (root duration minus the
+// upstream total). Reading the stamped value rather than recomputing keeps the
+// overhead metric and the span attribute in lockstep. Returns false when the
+// request carried no measurement; absent must not be reported as zero overhead.
+func overheadSecondsFromTrace(trace *schemas.Trace) (float64, bool) {
+	if trace == nil || trace.RootSpan == nil {
+		return 0, false
+	}
+	overheadMs, ok := getFloat64AttrOK(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+	if !ok {
+		return 0, false
+	}
+	return overheadMs / 1000.0, true
+}
+
+func getFloat64AttrOK(attrs map[string]any, key string) (float64, bool) {
+	if attrs == nil {
+		return 0, false
+	}
+	switch v := attrs[key].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	}
+	return 0, false
+}
+
 // buildSpanAttrs extracts metric dimension attrs from a single attempt span.
 func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	attrs := span.Attributes
@@ -906,6 +941,21 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 		if finalSpan == nil || span.EndTime.After(finalSpan.EndTime) {
 			finalSpan = span
 		}
+	}
+
+	// Bifrost's own overhead. Derived once per trace from the root span, which is
+	// the only span whose duration covers the whole request — including queue
+	// wait, plugin hooks and transport work that no llm.call span sees.
+	//
+	// Labelled off the final attempt span so provider/model dimensions match the
+	// other per-request metrics (retries, tokens, cost). The root span carries
+	// only HTTP attributes.
+	if overheadSeconds, ok := overheadSecondsFromTrace(trace); ok {
+		labelSpan := finalSpan
+		if labelSpan == nil {
+			labelSpan = trace.RootSpan
+		}
+		exporter.RecordOverheadLatency(ctx, overheadSeconds, buildSpanAttrs(labelSpan)...)
 	}
 
 	if finalSpan == nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -55,6 +55,7 @@ type MetricsExporter struct {
 
 	// Bifrost metrics - histograms
 	upstreamLatencySeconds         *syncFloat64Histogram
+	overheadLatencySeconds         *syncFloat64Histogram
 	streamFirstTokenLatencySeconds *syncFloat64Histogram
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
@@ -131,6 +132,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets. A different scale entirely from upstream latency —
+	// healthy values are sub-millisecond to low tens of ms, dominated by request and
+	// response marshalling. Reusing upstreamLatencyBuckets would pile almost every
+	// request into the first two buckets and make regressions invisible. The long
+	// tail up to 30s exists to catch queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1,
+		.25, .5, 1, 2.5, 5, 10, 30,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -392,6 +404,14 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: upstreamLatencyBuckets,
 	}
 
+	m.overheadLatencySeconds = &syncFloat64Histogram{
+		name:       "bifrost_overhead_latency_seconds",
+		desc:       "Latency added by Bifrost itself: total request time minus time blocked on upstream providers",
+		unit:       "s",
+		meter:      m.meter,
+		boundaries: overheadLatencyBuckets,
+	}
+
 	m.streamFirstTokenLatencySeconds = &syncFloat64Histogram{
 		name:       "bifrost_stream_first_token_latency_seconds",
 		desc:       "Latency of the first token of a stream response",
@@ -524,6 +544,13 @@ func (m *MetricsExporter) RecordCost(ctx context.Context, cost float64, attrs ..
 // RecordUpstreamLatency records upstream latency metric
 func (m *MetricsExporter) RecordUpstreamLatency(ctx context.Context, latencySeconds float64, attrs ...attribute.KeyValue) {
 	m.upstreamLatencySeconds.Record(ctx, latencySeconds, metric.WithAttributes(attrs...))
+}
+
+// RecordOverheadLatency records the latency Bifrost itself added to a request.
+// Recorded once per trace (off the root span), not once per attempt — the
+// underlying accumulator already spans every retry and fallback.
+func (m *MetricsExporter) RecordOverheadLatency(ctx context.Context, overheadSeconds float64, attrs ...attribute.KeyValue) {
+	m.overheadLatencySeconds.Record(ctx, overheadSeconds, metric.WithAttributes(attrs...))
 }
 
 // RecordStreamFirstTokenLatency records first token latency metric

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,6 +35,11 @@ const (
 	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
 	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
 	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
+
+	// Overhead is measured across the transport hooks rather than the LLM hooks,
+	// so the window matches the OTEL root span. See recordOverhead.
+	transportStartTimeKey schemas.BifrostContextKey = "bf-prom-transport-start-time"
+	overheadLabelsKey     schemas.BifrostContextKey = "bf-prom-overhead-labels"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -160,6 +166,7 @@ type PrometheusPlugin struct {
 	HTTPResponseSizeBytes          *prometheus.HistogramVec
 	UpstreamRequestsTotal          *prometheus.CounterVec
 	UpstreamLatencySeconds         *prometheus.HistogramVec
+	OverheadLatencySeconds         *prometheus.HistogramVec
 	SuccessRequestsTotal           *prometheus.CounterVec
 	ErrorRequestsTotal             *prometheus.CounterVec
 	InputTokensTotal               *prometheus.CounterVec
@@ -213,6 +220,17 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
+	}
+
+	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
+	// blocked on upstream sockets. A different scale entirely from upstream latency —
+	// healthy values are sub-millisecond to low tens of ms, dominated by request and
+	// response marshalling. Reusing upstreamLatencyBuckets would pile almost every
+	// request into the first two buckets and make regressions invisible. The long
+	// tail up to 30s exists to catch queue saturation and pathological payloads.
+	overheadLatencyBuckets = []float64{
+		.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1,
+		.25, .5, 1, 2.5, 5, 10, 30,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -387,6 +405,18 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(append(defaultBifrostLabels, "is_success"), filteredCustomLabels...),
 	)
 
+	// Labelled without is_success: unlike upstream latency, overhead is dominated by
+	// payload marshalling and is not expected to differ between success and failure,
+	// and a failed request often has no response to marshal at all.
+	bifrostOverheadLatencySeconds := factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bifrost_overhead_latency_seconds",
+			Help:    "Latency added by Bifrost itself: total request time minus time blocked on upstream providers.",
+			Buckets: overheadLatencyBuckets,
+		},
+		append(defaultBifrostLabels, filteredCustomLabels...),
+	)
+
 	bifrostSuccessRequestsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_success_requests_total",
@@ -550,6 +580,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		HTTPResponseSizeBytes:          httpResponseSizeBytes,
 		UpstreamRequestsTotal:          bifrostUpstreamRequestsTotal,
 		UpstreamLatencySeconds:         bifrostUpstreamLatencySeconds,
+		OverheadLatencySeconds:         bifrostOverheadLatencySeconds,
 		SuccessRequestsTotal:           bifrostSuccessRequestsTotal,
 		ErrorRequestsTotal:             bifrostErrorRequestsTotal,
 		InputTokensTotal:               bifrostInputTokensTotal,
@@ -656,12 +687,41 @@ func (p *PrometheusPlugin) RedactConfig(raw map[string]any) (map[string]any, err
 
 // HTTPTransportPreHook is not used for this plugin
 func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	ctx.SetValue(transportStartTimeKey, time.Now())
 	return nil, nil
 }
 
-// HTTPTransportPostHook is not used for this plugin
+// HTTPTransportPostHook records Bifrost's own overhead.
+//
+// This is the widest window the plugin can see — the middleware order is
+// Tracing.pre → TransportInterceptor.pre → handler → TransportInterceptor.post
+// → Tracing.defer — so it brackets request parsing, the full core pipeline and
+// response marshalling, matching what OTEL derives from the root span. Measuring
+// across PreLLMHook/PostLLMHook instead would miss the transport work, and
+// marshalling a large response body is a real part of the cost.
+//
+// Running here also makes the observation once-per-request rather than
+// once-per-attempt, so a retried request no longer contributes several times.
 func (p *PrometheusPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	start, ok := ctx.Value(transportStartTimeKey).(time.Time)
+	if !ok {
+		return nil
+	}
+	p.recordOverhead(ctx, time.Since(start))
 	return nil
+}
+
+// recordOverhead observes total-minus-upstream against the labels the LLM hook
+// resolved. Silent when either is missing: no accumulator means upstream was
+// never measured, and reporting the full duration as overhead would be wrong.
+func (p *PrometheusPlugin) recordOverhead(ctx *schemas.BifrostContext, total time.Duration) {
+	labels, ok := ctx.Value(overheadLabelsKey).([]string)
+	if !ok || len(labels) == 0 {
+		return
+	}
+	if overhead, ok := schemas.CalculateOverhead(ctx, total); ok {
+		p.OverheadLatencySeconds.WithLabelValues(labels...).Observe(overhead.Seconds())
+	}
 }
 
 // HTTPTransportStreamChunkHook passes through streaming chunks unchanged
@@ -918,6 +978,13 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
+	// Labels for HTTPTransportPostHook, which observes overhead. Written before
+	// the goroutine launches so the transport hook can't race it; on a retry the
+	// final attempt's labels win.
+	if isStreamFinal {
+		ctx.SetValue(overheadLabelsKey, slices.Clone(promLabelValues))
+	}
+
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
 	go func() {
 		// For streaming requests, handle per-token metrics for intermediate chunks
@@ -975,6 +1042,11 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		latencyLabelValues = append(latencyLabelValues, strconv.FormatBool(bifrostErr == nil))            // is_success
 		latencyLabelValues = append(latencyLabelValues, promLabelValues[len(p.defaultBifrostLabels):]...) // then custom labels
 		p.UpstreamLatencySeconds.WithLabelValues(latencyLabelValues...).Observe(duration)
+
+		// SDK caller — no transport hooks, so this window is all there is.
+		if _, viaTransport := ctx.Value(transportStartTimeKey).(time.Time); !viaTransport {
+			p.recordOverhead(ctx, time.Since(startTime))
+		}
 
 		// Record cost using the dedicated cost counter
 		if cost > 0 {

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -259,6 +260,11 @@ const (
 	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
 	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
 	HeaderBifrostRequestType   = "x-bifrost-request-type"
+	// Cumulative milliseconds this request spent blocked on upstream sockets,
+	// summed across every attempt and fallback. Subtract from the caller's own
+	// elapsed time to get what Bifrost cost. Distinct from the per-attempt
+	// latency in the response body's extra_fields, which only holds the last try.
+	HeaderBifrostUpstreamLatency = "x-bifrost-upstream-latency-ms"
 )
 
 // applyBifrostResponseHeaders writes both the upstream provider response
@@ -290,6 +296,10 @@ func applyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.B
 	if bifrostCtx != nil {
 		if idx, ok := bifrostCtx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok && idx > 0 {
 			ctx.Response.Header.Set(HeaderBifrostFallbackIndex, strconv.Itoa(idx))
+		}
+		if upstream, ok := schemas.GetUpstreamLatency(bifrostCtx); ok {
+			ctx.Response.Header.Set(HeaderBifrostUpstreamLatency,
+				strconv.FormatFloat(float64(upstream)/float64(time.Millisecond), 'f', 3, 64))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Introduces a per-request upstream latency accumulator that tracks cumulative time Bifrost spends blocked on provider sockets across every attempt, retry, fallback, MCP tool call, and media fetch. Subtracting this from total wall time gives Bifrost's own processing overhead — a number that was previously impossible to derive accurately.

## Changes

- **New `upstreamlatency.go` schema**: Installs an `*atomic.Int64` accumulator on the `BifrostContext` once per request. Uses an atomic pointer so streaming goroutines can keep writing after the request handler returns without touching the context's value map.
- **`ResetUpstreamLatency` / `AddUpstreamLatency` / `GetUpstreamLatency`**: Core API for the accumulator. `Reset` is mandatory at request entry because Bifrost reuses a single process-global context for nil-ctx SDK callers; without it the counter would grow unboundedly.
- **`DoStreamingRequest` / `DoHTTPRequest` helpers**: Thin wrappers around `fasthttp.Client.Do` and `net/http.Client.Do` that record the call duration as upstream latency. All provider call sites are migrated to these helpers.
- **`idleTimeoutReader.Read` instrumentation**: Each blocking read in a streaming response is counted as upstream time, covering the token-generation window that `DoStreamingRequest` (which returns at first byte) cannot see.
- **MCP tool call instrumentation**: `executeToolInternal` wraps `CallTool` with the same accumulator, since waiting on an MCP server is upstream time, not Bifrost overhead.
- **`FetchAndEncodeURL` instrumentation**: Remote media fetches are counted as upstream, preventing multi-second fetches from appearing as Bifrost overhead.
- **`StampUpstreamLatency` / `PopulateUpstreamLatency`**: Write the accumulated total onto the root trace span (`bifrost.upstream.duration_ms`) and onto `BifrostResponseExtraFields.UpstreamLatency` respectively. Both are called via a named-return `defer` in `handleRequest` so they fire even on error paths.
- **`Trace.StampOverheadDuration`**: Computes `bifrost.overhead.duration_ms = root_span_duration - upstream_total` on the export snapshot, after the root span has ended. Clamped at zero to absorb clock skew.
- **OTel plugin**: Reads `AttrBifrostOverheadDurationMs` from the root span and records it as a new `bifrost_overhead_latency_seconds` histogram with fine-grained sub-millisecond buckets appropriate for processing overhead rather than network latency.
- **Prometheus plugin**: Records the same overhead histogram via the `HTTPTransportPreHook`/`HTTPTransportPostHook` window (widest available, matching the OTel root span). Falls back to the `PostLLMHook` window for SDK callers that bypass the transport layer.
- **HTTP transport**: Emits `x-bifrost-upstream-latency-ms` response header so proxy callers can derive overhead from their own elapsed time without parsing the response body.
- **New trace attributes**: `bifrost.upstream.duration_ms` and `bifrost.overhead.duration_ms` added to the attribute constant set.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Make a request through the HTTP transport and verify the `x-bifrost-upstream-latency-ms` response header is present and less than the total elapsed time.
- Make a streaming request and confirm the header value grows to reflect the full generation window, not just time-to-first-byte.
- Make a request that triggers a fallback and confirm the upstream latency reflects the sum of both attempts.
- In OTel/Prometheus dashboards, verify `bifrost_overhead_latency_seconds` appears and that its values are in the sub-millisecond to low-tens-of-milliseconds range for healthy requests.
- Confirm `bifrost.upstream.duration_ms` and `bifrost.overhead.duration_ms` appear on root spans in exported traces.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The upstream latency value is derived from internal timing and contains no secrets or PII. The new response header exposes only a duration in milliseconds.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable