### PR TITLE
feat: bedrock batch role arn in key config

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2956,10 +2956,14 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 		return nil, err
 	}
 
-	// Require RoleArn in extra params
+	// Resolve the batch service role
 	roleArn := ""
-	// First we will honor the role_arn coming from the client side if present
-	if request.ExtraParams != nil {
+	// Server-configured batch role takes priority over the client-sent value
+	if key.BedrockKeyConfig.BatchRoleARN != nil {
+		roleArn = key.BedrockKeyConfig.BatchRoleARN.GetValue()
+	}
+	// Then we will honor the role_arn coming from the client side if present
+	if roleArn == "" && request.ExtraParams != nil {
 		if r, ok := request.ExtraParams["role_arn"].(string); ok {
 			roleArn = r
 		}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -697,6 +697,10 @@ type BedrockKeyConfig struct {
 	ExternalID      *SecretVar `json:"external_id,omitempty"`
 	RoleSessionName *SecretVar `json:"session_name,omitempty"`
 
+	// BatchRoleARN is the service role passed to Bedrock batch jobs for S3 access.
+	// When set, it takes priority over any role_arn sent in the request.
+	BatchRoleARN *SecretVar `json:"batch_role_arn,omitempty"`
+
 	// ProjectID scopes the Bedrock Mantle sub-surface (OpenAI-compatible gpt-*/Gemma routing and the
 	// mantle catalog merge in ListModels) to a specific Bedrock project via the "OpenAI-Project"
 	// header. When empty, AWS routes to the account's default project. It has no effect on the

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -598,6 +598,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockKeyConfig.RoleSessionName != nil {
 				bedrockConfig.RoleSessionName = key.BedrockKeyConfig.RoleSessionName.Redacted()
 			}
+			if key.BedrockKeyConfig.BatchRoleARN != nil {
+				bedrockConfig.BatchRoleARN = key.BedrockKeyConfig.BatchRoleARN.Redacted()
+			}
 			// Mantle project ID is an identifier, not a credential — surface it in plaintext.
 			if key.BedrockKeyConfig.ProjectID != nil {
 				bedrockConfig.ProjectID = key.BedrockKeyConfig.ProjectID

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -453,6 +453,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_webhook_config_client_column"}, run: migrationAddWebhookConfigClientColumn},
 	{IDs: []string{"add_oauth_config_resource_column"}, run: migrationAddOauthConfigResourceColumn},
 	{IDs: []string{"add_use_anthropic_endpoints_column"}, run: migrationAddUseAnthropicEndpointsColumn},
+	{IDs: []string{"add_bedrock_batch_role_arn_column"}, run: migrationAddBedrockBatchRoleARNColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10884,6 +10885,30 @@ func migrationAddWebhookJobsTable(ctx context.Context, db *gorm.DB, logger schem
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running webhook jobs table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddBedrockBatchRoleARNColumn adds the bedrock_batch_role_arn column to the config_keys
+// table. It stores the service role passed to Bedrock batch jobs for S3 access, kept separate from
+// the STS AssumeRole identity in bedrock_role_arn.
+func migrationAddBedrockBatchRoleARNColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_bedrock_batch_role_arn_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return addColumnIfNotExists(tx, logger, &tables.TableKey{}, "bedrock_batch_role_arn")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &tables.TableKey{}, "bedrock_batch_role_arn")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -217,6 +217,7 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 		dbKey.BedrockRoleARN = key.BedrockKeyConfig.RoleARN
 		dbKey.BedrockExternalID = key.BedrockKeyConfig.ExternalID
 		dbKey.BedrockRoleSessionName = key.BedrockKeyConfig.RoleSessionName
+		dbKey.BedrockBatchRoleARN = key.BedrockKeyConfig.BatchRoleARN
 		if key.BedrockKeyConfig.BatchS3Config != nil {
 			data, err := sonic.Marshal(key.BedrockKeyConfig.BatchS3Config)
 			if err != nil {
@@ -760,6 +761,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				dbKey.BedrockRoleARN = key.BedrockKeyConfig.RoleARN
 				dbKey.BedrockExternalID = key.BedrockKeyConfig.ExternalID
 				dbKey.BedrockRoleSessionName = key.BedrockKeyConfig.RoleSessionName
+				dbKey.BedrockBatchRoleARN = key.BedrockKeyConfig.BatchRoleARN
 				if key.BedrockKeyConfig.BatchS3Config != nil {
 					data, err := sonic.Marshal(key.BedrockKeyConfig.BatchS3Config)
 					if err != nil {
@@ -991,6 +993,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			dbKey.BedrockRoleARN = key.BedrockKeyConfig.RoleARN
 			dbKey.BedrockExternalID = key.BedrockKeyConfig.ExternalID
 			dbKey.BedrockRoleSessionName = key.BedrockKeyConfig.RoleSessionName
+			dbKey.BedrockBatchRoleARN = key.BedrockKeyConfig.BatchRoleARN
 			if key.BedrockKeyConfig.BatchS3Config != nil {
 				data, err := sonic.Marshal(key.BedrockKeyConfig.BatchS3Config)
 				if err != nil {
@@ -1130,6 +1133,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 			dbKey.BedrockRoleARN = key.BedrockKeyConfig.RoleARN
 			dbKey.BedrockExternalID = key.BedrockKeyConfig.ExternalID
 			dbKey.BedrockRoleSessionName = key.BedrockKeyConfig.RoleSessionName
+			dbKey.BedrockBatchRoleARN = key.BedrockKeyConfig.BatchRoleARN
 			if key.BedrockKeyConfig.BatchS3Config != nil {
 				data, err := sonic.Marshal(key.BedrockKeyConfig.BatchS3Config)
 				if err != nil {

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -55,6 +55,7 @@ type TableKey struct {
 	BedrockRoleARN           *schemas.SecretVar `gorm:"type:text" json:"bedrock_role_arn,omitempty"`
 	BedrockExternalID        *schemas.SecretVar `gorm:"type:text" json:"bedrock_external_id,omitempty"`
 	BedrockRoleSessionName   *schemas.SecretVar `gorm:"type:text" json:"bedrock_role_session_name,omitempty"`
+	BedrockBatchRoleARN      *schemas.SecretVar `gorm:"type:text" json:"bedrock_batch_role_arn,omitempty"`
 	BedrockProjectID         *schemas.SecretVar `gorm:"type:text" json:"bedrock_project_id,omitempty"`
 	BedrockBatchS3ConfigJSON *string            `gorm:"type:text" json:"-"` // JSON serialized schemas.BatchS3Config
 
@@ -277,6 +278,12 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		} else {
 			k.BedrockRoleSessionName = nil
 		}
+		if k.BedrockKeyConfig.BatchRoleARN != nil {
+			bra := *k.BedrockKeyConfig.BatchRoleARN
+			k.BedrockBatchRoleARN = &bra
+		} else {
+			k.BedrockBatchRoleARN = nil
+		}
 		if k.BedrockKeyConfig.ProjectID != nil {
 			pid := *k.BedrockKeyConfig.ProjectID
 			k.BedrockProjectID = &pid
@@ -302,6 +309,7 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.BedrockRoleARN = nil
 		k.BedrockExternalID = nil
 		k.BedrockRoleSessionName = nil
+		k.BedrockBatchRoleARN = nil
 		k.BedrockProjectID = nil
 		k.BedrockBatchS3ConfigJSON = nil
 	}
@@ -485,6 +493,9 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		if err := encryptSecretVarPtr(&k.BedrockRoleSessionName); err != nil {
 			return fmt.Errorf("failed to encrypt bedrock role session name: %w", err)
 		}
+		if err := encryptSecretVarPtr(&k.BedrockBatchRoleARN); err != nil {
+			return fmt.Errorf("failed to encrypt bedrock batch role arn: %w", err)
+		}
 		if err := encryptSecretVarPtr(&k.BedrockProjectID); err != nil {
 			return fmt.Errorf("failed to encrypt bedrock project id: %w", err)
 		}
@@ -596,6 +607,9 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		}
 		if err := decryptSecretVarPtr(&k.BedrockRoleSessionName); err != nil {
 			return fmt.Errorf("failed to decrypt bedrock role session name: %w", err)
+		}
+		if err := decryptSecretVarPtr(&k.BedrockBatchRoleARN); err != nil {
+			return fmt.Errorf("failed to decrypt bedrock batch role arn: %w", err)
 		}
 		if err := decryptSecretVarPtr(&k.BedrockProjectID); err != nil {
 			return fmt.Errorf("failed to decrypt bedrock project id: %w", err)
@@ -714,7 +728,7 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		k.VertexKeyConfig = config
 	}
 	// Reconstruct Bedrock config if fields are present
-	if k.BedrockAccessKey != nil || k.BedrockSecretKey != nil || k.BedrockSessionToken != nil || k.BedrockRegion != nil || k.BedrockARN != nil || k.BedrockRoleARN != nil || k.BedrockExternalID != nil || k.BedrockRoleSessionName != nil || k.BedrockProjectID != nil || (k.BedrockBatchS3ConfigJSON != nil && *k.BedrockBatchS3ConfigJSON != "") {
+	if k.BedrockAccessKey != nil || k.BedrockSecretKey != nil || k.BedrockSessionToken != nil || k.BedrockRegion != nil || k.BedrockARN != nil || k.BedrockRoleARN != nil || k.BedrockExternalID != nil || k.BedrockRoleSessionName != nil || k.BedrockBatchRoleARN != nil || k.BedrockProjectID != nil || (k.BedrockBatchS3ConfigJSON != nil && *k.BedrockBatchS3ConfigJSON != "") {
 		bedrockConfig := &schemas.BedrockKeyConfig{}
 
 		if k.BedrockAccessKey != nil {
@@ -727,6 +741,7 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		bedrockConfig.RoleARN = k.BedrockRoleARN
 		bedrockConfig.ExternalID = k.BedrockExternalID
 		bedrockConfig.RoleSessionName = k.BedrockRoleSessionName
+		bedrockConfig.BatchRoleARN = k.BedrockBatchRoleARN
 		bedrockConfig.ProjectID = k.BedrockProjectID
 
 		if k.BedrockSecretKey != nil {

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -383,7 +383,7 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, updateKey schemas.Key) (sch
 	}
 
 	if mergedKey.BedrockKeyConfig != nil {
-		var accessKey, secretKey, sessionToken, region, arn, roleARN, externalID, sessionName *schemas.SecretVar
+		var accessKey, secretKey, sessionToken, region, arn, roleARN, externalID, sessionName, batchRoleARN *schemas.SecretVar
 		if oldRawKey.BedrockKeyConfig != nil {
 			accessKey = &oldRawKey.BedrockKeyConfig.AccessKey
 			secretKey = &oldRawKey.BedrockKeyConfig.SecretKey
@@ -393,6 +393,7 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, updateKey schemas.Key) (sch
 			roleARN = oldRawKey.BedrockKeyConfig.RoleARN
 			externalID = oldRawKey.BedrockKeyConfig.ExternalID
 			sessionName = oldRawKey.BedrockKeyConfig.RoleSessionName
+			batchRoleARN = oldRawKey.BedrockKeyConfig.BatchRoleARN
 		}
 		for _, item := range []struct {
 			incoming *schemas.SecretVar
@@ -407,6 +408,7 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, updateKey schemas.Key) (sch
 			{mergedKey.BedrockKeyConfig.RoleARN, roleARN, "bedrock_key_config.role_arn"},
 			{mergedKey.BedrockKeyConfig.ExternalID, externalID, "bedrock_key_config.external_id"},
 			{mergedKey.BedrockKeyConfig.RoleSessionName, sessionName, "bedrock_key_config.session_name"},
+			{mergedKey.BedrockKeyConfig.BatchRoleARN, batchRoleARN, "bedrock_key_config.batch_role_arn"},
 		} {
 			if err := preserve(item.incoming, item.stored, item.field); err != nil {
 				return schemas.Key{}, err

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3888,6 +3888,10 @@
                   "type": "string",
                   "description": "Role session name for AssumeRole (can use env. prefix)"
                 },
+                "batch_role_arn": {
+                  "type": "string",
+                  "description": "Service role ARN passed to Bedrock batch jobs for S3 access; takes priority over any role_arn sent in the request (can use env. prefix)"
+                },
                 "project_id": {
                   "type": "string",
                   "description": "Bedrock project ID scoping the Mantle sub-surface (OpenAI-compatible gpt-*/Gemma routing) via the OpenAI-Project header. When empty, AWS routes to the account's default project. No effect on the Converse/bedrock-runtime paths (can use env. prefix)."

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -1013,6 +1013,28 @@ export function ApiKeyFormFragment({ control, providerName, baseProviderType, fo
 							</FormItem>
 						)}
 					/>
+					{supportsBatchAPI && (
+						<FormField
+							control={control}
+							name={`key.bedrock_key_config.batch_role_arn`}
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>Batch Role ARN (Optional)</FormLabel>
+									<FormDescription>
+										Service role Bedrock assumes for batch S3 access. When set, it takes priority over the role_arn sent in requests.
+									</FormDescription>
+									<FormControl>
+										<SecretVarInput
+											data-testid="apikey-bedrock-batch-role-arn-input"
+											placeholder="arn:aws:iam::123456789:role/BatchRole or env.AWS_BATCH_ROLE_ARN"
+											{...field}
+										/>
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					)}
 					{supportsBatchAPI && <BatchAPIFormField control={control} form={form} />}
 				</div>
 			)}

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -113,6 +113,7 @@ const BedrockKeyConfigSchema = z
 		role_arn: z.string().optional(),
 		external_id: z.string().optional(),
 		session_name: z.string().optional(),
+		batch_role_arn: z.string().optional(),
 		arn: z.string().optional(),
 		project_id: z.string().optional(),
 		batch_s3_config: BatchS3ConfigSchema.optional(),

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -162,6 +162,7 @@ export const bedrockKeyConfigSchema = z
 		role_arn: secretVarSchema.optional(),
 		external_id: secretVarSchema.optional(),
 		session_name: secretVarSchema.optional(),
+		batch_role_arn: secretVarSchema.optional(),
 		arn: secretVarSchema.optional(),
 		project_id: secretVarSchema.optional(),
 		batch_s3_config: batchS3ConfigSchema.optional(),


### PR DESCRIPTION
## Summary

Adds a server-configured `batch_role_arn` field to the Bedrock key configuration, allowing operators to pin the IAM service role used for Bedrock batch jobs at the server level rather than relying on clients to supply it via `role_arn` in request extra params. When set, the server-side value takes priority over any client-provided `role_arn`.

## Changes

- Added `BatchRoleARN *SecretVar` to `BedrockKeyConfig` in `schemas/account.go`, stored under the JSON key `batch_role_arn` and kept separate from the STS AssumeRole identity (`bedrock_role_arn`).
- Updated `BatchCreate` in `bedrock.go` so that `key.BedrockKeyConfig.BatchRoleARN` is resolved first; the client-supplied `role_arn` in `ExtraParams` is only used as a fallback when the server value is absent.
- Added a database migration (`add_bedrock_batch_role_arn_column`) that adds the `bedrock_batch_role_arn` column to `config_keys`, with rollback support.
- Wired `BedrockBatchRoleARN` through all RDB read/write paths (`tableKeyFromSchemaKey`, `UpdateProvidersConfig`, `UpdateProvider`, `AddProvider`) and through `BeforeSave`/`AfterFind` hooks including encryption and decryption.
- Updated the `AfterFind` Bedrock config reconstruction condition to include `BedrockBatchRoleARN`.
- Added `BatchRoleARN` to the `mergeUpdatedKey` preserve logic in the HTTP handler so partial updates do not accidentally clear the field.
- Added `batch_role_arn` to the config JSON schema with a description noting its priority semantics and `env.` prefix support.
- Added `batch_role_arn` to the Zod schemas (`providerForm.ts`, `schemas.ts`) and rendered a **Batch Role ARN** input field in the UI form, visible only when the provider supports the batch API.
- Added redaction support for `BatchRoleARN` in `clientconfig.go`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

**Manual validation:**

1. Configure a Bedrock provider key with `batch_role_arn` set (either as a literal ARN or via `env.AWS_BATCH_ROLE_ARN`).
2. Submit a batch create request that also includes `role_arn` in `extra_params`.
3. Confirm that the server-configured `batch_role_arn` is used and the client-supplied value is ignored.
4. Remove `batch_role_arn` from the key config and resubmit; confirm the client-supplied `role_arn` is now used.
5. Verify the value is stored encrypted in the database and appears redacted in API responses.

**New config field:**

| Field | JSON key | Description |
|---|---|---|
| `BatchRoleARN` | `batch_role_arn` | Service role ARN Bedrock assumes for batch S3 access. Supports `env.` prefix. Takes priority over client-supplied `role_arn`. |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`BatchRoleARN` is treated as a secret: it is encrypted at rest via the existing `encryptSecretVarPtr`/`decryptSecretVarPtr` pipeline and redacted in API responses, consistent with other credential fields such as `RoleARN` and `ExternalID`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable