### PR TITLE
chore: update flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780965770,
-        "narHash": "sha256-g13MEx3zFQG2HiYiEuM3QzLvGwnYiCuzRrIVYrTeSro=",
+        "lastModified": 1784875910,
+        "narHash": "sha256-UfxGmmJheitip1PVQHHJC3bIicCuVRxjAxB/Bis2kgI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a817a86f2e8684a19f9982b4598b3b65a3d38e6",
+        "rev": "a0f7233e070eb72d7f415eda943a1aa2290427c5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 
-      # Temporary workaround until nixpkgs includes Go 1.26.4.
-      go_1_26_4_overlay = final: prev: {
+      # Temporary workaround until nixpkgs includes Go 1.26.5.
+      go_1_26_5_overlay = final: prev: {
         go_1_26 = prev.go_1_26.overrideAttrs (oldAttrs: rec {
-          version = "1.26.4";
+          version = "1.26.5";
           src = final.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            sha256 = "0bb089d2bfszfc8r4cra94qsdb8x5y69dyw1m3k344gwzcr8lrjg";
+            sha256 = "495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42";
           };
         });
         go = final.go_1_26;
@@ -39,7 +39,7 @@
             # Provides a system-specific, configured Nixpkgs
             pkgs = import inputs.nixpkgs {
               inherit system;
-              overlays = [ go_1_26_4_overlay ];
+              overlays = [ go_1_26_5_overlay ];
               # Enable using unfree packages
               config.allowUnfree = true;
             };


### PR DESCRIPTION
## Summary

Bumps the Go version used in the Nix development environment from 1.26.4 to 1.26.5 and updates the nixpkgs input to a newer revision.

## Changes

- Updated the nixpkgs flake input to revision `a0f7233e070eb72d7f415eda943a1aa2290427c5`
- Replaced the `go_1_26_4_overlay` with `go_1_26_5_overlay`, overriding `go_1_26` to use Go 1.26.5 with its updated source hash

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Verify the correct Go version is active in the Nix shell
nix develop
go version
# Expected: go version go1.26.5 ...

# Run tests to confirm nothing is broken
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Go patch releases typically include security fixes. Upgrading to 1.26.5 ensures any vulnerabilities addressed in the patch are resolved in the development environment.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable