### PR TITLE
feat: add `ModelReasoning` schema field and resolve provider-qualified model IDs for model-parameters lookup

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -163,6 +163,7 @@ type Model struct {
 	PerRequestLimits    *PerRequestLimits  `json:"per_request_limits,omitempty"`
 	SupportedParameters []string           `json:"supported_parameters,omitempty"`
 	DefaultParameters   *DefaultParameters `json:"default_parameters,omitempty"`
+	Reasoning           *ModelReasoning    `json:"reasoning,omitempty"`
 	HuggingFaceID       *string            `json:"hugging_face_id,omitempty"`
 	Description         *string            `json:"description,omitempty"`
 
@@ -213,6 +214,17 @@ type DefaultParameters struct {
 	Temperature      *float64 `json:"temperature,omitempty"`
 	TopP             *float64 `json:"top_p,omitempty"`
 	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+}
+
+// ModelReasoning describes a model's reasoning capabilities as advertised by
+// the provider's list-models API (e.g. OpenRouter's per-model `reasoning`
+// object). All fields are optional — providers omit `supported_efforts` /
+// `default_effort` for models whose reasoning has no selectable effort level.
+type ModelReasoning struct {
+	Mandatory        *bool    `json:"mandatory,omitempty"`
+	DefaultEnabled   *bool    `json:"default_enabled,omitempty"`
+	SupportedEfforts []string `json:"supported_efforts,omitempty"`
+	DefaultEffort    *string  `json:"default_effort,omitempty"`
 }
 
 // paginationCursor represents the internal cursor structure for pagination.

--- a/core/schemas/models_test.go
+++ b/core/schemas/models_test.go
@@ -115,3 +115,48 @@ func TestKeyStatusMarshalJSON_PreservesErrorFields(t *testing.T) {
 	assert.Contains(t, dataStr, `"original_model_requested":"gpt-4"`)
 	assert.Contains(t, dataStr, `"status_code":401`)
 }
+
+// TestModelReasoningRoundTrip verifies that provider list-models payloads
+// carrying an OpenRouter-style `reasoning` object survive decode/encode
+// through schemas.Model, including partial shapes with no effort levels.
+func TestModelReasoningRoundTrip(t *testing.T) {
+	payload := []byte(`{
+		"id": "google/gemini-3.6-flash",
+		"supported_parameters": ["reasoning", "include_reasoning"],
+		"reasoning": {
+			"mandatory": true,
+			"default_enabled": true,
+			"supported_efforts": ["high", "medium", "low", "minimal"],
+			"default_effort": "medium"
+		}
+	}`)
+
+	var model Model
+	require.NoError(t, json.Unmarshal(payload, &model))
+	require.NotNil(t, model.Reasoning)
+	assert.Equal(t, Ptr(true), model.Reasoning.Mandatory)
+	assert.Equal(t, Ptr(true), model.Reasoning.DefaultEnabled)
+	assert.Equal(t, []string{"high", "medium", "low", "minimal"}, model.Reasoning.SupportedEfforts)
+	assert.Equal(t, Ptr("medium"), model.Reasoning.DefaultEffort)
+
+	encoded, err := json.Marshal(model)
+	require.NoError(t, err)
+	var decoded Model
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, model.Reasoning, decoded.Reasoning)
+
+	// Partial shape: reasoning supported but no selectable effort.
+	var partial Model
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"x","reasoning":{"mandatory":false,"default_enabled":true}}`), &partial))
+	require.NotNil(t, partial.Reasoning)
+	assert.Nil(t, partial.Reasoning.SupportedEfforts)
+	assert.Nil(t, partial.Reasoning.DefaultEffort)
+
+	// No reasoning object → field stays nil and is omitted on encode.
+	var absent Model
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"x"}`), &absent))
+	assert.Nil(t, absent.Reasoning)
+	encoded, err = json.Marshal(absent)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "reasoning")
+}

--- a/framework/modelcatalog/datasheet/params.go
+++ b/framework/modelcatalog/datasheet/params.go
@@ -3,16 +3,19 @@ package datasheet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"slices"
+	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/tidwall/gjson"
 )
@@ -249,4 +252,75 @@ func (s *Store) GetModelParametersByModel(ctx context.Context, model string) (*c
 		return nil, nil
 	}
 	return s.configStore.GetModelParametersByModel(ctx, model)
+}
+
+// ResolveModelParameters looks up a model-parameter row for model, falling
+// back through equivalent identifiers when the exact key has no row. The
+// model-parameters datasheet keys models inconsistently — some bare
+// ("gpt-5.5"), some provider-qualified ("openrouter/moonshotai/kimi-k2.5") —
+// so clients querying with the IDs returned by /v1/models need this
+// resolution to land on the stored key. Mirrors GetCapabilityEntry's
+// exact → stripped → base-model fallback chain.
+func (s *Store) ResolveModelParameters(ctx context.Context, model string) (*configstoreTables.TableModelParameters, error) {
+	if s.configStore == nil {
+		return nil, nil
+	}
+	var firstErr error
+	for _, candidate := range s.modelParameterCandidates(model) {
+		params, err := s.configStore.GetModelParametersByModel(ctx, candidate)
+		if err == nil {
+			return params, nil
+		}
+		if !errors.Is(err, configstore.ErrNotFound) {
+			return nil, err
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr
+}
+
+// modelParameterCandidates returns the ordered lookup keys tried by
+// ResolveModelParameters: the exact model, each progressively
+// provider-stripped form ("openrouter/openai/gpt-5.5" → "openai/gpt-5.5" →
+// "gpt-5.5"), the canonical base name, and finally any datasheet keys that
+// qualify the bare name with a provider path ("kimi-k2.5" →
+// "openrouter/moonshotai/kimi-k2.5"). Suffix matches are sorted so
+// resolution is deterministic when multiple qualified keys exist.
+func (s *Store) modelParameterCandidates(model string) []string {
+	candidates := []string{model}
+	add := func(c string) {
+		if c != "" && !slices.Contains(candidates, c) {
+			candidates = append(candidates, c)
+		}
+	}
+
+	bare := model
+	for {
+		_, stripped := schemas.ParseModelString(bare, "")
+		if stripped == bare {
+			break
+		}
+		add(stripped)
+		bare = stripped
+	}
+
+	add(s.BaseModelName(model))
+
+	suffix := "/" + bare
+	var qualified []string
+	s.mu.RLock()
+	for key := range s.supportedParams {
+		if strings.HasSuffix(key, suffix) {
+			qualified = append(qualified, key)
+		}
+	}
+	s.mu.RUnlock()
+	slices.Sort(qualified)
+	for _, key := range qualified {
+		add(key)
+	}
+
+	return candidates
 }

--- a/framework/modelcatalog/datasheet/params_test.go
+++ b/framework/modelcatalog/datasheet/params_test.go
@@ -1,0 +1,62 @@
+package datasheet
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestModelParameterCandidates(t *testing.T) {
+	s := NewTestStore(map[string]string{
+		"gpt-4o-2024-08-06": "gpt-4o",
+	})
+	s.mu.Lock()
+	s.supportedParams = map[string][]string{
+		"gpt-5.5":                          {"temperature"},
+		"openrouter/moonshotai/kimi-k2.5":  {"temperature"},
+		"openrouter/openai/gpt-5.5":        {"temperature"},
+		"openrouter/moonshotai/kimi-k2.7":  {"temperature"},
+		"openrouter/moonshotai2/kimi-k2.5": {"temperature"},
+	}
+	s.mu.Unlock()
+
+	tests := []struct {
+		name  string
+		model string
+		want  []string
+	}{
+		{
+			name:  "bare model stays first",
+			model: "gpt-5.5",
+			want:  []string{"gpt-5.5", "openrouter/openai/gpt-5.5"},
+		},
+		{
+			name:  "provider-qualified strips to bare",
+			model: "openai/gpt-5.5",
+			want:  []string{"openai/gpt-5.5", "gpt-5.5", "openrouter/openai/gpt-5.5"},
+		},
+		{
+			name:  "double-qualified openrouter id strips progressively",
+			model: "openrouter/openai/gpt-5.5",
+			want:  []string{"openrouter/openai/gpt-5.5", "openai/gpt-5.5", "gpt-5.5"},
+		},
+		{
+			name:  "bare alias finds qualified datasheet keys sorted",
+			model: "kimi-k2.5",
+			want:  []string{"kimi-k2.5", "openrouter/moonshotai/kimi-k2.5", "openrouter/moonshotai2/kimi-k2.5"},
+		},
+		{
+			name:  "dated model includes canonical base name",
+			model: "gpt-4o-2024-08-06",
+			want:  []string{"gpt-4o-2024-08-06", "gpt-4o"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.modelParameterCandidates(tt.model)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("modelParameterCandidates(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -27,6 +27,13 @@ func (mc *ModelCatalog) GetSupportedParameters(model string) []string {
 	return mc.datasheet.GetSupportedParameters(model)
 }
 
+// ResolveModelParameters reads the model-parameters row for model, resolving
+// provider-qualified or bare aliases to the datasheet's stored key (exact →
+// provider-prefix-stripped → base model → provider-qualified variants).
+func (mc *ModelCatalog) ResolveModelParameters(ctx context.Context, model string) (*configstoreTables.TableModelParameters, error) {
+	return mc.datasheet.ResolveModelParameters(ctx, model)
+}
+
 func (mc *ModelCatalog) IsTextCompletionSupported(model string, provider schemas.ModelProvider) bool {
 	return mc.datasheet.IsTextCompletionSupported(model, provider)
 }

--- a/transports/bifrost-http/handlers/model_parameters_test.go
+++ b/transports/bifrost-http/handlers/model_parameters_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestGetModelParameters_ResolvesQualifiedAndBareIDs(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := context.Background()
+
+	dbPath := t.TempDir() + "/config.db"
+	store, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: dbPath},
+	}, &mockLogger{})
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertModelParametersBatch(ctx, []configstoreTables.TableModelParameters{
+		{Model: "gpt-5.5", Data: `{"model_parameters":[{"id":"reasoning_effort"}]}`},
+		{Model: "openrouter/moonshotai/kimi-k2.5", Data: `{"model_parameters":[{"id":"temperature"}]}`},
+	}))
+
+	ds := datasheet.New(store, &mockLogger{}, datasheet.Config{})
+	rows, err := ds.LoadModelParamsFromDB(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, rows)
+
+	h := &ProviderHandler{
+		dbStore: store,
+		inMemoryStore: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalogWithDatasheet(ds),
+		},
+	}
+
+	tests := []struct {
+		name       string
+		model      string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "exact bare key",
+			model:      "gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "provider-qualified resolves to bare key",
+			model:      "openai/gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "openrouter double-qualified resolves to bare key",
+			model:      "openrouter/openai/gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "bare alias resolves to openrouter-qualified key",
+			model:      "kimi-k2.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"temperature"}]}`,
+		},
+		{
+			name:       "unknown model still 404s",
+			model:      "definitely-not-a-model",
+			wantStatus: fasthttp.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req fasthttp.Request
+			req.SetRequestURI(fmt.Sprintf("/api/models/parameters?model=%s", tt.model))
+			reqCtx := &fasthttp.RequestCtx{}
+			reqCtx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+			h.getModelParameters(reqCtx)
+
+			require.Equal(t, tt.wantStatus, reqCtx.Response.StatusCode())
+			if tt.wantBody != "" {
+				require.Equal(t, tt.wantBody, string(reqCtx.Response.Body()))
+			}
+		})
+	}
+
+	t.Run("nil inMemoryStore falls back to exact DB lookup", func(t *testing.T) {
+		bare := &ProviderHandler{dbStore: store}
+
+		var req fasthttp.Request
+		req.SetRequestURI("/api/models/parameters?model=gpt-5.5")
+		reqCtx := &fasthttp.RequestCtx{}
+		reqCtx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+		bare.getModelParameters(reqCtx)
+
+		require.Equal(t, fasthttp.StatusOK, reqCtx.Response.StatusCode())
+		require.Equal(t, `{"model_parameters":[{"id":"reasoning_effort"}]}`, string(reqCtx.Response.Body()))
+	})
+}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -984,7 +984,20 @@ func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	params, err := h.dbStore.GetModelParametersByModel(ctx, modelParam)
+	// Prefer catalog-aware resolution so provider-qualified IDs from
+	// /v1/models ("openai/gpt-5.5", "openrouter/openai/gpt-5.5") and bare
+	// aliases resolve to the datasheet's stored key instead of 404ing on an
+	// exact-match miss.
+	var params *tables.TableModelParameters
+	var err error
+	if h.inMemoryStore != nil && h.inMemoryStore.ModelCatalog != nil {
+		params, err = h.inMemoryStore.ModelCatalog.ResolveModelParameters(ctx, modelParam)
+	} else {
+		params, err = h.dbStore.GetModelParametersByModel(ctx, modelParam)
+	}
+	if err == nil && params == nil {
+		err = configstore.ErrNotFound
+	}
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
 			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("no parameters found for model %s", modelParam))


### PR DESCRIPTION
## Summary

The `GET /api/models/parameters` endpoint was returning 404 for valid models when the query used a provider-qualified ID (e.g. `openai/gpt-5.5`, `openrouter/openai/gpt-5.5`) or a bare alias (e.g. `kimi-k2.5`) that didn't exactly match the key stored in the model-parameters datasheet. This PR introduces a fallback resolution chain so those IDs correctly resolve to their stored row.

## Changes

- Added a `ModelReasoning` struct to `schemas.Model` that captures provider-advertised reasoning capabilities (mandatory flag, default enabled, supported effort levels, default effort), matching the shape returned by OpenRouter's list-models API.
- Added `ResolveModelParameters` to the datasheet `Store`, which walks an ordered candidate list — exact key → progressively provider-prefix-stripped forms → canonical base model name → provider-qualified suffix matches — until a row is found or all candidates are exhausted.
- Added `modelParameterCandidates` as the internal helper that builds that ordered list, with deterministic sorting for suffix-matched qualified keys.
- Exposed `ResolveModelParameters` on `ModelCatalog` so the HTTP handler can use it.
- Updated `getModelParameters` in the HTTP handler to call `ResolveModelParameters` when a model catalog is available, falling back to the direct DB lookup only when it isn't. A `nil` result with no error is now normalized to `ErrNotFound`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/modelcatalog/datasheet/... ./transports/bifrost-http/handlers/...
```

The new `TestModelParameterCandidates` test covers the resolution candidate ordering for bare, provider-qualified, double-qualified, alias, and dated model IDs. `TestGetModelParameters_ResolvesQualifiedAndBareIDs` is an integration test that seeds a SQLite config store with `gpt-5.5` and `openrouter/moonshotai/kimi-k2.5` rows and verifies that all equivalent ID forms return HTTP 200 with the correct body, while an unknown model still returns 404.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues  
https://github.com/maximhq/bifrost/issues/5105

## Security considerations

None. The change only affects read-path model-parameter lookups and introduces no new auth surface, secret handling, or PII exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable