### PR TITLE
fix: Bedrock document format from OpenAI file data-URL MIME (#5472)

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4541,6 +4541,162 @@ func TestDocumentFormatMapping(t *testing.T) {
 	}
 }
 
+// TestDocumentFormatFromDataURLMediaType covers the OpenAI Chat Completions shape
+// that LibreChat and similar clients send: type:"file" with MIME only inside
+// file_data (data:<mime>;base64,...) and no file_type. Before #5472 this always
+// defaulted to format=pdf and Bedrock rejected non-PDF office bytes.
+func TestDocumentFormatFromDataURLMediaType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		mediaType      string
+		filename       string
+		expectedFormat string
+	}{
+		{"XLSX_DataURL_NoFileType", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "sheet.xlsx", "xlsx"},
+		{"DOCX_DataURL_NoFileType", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "doc.docx", "docx"},
+		{"PDF_DataURL_NoFileType", "application/pdf", "doc.pdf", "pdf"},
+		{"CSV_DataURL_NoFileType", "text/csv", "data.csv", "csv"},
+		{"XLS_DataURL_NoFileType", "application/vnd.ms-excel", "legacy.xls", "xls"},
+		{"DOC_DataURL_NoFileType", "application/msword", "legacy.doc", "doc"},
+		{"HTML_DataURL_NoFileType", "text/html", "page.html", "html"},
+		{"MD_DataURL_NoFileType", "text/markdown", "notes.md", "md"},
+		{"TXT_DataURL_NoFileType", "text/plain", "notes.txt", "txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := "ZmFrZS1ieXRlcw==" // base64("fake-bytes")
+			fileData := "data:" + tt.mediaType + ";base64," + payload
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: schemas.Bedrock,
+				Model:    "anthropic.claude-3-5-sonnet-v2",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentBlocks: []schemas.ChatContentBlock{
+								{
+									Type: schemas.ChatContentBlockTypeText,
+									Text: schemas.Ptr("Summarize this document."),
+								},
+								{
+									Type: schemas.ChatContentBlockTypeFile,
+									File: &schemas.ChatInputFile{
+										Filename: schemas.Ptr(tt.filename),
+										// FileType intentionally nil — OpenAI clients omit it
+										FileData: &fileData,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, result.Messages, 1)
+			require.GreaterOrEqual(t, len(result.Messages[0].Content), 2)
+			docBlock := result.Messages[0].Content[1]
+			require.NotNil(t, docBlock.Document, "type:file must become a Bedrock document block, not image")
+			assert.Nil(t, docBlock.Image, "type:file must not become an image block")
+			assert.Equal(t, tt.expectedFormat, docBlock.Document.Format,
+				"data URL media type %q / filename %q should map to format %q", tt.mediaType, tt.filename, tt.expectedFormat)
+			require.NotNil(t, docBlock.Document.Source)
+			require.NotNil(t, docBlock.Document.Source.Bytes)
+			assert.Equal(t, payload, *docBlock.Document.Source.Bytes)
+		})
+	}
+}
+
+// TestDocumentFormatFromFilenameExtension covers raw base64 file_data (no data:
+// URL MIME) where the only type signal is the filename extension.
+func TestDocumentFormatFromFilenameExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		filename       string
+		expectedFormat string
+	}{
+		{"XLSX_Filename", "report.xlsx", "xlsx"},
+		{"DOCX_Filename", "report.docx", "docx"},
+		{"PDF_Filename", "report.pdf", "pdf"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := "ZmFrZS1ieXRlcw=="
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: schemas.Bedrock,
+				Model:    "anthropic.claude-3-5-sonnet-v2",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentBlocks: []schemas.ChatContentBlock{
+								{
+									Type: schemas.ChatContentBlockTypeFile,
+									File: &schemas.ChatInputFile{
+										Filename: schemas.Ptr(tt.filename),
+										FileData: &payload,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+			require.NotNil(t, result.Messages[0].Content[0].Document)
+			assert.Equal(t, tt.expectedFormat, result.Messages[0].Content[0].Document.Format)
+			assert.Equal(t, payload, *result.Messages[0].Content[0].Document.Source.Bytes)
+		})
+	}
+}
+
+// TestDocumentFormatDataURLOverridesWrongDefault ensures a recognizable data-URL
+// MIME wins over the pdf default even when filename lacks an extension.
+func TestDocumentFormatDataURLOverridesWrongDefault(t *testing.T) {
+	t.Parallel()
+
+	payload := "ZmFrZS14bHN4"
+	fileData := "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64," + payload
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-3-5-sonnet-v2",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{
+							Type: schemas.ChatContentBlockTypeFile,
+							File: &schemas.ChatInputFile{
+								Filename: schemas.Ptr("untitled"),
+								FileData: &fileData,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockChatCompletionRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, result.Messages[0].Content[0].Document)
+	assert.Equal(t, "xlsx", result.Messages[0].Content[0].Document.Format)
+}
+
 func TestBedrockStopReasonMapping(t *testing.T) {
 	t.Parallel()
 

--- a/core/providers/bedrock/document_format_test.go
+++ b/core/providers/bedrock/document_format_test.go
@@ -1,0 +1,89 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBedrockDocumentFormatFromMediaType(t *testing.T) {
+	t.Parallel()
+
+	format, isText, ok := bedrockDocumentFormatFromMediaType(
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet; charset=binary")
+	require.True(t, ok)
+	assert.Equal(t, "xlsx", format)
+	assert.False(t, isText)
+
+	format, isText, ok = bedrockDocumentFormatFromMediaType("text/plain; charset=utf-8")
+	require.True(t, ok)
+	assert.Equal(t, "txt", format)
+	assert.True(t, isText)
+
+	format, isText, ok = bedrockDocumentFormatFromMediaType("text/x-custom")
+	require.True(t, ok)
+	assert.Equal(t, "txt", format)
+	assert.True(t, isText)
+
+	_, _, ok = bedrockDocumentFormatFromMediaType("application/octet-stream")
+	assert.False(t, ok)
+
+	format, isText, ok = bedrockDocumentFormatFromFilename("Quarterly Report.XLSX")
+	require.True(t, ok)
+	assert.Equal(t, "xlsx", format)
+	assert.False(t, isText)
+
+	_, _, ok = bedrockDocumentFormatFromFilename("noext")
+	assert.False(t, ok)
+}
+
+// TestResponsesFileDataURLMediaTypeMapsDocumentFormat covers the Responses API
+// sibling of #5472: input_file with MIME only in file_data and no file_type.
+func TestResponsesFileDataURLMediaTypeMapsDocumentFormat(t *testing.T) {
+	t.Parallel()
+
+	payload := "ZmFrZS14bHN4"
+	fileData := "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64," + payload
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-3-5-sonnet-v2",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeText,
+							Text: schemas.Ptr("Summarize this spreadsheet."),
+						},
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+							ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+								Filename: schemas.Ptr("sheet.xlsx"),
+								FileData: &fileData,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bedrockReq, err := ToBedrockResponsesRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bedrockReq)
+	require.NotEmpty(t, bedrockReq.Messages)
+	require.GreaterOrEqual(t, len(bedrockReq.Messages[0].Content), 2)
+	doc := bedrockReq.Messages[0].Content[1].Document
+	require.NotNil(t, doc, "Responses input_file must become a Bedrock document block")
+	assert.Nil(t, bedrockReq.Messages[0].Content[1].Image)
+	assert.Equal(t, "xlsx", doc.Format)
+	require.NotNil(t, doc.Source)
+	require.NotNil(t, doc.Source.Bytes)
+	assert.Equal(t, payload, *doc.Source.Bytes)
+}

--- a/core/providers/bedrock/document_format_test.go
+++ b/core/providers/bedrock/document_format_test.go
@@ -87,3 +87,52 @@ func TestResponsesFileDataURLMediaTypeMapsDocumentFormat(t *testing.T) {
 	require.NotNil(t, doc.Source.Bytes)
 	assert.Equal(t, payload, *doc.Source.Bytes)
 }
+
+// TestResponsesUnknownFileTypeFallsBackToFilename covers CodeRabbit #5503:
+// a non-nil unrecognized file_type (e.g. application/octet-stream) must not
+// skip filename inference, or report.xlsx would stay the Bedrock pdf default.
+func TestResponsesUnknownFileTypeFallsBackToFilename(t *testing.T) {
+	t.Parallel()
+
+	payload := "ZmFrZS14bHN4"
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-3-5-sonnet-v2",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeText,
+							Text: schemas.Ptr("Summarize this spreadsheet."),
+						},
+						{
+							Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+							ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+								Filename: schemas.Ptr("report.xlsx"),
+								FileType: schemas.Ptr("application/octet-stream"),
+								FileData: &payload,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bedrockReq, err := ToBedrockResponsesRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bedrockReq)
+	require.NotEmpty(t, bedrockReq.Messages)
+	require.GreaterOrEqual(t, len(bedrockReq.Messages[0].Content), 2)
+	doc := bedrockReq.Messages[0].Content[1].Document
+	require.NotNil(t, doc, "Responses input_file must become a Bedrock document block")
+	assert.Equal(t, "xlsx", doc.Format,
+		"unrecognized file_type must fall back to filename extension")
+	require.NotNil(t, doc.Source)
+	require.NotNil(t, doc.Source.Bytes)
+	assert.Equal(t, payload, *doc.Source.Bytes)
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4539,13 +4539,18 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					// Data-URL media type is applied below and can refine further
 					// (OpenAI file parts often omit file_type and only put MIME in
 					// the data: URL — same #5472 failure mode as chat completions).
+					// Unrecognized MIME (e.g. application/octet-stream) must still
+					// fall back to the filename so report.xlsx does not stay pdf.
 					isTextFile := false
+					formatSet := false
 					if block.ResponsesInputMessageContentBlockFile.FileType != nil {
 						if format, text, ok := bedrockDocumentFormatFromMediaType(*block.ResponsesInputMessageContentBlockFile.FileType); ok {
 							doc.Format = format
 							isTextFile = text
+							formatSet = true
 						}
-					} else if block.ResponsesInputMessageContentBlockFile.Filename != nil {
+					}
+					if !formatSet && block.ResponsesInputMessageContentBlockFile.Filename != nil {
 						if format, text, ok := bedrockDocumentFormatFromFilename(*block.ResponsesInputMessageContentBlockFile.Filename); ok {
 							doc.Format = format
 							isTextFile = text

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4535,33 +4535,20 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 						doc.Name = normalizeBedrockFilename(*block.ResponsesInputMessageContentBlockFile.Filename)
 					}
 
-					// Determine format: text or PDF based on FileType
+					// Determine format from file_type, then filename extension.
+					// Data-URL media type is applied below and can refine further
+					// (OpenAI file parts often omit file_type and only put MIME in
+					// the data: URL — same #5472 failure mode as chat completions).
 					isTextFile := false
 					if block.ResponsesInputMessageContentBlockFile.FileType != nil {
-						fileType := *block.ResponsesInputMessageContentBlockFile.FileType
-						// Check if it's a text type
-						if fileType == "text/markdown" || fileType == "md" {
-							doc.Format = "md"
-							isTextFile = true
-						} else if fileType == "text/html" || fileType == "html" {
-							doc.Format = "html"
-							isTextFile = true
-						} else if fileType == "text/csv" || fileType == "csv" {
-							doc.Format = "csv"
-							isTextFile = true
-						} else if strings.HasPrefix(fileType, "text/") || fileType == "txt" {
-							doc.Format = "txt"
-							isTextFile = true
-						} else if strings.Contains(fileType, "pdf") || fileType == "pdf" {
-							doc.Format = "pdf"
-						} else if strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx" {
-							doc.Format = "xlsx"
-						} else if fileType == "application/vnd.ms-excel" || fileType == "xls" {
-							doc.Format = "xls"
-						} else if strings.Contains(fileType, "wordprocessingml") || fileType == "docx" {
-							doc.Format = "docx"
-						} else if fileType == "application/msword" || fileType == "doc" {
-							doc.Format = "doc"
+						if format, text, ok := bedrockDocumentFormatFromMediaType(*block.ResponsesInputMessageContentBlockFile.FileType); ok {
+							doc.Format = format
+							isTextFile = text
+						}
+					} else if block.ResponsesInputMessageContentBlockFile.Filename != nil {
+						if format, text, ok := bedrockDocumentFormatFromFilename(*block.ResponsesInputMessageContentBlockFile.Filename); ok {
+							doc.Format = format
+							isTextFile = text
 						}
 					}
 
@@ -4572,8 +4559,14 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 						// Check if it's a data URL (e.g., "data:application/pdf;base64,...")
 						if strings.HasPrefix(fileData, "data:") {
 							urlInfo := schemas.ExtractURLTypeInfo(fileData)
+							if urlInfo.MediaType != nil {
+								if format, text, ok := bedrockDocumentFormatFromMediaType(*urlInfo.MediaType); ok {
+									doc.Format = format
+									isTextFile = text
+								}
+							}
 							if urlInfo.DataURLWithoutPrefix != nil {
-								// PDF or other binary - keep as base64
+								// Binary / already-base64 payload - keep as bytes
 								doc.Source.Bytes = urlInfo.DataURLWithoutPrefix
 								bedrockBlock.Document = doc
 								break

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -188,6 +188,61 @@ func normalizeBedrockFilename(filename string) string {
 	return normalized
 }
 
+// bedrockDocumentFormatFromMediaType maps a MIME type or short format name to a
+// Bedrock Converse document format. OpenAI Chat Completions file parts typically
+// carry the MIME only inside a data: URL (not in file_type), so callers must also
+// pass ExtractURLTypeInfo(...).MediaType through this helper. ok is false when the
+// type is unrecognized (caller keeps its existing default, usually "pdf").
+func bedrockDocumentFormatFromMediaType(fileType string) (format string, isText bool, ok bool) {
+	fileType = strings.TrimSpace(fileType)
+	if fileType == "" {
+		return "", false, false
+	}
+	if mt, _, err := mime.ParseMediaType(fileType); err == nil {
+		fileType = mt
+	}
+	switch {
+	case fileType == "text/plain" || fileType == "txt":
+		return "txt", true, true
+	case fileType == "text/markdown" || fileType == "md":
+		return "md", true, true
+	case fileType == "text/html" || fileType == "html":
+		return "html", true, true
+	case fileType == "text/csv" || fileType == "csv":
+		return "csv", true, true
+	case strings.HasPrefix(fileType, "text/"):
+		return "txt", true, true
+	case fileType == "application/msword" || fileType == "doc":
+		return "doc", false, true
+	case strings.Contains(fileType, "wordprocessingml") || fileType == "docx":
+		return "docx", false, true
+	case fileType == "application/vnd.ms-excel" || fileType == "xls":
+		return "xls", false, true
+	case strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx":
+		return "xlsx", false, true
+	case fileType == "application/pdf" || fileType == "pdf" || strings.Contains(fileType, "pdf"):
+		return "pdf", false, true
+	default:
+		return "", false, false
+	}
+}
+
+// bedrockDocumentFormatFromFilename infers a Bedrock document format from a
+// filename extension when MIME / file_type are absent.
+func bedrockDocumentFormatFromFilename(filename string) (format string, isText bool, ok bool) {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return "", false, false
+	}
+	ext := strings.ToLower(filename)
+	if i := strings.LastIndex(ext, "."); i >= 0 && i+1 < len(ext) {
+		ext = ext[i+1:]
+	} else {
+		return "", false, false
+	}
+	return bedrockDocumentFormatFromMediaType(ext)
+}
+
 // bedrockAliasToolName returns a Bedrock-safe tool name and records a reverse mapping.
 func bedrockAliasToolName(ctx context.Context, name string) string {
 	if len(name) <= 64 && !bedrockUnsafeToolNameCharRegex.MatchString(name) {
@@ -1119,33 +1174,25 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 			documentSource.Name = normalizeBedrockFilename(*block.File.Filename)
 		}
 
-		// Convert MIME type to Bedrock format
+		// Convert MIME type / short name to Bedrock format. Standard OpenAI clients
+		// often omit file_type and only put the MIME in the data: URL; apply every
+		// available signal (file_type, data-URL media type, fetch Content-Type,
+		// filename extension) before falling back to pdf.
 		isText := false
+		formatSet := false
+		applyFormat := func(format string, text bool) {
+			documentSource.Format = format
+			isText = text
+			formatSet = true
+		}
 		if block.File.FileType != nil {
-			fileType := *block.File.FileType
-			switch {
-			case fileType == "text/plain" || fileType == "txt":
-				documentSource.Format = "txt"
-				isText = true
-			case fileType == "text/markdown" || fileType == "md":
-				documentSource.Format = "md"
-				isText = true
-			case fileType == "text/html" || fileType == "html":
-				documentSource.Format = "html"
-				isText = true
-			case fileType == "text/csv" || fileType == "csv":
-				documentSource.Format = "csv"
-				isText = true
-			case fileType == "application/msword" || fileType == "doc":
-				documentSource.Format = "doc"
-			case strings.Contains(fileType, "wordprocessingml") || fileType == "docx":
-				documentSource.Format = "docx"
-			case fileType == "application/vnd.ms-excel" || fileType == "xls":
-				documentSource.Format = "xls"
-			case strings.Contains(fileType, "spreadsheetml") || fileType == "xlsx":
-				documentSource.Format = "xlsx"
-			case strings.Contains(fileType, "pdf") || fileType == "pdf":
-				documentSource.Format = "pdf"
+			if format, text, ok := bedrockDocumentFormatFromMediaType(*block.File.FileType); ok {
+				applyFormat(format, text)
+			}
+		}
+		if !formatSet && block.File.Filename != nil {
+			if format, text, ok := bedrockDocumentFormatFromFilename(*block.File.Filename); ok {
+				applyFormat(format, text)
 			}
 		}
 
@@ -1157,34 +1204,9 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 				return nil, fetchErr
 			}
 			// Refine format from response Content-Type when present (more reliable
-			// than file extension or upstream-declared media type). Normalize to
-			// strip parameters (e.g. "; charset=utf-8") and lowercase the base type.
-			if mt, _, err := mime.ParseMediaType(fetchedMediaType); err == nil {
-				fetchedMediaType = mt
-			}
-			switch fetchedMediaType {
-			case "application/pdf":
-				documentSource.Format = "pdf"
-			case "text/plain":
-				documentSource.Format = "txt"
-				isText = true
-			case "text/markdown":
-				documentSource.Format = "md"
-				isText = true
-			case "text/html":
-				documentSource.Format = "html"
-				isText = true
-			case "text/csv":
-				documentSource.Format = "csv"
-				isText = true
-			case "application/msword":
-				documentSource.Format = "doc"
-			case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
-				documentSource.Format = "docx"
-			case "application/vnd.ms-excel":
-				documentSource.Format = "xls"
-			case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
-				documentSource.Format = "xlsx"
+			// than file extension or upstream-declared media type).
+			if format, text, ok := bedrockDocumentFormatFromMediaType(fetchedMediaType); ok {
+				applyFormat(format, text)
 			}
 			documentSource.Source.Bytes = &fetchedB64
 			return []BedrockContentBlock{
@@ -1201,6 +1223,13 @@ func convertContentBlock(ctx context.Context, block schemas.ChatContentBlock) ([
 			// Check if it's a data URL and extract raw base64
 			if strings.HasPrefix(fileData, "data:") {
 				urlInfo := schemas.ExtractURLTypeInfo(fileData)
+				// Prefer the data-URL media type when present (OpenAI Chat Completions
+				// puts MIME only here; this is the #5472 failure mode for xlsx/docx).
+				if urlInfo.MediaType != nil {
+					if format, text, ok := bedrockDocumentFormatFromMediaType(*urlInfo.MediaType); ok {
+						applyFormat(format, text)
+					}
+				}
 				if urlInfo.DataURLWithoutPrefix != nil {
 					documentSource.Source.Bytes = urlInfo.DataURLWithoutPrefix
 					return []BedrockContentBlock{

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1345,9 +1345,14 @@ func responsesToolArgumentsToString(raw json.RawMessage) string {
 	return string(raw)
 }
 
-// MarshalJSON preserves OpenAI's per-item argument shape after UnmarshalJSON
-// normalizes both forms into the internal string field.
+// MarshalJSON re-emits preserved tool_search / additional_tools items verbatim
+// and otherwise preserves OpenAI's per-item argument shape after UnmarshalJSON
+// normalizes both string and object forms into the internal string field.
 func (m ResponsesMessage) MarshalJSON() ([]byte, error) {
+	if m.rawPreserved != nil {
+		return m.rawPreserved, nil
+	}
+
 	type Alias ResponsesMessage
 
 	// Re-emit the raw tools captured during unmarshal so the type discriminator survives.


### PR DESCRIPTION
﻿## Summary

Fixes #5472. OpenAI Chat Completions `type:"file"` parts usually put the MIME type only inside `file_data` (`data:<mime>;base64,...`). Bedrock conversion ignored that media type and always defaulted `document.format` to `pdf`, so XLSX/DOCX bytes were sent labeled as PDF and AWS rejected them with "The PDF specified was not valid."

## Changes

- Shared `bedrockDocumentFormatFromMediaType` / filename-extension helpers for Bedrock Converse document formats
- Chat `convertContentBlock` (`type:file`) and Responses `input_file` both apply data-URL media type, then filename extension, before falling back to `pdf`
- URL fetch Content-Type path uses the same helper
- Tests for data-URL MIME (no `file_type`), filename fallback, and Responses sibling path; asserts document block (not image)
- Separate commit: remove duplicate `ResponsesMessage` consts / `MarshalJSON` left by #5498 so `core` builds again on current `dev`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/bedrock/ -count=1 -run "TestDocumentFormat|TestBedrockDocumentFormat|TestResponsesFileDataURL"
```

## Evidence

```
ok  	github.com/maximhq/bifrost/core/providers/bedrock	2.267s
```

What was not tested: live Bedrock Converse call with a real XLSX against AWS (no Bedrock credentials in this session). Conversion path covered by unit tests matching the reporter's OpenAI payload shape.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5472

## AI assistance

This change was developed with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128). Logic and tests were reviewed before opening this PR.

## Security considerations

No auth/secrets changes. Document bytes still follow the existing inline base64 Converse path.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go targeted bedrock tests)
- [ ] I verified the CI pipeline passes locally if applicable
