### PR TITLE
compilation fixes

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1310,15 +1310,10 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -1436,15 +1431,10 @@ func (s *RDBLogStore) GetThroughputHistogram(ctx context.Context, filters Search
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -1530,15 +1520,10 @@ func (s *RDBLogStore) GetProviderThroughputHistogram(ctx context.Context, filter
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getProviderThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getProviderThroughputHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -1630,15 +1615,10 @@ func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilter
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getCostHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getCostHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -1743,15 +1723,10 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600 // Default to 1 hour
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getModelHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getModelHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -1889,15 +1864,10 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -2638,15 +2608,10 @@ func (s *RDBLogStore) GetProviderCostHistogram(ctx context.Context, filters Sear
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getProviderCostHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getProviderCostHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -2740,15 +2705,10 @@ func (s *RDBLogStore) GetProviderTokenHistogram(ctx context.Context, filters Sea
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getProviderTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getProviderTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -2854,15 +2814,10 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getProviderLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getProviderLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 
 	dialect := s.db.Dialector.Name()
@@ -3225,15 +3180,10 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 		dimValueExpr = bucketedIDExpr(dimCol)
 		groupCol = dimValueExpr
 	}
-<<<<<<< HEAD
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getDimensionCostHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
-=======
 	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionCostHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
@@ -3332,15 +3282,10 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 		dimValueExpr = bucketedIDExpr(dimCol)
 		groupCol = dimValueExpr
 	}
-<<<<<<< HEAD
-	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getDimensionTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
-=======
 	if !bucketed && dialect == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionTokenHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
@@ -3448,15 +3393,10 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	if bucketSizeSeconds <= 0 {
 		bucketSizeSeconds = 3600
 	}
-<<<<<<< HEAD
-	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 && bucketSizeSeconds%3600 == 0 {
-		return s.getDimensionLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension)
-=======
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatView(filters) && bucketSizeSeconds >= 3600 {
 		if res, err := s.getDimensionLatencyHistogramFromMatView(ctx, filters, bucketSizeSeconds, dimension); !s.fallBackToRaw(err) {
 			return res, err
 		}
->>>>>>> 5b4b7fe74 (add cached tokens to matview; allow matview refersh on the fly)
 	}
 	dialect := s.db.Dialector.Name()
 	baseQuery := s.ScopedDB(ctx).Model(&Log{})


### PR DESCRIPTION
## Summary

Resolves a merge conflict in `rdb.go` by adopting the materialized view fallback pattern introduced in `5b4b7fe74`. The previous HEAD version returned immediately from matview queries and required bucket sizes to be exact multiples of 3600 seconds. The merged version removes the modulo constraint and falls back to raw queries when the matview query fails.

## Changes

- Removed the `bucketSizeSeconds%3600 == 0` constraint across all histogram matview query paths, allowing any bucket size ≥ 3600 seconds to use the matview.
- Replaced direct returns from matview queries with a fallback pattern: if the matview query returns an error that satisfies `fallBackToRaw`, the query is retried against the raw table instead of surfacing the error to the caller.
- Affected histogram methods: `GetTokenHistogram`, `GetThroughputHistogram`, `GetProviderThroughputHistogram`, `GetCostHistogram`, `GetModelHistogram`, `GetLatencyHistogram`, `GetProviderCostHistogram`, `GetProviderTokenHistogram`, `GetProviderLatencyHistogram`, `GetDimensionCostHistogram`, `GetDimensionTokenHistogram`, and `GetDimensionLatencyHistogram`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

Verify that histogram queries with non-hour-aligned bucket sizes (e.g. 7200, 10800) correctly use the materialized view on PostgreSQL, and that queries fall back to raw table scans when the matview is unavailable or returns an error.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes conflict introduced between HEAD and `5b4b7fe74 (add cached tokens to matview; allow matview refresh on the fly)`.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable