### PR TITLE
fix: models-catalog/list docs page

### DIFF
--- a/docs/models-catalog/list.mdx
+++ b/docs/models-catalog/list.mdx
@@ -80,7 +80,6 @@ export const ModelsCatalog = () => {
         onClose={onClose}
         onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
         className="model-dialog-panel m-auto p-0 bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl ring-1 ring-zinc-950/10 dark:ring-white/10 max-w-2xl w-[calc(100%-2rem)] max-h-[85vh] overflow-hidden"
-        aria-label={`Details for ${model.model}`}
       >
         <div className="flex flex-col max-h-[85vh]">
           <div className="flex items-start gap-3 p-5 border-b border-zinc-950/10 dark:border-white/10">


### PR DESCRIPTION
## Summary

Removes the `aria-label` attribute from the model dialog panel component in the models catalog to address an accessibility or rendering issue caused by the redundant or incorrect label.

## Changes

- Removed `aria-label={`Details for ${model.model}`}` from the dialog panel element, which may have been conflicting with other accessibility attributes or causing unintended behavior in screen readers or dialog handling.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the models catalog page.
2. Click on a model to open the detail dialog.
3. Verify the dialog opens correctly and functions as expected.
4. Inspect with a screen reader or accessibility tool to confirm no regressions in accessibility behavior.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable