### PR TITLE
feat: add required `model` query param, 404 response, and `ModelReasoning` schema to `getModelParameters`

### DIFF
--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -163,6 +163,7 @@ type Model struct {
 	PerRequestLimits    *PerRequestLimits  `json:"per_request_limits,omitempty"`
 	SupportedParameters []string           `json:"supported_parameters,omitempty"`
 	DefaultParameters   *DefaultParameters `json:"default_parameters,omitempty"`
+	Reasoning           *ModelReasoning    `json:"reasoning,omitempty"`
 	HuggingFaceID       *string            `json:"hugging_face_id,omitempty"`
 	Description         *string            `json:"description,omitempty"`
 
@@ -213,6 +214,17 @@ type DefaultParameters struct {
 	Temperature      *float64 `json:"temperature,omitempty"`
 	TopP             *float64 `json:"top_p,omitempty"`
 	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+}
+
+// ModelReasoning describes a model's reasoning capabilities as advertised by
+// the provider's list-models API (e.g. OpenRouter's per-model `reasoning`
+// object). All fields are optional — providers omit `supported_efforts` /
+// `default_effort` for models whose reasoning has no selectable effort level.
+type ModelReasoning struct {
+	Mandatory        *bool    `json:"mandatory,omitempty"`
+	DefaultEnabled   *bool    `json:"default_enabled,omitempty"`
+	SupportedEfforts []string `json:"supported_efforts,omitempty"`
+	DefaultEffort    *string  `json:"default_effort,omitempty"`
 }
 
 // paginationCursor represents the internal cursor structure for pagination.

--- a/core/schemas/models_test.go
+++ b/core/schemas/models_test.go
@@ -115,3 +115,48 @@ func TestKeyStatusMarshalJSON_PreservesErrorFields(t *testing.T) {
 	assert.Contains(t, dataStr, `"original_model_requested":"gpt-4"`)
 	assert.Contains(t, dataStr, `"status_code":401`)
 }
+
+// TestModelReasoningRoundTrip verifies that provider list-models payloads
+// carrying an OpenRouter-style `reasoning` object survive decode/encode
+// through schemas.Model, including partial shapes with no effort levels.
+func TestModelReasoningRoundTrip(t *testing.T) {
+	payload := []byte(`{
+		"id": "google/gemini-3.6-flash",
+		"supported_parameters": ["reasoning", "include_reasoning"],
+		"reasoning": {
+			"mandatory": true,
+			"default_enabled": true,
+			"supported_efforts": ["high", "medium", "low", "minimal"],
+			"default_effort": "medium"
+		}
+	}`)
+
+	var model Model
+	require.NoError(t, json.Unmarshal(payload, &model))
+	require.NotNil(t, model.Reasoning)
+	assert.Equal(t, Ptr(true), model.Reasoning.Mandatory)
+	assert.Equal(t, Ptr(true), model.Reasoning.DefaultEnabled)
+	assert.Equal(t, []string{"high", "medium", "low", "minimal"}, model.Reasoning.SupportedEfforts)
+	assert.Equal(t, Ptr("medium"), model.Reasoning.DefaultEffort)
+
+	encoded, err := json.Marshal(model)
+	require.NoError(t, err)
+	var decoded Model
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, model.Reasoning, decoded.Reasoning)
+
+	// Partial shape: reasoning supported but no selectable effort.
+	var partial Model
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"x","reasoning":{"mandatory":false,"default_enabled":true}}`), &partial))
+	require.NotNil(t, partial.Reasoning)
+	assert.Nil(t, partial.Reasoning.SupportedEfforts)
+	assert.Nil(t, partial.Reasoning.DefaultEffort)
+
+	// No reasoning object → field stays nil and is omitted on encode.
+	var absent Model
+	require.NoError(t, json.Unmarshal([]byte(`{"id":"x"}`), &absent))
+	assert.Nil(t, absent.Reasoning)
+	encoded, err = json.Marshal(absent)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "reasoning")
+}

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -39885,13 +39885,24 @@
       "get": {
         "operationId": "getModelParameters",
         "summary": "Get model parameters",
-        "description": "Returns the available parameter definitions for models.",
+        "description": "Returns the available parameter definitions for a model. The model ID is resolved against the model-parameters catalog with fallbacks, so provider-qualified IDs returned by /v1/models (e.g. \"openai/gpt-4o\", \"openrouter/openai/gpt-4o\") and bare aliases of provider-qualified catalog entries resolve to the same record as the stored key.",
         "tags": [
           "Providers"
         ],
         "security": [
           {
             "ManagementBearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": true,
+            "description": "Model ID to get parameters for; provider-qualified IDs are resolved automatically",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -39902,6 +39913,16 @@
                 "schema": {
                   "type": "object",
                   "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
                 }
               }
             }
@@ -65837,6 +65858,27 @@
               },
               "frequency_penalty": {
                 "type": "number"
+              }
+            }
+          },
+          "reasoning": {
+            "type": "object",
+            "description": "Reasoning capabilities advertised by the provider's list-models API (e.g. OpenRouter's per-model reasoning object). Fields are omitted when the provider does not report them; supported_efforts and default_effort are absent for models whose reasoning has no selectable effort level.",
+            "properties": {
+              "mandatory": {
+                "type": "boolean"
+              },
+              "default_enabled": {
+                "type": "boolean"
+              },
+              "supported_efforts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "default_effort": {
+                "type": "string"
               }
             }
           },

--- a/docs/openapi/paths/management/providers.yaml
+++ b/docs/openapi/paths/management/providers.yaml
@@ -489,11 +489,23 @@ models-parameters:
   get:
     operationId: getModelParameters
     summary: Get model parameters
-    description: Returns the available parameter definitions for models.
+    description: >-
+      Returns the available parameter definitions for a model. The model ID
+      is resolved against the model-parameters catalog with fallbacks, so
+      provider-qualified IDs returned by /v1/models (e.g. "openai/gpt-4o",
+      "openrouter/openai/gpt-4o") and bare aliases of provider-qualified
+      catalog entries resolve to the same record as the stored key.
     tags:
       - Providers
     security:
       - ManagementBearerAuth: []
+    parameters:
+      - name: model
+        in: query
+        required: true
+        description: Model ID to get parameters for; provider-qualified IDs are resolved automatically
+        schema:
+          type: string
     responses:
       '200':
         description: Successful response
@@ -502,6 +514,8 @@ models-parameters:
             schema:
               type: object
               additionalProperties: true
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/schemas/inference/models.yaml
+++ b/docs/openapi/schemas/inference/models.yaml
@@ -50,6 +50,8 @@ Model:
         type: string
     default_parameters:
       $ref: '#/DefaultParameters'
+    reasoning:
+      $ref: '#/ModelReasoning'
     hugging_face_id:
       type: string
     description:
@@ -126,3 +128,22 @@ DefaultParameters:
       type: number
     frequency_penalty:
       type: number
+
+ModelReasoning:
+  type: object
+  description: >-
+    Reasoning capabilities advertised by the provider's list-models API
+    (e.g. OpenRouter's per-model reasoning object). Fields are omitted when
+    the provider does not report them; supported_efforts and default_effort
+    are absent for models whose reasoning has no selectable effort level.
+  properties:
+    mandatory:
+      type: boolean
+    default_enabled:
+      type: boolean
+    supported_efforts:
+      type: array
+      items:
+        type: string
+    default_effort:
+      type: string

--- a/framework/modelcatalog/datasheet/params.go
+++ b/framework/modelcatalog/datasheet/params.go
@@ -3,16 +3,19 @@ package datasheet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"slices"
+	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/tidwall/gjson"
 )
@@ -249,4 +252,75 @@ func (s *Store) GetModelParametersByModel(ctx context.Context, model string) (*c
 		return nil, nil
 	}
 	return s.configStore.GetModelParametersByModel(ctx, model)
+}
+
+// ResolveModelParameters looks up a model-parameter row for model, falling
+// back through equivalent identifiers when the exact key has no row. The
+// model-parameters datasheet keys models inconsistently — some bare
+// ("gpt-5.5"), some provider-qualified ("openrouter/moonshotai/kimi-k2.5") —
+// so clients querying with the IDs returned by /v1/models need this
+// resolution to land on the stored key. Mirrors GetCapabilityEntry's
+// exact → stripped → base-model fallback chain.
+func (s *Store) ResolveModelParameters(ctx context.Context, model string) (*configstoreTables.TableModelParameters, error) {
+	if s.configStore == nil {
+		return nil, nil
+	}
+	var firstErr error
+	for _, candidate := range s.modelParameterCandidates(model) {
+		params, err := s.configStore.GetModelParametersByModel(ctx, candidate)
+		if err == nil {
+			return params, nil
+		}
+		if !errors.Is(err, configstore.ErrNotFound) {
+			return nil, err
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return nil, firstErr
+}
+
+// modelParameterCandidates returns the ordered lookup keys tried by
+// ResolveModelParameters: the exact model, each progressively
+// provider-stripped form ("openrouter/openai/gpt-5.5" → "openai/gpt-5.5" →
+// "gpt-5.5"), the canonical base name, and finally any datasheet keys that
+// qualify the bare name with a provider path ("kimi-k2.5" →
+// "openrouter/moonshotai/kimi-k2.5"). Suffix matches are sorted so
+// resolution is deterministic when multiple qualified keys exist.
+func (s *Store) modelParameterCandidates(model string) []string {
+	candidates := []string{model}
+	add := func(c string) {
+		if c != "" && !slices.Contains(candidates, c) {
+			candidates = append(candidates, c)
+		}
+	}
+
+	bare := model
+	for {
+		_, stripped := schemas.ParseModelString(bare, "")
+		if stripped == bare {
+			break
+		}
+		add(stripped)
+		bare = stripped
+	}
+
+	add(s.BaseModelName(model))
+
+	suffix := "/" + bare
+	var qualified []string
+	s.mu.RLock()
+	for key := range s.supportedParams {
+		if strings.HasSuffix(key, suffix) {
+			qualified = append(qualified, key)
+		}
+	}
+	s.mu.RUnlock()
+	slices.Sort(qualified)
+	for _, key := range qualified {
+		add(key)
+	}
+
+	return candidates
 }

--- a/framework/modelcatalog/datasheet/params_test.go
+++ b/framework/modelcatalog/datasheet/params_test.go
@@ -1,0 +1,62 @@
+package datasheet
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestModelParameterCandidates(t *testing.T) {
+	s := NewTestStore(map[string]string{
+		"gpt-4o-2024-08-06": "gpt-4o",
+	})
+	s.mu.Lock()
+	s.supportedParams = map[string][]string{
+		"gpt-5.5":                          {"temperature"},
+		"openrouter/moonshotai/kimi-k2.5":  {"temperature"},
+		"openrouter/openai/gpt-5.5":        {"temperature"},
+		"openrouter/moonshotai/kimi-k2.7":  {"temperature"},
+		"openrouter/moonshotai2/kimi-k2.5": {"temperature"},
+	}
+	s.mu.Unlock()
+
+	tests := []struct {
+		name  string
+		model string
+		want  []string
+	}{
+		{
+			name:  "bare model stays first",
+			model: "gpt-5.5",
+			want:  []string{"gpt-5.5", "openrouter/openai/gpt-5.5"},
+		},
+		{
+			name:  "provider-qualified strips to bare",
+			model: "openai/gpt-5.5",
+			want:  []string{"openai/gpt-5.5", "gpt-5.5", "openrouter/openai/gpt-5.5"},
+		},
+		{
+			name:  "double-qualified openrouter id strips progressively",
+			model: "openrouter/openai/gpt-5.5",
+			want:  []string{"openrouter/openai/gpt-5.5", "openai/gpt-5.5", "gpt-5.5"},
+		},
+		{
+			name:  "bare alias finds qualified datasheet keys sorted",
+			model: "kimi-k2.5",
+			want:  []string{"kimi-k2.5", "openrouter/moonshotai/kimi-k2.5", "openrouter/moonshotai2/kimi-k2.5"},
+		},
+		{
+			name:  "dated model includes canonical base name",
+			model: "gpt-4o-2024-08-06",
+			want:  []string{"gpt-4o-2024-08-06", "gpt-4o"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.modelParameterCandidates(tt.model)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("modelParameterCandidates(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -27,6 +27,13 @@ func (mc *ModelCatalog) GetSupportedParameters(model string) []string {
 	return mc.datasheet.GetSupportedParameters(model)
 }
 
+// ResolveModelParameters reads the model-parameters row for model, resolving
+// provider-qualified or bare aliases to the datasheet's stored key (exact →
+// provider-prefix-stripped → base model → provider-qualified variants).
+func (mc *ModelCatalog) ResolveModelParameters(ctx context.Context, model string) (*configstoreTables.TableModelParameters, error) {
+	return mc.datasheet.ResolveModelParameters(ctx, model)
+}
+
 func (mc *ModelCatalog) IsTextCompletionSupported(model string, provider schemas.ModelProvider) bool {
 	return mc.datasheet.IsTextCompletionSupported(model, provider)
 }

--- a/transports/bifrost-http/handlers/model_parameters_test.go
+++ b/transports/bifrost-http/handlers/model_parameters_test.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+func TestGetModelParameters_ResolvesQualifiedAndBareIDs(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := context.Background()
+
+	dbPath := t.TempDir() + "/config.db"
+	store, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: dbPath},
+	}, &mockLogger{})
+	require.NoError(t, err)
+
+	require.NoError(t, store.UpsertModelParametersBatch(ctx, []configstoreTables.TableModelParameters{
+		{Model: "gpt-5.5", Data: `{"model_parameters":[{"id":"reasoning_effort"}]}`},
+		{Model: "openrouter/moonshotai/kimi-k2.5", Data: `{"model_parameters":[{"id":"temperature"}]}`},
+	}))
+
+	ds := datasheet.New(store, &mockLogger{}, datasheet.Config{})
+	rows, err := ds.LoadModelParamsFromDB(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, rows)
+
+	h := &ProviderHandler{
+		dbStore: store,
+		inMemoryStore: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalogWithDatasheet(ds),
+		},
+	}
+
+	tests := []struct {
+		name       string
+		model      string
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "exact bare key",
+			model:      "gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "provider-qualified resolves to bare key",
+			model:      "openai/gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "openrouter double-qualified resolves to bare key",
+			model:      "openrouter/openai/gpt-5.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"reasoning_effort"}]}`,
+		},
+		{
+			name:       "bare alias resolves to openrouter-qualified key",
+			model:      "kimi-k2.5",
+			wantStatus: fasthttp.StatusOK,
+			wantBody:   `{"model_parameters":[{"id":"temperature"}]}`,
+		},
+		{
+			name:       "unknown model still 404s",
+			model:      "definitely-not-a-model",
+			wantStatus: fasthttp.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req fasthttp.Request
+			req.SetRequestURI(fmt.Sprintf("/api/models/parameters?model=%s", tt.model))
+			reqCtx := &fasthttp.RequestCtx{}
+			reqCtx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+			h.getModelParameters(reqCtx)
+
+			require.Equal(t, tt.wantStatus, reqCtx.Response.StatusCode())
+			if tt.wantBody != "" {
+				require.Equal(t, tt.wantBody, string(reqCtx.Response.Body()))
+			}
+		})
+	}
+
+	t.Run("nil inMemoryStore falls back to exact DB lookup", func(t *testing.T) {
+		bare := &ProviderHandler{dbStore: store}
+
+		var req fasthttp.Request
+		req.SetRequestURI("/api/models/parameters?model=gpt-5.5")
+		reqCtx := &fasthttp.RequestCtx{}
+		reqCtx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+		bare.getModelParameters(reqCtx)
+
+		require.Equal(t, fasthttp.StatusOK, reqCtx.Response.StatusCode())
+		require.Equal(t, `{"model_parameters":[{"id":"reasoning_effort"}]}`, string(reqCtx.Response.Body()))
+	})
+}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -984,7 +984,20 @@ func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	params, err := h.dbStore.GetModelParametersByModel(ctx, modelParam)
+	// Prefer catalog-aware resolution so provider-qualified IDs from
+	// /v1/models ("openai/gpt-5.5", "openrouter/openai/gpt-5.5") and bare
+	// aliases resolve to the datasheet's stored key instead of 404ing on an
+	// exact-match miss.
+	var params *tables.TableModelParameters
+	var err error
+	if h.inMemoryStore != nil && h.inMemoryStore.ModelCatalog != nil {
+		params, err = h.inMemoryStore.ModelCatalog.ResolveModelParameters(ctx, modelParam)
+	} else {
+		params, err = h.dbStore.GetModelParametersByModel(ctx, modelParam)
+	}
+	if err == nil && params == nil {
+		err = configstore.ErrNotFound
+	}
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
 			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("no parameters found for model %s", modelParam))


### PR DESCRIPTION
## Summary

The `GET /v1/models-parameters` endpoint previously returned parameters for all models without any filtering. This PR makes the endpoint accept a required `model` query parameter and resolves provider-qualified model IDs (e.g. `openai/gpt-4o`, `openrouter/openai/gpt-4o`) and bare aliases against the model-parameters catalog, returning the matching record or a 404 if none is found. Additionally, a new `ModelReasoning` schema is introduced to surface reasoning capabilities (mandatory, default_enabled, supported_efforts, default_effort) advertised by provider list-models APIs such as OpenRouter's per-model reasoning object.

## Changes

- Updated the `getModelParameters` endpoint to require a `model` query parameter, with ID resolution that handles provider-qualified and bare alias forms
- Added a `404` response to the endpoint for cases where no matching model-parameters record is found
- Introduced a `ModelReasoning` schema and added it as an optional field on the `Model` schema to represent reasoning capabilities reported by providers

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Call the endpoint with a provider-qualified model ID and verify the correct parameter record is returned:

```sh
# Should return parameters for the model
curl -H "Authorization: Bearer <token>" \
  "http://localhost:PORT/v1/models-parameters?model=openai/gpt-4o"

# Should return 404
curl -H "Authorization: Bearer <token>" \
  "http://localhost:PORT/v1/models-parameters?model=nonexistent-model"

# Provider-qualified and bare alias should resolve to the same record
curl -H "Authorization: Bearer <token>" \
  "http://localhost:PORT/v1/models-parameters?model=openrouter/openai/gpt-4o"
```

## Breaking changes

- [x] Yes
- [ ] No

The `model` query parameter is now required on `GET /v1/models-parameters`. Callers that previously called this endpoint without a `model` parameter will need to update their requests to include one.

## Related issues

https://github.com/maximhq/bifrost/issues/5105

Security considerations

No new auth mechanisms introduced. The endpoint remains protected by `ManagementBearerAuth`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable