### PR TITLE
fix: forward vLLM responses-stream chunks and completion events

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1871,9 +1871,8 @@ func HandleOpenAIResponsesStreaming(
 
 			// Parse into bifrost response
 			var response schemas.BifrostResponsesStreamResponse
-			// TODO fix this
 			if customResponseHandler != nil {
-				rawRequest, rawResponse, bifrostErr := customResponseHandler([]byte(jsonData), &response, nil, false, false)
+				rawRequest, rawResponse, bifrostErr := customResponseHandler([]byte(jsonData), &response, nil, sendBackRawRequest, sendBackRawResponse)
 				if bifrostErr != nil {
 					if sendBackRawRequest {
 						bifrostErr.ExtraFields.RawRequest = rawRequest
@@ -1884,6 +1883,9 @@ func HandleOpenAIResponsesStreaming(
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, nil, sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
 					return
+				}
+				if sendBackRawResponse {
+					response.ExtraFields.RawResponse = jsonData
 				}
 			} else {
 				if err := sonic.UnmarshalString(jsonData, &response); err != nil {
@@ -1902,79 +1904,79 @@ func HandleOpenAIResponsesStreaming(
 				if sendBackRawResponse {
 					response.ExtraFields.RawResponse = jsonData
 				}
-
-				if response.Type == schemas.ResponsesStreamResponseTypeError {
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeError)),
-						IsBifrostError: false,
-						Error:          &schemas.ErrorField{},
-					}
-
-					if response.Message != nil {
-						bifrostErr.Error.Message = *response.Message
-					}
-					if response.Param != nil {
-						bifrostErr.Error.Param = *response.Param
-					}
-					if response.Code != nil {
-						bifrostErr.Error.Code = response.Code
-					}
-					if response.Error != nil {
-						if response.Error.Message != "" && bifrostErr.Error.Message == "" {
-							bifrostErr.Error.Message = response.Error.Message
-						}
-						if response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
-							bifrostErr.Error.Code = &response.Error.Code
-						}
-					}
-					if response.Response != nil && response.Response.Error != nil {
-						if response.Response.Error.Message != "" && bifrostErr.Error.Message == "" {
-							bifrostErr.Error.Message = response.Response.Error.Message
-						}
-						if response.Response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
-							bifrostErr.Error.Code = schemas.Ptr(response.Response.Error.Code)
-						}
-					}
-
-					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
-					return
-				}
-
-				// Some providers (e.g. Fireworks) send response.failed on HTTP 200 streams
-				// instead of a pre-stream 4xx. Convert to BifrostError for consistent handling.
-				if response.Type == schemas.ResponsesStreamResponseTypeFailed {
-					bifrostErr := &schemas.BifrostError{
-						Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeFailed)),
-						IsBifrostError: false,
-						Error:          &schemas.ErrorField{},
-					}
-					if response.Response != nil && response.Response.Error != nil {
-						bifrostErr.Error.Message = response.Response.Error.Message
-						bifrostErr.Error.Code = &response.Response.Error.Code
-					}
-					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
-					return
-				}
-
-				response.ExtraFields.ChunkIndex = response.SequenceNumber
-				if response.Type == schemas.ResponsesStreamResponseTypeCompleted || response.Type == schemas.ResponsesStreamResponseTypeIncomplete {
-					// Set raw request if enabled
-					if sendBackRawRequest {
-						providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
-					}
-					response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
-					return
-				}
-
-				response.ExtraFields.Latency = time.Since(lastChunkTime).Milliseconds()
-				lastChunkTime = time.Now()
-
-				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
+
+			if response.Type == schemas.ResponsesStreamResponseTypeError {
+				bifrostErr := &schemas.BifrostError{
+					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeError)),
+					IsBifrostError: false,
+					Error:          &schemas.ErrorField{},
+				}
+
+				if response.Message != nil {
+					bifrostErr.Error.Message = *response.Message
+				}
+				if response.Param != nil {
+					bifrostErr.Error.Param = *response.Param
+				}
+				if response.Code != nil {
+					bifrostErr.Error.Code = response.Code
+				}
+				if response.Error != nil {
+					if response.Error.Message != "" && bifrostErr.Error.Message == "" {
+						bifrostErr.Error.Message = response.Error.Message
+					}
+					if response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
+						bifrostErr.Error.Code = &response.Error.Code
+					}
+				}
+				if response.Response != nil && response.Response.Error != nil {
+					if response.Response.Error.Message != "" && bifrostErr.Error.Message == "" {
+						bifrostErr.Error.Message = response.Response.Error.Message
+					}
+					if response.Response.Error.Code != "" && (bifrostErr.Error.Code == nil || *bifrostErr.Error.Code == "") {
+						bifrostErr.Error.Code = new(response.Response.Error.Code)
+					}
+				}
+
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
+				return
+			}
+
+			// Some providers (e.g. Fireworks) send response.failed on HTTP 200 streams
+			// instead of a pre-stream 4xx. Convert to BifrostError for consistent handling.
+			if response.Type == schemas.ResponsesStreamResponseTypeFailed {
+				bifrostErr := &schemas.BifrostError{
+					Type:           schemas.Ptr(string(schemas.ResponsesStreamResponseTypeFailed)),
+					IsBifrostError: false,
+					Error:          &schemas.ErrorField{},
+				}
+				if response.Response != nil && response.Response.Error != nil {
+					bifrostErr.Error.Message = response.Response.Error.Message
+					bifrostErr.Error.Code = &response.Response.Error.Code
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, []byte(jsonData), sendBackRawRequest, sendBackRawResponse, latency), responseChan, logger, postHookSpanFinalizer)
+				return
+			}
+
+			response.ExtraFields.ChunkIndex = response.SequenceNumber
+			if response.Type == schemas.ResponsesStreamResponseTypeCompleted || response.Type == schemas.ResponsesStreamResponseTypeIncomplete {
+				// Set raw request if enabled
+				if sendBackRawRequest {
+					providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
+				}
+				response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+				return
+			}
+
+			response.ExtraFields.Latency = time.Since(lastChunkTime).Milliseconds()
+			lastChunkTime = time.Now()
+
+			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
 		}
 	}()
 

--- a/core/providers/vllm/responses_stream_test.go
+++ b/core/providers/vllm/responses_stream_test.go
@@ -1,0 +1,264 @@
+package vllm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// noopTestLogger is a minimal schemas.Logger implementation for tests that
+// don't want to pull in the core package (which itself imports this
+// package, so importing it back here would create an import cycle).
+type noopTestLogger struct{}
+
+func (noopTestLogger) Debug(string, ...any)                   {}
+func (noopTestLogger) Info(string, ...any)                    {}
+func (noopTestLogger) Warn(string, ...any)                    {}
+func (noopTestLogger) Error(string, ...any)                   {}
+func (noopTestLogger) Fatal(string, ...any)                   {}
+func (noopTestLogger) SetLevel(schemas.LogLevel)              {}
+func (noopTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (noopTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+// newTestVLLMResponsesStreamProvider creates a VLLMProvider with a real
+// streaming client (via NewVLLMProvider) so ResponsesStream exercises the
+// same fasthttp streaming path used in production.
+func newTestVLLMResponsesStreamProvider(t *testing.T, sendBackRawRequest, sendBackRawResponse bool) *VLLMProvider {
+	t.Helper()
+
+	provider, err := NewVLLMProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			DefaultRequestTimeoutInSeconds: 10,
+		},
+		SendBackRawRequest:  sendBackRawRequest,
+		SendBackRawResponse: sendBackRawResponse,
+	}, noopTestLogger{})
+	if err != nil {
+		t.Fatalf("failed to create vLLM provider: %v", err)
+	}
+	return provider
+}
+
+func testVLLMResponsesStreamRequest() *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.VLLM,
+		Model:    "fake-model",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("hi"),
+				},
+			},
+		},
+	}
+}
+
+// drainStreamWithTimeout collects every chunk from stream until it closes,
+// failing fast (instead of hanging until the test binary's own timeout) if
+// the channel never closes — which is exactly the failure mode of #5504.
+func drainStreamWithTimeout(t *testing.T, stream chan *schemas.BifrostStreamChunk, timeout time.Duration) []*schemas.BifrostStreamChunk {
+	t.Helper()
+
+	var chunks []*schemas.BifrostStreamChunk
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for chunk := range stream {
+			chunks = append(chunks, chunk)
+		}
+	}()
+
+	select {
+	case <-done:
+		return chunks
+	case <-time.After(timeout):
+		t.Fatalf("stream did not close within %s — possible regression of the vLLM streaming hang (issue #5504)", timeout)
+		return nil
+	}
+}
+
+// sseServer builds an httptest server that serves the given raw SSE body
+// (each element already formatted as "data: {...}\n\n") at /v1/responses.
+func sseServer(events ...string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, e := range events {
+			fmt.Fprint(w, e)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+}
+
+func testVLLMKey(serverURL string) schemas.Key {
+	return schemas.Key{
+		ID:    "test-key",
+		Value: schemas.SecretVar{Val: "test-api-key"},
+		VLLMKeyConfig: &schemas.VLLMKeyConfig{
+			URL: schemas.SecretVar{Val: serverURL},
+		},
+	}
+}
+
+var noopPostHookRunner schemas.PostHookRunner = func(_ *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return result, err
+}
+
+// TestResponsesStream_SSEErrorEvent_SurfacesErrorAndCloses is a regression
+// test for #5504: an in-band SSE "type":"error" event (a normal 200 stream
+// that reports failure via a chunk, not an HTTP-level error) must surface as
+// a BifrostError chunk and the stream must close promptly, not hang.
+func TestResponsesStream_SSEErrorEvent_SurfacesErrorAndCloses(t *testing.T) {
+	t.Parallel()
+
+	server := sseServer(
+		"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":0,\"delta\":\"he\"}\n\n",
+		"data: {\"type\":\"error\",\"sequence_number\":1,\"message\":\"rate limit exceeded\",\"code\":\"rate_limit_exceeded\"}\n\n",
+	)
+	defer server.Close()
+
+	provider := newTestVLLMResponsesStreamProvider(t, false, false)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := testVLLMKey(server.URL)
+
+	stream, bifrostErr := provider.ResponsesStream(ctx, noopPostHookRunner, nil, key, testVLLMResponsesStreamRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesStream returned error synchronously: %v", bifrostErr.Error.Message)
+	}
+
+	chunks := drainStreamWithTimeout(t, stream, 5*time.Second)
+
+	var errChunk *schemas.BifrostStreamChunk
+	for _, c := range chunks {
+		if c != nil && c.BifrostError != nil {
+			errChunk = c
+			break
+		}
+	}
+
+	if errChunk == nil {
+		t.Fatalf("expected a BifrostError chunk for the in-band SSE error event, got %d chunks: %+v", len(chunks), chunks)
+	}
+	if errChunk.BifrostError.Error == nil || errChunk.BifrostError.Error.Message != "rate limit exceeded" {
+		t.Fatalf("expected error message %q, got %+v", "rate limit exceeded", errChunk.BifrostError.Error)
+	}
+	if errChunk.BifrostError.Error.Code == nil || *errChunk.BifrostError.Error.Code != "rate_limit_exceeded" {
+		t.Fatalf("expected error code %q, got %+v", "rate_limit_exceeded", errChunk.BifrostError.Error.Code)
+	}
+}
+
+// TestResponsesStream_SSEResponseFailedEvent_SurfacesErrorAndCloses is a
+// regression test for #5504: a "response.failed" event (used by vLLM/some
+// OpenAI-compatible backends to report generation failure on an HTTP 200
+// stream) must be converted to a BifrostError and end the stream, not be
+// silently dropped.
+func TestResponsesStream_SSEResponseFailedEvent_SurfacesErrorAndCloses(t *testing.T) {
+	t.Parallel()
+
+	server := sseServer(
+		"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":0,\"delta\":\"he\"}\n\n",
+		"data: {\"type\":\"response.failed\",\"sequence_number\":1,\"response\":{\"id\":\"r1\",\"object\":\"response\",\"created_at\":1,\"model\":\"fake-model\",\"status\":\"failed\",\"error\":{\"message\":\"upstream engine error\",\"code\":\"engine_error\"}}}\n\n",
+	)
+	defer server.Close()
+
+	provider := newTestVLLMResponsesStreamProvider(t, false, false)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := testVLLMKey(server.URL)
+
+	stream, bifrostErr := provider.ResponsesStream(ctx, noopPostHookRunner, nil, key, testVLLMResponsesStreamRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesStream returned error synchronously: %v", bifrostErr.Error.Message)
+	}
+
+	chunks := drainStreamWithTimeout(t, stream, 5*time.Second)
+
+	var errChunk *schemas.BifrostStreamChunk
+	for _, c := range chunks {
+		if c != nil && c.BifrostError != nil {
+			errChunk = c
+			break
+		}
+	}
+
+	if errChunk == nil {
+		t.Fatalf("expected a BifrostError chunk for the response.failed event, got %d chunks: %+v", len(chunks), chunks)
+	}
+	if errChunk.BifrostError.Error == nil || errChunk.BifrostError.Error.Message != "upstream engine error" {
+		t.Fatalf("expected error message %q, got %+v", "upstream engine error", errChunk.BifrostError.Error)
+	}
+	if errChunk.BifrostError.Error.Code == nil || *errChunk.BifrostError.Error.Code != "engine_error" {
+		t.Fatalf("expected error code %q, got %+v", "engine_error", errChunk.BifrostError.Error.Code)
+	}
+}
+
+// TestResponsesStream_CompletesWithoutHanging is a regression guard for the
+// root cause of #5504: every delta chunk must actually be forwarded (not
+// silently dropped) and the stream must close as soon as response.completed
+// arrives, instead of reading through to genuine EOF and hanging in cleanup.
+func TestResponsesStream_CompletesWithoutHanging(t *testing.T) {
+	t.Parallel()
+
+	server := sseServer(
+		"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":0,\"delta\":\"hel\"}\n\n",
+		"data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,\"delta\":\"lo\"}\n\n",
+		"data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"r1\",\"object\":\"response\",\"created_at\":1,\"model\":\"fake-model\",\"status\":\"completed\",\"output\":[{\"id\":\"msg_1\",\"type\":\"message\",\"status\":\"completed\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"hello\",\"annotations\":[],\"logprobs\":[]}]}]}}\n\n",
+	)
+	defer server.Close()
+
+	provider := newTestVLLMResponsesStreamProvider(t, false, false)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := testVLLMKey(server.URL)
+
+	stream, bifrostErr := provider.ResponsesStream(ctx, noopPostHookRunner, nil, key, testVLLMResponsesStreamRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesStream returned error synchronously: %v", bifrostErr.Error.Message)
+	}
+
+	chunks := drainStreamWithTimeout(t, stream, 5*time.Second)
+
+	var deltaCount int
+	var sawCompleted bool
+	seenChunkIndexes := map[int]bool{}
+	for _, c := range chunks {
+		if c == nil {
+			continue
+		}
+		if c.BifrostError != nil {
+			t.Fatalf("unexpected error chunk: %s", c.BifrostError.Error.Message)
+		}
+		if c.BifrostResponsesStreamResponse == nil {
+			continue
+		}
+		seenChunkIndexes[c.BifrostResponsesStreamResponse.ExtraFields.ChunkIndex] = true
+		switch c.BifrostResponsesStreamResponse.Type {
+		case schemas.ResponsesStreamResponseTypeCompleted:
+			sawCompleted = true
+		default:
+			if c.BifrostResponsesStreamResponse.Delta != nil {
+				deltaCount++
+			}
+		}
+	}
+
+	if deltaCount != 2 {
+		t.Fatalf("expected 2 delta chunks to be forwarded (not silently dropped), got %d: %+v", deltaCount, chunks)
+	}
+	if !sawCompleted {
+		t.Fatalf("expected a response.completed chunk, got %+v", chunks)
+	}
+	// ChunkIndex must track SequenceNumber, not stay stuck at 0 for every chunk.
+	if len(seenChunkIndexes) < 2 {
+		t.Fatalf("expected ChunkIndex to vary across chunks (regression: always 0), got indexes: %v", seenChunkIndexes)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `customResponseHandler` path in `HandleOpenAIResponsesStreaming` where `sendBackRawRequest` and `sendBackRawResponse` were hardcoded to `false`, and where subsequent error/completion handling was incorrectly scoped inside the `else` block, causing it to be skipped entirely when a custom response handler was provided. Fixes #5504

## Changes

- Replaced hardcoded `false, false` arguments in the `customResponseHandler` call with the actual `sendBackRawRequest` and `sendBackRawResponse` values.
- Added `RawResponse` population for the custom handler path, mirroring the existing behavior in the non-custom handler path.
- Moved error type handling (`ResponsesStreamResponseTypeError`, `ResponsesStreamResponseTypeFailed`), completion handling (`ResponsesStreamResponseTypeCompleted`, `ResponsesStreamResponseTypeIncomplete`), and chunk dispatch outside of the `else` block so they execute regardless of whether a custom response handler is used.
- Removed the `// TODO fix this` comment that tracked this known issue.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable