### PR TITLE
fix: minor fixes, error message and bedrock helm update

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2976,8 +2976,8 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 	// And if still we don't get role ARN
 	if roleArn == "" {
-		provider.logger.Error("role_arn is required for Bedrock batch API (provide in extra_params)")
-		return nil, providerUtils.NewBifrostOperationError("role_arn is required for Bedrock batch API (provide in extra_params)", nil)
+		provider.logger.Error("role_arn is required for Bedrock batch API (send it in extra_params or set batch_role_arn in the key config)")
+		return nil, providerUtils.NewBifrostOperationError("role_arn is required for Bedrock batch API (send it in extra_params or set batch_role_arn in the key config)", nil)
 	}
 	// Get output S3 URI from extra params
 	outputS3Uri := ""

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5247,6 +5247,10 @@
               "type": "string",
               "description": "Role session name for AssumeRole (can use env. prefix)"
             },
+            "batch_role_arn": {
+              "type": "string",
+              "description": "Service role ARN passed to Bedrock batch jobs for S3 access; takes priority over any role_arn sent in the request (can use env. prefix)"
+            },
             "project_id": {
               "type": "string",
               "description": "Bedrock project ID scoping inference and model listing. Sent as the OpenAI-Project header on the OpenAI-compatible surface and the anthropic-workspace-id header on the native-Anthropic (Claude) surface. When empty, AWS routes to the account's default project (can use env. prefix)"
@@ -6180,6 +6184,10 @@
                   "session_name": {
                     "type": "string",
                     "description": "Role session name for AssumeRole (can use env. prefix)"
+                  },
+                  "batch_role_arn": {
+                    "type": "string",
+                    "description": "Service role ARN passed to Bedrock batch jobs for S3 access; takes priority over any role_arn sent in the request (can use env. prefix)"
                   },
                   "deployments": {
                     "type": "object",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -447,6 +447,7 @@ bifrost:
   #         region: "us-east-1"
   #         access_key: "env.AWS_ACCESS_KEY_ID"
   #         secret_key: "env.AWS_SECRET_ACCESS_KEY"
+  #         # batch_role_arn: ""  # Optional: service role Bedrock assumes for batch S3 access; takes priority over role_arn sent in the request (can use env. prefix)
   #         project_id: ""  # Optional: Bedrock project ID scoping inference and model listing (can use env. prefix)
   #
   # # AWS Bedrock Mantle example (requires bedrock_mantle_key_config)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -841,7 +841,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return string(resp.Type), resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return string(resp.Type), resp, nil
+					converted := resp.WithDefaults()
+					if converted == nil {
+						return "", nil, nil
+					}
+					return string(resp.Type), converted, nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err


### PR DESCRIPTION
## Summary

Adds support for configuring a `batch_role_arn` directly in the Bedrock key config, so operators no longer need to pass the service role ARN on every batch request via `extra_params`. The error message for a missing role ARN is also updated to reflect both configuration paths. Additionally, fixes a nil-pointer issue in the OpenAI batch response converter by calling `WithDefaults()` before returning the response.

## Changes

- Added `batch_role_arn` as a first-class field in the Bedrock key config, with priority over any `role_arn` sent in the request. This allows the role to be set once at the key level (including via `env.` prefix) rather than requiring callers to supply it per-request.
- Updated the error message when `role_arn` is missing to mention both `extra_params` and the new `batch_role_arn` key config field.
- Updated the Helm chart `values.schema.json` and `values.yaml` to document and validate the new `batch_role_arn` field for both top-level and nested Bedrock key configs.
- Fixed the OpenAI batch response converter to call `resp.WithDefaults()` and guard against a `nil` return before passing the response downstream, preventing a potential nil-pointer dereference.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Configure a Bedrock key with `batch_role_arn` set (either as a literal ARN or via `env.MY_ROLE_ARN`).
2. Submit a batch request without passing `role_arn` in `extra_params` and confirm the job is created successfully using the configured ARN.
3. Submit a batch request with `role_arn` in `extra_params` alongside a `batch_role_arn` in the key config and confirm the key config value takes priority.
4. Submit a batch request with neither configured and confirm the error message reads: `role_arn is required for Bedrock batch API (send it in extra_params or set batch_role_arn in the key config)`.
5. Trigger an OpenAI batch response and confirm no nil-pointer panic occurs when `WithDefaults()` returns `nil`.

**New config field:**

| Field | Location | Description |
|---|---|---|
| `batch_role_arn` | Bedrock key config | Service role ARN Bedrock assumes for batch S3 access. Supports `env.` prefix. Takes priority over `role_arn` in `extra_params`. |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`batch_role_arn` supports the `env.` prefix, consistent with other sensitive fields in the Bedrock key config, so the ARN can be injected from environment variables rather than hardcoded in config files.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable