### PR TITLE
fix: avoid duplicating inference-provider segment in backfilled huggingface

### DIFF
--- a/core/providers/huggingface/models.go
+++ b/core/providers/huggingface/models.go
@@ -53,12 +53,12 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 			newModel := schemas.Model{
 				// inferenceProvider stays in the compound ID; aliases rename only the model segment
 				ID:               fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, result.ResolvedID),
-				Name:             schemas.Ptr(model.ModelID),
+				Name:             new(model.ModelID),
 				SupportedMethods: supported,
-				HuggingFaceID:    schemas.Ptr(model.ID),
+				HuggingFaceID:    new(model.ID),
 			}
 			if result.AliasValue != "" {
-				newModel.Alias = schemas.Ptr(result.AliasValue)
+				newModel.Alias = new(result.AliasValue)
 			}
 			bifrostResponse.Data = append(bifrostResponse.Data, newModel)
 			included[strings.ToLower(result.ResolvedID)] = true
@@ -67,14 +67,77 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 
 	// Backfill: use standard pipeline. Note that backfilled HF entries use a simplified
 	// compound ID since we don't know which inferenceProvider to assign them to.
-	for _, m := range pipeline.BackfillModels(included) {
-		// Re-wrap the backfill ID to include the inferenceProvider segment
+	backfilled := pipeline.BackfillModels(included)
+
+	var byModelID map[string]*HuggingFaceModel
+	if len(backfilled) > 0 {
+		byModelID = make(map[string]*HuggingFaceModel, len(response.Models))
+		for i := range response.Models {
+			byModelID[strings.ToLower(response.Models[i].ModelID)] = &response.Models[i]
+		}
+	}
+
+	for _, m := range backfilled {
 		rawID := strings.TrimPrefix(m.ID, string(providerKey)+"/")
-		m.ID = fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, rawID)
+		// lookupID is the plain HF model ID (no provider/policy segment), used to
+		// find the matching entry in response.Models below.
+		lookupID := rawID
+		// Allowlist entries selected from a previous ListModels response already
+		// carry an inference-provider segment (e.g. "featherless-ai/org/model")
+		// or the "auto" policy. Prepending another segment here duplicates the
+		// provider in the compound ID and breaks request routing (#4215).
+		if first, modelName, found := strings.Cut(rawID, "/"); found && isKnownInferenceProviderOrPolicy(first) {
+			m.Name = &modelName
+			lookupID = modelName
+			switch {
+			case strings.EqualFold(first, string(auto)):
+				// "auto" is owned by no inference-provider pass: the model
+				// listing loop iterates INFERENCE_PROVIDERS, which excludes it.
+				// Emit the entry exactly once, during the canonical first pass,
+				// so a routable auto-policy allowlist entry still surfaces in
+				// the listing instead of being dropped from every pass. Every
+				// other pass skips it to avoid duplicating it once per provider.
+				if len(INFERENCE_PROVIDERS) == 0 || inferenceProvider != INFERENCE_PROVIDERS[0] {
+					continue
+				}
+				m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
+			case !strings.EqualFold(first, string(inferenceProvider)):
+				// The entry belongs to a different inference provider's listing;
+				// it is emitted in that provider's pass. Skip it here to avoid
+				// duplicating the entry once per inference provider.
+				continue
+			default:
+				m.ID = fmt.Sprintf("%s/%s", providerKey, rawID)
+			}
+		} else {
+			// Re-wrap the backfill ID to include the inferenceProvider segment
+			m.ID = fmt.Sprintf("%s/%s/%s", providerKey, inferenceProvider, rawID)
+		}
+
+		// BackfillModels only knows about ID/Name/Alias, so a backfilled entry
+		// is otherwise missing HuggingFaceID and SupportedMethods. When the
+		// model is actually present in this response (e.g. it was skipped
+		// upstream for an unrecognized pipeline tag), recover those fields
+		// via the lazily-built index above.
+		if hfModel := byModelID[strings.ToLower(lookupID)]; hfModel != nil {
+			m.HuggingFaceID = new(hfModel.ID)
+			if methods := deriveSupportedMethods(hfModel.PipelineTag, hfModel.Tags); len(methods) > 0 {
+				m.SupportedMethods = methods
+			}
+		}
+
 		bifrostResponse.Data = append(bifrostResponse.Data, m)
 	}
 
 	return bifrostResponse
+}
+
+// isKnownInferenceProviderOrPolicy reports whether segment names one of the
+// supported inference providers or the "auto" policy (case-insensitive).
+func isKnownInferenceProviderOrPolicy(segment string) bool {
+	return slices.ContainsFunc(PROVIDERS_OR_POLICIES, func(p inferenceProvider) bool {
+		return strings.EqualFold(segment, string(p))
+	})
 }
 
 func deriveSupportedMethods(pipeline string, tags []string) []string {

--- a/core/providers/huggingface/models_test.go
+++ b/core/providers/huggingface/models_test.go
@@ -1,0 +1,170 @@
+package huggingface
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for https://github.com/maximhq/bifrost/issues/4215.
+//
+// Allowlist entries selected from a previous ListModels response carry an
+// inference-provider segment (e.g. "featherless-ai/org/model"). The backfill
+// re-wrap used to blindly prepend the current inference provider, producing
+// IDs like "huggingface/cohere/featherless-ai/org/model" that duplicate the
+// provider segment and fail request routing.
+func TestToBifrostListModelsResponse_AllowlistWithInferenceProviderSegment(t *testing.T) {
+	t.Parallel()
+
+	allowlist := schemas.WhiteList{"featherless-ai/deepseek-ai/DeepSeek-V4-Pro"}
+
+	t.Run("matching provider emits single correctly-prefixed entry", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{
+			Models: []HuggingFaceModel{
+				{
+					ID:          "abc123",
+					ModelID:     "deepseek-ai/DeepSeek-V4-Pro",
+					PipelineTag: "conversational",
+				},
+			},
+		}
+
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		require.Len(t, result.Data, 1)
+		assert.Equal(t, "huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID)
+	})
+
+	t.Run("other providers do not duplicate the entry", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{
+			Models: []HuggingFaceModel{
+				{
+					ID:          "def456",
+					ModelID:     "CohereLabs/aya-vision-32b",
+					PipelineTag: "conversational",
+				},
+			},
+		}
+
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, cohere, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Data, "an allowlist entry pinned to featherless-ai must not be backfilled under cohere")
+	})
+}
+
+// Allowlist entries prefixed with the "auto" policy must not be re-prefixed
+// with an inference provider: "auto" is owned by no provider pass (the listing
+// loop iterates INFERENCE_PROVIDERS, which excludes it). To keep the entry from
+// being dropped entirely, it is emitted exactly once during the canonical first
+// pass and skipped in every other pass, so it surfaces in the listing without
+// being duplicated once per provider. The "auto/" prefix is preserved, so it
+// stays routable: splitIntoModelProvider recognizes "auto" as a valid policy.
+func TestToBifrostListModelsResponse_AllowlistWithAutoPolicySegment(t *testing.T) {
+	t.Parallel()
+
+	allowlist := schemas.WhiteList{"auto/deepseek-ai/DeepSeek-V4-Pro"}
+
+	t.Run("canonical first pass emits the auto-policy entry exactly once", func(t *testing.T) {
+		t.Parallel()
+		response := &HuggingFaceListModelsResponse{Models: nil}
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, INFERENCE_PROVIDERS[0], allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		require.Len(t, result.Data, 1)
+		assert.Equal(t, "huggingface/auto/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID,
+			"the auto-policy entry keeps its prefix and is not re-wrapped with an inference provider")
+	})
+
+	t.Run("non-canonical passes do not duplicate the auto-policy entry", func(t *testing.T) {
+		t.Parallel()
+		require.Greater(t, len(INFERENCE_PROVIDERS), 1)
+		nonCanonicalProvider := INFERENCE_PROVIDERS[1]
+
+		response := &HuggingFaceListModelsResponse{Models: nil}
+		result := response.ToBifrostListModelsResponse(schemas.HuggingFace, nonCanonicalProvider, allowlist, nil, nil, false)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Data, "a non-canonical pass must not re-emit the auto-policy entry")
+	})
+}
+
+// Entries without an inference-provider segment keep the existing backfill
+// behavior: the current inference provider is prepended.
+func TestToBifrostListModelsResponse_BackfillWithoutInferenceProviderSegment(t *testing.T) {
+	t.Parallel()
+
+	response := &HuggingFaceListModelsResponse{Models: nil}
+	allowlist := schemas.WhiteList{"deepseek-ai/DeepSeek-V4-Pro"}
+
+	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+	require.NotNil(t, result)
+	require.Len(t, result.Data, 1)
+	assert.Equal(t, "huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro", result.Data[0].ID)
+	// No matching entry in response.Models, so there is nothing to enrich from.
+	assert.Nil(t, result.Data[0].HuggingFaceID)
+	assert.Empty(t, result.Data[0].SupportedMethods)
+}
+
+// A backfilled entry whose model is actually present in response.Models (e.g.
+// its provider-prefixed allowlist entry didn't string-match model.ModelID
+// during the main filter pass) should still surface HuggingFaceID and
+// SupportedMethods, not just ID/Name, since the data is available right there
+// in the same response.
+func TestToBifrostListModelsResponse_BackfillEnrichesHuggingFaceIDAndSupportedMethods(t *testing.T) {
+	t.Parallel()
+
+	allowlist := schemas.WhiteList{"featherless-ai/deepseek-ai/DeepSeek-V4-Pro"}
+	response := &HuggingFaceListModelsResponse{
+		Models: []HuggingFaceModel{
+			{
+				ID:          "abc123",
+				ModelID:     "deepseek-ai/DeepSeek-V4-Pro",
+				PipelineTag: "conversational",
+			},
+		},
+	}
+
+	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+	require.NotNil(t, result)
+	require.Len(t, result.Data, 1)
+
+	got := result.Data[0]
+	assert.Equal(t, "huggingface/featherless-ai/deepseek-ai/DeepSeek-V4-Pro", got.ID)
+	require.NotNil(t, got.HuggingFaceID)
+	assert.Equal(t, "abc123", *got.HuggingFaceID)
+	assert.ElementsMatch(t, []string{
+		string(schemas.ChatCompletionRequest),
+		string(schemas.ChatCompletionStreamRequest),
+		string(schemas.ResponsesRequest),
+		string(schemas.ResponsesStreamRequest),
+	}, got.SupportedMethods)
+}
+
+// If the backfilled model is present in response.Models but has no
+// recognizable pipeline tag/tags, HuggingFaceID is still recovered but
+// SupportedMethods stays unset rather than being forced to an empty slice.
+func TestToBifrostListModelsResponse_BackfillEnrichesHuggingFaceIDOnlyWhenMethodsUnknown(t *testing.T) {
+	t.Parallel()
+
+	allowlist := schemas.WhiteList{"deepseek-ai/DeepSeek-V4-Pro"}
+	response := &HuggingFaceListModelsResponse{
+		Models: []HuggingFaceModel{
+			{
+				ID:          "abc123",
+				ModelID:     "deepseek-ai/DeepSeek-V4-Pro",
+				PipelineTag: "some-unrecognized-pipeline",
+			},
+		},
+	}
+
+	result := response.ToBifrostListModelsResponse(schemas.HuggingFace, featherlessAI, allowlist, nil, nil, false)
+	require.NotNil(t, result)
+	require.Len(t, result.Data, 1)
+
+	got := result.Data[0]
+	require.NotNil(t, got.HuggingFaceID)
+	assert.Equal(t, "abc123", *got.HuggingFaceID)
+	assert.Nil(t, got.SupportedMethods)
+}


### PR DESCRIPTION
# Fix duplicate inference-provider segment in HuggingFace model IDs

## Summary

Allowlist entries selected from a previous `ListModels` response already carry an inference-provider segment (e.g. `featherless-ai/org/model`). The backfill re-wrap was blindly prepending the current inference provider, producing compound IDs like `huggingface/cohere/featherless-ai/org/model` that duplicate the provider segment and break request routing.

This fix detects when a backfill entry's raw ID already begins with a known inference provider or the `auto` policy, and routes it accordingly instead of prepending another provider segment.

## Changes

- When a backfill entry's raw ID starts with a known inference provider, it is only emitted during that provider's pass and skipped in all others, preventing duplication across passes.
- When a backfill entry's raw ID starts with `auto`, it is emitted exactly once during the canonical first pass (the first entry in `INFERENCE_PROVIDERS`) and skipped in every other pass, since `auto` is not itself an inference provider in the listing loop.
- Entries without an inference-provider segment retain the existing behavior: the current inference provider is prepended as before.
- Added `isKnownInferenceProviderOrPolicy` helper to check whether a segment names a supported inference provider or the `auto` policy.
- Added regression tests covering all three cases.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/huggingface/...
```

Expected: all three regression test cases pass — matching provider emits a single correctly-prefixed entry, non-matching providers do not duplicate the entry, and the `auto`\-policy entry is emitted exactly once from the canonical first pass.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #4215

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable