### PR TITLE
chore: release Bifrost Helm chart v2.1.32

### DIFF
--- a/docs/changelogs/helm-v2.1.32.mdx
+++ b/docs/changelogs/helm-v2.1.32.mdx
@@ -1,0 +1,18 @@
+---
+title: "v2.1.32"
+description: "Helm v2.1.32 changelog - 2026-07-24"
+---
+
+<Update label="Bifrost Helm" description="v2.1.32">
+
+## Changelog
+
+- Extended `bifrost.accessProfiles[].provider_configs[]` with `blacklisted_models` (denylist that wins over `allowed_models`; `["*"]` blocks every model, while an empty or omitted list blocks none), `weight` (load-balancer seed weight; `null` opts out), and `model_budgets[]` (per-model budget groups; each entry requires `model_name` and may carry optional `budgets[]` and a `rate_limit`). These pass through into `access_profiles[].provider_configs[]`.
+- Added `bifrost.scim.config.additionalScopes` (Okta) — an array of extra OAuth scopes requested on top of the base `openid/profile/email/offline_access` set, for Custom Authorization Servers where claims like `groups` are gated behind a scope Bifrost does not request by default. Passes through into `scim_config.config.additionalScopes`.
+- Added `bifrost.framework.pricing.liveModelsSyncInterval` (default `3600` seconds, minimum `60`, `0` disables) to control how often each provider's list-models response is re-fetched in the background. Renders into `framework.pricing.live_models_sync_interval`.
+- Added `storage.configStore.connMaxIdleTime` and `storage.logsStore.connMaxIdleTime` (Go duration, e.g. `5m`) to cap how long an idle PostgreSQL connection is kept before closing, so bursts above `maxIdleConns` stop churning physical connections. Each renders into its store's `conn_max_idle_time`.
+- Added `storage.logsStore.matviewRefreshTimeout` (Go duration, min 30s, max 30m; unset derives 5× the refresh interval, at least 5m) to bound a single materialized-view refresh pass. Renders into `logs_store.matview_refresh_timeout`.
+- Added `bifrost.plugins.otel.config.export_timeout` (seconds, 1–60, default 5) to bound a single trace export — the only timeout on gRPC exports. Renders into the OTEL plugin config's `export_timeout`, and is omitted from the generated config when unset (or `0`).
+- Added `postgresql.external.passwordCommand.cache_ttl` (Go duration, default 60s) to control how long a resolved password is reused across new physical connections instead of re-running the command per connection. Passes through into `password_command.cache_ttl`.
+
+</Update>

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,9 +8,15 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
-### Upcoming
+### 2.1.32
 
+- Extended `bifrost.accessProfiles[].provider_configs[]` with `blacklisted_models` (denylist that wins over `allowed_models`; `["*"]` blocks every model, while an empty or omitted list blocks none), `weight` (load-balancer seed weight; `null` opts out), and `model_budgets[]` (per-model budget groups; each entry requires `model_name` and may carry optional `budgets[]` and a `rate_limit`). These pass through into `access_profiles[].provider_configs[]`.
+- Added `bifrost.scim.config.additionalScopes` (Okta) — an array of extra OAuth scopes requested on top of the base `openid/profile/email/offline_access` set, for Custom Authorization Servers where claims like `groups` are gated behind a scope Bifrost does not request by default. Passes through into `scim_config.config.additionalScopes`.
 - Added `bifrost.framework.pricing.liveModelsSyncInterval` (default `3600` seconds, minimum `60`, `0` disables) to control how often each provider's list-models response is re-fetched in the background. Renders into `framework.pricing.live_models_sync_interval`.
+- Added `storage.configStore.connMaxIdleTime` and `storage.logsStore.connMaxIdleTime` (Go duration, e.g. `5m`) to cap how long an idle PostgreSQL connection is kept before closing, so bursts above `maxIdleConns` stop churning physical connections. Each renders into its store's `conn_max_idle_time`.
+- Added `storage.logsStore.matviewRefreshTimeout` (Go duration, min 30s, max 30m; unset derives 5× the refresh interval, at least 5m) to bound a single materialized-view refresh pass. Renders into `logs_store.matview_refresh_timeout`.
+- Added `bifrost.plugins.otel.config.export_timeout` (seconds, 1–60, default 5) to bound a single trace export — the only timeout on gRPC exports. Renders into the OTEL plugin config's `export_timeout` (also wired the field through `_helpers.tpl`), and is omitted from the generated config when unset (or `0`).
+- Added `postgresql.external.passwordCommand.cache_ttl` (Go duration, default 60s) to control how long a resolved password is reused across new physical connections instead of re-running the command per connection. Passes through into `password_command.cache_ttl`.
 
 ### 2.1.31
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1380,6 +1380,9 @@ false
 {{- if $inputConfig.protocol }}
 {{- $_ := set $otelConfig "protocol" $inputConfig.protocol }}
 {{- end }}
+{{- if $inputConfig.export_timeout }}
+{{- $_ := set $otelConfig "export_timeout" ($inputConfig.export_timeout | int) }}
+{{- end }}
 {{- if hasKey $inputConfig "metrics_enabled" }}
 {{- $_ := set $otelConfig "metrics_enabled" $inputConfig.metrics_enabled }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2346,6 +2346,11 @@
                         "type": "string",
                         "description": "JWT audience for validation (optional)"
                       },
+                      "additionalScopes": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Extra OAuth scopes requested on top of the base openid/profile/email/offline_access set. Primarily for Custom Authorization Servers where claims like 'groups' are gated behind a scope Bifrost does not request by default."
+                      },
                       "userIdField": {
                         "type": "string",
                         "description": "JWT claim field for user ID (default: 'sub')",
@@ -3235,7 +3240,79 @@
                           "type": "string"
                         }
                       },
+                      "required": ["id"],
                       "additionalProperties": false
+                    },
+                    "blacklisted_models": {
+                      "type": "array",
+                      "description": "Models blocked for this provider even if matched by allowed_models (denylist wins). Use [\"*\"] to block all.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "weight": {
+                      "type": ["number", "null"],
+                      "description": "Load-balancer seed weight for this provider (null opts out of weighted routing).",
+                      "default": null
+                    },
+                    "model_budgets": {
+                      "type": "array",
+                      "description": "Per-model budgets and rate limits scoped to this provider.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "model_name": {
+                            "type": "string"
+                          },
+                          "budgets": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "max_limit": {
+                                  "type": "number"
+                                },
+                                "reset_duration": {
+                                  "type": "string"
+                                },
+                                "calendar_aligned": {
+                                  "type": "boolean",
+                                  "default": false
+                                }
+                              },
+                              "required": ["id", "max_limit", "reset_duration"],
+                              "additionalProperties": false
+                            }
+                          },
+                          "rate_limit": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "token_max_limit": {
+                                "type": "integer"
+                              },
+                              "token_reset_duration": {
+                                "type": "string"
+                              },
+                              "request_max_limit": {
+                                "type": "integer"
+                              },
+                              "request_reset_duration": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id"],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": ["model_name"],
+                        "additionalProperties": false
+                      }
                     },
                     "key_ids": {
                       "type": "array",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -939,6 +939,10 @@ bifrost:
       # clientSecret: ""
       # apiToken: ""
       # audience: ""
+      # # Extra OAuth scopes on top of the base openid/profile/email/offline_access set
+      # # (for Custom Authorization Servers where claims like "groups" are gated behind a scope).
+      # additionalScopes:
+      #   - "groups"
       # userIdField: "sub"
       # teamIdsField: "groups"
       # rolesField: "roles"
@@ -1162,6 +1166,20 @@ bifrost:
     #     - provider_name: "openai"
     #       all_models_allowed: false
     #       allowed_models: ["gpt-4o", "gpt-4o-mini"]
+    #       blacklisted_models: ["gpt-4o-realtime-preview"]  # Denylist wins over allowed_models; ["*"] blocks all
+    #       weight: 1.0  # Load-balancer seed weight; null/omit opts out of weighted routing
+    #       model_budgets:  # Per-model budgets + rate limits scoped to this provider
+    #         - model_name: "gpt-4o"
+    #           budgets:
+    #             - id: "ap-openai-gpt4o-budget"
+    #               max_limit: 50
+    #               reset_duration: "1M"
+    #           rate_limit:
+    #             id: "ap-openai-gpt4o-rl"
+    #             token_max_limit: 100000
+    #             token_reset_duration: "1h"
+    #             request_max_limit: 500
+    #             request_reset_duration: "1h"
     #   mcp_tool_groups:
     #     - tool_group_id: 1
     #   mcp_servers:

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5725,6 +5725,11 @@
           "type": "string",
           "description": "JWT audience for validation (optional)"
         },
+        "additionalScopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra OAuth scopes requested on top of the base openid/profile/email/offline_access set. Primarily for Custom Authorization Servers where claims like 'groups' are gated behind a scope Bifrost does not request by default."
+        },
         "userIdField": {
           "type": "string",
           "description": "JWT claim field for user ID (default: 'sub')",
@@ -6586,6 +6591,25 @@
         "rate_limit": {
           "$ref": "#/$defs/rate_limit_line"
         },
+        "blacklisted_models": {
+          "type": "array",
+          "description": "Models blocked for this provider even if matched by allowed_models (denylist wins). Use [\"*\"] to block all; empty array or omitted blocks none.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "weight": {
+          "type": ["number", "null"],
+          "description": "Load-balancer seed weight for this provider (null opts out of weighted routing / no override)",
+          "default": null
+        },
+        "model_budgets": {
+          "type": "array",
+          "description": "Per-model budgets and rate limits scoped to this provider. Each entry targets one model and materializes as a user-scoped model config on assignment.",
+          "items": {
+            "$ref": "#/$defs/access_profile_provider_model_budget"
+          }
+        },
         "key_ids": {
           "type": "array",
           "description": "Key IDs allowed for this provider config. Use [\"*\"] to allow all keys; empty array or omitted denies all keys. Specific IDs restrict access to those keys only.",
@@ -6595,6 +6619,28 @@
         }
       },
       "required": ["provider_name"],
+      "additionalProperties": false
+    },
+    "access_profile_provider_model_budget": {
+      "type": "object",
+      "description": "Per-model budget group under an access-profile provider config, with optional per-model rate limit",
+      "properties": {
+        "model_name": {
+          "type": "string",
+          "description": "Model this budget group applies to (scoped to the parent provider)"
+        },
+        "budgets": {
+          "type": "array",
+          "description": "Spend budgets for this model",
+          "items": {
+            "$ref": "#/$defs/budget_line"
+          }
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/rate_limit_line"
+        }
+      },
+      "required": ["model_name"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_group": {


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart to v2.1.32, introducing per-model governance controls on access profile provider configs, additional OAuth scopes for SCIM/Okta, and validation for the Bedrock batch job role ARN.

## Changes

- Extended `bifrost.accessProfiles[].provider_configs[]` with three new fields: `blacklisted_models` (a denylist that wins over `allowed_models`; `["*"]` blocks all models), `weight` (load-balancer seed weight; `null` opts out of weighted routing), and `model_budgets[]` (per-model budget groups, each carrying `budgets` and an optional `rate_limit`). These pass through into `access_profiles[].provider_configs[]` in config.json and are validated in both `values.schema.json` and `transports/config.schema.json`.
- Added `bifrost.scim.config.additionalScopes` — an array of extra OAuth scopes appended to the base `openid/profile/email/offline_access` set. This is needed for Okta Custom Authorization Servers where claims like `groups` are gated behind a scope that Bifrost does not request by default. The field is validated in both `values.schema.json` and `transports/config.schema.json` so configs are validated at startup.
- Documented and validated `bifrost.providers.<provider>.keys[*].bedrock_key_config.batch_role_arn` — the service role ARN passed to Bedrock batch jobs for S3 access, which takes priority over any `role_arn` sent in the request.
- Added the v2.1.32 changelog entry and registered it in the docs navigation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the updated Helm chart and verify the new fields are accepted:

```sh
# Validate the Helm chart schema
helm lint helm-charts/bifrost

# Install/upgrade with additionalScopes and model governance configured
helm upgrade --install bifrost helm-charts/bifrost \
  --set bifrost.scim.config.additionalScopes[0]=groups

# Confirm the generated config passes schema validation at startup by
# checking Bifrost logs for no schema validation errors on boot.
```

**New config fields:**

| Field | Type | Description |
|---|---|---|
| `bifrost.accessProfiles[].provider_configs[].blacklisted_models` | `[]string` | Denylist of models blocked even if matched by `allowed_models`; `["*"]` blocks all |
| `bifrost.accessProfiles[].provider_configs[].weight` | `number\|null` | Load-balancer seed weight; `null` opts out of weighted routing |
| `bifrost.accessProfiles[].provider_configs[].model_budgets[]` | `object[]` | Per-model budget groups with `budgets` and optional `rate_limit` |
| `bifrost.scim.config.additionalScopes` | `[]string` | Extra OAuth scopes beyond `openid/profile/email/offline_access` |
| `bifrost.providers.<provider>.keys[*].bedrock_key_config.batch_role_arn` | `string` | Service role ARN for Bedrock batch job S3 access |

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

`additionalScopes` expands the OAuth token scopes requested from Okta. Operators should ensure only necessary scopes are added to follow least-privilege principles. `batch_role_arn` is an IAM role ARN and should be scoped to the minimum permissions required for Bedrock batch S3 access. `blacklisted_models` and `weight` affect routing and access control — misconfiguration could inadvertently expose or block model access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable