### PR TITLE
fix: fixes whitespace trimming on connectors form fields

### DIFF
--- a/ui/lib/utils/secretVarForm.ts
+++ b/ui/lib/utils/secretVarForm.ts
@@ -9,6 +9,12 @@ function inferType(ref: string | undefined): SecretVar["type"] | undefined {
 
 export const emptySecretVar = (): SecretVar => ({ value: "", ref: "" });
 
+// trimSecretVar strips stray whitespace from a SecretVar form value's literal value and reference.
+export const trimSecretVar = <T extends { value?: string; ref?: string } | undefined>(field: T): T => {
+	if (!field) return field;
+	return { ...field, value: field.value?.trim(), ref: field.ref?.trim() };
+};
+
 export const toSecretVarFormValue = (field?: SecretVar | string): SecretVar => {
 	if (!field) return emptySecretVar();
 	if (typeof field === "string") {

--- a/ui/lib/utils/strings.test.ts
+++ b/ui/lib/utils/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { cleanNumericInput } from "./strings";
+import { cleanNumericInput, trimFields } from "./strings";
 
 // Simulate what onChange does: clean → Number()
 function simulateOnChange(raw: string): { display: string; value: number | undefined } {
@@ -200,5 +200,32 @@ describe("simulateOnBlur (normalize display)", () => {
 	});
 	test("1000 → 1000", () => {
 		expect(simulateOnBlur("1000")).toEqual({ display: "1000", value: 1000 });
+	});
+});
+describe("trimFields", () => {
+	test("trims string fields in place", () => {
+		const obj = { topic: " my-topic ", project: "\tproj\n" };
+		trimFields(obj, "topic", "project");
+		expect(obj).toEqual({ topic: "my-topic", project: "proj" });
+	});
+	test("trims string array fields", () => {
+		const obj = { brokers: [" a:9092", "b:9092 ", " c:9092 "] };
+		trimFields(obj, "brokers");
+		expect(obj.brokers).toEqual(["a:9092", "b:9092", "c:9092"]);
+	});
+	test("leaves undefined fields untouched", () => {
+		const obj: { name: string; ml_app?: string } = { name: " x " };
+		trimFields(obj, "name", "ml_app");
+		expect(obj).toEqual({ name: "x" });
+		expect("ml_app" in obj).toBe(false);
+	});
+	test("only touches the named fields", () => {
+		const obj = { a: " x ", b: " y " };
+		trimFields(obj, "a");
+		expect(obj).toEqual({ a: "x", b: " y " });
+	});
+	test("returns the same object", () => {
+		const obj = { a: " x " };
+		expect(trimFields(obj, "a")).toBe(obj);
 	});
 });

--- a/ui/lib/utils/strings.ts
+++ b/ui/lib/utils/strings.ts
@@ -2,6 +2,22 @@ export function capitalize(name: string) {
 	return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
+export type TrimmableKeys<T> = { [K in keyof T]: T[K] extends string | string[] | undefined ? K : never }[keyof T];
+
+// trimFields trims whitespace from the named string (or string[]) fields of obj, in place.
+// Undefined fields are left untouched.
+export function trimFields<T extends object>(obj: T, ...keys: TrimmableKeys<T>[]): T {
+	for (const key of keys) {
+		const value = obj[key];
+		if (typeof value === "string") {
+			obj[key] = value.trim() as T[typeof key];
+		} else if (Array.isArray(value)) {
+			obj[key] = value.map((item) => (typeof item === "string" ? item.trim() : item)) as T[typeof key];
+		}
+	}
+	return obj;
+}
+
 // Cleans raw input into a valid numeric string:
 // - Single non-alphabetic separator between digits (commas, spaces, underscores) → stripped
 // - Alphabetic characters → stop processing


### PR DESCRIPTION
## Summary

Adds two utility helpers for trimming stray whitespace from form inputs before submission: `trimFields` for mutating named string or string-array fields on an object in place, and `trimSecretVar` for producing a trimmed copy of a `SecretVar` form value.

## Changes

- Added `trimFields<T>` to `ui/lib/utils/strings.ts` — trims whitespace from named string or `string[]` fields on an object in place, leaving undefined fields untouched. Uses a `TrimmableKeys` conditional type to restrict callers to only string-compatible keys.
- Added `trimSecretVar` to `ui/lib/utils/secretVarForm.ts` — returns a shallow copy of a `SecretVar`-shaped field with `value` and `ref` trimmed, preserving the original type parameter.
- Added unit tests for `trimFields` covering string fields, string array fields, undefined fields, partial key selection, and return-value identity.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Trimming whitespace from secret variable references and literal values reduces the risk of accidentally storing or submitting credentials with leading/trailing whitespace that could cause silent authentication failures.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable