### PR TITLE
helm and docs changes

### DIFF
--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -399,9 +399,8 @@ bifrost:
   governance:
     complexityAnalyzerConfig:
       tier_boundaries:
-        simple_medium: 0.15
-        medium_complex: 0.35
-        complex_reasoning: 0.60
+        simple_medium: 0.20
+        medium_complex: 0.40
       keywords:
         code_keywords: ["function", "class", "api", "debug", "deploy"]
         reasoning_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -6,11 +6,11 @@ icon: "sliders"
 
 ## Overview
 
-The Complexity Router analyzes incoming requests and assigns a tier - **Simple**, **Medium**, **Complex**, or **Reasoning** - when the latest user message contains a clear complexity signal. The result is exposed as a flat string variable (`complexity_tier`) in Bifrost's CEL routing engine, so you can write routing rules like:
+The Complexity Router analyzes incoming requests and assigns a tier - **Simple**, **Medium**, or **Complex** - when the latest user message contains a clear complexity signal. The result is exposed as a flat string variable (`complexity_tier`) in Bifrost's CEL routing engine, so you can write routing rules like:
 
 ```cel
-complexity_tier == "REASONING"
-complexity_tier in ["COMPLEX", "REASONING"]
+complexity_tier == "COMPLEX"
+complexity_tier in ["MEDIUM", "COMPLEX"]
 ```
 
 This lets you route simple greetings to a fast, cheap model and deep reasoning tasks to a frontier model — automatically, with no changes to your application code. When the latest user message does not match a configured signal, Bifrost leaves `complexity_tier` unknown and keeps the request on its existing routing path instead of guessing. The algorithm is fast and deterministic: it runs entirely in-process using pre-compiled literal and stemmed keyword matching, adds less than 1 ms to request latency, and makes zero external calls.
@@ -27,9 +27,9 @@ Classified requests produce a score between 0.0 and 1.0. The analyzer starts wit
 
 | Dimension | Weight | What it measures |
 |---|---|---|
-| Code presence | 30% | Code, debugging, and programming artifacts |
-| Reasoning markers | 25% | Analytical and multi-step reasoning language |
-| Technical terms | 25% | Architecture, infra, and operational terminology |
+| Code presence | 34% | Code, debugging, and programming artifacts |
+| Reasoning markers | 28% | Analytical and multi-step reasoning language |
+| Technical terms | 28% | Architecture, infra, and operational terminology |
 | Word count | 10% | Prompt length measured by whitespace-delimited words, used only after a signal or continuation is detected |
 | Simple indicators | -5% | Greetings, definitions, translation requests, and other straightforward asks |
 
@@ -41,20 +41,23 @@ When the latest user message already has a code, technical, or reasoning signal,
 
 ### Conversation context blending
 
-For multi-turn conversations, prior context is used only when the latest user message has its own code, technical, or reasoning signal, or when the latest message is a configured continuation phrase such as "do it", "try again", "continue", or "go ahead" and the prior-context score is at least 0.20. In those cases, the score blends the current message with history from up to the last 10 user turns (recency-weighted: earlier turns count less):
+For multi-turn conversations, prior context is used only when the latest user message has its own code, technical, or reasoning signal, or when the latest message reads as a continuation of the conversation and the prior-context score is at least 0.20. A message counts as a continuation when it is a configured continuation phrase such as "do it", "try again", "continue", or "go ahead", **or** when it is 12 words or fewer with no simple-keyword match — brevity itself is the signal in follow-ups like "yes but make it faster". Conversation closers like "thanks!" match a simple keyword, so they still classify as Simple instead of inheriting the conversation's complexity.
+
+In those cases, the score blends the current message with history from up to the last 10 user turns (recency-weighted: earlier turns count less):
 
 - **Default blend:** 60% last message + 40% conversation history
 - **Continuation blend:** 35% last message + 65% conversation history
+- **Continuation with no signal of its own** ("why?", "fix it"): 100% conversation history — the follow-up adds no content, so the conversation score is inherited as-is
 
-An explicit continuation phrase inherits most of its score from prior context rather than being classified on its own. A low-signal latest message that is not an explicit continuation does not inherit old context; `complexity_tier` remains unknown and routing falls through to the original model.
+A low-signal latest message that is not a continuation does not inherit old context; `complexity_tier` remains unknown and routing falls through to the original model.
 
 The final score is `max(last_message_score, weighted_blend)` — the current message always sets a floor.
 
 ### Reasoning override
 
-When two or more **reasoning keywords** are detected in the last user message, the tier is forced to **Reasoning** regardless of the numeric score. The same override applies when one strong reasoning keyword appears alongside strong code or technical signals.
+When two or more **reasoning keywords** are detected in the last user message, the tier is promoted to **Complex** regardless of the numeric score. The same override applies when one strong reasoning keyword appears alongside strong code or technical signals.
 
-This handles prompts like "step by step, explain why the authentication flow fails" that would score moderately on each individual dimension but clearly require deep reasoning.
+This handles prompts like "step by step, explain why the authentication flow fails" that would score moderately on each individual dimension but clearly deserve the strongest model.
 
 ### Tier classification
 
@@ -62,10 +65,13 @@ The final score maps to a tier using configurable boundaries (defaults shown):
 
 | Tier | Score range (defaults) | Typical requests |
 |---|---|---|
-| Simple | < 0.15 | Greetings, definitions, simple lookups |
-| Medium | 0.15 – 0.35 | General questions, short explanations |
-| Complex | 0.35 – 0.60 | Technical questions, code help, multi-step tasks |
-| Reasoning | ≥ 0.60 (or override) | Analysis, architecture decisions, root-cause investigation |
+| Simple | < 0.20 | Greetings, definitions, simple lookups |
+| Medium | 0.20 – 0.40 | General questions, short explanations |
+| Complex | ≥ 0.40 (or override) | Technical questions, code help, analysis, root-cause investigation |
+
+<Note>
+Earlier Bifrost versions had a fourth tier, **REASONING**, above Complex. It has been merged into **COMPLEX**: the `complex_reasoning` boundary no longer exists, and the reasoning-keyword override now promotes to Complex. Historical log rows keep their recorded `REASONING` tier and stay reachable through the logs filter as a legacy value, but the CEL builder no longer offers it — update any routing rules that match on `"REASONING"`.
+</Note>
 
 ![Complexity Analyzer Pipeline](../../media/complexity-logic-architecture.png)
 
@@ -87,7 +93,7 @@ The **Complexity Spectrum** bar updates live as you type boundary values, so you
 ![Complexity Router Tier Configuration](../../media/ui-complexity-router-config.png)
 
 1. Enter a value between 0 and 1 for each boundary.
-2. Boundaries must be strictly increasing: `simple_medium` < `medium_complex` < `complex_reasoning`.
+2. Boundaries must be strictly increasing: `simple_medium` < `medium_complex`.
 3. Click **Save changes** to apply immediately (hot-reloaded, no restart required).
 4. Click **Restore defaults** to reset all boundaries and keyword lists to factory values.
 
@@ -103,9 +109,8 @@ curl -X PUT http://localhost:8080/api/governance/complexity-analyzer-config \
   -H "Content-Type: application/json" \
   -d '{
     "tier_boundaries": {
-      "simple_medium": 0.15,
-      "medium_complex": 0.35,
-      "complex_reasoning": 0.60
+      "simple_medium": 0.20,
+      "medium_complex": 0.40
     },
     "keywords": {
       "code_keywords": ["function", "class", "api", "debug"],
@@ -123,9 +128,8 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
 ```json
 {
   "tier_boundaries": {
-    "simple_medium": 0.15,
-    "medium_complex": 0.35,
-    "complex_reasoning": 0.60
+    "simple_medium": 0.20,
+    "medium_complex": 0.40
   },
   "keywords": {
     "code_keywords": ["function", "class", "..."],
@@ -144,9 +148,8 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
   "governance": {
     "complexity_analyzer_config": {
       "tier_boundaries": {
-        "simple_medium": 0.15,
-        "medium_complex": 0.35,
-        "complex_reasoning": 0.60
+        "simple_medium": 0.20,
+        "medium_complex": 0.40
       },
       "keywords": {
         "code_keywords": ["function", "class", "api", "debug", "deploy"],
@@ -161,11 +164,10 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `tier_boundaries.simple_medium` | number | Yes | 0.15 | Score threshold between Simple and Medium (exclusive: 0 < value < 1) |
-| `tier_boundaries.medium_complex` | number | Yes | 0.35 | Score threshold between Medium and Complex |
-| `tier_boundaries.complex_reasoning` | number | Yes | 0.60 | Score threshold between Complex and Reasoning |
+| `tier_boundaries.simple_medium` | number | Yes | 0.20 | Score threshold between Simple and Medium (exclusive: 0 < value < 1) |
+| `tier_boundaries.medium_complex` | number | Yes | 0.40 | Score threshold between Medium and Complex; scores at or above are Complex |
 | `keywords.code_keywords` | string[] | Yes | built-in defaults | Signals for code/debugging/programming requests |
-| `keywords.reasoning_keywords` | string[] | Yes | built-in defaults | Strong reasoning triggers — matches can force the Reasoning tier |
+| `keywords.reasoning_keywords` | string[] | Yes | built-in defaults | Strong reasoning triggers — matches can promote the request to the Complex tier |
 | `keywords.technical_keywords` | string[] | Yes | built-in defaults | Architecture/infra/operations signals |
 | `keywords.simple_keywords` | string[] | Yes | built-in defaults | Phrases that slightly reduce complexity and classify straightforward requests |
 
@@ -200,13 +202,13 @@ Type a keyword or phrase and press **Enter** to add it. Click the × on any tag 
 
 | List | Effect | When to customize |
 |---|---|---|
-| **Code keywords** | Each match contributes to the Code dimension (30% weight) | Add domain-specific tooling, frameworks, or file types your users frequently mention |
-| **Reasoning keywords** | Strong triggers — two or more matches, or one match alongside strong code/technical signals, forces the Reasoning tier regardless of score | Narrow this list to the phrases that truly demand your most capable model. The default list is intentionally conservative. |
-| **Technical keywords** | Each match contributes to the Technical dimension (25% weight) | Add industry-specific jargon (e.g. "SOC 2", "HIPAA", "proration") relevant to your product |
+| **Code keywords** | Each match contributes to the Code dimension (34% weight) | Add domain-specific tooling, frameworks, or file types your users frequently mention |
+| **Reasoning keywords** | Strong triggers — two or more matches, or one match alongside strong code/technical signals, promotes the request to the Complex tier regardless of score | Narrow this list to the phrases that truly demand your most capable model. The default list is intentionally conservative. |
+| **Technical keywords** | Each match contributes to the Technical dimension (28% weight) | Add industry-specific jargon (e.g. "SOC 2", "HIPAA", "proration") relevant to your product |
 | **Simple keywords** | Each match slightly reduces the score and can classify straightforward requests as Simple | Add domain-specific phrases that signal trivial intent in your app context |
 
 <Warning>
-The **reasoning keywords** list gates the tier-override path, not just scoring. Adding broad terms like "explain" or "analyze" will push many requests to Reasoning. Prefer specific multi-word phrases like "step by step" or "root cause analysis".
+The **reasoning keywords** list gates the tier-override path, not just scoring. Adding broad terms like "explain" or "analyze" will push many requests to Complex. Prefer specific multi-word phrases like "step by step" or "root cause analysis".
 </Warning>
 
 </Tab>
@@ -221,16 +223,16 @@ Once the analyzer is configured, use `complexity_tier` as a variable in any CEL 
 `complexity_tier` is not a special standalone rule type. In the Routing Rules builder, it behaves like any other field, so you can combine it with headers, request type, team/customer scope, budgets, and other predicates in the same rule or nested rule group.
 
 <Note>
-Complexity Router only exposes `complexity_tier`; it does not create rules automatically. Add rules for the tiers you want to route. For deterministic four-tier routing, create rules for Simple, Medium, Complex, and Reasoning.
+Complexity Router only exposes `complexity_tier`; it does not create rules automatically. Add rules for the tiers you want to route. For deterministic three-tier routing, create rules for Simple, Medium, and Complex.
 </Note>
 
 ### Available operators
 
 | Operator | CEL syntax | Example |
 |---|---|---|
-| Equal | `==` | `complexity_tier == "REASONING"` |
+| Equal | `==` | `complexity_tier == "COMPLEX"` |
 | Not equal | `!=` | `complexity_tier != "SIMPLE"` |
-| In list | `in` | `complexity_tier in ["COMPLEX", "REASONING"]` |
+| In list | `in` | `complexity_tier in ["MEDIUM", "COMPLEX"]` |
 | Not in list | `!(x in [...])` | `!(complexity_tier in ["SIMPLE", "MEDIUM"])` |
 
 
@@ -239,45 +241,45 @@ Complexity Router only exposes `complexity_tier`; it does not create rules autom
 You can mix complexity with any other routing condition the CEL builder supports:
 
 ```cel
-headers["x-tier"] == "premium" && complexity_tier == "REASONING"
-headers["x-region"] == "us-east" && complexity_tier in ["COMPLEX", "REASONING"]
+headers["x-tier"] == "premium" && complexity_tier == "COMPLEX"
+headers["x-region"] == "us-east" && complexity_tier in ["MEDIUM", "COMPLEX"]
 request_type == "chat_completion" && complexity_tier != "SIMPLE"
-team_name == "ml-research" && headers["x-env"] == "prod" && complexity_tier == "REASONING"
+team_name == "ml-research" && headers["x-env"] == "prod" && complexity_tier == "COMPLEX"
 ```
 
 ### Setting up a complexity-based routing rule
 
-The best first rollout is usually a single **Reasoning** rule. It is easy to validate, has the smallest blast radius, and leaves Simple, Medium, and Complex traffic on your existing routing path.
+The best first rollout is usually a single **Complex** rule. It is easy to validate, has the smallest blast radius, and leaves Simple and Medium traffic on your existing routing path.
 
 1. Go to **Routing Rules** in the sidebar.
 2. Create a new rule and open the CEL builder.
-3. Add a condition: field = **Complexity Tier**, operator = **=**, value = **Reasoning**.
-4. Set the target provider and model to your strongest reasoning model.
+3. Add a condition: field = **Complexity Tier**, operator = **=**, value = **Complex**.
+4. Set the target provider and model to your strongest model.
 5. Save and enable the rule.
 
-Once you are happy with the classifications, add complementary rules for Simple, Medium, and Complex if you want a full tier-based routing ladder. An example is shown below.
+Once you are happy with the classifications, add complementary rules for Simple and Medium if you want a full tier-based routing ladder. An example is shown below.
 
 ![Routing Rule with Complexity Tier](../../media/ui-routing-rule-complexity.png)
 
 ### Use case examples
 
-#### Start with a Reasoning carve-out
+#### Start with a Complex carve-out
 
 Route only frontier-worthy requests to your strongest model and let everything else keep using your existing routing:
 
 ```json
 {
-  "id": "complexity-reasoning",
-  "name": "Reasoning → Frontier model",
+  "id": "complexity-complex",
+  "name": "Complex → Frontier model",
   "enabled": true,
-  "cel_expression": "complexity_tier == \"REASONING\"",
+  "cel_expression": "complexity_tier == \"COMPLEX\"",
   "targets": [{ "provider": "anthropic", "model": "claude-opus-4-5", "weight": 1 }],
   "scope": "global",
   "priority": 0
 }
 ```
 
-#### Full four-tier ladder
+#### Full three-tier ladder
 
 Route every tier explicitly when you want deterministic model selection across the full spectrum:
 
@@ -303,21 +305,12 @@ Route every tier explicitly when you want deterministic model selection across t
   },
   {
     "id": "complexity-complex",
-    "name": "Complex → Strong general model",
+    "name": "Complex → Frontier model",
     "enabled": true,
     "cel_expression": "complexity_tier == \"COMPLEX\"",
-    "targets": [{ "provider": "anthropic", "model": "claude-sonnet-4-5", "weight": 1 }],
-    "scope": "global",
-    "priority": 2
-  },
-  {
-    "id": "complexity-reasoning",
-    "name": "Reasoning → Frontier model",
-    "enabled": true,
-    "cel_expression": "complexity_tier == \"REASONING\"",
     "targets": [{ "provider": "anthropic", "model": "claude-opus-4-5", "weight": 1 }],
     "scope": "global",
-    "priority": 3
+    "priority": 2
   }
 ]
 ```
@@ -328,10 +321,10 @@ Test complexity routing with a single team before enabling it globally:
 
 ```json
 {
-  "id": "team-reasoning-pilot",
-  "name": "Team pilot — reasoning route",
+  "id": "team-complex-pilot",
+  "name": "Team pilot — complex route",
   "enabled": true,
-  "cel_expression": "complexity_tier == \"REASONING\"",
+  "cel_expression": "complexity_tier == \"COMPLEX\"",
   "targets": [{ "provider": "anthropic", "model": "claude-opus-4-5", "weight": 1 }],
   "scope": "team",
   "scope_id": "team-uuid-456",
@@ -343,11 +336,35 @@ Test complexity routing with a single team before enabling it globally:
 
 ## Observability
 
-Complexity analysis is recorded in the routing log for every request where analysis ran and produced a tier. In the log detail view, look at the **Routing Decision Logs** section backed by `routing_engine_logs`.
+When a routing rule references `complexity_tier`, the classification outcome is recorded as structured fields on the request log:
+
+| Field | Values | Meaning |
+|---|---|---|
+| `complexity_tier` | `SIMPLE`, `MEDIUM`, `COMPLEX` | The tier the request was classified into |
+| `complexity_mechanism` | `lexical`, `skipped` | How the tier was produced. `lexical` is the keyword analyzer; `skipped` means a rule demanded a tier but classification produced none (unsupported input, no signal, or the analyzer is disabled) |
+| `complexity_score` | 0.0 – 1.0 | The raw score behind the tier |
+
+These fields are only set when a routing rule actually referenced `complexity_tier` — requests that never touched a complexity rule carry no complexity fields.
+
+### In the log explorer
+
+The log detail view shows **Complexity Tier** (as a colored badge), **Complexity Mechanism**, and **Complexity Score** in the request overview. The **Routing Decision Logs** section still carries the full prose trail (`Complexity: tier=COMPLEX score=0.38 words=25`) alongside the structured fields.
 
 ![Routing Logs with Complexity Tier](../../media/ui-routing-logs-complexity.png)
 
-You will see log lines like `Complexity: tier=REASONING score=0.38 words=25`. If no configured complexity signal matches the latest user message, the routing log records that complexity analysis was skipped and routing continues on the existing path. This lets you audit how traffic is being distributed and spot mis-classifications to tune thresholds or keyword lists.
+The logs filter sidebar can filter by **Complexity Tier** and **Complexity Mechanism**, so you can audit how traffic is being distributed and spot mis-classifications to tune thresholds or keyword lists. The same filters are available on the logs API as comma-separated query parameters:
+
+```bash
+curl "http://localhost:8080/api/logs?complexity_tiers=COMPLEX&complexity_mechanisms=lexical"
+```
+
+<Note>
+The raw `complexity_score` is displayed but not filterable — tier and mechanism are the supported filter dimensions. Log rows written before the tier merge keep their recorded `REASONING` tier; the tier filter offers it as a legacy value so those rows stay reachable.
+</Note>
+
+### In telemetry
+
+The tier and mechanism are also emitted as the span attributes `bifrost.complexity_tier` and `bifrost.complexity_mechanism`, and as low-cardinality labels on Prometheus metrics. The raw score is deliberately excluded from metrics (unbounded cardinality) — it lives only in the request logs. See [Telemetry](../telemetry) and [Prometheus](../observability/prometheus) for the full attribute and label reference.
 
 ---
 
@@ -374,7 +391,7 @@ It does **not** run for:
 - Chat or Responses requests where user content mixes text with image, file, or audio blocks
 - Requests that contain only system or developer text and no user text
 
-### All traffic classified as Reasoning
+### All traffic classified as Complex
 
 The **reasoning keywords** list is the most common cause. Check if any broad single-word terms were added (e.g. "explain", "analyze"). The override gate fires when two or more strong reasoning keywords match — a broad list will trigger it on most prompts. Replace single-word terms with specific multi-word phrases.
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -236,6 +236,8 @@ Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_ro
 - `virtual_key_id` / `virtual_key_name` - Virtual key identifiers
 - `routing_engine_used` - Comma-separated list of routing engines that contributed to the decision (e.g. `governance`, `routing-rule`, `loadbalancing`, `model-catalog`, `core`). `core` is emitted when the Bifrost orchestrator itself makes a routing decision — fallback transitions or retry transitions.
 - `routing_rule_id` / `routing_rule_name` - Routing rule that matched the request
+- `complexity_tier` - Complexity tier used for routing (`SIMPLE` / `MEDIUM` / `COMPLEX`); empty when no routing rule referenced `complexity_tier`
+- `complexity_mechanism` - How the complexity tier was classified (`lexical`, or `skipped` when classification was demanded but produced no tier). The raw complexity score is deliberately not a label — it has unbounded cardinality and lives only in the request logs
 - `selected_key_id` / `selected_key_name` - API key that successfully served the request (`""` when all attempts failed)
 - `fallback_index` - Fallback position
 - `team_id` / `team_name` - Team identifiers (empty when governance is not used)

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -73,6 +73,8 @@ Base Labels:
 - `routing_engine_used`: Comma-separated routing engines used (`routing-rule`, `governance`, `loadbalancing`, `model-catalog`, `core`). `core` is emitted when the Bifrost orchestrator itself makes a routing decision — i.e. a fallback transition or a retry transition.
 - `routing_rule_id`: Routing rule ID that matched the request
 - `routing_rule_name`: Routing rule name that matched the request
+- `complexity_tier`: Complexity tier used for routing (`SIMPLE` / `MEDIUM` / `COMPLEX`); empty when no routing rule referenced `complexity_tier`
+- `complexity_mechanism`: How the complexity tier was classified (`lexical`, or `skipped` when classification was demanded but produced no tier). The raw complexity score is deliberately not a label — unbounded cardinality; it lives only in the request logs
 - `selected_key_id`: ID of the key that successfully served the request (empty string `""` on final errors)
 - `selected_key_name`: Name of the key that successfully served the request (empty string `""` on final errors)
 - `fallback_index`: Fallback index (0 for first attempt, 1 for second attempt, etc.)

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -67498,7 +67498,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the reasoning tier\noverride. Matching is normalized to lowercase and duplicates are removed on save.\n",
+                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
                         "code_keywords",
@@ -67609,7 +67609,7 @@
                   },
                   "keywords": {
                     "type": "object",
-                    "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the reasoning tier\noverride. Matching is normalized to lowercase and duplicates are removed on save.\n",
+                    "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
                     "additionalProperties": false,
                     "required": [
                       "code_keywords",
@@ -67692,7 +67692,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the reasoning tier\noverride. Matching is normalized to lowercase and duplicates are removed on save.\n",
+                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
                         "code_keywords",
@@ -67816,7 +67816,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the reasoning tier\noverride. Matching is normalized to lowercase and duplicates are removed on save.\n",
+                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
                         "code_keywords",
@@ -67959,7 +67959,7 @@
           {
             "name": "complexity_tiers",
             "in": "query",
-            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX)",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
             "schema": {
               "type": "string"
             }
@@ -68555,7 +68555,7 @@
           {
             "name": "complexity_tiers",
             "in": "query",
-            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX)",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
             "schema": {
               "type": "string"
             }
@@ -68804,6 +68804,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -68889,22 +68905,6 @@
             "name": "stop_reasons",
             "in": "query",
             "description": "Comma-separated list of stop reasons to filter by",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "complexity_tiers",
-            "in": "query",
-            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX)",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "complexity_mechanisms",
-            "in": "query",
-            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -69082,6 +69082,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -69314,6 +69330,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -69541,6 +69573,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -69789,6 +69837,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -70020,6 +70084,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -70246,6 +70326,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -70489,6 +70585,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -70758,6 +70870,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -71012,6 +71140,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -71282,6 +71426,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -71690,6 +71850,22 @@
             }
           },
           {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "start_time",
             "in": "query",
             "description": "Start time filter (RFC3339 format)",
@@ -72048,6 +72224,22 @@
             "name": "routing_engine_used",
             "in": "query",
             "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_tiers",
+            "in": "query",
+            "description": "Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "complexity_mechanisms",
+            "in": "query",
+            "description": "Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)",
             "schema": {
               "type": "string"
             }
@@ -97421,42 +97613,25 @@
             "nullable": true
           },
           "complexity_tier": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "SIMPLE",
-                  "MEDIUM",
-                  "COMPLEX"
-                ]
-              },
-              {
-                "type": "null"
-              }
+            "type": "string",
+            "enum": [
+              "SIMPLE",
+              "MEDIUM",
+              "COMPLEX",
+              "REASONING"
             ],
-            "description": "Complexity tier used for routing; null when no routing rule referenced complexity_tier, or when classification was demanded but skipped (see complexity_mechanism)"
+            "description": "Complexity tier used for routing; null when no routing rule referenced complexity_tier, or when classification was demanded but skipped (see complexity_mechanism). REASONING is historical-only — it was merged into COMPLEX and is never emitted for new requests, but survives in log rows recorded under the old scheme.",
+            "nullable": true
           },
           "complexity_mechanism": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "How the complexity tier was classified (lexical, or skipped when classification was demanded but produced no tier)"
+            "type": "string",
+            "description": "How the complexity tier was classified (lexical, or skipped when classification was demanded but produced no tier)",
+            "nullable": true
           },
           "complexity_score": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Raw complexity score behind the tier"
+            "type": "number",
+            "description": "Raw complexity score behind the tier",
+            "nullable": true
           },
           "stream": {
             "type": "boolean"

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -1368,7 +1368,7 @@ complexity:
   put:
     operationId: updateComplexityAnalyzerConfig
     summary: Update complexity analyzer config
-    description: Replaces the full complexity analyzer runtime config and hot-reloads the governance plugin. Tier thresholds must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.
+    description: Replaces the full complexity analyzer runtime config and hot-reloads the governance plugin. Tier thresholds must satisfy 0 < simple_medium < medium_complex < 1.
     tags:
       - Governance
     requestBody:

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -47,6 +47,16 @@ logs:
         description: Comma-separated list of routing engines to filter by (routing-rule, governance, or loadbalancing)
         schema:
           type: string
+      - name: complexity_tiers
+        in: query
+        description: Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)
+        schema:
+          type: string
+      - name: complexity_mechanisms
+        in: query
+        description: Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)
+        schema:
+          type: string
       - name: start_time
         in: query
         description: Start time filter (RFC3339 format)
@@ -214,6 +224,16 @@ logs-stats:
         description: Comma-separated list of routing engines to filter by (routing-rule, governance, or loadbalancing)
         schema:
           type: string
+      - name: complexity_tiers
+        in: query
+        description: Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)
+        schema:
+          type: string
+      - name: complexity_mechanisms
+        in: query
+        description: Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)
+        schema:
+          type: string
       - name: start_time
         in: query
         description: Start time filter (RFC3339 format)
@@ -370,6 +390,8 @@ logs-histogram:
       - $ref: '#/_histogram-parameters/business_unit_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/period'
@@ -415,6 +437,8 @@ logs-histogram-tokens:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -455,6 +479,8 @@ logs-histogram-cost:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -495,6 +521,8 @@ logs-histogram-models:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -535,6 +563,8 @@ logs-histogram-latency:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -575,6 +605,8 @@ logs-histogram-cost-by-provider:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -615,6 +647,8 @@ logs-histogram-tokens-by-provider:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -655,6 +689,8 @@ logs-histogram-latency-by-provider:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -757,6 +793,18 @@ _histogram-parameters:
     name: routing_engine_used
     in: query
     description: Comma-separated list of routing engines to filter by
+    schema:
+      type: string
+  complexity_tiers:
+    name: complexity_tiers
+    in: query
+    description: Comma-separated list of routing complexity tiers to filter by (SIMPLE, MEDIUM, COMPLEX, or the legacy REASONING tier recorded on historical rows before it was merged into COMPLEX)
+    schema:
+      type: string
+  complexity_mechanisms:
+    name: complexity_mechanisms
+    in: query
+    description: Comma-separated list of complexity classification mechanisms to filter by (lexical, skipped)
     schema:
       type: string
   start_time:
@@ -1308,6 +1356,8 @@ logs-rankings:
       - $ref: '#/_histogram-parameters/business_unit_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/period'
@@ -1372,6 +1422,8 @@ logs-dashboard:
       - $ref: '#/_histogram-parameters/business_unit_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/period'
@@ -1438,6 +1490,8 @@ logs-histogram-cost-by-dimension:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -1486,6 +1540,8 @@ logs-histogram-tokens-by-dimension:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'
@@ -1534,6 +1590,8 @@ logs-histogram-latency-by-dimension:
       - $ref: '#/_histogram-parameters/virtual_key_ids'
       - $ref: '#/_histogram-parameters/routing_rule_ids'
       - $ref: '#/_histogram-parameters/routing_engine_used'
+      - $ref: '#/_histogram-parameters/complexity_tiers'
+      - $ref: '#/_histogram-parameters/complexity_mechanisms'
       - $ref: '#/_histogram-parameters/start_time'
       - $ref: '#/_histogram-parameters/end_time'
       - $ref: '#/_histogram-parameters/min_latency'

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2101,12 +2101,11 @@ ListPricingOverridesResponse:
 
 ComplexityTierBoundaries:
   type: object
-  description: Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.
+  description: Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < 1.
   additionalProperties: false
   required:
     - simple_medium
     - medium_complex
-    - complex_reasoning
   properties:
     simple_medium:
       type: number
@@ -2115,12 +2114,7 @@ ComplexityTierBoundaries:
       exclusiveMaximum: 1
     medium_complex:
       type: number
-      description: Score boundary between MEDIUM and COMPLEX tiers
-      exclusiveMinimum: 0
-      exclusiveMaximum: 1
-    complex_reasoning:
-      type: number
-      description: Score boundary between COMPLEX and REASONING tiers
+      description: Score boundary between MEDIUM and COMPLEX tiers; scores at or above are COMPLEX
       exclusiveMinimum: 0
       exclusiveMaximum: 1
 
@@ -2128,8 +2122,9 @@ ComplexityKeywordConfig:
   type: object
   description: |
     Editable keyword lists used by the complexity analyzer. Only the four user-facing
-    dimensions are exposed; `reasoning_keywords` entries drive the reasoning tier
-    override. Matching is normalized to lowercase and duplicates are removed on save.
+    dimensions are exposed; `reasoning_keywords` entries drive the override that
+    promotes requests to the COMPLEX tier. Matching is normalized to lowercase and
+    duplicates are removed on save.
   additionalProperties: false
   required:
     - code_keywords

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -49,6 +49,19 @@ LogEntry:
     routing_rule_name:
       type: string
       nullable: true
+    complexity_tier:
+      type: string
+      enum: ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"]
+      description: Complexity tier used for routing; null when no routing rule referenced complexity_tier. REASONING is historical-only — it was merged into COMPLEX and is never emitted for new requests, but survives in log rows recorded under the old scheme.
+      nullable: true
+    complexity_mechanism:
+      type: string
+      description: How the complexity tier was classified (lexical, or skipped when classification was demanded but produced no tier)
+      nullable: true
+    complexity_score:
+      type: number
+      description: Raw complexity score behind the tier
+      nullable: true
     stream:
       type: boolean
     raw_request:

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -1529,7 +1529,7 @@ Within each scope, rules are sorted by **priority** (ascending: 0 before 10).
 | **Capacity Awareness** | Access real-time budget and rate limit usage percentages               |
 
 <Info>
-For complexity-based routing driven by request content, see [Complexity Router](/features/governance/complexity-router). It adds a `complexity_tier` CEL variable that lets routing rules steer SIMPLE, MEDIUM, COMPLEX, and REASONING requests to different models.
+For complexity-based routing driven by request content, see [Complexity Router](/features/governance/complexity-router). It adds a `complexity_tier` CEL variable that lets routing rules steer SIMPLE, MEDIUM, and COMPLEX requests to different models.
 </Info>
 
 ### Integration with Governance

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -119,7 +119,7 @@ request > 90               // Switch providers when request limit near max
 #### Complexity Routing
 
 ```cel
-complexity_tier   // Automatically-classified request tier: "SIMPLE", "MEDIUM", "COMPLEX", or "REASONING"
+complexity_tier   // Automatically-classified request tier: "SIMPLE", "MEDIUM", or "COMPLEX"
 ```
 
 Bifrost analyzes each request's prompt content and assigns a tier before routing rules are evaluated. This lets you route cheap/fast requests to small models and deep reasoning tasks to frontier models with no application-side changes.
@@ -130,10 +130,10 @@ If complexity analysis is unavailable for a request (e.g. unparseable body), `co
 
 **Examples:**
 ```cel
-complexity_tier == "REASONING"                              // Only frontier-worthy tasks
-complexity_tier in ["COMPLEX", "REASONING"]                 // Complex and above
-!(complexity_tier in ["SIMPLE", "MEDIUM"])                  // Same as above, negated form
-complexity_tier == "REASONING" && team_name == "research"   // Scoped to a team
+complexity_tier == "COMPLEX"                                // Only frontier-worthy tasks
+complexity_tier in ["MEDIUM", "COMPLEX"]                    // Medium and above
+!(complexity_tier in ["SIMPLE", "MEDIUM"])                  // Complex only, negated form
+complexity_tier == "COMPLEX" && team_name == "research"     // Scoped to a team
 ```
 
 See [Complexity Router](/features/governance/complexity-router) for how tiers are computed and how to tune the thresholds and keyword lists.

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -889,10 +889,10 @@ bifrost:
       #   pricing_patch: "{\"input_cost_per_token\":0.000001,\"output_cost_per_token\":0.000002}"
     complexityAnalyzerConfig:
       null
+      # Legacy complex_reasoning boundary values remain accepted but are ignored.
       # tier_boundaries:
-      #   simple_medium: 0.15
-      #   medium_complex: 0.35
-      #   complex_reasoning: 0.60
+      #   simple_medium: 0.20   # Scores below this are SIMPLE
+      #   medium_complex: 0.40  # Scores below this (and >= simple_medium) are MEDIUM; at or above are COMPLEX
       # keywords:
       #   code_keywords: ["function", "class", "api", "debug", "deploy"]
       #   reasoning_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]


### PR DESCRIPTION
## Summary

The REASONING complexity tier has been removed and merged into COMPLEX. This simplifies the Complexity Router from a four-tier system (Simple, Medium, Complex, Reasoning) to three tiers (Simple, Medium, Complex). The `complex_reasoning` tier boundary is removed from configuration, default thresholds are adjusted, dimension weights are rebalanced, and the continuation detection logic is expanded to handle short follow-up messages beyond explicit continuation phrases.

## Changes

- Removed the `REASONING` tier entirely; the reasoning-keyword override now promotes requests to `COMPLEX` instead of a separate tier
- Removed `complex_reasoning` from `tier_boundaries` in the Helm values schema, API schema, and all documentation examples — values files that still set this field will fail schema validation
- Updated default tier boundaries: `simple_medium` 0.15 → 0.20, `medium_complex` 0.35 → 0.40
- Rebalanced dimension weights: Code presence 30% → 34%, Reasoning markers 25% → 28%, Technical terms 25% → 28%
- Expanded continuation detection: short messages (≤12 words with no simple-keyword match) now count as continuations, not just explicit phrases like "do it" or "continue"; added a 100% history blend for continuations with no signal of their own
- Added `complexity_tier`, `complexity_mechanism`, and `complexity_score` as structured fields on `LogEntry` in the logging schema
- Added `complexity_tiers` and `complexity_mechanisms` as query parameters across all log, histogram, ranking, and dashboard API endpoints
- Added `complexity_tier` and `complexity_mechanism` as Prometheus metric labels and telemetry span attributes; raw score is intentionally excluded from both due to cardinality
- Historical log rows with `REASONING` tier are preserved as a legacy filter value in the logs explorer
- Bumped Helm chart to v2.1.32

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Deploy Helm chart v2.1.32 with a values file that previously set `complex_reasoning` — confirm schema validation rejects it.
2. Remove `complex_reasoning` from the values file and redeploy — confirm the chart applies successfully.
3. Send a request matching two or more reasoning keywords and confirm `complexity_tier` is `COMPLEX` (not `REASONING`) in the routing log.
4. Send a short follow-up message (e.g. "why?") in a multi-turn conversation with a prior high-complexity score and confirm the tier inherits from conversation history.
5. Query the logs API with `?complexity_tiers=COMPLEX&complexity_mechanisms=lexical` and confirm filtering works.
6. Confirm that existing log rows with `REASONING` tier are still reachable via the legacy filter value.

## Breaking changes

- [x] Yes
- [ ] No

The `complex_reasoning` tier boundary field is removed. Any Helm values file, API payload, or routing rule that references `complex_reasoning` or `"REASONING"` must be updated before upgrading:

- **Helm values:** delete `bifrost.governance.complexityAnalyzerConfig.tier_boundaries.complex_reasoning`; the field now fails schema validation
- **Routing rules:** replace `complexity_tier == "REASONING"` with `complexity_tier == "COMPLEX"` and `complexity_tier in ["COMPLEX", "REASONING"]` with `complexity_tier in ["MEDIUM", "COMPLEX"]`
- **API payloads:** remove `complex_reasoning` from `tier_boundaries` in any `PUT /api/governance/complexity-analyzer-config` calls

Historical log rows retain their recorded `REASONING` value and remain queryable as a legacy filter; no log data is lost.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable