### PR TITLE
fix: hybrid matview count to prevent boundary bucket over-counting in paginated log search

### DIFF
--- a/framework/logstore/matview_count_test.go
+++ b/framework/logstore/matview_count_test.go
@@ -1,0 +1,255 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// insertCountTestLog inserts a minimal log row at the given timestamp for the
+// hybrid-count boundary tests.
+func insertCountTestLog(t *testing.T, db *gorm.DB, ts time.Time, status string) {
+	t.Helper()
+	insertCountTestModelLog(t, db, ts, status, "gpt-4", nil)
+}
+
+// insertCountTestModelLog is insertCountTestLog with an explicit wire model and
+// optional canonical model name, for the canonical-model filter tests.
+func insertCountTestModelLog(t *testing.T, db *gorm.DB, ts time.Time, status, model string, canonicalModelName *string) {
+	t.Helper()
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, canonical_model_name, status,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', ?, ?, ?, ?, 100, 0.01, 10, 5, 15)
+	`, uuid.New().String(), ts, model, canonicalModelName, status, ts).Error
+	require.NoError(t, err, "failed to insert count test log")
+}
+
+// TestSearchLogsMatViewCountMatchesRawRange is the regression test for
+// https://github.com/maximhq/bifrost/issues/5329: for matview-eligible windows
+// (>= 24h), pagination total_count came from mv_logs_hourly with predicates
+// that rounded both boundaries out to full hour buckets, counting logs the
+// exact-range row list can never page to. The hybrid count must match the
+// number of logs strictly within [StartTime, EndTime] that the row list can
+// page to - terminal logs plus in-flight ("processing") logs, which the row
+// list shows but mv_logs_hourly cannot see.
+//
+// The expectations hold regardless of the server's session TimeZone (which
+// shifts the date_trunc('hour') bucket grid — e.g. Asia/Kolkata puts buckets
+// on :30 UTC boundaries): the hybrid count does all grid arithmetic in SQL.
+func TestSearchLogsMatViewCountMatchesRawRange(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	start := day.Add(10*time.Hour + 30*time.Minute) // 10:30, mid-hour
+	end := day.Add(35*time.Hour + 45*time.Minute)   // next day 11:45 (25h15m window)
+
+	insertCountTestLog(t, db, day.Add(10*time.Hour+15*time.Minute), "success")   // before start -> excluded
+	insertCountTestLog(t, db, day.Add(10*time.Hour+45*time.Minute), "success")   // just after start -> counted
+	insertCountTestLog(t, db, day.Add(18*time.Hour), "success")                  // interior -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour), "success")                  // near end, in range -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour+30*time.Minute), "error")     // just before end -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour+50*time.Minute), "success")   // after end -> excluded
+	insertCountTestLog(t, db, day.Add(18*time.Hour+5*time.Minute), "processing") // in-flight -> counted (visible in the row list)
+
+	refreshTestMatViews(t, db)
+	store.matViewsReady.Store(true) // force the matview count path
+
+	filters := SearchFilters{StartTime: &start, EndTime: &end}
+	require.True(t, store.canUseMatViewForFreshAggregate(filters), "window must take the matview count path")
+
+	result, err := store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), result.Pagination.TotalCount,
+		"total_count must include every log inside [start, end] the row list can page to, in-flight included")
+	assert.Len(t, result.Logs, 5, "row list and total_count must agree on the same population")
+
+	// Hour-aligned end: nothing after end may be counted (the old `hour <= end`
+	// predicate included the entire bucket starting exactly at end), while a
+	// log exactly at end stays included.
+	alignedEnd := day.Add(35 * time.Hour) // next day 11:00
+	filters = SearchFilters{StartTime: &start, EndTime: &alignedEnd}
+	require.True(t, store.canUseMatViewForFreshAggregate(filters))
+
+	result, err = store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), result.Pagination.TotalCount,
+		"hour-aligned end must include a log exactly at end but nothing after it")
+
+	// Hour-aligned start: everything at-or-after start is counted, including
+	// the 10:15 log that the mid-hour start above excluded.
+	alignedStart := day.Add(10 * time.Hour) // 10:00
+	filters = SearchFilters{StartTime: &alignedStart, EndTime: &end}
+	require.True(t, store.canUseMatViewForFreshAggregate(filters))
+
+	result, err = store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(6), result.Pagination.TotalCount,
+		"hour-aligned start must count everything from start onward")
+}
+
+// TestSearchLogsMatViewCountCanonicalModelFilter verifies that a Models filter
+// counts aliased traffic the same way the raw row list does: applyFilters
+// matches (model IN ? OR canonical_model_name IN ?), so the matview predicates
+// must too. Before the fix the matview side matched only the wire model, so a
+// row with model "prod-alias" / canonical_model_name "gpt-4o-mini" landing in
+// an interior bucket was pageable but missing from total_count.
+func TestSearchLogsMatViewCountCanonicalModelFilter(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	start := day.Add(10*time.Hour + 30*time.Minute)
+	end := day.Add(35*time.Hour + 45*time.Minute) // 25h15m window, matview-eligible
+
+	canonical := "gpt-4o-mini"
+	interior := day.Add(18 * time.Hour) // deep inside the window, never a boundary sliver
+	insertCountTestModelLog(t, db, interior, "success", canonical, nil)                              // wire-model match
+	insertCountTestModelLog(t, db, interior.Add(time.Minute), "success", "prod-alias", &canonical)   // canonical-only match
+	insertCountTestModelLog(t, db, interior.Add(2*time.Minute), "success", "other-model", nil)       // no match
+	insertCountTestModelLog(t, db, start.Add(5*time.Minute), "success", "prod-alias", &canonical)    // canonical match in the head boundary sliver
+	insertCountTestModelLog(t, db, day.Add(9*time.Hour), "success", "prod-alias", &canonical)        // before start -> excluded
+
+	refreshTestMatViews(t, db)
+	store.matViewsReady.Store(true)
+
+	filters := SearchFilters{StartTime: &start, EndTime: &end, Models: []string{canonical}}
+	require.True(t, store.canUseMatViewForFreshAggregate(filters), "Models filter must stay matview-eligible")
+
+	result, err := store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), result.Pagination.TotalCount,
+		"total_count must include canonical-model matches in interior buckets and boundary slivers alike")
+	assert.Len(t, result.Logs, 3, "row list and total_count must agree on the same population")
+}
+
+// TestSearchLogsParentRequestIDForcesRawPath verifies the matview count path is
+// never taken for a fallback-chain search: mv_logs_hourly has no
+// parent_request_id dimension, so a matview interior sum would count every
+// terminal log in the window instead of just the chain's rows.
+func TestSearchLogsParentRequestIDForcesRawPath(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	start := day.Add(10*time.Hour + 30*time.Minute)
+	end := day.Add(35*time.Hour + 45*time.Minute) // >=24h: matview-eligible if the filter gate regresses
+
+	parentID := uuid.New().String()
+	interior := day.Add(18 * time.Hour)
+	insertCountTestLog(t, db, interior, "success") // unrelated chain -> must not be counted
+	insertCountTestLog(t, db, interior.Add(time.Minute), "success")
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status, parent_request_id,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', 'gpt-4', 'success', ?, ?, 100, 0.01, 10, 5, 15)
+	`, uuid.New().String(), interior.Add(2*time.Minute), parentID, interior).Error
+	require.NoError(t, err)
+
+	refreshTestMatViews(t, db)
+	store.matViewsReady.Store(true)
+
+	filters := SearchFilters{StartTime: &start, EndTime: &end, ParentRequestID: parentID}
+	require.False(t, store.canUseMatViewForFreshAggregate(filters),
+		"parent_request_id has no matview dimension; the count must take the raw path")
+
+	result, err := store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.Pagination.TotalCount,
+		"total_count must cover only the fallback chain's rows, not every log in the window")
+}
+
+// TestGetStatsMatViewMatchesPaginationTotal verifies the matview stats path is
+// exact-range like the pagination count: the Logs page renders both numbers
+// for the same filters, so GetStats' TotalRequests must equal SearchLogs'
+// total_count (terminal plus in-flight rows inside [start, end]), with rate
+// denominators terminal-only, mirroring the raw GetStats path.
+func TestGetStatsMatViewMatchesPaginationTotal(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	start := day.Add(10*time.Hour + 30*time.Minute)
+	end := day.Add(35*time.Hour + 45*time.Minute) // 25h15m window, matview-eligible
+
+	insertCountTestLog(t, db, day.Add(10*time.Hour+15*time.Minute), "success")   // before start -> excluded
+	insertCountTestLog(t, db, day.Add(10*time.Hour+45*time.Minute), "success")   // head sliver -> counted
+	insertCountTestLog(t, db, day.Add(18*time.Hour), "success")                  // interior -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour), "success")                  // tail sliver -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour+30*time.Minute), "error")     // tail sliver -> counted
+	insertCountTestLog(t, db, day.Add(35*time.Hour+50*time.Minute), "success")   // after end -> excluded
+	insertCountTestLog(t, db, day.Add(18*time.Hour+5*time.Minute), "processing") // in-flight -> in totals, not in rates
+
+	refreshTestMatViews(t, db)
+	store.matViewsReady.Store(true)
+
+	filters := SearchFilters{StartTime: &start, EndTime: &end}
+	require.True(t, store.canUseMatViewForFreshAggregate(filters), "window must take the matview stats path")
+
+	stats, err := store.GetStats(ctx, filters)
+	require.NoError(t, err)
+	searchResult, err := store.SearchLogs(ctx, filters, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+
+	assert.Equal(t, searchResult.Pagination.TotalCount, stats.TotalRequests,
+		"stat card total and pagination total render on the same page for the same filters and must agree")
+	assert.Equal(t, int64(5), stats.TotalRequests,
+		"4 terminal + 1 in-flight log inside [start, end]")
+	assert.InDelta(t, 75.0, stats.SuccessRate, 0.001,
+		"success rate is terminal-only: 3 successes out of 4 completed")
+	require.NotNil(t, stats.CacheHitRateTotalRequests)
+	assert.Equal(t, int64(4), *stats.CacheHitRateTotalRequests,
+		"cache-hit denominator is the exact-range completed count")
+}
+
+// TestGetHistogramMatViewTrimsBoundaryBuckets verifies the matview histogram
+// path only counts in-window rows in the first and last display buckets,
+// matching the raw histogram path's exact timestamp predicates - previously
+// the boundary buckets included every row of their full hour, so the chart
+// disagreed with the exact-range stats total for the same filters.
+func TestGetHistogramMatViewTrimsBoundaryBuckets(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	day := time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+	start := day.Add(10*time.Hour + 30*time.Minute)
+	end := day.Add(35*time.Hour + 45*time.Minute)
+
+	insertCountTestLog(t, db, day.Add(10*time.Hour+15*time.Minute), "success")   // before start -> must not appear
+	insertCountTestLog(t, db, day.Add(10*time.Hour+45*time.Minute), "success")   // head sliver -> first bar
+	insertCountTestLog(t, db, day.Add(18*time.Hour), "error")                    // interior
+	insertCountTestLog(t, db, day.Add(35*time.Hour+30*time.Minute), "success")   // tail sliver -> last bar
+	insertCountTestLog(t, db, day.Add(35*time.Hour+50*time.Minute), "success")   // after end -> must not appear
+	insertCountTestLog(t, db, day.Add(18*time.Hour+5*time.Minute), "processing") // in-flight -> histograms are terminal-only on both paths
+
+	refreshTestMatViews(t, db)
+	store.matViewsReady.Store(true)
+
+	filters := SearchFilters{StartTime: &start, EndTime: &end}
+	require.True(t, store.canUseMatView(filters), "filters must take the matview histogram path")
+
+	hist, err := store.GetHistogram(ctx, filters, 3600)
+	require.NoError(t, err)
+
+	var total, success, errCount int64
+	byBucket := make(map[int64]int64, len(hist.Buckets))
+	for _, b := range hist.Buckets {
+		total += b.Count
+		success += b.Success
+		errCount += b.Error
+		byBucket[b.Timestamp.Unix()] = b.Count
+	}
+	assert.Equal(t, int64(3), total, "bars must sum to the terminal logs inside [start, end] only")
+	assert.Equal(t, int64(2), success)
+	assert.Equal(t, int64(1), errCount)
+	assert.Equal(t, int64(1), byBucket[day.Add(10*time.Hour).Unix()],
+		"first bar holds only the in-window sliver row, not the pre-start row from the same hour")
+	assert.Equal(t, int64(1), byBucket[day.Add(35*time.Hour).Unix()],
+		"last bar holds only the in-window sliver row, not the post-end row from the same hour")
+}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -777,10 +777,11 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Durat
 }
 
 // canUseMatViewFilters returns true if the given filters can be served from
-// mv_logs_hourly. Per-row filters (content search, metadata, numeric ranges)
-// require the raw logs table.
+// mv_logs_hourly. Per-row filters (content search, parent request ID, metadata,
+// numeric ranges) require the raw logs table.
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
+		f.ParentRequestID == "" &&
 		len(f.MetadataFilters) == 0 &&
 		canUseMatViewStatusFilter(f.Status) &&
 		len(f.RoutingEngineUsed) == 0 &&
@@ -880,7 +881,12 @@ func applyMatViewFiltersOnly(q *gorm.DB, f SearchFilters) *gorm.DB {
 		q = q.Where("provider IN ?", f.Providers)
 	}
 	if len(f.Models) > 0 {
-		q = q.Where("model IN ?", f.Models)
+		// Match either the wire model or the canonical model name, mirroring
+		// applyFilters on the raw logs table, so matview aggregates and the raw
+		// row list select the same population for a Models filter. The view
+		// stores COALESCE(canonical_model_name, '') so unaliased buckets can
+		// only match via model.
+		q = q.Where("(model IN ? OR canonical_model_name IN ?)", f.Models, f.Models)
 	}
 	if len(f.Aliases) > 0 {
 		q = q.Where("alias IN ?", f.Aliases)
@@ -921,46 +927,276 @@ func applyMatViewFiltersOnly(q *gorm.DB, f SearchFilters) *gorm.DB {
 
 // getCountFromMatView returns the total number of logs matching the filters
 // by summing pre-aggregated counts from mv_logs_hourly.
+//
+// For time-bounded windows the count is hybrid: mv_logs_hourly rows are hourly
+// buckets, so predicates on `hour` alone round the window out to full hours and
+// count logs the (exact-range, raw-table) row list can never page to — the
+// pagination total then disagrees with the visible rows. Instead, only buckets
+// fully contained in [StartTime, EndTime] are summed from the matview, and the
+// partial boundary buckets (at most one on each side) are counted from the raw
+// logs table, where a timestamp-indexed scan over ≤2 hours of rows is cheap.
+// The raw tail also sidesteps matview refresh lag at the newest edge of the
+// window. The boundary count is restricted to the matview's terminal statuses
+// when no status filter is present so both halves count the same population;
+// in-flight (non-terminal) rows, which the row list shows but the matview
+// cannot see, are then added back with a separate raw count over the exact
+// window so total_count matches what the list can page to.
+//
+// All bucket-grid arithmetic happens in SQL, never in Go: date_trunc('hour',
+// timestamptz) truncates in the session's TimeZone, so on servers with a
+// fractional-hour offset (e.g. Asia/Kolkata, +05:30) buckets land on :30 UTC
+// boundaries and a Go-side time.Truncate(time.Hour) would misalign with the
+// grid, double-counting rows where the interior and slivers overlap.
 func (s *RDBLogStore) getCountFromMatView(ctx context.Context, filters SearchFilters) (int64, error) {
-	var total int64
+	// The row list and the raw aggregate paths include in-flight rows, which
+	// mv_logs_hourly structurally excludes; add them back from the raw table
+	// (an equality scan on the indexed status column over the few in-flight
+	// rows) so total_count matches the rows the list can actually page to.
+	var nonTerminal int64
+	if len(filters.Status) == 0 {
+		var err error
+		if nonTerminal, err = s.countRawNonTerminal(ctx, filters); err != nil {
+			return 0, err
+		}
+	}
+
+	// Time predicates are applied explicitly below; strip them from the copies
+	// so the filter helpers only contribute the dimension predicates.
+	dimFilters := filters
+	dimFilters.StartTime, dimFilters.EndTime = nil, nil
+
+	if isDegenerateHybridWindow(filters.StartTime, filters.EndTime) {
+		// Short window (never matview-eligible via
+		// canUseMatViewForFreshAggregate, but guard anyway): the boundary
+		// slivers would overlap, so count the whole range raw.
+		terminal, err := s.countRawTerminal(ctx, dimFilters,
+			"timestamp >= ? AND timestamp <= ?", *filters.StartTime, *filters.EndTime)
+		if err != nil {
+			return 0, err
+		}
+		return terminal + nonTerminal, nil
+	}
+
+	var interior int64
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
-	q = s.applyMatViewFilters(q, filters)
-	if err := q.Select("COALESCE(SUM(count), 0)").Row().Scan(&total); err != nil {
+	q = s.applyMatViewFilters(q, dimFilters)
+	q = applyInteriorBucketWindow(q, filters.StartTime, filters.EndTime)
+	if err := q.Select("COALESCE(SUM(count), 0)").Row().Scan(&interior); err != nil {
 		return 0, err
 	}
-	return total, nil
+
+	sliverSQL, sliverArgs := boundarySliverWhere(filters.StartTime, filters.EndTime)
+	if sliverSQL == "" {
+		return interior + nonTerminal, nil
+	}
+	boundary, err := s.countRawTerminal(ctx, dimFilters, sliverSQL, sliverArgs...)
+	if err != nil {
+		return 0, err
+	}
+	return interior + boundary + nonTerminal, nil
 }
 
-// getStatsFromMatView computes dashboard statistics (total requests, success
-// rate, average latency, total tokens, total cost) from mv_logs_hourly.
-// Latency is a weighted average across hourly buckets.
-func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFilters) (*SearchStats, error) {
-	var result struct {
-		TotalCount       int64   `gorm:"column:total_count"`
-		SuccessCount     int64   `gorm:"column:success_count"`
-		AvgLatency       float64 `gorm:"column:avg_latency"`
-		TotalTokens      int64   `gorm:"column:total_tokens"`
-		PromptTokens     int64   `gorm:"column:prompt_tokens"`
-		CompletionTokens int64   `gorm:"column:completion_tokens"`
-		TotalCost        float64 `gorm:"column:total_cost"`
+// applyInteriorBucketWindow adds mv_logs_hourly predicates selecting only the
+// hour buckets fully contained in the filter window. `hour >= start` admits a
+// bucket only when its start lies at-or-after start (ceil semantics on the
+// server's own grid); `hour < date_trunc(end)` excludes the partial bucket
+// containing end (and, when end sits exactly on the grid, the untouched
+// bucket that begins at end). Nil bounds contribute no predicate.
+func applyInteriorBucketWindow(q *gorm.DB, start, end *time.Time) *gorm.DB {
+	if start != nil {
+		q = q.Where("hour >= ?", *start)
 	}
+	if end != nil {
+		q = q.Where("hour < date_trunc('hour', ?::timestamptz)", *end)
+	}
+	return q
+}
+
+// boundarySliverWhere returns the raw-table predicate selecting the rows in
+// the partial boundary bucket(s) that applyInteriorBucketWindow excluded.
+// Head: rows at-or-after start whose bucket began before start. Tail: rows
+// at-or-before end whose bucket is the one containing end (or starting at
+// it). Each per-row date_trunc only runs inside a ≤1h timestamp-indexed
+// range. Returns "" when the window has no bounds (no slivers exist). The two
+// ranges cannot overlap as long as callers route windows shorter than 2h
+// (isDegenerateHybridWindow) to a whole-range raw query instead.
+func boundarySliverWhere(start, end *time.Time) (string, []any) {
+	var conds []string
+	var args []any
+	if start != nil {
+		conds = append(conds, "(timestamp >= ? AND timestamp < ? AND date_trunc('hour', timestamp) < ?::timestamptz)")
+		args = append(args, *start, start.Add(time.Hour), *start)
+	}
+	if end != nil {
+		conds = append(conds, "(timestamp > ? AND timestamp <= ? AND date_trunc('hour', timestamp) >= date_trunc('hour', ?::timestamptz))")
+		args = append(args, end.Add(-time.Hour), *end, *end)
+	}
+	return strings.Join(conds, " OR "), args
+}
+
+// isDegenerateHybridWindow reports whether the window is too short for the
+// interior/sliver split (the two slivers would overlap): both bounds set and
+// less than two full hour buckets apart. Such windows are aggregated wholly
+// from the raw table.
+func isDegenerateHybridWindow(start, end *time.Time) bool {
+	return start != nil && end != nil && end.Sub(*start) < 2*time.Hour
+}
+
+// countRawTerminal counts raw logs rows matching the dimension filters plus an
+// explicit time predicate, restricted to terminal statuses when the filters do
+// not already pin status — mirroring mv_logs_hourly's WHERE clause so hybrid
+// counts sum a consistent population across the matview and raw halves.
+func (s *RDBLogStore) countRawTerminal(ctx context.Context, dimFilters SearchFilters, timePredicate string, timeArgs ...any) (int64, error) {
+	var count int64
+	q := s.ScopedDB(ctx).Model(&Log{})
+	q = s.applyFilters(q, dimFilters)
+	q = q.Where(timePredicate, timeArgs...)
+	if len(dimFilters.Status) == 0 {
+		q = q.Where("status IN ?", terminalLogStatuses)
+	}
+	if err := q.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// countRawNonTerminal counts in-flight rows matching the full filters (time
+// predicates included, via applyFilters). Equality on the indexed status
+// column keeps the cost proportional to the number of in-flight rows (bounded
+// by request concurrency plus the logging plugin's 30-minute stale-row
+// cleanup), not to the window size. Callers only invoke this when no status
+// filter is set; an explicit status filter is terminal-only by matview
+// eligibility and excludes in-flight rows on every path.
+func (s *RDBLogStore) countRawNonTerminal(ctx context.Context, filters SearchFilters) (int64, error) {
+	var count int64
+	q := s.ScopedDB(ctx).Model(&Log{})
+	q = s.applyFilters(q, filters)
+	q = q.Where("status IN ?", nonTerminalLogStatuses)
+	if err := q.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// matViewStatsAgg holds the additive stat fields that the hybrid stats path
+// sums across the matview interior and the raw boundary slivers. LatencySum is
+// the total latency over counted rows (SUM(avg_latency*count) on the matview,
+// SUM(latency) on raw), divided once at the end for the combined average.
+type matViewStatsAgg struct {
+	Count            int64   `gorm:"column:total_count"`
+	SuccessCount     int64   `gorm:"column:success_count"`
+	LatencySum       float64 `gorm:"column:latency_sum"`
+	TotalTokens      int64   `gorm:"column:total_tokens"`
+	PromptTokens     int64   `gorm:"column:prompt_tokens"`
+	CompletionTokens int64   `gorm:"column:completion_tokens"`
+	TotalCost        float64 `gorm:"column:total_cost"`
+}
+
+func (a *matViewStatsAgg) add(b matViewStatsAgg) {
+	a.Count += b.Count
+	a.SuccessCount += b.SuccessCount
+	a.LatencySum += b.LatencySum
+	a.TotalTokens += b.TotalTokens
+	a.PromptTokens += b.PromptTokens
+	a.CompletionTokens += b.CompletionTokens
+	a.TotalCost += b.TotalCost
+}
+
+// matViewInteriorStatsAgg sums the additive stat fields over the hour buckets
+// fully contained in the window.
+func (s *RDBLogStore) matViewInteriorStatsAgg(ctx context.Context, dimFilters SearchFilters, start, end *time.Time) (matViewStatsAgg, error) {
+	var agg matViewStatsAgg
 	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
-	q = s.applyMatViewFilters(q, filters)
-	if err := q.Select(`
+	q = s.applyMatViewFilters(q, dimFilters)
+	q = applyInteriorBucketWindow(q, start, end)
+	err := q.Select(`
 		COALESCE(SUM(count), 0) AS total_count,
 		COALESCE(SUM(success_count), 0) AS success_count,
-		CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_latency,
+		COALESCE(SUM(avg_latency * count), 0) AS latency_sum,
 		COALESCE(SUM(total_tokens), 0) AS total_tokens,
 		COALESCE(SUM(total_prompt_tokens), 0) AS prompt_tokens,
 		COALESCE(SUM(total_completion_tokens), 0) AS completion_tokens,
 		COALESCE(SUM(total_cost), 0) AS total_cost
-	`).Scan(&result).Error; err != nil {
-		return nil, err
+	`).Scan(&agg).Error
+	return agg, err
+}
+
+// rawTerminalStatsAgg mirrors matViewInteriorStatsAgg over raw logs rows for
+// an explicit time predicate (boundary slivers or a degenerate whole window),
+// restricted to terminal statuses when no status filter is present so both
+// halves of the hybrid aggregate the same population.
+func (s *RDBLogStore) rawTerminalStatsAgg(ctx context.Context, dimFilters SearchFilters, timePredicate string, timeArgs ...any) (matViewStatsAgg, error) {
+	var agg matViewStatsAgg
+	q := s.ScopedDB(ctx).Model(&Log{})
+	q = s.applyFilters(q, dimFilters)
+	q = q.Where(timePredicate, timeArgs...)
+	if len(dimFilters.Status) == 0 {
+		q = q.Where("status IN ?", terminalLogStatuses)
+	}
+	err := q.Select(`
+		COUNT(*) AS total_count,
+		COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0) AS success_count,
+		COALESCE(SUM(latency), 0) AS latency_sum,
+		COALESCE(SUM(total_tokens), 0) AS total_tokens,
+		COALESCE(SUM(prompt_tokens), 0) AS prompt_tokens,
+		COALESCE(SUM(completion_tokens), 0) AS completion_tokens,
+		COALESCE(SUM(cost), 0) AS total_cost
+	`).Scan(&agg).Error
+	return agg, err
+}
+
+// getStatsFromMatView computes dashboard statistics (total requests, success
+// rate, average latency, total tokens, total cost) from mv_logs_hourly using
+// the same exact-range hybrid as getCountFromMatView: interior buckets from
+// the matview, partial boundary buckets from the raw table, and in-flight
+// rows added to TotalRequests. This keeps the stats total equal to the
+// pagination total for the same filters (both halves of the same UI page).
+// Latency is a weighted average across the combined population.
+func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFilters) (*SearchStats, error) {
+	// Time predicates are applied explicitly; strip them so the filter helpers
+	// only contribute dimension predicates.
+	dimFilters := filters
+	dimFilters.StartTime, dimFilters.EndTime = nil, nil
+
+	var agg matViewStatsAgg
+	if isDegenerateHybridWindow(filters.StartTime, filters.EndTime) {
+		var err error
+		agg, err = s.rawTerminalStatsAgg(ctx, dimFilters,
+			"timestamp >= ? AND timestamp <= ?", *filters.StartTime, *filters.EndTime)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		var err error
+		agg, err = s.matViewInteriorStatsAgg(ctx, dimFilters, filters.StartTime, filters.EndTime)
+		if err != nil {
+			return nil, err
+		}
+		if sliverSQL, sliverArgs := boundarySliverWhere(filters.StartTime, filters.EndTime); sliverSQL != "" {
+			boundary, err := s.rawTerminalStatsAgg(ctx, dimFilters, sliverSQL, sliverArgs...)
+			if err != nil {
+				return nil, err
+			}
+			agg.add(boundary)
+		}
 	}
 
-	var successRate float64
-	if result.TotalCount > 0 {
-		successRate = float64(result.SuccessCount) / float64(result.TotalCount) * 100
+	// TotalRequests includes in-flight rows, mirroring the raw GetStats path
+	// (whose total count "includes processing status") and the pagination
+	// total; rate denominators stay terminal-only, also mirroring raw.
+	var nonTerminal int64
+	if len(filters.Status) == 0 {
+		var err error
+		if nonTerminal, err = s.countRawNonTerminal(ctx, filters); err != nil {
+			return nil, err
+		}
+	}
+
+	completed := agg.Count
+	var successRate, avgLatency float64
+	if completed > 0 {
+		successRate = float64(agg.SuccessCount) / float64(completed) * 100
+		avgLatency = agg.LatencySum / float64(completed)
 	}
 
 	// User-facing success rate requires per-request fallback chain data which is not
@@ -968,33 +1204,26 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 	// (>100 GB) can take minutes, so the matview path uses the per-attempt success rate
 	// as a fast approximation. Accurate chain-level computation runs in the raw-table path.
 
-	cacheHitRateTotalRequests := result.TotalCount
 	stats := &SearchStats{
-		TotalRequests:             result.TotalCount,
+		TotalRequests:             completed + nonTerminal,
 		SuccessRate:               successRate,
 		UserFacingSuccessRate:     successRate,
-		UserFacingTotalRequests:   result.TotalCount, // matview approximation; no per-chain data available
-		AverageLatency:            result.AvgLatency,
-		TotalTokens:               result.TotalTokens,
-		PromptTokens:              result.PromptTokens,
-		CompletionTokens:          result.CompletionTokens,
-		TotalCost:                 result.TotalCost,
-		CacheHitRateTotalRequests: &cacheHitRateTotalRequests,
+		UserFacingTotalRequests:   completed, // matview approximation; no per-chain data available
+		AverageLatency:            avgLatency,
+		TotalTokens:               agg.TotalTokens,
+		PromptTokens:              agg.PromptTokens,
+		CompletionTokens:          agg.CompletionTokens,
+		TotalCost:                 agg.TotalCost,
+		CacheHitRateTotalRequests: &completed,
 	}
 
-	// cache_debug is not stored in the matview — query the raw logs table directly.
-	// Align the time window to hour boundaries to match the matview denominator (TotalRequests).
-	alignedFilters := filters
-	if filters.StartTime != nil {
-		aligned := filters.StartTime.Truncate(time.Hour)
-		alignedFilters.StartTime = &aligned
-	}
-	if filters.EndTime != nil {
-		alignedEnd := filters.EndTime.Truncate(time.Hour).Add(time.Hour - time.Nanosecond)
-		alignedFilters.EndTime = &alignedEnd
-	}
+	// cache_debug is not stored in the matview — query the raw logs table
+	// directly over the exact window. The denominator (the hybrid terminal
+	// count) is exact-range now, so no hour alignment is needed; this also
+	// avoids Go-side time.Truncate, which would misalign with the SQL
+	// date_trunc grid on servers with fractional-hour timezone offsets.
 	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", terminalLogStatuses)
-	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, alignedFilters)
+	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, filters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
 	} else if direct != nil || semantic != nil {
@@ -1006,40 +1235,122 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 }
 
 // getHistogramFromMatView returns time-bucketed request counts (total,
-// success, error, cancelled) by re-aggregating hourly buckets from mv_logs_hourly.
+// success, error, cancelled) by re-aggregating hourly buckets from
+// mv_logs_hourly. Like getCountFromMatView, boundary display buckets are
+// exact-range: only hour buckets fully contained in the window come from the
+// matview; rows in the partial boundary hour(s) are re-bucketed from the raw
+// table, so the first and last bars only count in-window rows, matching the
+// raw histogram path (which applies exact timestamp predicates). Both halves
+// are terminal-only, mirroring the raw path's status restriction.
 func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*HistogramResult, error) {
-	var results []struct {
+	type histAgg struct {
 		BucketTimestamp int64 `gorm:"column:bucket_timestamp"`
 		Total           int64 `gorm:"column:total"`
 		Success         int64 `gorm:"column:success"`
 		ErrorCount      int64 `gorm:"column:error_count"`
 		CancelledCount  int64 `gorm:"column:cancelled_count"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
-	q = s.applyMatViewFilters(q, filters)
-	if err := q.Select(fmt.Sprintf(`
-		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
-		SUM(count) AS total,
-		SUM(success_count) AS success,
-		SUM(error_count) AS error_count,
-		SUM(cancelled_count) AS cancelled_count
-	`, bucketSizeSeconds, bucketSizeSeconds)).
-		Group("bucket_timestamp").
-		Order("bucket_timestamp ASC").
-		Find(&results).Error; err != nil {
-		return nil, err
+
+	// Time predicates are applied explicitly; strip them so the filter helpers
+	// only contribute dimension predicates.
+	dimFilters := filters
+	dimFilters.StartTime, dimFilters.EndTime = nil, nil
+
+	acc := make(map[int64]*struct{ total, success, errCount, cancelledCount int64 })
+	merge := func(rows []histAgg) {
+		for _, r := range rows {
+			b, ok := acc[r.BucketTimestamp]
+			if !ok {
+				b = &struct{ total, success, errCount, cancelledCount int64 }{}
+				acc[r.BucketTimestamp] = b
+			}
+			b.total += r.Total
+			b.success += r.Success
+			b.errCount += r.ErrorCount
+			b.cancelledCount += r.CancelledCount
+		}
 	}
 
-	resultMap := make(map[int64]*struct{ total, success, errCount, cancelledCount int64 }, len(results))
-	for _, r := range results {
-		resultMap[r.BucketTimestamp] = &struct{ total, success, errCount, cancelledCount int64 }{r.Total, r.Success, r.ErrorCount, r.CancelledCount}
+	rawBucketed := func(timePredicate string, timeArgs ...any) ([]histAgg, error) {
+		var rows []histAgg
+		q := s.ScopedDB(ctx).Model(&Log{})
+		q = s.applyFilters(q, dimFilters)
+		q = q.Where(timePredicate, timeArgs...)
+		q = q.Where("status IN ?", terminalLogStatuses)
+		err := q.Select(fmt.Sprintf(`
+			%s AS bucket_timestamp,
+			COUNT(*) AS total,
+			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS success,
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_count,
+			SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) AS cancelled_count
+		`, unixBucketExpr("postgres", bucketSizeSeconds))).
+			Group("bucket_timestamp").
+			Find(&rows).Error
+		return rows, err
+	}
+
+	if isDegenerateHybridWindow(filters.StartTime, filters.EndTime) {
+		// Window too short for the interior/sliver split (reachable here:
+		// GetHistogram gates on canUseMatView, which has no window check).
+		rows, err := rawBucketed("timestamp >= ? AND timestamp <= ?", *filters.StartTime, *filters.EndTime)
+		if err != nil {
+			return nil, err
+		}
+		merge(rows)
+	} else {
+		var results []histAgg
+		q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		q = s.applyMatViewFilters(q, dimFilters)
+		q = applyInteriorBucketWindow(q, filters.StartTime, filters.EndTime)
+		if err := q.Select(fmt.Sprintf(`
+			CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
+			SUM(count) AS total,
+			SUM(success_count) AS success,
+			SUM(error_count) AS error_count,
+			SUM(cancelled_count) AS cancelled_count
+		`, bucketSizeSeconds, bucketSizeSeconds)).
+			Group("bucket_timestamp").
+			Find(&results).Error; err != nil {
+			return nil, err
+		}
+		merge(results)
+
+		if sliverSQL, sliverArgs := boundarySliverWhere(filters.StartTime, filters.EndTime); sliverSQL != "" {
+			rows, err := rawBucketed(sliverSQL, sliverArgs...)
+			if err != nil {
+				return nil, err
+			}
+			merge(rows)
+		}
 	}
 
 	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+	if len(allTimestamps) == 0 {
+		// No fully-bounded range to enumerate: return the populated buckets in
+		// order, mirroring the raw path's unbounded-range behavior.
+		keys := make([]int64, 0, len(acc))
+		for ts := range acc {
+			keys = append(keys, ts)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		buckets := make([]HistogramBucket, 0, len(keys))
+		for _, ts := range keys {
+			a := acc[ts]
+			buckets = append(buckets, HistogramBucket{
+				Timestamp: time.Unix(ts, 0).UTC(),
+				Count:     a.total,
+				Success:   a.success,
+				Error:     a.errCount,
+				Cancelled: a.cancelledCount,
+			})
+		}
+		return &HistogramResult{Buckets: buckets, BucketSizeSeconds: bucketSizeSeconds}, nil
+	}
+
 	buckets := make([]HistogramBucket, 0, len(allTimestamps))
 	for _, ts := range allTimestamps {
 		b := HistogramBucket{Timestamp: time.Unix(ts, 0).UTC()}
-		if a, ok := resultMap[ts]; ok {
+		if a, ok := acc[ts]; ok {
 			b.Count = a.total
 			b.Success = a.success
 			b.Error = a.errCount

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -88,4 +88,5 @@ func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
 	assert.False(t, canUseMatViewFilters(SearchFilters{TeamIDs: []string{"t1"}}), "team filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{BusinessUnitIDs: []string{"bu1"}}), "BU filter must force the raw path")
 	assert.False(t, canUseMatViewFilters(SearchFilters{CustomerIDs: []string{"c1"}}), "customer filter must force the raw path")
+	assert.False(t, canUseMatViewFilters(SearchFilters{ParentRequestID: "req-1"}), "parent request filter has no matview dimension and must force the raw path")
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -46,6 +46,12 @@ const (
 
 var terminalLogStatuses = []string{"success", "error", "cancelled"}
 
+// nonTerminalLogStatuses are the in-flight statuses structurally absent from
+// mv_logs_hourly (its DDL filters to terminalLogStatuses). Matview-backed
+// counts add these back from the raw table so totals match the row list and
+// the raw aggregate paths, which do not exclude in-flight rows.
+var nonTerminalLogStatuses = []string{"processing"}
+
 // RDBLogStore represents a log store that uses a SQLite database.
 type RDBLogStore struct {
 	db            *gorm.DB
@@ -1183,7 +1189,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1295,7 +1301,7 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1414,7 +1420,7 @@ func (s *RDBLogStore) GetThroughputHistogram(ctx context.Context, filters Search
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1501,7 +1507,7 @@ func (s *RDBLogStore) GetProviderThroughputHistogram(ctx context.Context, filter
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getProviderThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1594,7 +1600,7 @@ func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilter
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getCostHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1700,7 +1706,7 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getModelHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -1839,7 +1845,7 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -2571,7 +2577,7 @@ func (s *RDBLogStore) GetProviderCostHistogram(ctx context.Context, filters Sear
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getProviderCostHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -2666,7 +2672,7 @@ func (s *RDBLogStore) GetProviderTokenHistogram(ctx context.Context, filters Sea
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getProviderTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -2773,7 +2779,7 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getProviderLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds)
 	}
 
@@ -3137,7 +3143,7 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 		dimValueExpr = bucketedIDExpr(dimCol)
 		groupCol = dimValueExpr
 	}
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getDimensionCostHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
@@ -3237,7 +3243,7 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 		dimValueExpr = bucketedIDExpr(dimCol)
 		groupCol = dimValueExpr
 	}
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getDimensionTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
@@ -3346,7 +3352,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
+	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
 		return s.getDimensionLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
 	}
 	dialect := s.db.Dialector.Name()


### PR DESCRIPTION
## Summary

Fixes a pagination `total_count` bug where matview-eligible windows (≥24h) returned an inflated count because `mv_logs_hourly` predicates on `hour` rounded both time boundaries out to full hour buckets, counting logs that the exact-range row list could never page to. Closes #5329.

## Changes

- Replaced the single `mv_logs_hourly` sum in `getCountFromMatView` with a hybrid approach: only buckets fully contained within `[StartTime, EndTime]` are summed from the matview; the partial boundary buckets (at most one on each side) are counted directly from the raw `logs` table using a timestamp-indexed scan over ≤2 hours of rows.
- Introduced `countRawTerminal` to count raw log rows restricted to terminal statuses when no status filter is present, ensuring both halves of the hybrid count cover the same population as `mv_logs_hourly`.
- All bucket-grid arithmetic is performed in SQL via `date_trunc('hour', timestamptz)` rather than Go-side `time.Truncate`, so servers with fractional-hour timezone offsets (e.g. `Asia/Kolkata`, +05:30) produce correct bucket boundaries without misalignment.
- Added `TestSearchLogsMatViewCountMatchesRawRange` to assert that `total_count` matches the number of terminal logs strictly within `[StartTime, EndTime]` across mid-hour, hour-aligned-start, and hour-aligned-end boundary cases.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/... -run TestSearchLogsMatViewCountMatchesRawRange -v
```

The test inserts logs at known timestamps straddling a 25h15m window, refreshes the matviews, forces the matview count path, and asserts that `total_count` equals exactly the number of terminal logs inside `[start, end]` for three boundary configurations (mid-hour boundaries, hour-aligned end, hour-aligned start).

## Breaking changes

- [x] No

## Related issues

Closes #5329

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable