### PR TITLE
fix: preserve video_url chat content part payload

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1504,15 +1504,11 @@ type ChatInputImage struct {
 	Detail *string `json:"detail,omitempty"`
 }
 
-// ChatInputVideo represents video data in a message (vLLM/Qwen-style
-// `video_url` content parts). URL carries either a remote URL or a
-// data: URI with base64-encoded video content. Not part of OpenAI's
-// published schema, but accepted by OpenAI-compatible multimodal
-// backends (vLLM, SGLang, Dashscope); without this field the payload
-// was silently dropped at unmarshal and providers received
-// `{"type":"video_url"}` with no body.
+// ChatInputVideo represents video data in a message (vLLM/Qwen-style `video_url`
+// content parts). Not part of OpenAI's published schema, but accepted by
+// OpenAI-compatible multimodal backends (vLLM, SGLang, Dashscope).
 type ChatInputVideo struct {
-	URL string `json:"url,omitempty"`
+	URL string `json:"url,omitempty"` // Remote URL, or data: URI with base64-encoded video
 }
 
 // ChatInputAudio represents audio data in a message.

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1261,6 +1261,7 @@ const (
 	ChatContentBlockTypeInputAudio ChatContentBlockType = "input_audio"
 	ChatContentBlockTypeFile       ChatContentBlockType = "file"
 	ChatContentBlockTypeRefusal    ChatContentBlockType = "refusal"
+	ChatContentBlockTypeVideo      ChatContentBlockType = "video_url"
 )
 
 // ChatContentBlock represents a content block in a message.
@@ -1269,6 +1270,7 @@ type ChatContentBlock struct {
 	Text           *string              `json:"text,omitempty"`
 	Refusal        *string              `json:"refusal,omitempty"`
 	ImageURLStruct *ChatInputImage      `json:"image_url,omitempty"`
+	VideoURLStruct *ChatInputVideo      `json:"video_url,omitempty"`
 	InputAudio     *ChatInputAudio      `json:"input_audio,omitempty"`
 	File           *ChatInputFile       `json:"file,omitempty"`
 
@@ -1500,6 +1502,17 @@ type ChatInputImage struct {
 	URL    string  `json:"url,omitempty"`
 	FileID *string `json:"file_id,omitempty"` // Reference to an uploaded file (in place of URL)
 	Detail *string `json:"detail,omitempty"`
+}
+
+// ChatInputVideo represents video data in a message (vLLM/Qwen-style
+// `video_url` content parts). URL carries either a remote URL or a
+// data: URI with base64-encoded video content. Not part of OpenAI's
+// published schema, but accepted by OpenAI-compatible multimodal
+// backends (vLLM, SGLang, Dashscope); without this field the payload
+// was silently dropped at unmarshal and providers received
+// `{"type":"video_url"}` with no body.
+type ChatInputVideo struct {
+	URL string `json:"url,omitempty"`
 }
 
 // ChatInputAudio represents audio data in a message.

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1856,3 +1856,26 @@ func TestEmbeddingData_EncodingFormatSurvivesRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// --- ChatContentBlock video_url ---
+
+// Regression: video_url content parts (vLLM/Qwen-style multimodal video input)
+// previously had no struct field, so the payload was silently dropped at
+// unmarshal and OpenAI-compatible backends received `{"type":"video_url"}`
+// with no body, failing validation ("video_url Field required").
+func TestSonic_ChatContentBlock_VideoURLRoundTrip(t *testing.T) {
+	input := `{"type":"video_url","video_url":{"url":"data:video/mp4;base64,AAAA"}}`
+
+	var block ChatContentBlock
+	err := Unmarshal([]byte(input), &block)
+	require.NoError(t, err)
+
+	assert.Equal(t, ChatContentBlockTypeVideo, block.Type)
+	require.NotNil(t, block.VideoURLStruct, "video_url payload must survive unmarshal")
+	assert.Equal(t, "data:video/mp4;base64,AAAA", block.VideoURLStruct.URL)
+
+	output, err := Marshal(block)
+	require.NoError(t, err)
+	assert.Contains(t, string(output), `"video_url"`)
+	assert.Contains(t, string(output), `data:video/mp4;base64,AAAA`)
+}


### PR DESCRIPTION
## Summary

OpenAI-style **`video_url` chat content parts lose their payload** passing through Bifrost. `ChatContentBlock` has no `video_url` field, so JSON unmarshal keeps the `type` string but silently drops the payload key — OpenAI-compatible multimodal backends (vLLM, SGLang) receive `{"type":"video_url"}` with no body and reject the request:

```
1 validation error for ChatCompletionContentPartVideoParam
video_url
  Field required [type=missing, input_value={'type': 'video_url'}, ...]
```

Image (`image_url`) and audio (`input_audio`) parts have fields and pass through fine; video is the only multimodal input type affected.

## Changes

- `core/schemas/chatcompletions.go`: add `ChatContentBlockTypeVideo` const, `ChatInputVideo` struct (`url`, matching the vLLM/Qwen wire shape), and a `VideoURLStruct *ChatInputVideo `json:"video_url,omitempty"`` field on `ChatContentBlock`.
- `core/schemas/serialization_test.go`: sonic round-trip regression test (`TestSonic_ChatContentBlock_VideoURLRoundTrip`).

No converter changes needed: the openai provider's message converters pass `Content` through by reference, so the schema field alone restores end-to-end passthrough. `ChatContentBlock.UnmarshalJSON` only rewrites Anthropic-style `document` blocks before delegating to the default unmarshal, so `video_url` blocks take the normal path.

This is distinct from the existing `video_url` handling in `transports/bifrost-http/handlers/inference.go`, which belongs to the video **edit/generation** API, not chat content parts.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```bash
cd core && go test ./schemas/ -run TestSonic_ChatContentBlock_VideoURLRoundTrip -v
```

Rebased onto current `dev` (`ce56d2de6`); `go build ./schemas/`, `go vet ./schemas/`, and the full `./schemas/` suite are green on Go 1.27.0.

Verified end-to-end against a self-hosted vLLM backend serving `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4` behind Bifrost (custom openai-compatible provider): before the patch, video requests through the gateway 400 with the error above while the same request direct to vLLM succeeds; with the patch, the gateway path returns the model's answer on the video clip.
