### PR TITLE
expose tier/mechanism on every surface

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -90,6 +90,8 @@ export default function LogsPage() {
 			routing_engine_used: parseAsSafeArrayOf.withDefault([]),
 			apps: parseAsSafeArrayOf.withDefault([]),
 			user_agents: parseAsSafeArrayOf.withDefault([]),
+			complexity_tiers: parseAsSafeArrayOf.withDefault([]),
+			complexity_mechanisms: parseAsSafeArrayOf.withDefault([]),
 			user_ids: parseAsSafeArrayOf.withDefault([]),
 			team_ids: parseAsSafeArrayOf.withDefault([]),
 			customer_ids: parseAsSafeArrayOf.withDefault([]),
@@ -139,6 +141,8 @@ export default function LogsPage() {
 			routing_engine_used: urlState.routing_engine_used,
 			apps: urlState.apps,
 			user_agents: urlState.user_agents,
+			complexity_tiers: urlState.complexity_tiers,
+			complexity_mechanisms: urlState.complexity_mechanisms,
 			user_ids: urlState.user_ids,
 			team_ids: urlState.team_ids,
 			customer_ids: urlState.customer_ids,
@@ -177,6 +181,8 @@ export default function LogsPage() {
 			urlState.routing_engine_used,
 			urlState.apps,
 			urlState.user_agents,
+			urlState.complexity_tiers,
+			urlState.complexity_mechanisms,
 			urlState.user_ids,
 			urlState.team_ids,
 			urlState.customer_ids,
@@ -211,8 +217,7 @@ export default function LogsPage() {
 			// period mode `newFilters` carries no start/end, so only touch time when an
 			// explicit range is actually provided — otherwise we'd wipe the active period/range.
 			const hasExplicitTime = !!newFilters.start_time && !!newFilters.end_time;
-			const timeChanged =
-				hasExplicitTime && (newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time);
+			const timeChanged = hasExplicitTime && (newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time);
 			if (timeChanged) {
 				userModifiedTimeRange.current = true;
 			}
@@ -237,6 +242,8 @@ export default function LogsPage() {
 				routing_engine_used: newFilters.routing_engine_used || [],
 				apps: newFilters.apps || [],
 				user_agents: newFilters.user_agents || [],
+				complexity_tiers: newFilters.complexity_tiers || [],
+				complexity_mechanisms: newFilters.complexity_mechanisms || [],
 				user_ids: newFilters.user_ids || [],
 				team_ids: newFilters.team_ids || [],
 				customer_ids: newFilters.customer_ids || [],

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -28,6 +28,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { ProviderIconType, RenderProviderIcon, RoutingEngineUsedIcons } from "@/lib/constants/icons";
 import {
+	ComplexityTierColors,
 	logAppDisplayName,
 	mapAppToClientApp,
 	mapUserAgentToApp,
@@ -37,6 +38,7 @@ import {
 	RoutingEngineUsedLabels,
 	Status,
 } from "@/lib/constants/logs";
+import { COMPLEXITY_MECHANISM_LABELS } from "@/lib/types/complexityRouter";
 import { ContentBlock, LogEntry, ResponsesMessage } from "@/lib/types/logs";
 import { useGetUserAgentMappingsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
@@ -477,6 +479,34 @@ const messageRoleLabel: Record<MessageRole, string> = {
 	tool: "Tool Result",
 };
 
+// deriveComplexityRouting returns the complexity tier / classification mechanism /
+// raw score behind a routing decision. Rows written since the structured columns
+// exist carry them directly; older rows fall back to parsing the prose routing
+// log lines ("Complexity: tier=X score=Y words=Z" / "Complexity analysis skipped").
+// REASONING only exists in that historical prose: the tier was merged into
+// COMPLEX, but old rows keep recording what the router actually decided.
+function deriveComplexityRouting(log: LogEntry): {
+	tier?: string;
+	mechanism?: string;
+	score?: number;
+} {
+	if (log.complexity_tier || log.complexity_mechanism || log.complexity_score !== undefined) {
+		return {
+			tier: log.complexity_tier,
+			mechanism: log.complexity_mechanism,
+			score: log.complexity_score,
+		};
+	}
+	const m = log.routing_engine_logs?.match(/Complexity: tier=(SIMPLE|MEDIUM|COMPLEX|REASONING) score=([0-9.]+)/);
+	if (m) {
+		return { tier: m[1], mechanism: "lexical", score: Number(m[2]) };
+	}
+	if (log.routing_engine_logs?.includes("Complexity analysis skipped")) {
+		return { mechanism: "skipped" };
+	}
+	return {};
+}
+
 function RoutingDecisionLogs({ logs }: { logs: string }) {
 	const { copy } = useCopyToClipboard({ successMessage: "Copied" });
 	return (
@@ -656,6 +686,7 @@ export function LogDetailView({
 	const detectedAppIcon = log.app && detectedApp ? customAppIcons[log.app] || detectedApp.icon : detectedApp?.icon;
 	const detectedAppLabel = detectedApp ? logAppDisplayName(detectedApp, log.user_agent) : "";
 	const showTabs = !isContainer;
+	const complexityRouting = deriveComplexityRouting(log);
 	const isPassthrough = isPassthroughOperation(log.object);
 	const isRealtimeTurn = log.object === "realtime.turn";
 	const passthroughParams = isPassthrough
@@ -1291,6 +1322,33 @@ export function LogDetailView({
 										</Link>
 									}
 								/>
+							)}
+							{complexityRouting.tier && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Complexity Tier"
+									value={
+										<Badge
+											className={cn(
+												"border-0 py-1 uppercase",
+												ComplexityTierColors[complexityRouting.tier as keyof typeof ComplexityTierColors] ?? "bg-gray-100 text-gray-800",
+											)}
+											data-testid="logdetails-complexity-tier-badge"
+										>
+											{complexityRouting.tier}
+										</Badge>
+									}
+								/>
+							)}
+							{complexityRouting.mechanism && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Complexity Mechanism"
+									value={COMPLEXITY_MECHANISM_LABELS[complexityRouting.mechanism] ?? complexityRouting.mechanism}
+								/>
+							)}
+							{complexityRouting.score !== undefined && (
+								<LogEntryDetailsView className="w-full" label="Complexity Score" value={complexityRouting.score.toFixed(2)} />
 							)}
 
 							{(log.params as any)?.audio && (

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -292,8 +292,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 				: createRoutingRule(payload).unwrap();
 
 		submitPromise
-			.then(() => {
+			.then((result) => {
 				toast.success(isEditing ? "Routing rule updated successfully" : "Routing rule created successfully");
+				if (result.warning) {
+					toast.warning(result.warning);
+				}
 				reset();
 				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 				setQuery(defaultQuery);

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } from "@/lib/constants/logs";
 import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
+import { COMPLEXITY_TIER_VALUES, LEGACY_COMPLEXITY_TIER_VALUES, COMPLEXITY_MECHANISM_LABELS, COMPLEXITY_MECHANISM_VALUES } from "@/lib/types/complexityRouter";
 import type { LogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { ChevronDown, LoaderCircle, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw, Search } from "lucide-react";
@@ -117,6 +118,8 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 					<AliasesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<RoutingEnginesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<RoutingRulesFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<ComplexityTierFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<ComplexityMechanismFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<LocalCachingFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<UserFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<TeamFilter filters={filters} onFiltersChange={onFiltersChange} />
@@ -865,6 +868,63 @@ function RoutingRulesFilter({ filters, onFiltersChange, defaultOpen }: FilterCom
 				fetching={isFetching}
 				testIdPrefix="routing-rules-filter"
 			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ComplexityTierFilter – static enum, no fetch (tiers are a closed value set)
+// ---------------------------------------------------------------------------
+
+function ComplexityTierFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.complexity_tiers || []).length > 0;
+	// Legacy tiers (REASONING, merged into COMPLEX) are offered so historical
+	// rows recorded under the old scheme stay reachable through the filter.
+	const tiers: { value: string; label: string }[] = [
+		...COMPLEXITY_TIER_VALUES.map((tier) => ({ value: tier as string, label: tier.toLowerCase() })),
+		...LEGACY_COMPLEXITY_TIER_VALUES.map((tier) => ({ value: tier as string, label: `${tier.toLowerCase()} (legacy)` })),
+	];
+	return (
+		<FilterSection title="Complexity Tier" defaultOpen={defaultOpen || hasActive} testId="complexity-tier-filter-toggle">
+			{tiers.map(({ value, label }) => (
+				<CheckboxFilterItem
+					key={value}
+					labelClassName="capitalize"
+					label={label}
+					checked={(filters.complexity_tiers || []).includes(value)}
+					onCheckedChange={() => {
+						const current = filters.complexity_tiers || [];
+						const next = current.includes(value) ? current.filter((t) => t !== value) : [...current, value];
+						onFiltersChange({ ...filters, complexity_tiers: next });
+					}}
+					testId={`complexity-tier-filter-checkbox-${value.toLowerCase()}`}
+				/>
+			))}
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ComplexityMechanismFilter – static enum, no fetch (mechanisms are a closed value set)
+// ---------------------------------------------------------------------------
+
+function ComplexityMechanismFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.complexity_mechanisms || []).length > 0;
+	return (
+		<FilterSection title="Complexity Mechanism" defaultOpen={defaultOpen || hasActive} testId="complexity-mechanism-filter-toggle">
+			{COMPLEXITY_MECHANISM_VALUES.map((mechanism) => (
+				<CheckboxFilterItem
+					key={mechanism}
+					label={COMPLEXITY_MECHANISM_LABELS[mechanism] ?? mechanism}
+					checked={(filters.complexity_mechanisms || []).includes(mechanism)}
+					onCheckedChange={() => {
+						const current = filters.complexity_mechanisms || [];
+						const next = current.includes(mechanism) ? current.filter((m) => m !== mechanism) : [...current, mechanism];
+						onFiltersChange({ ...filters, complexity_mechanisms: next });
+					}}
+					testId={`complexity-mechanism-filter-checkbox-${mechanism}`}
+				/>
+			))}
 		</FilterSection>
 	);
 }

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -426,4 +426,10 @@ export const RoutingEngineUsedColors = {
 	core: "bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-300",
 } as const;
 
+export const ComplexityTierColors = {
+	SIMPLE: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+	MEDIUM: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300",
+	COMPLEX: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+} as const;
+
 export type Status = (typeof Statuses)[number];

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -62,6 +62,12 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	if (filters.stop_reasons && filters.stop_reasons.length > 0) {
 		params.stop_reasons = filters.stop_reasons.join(",");
 	}
+	if (filters.complexity_tiers && filters.complexity_tiers.length > 0) {
+		params.complexity_tiers = filters.complexity_tiers.join(",");
+	}
+	if (filters.complexity_mechanisms && filters.complexity_mechanisms.length > 0) {
+		params.complexity_mechanisms = filters.complexity_mechanisms.join(",");
+	}
 	if (filters.period) {
 		params.period = filters.period;
 	} else {

--- a/ui/lib/store/apis/routingRulesApi.ts
+++ b/ui/lib/store/apis/routingRulesApi.ts
@@ -37,17 +37,23 @@ export const routingRulesApi = baseApi.injectEndpoints({
 			providesTags: (result, error, arg) => [{ type: "RoutingRules", id: arg }],
 		}),
 
-		// Create a new routing rule
-		createRoutingRule: builder.mutation<RoutingRule, CreateRoutingRuleRequest>({
+		// Create a new routing rule. `warning` carries server-side deprecation
+		// notices (e.g. a REASONING tier comparison rewritten to COMPLEX).
+		createRoutingRule: builder.mutation<{ rule: RoutingRule; warning?: string }, CreateRoutingRuleRequest>({
 			query: (body) => ({
 				url: `/governance/routing-rules`,
 				method: "POST",
 				body,
 			}),
-			transformResponse: (response: { rule: RoutingRule }) => response.rule,
+			transformResponse: (response: { rule: RoutingRule; warning?: string }) => ({
+				rule: response.rule,
+				warning: response.warning,
+			}),
 			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
-					const { data: newRule } = await queryFulfilled;
+					const {
+						data: { rule: newRule },
+					} = await queryFulfilled;
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getRoutingRules" || entry?.status !== "fulfilled") continue;
@@ -67,17 +73,23 @@ export const routingRulesApi = baseApi.injectEndpoints({
 			},
 		}),
 
-		// Update an existing routing rule
-		updateRoutingRule: builder.mutation<RoutingRule, { id: string; data: UpdateRoutingRuleRequest }>({
+		// Update an existing routing rule. `warning` carries server-side deprecation
+		// notices (e.g. a REASONING tier comparison rewritten to COMPLEX).
+		updateRoutingRule: builder.mutation<{ rule: RoutingRule; warning?: string }, { id: string; data: UpdateRoutingRuleRequest }>({
 			query: ({ id, data }) => ({
 				url: `/governance/routing-rules/${id}`,
 				method: "PUT",
 				body: data,
 			}),
-			transformResponse: (response: { rule: RoutingRule }) => response.rule,
+			transformResponse: (response: { rule: RoutingRule; warning?: string }) => ({
+				rule: response.rule,
+				warning: response.warning,
+			}),
 			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
-					const { data: updatedRule } = await queryFulfilled;
+					const {
+						data: { rule: updatedRule },
+					} = await queryFulfilled;
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getRoutingRules" || entry?.status !== "fulfilled") continue;

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -24,6 +24,21 @@ export type KeywordListKey = keyof EditableKeywordConfig;
 
 export const COMPLEXITY_TIER_VALUES = ["SIMPLE", "MEDIUM", "COMPLEX"] as const;
 
+// REASONING was merged into COMPLEX and survives only in historical log rows.
+// Kept out of COMPLEXITY_TIER_VALUES so the CEL builder never offers it; the
+// logs filter renders it separately so those old rows stay reachable.
+export const LEGACY_COMPLEXITY_TIER_VALUES = ["REASONING"] as const;
+
+// Mirrors the complexity_mechanism values recorded by the gateway (plugins/governance/complexity).
+// "skipped" means classification was demanded by a routing rule but produced no tier.
+// Future classifiers add their values here (e.g. "semantic", "llm").
+export const COMPLEXITY_MECHANISM_VALUES = ["lexical", "skipped"] as const;
+
+export const COMPLEXITY_MECHANISM_LABELS: Record<string, string> = {
+	lexical: "Lexical",
+	skipped: "Skipped",
+};
+
 export const KEYWORD_LIST_DEFINITIONS: Array<{
 	key: KeywordListKey;
 	label: string;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -567,6 +567,9 @@ export interface LogEntry {
 	routing_engines_used?: string[];
 	routing_rule_id?: string;
 	routing_rule_name?: string;
+	complexity_tier?: string; // Complexity tier used for routing ("SIMPLE", "MEDIUM", "COMPLEX"); absent when no routing rule referenced complexity_tier
+	complexity_mechanism?: string; // How the complexity tier was classified ("lexical", "skipped"; later "semantic", "llm")
+	complexity_score?: number; // Raw complexity score behind the tier
 	routing_engine_logs?: string; // Human-readable routing decision logs
 	plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
 	selected_key?: DBKey;
@@ -642,6 +645,8 @@ export interface LogFilters {
 	routing_engine_used?: string[]; // For filtering by routing engine (routing-rule, governance, loadbalancing)
 	status?: string[];
 	stop_reasons?: string[]; // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
+	complexity_tiers?: string[]; // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
+	complexity_mechanisms?: string[]; // For filtering by complexity classification mechanism (lexical, skipped)
 	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
 	start_time?: string; // RFC3339 format
 	end_time?: string; // RFC3339 format


### PR DESCRIPTION
## Summary

Adds `complexity_tier` and `routing_mechanism` as first-class observability dimensions across the tracing, metrics, and logs UI layers. Previously, complexity routing information was only available by parsing free-text routing engine log lines. This PR promotes those values to structured span attributes, Prometheus labels, and log filter fields.

## Changes

- Added `AttrBifrostComplexityTier` and `AttrBifrostRoutingMechanism` span attribute constants and registered them as metric-safe `EnrichmentDim` entries. The raw complexity score is intentionally excluded as a dimension due to unbounded cardinality — it remains available only in logstore columns.
- Updated the tracer's `PopulateLLMResponseAttributes` to write both new attributes onto the span when present in context.
- Added `complexity_tier` and `routing_mechanism` to the Prometheus plugin's default label set and `PostLLMHook` label map.
- Extended `LogEntry` with `complexity_tier`, `routing_mechanism`, and `complexity_score` fields, and added `complexity_tiers` / `routing_mechanisms` to `LogFilters` with corresponding API query parameter serialization.
- Added `ROUTING_MECHANISM_VALUES` and `ROUTING_MECHANISM_LABELS` constants to the `complexityRouter` types module.
- Added `ComplexityTierColors` constants for badge styling in the UI.
- Introduced `deriveComplexityRouting` in the log detail view to surface structured values when available, with a fallback that parses legacy free-text routing log lines for backward compatibility with older rows.
- Added `ComplexityTierFilter` and `RoutingMechanismFilter` sidebar filter components backed by static closed value sets (no API fetch required).
- Wired `complexity_tiers` and `routing_mechanisms` into the logs page URL state, filter application, and dependency arrays.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Send a request through a routing rule that references `complexity_tier`.
2. Verify the resulting trace span carries `bifrost.complexity_tier` and `bifrost.routing_mechanism` attributes.
3. Verify Prometheus metrics expose `complexity_tier` and `routing_mechanism` labels on the relevant counters/histograms.
4. Open the logs UI, confirm the log detail view shows **Complexity Tier**, **Routing Mechanism**, and **Complexity Score** fields.
5. Use the new sidebar filters to filter by tier (SIMPLE/MEDIUM/COMPLEX) and mechanism (Lexical/Skipped) and confirm results are scoped correctly.
6. Open a log entry written before this change and confirm the fallback parsing of routing engine log lines still surfaces tier and mechanism correctly.

## Screenshots/Recordings

_Add before/after screenshots of the log detail view and filter sidebar showing the new complexity tier badge and filter sections._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

No new secrets, auth paths, or PII introduced. Complexity tier and routing mechanism are internal routing metadata with a closed value set.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable