### PR TITLE
fix: pass routing info headers in error/passthrough paths

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3926,6 +3926,28 @@ func TestGenAIThinkingLevel_RoundTripPreservesLevelNotBudget(t *testing.T) {
 	assert.Nil(t, tc.ThinkingBudget, "round-trip must not synthesize thinkingBudget from level-only config")
 }
 
+// Regression: generationConfig.mediaResolution must survive Gemini → Bifrost → Gemini on the
+// GenAI generateContent path. It used to be dropped, so image token counts ignored the field.
+func TestGenAIMediaResolution_PreservedThroughBifrostRoundTrip(t *testing.T) {
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini-2.5-flash",
+		GenerationConfig: gemini.GenerationConfig{
+			MediaResolution: "MEDIA_RESOLUTION_LOW",
+		},
+	}
+
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
+	require.NotNil(t, bifrostReq.Params)
+	assert.Equal(t, "MEDIA_RESOLUTION_LOW", bifrostReq.Params.ExtraParams["media_resolution"])
+
+	roundTrip, err := gemini.ToGeminiResponsesRequest(nil, bifrostReq)
+	require.NoError(t, err)
+	require.NotNil(t, roundTrip)
+	assert.Equal(t, "MEDIA_RESOLUTION_LOW", roundTrip.GenerationConfig.MediaResolution,
+		"mediaResolution must round-trip into the outbound generationConfig")
+}
+
 // Regression: MAX_TOKENS from Gemini must survive Gemini → Bifrost → Gemini on the GenAI path
 // (StopReason used to be dropped, so clients saw STOP instead of MAX_TOKENS).
 func TestGenAIFinishReasonMaxTokens_PersistsThroughBifrostRoundTrip(t *testing.T) {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2949,6 +2949,12 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 				config.StopSequences = val
 			}
 		}
+		if mediaResolution, ok := params.ExtraParams["media_resolution"]; ok {
+			delete(params.ExtraParams, "media_resolution")
+			if val, success := schemas.SafeExtractString(mediaResolution); success {
+				config.MediaResolution = val
+			}
+		}
 
 	}
 

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -282,6 +282,9 @@ func (r *GeminiGenerationRequest) convertGenerationConfigToResponsesParameters()
 	if config.MaxOutputTokens > 0 {
 		params.MaxOutputTokens = schemas.Ptr(int(config.MaxOutputTokens))
 	}
+	if config.MediaResolution != "" {
+		params.ExtraParams["media_resolution"] = config.MediaResolution
+	}
 	if config.ThinkingConfig != nil {
 		params.Reasoning = &schemas.ResponsesParametersReasoning{}
 		if strings.Contains(r.Model, "openai") {

--- a/core/providers/replicate/replicate_test.go
+++ b/core/providers/replicate/replicate_test.go
@@ -607,60 +607,6 @@ func TestBifrostToReplicateImageGenerationConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "InputImages_SingleImageField",
-			input: &schemas.BifrostImageGenerationRequest{
-				Model: "black-forest-labs/flux-kontext-pro",
-				Input: &schemas.ImageGenerationInput{
-					Prompt: prompt,
-				},
-				Params: &schemas.ImageGenerationParameters{
-					InputImages: []string{"https://example.com/a.png", "https://example.com/b.png"},
-				},
-			},
-			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
-				require.NotNil(t, result)
-				require.NotNil(t, result.Input)
-				require.NotNil(t, result.Input.InputImage)
-				assert.Equal(t, "https://example.com/a.png", *result.Input.InputImage)
-				assert.Nil(t, result.Input.InputImages)
-				assert.Nil(t, result.Input.ImagePrompt)
-				assert.Nil(t, result.Input.Image)
-			},
-		},
-		{
-			name: "InputImages_ArrayFieldWithBase64Normalization",
-			input: &schemas.BifrostImageGenerationRequest{
-				Model: "some-owner/some-model",
-				Input: &schemas.ImageGenerationInput{
-					Prompt: prompt,
-				},
-				Params: &schemas.ImageGenerationParameters{
-					InputImages: []string{"iVBORw0KGgoAAAANSUhEUg", "https://example.com/b.png"},
-				},
-			},
-			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
-				require.NotNil(t, result)
-				require.NotNil(t, result.Input)
-				require.Len(t, result.Input.InputImages, 2)
-				assert.Equal(t, "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg", result.Input.InputImages[0])
-				assert.Equal(t, "https://example.com/b.png", result.Input.InputImages[1])
-				assert.Nil(t, result.Input.InputImage)
-			},
-		},
-		{
-			name: "InputImages_InvalidURL",
-			input: &schemas.BifrostImageGenerationRequest{
-				Model: "black-forest-labs/flux-dev",
-				Input: &schemas.ImageGenerationInput{
-					Prompt: prompt,
-				},
-				Params: &schemas.ImageGenerationParameters{
-					InputImages: []string{"file:///etc/passwd"},
-				},
-			},
-			wantErr: true,
-		},
-		{
 			name:    "NilRequest",
 			input:   nil,
 			wantErr: false, // Function returns nil, not error
@@ -695,6 +641,173 @@ func TestBifrostToReplicateImageGenerationConversion(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReplicateImageGenerationInputImagesFieldMapping pins the input_images →
+// model-specific field mapping on the image generation path across every model in the
+// mapping table plus the default. This is the fallback-critical invariant: the same
+// input_images array must land in whatever field name the target model expects, so a
+// fallback re-sending the body under a different model still delivers the image.
+func TestReplicateImageGenerationInputImagesFieldMapping(t *testing.T) {
+	const prompt = "a lighthouse at night"
+
+	// fieldOf reports which single image field (if any) the mapping populated, and its value.
+	imageFieldOf := func(t *testing.T, in *replicate.ReplicatePredictionRequestInput) (field string, single string, array []string) {
+		t.Helper()
+		set := 0
+		if in.ImagePrompt != nil {
+			field, single = "image_prompt", *in.ImagePrompt
+			set++
+		}
+		if in.InputImage != nil {
+			field, single = "input_image", *in.InputImage
+			set++
+		}
+		if in.Image != nil {
+			field, single = "image", *in.Image
+			set++
+		}
+		if in.InputImages != nil {
+			field, array = "input_images", in.InputImages
+			set++
+		}
+		require.LessOrEqual(t, set, 1, "at most one image field may be populated, got %d", set)
+		return field, single, array
+	}
+
+	// Every model in modelInputImageFieldMap, grouped by the field it should map to.
+	byField := map[string][]string{
+		"image_prompt": {
+			"black-forest-labs/flux-1.1-pro",
+			"black-forest-labs/flux-1.1-pro-ultra",
+			"black-forest-labs/flux-pro",
+			"black-forest-labs/flux-1.1-pro-ultra-finetuned",
+		},
+		"input_image": {
+			"black-forest-labs/flux-kontext-pro",
+			"black-forest-labs/flux-kontext-max",
+			"black-forest-labs/flux-kontext-dev",
+		},
+		"image": {
+			"black-forest-labs/flux-dev",
+			"black-forest-labs/flux-fill-pro",
+			"black-forest-labs/flux-dev-lora",
+			"black-forest-labs/flux-krea-dev",
+		},
+	}
+
+	// Two images so we also verify single-field models truncate to the first while the
+	// array field preserves all.
+	images := []string{"https://example.com/a.png", "https://example.com/b.png"}
+
+	t.Run("MappedModels", func(t *testing.T) {
+		for expectedField, models := range byField {
+			for _, model := range models {
+				t.Run(model, func(t *testing.T) {
+					req := &schemas.BifrostImageGenerationRequest{
+						Model: model,
+						Input: &schemas.ImageGenerationInput{Prompt: prompt},
+						Params: &schemas.ImageGenerationParameters{
+							InputImages: images,
+						},
+					}
+					result, err := replicate.ToReplicateImageGenerationInput(req)
+					require.NoError(t, err)
+					require.NotNil(t, result)
+					require.NotNil(t, result.Input)
+
+					field, single, _ := imageFieldOf(t, result.Input)
+					assert.Equal(t, expectedField, field, "model %s should map input_images to %s", model, expectedField)
+					assert.Equal(t, images[0], single, "single-image field should use the first input image")
+				})
+			}
+		}
+	})
+
+	t.Run("DefaultModelUsesInputImagesArray", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model: "some-owner/some-model",
+			Input: &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{
+				InputImages: images,
+			},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		require.NoError(t, err)
+		field, _, array := imageFieldOf(t, result.Input)
+		assert.Equal(t, "input_images", field)
+		assert.Equal(t, images, array, "array field should preserve all input images")
+	})
+
+	t.Run("VersionSuffixStillMaps", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model: "black-forest-labs/flux-kontext-pro:1234567890abcdef",
+			Input: &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{
+				InputImages: images,
+			},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		require.NoError(t, err)
+		field, single, _ := imageFieldOf(t, result.Input)
+		assert.Equal(t, "input_image", field)
+		assert.Equal(t, images[0], single)
+	})
+
+	t.Run("ModelNameIsCaseInsensitive", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model: "Black-Forest-Labs/FLUX-DEV",
+			Input: &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{
+				InputImages: images,
+			},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		require.NoError(t, err)
+		field, single, _ := imageFieldOf(t, result.Input)
+		assert.Equal(t, "image", field)
+		assert.Equal(t, images[0], single)
+	})
+
+	t.Run("RawBase64NormalizedToDataURL", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model: "some-owner/some-model",
+			Input: &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{
+				InputImages: []string{"iVBORw0KGgoAAAANSUhEUg", "https://example.com/b.png"},
+			},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		require.NoError(t, err)
+		require.Len(t, result.Input.InputImages, 2)
+		assert.Equal(t, "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg", result.Input.InputImages[0])
+		assert.Equal(t, "https://example.com/b.png", result.Input.InputImages[1])
+	})
+
+	t.Run("InvalidURLReturnsError", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model: "black-forest-labs/flux-dev",
+			Input: &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{
+				InputImages: []string{"file:///etc/passwd"},
+			},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("NoInputImagesLeavesAllFieldsUnset", func(t *testing.T) {
+		req := &schemas.BifrostImageGenerationRequest{
+			Model:  "black-forest-labs/flux-kontext-pro",
+			Input:  &schemas.ImageGenerationInput{Prompt: prompt},
+			Params: &schemas.ImageGenerationParameters{},
+		}
+		result, err := replicate.ToReplicateImageGenerationInput(req)
+		require.NoError(t, err)
+		field, _, _ := imageFieldOf(t, result.Input)
+		assert.Empty(t, field, "no image field should be set when input_images is absent")
+	})
 }
 
 // TestBifrostToReplicateResponsesRequestConversion tests the conversion from Bifrost responses request to Replicate format

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -41916,6 +41916,351 @@
           }
         }
       ]
+    },
+    {
+      "name": "30. Replicate input_images field mapping (image-to-image on /v1/images/generations)",
+      "description": "Pins Replicate image-to-image on the native /v1/images/generations path. input_images was previously dropped on the generations path because the input_images -> model-specific field mapping (image_prompt / input_image / image / input_images) was only applied on the edits path, so a request carrying input_images to a kontext model generated from the prompt alone and returned a 200 with a default 1024x1024 square image. The case sends a real landscape image (scones.jpg, 1280x853) with aspect_ratio \"match_input_image\" and asserts the output stays landscape, which proves the image reached the model rather than being silently dropped. Exhaustive per-model field mapping is covered by the Go table test TestReplicateImageGenerationInputImagesFieldMapping. A streaming variant is intentionally omitted: flux-kontext does not stream partial images, so Bifrost forwards no image bytes on the stream and there is nothing to assert on.",
+      "item": [
+        {
+          "name": "replicate/black-forest-labs/flux-kontext-pro input_images -> input_image (match_input_image)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Replicate image-to-image on the NATIVE /v1/images/generations path.",
+                  "// Regression: input_images was silently dropped on the generations path (the",
+                  "// input_images -> model-specific field mapping existed only on the edits path), so",
+                  "// kontext never received its native \"input_image\" and Replicate generated from the",
+                  "// prompt alone, returning a 200 with a default 1024x1024 SQUARE image.",
+                  "//",
+                  "// Fixture is a real landscape photo (scones.jpg, 1280x853) sent with aspect_ratio",
+                  "// \"match_input_image\": if the image reaches the model the output keeps the landscape",
+                  "// aspect ratio (width > height); if it was dropped the output is the default square.",
+                  "// Asserting landscape is what catches the silent 200 that a status-only check cannot.",
+                  "// Exhaustive per-model field mapping lives in the Go test",
+                  "// TestReplicateImageGenerationInputImagesFieldMapping.",
+                  "",
+                  "// Infra guard: skip on auth/rate/server noise. NOT 400 - a 400 here is a real",
+                  "// regression signature and must fail loudly. (The collection-level 2xx test still",
+                  "// asserts status, so kontext rate-limits/5xx surface as failures for triage.)",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "",
+                  "pm.test('images/generations returned success', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "",
+                  "var body = pm.response.json();",
+                  "pm.test('response carries an output image', function () {",
+                  "  pm.expect(body.data && body.data.length, 'no data in response: ' + pm.response.text()).to.be.above(0);",
+                  "});",
+                  "if (!body.data || !body.data.length) { return; }",
+                  "",
+                  "// PNG dimensions live in the IHDR chunk: width at byte 16, height at byte 20.",
+                  "function pngDims(buf) {",
+                  "  if (!buf || buf.length < 24) { return null; }",
+                  "  if (buf[0] !== 0x89 || buf[1] !== 0x50 || buf[2] !== 0x4E || buf[3] !== 0x47) { return null; }",
+                  "  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };",
+                  "}",
+                  "function toBuffer(stream) {",
+                  "  if (Buffer.isBuffer(stream)) { return stream; }",
+                  "  if (stream && stream.type === 'Buffer' && Array.isArray(stream.data)) { return Buffer.from(stream.data); }",
+                  "  return Buffer.from(stream);",
+                  "}",
+                  "function assertImageUsed(buf) {",
+                  "  var dims = pngDims(buf);",
+                  "  if (!dims) {",
+                  "    // Not a decodable PNG despite output_format=png - degrade to 'image present' so a",
+                  "    // format surprise does not false-fail, but surface it.",
+                  "    console.log('WARN: output was not a decodable PNG; skipped dimension check');",
+                  "    return;",
+                  "  }",
+                  "  pm.test('output keeps input landscape aspect ratio => image was used (not dropped to square)', function () {",
+                  "    pm.expect(dims.width, 'expected landscape output (input 1280x853), got ' + dims.width + 'x' + dims.height).to.be.above(dims.height);",
+                  "  });",
+                  "}",
+                  "",
+                  "var first = body.data[0];",
+                  "if (first.b64_json) {",
+                  "  assertImageUsed(Buffer.from(first.b64_json, 'base64'));",
+                  "} else if (first.url) {",
+                  "  pm.sendRequest({ url: first.url, method: 'GET' }, function (err, res) {",
+                  "    if (err) { console.log('WARN: could not download output image: ' + err); return; }",
+                  "    assertImageUsed(toBuffer(res.stream));",
+                  "  });",
+                  "} else {",
+                  "  pm.expect.fail('response image had neither url nor b64_json: ' + pm.response.text());",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"replicate/black-forest-labs/flux-kontext-pro\",\n  \"prompt\": \"add a soft warm glow to the scene\",\n  \"aspect_ratio\": \"match_input_image\",\n  \"output_format\": \"png\",\n  \"input_images\": [\n    \"https://storage.googleapis.com/generativeai-downloads/images/scones.jpg\"\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/images/generations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "images",
+                "generations"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "31. Gemini/Vertex generationConfig.mediaResolution honored (image prompt tokens)",
+      "description": "Regression: generationConfig.mediaResolution was silently dropped in the Gemini -> Bifrost -> Gemini\nResponses conversion on the /genai generateContent path, so a Vertex/Gemini image request billed the\nmodel-default image token count regardless of MEDIA_RESOLUTION_LOW/HIGH (e.g. ~1290 instead of ~74\nprompt tokens for a 1024x1024 image). thinkingConfig survived because both conversion legs handle it;\nmediaResolution was handled by neither.\n\nFix: round mediaResolution through ExtraParams[\"media_resolution\"] in core/providers/gemini\n(convertGenerationConfigToResponsesParameters inbound + convertParamsToGenerationConfigResponses outbound).\n\nThe only external signal is usageMetadata.promptTokenCount, so each pair sends the SAME 1024x1024 image\n(folder-level prerequest sets {{mediaResImage}}) and asserts the HIGH request reports more prompt tokens\nthan the LOW request. If the field is dropped, both fall back to the same default => equal counts =>\nthe HIGH-exceeds-LOW assertion fails, independent of what the model default is. 31.1/31.2 pin the fix on\nthe GenAI route (needs only {{genaiKey}}); 31.3/31.4 pin the same invariant on Vertex (the reported\nroute) and skip cleanly if Vertex is not configured.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// 1024x1024 JPEG (base64), large enough that MEDIA_RESOLUTION_HIGH tiles into more image",
+              "// tokens than LOW. Image pixel dimensions (not content) drive Gemini image token counts.",
+              "pm.collectionVariables.set('mediaResImage', '/9j/2wCEABQODxIPDRQSEBIXFRQYHjIhHhwcHj0sLiQySUBMS0dARkVQWnNiUFVtVkVGZIhlbXd7gYKBTmCNl4x9lnN+gXwBFRcXHhoeOyEhO3xTRlN8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fP/AABEIBAAEAAMBIgACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AOzpKKKACiikoELSUUUAFFJRQI8eopaKDUKKKWmMSloooAKKKWgZ65RRSVJyC0lFFABRSUUCCiiigR5PRRS1Z6AlLRRQMKKKWgYlLRRQM9UpKKKzPJCiikoEFFFFAgopKKAPMKWiitT2woopaBiUtFFABRRS0DPSqKKSsT54KKKKACikooEFFFFAjzmiilrY+nEpaKKYBRRS0DCiiigZ6DRRRXOfJhRSUUCCiiigQUlFFAHBUtFFdJ9iFFFLQMSloooGFFLRQB3FFJRXKfEBRRRQIKSiigAoopKBHGUUUtdR96JS0UUwCiiloGFFFFAzr6KKK4z89CikooEFFFFAgpKKKBHKUtFFdh+kBRRS0xhRRRQMKKWigDpqKSiuE/MgooooEFJRRQAUUUlAjnqKKWu4/UwooopjCilooAKKKKBnoNJRRXOfKBRRSUCFpKKKBBRSUUAeQUUtFBYUUUtAxKWiimMKKKWgD1qiikqTmFpKKKBBRSUUAFFFFAjymiilqjvEpaKKYBRRS0DEpaKKBnqVJRRWZ5YUUUlAgooooEFFJRQI8ypaKK0PaCiilpjEpaKKBhRS0UAekUUUlYngBRRRQIKKSigAooooEed0UUtbH0olLRRQMKKWimAUUUUDPQKSiiuc+UCikooAKKKKBBRSUUCOEpaKK6D7AKKKWmMSloooGFFLRQM7aikorlPiQooooEFFJRQIKKKSgDjqKKWuo+7EpaKKBhRS0UwCiiigZ1tFFFcZ+fBRSUUAFFFFAgpKKKBHLUtFFdh+jhRS0UAFFFFMYUUtFAzpKKSiuE/MwooooEFJRRQIKKKSgDAopaK7j9RCiiimMKKWigYUUUtAHfUlFFc58qFFFJQAtJRRQIKKSigR5FS0UUFBRRS0DEpaKKBhRRS0xnrFFFJUnOLSUUUCCikooEFFFFAHldFFLVHaJS0UUDCiilpgFFFFAz1CkoorM8wKKSigAooooEFFJRQI80paKK0PZCiiloASloopjCilooGejUUlFYnghRRRQIKKSigQUUUlAHn1FFLWx9GJS0UUDCiiloGFFFFMDvqSiiuc+WCikooEFFFFABRSUUCOGpaKK6D68KKKWgAooopjCilooGdpRSUVynxYUUUUCCikooEFFFJQI5CiilrqPugooooGFFLRQMKKKKYHV0UUVxnwAUUlFAgoopKAFpKKKBHMUtFFdh+ihRS0UDCiiigAopaKYzoqKSiuE/NAoopKAFpKKKBBRRSUCMKiloruP1EKKKKACilooGFFFLTGd5SUUVznywUUUlAgooooAKKSigR5JS0UUDCiiloASloooGFFFLQM9WoopKRiFFFFAgopKKBBRRRQI8toopao7BKWiigYUUUtAwooopgem0UUVmecFFJRQIKKKKACikooEebUtFFaHrhRRS0DEpaKKACilopjPRKKSisTwgooooAKKSigQUUUlAjgKKKWtj6ISloooGFFLRQMKKKKBnd0UUVgfLhRSUUCCiiigQUlFFAHEUtFFdB9aFFFLQMKKKKACilopjOyopKK5T4wKKKKACkoooEFFFJQI5KiilrqPuQooooAKKWigYUUUUDOpooorkPgQpKKKBBRRSUCFpKKKAOapaKK7D9DCilooGFFFFAwopaKAOgopKK4z82CiikpCFpKKKACiikoEYlFLRXcfp4UUUUDCilooAKKKWgZzdFLRWB8kFFFFAwopaKBhRRS0AesUUUUDCkoooEFFFJQAtJRRQI8rooooNQopaKYwoopaAEpaKKBnqFJRRUnIFFFJQAtJRRQIKKKSgR5pRS0VZ6AUUUtAxKWiigYUUUtAz0aiikrM8kWkoooEFFFJQIWkoooA89ooorU9sKWiigYUUUtACUtFFAzvqSiisT54KKKSgBaSiigQUUlFAjhqKWitj6cKKKWmAlLRRQMKKKWgZ2lFFJXOfJi0lFFAgoopKBBRRRQBx9FFLXSfYiUtFFAwoopaBiUtFFAHWUlFFcp8QFFFJQIKKKKACikooEcxS0UV1H3oUUUtMBKWiigYUUtFAzoqKKSuM/PRaSiigQUUlFAgooooEYNFFLXYfpAlLRRTGFFFLQMKKKKANqkoorhPzIKKSigQUUUUAFFJRQI4eilorY+mCiiimAUUtFAwoopaBnq1FFJQULSUUUCCiikoELSUUUAeW0UUUFhRS0UDCiilpjEpaKKAPTqSiipOYKKKSgQtJRRQAUUlFAjzailoqjvCiilpgJS0UUDCiiloGeiUUUlZnli0lFFAgoopKBBRRRQI8/ooorQ9oKWiimMKKKWgYlLRRQB3lJRRWJ4AUUUlAgooooAKKSigRxFFLRWx9KFFFLQMSloopgFFFLQM7KiikrnPlBaSiigAopKKBBRRRQI5GiilroPsBKWiimMKKKWgYlLRRQM6qkoorlPiQopKKBBRRRQIKKSigDmqWiiuo+7CiiloGJS0UUwCiiloGdBRSUVxn58FFFFABRSUUCCiiigRh0UUtdh+jiUtFFABRRS0xhRRRQM16KKK4T8zCikooEFFFFAgpKKKAOJopaK2PpAooooGFFLRTAKKKWgZ6pRRSUFi0lFFABRRSUCFpKKKBHl9FFFBQUUtFAwoopaBiUtFFMZ6ZSUUVJzhRRSUCFpKKKBBRSUUAecUUtFUdoUUUtAxKWiimAUUUtAz0KiikrM8wWkoooAKKKSgQUUUUCOBoopa0PZEpaKKACiilpjEpaKKBndUlFFYnghRRSUCFpKKKBBRSUUAcVRS0VsfRhRRS0DEpaKKBhRRS0wOwoopK5z5YWkoooEFFJRQAUUUUCOToopa6D68SloooAKKKWmMSloooGdRSUUVynxYUUlFAgooooEFFJRQI5yloorqPugoopaBiUtFFAwopaKYG9RRSVxnwAUUUUCCikooAKKKKBGLRRS12H6KJS0UUDCilooAKKKKYzVooorhPzQKKSigAooooEFJRRQI4uilorY+jCiiigYUtFFAwoopaYHqVFFJQai0lFFAgoopKAFpKKKBHmNFFFAwpaKKACiiloGJS0UUDPSqSiikYhRRSUCFpKKKBBRSUUCPOqWiiqOwKKKWgYlLRRQMKKKWmB6BRRSVmecLSUUUCCikooAKKKKBHB0UUtaHriUtFFAwoopaAEpaKKYzuKSiisTwgopKKACiiigQUUlFAjjKWiitj6IKKKWgYlLRRQMKKKWgZ11FFJWB8uLSUUUCCikooEFFFFAHK0UUtdB9aJS0UUDCiiloAKKKKYzpqSiiuU+MCikooAKKKKBBRSUUCOepaKK6j7kKKKWgAooooGFFLRQM3KKSiuQ+BCiiigQUUlFAgoopKAMiiilrsP0MSloooGFFLRQMKKKKANOiiiuM/NgopKKQgoopKAFpKKKBHR0UUV0H1oUUlFAgooooEFJRRQB5dS0UUjAKKKWgYUUUUDCilooA9MopKKBhRRRQIKSiigAoopKBHnFFFLQahRRRTGFFLRQAUUUUDPQ6KKKk5ApKKKACiikoELSUUUCOBoooqz0AopaKBhRRRQMKKWigZ3VFJRWZ5IUUUlAhaSiigQUUUlAHFUUtFanthRRRQMKKWigAoopaBnYUUUVifPBSUUUAFFFJQIWkoooEcnRRRWx9OFFLRTAKKKKBhS0UUDOopKKK5z5MKKKSgQtJRRQIKKKSgDnKKWiuk+xCiiigYUtFFAwoopaAN6iikrlPiBaSiigAoopKBBRRRQIxaKKK6j70KKWimAUUUtAxKWiigZrUlFFcZ+ehRRSUCFpKKKBBRSUUCM6ilorsP0gKKKWmMSloooGFFFLQB19FFFYnz4UUlFABRRRQIKSiigR5hS0UVJgFFLRTAKKKKBhRS0UDPSqKSigoKKKKBBSUUUCCiikoA86opaKCwooooGFFLRTGFFFLQB6BRRRUnMFJRRQIKKKSgBaSiigRwdFFFUd4UUtFMAoopaBiUtFFAzuKKSiszywoopKBC0lFFAgoopKBHGUUtFaHtBRRRTGFLRRQMKKKWgDrqKKKxPACkoooEFFFJQAtJRRQI5Wiiitj6UKKWigYUUUtMBKWiigZ01JRRXOfKBRRSUALSUUUCCiikoEc9RS0V0H2AUUUtMYlLRRQMKKKWgZuUUUlcp8SLSUUUCCiikoAKKKKBGPRRS11H3YlLRRQMKKKWmAlLRRQM1KSiiuM/PgoopKAFpKKKBBRSUUCKFLRRXYfo4UUUtACUtFFMYUUUtAzraKKKxPACikooEFFFJQAtJRRQI8ypaKKk5gopaKBhRRRTAKKWigZ6RRSUUFhRRSUALSUUUCCiikoEeeUUtFBQUUUUDCilooGFFFLTGd9RRSVJzi0lFFAgoopKBC0lFFAHC0UUVR2hRS0UDCiiimAUtFFAztqSiiszzAoopKAFpKKKBBRRSUCOOopaK0PZCiiigAopaKYwoopaBnWUUUlYngi0lFFAgoopKBC0lFFAHL0UUVsfRhRS0UDCiiloGJS0UUwOkpKKK5z5YKKKSgQtJRRQAUUlFAjAopaK6D68KKKWgBKWiimMKKKWgZtUUUlcp8WLSUUUCCikooEFFFFAGTRRS11H3IlLRRQMKKKWgYlLRRTA0qSiiuM+ACikooEFFFFABRSUUCKVLRRXYfooUUUtAxKWiigAoopaYzq6KKKxPCCikooEFFFJQIWkoooA80paKKk5AopaKBhRRRQMKKWimB6NRSUUGoUUUlAhaSiigAoopKBHn1FLRQMKKKKACilooGFFFLQM7yiikpGItJRRQIKKKSgQtJRRQI4eiiiqOwKKWigYUUUtAxKWiimB2lJRRWZ5wUUUlAhaSiigAoopKBHIUUtFaHrhRRS0DEpaKKACiilpjOqoopKxPCFpKKKACiikoELSUUUCOZooorY+iCilooGFFFLQMSloooGdFSUUVifLhRRSUhC0lFFAgopKKAMKiloroPrQoopaBiUtFFABRRS0xmxRRSVynxgtJRRQAUUlFAgooooEZdFFLXUfciUtFFABRRS0DEpaKKBmhSUUVynwIUUUlIQUUUUCCikooAqUtFFdh+hhRRS0DEpaKKBhRS0UAc3S0UVznyYUUUtMBKWiigYUUUtAz0iiikqjsFpKKKBBRSUUCCiiigDzuiilpGAlLRRQMKKKWgYUUUUAegUlFFAwopKKBBRRRQAUUlFAjhKWiig1CiilpjCiiigAopaKBnbUUlFScgUUUUAFFJRQIKKKSgRx1FFLVnoBRRRQMKKWigYUUUUDOtooorM8kKKSigQUUUlAhaSiigDlqWiitT2woopaBhRRRQAUUtFAzpKKSisT54KKKKACikooEFFFJQIwKKKWtj6cKKKKYBRS0UDCiiigZt0UUVznyYUUlFAgoopKBC0lFFAGTRRRXSfYhRS0UDCiiigApaKKBmlRSUVynxAUUUlAC0lFFAgoopKBFKilorqPvQooopgFLRRQMKKKWgZYoopK4z89FpKKKBBRRSUCFpKKKBHL0tFFaHthRRS0DEpaKKYBRRS0DPRqKKSqO0KKKKACikooEFFFFAjz2iilqTASloopgFFFLQMKKKKBne0UUUFBRSUUCCiiigQUlFFAHDUtFFBYUUUtAwooopjCilooA7SikoqTmCiiigQUlFFABRRSUCOQoopao7xKWiimAUUtFAwooooGdXRRRWZ5YUUlFAgoopKBC0lFFAjmKWiitD2goopaYwooooGFFLRQB0VFJRWJ4AUUUUCCkoooAKKKSgRhUUUtbH0oUUUUDCilopgFFFFAzZooornPlApKKKACiikoELSUUUCMuiiiug+wCilopjCiiigYUtFFAGhSUUVynxQUUUlAhaSiigAoopKBFSilorqPuwooooGFFLRTAKKKWgZNRRSVxn58LSUUUAFFFJQIWkoooEczS0UVoeyFFFLQMSloooGFFLRTA9EoopKo7wooooEFFJRQAUUUUCPP6KKWpOYSloooGFFLRTAKKKKBnd0UUUFhRSUUAFFFFAgpKKKBHEUtFFBQUUtFAwooooGFFLRTGdlRSUVJzhRRRQIKKSigQUUUlAHJUUtFUdoUUUUDCilopgFFFLQM6iiiiszzAopKKACiikoELSUUUCOapaKK0PZCilooAKKKKYwopaKBnQUUlFYnghRRRQIKSiigQUUUlAGJRS0VsfRhRRRQMKKWigYUUUtMDWooornPlgpKKKBBRRSUALSUUUCM2iiiug+vCilooAKKKWmMSloooGXqSiiuU+LCiikoELSUUUCCiikoArUUtFdR9yFFFLQMSloooGFFFLTAkoopK4z4AWkoooEFFFJQAtJRRQI5uloorQ9gKKKWgBKWiigYUUtFAz0Kikoqz0AooooEFFJRQIKKKSgDgqKKWpOQSloooGFFLRQMKKKKYHc0UUUGoUUlFAgoopKAFpKKKBHFUtFFAwoopaACiiigYUUtFAzsKKSikYhRRSUCFpKKKBBRRSUCOUoopao7AooooGFFLRQMKKKKYHT0UUlZnnC0lFFAgoopKAFpKKKBHOUtFFaHrhRS0UDCiiigAopaKYzeopKKxPCCiikoAWkoooEFFFJQIxqKWitj6IKKKKBhRS0UDCiiloGalFFJWJ8uLSUUUhBRRSUCFpKKKAM+iiiug+tCilooGFFFLQAlLRRTGXKSiiuU+MCiikoAWkoooEFFJRQIgopaK6j7kKKKWgBKWiigYUUUtAx1FFJXKfAi0lFFIQUUlFAgooooA6OiikroPrBaSiigAoopKBC0lFFAjz+iiiszzgopaKYBRRS0DEpaKKBneUlFFUdgUUUlAhaSiigQUUlFAHEUUtFIwCiiloGJS0UUDCiiloA7KiikoGLSUUUCCiikoAKKKKBHI0UUUGoUtFFMYUUUtACUtFFAzqqSiipOQKKKSgAooooEFFJRQI5qlooqz0AoopaBiUtFFAwoopaBnQUUUlZnki0lFFAgopKKBBRRRQBh0UUVqe2FLRRQMKKKWgBKWiigZsUlFFYnzwUUlFABRRRQIKKSigRmUtFFbH04UUUtMBKWiigYUUUtAy9RRSVznyYUUUUCCikooEFFFFAFWiilrpPsRKWiigYUUUtABRRRQMlooorlPiAopKKBBRRRQAUlFFAhKWiiuo+9CiilpgFFFFAwopaKBm/RRSVmeULSUUUCCiikoAWkoooEcDRRRWZ5gUtFFAwoopaYCUtFFAzuqSiiqO0KKKSgBaSiigQUUlFAjiqWiipMAoopaYCUtFFAwoopaBnYUUUlBQtJRRQIKKKSgQUUUUAcnRRS0FiUtFFAwoopaYxKWiigDqKSiipOYKKKSgQUUUUAFFJRQI5ylooqjvCiilpgJS0UUDCilooGb1FFJWZ5YtJRRQIKKKSgQUUUUCMWiilrQ9oSloopjCiiloGJS0UUAa1JRRWJ4AUUUlAgooooAKKSigRnUtFFbH0oUUUtAxKWiimAUUtFAy5RRSVznygUUUUAFFJRQIKKKKBFeiilroPsBKWiimMKKWigYUUUUAPooorlPigopKKBBRRRQIKSiigBaWiiuo+7CilooGFFFFMAopaKBm7RRSVmeYLSUUUCCikooEFFFFAHB0UUVmeUFLRRQMKKKWgYlLRRTA7ikooqjvCiikoEFFFFABRSUUCOMpaKKk5goopaBiUtFFMAoopaBnXUUUlBYtJRRQAUUlFAgooooEcrRRS0FCUtFFAwoopaBiUtFFMZ01JRRUnOFFJRQIKKKKBBRSUUAc9S0UVR2hRRS0DEpaKKYBRS0UDNyiikrM8wWkoooAKKSigQUUUUCMeiilrQ9kSloooAKKKWmMKKKKBmpSUUVieCFFJRQIKKKKBBRSUUAUKWiitj6MKKKWgYlLRRQMKKWimBaopKK5z5YKKKKBBRSUUAFFFJQIioopa6D68SloooAKKWimMKKKKBi0UUVynxYUUlFAgoopKBC0lFFAh9LRRXUfdBRS0UDCiiigYUUtFMDboopKzPNFpKKKACiikoEFFFFAjhaKKWszyhKWiigAoopaBiUtFFAztqSiirPQCiikoEFFFFAgopKKAOOpaKKk5AoopaBiUtFFAwopaKYHWUUUlBqLSUUUCCikooAKKKKBHL0UUtAxKWiigAoopaBiUtFFAzpKSiikYBRSUUAFFFFAgopKKBGBS0UVR2BRRS0DEpaKKBhRS0UwNqikorM84KKKKBBRSUUAFFFFAjJoopa0PXEpaKKBhRRS0AJS0UUxmjRRRWJ4QUUlFABRRRQIKSiigRSpaKK2PowoopaAEpaKKBhRS0UDLFFJRWB8uFFFFAgopKKBBRRSUAMoopa6D60SloooGFFLRQAUUUUxiUUUVynxgUUlFABRRSUCFpKKKBEtLRRXUfchRS0UAFFFFAwopaKBnOUUUVgfJBRS0UDCiiigApaKKBncUUlFaHrhRRSUALSUUUCCiikoEcZRS0VmecFFFFMAopaKBhRRRQM6+iikqjsFpKKKBBRRSUCFpKKKAOVooopGAUUtFAwooooGFLRRQB01FJRQMKKKSgQtJRRQAUUUlAjnqKWig1CiiimMKWiigAoopaBm5RRSVJyC0lFFABRRSUCFpKKKBGPRRRVnoBRS0UDCiiloGJS0UUDNSikorM8kKKKSgQtJRRQIKKKSgChRS0Vqe2FFFLQMSloooAKKKWgZaoopKxPnhaSiigAoopKBC0lFFAiGiiitj6cKWiimAUUUtAxKWiigY6koornPkwoopKBC0lFFAgopKKAH0tFFdJ9iFFFLQMSloooAKKKWgZXoopK5T4gWkoooEFFJRQAUUUUCMiiiiqO8KKWimMKKKKBhRS0UAdtSUUVoeyFFFJQIWkoooAKKKSgRx1FLRWZ5gUUUUDCilopgFFFLQM6yiiiqO0KSiigAoopKBC0lFFAjl6KKKk5wopaKYwooooGFLRRQM6SkoooKCiikoELSUUUCCiikoAwKKWigsKKKKBhS0UUxhRRS0AbVFFJUnMLSUUUCCiikoAKKKKBGTRRRVHeFLRRTAKKKWgYlLRRQM0qSiiszywoopKBC0lFFAgopKKBFKilorQ9oKKKKYwpaKKBhRRS0AWKKKSsTwBaSiigQUUUlABRRRQIjooorY+lCloooGFFFLTASloooGFJRRXOfKBRRSUAFFFFAgopKKBEtLRRXQfYBRRS0xiUtFFAwoopaAKtFFJXKfFBRRRQIKKSigQUUUUAZVFFFUdwUUtFABRRS0xiUtFFAztKKSitD2goopKBC0lFFAgoopKAOQopaKzPKCiiigYUtFFAwoopaYHVUUUlUd4tJRRQIKKKSgBaSiigRzNFFFScwUUtFABRRS0xiUtFFAzoqSiigsKKKSgBaSiigQUUUlAjCopaKCgoopaBiUtFFAwoopaYzYoopKk5xaSiigQUUUlAgooooAy6KKKo7QopaKBhRRS0wEpaKKBmhSUUVmeYFFFJQAtJRRQIKKKSgRUopaK0PZCiiloASloopjCiiloGTUUUlYngi0lFFAgoopKBBRRRQA2iilrY+jEpaKKBhRRS0DEpaKKYDaSiiuc+WCiikoEFFFFABRSUUCJ6Wiiug+vCiiloASloooGFFLRTGU6KKSuU+LCiiigQUUlFAgooooEZlFFFUdoUUtFAwoopaAEpaKKYzsqSiitD2woopKAFpKKKBBRSUUCOSopaKzPKCiiigAopaKBhRRS0DOooopKs9AWkoooEFFFJQIKKKKAOboooqTkCilooGFFFLQAlLRRTGdBSUUUGoUUUlAhaSiigAopKKBGJRS0UDCiiloASloooGFFFLQM1qKKSkYC0lFFABRSUUCCiiigRm0UUtUdglLRRQMKKKWgYlLRRTAvUlFFZnnBRRSUCFpKKKACikooEVqWiitD1woopaBiUtFFABRRS0xklFFJWJ4QtJRRQAUUlFAgooooEFFFLWx9EJS0UUDCiiloGJS0UUDI6SiisD5cKKSigQUUUUCCikooAs0tFFdB9aFFFLQMSloooAKKWigZRopKK5j4wKKKKACikooEFFFJQI6SikoroPrQooooEFFJRQIKKKSgDkKKKWsjwhKWiigYUUtFABRRRQM6uiiitD1wopKKACiiigQUUlFAjmKWiiszzgopaKYBRRRQMKKWigZ0VFJRVHYFFFFAgopKKBBRRSUAYVFFLSMBKWiigYUUtFAwooooA2aKKKBhRSUUCCiikoAWkoooEZVLRRQahRS0UxhRRRQAUUtFAzQopKKk5AoopKAFpKKKBBRRSUCKlFFLVnoBRRRQMKKWigYUUUUDJ6KKKzPJCkoooEFFFJQIWkoooAZS0UVqe2FFLRQMKKKKACilooGNopKKxPngoopKAFpKKKBBRRSUCJ6KWitj6cKKKKYBRS0UDCiiloGU6KKSuc+TFpKKKBBRRSUCFpKKKANCiiiug+xCilopjCiiloASloooGX6KSipOUKKKKACikooEFFFJQI5KiilrE8EKKKKYwopaKBhRRRQB1NFFFaHshRSUUCCiikoAWkoooEc1S0UVmeYFFFLQMKKKKYBRS0UDOgopKKo7QooooAKKSigQUUUlAjEoopak5wooopjCilooGFFFFAzXooooKCikooEFFFJQIWkoooAzaKKKCwopaKBhRRRTGFLRRQBeopKKk5gooooEFJRRQAUUUlAitRS0VR3hRRRTAKKWigYUUUtAySiiiszywopKKBBRRSUCFpKKKBBRRRWh7QUUtFMYUUUUDCloooAjopKKxPACiikoELSUUUAFFFJQIs0UtFbH0oUUUUDCloopgFFFLQMo0UUlc58oLSUUUAFFFJQIWkoooEaVFFFdB9gFLRRQMKKKWmMSloooAu0UlFSc4UUUUAFJRRQIKKKSgRylFFLWJ4AUUUUAFFLRQMKKKKYzp6KKK0PaCkoooEFFFJQIWkoooA5yloorM8oKKWigYUUUUDCilopgb1FJRVHeFFFFAgpKKKACiikoEY1FFLUnMFFFFABRS0UxhRRRQM1aKKKCwpKKKACiikoELSUUUCM+iiigoKKWigYUUUUDCloopjLlFJRUnOFFFJQIWkoooEFFFJQBBRS0VR2hRRRQMKKWimAUUUtAx1FFJWZ5gtJRRQAUUUlAhaSiigQ6iiitD2QopaKACiiimMKWiigZDSUUVieCFFFJQIWkoooEFFFJQBbopaK2PowooooGFLRRQMKKKWmBn0UUlc58sLSUUUCCiikoAKKKKBGpRRRXQfXhS0UUAFFFLQMSloopjLdFJRUmAUUUUCCkoooAKKKSgRy1FLRWJ88FFFFAwopaKACiiloGdJRRRWp7YUUlFABRRSUCFpKKKBHP0UUVmeUFFLRQAUUUUDCloooGblFJRVnoBRRRQIKSiigQUUUlAGRRS0VJyBRRRQMKKWigAoopaYzSooooNQpKKKBBRRSUALSUUUCKNFFFAwopaKACiiloGJS0UUDLVJRRSMQoopKBC0lFFAgoopKBEVFLRVHYFFFFAwopaKBhRRS0wCiikrM84WkoooEFFFJQAtJRRQIkooorQ9cKKWigYUUUtACUtFFMZXpKKKxPCCiikoAWkoooEFFFJQIu0UtFbH0QUUUtAxKWiigYUUUtAzNoopKwPlxaSiigQUUUlAgooooA1qKKWug+tEpaKKBhRRS0AJS0UUDOcoopawPkhKWiigYUUUtAxKWiigZ1FJRRWx9EFFJRQIKKKKBBRSUUAc5S0UVieEFFFLTGJS0UUAFFFLQM3qKSitD1wooooAKKSigQUUUUCMWiilrM84SloopgFFFLQMSloooGa1JRRVHYFFJRQIKKKKBBRSUUAZ1LRRSMAoopaBiUtFFAwopaKALlFJRQMKKKKBBRSUUAFFFJQIgoopaDUSloopjCilooAKKKKBklJRRUnIFFJRQAUUUUCCikooELS0UVZ6AUUUtAwooooGFFLRQMhopKKzPJCiiigQUUlFAgoopKALdFFLWp7YlLRRQMKKWigAooooGUKKKKxPngopKKACiikoELSUUUCNOloorY+nCilopgFFFFAwopaKBmPRSUVznyYUUUlAhaSiigQUUUlAENFFLQaCUtFFMAoopaBiUtFFAzpqSiitj6MKKKSgAooooEFFJRQI56loorE8EKKKWgYlLRRTGFFLRQBuUUUlaHshRRRQIKKSigAooooEY9FFLWZ5glLRRQMKKKWmAlLRRQM1KSiiqO0KKSigAooooEFFJRQIoUtFFSc4UUUtMYlLRRQMKKWigZaopKKCgooooEFFJRQIKKKSgCKiiloLEpaKKBhRRS0xhRRRQAtFFFScwUUlFAgooooAKSiigQ+looqjvCiilpgFFFFAwopaKBleikorM8sKKKKBBSUUUCCiikoEXaKKWtD2hKWiimMKKWigYUUUUAZ1FFFYngBRSUUCCiikoAWkoooEatLRRWx9KFFLRQMKKKKYBRS0UDMWikornPlAoopKAFpKKKBBRRSUCI6KKWgsSloooGFFFLTAKKKKBnSUlFFbH0oUUlFAgooooAKKSigRgUtFFYngBRRS0AFFFFAwopaKYzaopKK0PaCiiigQUUlFAgoopKAMqiilrM8oSloooGFFFLQMKKKKYGlSUUVR3hRSUUCCiiigAopKKBFKlooqTmCiiloAKKKKYwopaKBliikooLCiiigAopKKBBRRSUCGUUUtBQlLRRQMKKWigYUUUUxiUUUVJzhRSUUCCiiigQUlFFAEtLRRVHaFFLRQMKKKKYBRS0UDKtFJRWZ5gUUUUAFFJRQIKKKSgRfopaK0PZCiiigAopaKBhRRRTGZlFFFYnghRSUUCCiikoELSUUUAbFFFFbH0YUUtFAwooooGFLRRTAw6KSiuc+WCiikoELSUUUAFFFJQIbRRS0DEpaKKBhRRS0DEpaKKYHQ0UUVsfThRSUUCCiiigQUlFFAGFS0UVifPBRRS0DEpaKKACilooGbFFJRWp7YUUUUAFJRRQIKKKSgRmUUUtZnkiUtFFAwoopaBhRRRQMv0UUVZ6AUUlFAgooooEFJRRQBUpaKKk5AoopaBhRRRQAUUtFMZNRSUUGoUUUUCCkoooAKKKSgQlFFLQMSloooAKKWigYUUUUDGUUUUjEKKSigQUUUlAhaSiigRPS0UVR2BRS0UDCiiigYUUtFMCnRSUVmecFFFJQIWkoooAKKKSgRo0UUtaHrhRRRQMKKWigAooooGZVFFFZHhBSUUUAFFFJQIWkoooEbVFFFbH0QUUtFAwooooGFLRRQMwaSiisD5cKKKSgQtJRRQIKKKSgDpKKSiug+sCiikoAWkoooEFFFJQIwKKWisD5gKKKKACilooGFFFLQM2qKKStj6IWkoooEFFFJQIWkoooAyaKKKyPCCilooGFFFLQMSloooA0qSiitD1woopKAFpKKKBBRRSUCKVFLRWZ5wUUUUwCilooGFFFLQMsUUUlUdgtJRRQIKKKSgQtJRRQBHRRRSMAopaKBhRRS0DEpaKKACkoooGFFFJQIWkoooAKKSigRLRS0UGoUUUtMYlLRRQAUUUtAyrRRSVJyC0lFFABRSUUCCiiigReoopas9ASloooGFFFLQMSloooGZtJRRWZ5IUUUlAgooooEFFJRQBr0tFFanthRRS0DEpaKKACiiloGYdFFJWJ88FFFFABRSUUCCiiigR0FFFLWx9OJS0UUwCiiloGFFFFAxKKSigYUUUlAhaSiigAoopKBGFRS0VgfLBRRRQMKWiigAoopaBmxRRSVsfRi0lFFABRRSUCFpKKKBGXRRRWJ4IUtFFMYUUUtAxKWiigZoUlFFaHsBRRSUCFpKKKACiikoEVKKWiszzAooooGFLRRTAKKKWgZNRRSVR2i0lFFABRRSUCFpKKKBDaKKKkwCloopgFFFLQMSloooGNpKKKCgoopKBC0lFFAgopKKAJ6WiigsKKKWgYlLRRTGFFFLQBToopKk5haSiigQUUlFABRRRQI0KKKWqO8SloopgFFFLQMKKKKBmXSUUVmeWFFFJQIKKKKBBRSUUCNmloorQ9oKKKWmMSloooGFFLRQBg0UUlYngBRRRQIKKSigAooooEdFRRS1sfSiUtFFAwopaKYBRRRQMZSUUUFhRRSUCFpKKKBBRRSUAYlFLRXOfKBRRRTGFLRRQMKKKWgDWoopK2PpRaSiigQUUUlABRRRQIzaKKKxPACloooAKKKWmMSloooGXqSiitD2goopKBC0lFFAgopKKAK1FLRWZ5QUUUUDCloooGFFFLTAkoopKo7xaSiigQUUUlABRRRQIKKKKk5gpaKKBhRRS0wEpaKKBkdJRRQWFFFJQAUUUUCCikooEWaWiigoKKKWgYlLRRQMKKKWmMo0UUlSc4UUUUCCikooEFFFFAGlRRS1R2iUtFFAwoopaYBRRRQMyaSiiszzAopKKACiiigQUUlFAjbpaKK0PZCiiloASloopjCilooGc/RSUVieCFFFFAgopKKBBRRSUAdLRRS1sfRiUtFFAwopaKBhRRRTAipKKKDQKKKSgBaSiigQUUUlAjGopaK5z5MKKKWgYlLRRTGFFFLQM1KKKStj6YWkoooEFFFJQIKKKKAM+iilrE+eEpaKKBhRRS0AJS0UUxlykoorQ9sKKKSgBaSiigQUUlFAiCilorM8oKKKWgBKWiigYUUUtAx1FFJVnoC0lFFAgoopKBBRRRQA6iilqTkEpaKKBhRRS0DEpaKKYENJRRQahRRSUCCiiigAopKKBFuloooGFFFLQAlLRRQMKKWigZn0UUlIxCiiigQUUlFAgooooEalFFLVHYJS0UUDCilooGFFFFMDGooorM84KKSigQUUUUAFFJRQI3aWiitD1woopaBiUtFFABRS0UxnO0UlFYnhBRRRQAUUlFAgoopKBHT0UUtbH0QlLRRQMKKWigYUUUUDOcoopawPkhKWiigYUUtFABRRRQM16KKK6D60KKSigAoopKBC0lFFAjMpaKKwPmAopaKACiiigYUUtFAy9RSUVsfRBRRSUCFpKKKBBRRSUAVqKKWsjwgooooGFFLRQAUUUUDJaKKK0PXCikooAKKKSgQtJRRQISloorM84KKWimAUUUUDCilooGR0UlFUdgUUUlAhaSiigQUUUlAFmilopGAUUUUDCilooGFFFLQBRoopKBi0lFFAgoopKAFpKKKBGlRRRQahRS0UxhRRS0AJS0UUDMmkooqTkCiikoAWkoooEFFJRQI26KWirPQCiiloGJS0UUDCiiloGc/RRSVmeSLSUUUCCiikoELSUUUAdJRRRWp7YUtFFAwoopaAEpaKKBnL0lFFYnzwUUUlAC0lFFAgopKKBFqiilqTASloopjCilooGFFFFAGrRRRXQfXhRSUUCCiikoAWkoooEZ1LRRWB8sFFLRQMKKKKACilooGXKKSitj6MKKKSgBaSiigQUUUlAiCiilrE8EKKKKYwopaKBhRRRQA+iiitD2QpKKKBBRRSUALSUUUCFpaKKzPMCilooGFFFFMAopaKBkNFJRVHaFFFJQAtJRRQIKKKSgRbopaKkwCiiimAUUtFAwoopaBmfRRSUFC0lFFAgoopKBC0lFFAGpRRRQWFFLRQMKKKWmMSloooAx6SiipOYKKKSgQtJRRQAUUlFAjdopaKo7woopaYCUtFFAwoopaBnO0UUlZnli0lFFAgoopKBBRRRQI6aiiitD2gpaKKYwoopaBiUtFFAHK0lFFYngBRRSUCCiiigAopKKBFyiilqTnCiiigAopaKYwooooGadFFFdB9gFFJRQIKKKSgQtJRRQBRooornPlAopaKYwooooGFLRRQBaopKK2PpQoopKBC0lFFABRRSUCIqKWisTwAooooAKKWimMKKKWgYUUUVoe0FJRRQIKKKSgQtJRRQBJRRRWZ5QUUtFAwooooGFLRRTAr0UlFUd4UUUlAhaSiigAoopKBF2iloqTmCiiigYUtFFMAoopaBmbRRSUFi0lFFABRRSUCFpKKKBGtRRRQUFLRRQMKKKWgYlLRRTGYtJRRUnOFFFJQIWkoooEFFJRQBv0UtFUdoUUUtAxKWiimAUUUtAzm6KKSszzBaSiigAoopKBBRRRQI6iiilrQ9kSloooAKKKWmMSloooGcnSUUVieCFFFJQIKKKKBBRSUUAXqKKWpOUKKKKBhRS0UAFFFFMZo0UUV0H2IUlFFABRRSUCFpKKKBFOiiiuc+TCilooGFFFFAwpaKKYyxSUUVsfTBRRSUCFpKKKBBRRSUAMopaKxPngooooGFFLRQAUUUtMY2iikrQ9sWkoooAKKKSgQtJRRQImooorM8oKKWigAooooGFLRRQMq0lFFWegFFFJQIWkoooEFFFJQBfopaKk5AooooGFLRRQMKKKWmBl0UUlBqLSUUUCCiikoAKKKKBGxRRRQMKWiigAoopaBiUtFFAzDpKKKRiFFFJQIKKKKBBRSUUCOhpaKKo7AoopaBiUtFFAwoopaYHM0UUlZnnC0lFFAgopKKACiiigR1VFFLWh64lLRRQMKKKWgBKWiimM5GkoorE8IKKSigAooooEFFJRQI6SkooroPrQoopKBBRRRQAUUlFAihS0UVzHxgUUUtAxKWiigAopaKBlqiikroPrQooooAKKSigQUUUUCIaKKWsD5gSloooAKKWigYUUUUDHUlFFbH0QUUlFAgooooEFJRRQA+loorI8IKKKWgYlLRRQAUUtFAyvRSUVoeuFFFFABRSUUCCiiigRcoopazPOEpaKKYBRS0UDCiiigZnUUUVR2BRSUUCCiiigQUlFFAGrS0UUjAKKWigYUUUUDCilooAxaKSigYUUUUCCkoooAKKKSgRv0UtFBqFFFFMYUUtFABRRS0DOboooqTkCkoooAKKKSgQtJRRQI6iiiirPQCilooGFFFFAwopaKBnJ0UlFZnkhRRSUCFpKKKBBRRSUAdjRS0Vqe2FFFFAwopaKACiiloGZtJRRVHaFFJRQIKKKKBBRSUUAUqWiiuU+KCiilpjEpaKKBhRS0UAWKKSiug+vCiiigQUUlFABRRSUCGUUUtc58sJS0UUxhRS0UAFFFFAwpKKK2PowopKKACiiigQUUlFAiWloorE8EKKWimMKKKKBhRS0UAVaKSitD2QooooEFFJRQAUUUlAi/RRS1meYJS0UUDCilopgFFFFAzMoooqjtCikooAKKKSgQtJRRQI16WiipMAopaKYBRRRQMKKWigZh0UlFBQUUUlAhaSiigQUUUlAHQ0UtFBYUUUUDCilopjCiiloA5miiipOYKSiigQUUUlAC0lFFAjqqKKKo7wopaKYBRRS0DEpaKKBnI0UlFZnlhRRSUCFpKKKBBRRSUCOzopaK0PaCiiimMKWiigYUUUtAGXSUUVR3BRSUUAFFFFAgopKKBFSloorlPigoopaAEpaKKYwopaKBk1FJRXQfYBRRRQIKKSigQUUUlACUUUtc58oJS0UUDCilopjCiiigBlFFFbH0oUUlFAgoopKAFpKKKBE9LRRWJ4AUUUtABRRRTGFFLRQMp0UlFaHtBRRRQIKSiigQUUUlAGjRRS1meUJS0UUDCilooGFFFFMDKoooqjvCikooEFFFJQAtJRRQI2aWiipOYKKWigYUUUUwCilooGYNFJRQWFFFJQAtJRRQIKKKSgR0dFLRQUFFFFAwopaKBhRRS0xnL0UUlSc4tJRRQIKKKSgQtJRRQB1lFFFUdoUUtFAwoopaYCUtFFAzj6SiiszzAoopKAFpKKKBBRRSUCO1opaK0PZCiiigApaKKYwoopaBmTSUUVR3hRSUUCCiiigAopKKBFaloorlPiAoopaBhRRRQAUUtFMZJRSUV0H2IUUUUAFFJRQIKKKSgQtFFLXOfJhRRRQMKKWigYUUUUxkVFFFbH0wUUlFAgooooEFJRRQBZpaKKxPngopaKBhRRRQAUUtFMZRopKK0PbCiiigApKKKBBRRSUCNOilorM8oKKKKACilooGFFFFAzIoooqz0AopKKBBRRSUCFpKKKANyiiipOQKKWigYUUUUDCloopgc/RSUUGoUUUlAhaSiigAoopKBHS0UtFAwooooAKWiigYUUUtAzlaKKSkYi0lFFAgoopKBC0lFFAjrqKKKo7AopaKBhRRS0DEpaKKYHG0lFFZnnBRRSUCFpKKKACiikoEdvRS0VoeuFFFLQMSloooAKKKWmM5uilornPkgooooGFLRRQMKKKWgCaiikrqPuRaSiigQUUUlABRRRQIbRRRXMfGBS0UUDCiiloASloooGNpKKK6D60KKKSgAooooEFFJRQInpaKKwPlwoopaBiUtFFAwoopaBlOiikrY+iFpKKKBBRSUUCCiiigDQoopayPCEpaKKBhRRS0AJS0UUDMukoorQ9cKKSigAooooEFFJRQI2aWiiszzgoopaYCUtFFAwoopaBmDRRSVR2BRRRQIKKSigQUUUUAdFRRS0jASloooGFFFLQMKKKKAOYooooGFFJRQIKKKKACkoooEdXS0UUGoUUUtMYUUUUAFFLRQM4+ikoqTkCiiigAopKKBBRRSUCO1oopas9AKKKKBhRS0UDCiiigZw1FFFZnkhRSUUCCiikoELSUUUAbVFLRUHmhRRS0AJS0UUDCiiloGSUUUldR90LSUUUCCiikoEFFFFABRRS1ynxQlLRRTGFFFLQMSloooAjpKKK6D68KKKSgQUUUUAFFJRQIs0UtFc58sFFFLTASloooGFFFLQMo0UUlbH0YtJRRQAUUlFAgooooEaVFFLWJ4IlLRRTGFFFLQMSloooAyaSiitD2QopKKBBRRRQAUUlFAjbpaKKzPMCiiloGJS0UUwCilooGc/RRSVR2hRRRQAUUlFAgooooEdJRRS1JgJS0UUwCilooGFFFFAzlqKKKCgopKKBBRRRQIKSiigDraWiigsKKKWgYUUUUxhRS0UAcbRSUVJzBRRRQIKSiigAoopKBHb0UUtUd4UUUUwCilooGFFFFAzhKKKKzPLCikooEFFFJQIWkoooEblFLRWZ5gUUUtMYlLRRQAUUUtAx1FFJXUfdi0lFFABRSUUCCiiigQ6iilrlPihKWiigAoopaYxKWiigZDSUUV0H2AUUlFAgooooEFFJRQBbpaKK5z5QKKKWgYlLRRTAKKKWgZn0UUlbH0otJRRQIKKSigAooooEalFFLWJ4AlLRRQAUUUtMYUUUUDMekoorQ9oKKSigQUUUUCCikooA3aWiiszygoopaBiUtFFAwopaKYHO0UlFUd4UUUUCCikooAKKKSgR09FFLUnMJS0UUDCilopgFFFFAzlKKKKCwopKKACiikoELSUUUCOvpaKKCgopaKBhRRRQMKKWimM4uikoqTnCiiigQUlFFAgoopKAO5opaKo7QooooGFFLRTAKKKWgZwNFFFZnmBRSUUAFFFJQIWkoooEb1FLRWZ5QUUUtAxKWiigYUUUtMAoopK6j70WkoooEFFJRQAUUUUCJKKKWuU+IEpaKKBhRRS0AJS0UUxlekooroPsQopKKACiiigQUUlFAi7S0UVznyYUUUtAxKWiigYUUUtMDNoopK2PpwooooEFFJRQIKKKKANaiilrE+eEpaKKBhRRS0AFFFFMZiUUUVoe2FFJRQAUUUUCCkoooEb9LRRWZ5QUUUtACUtFFAwopaKBnN0UlFWegFFFFAgopKKBBRRSUAdTRRS1JyCUtFFAwopaKBhRRRTA5Kiiig1CikooEFFFJQAtJRRQI7GloooGFFLRQAUUUUDCilooGcTRSUUjEKKKSgQtJRRQIKKKSgR3dFLRVHYFFFFAwopaKBhRRS0wPP6KKSszzhaSiigQUUUlAC0lFFAjo6KKK6D60KKSigQUUUUCCkoooELS0UVyHwIUUUtAwooooGFFLRQMhopKK6j7gKKKKBBSUUUCCiikoAt0UUtcx8YFFFFAwopaKACiiigZQoooroPrQpKKKACiikoELSUUUCNSiiisD5cKKWigYUUUUDCloooGY9JRRWx9EFFFJQIWkoooEFFFJQBu0UtFZHhBRRRQMKKWigAoopaBnO0UUlaHri0lFFABRRSUCFpKKKBHTUUUVmecFFLRTAKKKWgYlLRRQM5WkooqjsCiikoELSUUUCCiikoA6+ilopGAUUUtAxKWiigYUUUtAHF0UUlAxaSiigQUUUlABRRRQI7iiiloNRKWiimMKKKWgBKWiigZwdJRRUnIFFFJQAUUUUCCikooEeg0tFFWegFFFLQMSloooGFFLRQM5yiiitD1wopKKACiiigQUlFFAh9LRRXGfABRS0UwCiiigYUUtFAyvRSUV1H3QUUUUCCkoooEFFFJQIu0UtFcp8WFFFFMYUUtFAwoopaAM2iiiug+vCkoooEFFFJQAtJRRQI1qKKK5z5YKKWimAUUUtAxKWiigZi0lFFbH0YUUUlAC0lFFAgoopKBG/RS0VieCFFFLTGJS0UUDCiiloA5uiikrQ9kWkoooEFFFJQAtJRRQI6iiiiszzApaKKBhRRS0wEpaKKBnJ0lFFUdoUUUlAC0lFFAgopKKBHY0tFFSYBRRS0wEpaKKBhRRS0DOJoopKChaSiigQUUlFAgooooA7qiiloLEpaKKBhRRS0xhRRRQBwNJRRUnMFFJRQIKKKKACikooEeh0tFFUd4UUUtMAooooGFFLRQM5qiiitD2QopKKBBRRSUALSUUUCJaWiiuM/PgopaKBhRRRTAKKWigZVopKK6j7sKKKSgBaSiigQUUUlAi/RS0VynxQUUUUAFFLRTGFFFLQMy6KKSug+wFpKKKBBRRSUCFpKKKANiiiiuc+UCilooGFFFLTASloooGYdJRRWx9KFFFJQIWkoooAKKSigR0NFLRWJ4AUUUUAFLRRQMKKKWmM5miikrQ9oWkoooEFFJRQIKKKKAOqooorM8oKKWigYUUUtAxKWiimByNJRRVHeFFFJQIKKKKACikooEdnRS0VJzBRRS0DEpaKKYBRRS0DOHoopKCwooooAKKSigQUUUUCO8oopaChKWiigYUUUtAxKWiimM8+oooqTnCikooEFFFFAgpKKKAPRaWiiqO0KKKWgYlLRRTAKKWigZzFFFFaHthSUUUCCiikoELSUUUAT0tFFcZ+eBRS0UDCiiigYUUtFMCnRSUV1H3oUUUlAhaSiigAoopKBGjRS0VynxAUUUUDCilooAKKKWmMyaKKSug+xFpKKKACiikoELSUUUCNqiiiuc+TCilooGFFFLQMSloopgYNJRRWx9OFFFJQIWkoooEFFJRQB0dFLRWJ88FFFLQMSloooAKKKWgZy9FFJWp7YtJRRQAUUUlAgooooEdZRRS1meUJS0UUAFFFLQMSloooGcfSUUVZ6AUUUlAhaSiigQUUlFAHa0tFFScgUUUtAxKWiigYUUtFMDhaKKSg1FpKKKBBRSUUAFFFFAjvqKKWgYlLRRQAUUtFAwooooGee0lFFIwCikooAKKKKBBRSUUCPR6WiiqOwKKWigYUUUUDCilopgc3S0UVznyYUUUtACUtFFAwopaKBlWiikrsP0QWkoooEFFJRQIKKKKBF6iilrkPgRKWiigYUUUtAwooooGZtJRRXUfcBRSUUCCiiigQUUlFAGvS0UVzHxgUUUtAwooooAKKWigZh0UlFdB9aFFFFABRSUUCCiikoEdDRRS1gfLhRRRQMKKWigYUUUUDOaooorY+iCikooEFFFJQIWkoooA6qiiisjwgopaKBhRRRQAUtFFAzkaKSitD1woopKAFpKKKBBRRSUCOzoopazPOCiiimAUUtFAwooooGcRRRSVR2C0lFFAgoopKBC0lFFAHeUUUUjAKKWigYUUUUDCloooA8/pKKKBhRRSUCFpKKKACikooEei0UtFBqFFFFMYUtFFABRRS0DPNaKKSpOQWkoooAKKSigQUUUUCOqpaKKxPCCiilpjEpaKKACilooGU6KSiuw/RQooooAKKSigQUUUUCNCiilrjPgBKWiimAUUUtAwooooGZVFFFdR90FFJRQIKKKKBBSUUUCNmloorlPiwoopaYwooooGFFLRQBg0UlFdB9eFFFFAgpKKKACiikoEdHRRS1znywUUUUwCilooGFFFFAzmKKKK2PowpKKKACiikoELSUUUCOrpaKKxPBCilopjCiiigYUUtFAHH0lFFaHshRRSUCFpKKKACiikoEdrRS0VmeYFFFFAwopaKYBRRS0DOFoooqjtCkoooAKKKSgQtJRRQI76iiipOcKKWimMKKKWgYlLRRQM89pKKKCgoopKBC0lFFAgoopKAPR6KWigsKKKWgYlLRRTGFFFLQB5nRRSVJzC0lFFAgoopKACiiigR1lLRRWJ4AUUUtMYlLRRQMKKWigCjRSUV2H6OFFFFAgopKKACiiigRpUUUtcZ+fCUtFFAwopaKYBRRRQMyKKKK6j7sKKSigAooooEFJRRQI26WiiuU+KCilooAKKKKYwopaKBnP0UlFdB9gFFFFAgpKKKBBRRSUAdLRS0VznygUUUUDCilopgFFFLQM5Wiiitj6UKKSigQUUUlAC0lFFAjrqKKKxPACilooAKKKWmMSloooGcbRSUVoe0FFFJQIWkoooEFFFJQB29FLRWZ5QUUUUDCloooGFFFLTA4OiikqjvFpKKKBBRRSUALSUUUCPQKKKKk5gpaKKACiilpjEpaKKBnndJRRQWFFFJQAtJRRQIKKSigR6TS0UUFBRRS0DEpaKKBhRRS0xnmNFFJUnOLSUUUCCikooEFFFFAHXUtFFYnz4UUUtABRRRTGFFLRQMz6KSiuw/SAooooEFFJRQIKKKSgDVoopa4z88EpaKKBhRS0UDCiiimBjUUUV1H3oUUlFAgoopKAFpKKKBG7S0UVynxAUUtFAwooooAKKWimM52ikoroPsQoopKAFpKKKBBRRSUCOnopaK5z5MKKKKBhRS0UDCiiimBylFFJWx9OLSUUUCCiikoELSUUUAdhRRRWJ88FFLRQMKKKKACloopjOLpKKK0PbCiikoAWkoooEFFJRQI7milorM8oKKKKACilooGFFFLQM4Giikqz0BaSiigQUUUlAgooooA9CoooqTkCilooGFFFLQAlLRRTGec0lFFBqFFFJQIKKKKACikooEel0UtFAwoopaAEpaKKBhRRS0DPL6KKSkYBRRRQAUUlFAgooooEdHRRSV0H1otJRRQIKKKSgAooooEaVFFFcR+bBS0UUAFFFLQMSloooGZNJRRXYfogUUUlAhaSiigQUUlFAjbopaK5D4EKKKWgYlLRRQMKKKWgZz9FFJXUfcC0lFFAgopKKBBRRRQB0lFFLXMfGCUtFFAwoopaAEpaKKBnL0lFFdB9aFFFJQAUUUUCCikooEdbS0UVgfLhRRS0DEpaKKBhRS0UDONoopK2PogooooEFFJRQIKKKKAO2oopayPCEpaKKBhRS0UAFFFFAzhKKKK0PXCikooAKKKKBBRSUUCO/paKKzPOCilopgFFFFAwopaKBnndFJRVHYFFFFAgopKKBBRRSUAek0UtFIwCiiigYUUtFAwoopaAPMaKKKBhRSUUCCiikoAWkoooEepUUUUGoUUtFMYUUUtACUtFFAzjKKKStj6MWkoooEFFFJQIKKKKANSiilriPzQSloooGFFFLQAlLRRQMx6Siiuw/RQoopKAFpKKKBBRSUUCN2loorjPgAoopaYCUtFFAwoopaBnO0UUldR90LSUUUCCikooEFFFFAjpqKKWuU+LEpaKKYwoopaBhRRRQBytJRRXQfXhRSUUCCiiigAopKKBHX0tFFc58sFFFLTAKKKKBhRS0UDOLopKK2PpAooooEFFJRQIKKKSgR3NFFLWJ4IUUUUxhRS0UDCiiigDgqKKK0PZCikooEFFFJQAtJRRQI9BpaKKzPMCiiloGFFFFMAopaKBnnNFJRVHaFFFJQAtJRRQIKKKSgR6XRRS1JzhRRRTGFFLRQMKKKKBnmFFFJQULSUUUCCiikoELSUUUAeqUUUUFhRS0UDCiiimMKWiigDiqKKStj6UWkoooEFFJRQIKKKKBGtRRS1wn5mJS0UUxhRRS0DEpaKKAMWkoorsP0cKKSigQUUUUAFFJRQI36WiiuM/PgoopaBiUtFFMAoopaBnN0UUldR92FFFFABRSUUCCiiigR1FFFLXKfFCUtFFABRRS0DEpaKKYzkqKKK6D7AKKSigQUUUUCCkoooA7GloornPlAoopaBiUtFFMAopaKBnE0UlFbH0oUUUUAFJRRQIKKKSgR3dFFLWJ4AlLRRQAUUtFAwooopjOAooorQ9oKSiigQUUUlAhaSiigD0OloorM8oKKWigYUUUUDCilopgeb0UlFUd4UUUUCCkoooAKKKSgR6bRS0VJzBRRRQAUUtFMYUUUtAzy2iiigsKSiigAoopKBC0lFFAj1aiiigoKKWigYUUUtAxKWiimM4iiikrY+lFpKKKACikooEFFFFAjYoopa4T8yEpaKKACiilpjEpaKKBmHSUUV2H6QFFJRQIKKKKBBRSUUAdDS0UVxn54FFFLQMSloooGFFLRTA5miikrqPvQooooEFFJRQAUUUUCOqoopa5T4gSloooGFFLRQAUUUUDORpKKK6T7EKKSigAooooEFFJRQI7OloornPkwopaKBhRRRQMKKWimBw9FJRWx9OFFFFAgopKKACiikoEd7RS0VifPBRRRQMKKWigAoopaBnntFFFanthRSUUAFFFJQIWkoooEejUUUVmeUFFLRQAUUUUDCloooGea0UlFWegFFFJQIWkoooEFFFJQB6fRS0VJyBRRRQMKWiigAoopaYzyuiikoNRaSiigQUUUlAC0lFFAj1iiiigYUtFFABRRS0DEpaKKBnOUUUVgfJBRS0UDCiiigYUtFFAGLRSUV3H6eFFFJQIWkoooAKKKSgRv0UtFcR+bBRRRQAUtFFAwoopaBnN0UUldh+iC0lFFAgoopKBC0lFFAjqKKKK5D4EKKWigYUUUtAxKWiigDk6Siiuo+5CiikoELSUUUCCikooA7GilorlPjAooopjCloooAKKKWgZxNFFJXQfWi0lFFABRSUUCCiiigR3VFFFYHy4UtFFAwoopaBiUtFFAzgaSiitj6IKKSigQUUUUCCikooA9DpaKKxPCCiilpjEpaKKACiiloGeb0UlFaHrhRRRQAUUlFAgooooEemUUUtZnnCUtFFMAoopaBiUtFFAzy6iiiqOwKKSigQUUUUCCkoooA9VpaKKRgFFFLQMSloooGFFLRQB5LRSUUDCiiigQUlFFABRRSUCO8ooornPlgopaKYwooooGFLRRQMw6Siiu4/UAoopKBC0lFFAgoopKAOhopaK4j80CiiigYUtFFABRRS0DOZoopK7D9FFpKKKACiikoELSUUUCOqooorjPgAopaKYBRRS0DEpaKKBnI0lFFdR90FFFJQIWkoooEFFFJQI7OilorlPiwoopaBiUtFFMYUUUtAHD0UUldB9eLSUUUCCiikoAKKKKBHeUUUtc58sJS0UUwCiiloGJS0UUDPP6Siitj6MKKKSgAooooEFFJRQI9FpaKKxPBCiiloGJS0UUxhRS0UAea0UUlaHshRRRQIKKSigAooooEenUUUtZnmCUtFFAwopaKYBRRRQM8tpKKKo7QopKKACiiigQUUlFAj1elooqTnCilopjCiiigYUUtFAzyOikooKCiiigQUUlFAgoopKAO+ooornPlQopaKACiilpjEpaKKBmDSUUV3H6kFFFJQIWkoooEFFFJQI6OilorhPzMKKKWmMSloooGFFFLQBy9FFJXYfo4tJRRQIKKKSgBaSiigR1lFFFcZ+fBS0UUDCiilpgJS0UUDOPpKKK6j7sKKKSgBaSiigQUUlFAjtaWiiuU+KCiiloASloooGFFFLTGcLRRSV0H2AtJRRQIKKSigQUUUUAd9RRS1znyglLRRQMKKKWmAUUUUDPPaSiitj6UKKSigQUUUUAFFJRQI9HpaKKxPACiiloAKKKKBhRS0UxnmdFJRWh7QUUUUCCikooEFFFJQB6jRRS1meUJS0UUDCiiloGFFFFMDyqiiiqO8KKSigQUUUlAC0lFFAj1mlooqTmCiiloAKKKKYwopaKBnkNFJRQWFFFJQAtJRRQIKKKSgR6BRRRXOfKBRS0UDCiiloASloopjOfpKKK7j9TCiikoAWkoooEFFJRQI6WilorhPzIKKKWgBKWiimMKKKWgZytFFJXYfpAtJRRQIKKSigQUUUUAddRRRXGfngUtFFAwoopaBiUtFFMDjaSiiuo+9CiikoEFFFFABRSUUCO3opaK5T4gKKKWgYlLRRQAUUUtAzg6KKSuk+xCiiigAopKKBBRRRQI9Aoopa5z5MSloooGFFFLQMSloopgedUUUVsfThRSUUCCiiigQUlFFAHpNLRRWJ88FFFLQMSloooAKKWigZ5jRSUVqe2FFFFABSUUUCCiikoEep0UUtZnkiUtFFAwopaKBhRRRQM8ooooqz0AopKKBBRRRQIKSiigD1ulooqTkCilooGFFFFABRS0Uxnj9FJRQahRRRQIKSiigAoopKBH/2Q==');"
+            ]
+          }
+        }
+      ],
+      "item": [
+        {
+          "name": "31.1 GenAI Gemini mediaResolution LOW - record image prompt tokens (gemini)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('GenAI Gemini mediaResolution LOW request succeeds', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "var body = pm.response.json();",
+                  "var low = body && body.usageMetadata && body.usageMetadata.promptTokenCount;",
+                  "pm.test('GenAI Gemini response reports usageMetadata.promptTokenCount', function () {",
+                  "  pm.expect(low, 'promptTokenCount missing: ' + pm.response.text()).to.be.a('number');",
+                  "});",
+                  "pm.collectionVariables.set('genaiMediaResLowPromptTokens', low);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-goog-api-key",
+                "value": "{{genaiKey}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"parts\": [\n        {\n          \"text\": \"Reply with the single word: ok.\"\n        },\n        {\n          \"inline_data\": {\n            \"mime_type\": \"image/jpeg\",\n            \"data\": \"{{mediaResImage}}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"generationConfig\": {\n    \"mediaResolution\": \"MEDIA_RESOLUTION_LOW\",\n    \"maxOutputTokens\": 2048\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/{{genaiModel}}:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "{{genaiModel}}:generateContent"
+              ]
+            }
+          }
+        },
+        {
+          "name": "31.2 GenAI Gemini mediaResolution HIGH exceeds LOW - field not dropped (gemini)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('GenAI Gemini mediaResolution HIGH request succeeds', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "var body = pm.response.json();",
+                  "var high = body && body.usageMetadata && body.usageMetadata.promptTokenCount;",
+                  "pm.test('GenAI Gemini HIGH response reports usageMetadata.promptTokenCount', function () {",
+                  "  pm.expect(high, 'promptTokenCount missing: ' + pm.response.text()).to.be.a('number');",
+                  "});",
+                  "var low = Number(pm.collectionVariables.get('genaiMediaResLowPromptTokens'));",
+                  "// Only assert the invariant when the LOW case actually recorded a value (it may have skipped).",
+                  "if (!isNaN(low) && low > 0) {",
+                  "  pm.test('mediaResolution honored: HIGH image prompt tokens exceed LOW (field not dropped)', function () {",
+                  "    pm.expect(high, 'HIGH=' + high + ' must exceed LOW=' + low + '; equal counts mean mediaResolution was dropped').to.be.above(low);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-goog-api-key",
+                "value": "{{genaiKey}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"parts\": [\n        {\n          \"text\": \"Reply with the single word: ok.\"\n        },\n        {\n          \"inline_data\": {\n            \"mime_type\": \"image/jpeg\",\n            \"data\": \"{{mediaResImage}}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"generationConfig\": {\n    \"mediaResolution\": \"MEDIA_RESOLUTION_HIGH\",\n    \"maxOutputTokens\": 2048\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/{{genaiModel}}:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "{{genaiModel}}:generateContent"
+              ]
+            }
+          }
+        },
+        {
+          "name": "31.3 Vertex Gemini mediaResolution LOW - record image prompt tokens (vertex)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Vertex Gemini mediaResolution LOW request succeeds', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "var body = pm.response.json();",
+                  "var low = body && body.usageMetadata && body.usageMetadata.promptTokenCount;",
+                  "pm.test('Vertex Gemini response reports usageMetadata.promptTokenCount', function () {",
+                  "  pm.expect(low, 'promptTokenCount missing: ' + pm.response.text()).to.be.a('number');",
+                  "});",
+                  "pm.collectionVariables.set('vertexMediaResLowPromptTokens', low);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-goog-api-key",
+                "value": "{{genaiKey}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"parts\": [\n        {\n          \"text\": \"Reply with the single word: ok.\"\n        },\n        {\n          \"inline_data\": {\n            \"mime_type\": \"image/jpeg\",\n            \"data\": \"{{mediaResImage}}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"generationConfig\": {\n    \"mediaResolution\": \"MEDIA_RESOLUTION_LOW\",\n    \"maxOutputTokens\": 2048\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/{{vertexModel}}:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "{{vertexModel}}:generateContent"
+              ]
+            }
+          }
+        },
+        {
+          "name": "31.4 Vertex Gemini mediaResolution HIGH exceeds LOW - field not dropped (vertex)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Vertex Gemini mediaResolution HIGH request succeeds', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "var body = pm.response.json();",
+                  "var high = body && body.usageMetadata && body.usageMetadata.promptTokenCount;",
+                  "pm.test('Vertex Gemini HIGH response reports usageMetadata.promptTokenCount', function () {",
+                  "  pm.expect(high, 'promptTokenCount missing: ' + pm.response.text()).to.be.a('number');",
+                  "});",
+                  "var low = Number(pm.collectionVariables.get('vertexMediaResLowPromptTokens'));",
+                  "// Only assert the invariant when the LOW case actually recorded a value (it may have skipped).",
+                  "if (!isNaN(low) && low > 0) {",
+                  "  pm.test('mediaResolution honored: HIGH image prompt tokens exceed LOW (field not dropped)', function () {",
+                  "    pm.expect(high, 'HIGH=' + high + ' must exceed LOW=' + low + '; equal counts mean mediaResolution was dropped').to.be.above(low);",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-goog-api-key",
+                "value": "{{genaiKey}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"parts\": [\n        {\n          \"text\": \"Reply with the single word: ok.\"\n        },\n        {\n          \"inline_data\": {\n            \"mime_type\": \"image/jpeg\",\n            \"data\": \"{{mediaResImage}}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"generationConfig\": {\n    \"mediaResolution\": \"MEDIA_RESOLUTION_HIGH\",\n    \"maxOutputTokens\": 2048\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/{{vertexModel}}:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "{{vertexModel}}:generateContent"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/e2e/api/runners/filter-collection.mjs
+++ b/tests/e2e/api/runners/filter-collection.mjs
@@ -54,6 +54,7 @@ const PROVIDER_KEYWORDS = {
   azure: ["azure", "deployments"],
   passthrough: ["_passthrough"],
   openrouter: ["openrouter"],
+  replicate: ["replicate", "/replicate", "flux", "black-forest-labs"],
 };
 
 // Haystack = item JSON + ancestor folder names. Folder names encode the harness

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -135,6 +135,13 @@ func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError
 		}
 	}
 
+	// Routed-identity headers from the error itself (provider/model/request-type +
+	// routing_info incl. is-fallback). Callers forward provider headers before this,
+	// so bifrost identity wins. No bifrostCtx here, so the ctx-only fallback-index /
+	// upstream-latency headers are omitted on native errors — the routing_info-*
+	// headers still carry which provider ran and whether a fallback fired.
+	lib.ApplyBifrostErrorResponseHeaders(ctx, nil, bifrostErr.ExtraFields)
+
 	ctx.SetContentType("application/json")
 	if encodeErr := json.NewEncoder(ctx).Encode(bifrostErr); encodeErr != nil {
 		logger.Warn(fmt.Sprintf("Failed to encode error response: %v", encodeErr))

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -3284,6 +3284,10 @@ func (g *GenericRouter) handlePassthroughNonStream(
 			ctx.Response.Header.Set(k, v)
 		}
 	}
+	// Passthrough forwards provider bytes 1:1, so extra_fields can't ride the body —
+	identityFields := resp.ExtraFields
+	identityFields.ProviderResponseHeaders = nil
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, identityFields)
 	ctx.Response.SetBody(resp.Body)
 }
 
@@ -3374,6 +3378,10 @@ func (g *GenericRouter) handlePassthroughStream(
 			ctx.Response.Header.Set(k, v)
 		}
 	}
+	// Routed identity via headers (passthrough body is provider bytes 1:1).
+	identityFields := passthroughResp.ExtraFields
+	identityFields.ProviderResponseHeaders = nil
+	lib.ApplyBifrostResponseHeaders(ctx, bifrostCtx, identityFields)
 
 	// Use SSEStreamReader to bypass fasthttp's internal pipe batching
 	reader := lib.NewSSEStreamReader()

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -166,6 +166,8 @@ func (g *GenericRouter) sendStreamError(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 			}
 		}
 	}
+	// Routed identity after provider headers so a chained upstream's x-bifrost-* can't overwrite it.
+	lib.ApplyBifrostErrorResponseHeaders(ctx, bifrostCtx, bifrostErr.ExtraFields)
 
 	// Set the HTTP status code from the provider error
 	if bifrostErr.StatusCode != nil {

--- a/transports/bifrost-http/lib/responseheaders.go
+++ b/transports/bifrost-http/lib/responseheaders.go
@@ -72,6 +72,24 @@ func ApplyBifrostStreamResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *sch
 	ApplyBifrostResponseHeaders(ctx, bifrostCtx, extra)
 }
 
+// ApplyBifrostErrorResponseHeaders emits the routed-identity headers on an
+// error response. Errors carry the same identity as successes — core populates
+// BifrostError.ExtraFields.RoutingInfo plus the deprecated triplet — so failed
+// and fallback-exhausted requests can still report which provider ran and
+// whether a fallback fired. This exists only to bridge the error's
+// BifrostErrorExtraFields to the shared writer (a different type than the
+// success path's BifrostResponseExtraFields); provider response headers are
+// forwarded separately by the caller.
+func ApplyBifrostErrorResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostErrorExtraFields) {
+	ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+		RequestType:            extra.RequestType,
+		RoutingInfo:            extra.RoutingInfo,
+		Provider:               extra.Provider,
+		OriginalModelRequested: extra.OriginalModelRequested,
+		ResolvedModelUsed:      extra.ResolvedModelUsed,
+	})
+}
+
 // ApplyBifrostResponseHeaders writes both the upstream provider response
 // headers (forwarded verbatim) and the bifrost-level `x-bifrost-*` routing
 // identity headers onto the fasthttp response. Empty fields are skipped so

--- a/transports/bifrost-http/lib/responseheaders_test.go
+++ b/transports/bifrost-http/lib/responseheaders_test.go
@@ -247,3 +247,70 @@ func TestApplyBifrostStreamResponseHeaders(t *testing.T) {
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
 	})
 }
+
+// TestApplyBifrostErrorResponseHeaders covers the error adapter used on failed /
+// fallback-exhausted requests: it bridges BifrostErrorExtraFields to the shared
+// writer so callers still learn which provider ran and whether a fallback fired.
+func TestApplyBifrostErrorResponseHeaders(t *testing.T) {
+	newBifrostCtx := func() *schemas.BifrostContext {
+		return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	}
+
+	t.Run("fallback-exhausted error emits identity and fallback headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 1)
+
+		primaryProvider := schemas.Anthropic
+		primaryModel := "claude-sonnet-4-6"
+		ApplyBifrostErrorResponseHeaders(ctx, bifrostCtx, schemas.BifrostErrorExtraFields{
+			RequestType:            schemas.ChatCompletionRequest,
+			Provider:               schemas.Bedrock,
+			OriginalModelRequested: "claude-sonnet-4-6",
+			ResolvedModelUsed:      "us.anthropic.claude-sonnet-4-6",
+			RoutingInfo: schemas.RoutingInfo{
+				Provider:        schemas.Bedrock,
+				Model:           "us.anthropic.claude-sonnet-4-6",
+				IsFallback:      true,
+				PrimaryProvider: &primaryProvider,
+				PrimaryModel:    &primaryModel,
+			},
+		})
+
+		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
+		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
+		assert.Equal(t, string(schemas.ChatCompletionRequest), string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoProvider)))
+		assert.Equal(t, "true", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoIsFallback)))
+		assert.Equal(t, "anthropic", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoPrimaryProvider)))
+		assert.Equal(t, "1", string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("nil ctx (native error path) emits identity but no ctx-only headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+
+		ApplyBifrostErrorResponseHeaders(ctx, nil, schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ChatCompletionRequest,
+			Provider:    schemas.OpenAI,
+			RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI, Model: "gpt-5.6"},
+		})
+
+		assert.Equal(t, "openai", string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Equal(t, "gpt-5.6", string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoModel)))
+		// ctx-only headers are absent when no context is threaded through.
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostUpstreamLatency)))
+	})
+
+	t.Run("empty error extra fields emit nothing", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+
+		ApplyBifrostErrorResponseHeaders(ctx, bifrostCtx, schemas.BifrostErrorExtraFields{})
+
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRoutingInfoProvider)))
+	})
+}


### PR DESCRIPTION
## Summary

Error responses and passthrough responses (both streaming and non-streaming) were not emitting `x-bifrost-*` routing identity headers, making it impossible for callers to determine which provider ran or whether a fallback fired when a request failed or was proxied verbatim.

## Changes

- Added `ApplyBifrostErrorResponseHeaders` in `lib/responseheaders.go` to bridge `BifrostErrorExtraFields` to the shared `ApplyBifrostResponseHeaders` writer, since error and success paths use different extra-fields types.
- Called `ApplyBifrostErrorResponseHeaders` in `handlers/utils.go` (`SendBifrostError`) and `integrations/utils.go` (`sendStreamError`) so all error responses carry routed-identity headers. Applied after provider-header forwarding so a chained upstream's `x-bifrost-*` headers cannot overwrite bifrost's own identity.
- Called `ApplyBifrostResponseHeaders` in `integrations/router.go` for both `handlePassthroughNonStream` and `handlePassthroughStream`, since passthrough responses forward provider bytes 1:1 and cannot carry `extra_fields` in the body.
- When `bifrostCtx` is `nil` (native error path), context-only headers such as `x-bifrost-fallback-index` and `x-bifrost-upstream-latency` are intentionally omitted; `routing_info-*` headers still report which provider ran and whether a fallback fired.
- Added `TestApplyBifrostErrorResponseHeaders` covering fallback-exhausted errors, the nil-context native error path, and empty extra fields.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/...
go test ./transports/bifrost-http/integrations/...
go test ./transports/bifrost-http/handlers/...
```

Send a request that triggers a provider error or exhausts all fallbacks and inspect the response headers — `x-bifrost-provider`, `x-bifrost-routing-info-is-fallback`, `x-bifrost-routing-info-provider`, and related headers should be present. Repeat with a passthrough route (streaming and non-streaming) and confirm the same identity headers appear after provider-forwarded headers.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII implications. Headers added are routing metadata already present on success responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable