### PR TITLE
fix: routing info headers on streaming fallbacks

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5233,16 +5233,18 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		if fallbackErr == nil {
 			// Layer Primary/IsFallback onto the ctx-stashed RoutingInfo (mirrors
 			// SetFallbackRoutingInfo) — chunks can't carry it (see above), but the
-			// transport's pre-stream response headers can.
+			// transport's pre-stream response headers can. Use SetRoutingInfoSnapshot
+			// (bypasses the restricted-writes guard) so this write isn't dropped when it
+			// races the streaming response's async per-chunk post-hooks.
 			if ri, ok := ctx.Value(schemas.BifrostContextKeyRoutingInfo).(schemas.RoutingInfo); ok {
 				ri.IsFallback = true
 				if provider != "" {
-					ri.PrimaryProvider = new(provider)
+					ri.PrimaryProvider = Ptr(provider)
 				}
 				if model != "" {
-					ri.PrimaryModel = new(model)
+					ri.PrimaryModel = Ptr(model)
 				}
-				ctx.SetValue(schemas.BifrostContextKeyRoutingInfo, ri)
+				ctx.SetRoutingInfoSnapshot(ri)
 			}
 			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, fmt.Sprintf("Request served by fallback %s/%s (attempt %d/%d)", fallback.Provider, fallback.Model, i+1, len(fallbacks)))
@@ -6738,6 +6740,28 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				// alias while this attempt's provider goroutine is still emitting chunks.
 				attemptResolvedModel := resolvedModel
 				attemptRoutingInfo = schemas.BuildRoutingInfo(req.Context, provider.GetProviderKey(), originalModelRequested, k)
+				// Layer fallback identity here — the reliable write point. The orchestrator's
+				// post-hand-off ctx write (handleStreamRequest) races the streaming response's
+				// async per-chunk post-hooks, so set IsFallback/Primary on the per-attempt
+				// RoutingInfo instead. This flows into BOTH the header snapshot below and the
+				// per-chunk RoutingInfo (perAttemptRoutingInfo), so headers and SSE body agree.
+				// fallback index > 0 ⟺ this attempt is a fallback; Primary comes from the
+				// previous attempt's snapshot (the primary, or the carried-through primary on a
+				// later fallback — clearCtxForFallback keeps BifrostContextKeyRoutingInfo).
+				if fi, _ := req.Context.Value(schemas.BifrostContextKeyFallbackIndex).(int); fi > 0 {
+					attemptRoutingInfo.IsFallback = true
+					if prev, ok := req.Context.Value(schemas.BifrostContextKeyRoutingInfo).(schemas.RoutingInfo); ok {
+						if prev.IsFallback && prev.PrimaryProvider != nil {
+							attemptRoutingInfo.PrimaryProvider = prev.PrimaryProvider
+							attemptRoutingInfo.PrimaryModel = prev.PrimaryModel
+						} else if prev.Provider != "" {
+							pp := prev.Provider
+							pm := prev.Model
+							attemptRoutingInfo.PrimaryProvider = &pp
+							attemptRoutingInfo.PrimaryModel = &pm
+						}
+					}
+				}
 				// Stash for the transport: streams carry RoutingInfo only on chunks, but
 				// response headers must be written before the first chunk arrives. Each
 				// retry overwrites, so the winning attempt's snapshot survives.

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -373,6 +373,16 @@ func (bc *BifrostContext) setReservedValue(key, value any) {
 	bc.userValues[key] = value
 }
 
+// SetRoutingInfoSnapshot writes the routed-identity RoutingInfo snapshot,
+// bypassing the restricted-writes guard. The orchestrator needs this because a
+// streaming response's async per-chunk post-hooks hold blockRestrictedWrites
+// while they run, and BifrostContextKeyRoutingInfo is reserved — a plain
+// SetValue from the orchestrator would be silently dropped whenever it races a
+// post-hook. Bifrost-internal (set by core - DO NOT SET THIS MANUALLY).
+func (bc *BifrostContext) SetRoutingInfoSnapshot(ri RoutingInfo) {
+	bc.setReservedValue(BifrostContextKeyRoutingInfo, ri)
+}
+
 // ClearValue clears a value from the internal userValues map.
 // For scoped contexts, delegates to the root context via valueDelegate.
 func (bc *BifrostContext) ClearValue(key any) {

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -211,6 +211,8 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 			}
 		}
 	}
+	// Routed identity after provider headers so a chained upstream's x-bifrost-* can't overwrite it.
+	lib.ApplyBifrostErrorResponseHeaders(ctx, bifrostCtx, bifrostErr.ExtraFields)
 
 	if bifrostErr.StatusCode != nil {
 		ctx.SetStatusCode(*bifrostErr.StatusCode)


### PR DESCRIPTION
## Summary

Fixes a race condition where `IsFallback` and `PrimaryProvider`/`PrimaryModel` routing identity fields were being silently dropped on streaming fallback responses. The orchestrator's post-hand-off context write raced against the streaming response's async per-chunk post-hooks, which hold `blockRestrictedWrites` while running — causing the plain `SetValue` call to be dropped whenever it lost the race.

## Changes

- Introduces `SetRoutingInfoSnapshot` on `BifrostContext`, which bypasses the `blockRestrictedWrites` guard via `setReservedValue`. This allows the orchestrator to reliably write fallback routing identity even when racing per-chunk post-hooks.
- Moves the authoritative fallback identity write (`IsFallback`, `PrimaryProvider`, `PrimaryModel`) into `requestWorker` at the per-attempt `RoutingInfo` construction point, rather than relying solely on the post-hand-off write in `handleStreamRequest`. This ensures both the pre-stream response header snapshot and the per-chunk `RoutingInfo` carry consistent fallback identity.
- When a fallback attempt is detected (`fallbackIndex > 0`), the primary provider/model are carried forward from the previous attempt's `RoutingInfo` snapshot, including chained fallback scenarios where the previous attempt was itself a fallback.
- Replaces `new(provider)` / `new(model)` pointer idioms with `Ptr(provider)` / `Ptr(model)` for consistency.
- Ensures `ApplyBifrostErrorResponseHeaders` is called after provider-chained upstream headers in `sendError`, preventing an upstream's `x-bifrost-*` headers from overwriting Bifrost's own routed identity headers on error responses.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

Send a streaming request that triggers a fallback (primary provider fails, fallback succeeds). Verify that:
- The pre-stream response headers contain the correct `IsFallback`, `PrimaryProvider`, and `PrimaryModel` values.
- Each SSE chunk's routing info agrees with the response headers.
- Under concurrent load, the fallback identity is never missing from headers or chunks.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable