### PR TITLE
fix: add enterprise-ui Tailwind source path and `hideSearchIcon` prop to ModelMultiselect

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -4,6 +4,8 @@
 @source "../app/**/*.tsx";
 @source "../node_modules/streamdown/dist/*.js";
 @source "../../../bifrost-enterprise/ui/**/*.tsx";
+/* app/enterprise is a symlink the scanner won't follow — point at the real path */
+@source "../../../bifrost-enterprise/enterprise-ui/**/*.tsx";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -20,6 +20,8 @@ interface ModelMultiselectPropsBase {
 	loadModelsOnEmptyProvider?: boolean | "base_models";
 	/** Prepends an "Allow All Models" option (value: "*") to the dropdown */
 	allowAllOption?: boolean;
+	/** Hides the search icon rendered inside the control */
+	hideSearchIcon?: boolean;
 	/** id for the search input (accessibility) */
 	inputId?: string;
 	/** id of element that labels this control (accessibility) */
@@ -259,6 +261,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 		<AsyncMultiSelect<ModelOption>
 			isSingleSelect={isSingleSelect}
 			hideSelectedOptions
+			hideSearchIcon={props.hideSearchIcon}
 			inputId={props.inputId}
 			ariaLabelledBy={props.ariaLabelledBy}
 			data-testid={props["data-testid"]}
@@ -327,7 +330,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 						>
 							<span className={cn("grow truncate text-sm", isDeprecated && "text-muted-foreground")}>{optionProps.data.label}</span>
 							{isDeprecated && (
-								<span className="text-muted-foreground border-border shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide">
+								<span className="text-muted-foreground border-border shrink-0 rounded-sm border px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase">
 									Deprecated
 								</span>
 							)}


### PR DESCRIPTION
## Summary

Fixes Tailwind CSS class scanning for enterprise UI components loaded via a symlink, and adds a `hideSearchIcon` prop to `ModelMultiselect` for more flexible control rendering.

## Changes

- Added an explicit `@source` directive pointing at the real path (`bifrost-enterprise/enterprise-ui/**/*.tsx`) because the `app/enterprise` symlink is not followed by the Tailwind scanner, which caused enterprise component styles to be missing from the build.
- Added a `hideSearchIcon` prop to `ModelMultiselect` (and wired it through to `AsyncMultiSelect`) to allow callers to suppress the search icon rendered inside the control.
- Minor class ordering fix on the "Deprecated" badge span (`uppercase` moved to end) to satisfy linting/formatting conventions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Verify that enterprise UI components render with correct Tailwind styles (no missing classes). Verify that `ModelMultiselect` renders without the search icon when `hideSearchIcon={true}` is passed.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable