### PR TITLE
feat: add `scope_id` filter to model configs query params and API

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4874,6 +4874,9 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 	if params.Scope != "" {
 		baseQuery = baseQuery.Where("scope = ?", params.Scope)
 	}
+	if params.ScopeID != "" {
+		baseQuery = baseQuery.Where("scope_id = ?", params.ScopeID)
+	}
 	if params.Provider != "" {
 		baseQuery = baseQuery.Where("provider = ?", params.Provider)
 	}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -35,6 +35,7 @@ type ModelConfigsQueryParams struct {
 	Offset   int
 	Search   string
 	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
+	ScopeID  string // optional; filters to an exact scope target (e.g. a virtual key or user ID)
 	Provider string // optional; filters to an exact provider value (e.g. "openai")
 }
 

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -3011,6 +3011,7 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 		}
 		search := string(ctx.QueryArgs().Peek("search"))
 		scopeFilter := string(ctx.QueryArgs().Peek("scope"))
+		scopeIDFilter := string(ctx.QueryArgs().Peek("scope_id"))
 		providerFilter := string(ctx.QueryArgs().Peek("provider"))
 		// Deep-copy into a value slice: top-level struct copy + nested pointer/slice fields
 		// so we never alias or mutate live governance state during serialization.
@@ -3024,6 +3025,11 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			}
 			if scopeFilter != "" && mc.Scope != scopeFilter {
 				continue
+			}
+			if scopeIDFilter != "" {
+				if mc.ScopeID == nil || *mc.ScopeID != scopeIDFilter {
+					continue
+				}
 			}
 			if providerFilter != "" {
 				if mc.Provider == nil || *mc.Provider != providerFilter {
@@ -3086,13 +3092,15 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 	offsetStr := string(ctx.QueryArgs().Peek("offset"))
 	search := string(ctx.QueryArgs().Peek("search"))
 	scope := string(ctx.QueryArgs().Peek("scope"))
+	scopeID := string(ctx.QueryArgs().Peek("scope_id"))
 	provider := string(ctx.QueryArgs().Peek("provider"))
 
-	if limitStr != "" || offsetStr != "" || search != "" || scope != "" || provider != "" {
+	if limitStr != "" || offsetStr != "" || search != "" || scope != "" || scopeID != "" || provider != "" {
 		// Paginated path
 		params := configstore.ModelConfigsQueryParams{
 			Search:   search,
 			Scope:    scope,
+			ScopeID:  scopeID,
 			Provider: provider,
 		}
 		if limitStr != "" {

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -509,6 +509,7 @@ export const governanceApi = baseApi.injectEndpoints({
 					...(params?.offset !== undefined && { offset: params.offset }),
 					...(params?.search && { search: params.search }),
 					...(params?.scope && { scope: params.scope }),
+					...(params?.scope_id && { scope_id: params.scope_id }),
 					...(params?.provider && { provider: params.provider }),
 				},
 			}),
@@ -540,6 +541,7 @@ export const governanceApi = baseApi.injectEndpoints({
 						const args = entry.originalArgs as GetModelConfigsParams | undefined;
 						if (args?.search && !mc.model_name.toLowerCase().includes(args.search.toLowerCase())) continue;
 						if (args?.scope && mc.scope !== args.scope) continue;
+						if (args?.scope_id && mc.scope_id !== args.scope_id) continue;
 						if (args?.provider && mc.provider !== args.provider) continue;
 						dispatch(
 							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -391,6 +391,7 @@ export interface GetModelConfigsParams {
 	offset?: number;
 	search?: string;
 	scope?: string;
+	scope_id?: string;
 	provider?: string;
 }
 


### PR DESCRIPTION
## Summary

Adds `scope_id` as a filterable query parameter when listing model configs, allowing callers to narrow results to a specific scope target (e.g. a particular virtual key or user ID).

## Changes

- Added `ScopeID` field to `ModelConfigsQueryParams` and wired it into the RDB query as a `WHERE scope_id = ?` clause
- Extended the HTTP handler to read the `scope_id` query argument and pass it through both the in-memory (non-paginated) and paginated code paths
- Added `scope_id` to the `GetModelConfigsParams` TypeScript interface and included it in the API request query params
- Applied `scope_id` filtering in the optimistic cache update logic so the UI cache stays consistent with the filter

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./...

# Start the server and query model configs filtered by scope_id
curl "http://localhost:PORT/api/model-configs?scope=virtual_key&scope_id=<your-virtual-key-id>"
# Verify only configs matching the given scope_id are returned

# UI
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `scope_id` value is passed as a parameterized query argument, so there is no SQL injection risk. No PII or secrets are exposed beyond what the existing `scope` filter already permits.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable