### PR TITLE
refactor: replace `pickTopSeries` with `computeDisplaySeries` to sync chart and legend series order

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/costChart.tsx
@@ -3,6 +3,7 @@ import { formatCurrencyNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
+	computeDisplaySeries,
 	formatCost,
 	formatFullTimestamp,
 	formatTimestamp,
@@ -10,7 +11,6 @@ import {
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
-	pickTopSeries,
 } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
@@ -79,9 +79,8 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 		let models: string[];
 		let hasOther = false;
 		if (selectedModel === "all") {
-			const top = pickTopSeries(data.buckets, data.models, (b, m) => b.by_model?.[m] ?? 0);
-			hasOther = top.length < data.models.length;
-			models = hasOther ? [...top, OTHER_SERIES_KEY] : top;
+			models = computeDisplaySeries(data.buckets, data.models, (b, m) => b.by_model?.[m] ?? 0);
+			hasOther = models[models.length - 1] === OTHER_SERIES_KEY;
 		} else {
 			models = [selectedModel];
 		}

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -4,13 +4,13 @@ import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
 	CHART_COLORS,
+	computeDisplaySeries,
 	formatFullTimestamp,
 	formatTimestamp,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
-	pickTopSeries,
 } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
@@ -102,10 +102,9 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 		let displayList: string[];
 		let topSet: Set<string> | null = null;
 		if (selectedModel === "all") {
-			const top = pickTopSeries(data.buckets, data.models, (b, m) => b.by_model?.[m]?.total ?? 0);
-			const hasOther = top.length < data.models.length;
-			displayList = hasOther ? [...top, OTHER_SERIES_KEY] : top;
-			topSet = hasOther ? new Set(top) : null;
+			displayList = computeDisplaySeries(data.buckets, data.models, (b, m) => b.by_model?.[m]?.total ?? 0);
+			const hasOther = displayList[displayList.length - 1] === OTHER_SERIES_KEY;
+			topSet = hasOther ? new Set(displayList.slice(0, -1)) : null;
 		} else {
 			displayList = data.models;
 		}

--- a/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
@@ -3,6 +3,7 @@ import { formatCurrencyNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
+	computeDisplaySeries,
 	formatCost,
 	formatFullTimestamp,
 	formatTimestamp,
@@ -10,7 +11,6 @@ import {
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
-	pickTopSeries,
 } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
@@ -79,9 +79,8 @@ function ProviderCostChartImpl({ data, chartType, startTime, endTime, selectedPr
 		let providers: string[];
 		let hasOther = false;
 		if (selectedProvider === "all") {
-			const top = pickTopSeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p] ?? 0);
-			hasOther = top.length < data.providers.length;
-			providers = hasOther ? [...top, OTHER_SERIES_KEY] : top;
+			providers = computeDisplaySeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p] ?? 0);
+			hasOther = providers[providers.length - 1] === OTHER_SERIES_KEY;
 		} else {
 			providers = [selectedProvider];
 		}

--- a/ui/app/workspace/dashboard/components/charts/providerLatencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerLatencyChart.tsx
@@ -1,7 +1,14 @@
 import type { ProviderLatencyHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatFullTimestamp, formatLatency, formatTimestamp, getModelColor, LATENCY_COLORS, pickTopSeries } from "../../utils/chartUtils";
+import {
+	formatFullTimestamp,
+	formatLatency,
+	formatTimestamp,
+	computeDisplaySeries,
+	getModelColor,
+	LATENCY_COLORS,
+} from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -99,7 +106,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 		// No "Other" bucket — averaging latencies across the long tail would mislead.
 		const providers = isSingleProvider
 			? [selectedProvider]
-			: pickTopSeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_requests ?? 0);
+			: computeDisplaySeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_requests ?? 0, false);
 
 		const processed = data.buckets.map((bucket, index) => {
 			const item: any = {

--- a/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
@@ -1,7 +1,14 @@
 import type { ProviderThroughputHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatFullTimestamp, formatTimestamp, formatTokensPerSecond, getModelColor, pickTopSeries, THROUGHPUT_COLOR } from "../../utils/chartUtils";
+import {
+	formatFullTimestamp,
+	formatTimestamp,
+	formatTokensPerSecond,
+	computeDisplaySeries,
+	getModelColor,
+	THROUGHPUT_COLOR,
+} from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -81,7 +88,7 @@ function ProviderThroughputChartImpl({ data, chartType, startTime, endTime, sele
 		// Rank by total_requests so we keep the highest-volume providers visible.
 		const providers = isSingleProvider
 			? [selectedProvider]
-			: pickTopSeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_requests ?? 0);
+			: computeDisplaySeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_requests ?? 0, false);
 
 		const processed = data.buckets.map((bucket, index) => {
 			const item: any = {

--- a/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
@@ -4,13 +4,13 @@ import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
 	CHART_COLORS,
+	computeDisplaySeries,
 	formatFullTimestamp,
 	formatTimestamp,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
-	pickTopSeries,
 } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
@@ -100,9 +100,8 @@ function ProviderTokenChartImpl({ data, chartType, startTime, endTime, selectedP
 		if (isSingleProvider) {
 			providers = [selectedProvider];
 		} else {
-			const top = pickTopSeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_tokens ?? 0);
-			hasOther = top.length < data.providers.length;
-			providers = hasOther ? [...top, OTHER_SERIES_KEY] : top;
+			providers = computeDisplaySeries(data.buckets, data.providers, (b, p) => b.by_provider?.[p]?.total_tokens ?? 0);
+			hasOther = providers[providers.length - 1] === OTHER_SERIES_KEY;
 		}
 		const topSet = new Set(providers);
 

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -11,7 +11,17 @@ import type {
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
 import NumberFlow from "@number-flow/react";
 import { memo, useMemo } from "react";
-import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, THROUGHPUT_COLOR, formatTokensPerSecond, getModelColor } from "../utils/chartUtils";
+import {
+	CHART_COLORS,
+	CHART_HEADER_LEGEND_CLASS,
+	LATENCY_COLORS,
+	OTHER_SERIES_COLOR,
+	OTHER_SERIES_KEY,
+	OTHER_SERIES_LABEL,
+	THROUGHPUT_COLOR,
+	formatTokensPerSecond,
+	getModelColor,
+} from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { CostChart } from "./charts/costChart";
@@ -291,10 +301,10 @@ function OverviewTabImpl({
 																<span
 																	className="h-2 w-2 shrink-0 rounded-full"
 																	style={{
-																		backgroundColor: getModelColor(idx + 1),
+																		backgroundColor: model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx + 1),
 																	}}
 																/>
-																{model}
+																{model === OTHER_SERIES_KEY ? OTHER_SERIES_LABEL : model}
 															</span>
 														))}
 													</div>
@@ -367,10 +377,10 @@ function OverviewTabImpl({
 																<span
 																	className="h-2 w-2 shrink-0 rounded-full"
 																	style={{
-																		backgroundColor: getModelColor(idx + 1),
+																		backgroundColor: model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx + 1),
 																	}}
 																/>
-																{model}
+																{model === OTHER_SERIES_KEY ? OTHER_SERIES_LABEL : model}
 															</span>
 														))}
 													</div>
@@ -457,7 +467,9 @@ function OverviewTabImpl({
 					loading={loadingThroughput}
 					testId="chart-throughput"
 					totalLabel="Avg"
-					total={throughputAvg !== null ? <span className="truncate whitespace-nowrap">{formatTokensPerSecond(throughputAvg)}</span> : undefined}
+					total={
+						throughputAvg !== null ? <span className="truncate whitespace-nowrap">{formatTokensPerSecond(throughputAvg)}</span> : undefined
+					}
 					totalTooltip={
 						throughputAvg !== null ? `${throughputAvg.toLocaleString("en-US", { maximumFractionDigits: 2 })} tokens/sec` : undefined
 					}
@@ -470,7 +482,11 @@ function OverviewTabImpl({
 						</div>
 					}
 					controls={
-						<ChartTypeToggle chartType={throughputChartType} onToggle={onThroughputChartToggle} data-testid="dashboard-throughput-chart-toggle" />
+						<ChartTypeToggle
+							chartType={throughputChartType}
+							onToggle={onThroughputChartToggle}
+							data-testid="dashboard-throughput-chart-toggle"
+						/>
 					}
 				>
 					<ThroughputChart data={throughputData} chartType={throughputChartType} startTime={startTime} endTime={endTime} />

--- a/ui/app/workspace/dashboard/components/providerUsageTab.tsx
+++ b/ui/app/workspace/dashboard/components/providerUsageTab.tsx
@@ -8,7 +8,17 @@ import type {
 	ProviderThroughputHistogramResponse,
 	ProviderTokenHistogramResponse,
 } from "@/lib/types/logs";
-import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, THROUGHPUT_COLOR, formatTokensPerSecond, getModelColor } from "../utils/chartUtils";
+import {
+	CHART_COLORS,
+	CHART_HEADER_LEGEND_CLASS,
+	LATENCY_COLORS,
+	OTHER_SERIES_COLOR,
+	OTHER_SERIES_KEY,
+	OTHER_SERIES_LABEL,
+	THROUGHPUT_COLOR,
+	formatTokensPerSecond,
+	getModelColor,
+} from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { ProviderCostChart } from "./charts/providerCostChart";
@@ -202,8 +212,11 @@ function ProviderUsageTabImpl({
 												<div className="flex flex-col gap-1">
 													{providerCostProviders.slice(1).map((provider, idx) => (
 														<span key={provider} className="flex items-center gap-1">
-															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
-															{provider}
+															<span
+																className="h-2 w-2 shrink-0 rounded-full"
+																style={{ backgroundColor: provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx + 1) }}
+															/>
+															{provider === OTHER_SERIES_KEY ? OTHER_SERIES_LABEL : provider}
 														</span>
 													))}
 												</div>
@@ -287,8 +300,11 @@ function ProviderUsageTabImpl({
 												<div className="flex flex-col gap-1">
 													{providerTokenProviders.slice(1).map((provider, idx) => (
 														<span key={provider} className="flex items-center gap-1">
-															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
-															{provider}
+															<span
+																className="h-2 w-2 shrink-0 rounded-full"
+																style={{ backgroundColor: provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx + 1) }}
+															/>
+															{provider === OTHER_SERIES_KEY ? OTHER_SERIES_LABEL : provider}
 														</span>
 													))}
 												</div>
@@ -443,10 +459,14 @@ function ProviderUsageTabImpl({
 				testId="chart-provider-throughput"
 				totalLabel="Avg"
 				total={
-					providerThroughputAvg !== null ? <span className="truncate whitespace-nowrap">{formatTokensPerSecond(providerThroughputAvg)}</span> : undefined
+					providerThroughputAvg !== null ? (
+						<span className="truncate whitespace-nowrap">{formatTokensPerSecond(providerThroughputAvg)}</span>
+					) : undefined
 				}
 				totalTooltip={
-					providerThroughputAvg !== null ? `${providerThroughputAvg.toLocaleString("en-US", { maximumFractionDigits: 2 })} tokens/sec` : undefined
+					providerThroughputAvg !== null
+						? `${providerThroughputAvg.toLocaleString("en-US", { maximumFractionDigits: 2 })} tokens/sec`
+						: undefined
 				}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>

--- a/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/overviewTabView.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
 import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import { computeDisplaySeries } from "../../utils/chartUtils";
 import type { DashboardData } from "../../utils/exportUtils";
 import type { ChartType } from "../charts/chartTypeToggle";
 import { OverviewTab } from "../overviewTab";
@@ -125,8 +126,13 @@ export const OverviewTabView = forwardRef<OverviewTabViewHandle, OverviewTabView
 		[histogramData, tokenData, costData, modelData, latencyData, loadData],
 	);
 
-	const costModels = useMemo(() => sanitizeSeriesLabels(costData?.models), [costData?.models]);
-	const usageModels = useMemo(() => sanitizeSeriesLabels(modelData?.models), [modelData?.models]);
+	// Legend lists mirror the charts' display order (top-N by volume + "Other"),
+	// not the API's alphabetical order — index-based colors must match the bars.
+	const costModels = useMemo(() => computeDisplaySeries(costData?.buckets, costData?.models, (b, m) => b.by_model?.[m] ?? 0), [costData]);
+	const usageModels = useMemo(
+		() => computeDisplaySeries(modelData?.buckets, modelData?.models, (b, m) => b.by_model?.[m]?.total ?? 0),
+		[modelData],
+	);
 	const availableModels = useMemo(
 		() => sanitizeSeriesLabels([...(costData?.models ?? []), ...(modelData?.models ?? [])]),
 		[costData?.models, modelData?.models],

--- a/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
+++ b/ui/app/workspace/dashboard/components/tabViews/providerUsageTabView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
 import { forwardRef, useCallback, useImperativeHandle, useMemo } from "react";
+import { computeDisplaySeries } from "../../utils/chartUtils";
 import type { DashboardData } from "../../utils/exportUtils";
 import type { ChartType } from "../charts/chartTypeToggle";
 import { ProviderUsageTab } from "../providerUsageTab";
@@ -79,7 +80,10 @@ export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, Provi
 	const { data: providerCostData, isLoading: loadingProviderCost } = useGetLogsProviderCostHistogramQuery(fetchArg, skipOpts);
 	const { data: providerTokenData, isLoading: loadingProviderTokens } = useGetLogsProviderTokenHistogramQuery(fetchArg, skipOpts);
 	const { data: providerLatencyData, isLoading: loadingProviderLatency } = useGetLogsProviderLatencyHistogramQuery(fetchArg, skipOpts);
-	const { data: providerThroughputData, isLoading: loadingProviderThroughput } = useGetLogsProviderThroughputHistogramQuery(fetchArg, skipOpts);
+	const { data: providerThroughputData, isLoading: loadingProviderThroughput } = useGetLogsProviderThroughputHistogramQuery(
+		fetchArg,
+		skipOpts,
+	);
 
 	const [triggerProviderCost] = useLazyGetLogsProviderCostHistogramQuery();
 	const [triggerProviderTokens] = useLazyGetLogsProviderTokenHistogramQuery();
@@ -118,12 +122,36 @@ export const ProviderUsageTabView = forwardRef<ProviderUsageTabViewHandle, Provi
 			]),
 		[providerCostData?.providers, providerTokenData?.providers, providerLatencyData?.providers, providerThroughputData?.providers],
 	);
-	const providerCostProviders = useMemo(() => sanitizeSeriesLabels(providerCostData?.providers), [providerCostData?.providers]);
-	const providerTokenProviders = useMemo(() => sanitizeSeriesLabels(providerTokenData?.providers), [providerTokenData?.providers]);
-	const providerLatencyProviders = useMemo(() => sanitizeSeriesLabels(providerLatencyData?.providers), [providerLatencyData?.providers]);
+	// Legend lists mirror each chart's display order (top-N by its own ranking
+	// metric, plus "Other" where the chart rolls up the tail) — index-based
+	// colors must match the drawn series, not the API's alphabetical order.
+	const providerCostProviders = useMemo(
+		() => computeDisplaySeries(providerCostData?.buckets, providerCostData?.providers, (b, p) => b.by_provider?.[p] ?? 0),
+		[providerCostData],
+	);
+	const providerTokenProviders = useMemo(
+		() => computeDisplaySeries(providerTokenData?.buckets, providerTokenData?.providers, (b, p) => b.by_provider?.[p]?.total_tokens ?? 0),
+		[providerTokenData],
+	);
+	const providerLatencyProviders = useMemo(
+		() =>
+			computeDisplaySeries(
+				providerLatencyData?.buckets,
+				providerLatencyData?.providers,
+				(b, p) => b.by_provider?.[p]?.total_requests ?? 0,
+				false,
+			),
+		[providerLatencyData],
+	);
 	const providerThroughputProviders = useMemo(
-		() => sanitizeSeriesLabels(providerThroughputData?.providers),
-		[providerThroughputData?.providers],
+		() =>
+			computeDisplaySeries(
+				providerThroughputData?.buckets,
+				providerThroughputData?.providers,
+				(b, p) => b.by_provider?.[p]?.total_requests ?? 0,
+				false,
+			),
+		[providerThroughputData],
 	);
 
 	return (

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -49,6 +49,7 @@ export default function DashboardPage() {
 			routing_rule_ids: parseAsSafeArrayOf.withDefault([]),
 			routing_engine_used: parseAsSafeArrayOf.withDefault([]),
 			stop_reasons: parseAsSafeArrayOf.withDefault([]),
+			cache_hit_types: parseAsSafeArrayOf.withDefault([]),
 			missing_cost_only: parseAsBoolean.withDefault(false),
 			metadata_filters: parseAsString.withDefault(""),
 			volume_chart: parseAsString.withDefault("bar"),
@@ -123,6 +124,7 @@ export default function DashboardPage() {
 				routing_engine_used: urlState.routing_engine_used,
 			}),
 			...(urlState.stop_reasons.length > 0 && { stop_reasons: urlState.stop_reasons }),
+			...(urlState.cache_hit_types.length > 0 && { cache_hit_types: urlState.cache_hit_types }),
 			...(urlState.missing_cost_only && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
@@ -149,6 +151,7 @@ export default function DashboardPage() {
 			urlState.routing_rule_ids,
 			urlState.routing_engine_used,
 			urlState.stop_reasons,
+			urlState.cache_hit_types,
 			urlState.missing_cost_only,
 			metadataFilters,
 			urlState.user_ids,
@@ -306,6 +309,7 @@ export default function DashboardPage() {
 				routing_rule_ids: newFilters.routing_rule_ids || [],
 				routing_engine_used: newFilters.routing_engine_used || [],
 				stop_reasons: newFilters.stop_reasons || [],
+				cache_hit_types: newFilters.cache_hit_types || [],
 				missing_cost_only: newFilters.missing_cost_only ?? false,
 				metadata_filters:
 					newFilters.metadata_filters && Object.keys(newFilters.metadata_filters).length > 0

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -97,6 +97,25 @@ export function pickTopSeries<T>(
 	return [...seriesLabels].sort((a, b) => (totals.get(b) ?? 0) - (totals.get(a) ?? 0)).slice(0, limit);
 }
 
+// The ordered series list as a chart draws it: top-N by total value with
+// OTHER_SERIES_KEY appended when the long tail was rolled up (unless the chart
+// opts out of the rollup, e.g. latency/throughput where averaging the tail
+// would mislead). Legends color entries by index into this list, so they must
+// consume the exact same list as the chart — deriving legend colors from the
+// API's (alphabetical) label order desyncs once the series count exceeds
+// TOP_SERIES_LIMIT and this list gets re-sorted by volume.
+export function computeDisplaySeries<T>(
+	buckets: T[] | undefined,
+	seriesLabels: string[] | undefined,
+	getValue: (bucket: T, label: string) => number,
+	includeOther: boolean = true,
+): string[] {
+	if (!buckets || !seriesLabels || seriesLabels.length === 0) return [];
+	const top = pickTopSeries(buckets, seriesLabels, getValue);
+	if (includeOther && top.length < seriesLabels.length) return [...top, OTHER_SERIES_KEY];
+	return top;
+}
+
 // Format latency values
 export function formatLatency(ms: number): string {
 	if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;


### PR DESCRIPTION
## Summary

Legend color indicators in dashboard charts were misaligned with their corresponding chart series when the number of series exceeded `TOP_SERIES_LIMIT`. The legend was deriving colors from the API's alphabetical label order, while the charts were rendering series sorted by volume. This PR fixes the desync by introducing `computeDisplaySeries`, a shared utility that produces the exact ordered series list (top-N by volume, with `OTHER_SERIES_KEY` appended for rolled-up tails) that both charts and legends consume.

## Changes

- Added `computeDisplaySeries` to `chartUtils.ts`, which wraps `pickTopSeries` and conditionally appends `OTHER_SERIES_KEY` when the tail is rolled up. An `includeOther` flag (defaulting to `true`) allows latency and throughput charts to opt out of the rollup, since averaging the long tail would produce misleading values.
- Replaced all direct `pickTopSeries` call sites in `costChart`, `modelUsageChart`, `providerCostChart`, `providerLatencyChart`, `providerThroughputChart`, and `providerTokenChart` with `computeDisplaySeries`.
- Updated `overviewTabView` and `providerUsageTabView` to derive legend provider/model lists using `computeDisplaySeries` instead of `sanitizeSeriesLabels` on the raw API label arrays, ensuring legend order and colors match what the charts draw.
- Fixed legend rendering in `overviewTab` and `providerUsageTab` to display `OTHER_SERIES_LABEL` and `OTHER_SERIES_COLOR` when the `OTHER_SERIES_KEY` sentinel appears in the series list.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the dashboard with a workspace that has more providers or models than `TOP_SERIES_LIMIT`. Verify that the legend color dots next to each series name match the colors of the corresponding bars or areas in the chart, including the "Other" entry.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Verify before/after that legend color dots align with chart series colors when more than the top-N series are present, and that the "Other" legend entry appears with the correct gray color.
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/d21db038-9528-467a-81a0-517a3407c5c0" />
<img width="1512" height="861" alt="image" src="https://github.com/user-attachments/assets/e80d1d17-19ca-4c03-933b-8589468b21b6" />


## Breaking changes

- [ ] Yes
- [x] No

## Related issues  
https://github.com/maximhq/bifrost/issues/5506

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable