### PR TITLE
fix: fixes connector UI redaction storage issue

### DIFF
--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -628,15 +628,23 @@ func restoreRedactedValue(incoming, existing any) any {
 	}
 }
 
-// isSecretVarObject returns true if m has the shape of a serialised SecretVar.
+// isSecretVarObject returns true if m has the shape of a serialised SecretVar: a string
+// "value" plus, optionally, only SecretVar keys. Plain-text SecretVars marshal as
+// {"value": "..."} alone (ref/type are omitempty), so value-only objects must match too —
+// e.g. the Kafka SASL credentials round-tripped by the UI after a redacted GET.
 func isSecretVarObject(m map[string]any) bool {
-	_, hasValue := m["value"]
-	_, hasSecretRef := m["ref"]
-	_, hasType := m["type"]
-	// shipped backward compat: env_var/from_env
-	_, hasEnvVar := m["env_var"]
-	_, hasFromEnv := m["from_env"]
-	return hasValue && ((hasSecretRef && hasType) || (hasEnvVar && hasFromEnv))
+	if _, ok := m["value"].(string); !ok {
+		return false
+	}
+	for k := range m {
+		switch k {
+		// "env_var"/"from_env" are shipped backward compat for "ref"/"type".
+		case "value", "ref", "type", "env_var", "from_env":
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // marshalSecretVarObject serialises a SecretVar-shaped map back to the JSON string that

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -141,6 +141,104 @@ func TestRestoreRedacted_OTELProfilesHeaders(t *testing.T) {
 	}
 }
 
+// TestRestoreRedacted_KafkaSecretVarObjects covers the Kafka connector shape: secrets are
+// stored in the DB as plain strings, but the redacted GET returns plain-text SecretVars as
+// value-only objects ({"value": "supe…cret"} — ref/type are omitempty). Saving that back
+// must restore the stored string, not persist the mask.
+func TestRestoreRedacted_KafkaSecretVarObjects(t *testing.T) {
+	realPassword := "REAL-KAFKA-SASL-PASSWORD-123"
+	realCACert := "-----BEGIN CERTIFICATE-----\nREAL\n-----END CERTIFICATE-----"
+	maskedPassword := schemas.NewSecretVar(realPassword).Redacted().GetValue()
+	maskedCACert := schemas.NewSecretVar(realCACert).Redacted().GetValue()
+
+	// What MarshalForStorage stored in the DB.
+	existing := map[string]any{
+		"brokers": []any{"localhost:9092"},
+		"ca_cert": realCACert,
+		"sasl": map[string]any{
+			"mechanism": "PLAIN",
+			"username":  "kafka-user",
+			"password":  realPassword,
+		},
+	}
+	// What the UI sends back after a redacted GET, untouched.
+	incoming := map[string]any{
+		"brokers": []any{"localhost:9092"},
+		"ca_cert": map[string]any{"value": maskedCACert},
+		"sasl": map[string]any{
+			"mechanism": "PLAIN",
+			"username":  map[string]any{"value": "kafka-user"},
+			"password":  map[string]any{"value": maskedPassword},
+		},
+	}
+
+	got := restoreRedactedFromExisting(incoming, existing)
+	if got["ca_cert"] != realCACert {
+		t.Errorf("ca_cert not restored: got %v, want %q", got["ca_cert"], realCACert)
+	}
+	sasl := got["sasl"].(map[string]any)
+	if sasl["password"] != realPassword {
+		t.Errorf("sasl.password not restored: got %v, want %q", sasl["password"], realPassword)
+	}
+	// A non-redacted value-only object (username shown in clear) must pass through.
+	if u, ok := sasl["username"].(map[string]any); !ok || u["value"] != "kafka-user" {
+		t.Errorf("sasl.username should pass through unchanged, got %v", sasl["username"])
+	}
+
+	// A genuinely rotated password ({"value": ..., "ref": ""} as SecretVarInput emits)
+	// must pass through, not be clobbered by the stored value.
+	rotated := map[string]any{
+		"sasl": map[string]any{
+			"password": map[string]any{"value": "A-BRAND-NEW-PASSWORD-5678", "ref": ""},
+		},
+	}
+	got2 := restoreRedactedFromExisting(rotated, existing)
+	p, ok := got2["sasl"].(map[string]any)["password"].(map[string]any)
+	if !ok || p["value"] != "A-BRAND-NEW-PASSWORD-5678" {
+		t.Errorf("new password should pass through, got %v", got2["sasl"].(map[string]any)["password"])
+	}
+
+	// Switching to an env reference must pass through (intentional update).
+	envRef := map[string]any{
+		"sasl": map[string]any{
+			"password": map[string]any{"value": "", "ref": "env.KAFKA_PASSWORD", "type": "env"},
+		},
+	}
+	got3 := restoreRedactedFromExisting(envRef, existing)
+	p3, ok := got3["sasl"].(map[string]any)["password"].(map[string]any)
+	if !ok || p3["ref"] != "env.KAFKA_PASSWORD" {
+		t.Errorf("env ref password should pass through, got %v", got3["sasl"].(map[string]any)["password"])
+	}
+}
+
+// TestRestoreRedacted_FullyRedactedSentinel covers the telemetry (Prometheus push gateway)
+// password shape: FullyRedacted() returns the fixed "<REDACTED>" sentinel instead of the
+// prefix/suffix mask, and the stored value is a plain string.
+func TestRestoreRedacted_FullyRedactedSentinel(t *testing.T) {
+	realPassword := "REAL-PUSHGATEWAY-PASSWORD"
+	sentinel := schemas.NewSecretVar(realPassword).FullyRedacted().GetValue()
+
+	existing := map[string]any{
+		"push_gateway": map[string]any{
+			"basic_auth": map[string]any{"username": "pgw-user", "password": realPassword},
+		},
+	}
+	incoming := map[string]any{
+		"push_gateway": map[string]any{
+			"basic_auth": map[string]any{
+				"username": map[string]any{"value": "pgw-user"},
+				"password": map[string]any{"value": sentinel},
+			},
+		},
+	}
+
+	got := restoreRedactedFromExisting(incoming, existing)
+	ba := got["push_gateway"].(map[string]any)["basic_auth"].(map[string]any)
+	if ba["password"] != realPassword {
+		t.Errorf("sentinel password not restored: got %v, want %q", ba["password"], realPassword)
+	}
+}
+
 func TestUpdatePlugin_ConfigMerge(t *testing.T) {
 	SetLogger(&mockLogger{})
 


### PR DESCRIPTION
## Summary

Fixes a bug where plain-text `SecretVar` objects (e.g. `{"value": "..."}` with no `ref`/`type` fields) were not being recognised as `SecretVar`-shaped during redaction restoration. This caused the UI to persist masked values instead of restoring the real stored secrets when saving Kafka SASL credentials or similar connectors that store secrets as plain strings but return them as value-only objects after a redacted GET.

## Changes

- `isSecretVarObject` previously required either `ref`+`type` or `env_var`+`from_env` alongside `value`, which excluded plain-text `SecretVar`s that marshal as `{"value": "..."}` alone (since `ref`/`type` are `omitempty`). The function now accepts any map whose keys are exclusively drawn from the known `SecretVar` field set (`value`, `ref`, `type`, `env_var`, `from_env`), with `value` required to be a string.
- This ensures that value-only objects round-tripped by the UI after a redacted GET are correctly identified and restored from the existing stored value, rather than being passed through with the masked content.
- Objects with a non-redacted value (e.g. username shown in clear) pass through unchanged, and intentional updates (new password, env reference) are not clobbered.
- Tests added for the Kafka SASL credential shape, the `FullyRedacted()` sentinel (`<REDACTED>`), and intentional secret rotation/env-ref switching.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

The new tests cover:
- Kafka SASL `password` and `ca_cert` restored from stored plain strings when the UI sends back value-only masked objects.
- `FullyRedacted()` sentinel (`<REDACTED>`) correctly triggers restoration.
- Rotated passwords and env-ref switches pass through without being overwritten by the stored value.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change affects how redacted secret values are handled during plugin configuration updates. The fix ensures masked values are never persisted in place of real secrets, and that intentional secret rotations or env-ref changes are not silently discarded. No new secret exposure surface is introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable