### PR TITLE
fix: send routing info headers for inference and integration apis

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -875,8 +875,8 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 	}
 
 	enrichListModelsResponse(resp, h.config.ModelCatalog)
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	// Send successful response
 	SendJSON(ctx, resp)
@@ -998,8 +998,8 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
@@ -1072,8 +1072,8 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 		SendBifrostError(ctx, bifrostErr)
 		return
 	}
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
@@ -1144,8 +1144,8 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1198,8 +1198,8 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1265,8 +1265,8 @@ func (h *CompletionHandler) rerank(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
@@ -1328,8 +1328,8 @@ func (h *CompletionHandler) ocr(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
@@ -1443,8 +1443,8 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 		bifrostCtx.SetValue(schemas.BifrostContextKeyLargeResponseContentDisposition, "attachment; filename="+attachmentFilename)
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
@@ -1571,8 +1571,8 @@ func (h *CompletionHandler) transcription(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1603,7 +1603,7 @@ func (h *CompletionHandler) countTokens(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	forwardProviderHeaders(ctx, response.ExtraFields.ProviderResponseHeaders)
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, response.ExtraFields)
 	// Send successful response
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1699,8 +1699,8 @@ func (h *CompletionHandler) responsesRetrieve(ctx *fasthttp.RequestCtx) {
 		SendBifrostError(ctx, bifrostErr)
 		return
 	}
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1730,8 +1730,8 @@ func (h *CompletionHandler) compaction(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if response != nil && response.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, response.ExtraFields.ProviderResponseHeaders)
+	if response != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, response.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1762,8 +1762,8 @@ func (h *CompletionHandler) responsesDelete(ctx *fasthttp.RequestCtx) {
 		SendBifrostError(ctx, bifrostErr)
 		return
 	}
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1794,8 +1794,8 @@ func (h *CompletionHandler) responsesCancel(ctx *fasthttp.RequestCtx) {
 		SendBifrostError(ctx, bifrostErr)
 		return
 	}
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -1844,8 +1844,8 @@ func (h *CompletionHandler) responsesInputItems(ctx *fasthttp.RequestCtx) {
 		SendBifrostError(ctx, bifrostErr)
 		return
 	}
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2267,8 +2267,8 @@ func (h *CompletionHandler) imageGeneration(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2474,8 +2474,8 @@ func (h *CompletionHandler) imageEdit(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2611,8 +2611,8 @@ func (h *CompletionHandler) imageVariation(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2679,8 +2679,8 @@ func (h *CompletionHandler) videoGeneration(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2732,8 +2732,8 @@ func (h *CompletionHandler) videoRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2790,8 +2790,8 @@ func (h *CompletionHandler) videoDownload(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2852,8 +2852,8 @@ func (h *CompletionHandler) videoList(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2903,8 +2903,8 @@ func (h *CompletionHandler) videoDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -2980,8 +2980,8 @@ func (h *CompletionHandler) videoRemix(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3073,8 +3073,8 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3133,8 +3133,8 @@ func (h *CompletionHandler) batchList(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3184,8 +3184,8 @@ func (h *CompletionHandler) batchRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3235,8 +3235,8 @@ func (h *CompletionHandler) batchCancel(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3286,8 +3286,8 @@ func (h *CompletionHandler) batchResults(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3442,9 +3442,7 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 
 	if resp != nil {
 		resp.ID = encodeStorageFileID(resp.ID)
-		if resp.ExtraFields.ProviderResponseHeaders != nil {
-			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
-		}
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3538,9 +3536,7 @@ func (h *CompletionHandler) fileList(ctx *fasthttp.RequestCtx) {
 		for i := range resp.Data {
 			resp.Data[i].ID = encodeStorageFileID(resp.Data[i].ID)
 		}
-		if resp.ExtraFields.ProviderResponseHeaders != nil {
-			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
-		}
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3592,9 +3588,7 @@ func (h *CompletionHandler) fileRetrieve(ctx *fasthttp.RequestCtx) {
 
 	if resp != nil {
 		resp.ID = encodeStorageFileID(resp.ID)
-		if resp.ExtraFields.ProviderResponseHeaders != nil {
-			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
-		}
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3646,9 +3640,7 @@ func (h *CompletionHandler) fileDelete(ctx *fasthttp.RequestCtx) {
 
 	if resp != nil {
 		resp.ID = encodeStorageFileID(resp.ID)
-		if resp.ExtraFields.ProviderResponseHeaders != nil {
-			forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
-		}
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3760,8 +3752,8 @@ func (h *CompletionHandler) containerCreate(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3819,8 +3811,8 @@ func (h *CompletionHandler) containerList(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3866,8 +3858,8 @@ func (h *CompletionHandler) containerRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -3913,8 +3905,8 @@ func (h *CompletionHandler) containerDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -4010,8 +4002,8 @@ func (h *CompletionHandler) containerFileCreate(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -4070,8 +4062,8 @@ func (h *CompletionHandler) containerFileList(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -4125,8 +4117,8 @@ func (h *CompletionHandler) containerFileRetrieve(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return
@@ -4235,8 +4227,8 @@ func (h *CompletionHandler) containerFileDelete(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if resp != nil && resp.ExtraFields.ProviderResponseHeaders != nil {
-		forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
+	if resp != nil {
+		lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, resp.ExtraFields)
 	}
 	if streamLargeResponseIfActive(ctx, bifrostCtx) {
 		return

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -1119,7 +1119,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		bifrostExtraFields = speechResponse.ExtraFields
 
-		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+		if g.tryStreamLargeResponse(ctx, bifrostCtx, bifrostExtraFields) {
 			return
 		}
 
@@ -1129,9 +1129,12 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert speech response"))
 				return
 			}
+			// Early return skips the common footer — apply routed-identity headers here.
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 			return
 		} else {
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			ctx.Response.Header.Set("Content-Type", "audio/mpeg")
 			ctx.Response.Header.Set("Content-Disposition", "attachment; filename=speech.mp3")
 			ctx.Response.Header.Set("Content-Length", strconv.Itoa(len(speechResponse.Audio)))
@@ -1159,7 +1162,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 
-		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+		if g.tryStreamLargeResponse(ctx, bifrostCtx, transcriptionResponse.ExtraFields) {
 			return
 		}
 
@@ -1171,7 +1174,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		// Used for plain-text transcription formats (text, srt, vtt).
 		if err == nil {
 			if rawBytes, ok := response.([]byte); ok {
-				applyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
+				lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 				ctx.SetStatusCode(fasthttp.StatusOK)
 				ctx.SetBody(rawBytes)
 				return
@@ -1203,7 +1206,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 
-		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+		if g.tryStreamLargeResponse(ctx, bifrostCtx, imageGenerationResponse.ExtraFields) {
 			return
 		}
 
@@ -1236,7 +1239,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 
-		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+		if g.tryStreamLargeResponse(ctx, bifrostCtx, imageEditResponse.ExtraFields) {
 			return
 		}
 
@@ -1269,7 +1272,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 
-		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+		if g.tryStreamLargeResponse(ctx, bifrostCtx, imageVariationResponse.ExtraFields) {
 			return
 		}
 
@@ -1357,6 +1360,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		// If converter returns binary content, write directly with content-type.
 		if err == nil {
 			if rawBytes, ok := response.([]byte); ok {
+				lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 				contentType := videoDownloadResponse.ContentType
 				if contentType == "" {
 					contentType = "application/octet-stream"
@@ -1605,9 +1609,9 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 	// Forward upstream provider response headers (filtered) plus the bifrost-level
 	// `x-bifrost-*` routing identity headers, only after conversion succeeds.
-	applyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 
-	if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+	if g.tryStreamLargeResponse(ctx, bifrostCtx, bifrostExtraFields) {
 		return
 	}
 
@@ -1819,6 +1823,7 @@ func (g *GenericRouter) markDeprecatedListModelsResponse(resp *schemas.BifrostLi
 func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, batchReq *BatchRequest, bifrostCtx *schemas.BifrostContext) {
 	var response interface{}
 	var err error
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch batchReq.Type {
 	case schemas.BatchCreateRequest:
@@ -1837,6 +1842,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchCreateResponseConverter != nil {
 			response, err = config.BatchCreateResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1859,6 +1865,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchListResponseConverter != nil {
 			response, err = config.BatchListResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1881,6 +1888,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchRetrieveResponseConverter != nil {
 			response, err = config.BatchRetrieveResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1903,6 +1911,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchCancelResponseConverter != nil {
 			response, err = config.BatchCancelResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1924,6 +1933,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchDeleteResponseConverter != nil {
 			response, err = config.BatchDeleteResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1946,6 +1956,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 				return
 			}
 		}
+		bifrostExtraFields = batchResponse.ExtraFields
 		if config.BatchResultsResponseConverter != nil {
 			response, err = config.BatchResultsResponseConverter(bifrostCtx, batchResponse)
 		} else {
@@ -1962,6 +1973,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 		return
 	}
 
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 }
 
@@ -1969,6 +1981,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, fileReq *FileRequest, bifrostCtx *schemas.BifrostContext) {
 	var response interface{}
 	var err error
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch fileReq.Type {
 	case schemas.FileUploadRequest:
@@ -1987,6 +2000,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 				return
 			}
 		}
+		bifrostExtraFields = fileResponse.ExtraFields
 		if config.FileUploadResponseConverter != nil {
 			response, err = config.FileUploadResponseConverter(bifrostCtx, fileResponse)
 		} else {
@@ -2009,6 +2023,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 				return
 			}
 		}
+		bifrostExtraFields = fileResponse.ExtraFields
 		if config.FileListResponseConverter != nil {
 			response, err = config.FileListResponseConverter(bifrostCtx, fileResponse)
 			if err != nil {
@@ -2017,6 +2032,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 			}
 			// Handle raw byte responses (e.g., XML for S3 APIs)
 			if rawBytes, ok := response.([]byte); ok {
+				lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 				ctx.SetBody(rawBytes)
 				return
 			}
@@ -2040,6 +2056,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 				return
 			}
 		}
+		bifrostExtraFields = fileResponse.ExtraFields
 		if config.FileRetrieveResponseConverter != nil {
 			response, err = config.FileRetrieveResponseConverter(bifrostCtx, fileResponse)
 		} else {
@@ -2062,6 +2079,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 				return
 			}
 		}
+		bifrostExtraFields = fileResponse.ExtraFields
 		if config.FileDeleteResponseConverter != nil {
 			response, err = config.FileDeleteResponseConverter(bifrostCtx, fileResponse)
 		} else {
@@ -2085,12 +2103,15 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 			}
 		}
 		// For file content, handle binary response specially if no converter is set
+		bifrostExtraFields = fileResponse.ExtraFields
 		if config.FileContentResponseConverter != nil {
 			response, err = config.FileContentResponseConverter(bifrostCtx, fileResponse)
 			if err != nil {
 				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert file content response"))
 				return
 			}
+			// Early return skips the common footer — apply routed-identity headers here.
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			// Check if response is raw bytes - write directly without JSON encoding
 			if rawBytes, ok := response.([]byte); ok {
 				ctx.Response.Header.Set("Content-Type", fileResponse.ContentType)
@@ -2101,6 +2122,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 			}
 		} else {
 			// Return raw file content
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			ctx.Response.Header.Set("Content-Type", fileResponse.ContentType)
 			ctx.Response.Header.Set("Content-Length", strconv.Itoa(len(fileResponse.Content)))
 			ctx.Response.SetBody(fileResponse.Content)
@@ -2122,6 +2144,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 		return
 	}
 
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 }
 
@@ -2129,6 +2152,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, containerReq *ContainerRequest, bifrostCtx *schemas.BifrostContext) {
 	var response interface{}
 	var err error
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch containerReq.Type {
 	case schemas.ContainerCreateRequest:
@@ -2147,6 +2171,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 				return
 			}
 		}
+		bifrostExtraFields = containerResponse.ExtraFields
 		if config.ContainerCreateResponseConverter != nil {
 			response, err = config.ContainerCreateResponseConverter(bifrostCtx, containerResponse)
 		} else {
@@ -2169,6 +2194,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 				return
 			}
 		}
+		bifrostExtraFields = containerResponse.ExtraFields
 		if config.ContainerListResponseConverter != nil {
 			response, err = config.ContainerListResponseConverter(bifrostCtx, containerResponse)
 		} else {
@@ -2191,6 +2217,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 				return
 			}
 		}
+		bifrostExtraFields = containerResponse.ExtraFields
 		if config.ContainerRetrieveResponseConverter != nil {
 			response, err = config.ContainerRetrieveResponseConverter(bifrostCtx, containerResponse)
 		} else {
@@ -2213,6 +2240,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 				return
 			}
 		}
+		bifrostExtraFields = containerResponse.ExtraFields
 		if config.ContainerDeleteResponseConverter != nil {
 			response, err = config.ContainerDeleteResponseConverter(bifrostCtx, containerResponse)
 		} else {
@@ -2229,6 +2257,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 		return
 	}
 
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 }
 
@@ -2236,6 +2265,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, containerFileReq *ContainerFileRequest, bifrostCtx *schemas.BifrostContext) {
 	var response interface{}
 	var err error
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch containerFileReq.Type {
 	case schemas.ContainerFileCreateRequest:
@@ -2254,6 +2284,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = containerFileResponse.ExtraFields
 		if config.ContainerFileCreateResponseConverter != nil {
 			response, err = config.ContainerFileCreateResponseConverter(bifrostCtx, containerFileResponse)
 		} else {
@@ -2276,6 +2307,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = containerFileResponse.ExtraFields
 		if config.ContainerFileListResponseConverter != nil {
 			response, err = config.ContainerFileListResponseConverter(bifrostCtx, containerFileResponse)
 		} else {
@@ -2298,6 +2330,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = containerFileResponse.ExtraFields
 		if config.ContainerFileRetrieveResponseConverter != nil {
 			response, err = config.ContainerFileRetrieveResponseConverter(bifrostCtx, containerFileResponse)
 		} else {
@@ -2321,12 +2354,15 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 			}
 		}
 		// For content requests, handle binary response specially if converter is set
+		bifrostExtraFields = containerFileResponse.ExtraFields
 		if config.ContainerFileContentResponseConverter != nil {
 			response, err = config.ContainerFileContentResponseConverter(bifrostCtx, containerFileResponse)
 			if err != nil {
 				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert container file content response"))
 				return
 			}
+			// Early return skips the common footer — apply routed-identity headers here.
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			// Check if response is raw bytes - write directly without JSON encoding
 			if rawBytes, ok := response.([]byte); ok {
 				ctx.Response.Header.Set("Content-Type", containerFileResponse.ContentType)
@@ -2337,6 +2373,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 			}
 		} else {
 			// Return raw binary content
+			lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 			ctx.Response.Header.Set("Content-Type", containerFileResponse.ContentType)
 			ctx.Response.Header.Set("Content-Length", strconv.Itoa(len(containerFileResponse.Content)))
 			ctx.Response.SetBody(containerFileResponse.Content)
@@ -2359,6 +2396,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = containerFileResponse.ExtraFields
 		if config.ContainerFileDeleteResponseConverter != nil {
 			response, err = config.ContainerFileDeleteResponseConverter(bifrostCtx, containerFileResponse)
 		} else {
@@ -2375,6 +2413,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 		return
 	}
 
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 }
 
@@ -2383,6 +2422,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, cachedReq *CachedContentRequest, bifrostCtx *schemas.BifrostContext) {
 	var response interface{}
 	var err error
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch cachedReq.Type {
 	case schemas.CachedContentCreateRequest:
@@ -2401,6 +2441,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = bifrostResp.ExtraFields
 		if config.CachedContentCreateResponseConverter != nil {
 			response, err = config.CachedContentCreateResponseConverter(bifrostCtx, bifrostResp)
 		} else {
@@ -2423,6 +2464,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = bifrostResp.ExtraFields
 		if config.CachedContentListResponseConverter != nil {
 			response, err = config.CachedContentListResponseConverter(bifrostCtx, bifrostResp)
 		} else {
@@ -2445,6 +2487,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = bifrostResp.ExtraFields
 		if config.CachedContentRetrieveResponseConverter != nil {
 			response, err = config.CachedContentRetrieveResponseConverter(bifrostCtx, bifrostResp)
 		} else {
@@ -2467,6 +2510,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = bifrostResp.ExtraFields
 		if config.CachedContentUpdateResponseConverter != nil {
 			response, err = config.CachedContentUpdateResponseConverter(bifrostCtx, bifrostResp)
 		} else {
@@ -2489,6 +2533,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 				return
 			}
 		}
+		bifrostExtraFields = bifrostResp.ExtraFields
 		if config.CachedContentDeleteResponseConverter != nil {
 			response, err = config.CachedContentDeleteResponseConverter(bifrostCtx, bifrostResp)
 		} else {
@@ -2505,6 +2550,7 @@ func (g *GenericRouter) handleCachedContentRequest(ctx *fasthttp.RequestCtx, con
 		return
 	}
 
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response, nil)
 }
 
@@ -2560,7 +2606,7 @@ func (g *GenericRouter) handleStreamingRequest(ctx *fasthttp.RequestCtx, config 
 	}
 
 	// Large payload streaming passthrough — bypass SSE event processing, pipe raw upstream
-	if g.tryStreamLargeResponse(ctx, bifrostCtx) {
+	if g.tryStreamLargeResponse(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{}) {
 		ctx.Response.Header.Set("Cache-Control", "no-cache")
 		ctx.Response.Header.Set("Connection", "keep-alive")
 		ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -241,69 +240,6 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 	ctx.SetBody(errorBody)
 }
 
-// HTTP response header names for the routed identity. Set on every successful
-// response from any integration so callers can recover the actual provider /
-// model that handled the request — even when the integration converts the
-// body to a provider-native shape (Anthropic, OpenAI, Bedrock) that has no
-// place to surface Bifrost's `extra_fields`.
-//
-// Header values are derived from BifrostResponseExtraFields (populated by
-// PopulateExtraFields at the end of every request path, including after
-// fallback / routing-rule resolution). FallbackIndex is read from the
-// BifrostContext because it isn't a field on the response struct.
-//
-// Naming follows the existing `x-bf-*` request-side convention (see
-// `x-bf-vk`, `x-bf-key-id`, etc.).
-const (
-	HeaderBifrostProvider      = "x-bifrost-provider"
-	HeaderBifrostOriginalModel = "x-bifrost-original-model"
-	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
-	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
-	HeaderBifrostRequestType   = "x-bifrost-request-type"
-	// Cumulative milliseconds this request spent blocked on upstream sockets,
-	// summed across every attempt and fallback. Subtract from the caller's own
-	// elapsed time to get what Bifrost cost. Distinct from the per-attempt
-	// latency in the response body's extra_fields, which only holds the last try.
-	HeaderBifrostUpstreamLatency = "x-bifrost-upstream-latency-ms"
-)
-
-// applyBifrostResponseHeaders writes both the upstream provider response
-// headers (forwarded verbatim) and the bifrost-level `x-bifrost-*` routing
-// identity headers onto the fasthttp response. Empty fields are skipped so
-// the headers never appear with a blank value. Safe to call when the case
-// didn't populate `extra` — the zero value for ExtraFields produces no
-// headers.
-func applyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostResponseExtraFields) {
-	for key, value := range extra.ProviderResponseHeaders {
-		ctx.Response.Header.Set(key, value)
-	}
-	if extra.Provider != "" {
-		ctx.Response.Header.Set(HeaderBifrostProvider, string(extra.Provider))
-	}
-	if extra.OriginalModelRequested != "" {
-		ctx.Response.Header.Set(HeaderBifrostOriginalModel, extra.OriginalModelRequested)
-	}
-	if extra.ResolvedModelUsed != "" {
-		ctx.Response.Header.Set(HeaderBifrostResolvedModel, extra.ResolvedModelUsed)
-	}
-	if extra.RequestType != "" {
-		ctx.Response.Header.Set(HeaderBifrostRequestType, string(extra.RequestType))
-	}
-	// Fallback index lives on the request context, not the response struct.
-	// 0 = primary provider succeeded; non-zero = which fallback fired
-	// (1-indexed). Only emit when non-zero so the absence of the header is
-	// the unambiguous "no fallback fired" signal.
-	if bifrostCtx != nil {
-		if idx, ok := bifrostCtx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok && idx > 0 {
-			ctx.Response.Header.Set(HeaderBifrostFallbackIndex, strconv.Itoa(idx))
-		}
-		if upstream, ok := schemas.GetUpstreamLatency(bifrostCtx); ok {
-			ctx.Response.Header.Set(HeaderBifrostUpstreamLatency,
-				strconv.FormatFloat(float64(upstream)/float64(time.Millisecond), 'f', 3, 64))
-		}
-	}
-}
-
 // sendSuccess sends a successful response with HTTP 200 status and JSON body.
 func (g *GenericRouter) sendSuccess(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, errorConverter ErrorConverter, response interface{}, extraHeaders map[string]string) {
 	ctx.SetStatusCode(fasthttp.StatusOK)
@@ -327,11 +263,16 @@ func (g *GenericRouter) sendSuccess(ctx *fasthttp.RequestCtx, bifrostCtx *schema
 // tryStreamLargeResponse checks if large response mode was activated by the provider,
 // sets the transport marker, and streams the response directly to the client.
 // Returns true if the response was handled (caller should return).
-func (g *GenericRouter) tryStreamLargeResponse(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) bool {
+// extra carries the routed identity of the response being streamed; callers
+// without one (pre-chunk streaming paths) pass the zero value, which emits nothing.
+func (g *GenericRouter) tryStreamLargeResponse(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostResponseExtraFields) bool {
 	isLargeResponse, ok := bifrostCtx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool)
 	if !ok || !isLargeResponse {
 		return false
 	}
+	// Routed-identity headers — large-response branches return early and skip
+	// the common footer that normally emits them.
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, extra)
 	// Forward provider response headers before streaming — providers store them in
 	// context via BifrostContextKeyProviderResponseHeaders, but some early-return
 	// branches in the router skip the common footer that normally forwards them.

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -299,76 +301,35 @@ func TestSendStreamError_ForwardsProviderHeaders(t *testing.T) {
 	assert.Equal(t, "ValidationException", string(ctx.Response.Header.Peek("x-amzn-errortype")))
 }
 
-// TestApplyBifrostResponseHeaders covers the routed-identity headers added so
-// drop-in integration callers (Anthropic SDK against `/anthropic/v1/messages`,
-// OpenAI SDK against `/openai/v1/chat/completions`, etc.) can recover the
-// actual provider/model that handled the request — including after fallback
-// or routing-rule resolution. The body shape they get back has no place to
-// surface this; headers do.
-func TestApplyBifrostResponseHeaders(t *testing.T) {
-	t.Run("routed identity emits all headers", func(t *testing.T) {
-		ctx := &fasthttp.RequestCtx{}
-		bifrostCtx := newTestBifrostContext()
+// TestTryStreamLargeResponse_AppliesRoutedIdentityHeaders verifies that
+// large-response early returns (speech audio, transcription, image bytes)
+// carry the routed-identity headers even though they skip the common footer
+// in handleNonStreamingRequest that normally emits them.
+func TestTryStreamLargeResponse_AppliesRoutedIdentityHeaders(t *testing.T) {
+	router := newTestGenericRouter()
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := newTestBifrostContext()
+	bifrostCtx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyLargeResponseReader, io.NopCloser(strings.NewReader("audio-bytes")))
 
-		extra := schemas.BifrostResponseExtraFields{
-			Provider:               schemas.Bedrock,
-			OriginalModelRequested: "claude-sonnet-4-6",
-			ResolvedModelUsed:      "us.anthropic.claude-sonnet-4-6",
-			RequestType:            schemas.ChatCompletionRequest,
-			ProviderResponseHeaders: map[string]string{
-				"x-amzn-requestid": "req-789",
-			},
-		}
-
-		applyBifrostResponseHeaders(ctx, bifrostCtx, extra)
-
-		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
-		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
-		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
-		assert.Equal(t, string(schemas.ChatCompletionRequest), string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
-		assert.Equal(t, "req-789", string(ctx.Response.Header.Peek("x-amzn-requestid")))
-		// No fallback fired — header must be absent.
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
-	})
-
-	t.Run("fallback index from context emits when non-zero", func(t *testing.T) {
-		ctx := &fasthttp.RequestCtx{}
-		bifrostCtx := newTestBifrostContext()
-		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 2)
-
-		extra := schemas.BifrostResponseExtraFields{
-			Provider:          schemas.Anthropic,
-			ResolvedModelUsed: "claude-haiku-4-5",
-		}
-
-		applyBifrostResponseHeaders(ctx, bifrostCtx, extra)
-
-		assert.Equal(t, "2", string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
-	})
-
-	t.Run("zero-value extra writes no headers", func(t *testing.T) {
-		ctx := &fasthttp.RequestCtx{}
-		bifrostCtx := newTestBifrostContext()
-
-		applyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{})
-
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
-	})
-
-	t.Run("primary-provider success (FallbackIndex=0) does not emit fallback header", func(t *testing.T) {
-		ctx := &fasthttp.RequestCtx{}
-		bifrostCtx := newTestBifrostContext()
-		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
-
-		applyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+	extra := schemas.BifrostResponseExtraFields{
+		Provider:          schemas.OpenAI,
+		ResolvedModelUsed: "tts-1",
+		RequestType:       schemas.SpeechRequest,
+		RoutingInfo: schemas.RoutingInfo{
 			Provider: schemas.OpenAI,
-		})
+			Model:    "tts-1",
+			Key:      "openai-key",
+		},
+	}
 
-		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)),
-			"FallbackIndex=0 means primary succeeded; absence of header is the signal")
-	})
+	handled := router.tryStreamLargeResponse(ctx, bifrostCtx, extra)
+
+	require.True(t, handled, "large response mode active — call must handle the response")
+	assert.Equal(t, "openai", string(ctx.Response.Header.Peek(lib.HeaderBifrostProvider)))
+	assert.Equal(t, "tts-1", string(ctx.Response.Header.Peek(lib.HeaderBifrostResolvedModel)))
+	assert.Equal(t, string(schemas.SpeechRequest), string(ctx.Response.Header.Peek(lib.HeaderBifrostRequestType)))
+	assert.Equal(t, "openai", string(ctx.Response.Header.Peek(lib.HeaderBifrostRoutingInfoProvider)))
+	assert.Equal(t, "tts-1", string(ctx.Response.Header.Peek(lib.HeaderBifrostRoutingInfoModel)))
+	assert.Equal(t, "openai-key", string(ctx.Response.Header.Peek(lib.HeaderBifrostRoutingInfoKey)))
 }

--- a/transports/bifrost-http/lib/responseheaders.go
+++ b/transports/bifrost-http/lib/responseheaders.go
@@ -1,0 +1,127 @@
+package lib
+
+// Routed-identity response headers. Shared by the native `/v1` handlers and
+// the drop-in integration routes: both surfaces emit the same `x-bifrost-*`
+// header contract on successful responses, so the writer lives here rather
+// than in either package.
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// HTTP response header names for the routed identity. Set on every successful
+// response from any integration so callers can recover the actual provider /
+// model that handled the request — even when the integration converts the
+// body to a provider-native shape (Anthropic, OpenAI, Bedrock) that has no
+// place to surface Bifrost's `extra_fields`.
+//
+// Header values are derived from BifrostResponseExtraFields (populated by
+// PopulateExtraFields at the end of every request path, including after
+// fallback / routing-rule resolution). FallbackIndex is read from the
+// BifrostContext because it isn't a field on the response struct.
+//
+// Naming follows the existing `x-bf-*` request-side convention (see
+// `x-bf-vk`, `x-bf-key-id`, etc.).
+const (
+	HeaderBifrostProvider      = "x-bifrost-provider"
+	HeaderBifrostOriginalModel = "x-bifrost-original-model"
+	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
+	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
+	HeaderBifrostRequestType   = "x-bifrost-request-type"
+	// Cumulative milliseconds this request spent blocked on upstream sockets,
+	// summed across every attempt and fallback. Subtract from the caller's own
+	// elapsed time to get what Bifrost cost. Distinct from the per-attempt
+	// latency in the response body's extra_fields, which only holds the last try.
+	HeaderBifrostUpstreamLatency = "x-bifrost-upstream-latency-ms"
+)
+
+// Headers mirroring the non-deprecated ExtraFields.RoutingInfo fields 1:1.
+// Emitted alongside the deprecated set above so header consumers get both
+// generations, matching the JSON body contract on native routes.
+const (
+	HeaderBifrostRoutingInfoProvider                = "x-bifrost-routing-info-provider"
+	HeaderBifrostRoutingInfoModel                   = "x-bifrost-routing-info-model"
+	HeaderBifrostRoutingInfoKey                     = "x-bifrost-routing-info-key"
+	HeaderBifrostRoutingInfoAliasModelID            = "x-bifrost-routing-info-alias-model-id"
+	HeaderBifrostRoutingInfoAliasModelName          = "x-bifrost-routing-info-alias-model-name"
+	HeaderBifrostRoutingInfoAliasModelFamily        = "x-bifrost-routing-info-alias-model-family"
+	HeaderBifrostRoutingInfoIsFallback              = "x-bifrost-routing-info-is-fallback"
+	HeaderBifrostRoutingInfoPrimaryProvider         = "x-bifrost-routing-info-primary-provider"
+	HeaderBifrostRoutingInfoPrimaryModel            = "x-bifrost-routing-info-primary-model"
+	HeaderBifrostRoutingInfoServerSideFallbackModel = "x-bifrost-routing-info-server-side-fallback-model"
+)
+
+// ApplyBifrostResponseHeaders writes both the upstream provider response
+// headers (forwarded verbatim) and the bifrost-level `x-bifrost-*` routing
+// identity headers onto the fasthttp response. Empty fields are skipped so
+// the headers never appear with a blank value. Safe to call when the caller
+// didn't populate `extra` — the zero value for ExtraFields produces no
+// headers.
+func ApplyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostResponseExtraFields) {
+	for key, value := range extra.ProviderResponseHeaders {
+		ctx.Response.Header.Set(key, value)
+	}
+	if extra.Provider != "" {
+		ctx.Response.Header.Set(HeaderBifrostProvider, string(extra.Provider))
+	}
+	if extra.OriginalModelRequested != "" {
+		ctx.Response.Header.Set(HeaderBifrostOriginalModel, extra.OriginalModelRequested)
+	}
+	if extra.ResolvedModelUsed != "" {
+		ctx.Response.Header.Set(HeaderBifrostResolvedModel, extra.ResolvedModelUsed)
+	}
+	if extra.RequestType != "" {
+		ctx.Response.Header.Set(HeaderBifrostRequestType, string(extra.RequestType))
+	}
+	ri := extra.RoutingInfo
+	if ri.Provider != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoProvider, string(ri.Provider))
+	}
+	if ri.Model != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoModel, ri.Model)
+	}
+	if ri.Key != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoKey, ri.Key)
+	}
+	if ri.ResolvedKeyAlias != nil {
+		if ri.ResolvedKeyAlias.ModelID != "" {
+			ctx.Response.Header.Set(HeaderBifrostRoutingInfoAliasModelID, ri.ResolvedKeyAlias.ModelID)
+		}
+		if ri.ResolvedKeyAlias.ModelName != nil && *ri.ResolvedKeyAlias.ModelName != "" {
+			ctx.Response.Header.Set(HeaderBifrostRoutingInfoAliasModelName, *ri.ResolvedKeyAlias.ModelName)
+		}
+		if ri.ResolvedKeyAlias.ModelFamily != nil && *ri.ResolvedKeyAlias.ModelFamily != "" {
+			ctx.Response.Header.Set(HeaderBifrostRoutingInfoAliasModelFamily, string(*ri.ResolvedKeyAlias.ModelFamily))
+		}
+	}
+	// Booleans follow the fallback-index convention: absent = false.
+	if ri.IsFallback {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoIsFallback, "true")
+	}
+	if ri.PrimaryProvider != nil && *ri.PrimaryProvider != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoPrimaryProvider, string(*ri.PrimaryProvider))
+	}
+	if ri.PrimaryModel != nil && *ri.PrimaryModel != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoPrimaryModel, *ri.PrimaryModel)
+	}
+	if ri.ServerSideFallbackModel != nil && *ri.ServerSideFallbackModel != "" {
+		ctx.Response.Header.Set(HeaderBifrostRoutingInfoServerSideFallbackModel, *ri.ServerSideFallbackModel)
+	}
+	// Fallback index lives on the request context, not the response struct.
+	// 0 = primary provider succeeded; non-zero = which fallback fired
+	// (1-indexed). Only emit when non-zero so the absence of the header is
+	// the unambiguous "no fallback fired" signal.
+	if bifrostCtx != nil {
+		if idx, ok := bifrostCtx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok && idx > 0 {
+			ctx.Response.Header.Set(HeaderBifrostFallbackIndex, strconv.Itoa(idx))
+		}
+		if upstream, ok := schemas.GetUpstreamLatency(bifrostCtx); ok {
+			ctx.Response.Header.Set(HeaderBifrostUpstreamLatency,
+				strconv.FormatFloat(float64(upstream)/float64(time.Millisecond), 'f', 3, 64))
+		}
+	}
+}

--- a/transports/bifrost-http/lib/responseheaders_test.go
+++ b/transports/bifrost-http/lib/responseheaders_test.go
@@ -1,0 +1,176 @@
+package lib
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+// TestApplyBifrostResponseHeaders covers the routed-identity headers added so
+// drop-in integration callers (Anthropic SDK against `/anthropic/v1/messages`,
+// OpenAI SDK against `/openai/v1/chat/completions`, etc.) can recover the
+// actual provider/model that handled the request — including after fallback
+// or routing-rule resolution. The body shape they get back has no place to
+// surface this; headers do. Native `/v1` routes emit the same set alongside
+// `extra_fields` in the body.
+func TestApplyBifrostResponseHeaders(t *testing.T) {
+	newBifrostCtx := func() *schemas.BifrostContext {
+		return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	}
+
+	t.Run("routed identity emits all headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+
+		extra := schemas.BifrostResponseExtraFields{
+			Provider:               schemas.Bedrock,
+			OriginalModelRequested: "claude-sonnet-4-6",
+			ResolvedModelUsed:      "us.anthropic.claude-sonnet-4-6",
+			RequestType:            schemas.ChatCompletionRequest,
+			ProviderResponseHeaders: map[string]string{
+				"x-amzn-requestid": "req-789",
+			},
+		}
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, extra)
+
+		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
+		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
+		assert.Equal(t, string(schemas.ChatCompletionRequest), string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Equal(t, "req-789", string(ctx.Response.Header.Peek("x-amzn-requestid")))
+		// No fallback fired — header must be absent.
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("fallback index from context emits when non-zero", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 2)
+
+		extra := schemas.BifrostResponseExtraFields{
+			Provider:          schemas.Anthropic,
+			ResolvedModelUsed: "claude-haiku-4-5",
+		}
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, extra)
+
+		assert.Equal(t, "2", string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("zero-value extra writes no headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{})
+
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+		// No accumulator installed — unmeasured must stay distinguishable from zero.
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostUpstreamLatency)))
+	})
+
+	t.Run("measured upstream latency emits milliseconds", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		bifrostCtx.ResetUpstreamLatency()
+		schemas.AddUpstreamLatency(bifrostCtx, 150*time.Millisecond)
+		schemas.AddUpstreamLatency(bifrostCtx, 500*time.Microsecond)
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{})
+
+		assert.Equal(t, "150.500", string(ctx.Response.Header.Peek(HeaderBifrostUpstreamLatency)))
+	})
+
+	t.Run("measured zero upstream latency emits 0.000, not absence", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		bifrostCtx.ResetUpstreamLatency()
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{})
+
+		assert.Equal(t, "0.000", string(ctx.Response.Header.Peek(HeaderBifrostUpstreamLatency)))
+	})
+
+	t.Run("primary-provider success (FallbackIndex=0) does not emit fallback header", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+			Provider: schemas.OpenAI,
+		})
+
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)),
+			"FallbackIndex=0 means primary succeeded; absence of header is the signal")
+	})
+
+	t.Run("routing info emits full x-bifrost-routing-info-* header set", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+
+		aliasName := "sonnet-prod"
+		family := schemas.ModelFamily("claude")
+		primaryProvider := schemas.Anthropic
+		primaryModel := "claude-sonnet-4-6"
+		serverSideFallback := "claude-haiku-4-5"
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+			RoutingInfo: schemas.RoutingInfo{
+				Provider: schemas.Bedrock,
+				Model:    "claude-sonnet-4-6",
+				Key:      "prod-key-1",
+				ResolvedKeyAlias: &schemas.ResolvedKeyAlias{
+					ModelID:     "us.anthropic.claude-sonnet-4-6",
+					ModelName:   &aliasName,
+					ModelFamily: &family,
+				},
+				IsFallback:              true,
+				PrimaryProvider:         &primaryProvider,
+				PrimaryModel:            &primaryModel,
+				ServerSideFallbackModel: &serverSideFallback,
+			},
+		})
+
+		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoProvider)))
+		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoModel)))
+		assert.Equal(t, "prod-key-1", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoKey)))
+		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoAliasModelID)))
+		assert.Equal(t, "sonnet-prod", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoAliasModelName)))
+		assert.Equal(t, "claude", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoAliasModelFamily)))
+		assert.Equal(t, "true", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoIsFallback)))
+		assert.Equal(t, "anthropic", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoPrimaryProvider)))
+		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoPrimaryModel)))
+		assert.Equal(t, "claude-haiku-4-5", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoServerSideFallbackModel)))
+	})
+
+	t.Run("primary-route routing info skips fallback and alias headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+			RoutingInfo: schemas.RoutingInfo{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-5.6",
+				Key:      "openai-key",
+			},
+		})
+
+		assert.Equal(t, "openai", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoProvider)))
+		assert.Equal(t, "gpt-5.6", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoModel)))
+		assert.Equal(t, "openai-key", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoKey)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoAliasModelID)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoIsFallback)),
+			"is-fallback header must be absent on primary-route success")
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoPrimaryProvider)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoPrimaryModel)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoServerSideFallbackModel)))
+	})
+}


### PR DESCRIPTION
## Summary

`ApplyBifrostResponseHeaders` was a package-private function living in the `integrations` package, making it inaccessible to the native `/v1` handlers in `handlers/inference.go`. Both surfaces need to emit the same `x-bifrost-*` routing identity headers on every successful response, so the function has been promoted to a shared `lib` package and extended to also emit the full `x-bifrost-routing-info-*` header set derived from `ExtraFields.RoutingInfo`.

## Changes

- Moved `applyBifrostResponseHeaders` (previously package-private in `integrations/utils.go`) to a new `transports/bifrost-http/lib/responseheaders.go` file as the exported `lib.ApplyBifrostResponseHeaders`, making it available to both the native handlers and the integration router.
- Extended the function to emit a new `x-bifrost-routing-info-*` header family that mirrors `ExtraFields.RoutingInfo` fields 1:1 (provider, model, key, alias model ID/name/family, is-fallback, primary provider/model, server-side fallback model). Boolean and pointer fields follow the existing convention of being omitted when false/nil/empty.
- Replaced all call sites in `handlers/inference.go` — previously calling the local `forwardProviderHeaders` with a nil-guard on `ProviderResponseHeaders` — with `lib.ApplyBifrostResponseHeaders`, which handles the nil case internally and also writes the routing identity headers.
- Replaced all call sites in `integrations/router.go` — previously calling the package-private `applyBifrostResponseHeaders` — with `lib.ApplyBifrostResponseHeaders`. Added `bifrostExtraFields` capture in `handleBatchRequest`, `handleFileRequest`, `handleContainerRequest`, `handleContainerFileRequest`, and `handleCachedContentRequest` so the headers are applied before `sendSuccess` on every code path, including early-return binary-response branches.
- Moved the `ApplyBifrostResponseHeaders` unit tests from `integrations/utils_test.go` into the new `lib/responseheaders_test.go` and added two new test cases covering the full `RoutingInfo` header set and the primary-route (no-fallback, no-alias) case.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Validate that a successful chat completion response includes the following headers:

- `x-bifrost-provider`
- `x-bifrost-original-model`
- `x-bifrost-resolved-model`
- `x-bifrost-request-type`
- `x-bifrost-routing-info-provider`
- `x-bifrost-routing-info-model`
- `x-bifrost-routing-info-key`
- `x-bifrost-fallback-index` (only present when a fallback fired)
- `x-bifrost-routing-info-is-fallback` (only present when `true`)

Both native `/v1/chat/completions` and drop-in integration routes (e.g. `/anthropic/v1/messages`, `/openai/v1/chat/completions`) should emit the same header set.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets, auth flows, or PII handling introduced. The forwarded provider response headers were already being passed through; this change does not alter the filtering logic for those headers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable