### PR TITLE
fix: opus 5 compatibility

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -798,16 +798,29 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 	return jsonBody, nil
 }
 
-// IsOpus47Plus returns true if the model is Claude Opus 4.7 or later (currently 4.7 and 4.8) where:
+// IsOpus47Plus returns true if the model is Claude Opus 4.7 or later (currently 4.7, 4.8, and 5) where:
 //   - Extended thinking (budget_tokens) is removed — only adaptive thinking is supported.
 //   - temperature, top_p, and top_k are not supported (setting them returns a 400).
+//
+// Opus 5 shares Opus 4.8's request surface, so it is matched here via IsOpus5Plus.
 func IsOpus47Plus(model string) bool {
 	model = strings.ToLower(model)
 	if !strings.Contains(model, "opus") {
 		return false
 	}
 	return strings.Contains(model, "4-7") || strings.Contains(model, "4.7") ||
-		strings.Contains(model, "4-8") || strings.Contains(model, "4.8")
+		strings.Contains(model, "4-8") || strings.Contains(model, "4.8") ||
+		IsOpus5Plus(model)
+}
+
+// IsOpus5Plus returns true for Claude Opus 5 (and later Opus 5.x). Opus 5 is a
+// drop-in for Opus 4.8's request surface: extended thinking (budget_tokens) is
+// removed, temperature/top_p/top_k are rejected with a 400, and it supports
+// adaptive thinking, the effort knob, fast mode, and mid-conversation system
+// messages. Matching "opus-5" excludes "opus-4-5" and matches
+// Bedrock/Vertex/date-suffixed forms.
+func IsOpus5Plus(model string) bool {
+	return strings.Contains(strings.ToLower(model), "opus-5")
 }
 
 // IsFableFamily returns true for Claude Fable / Mythos models (Fable 5,
@@ -863,7 +876,7 @@ func SupportsNativeEffort(model string) bool {
 
 // SupportsEffortParameter returns true if the model accepts the
 // output_config.effort parameter. Supported models: Claude Fable 5,
-// Claude Mythos 5, Claude Mythos Preview, Opus 4.8, Opus 4.7, Opus 4.6,
+// Claude Mythos 5, Claude Mythos Preview, Opus 5, Opus 4.8, Opus 4.7, Opus 4.6,
 // Sonnet 5, Sonnet 4.6, and Opus 4.5. All other models reject effort with a 400:
 //
 //	"This model does not support the effort parameter."
@@ -876,7 +889,7 @@ func SupportsNativeEffort(model string) bool {
 // Source: https://platform.claude.com/docs/en/build-with-claude/effort
 func SupportsEffortParameter(model string) bool {
 	m := strings.ToLower(model)
-	if IsFableFamily(m) || IsSonnet5Plus(m) {
+	if IsFableFamily(m) || IsSonnet5Plus(m) || IsOpus5Plus(m) {
 		return true
 	}
 	if strings.Contains(m, "haiku") {
@@ -922,9 +935,9 @@ func appendToSystemContent(existing *AnthropicContent, newContent AnthropicConte
 // SupportsMidConversationSystem returns true if the provider+model combination
 // supports role:"system" entries inside the messages array (mid-conversation
 // system messages). Available on the Anthropic API only — not on Bedrock or
-// Vertex. Supported on Claude Opus 4.8+ and the Claude Fable/Mythos family
-// (Fable post-dates Opus 4.8; the public doc lists Opus 4.8 but Fable supports
-// it as well). No beta header is required.
+// Vertex. Supported on Claude Opus 4.8+ (including Opus 5) and the Claude
+// Fable/Mythos family (Fable post-dates Opus 4.8; the public doc lists Opus 4.8
+// but Fable supports it as well). No beta header is required.
 //
 // Source: https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages
 func SupportsMidConversationSystem(provider schemas.ModelProvider, model string) bool {
@@ -932,7 +945,7 @@ func SupportsMidConversationSystem(provider schemas.ModelProvider, model string)
 		return false
 	}
 	m := strings.ToLower(model)
-	if IsFableFamily(m) {
+	if IsFableFamily(m) || IsOpus5Plus(m) {
 		return true
 	}
 	return strings.Contains(m, "opus") &&
@@ -940,8 +953,8 @@ func SupportsMidConversationSystem(provider schemas.ModelProvider, model string)
 }
 
 // SupportsFastMode returns true if the model supports speed:"fast" (research
-// preview). Supported on Opus 4.6, Opus 4.7, and Opus 4.8; requests carrying
-// speed:"fast" to any other model are rejected with 400.
+// preview). Supported on Opus 4.6, Opus 4.7, Opus 4.8, and Opus 5; requests
+// carrying speed:"fast" to any other model are rejected with 400.
 // Beta header: fast-mode-2026-02-01.
 //
 // Source: https://platform.claude.com/docs/en/build-with-claude/fast-mode

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2514,6 +2514,10 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		{"claude-opus-4.7-20260401", true},
 		{"claude-opus-4-6-20250514", true},
 		{"claude-opus-4.6-20250514", true},
+		// Opus 5: shares Opus 4.8's adaptive-only surface.
+		{"claude-opus-5", true},
+		{"claude-opus-5-20260601", true},
+		{"global.anthropic.claude-opus-5", true},
 		{"claude-sonnet-4-6-20250514", true},
 		{"claude-sonnet-4.6-20250514", true},
 		// Sonnet 5+: adaptive is the only thinking-on mode.
@@ -2609,6 +2613,42 @@ func TestIsSonnet5Plus(t *testing.T) {
 	}
 }
 
+// TestIsOpus5Plus pins the Opus 5 predicate. Opus 5 shares Opus 4.8's request
+// surface (adaptive-only thinking, temperature/top_p/top_k removed, fast mode,
+// effort, mid-conversation system). The "opus-5" substring must NOT match
+// "opus-4-5" / "opus-4.5".
+func TestIsOpus5Plus(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{"claude-opus-5", true},
+		{"claude-opus-5-20260601", true},
+		{"Claude-Opus-5", true},
+		{"global.anthropic.claude-opus-5", true},
+		{"anthropic.claude-opus-5-v1", true},
+		{"claude-opus-5@20260601", true},
+		// Must NOT match Opus 4.5 or other families.
+		{"claude-opus-4-5", false},
+		{"claude-opus-4.5-20251101", false},
+		{"claude-opus-4-5-20251101", false},
+		{"claude-opus-4-8", false},
+		{"claude-sonnet-5", false},
+		{"claude-fable-5", false},
+		{"claude-haiku-4-5", false},
+		{"", false},
+		{"some-non-claude-model", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			if got := IsOpus5Plus(tt.model); got != tt.expected {
+				t.Errorf("IsOpus5Plus(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestIsAdaptiveOnlyThinkingModel covers the union gate used for the thinking
 // and sampling-parameter surfaces: Opus 4.7+ OR Sonnet 5+ OR the Fable/Mythos family.
 func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
@@ -2616,10 +2656,13 @@ func TestIsAdaptiveOnlyThinkingModel(t *testing.T) {
 		model    string
 		expected bool
 	}{
-		// Opus 4.7+.
+		// Opus 4.7+ (including Opus 5).
 		{"claude-opus-4-8", true},
 		{"claude-opus-4-7", true},
 		{"claude-opus-4.8-20260601", true},
+		{"claude-opus-5", true},
+		{"claude-opus-5-20260601", true},
+		{"global.anthropic.claude-opus-5", true},
 		// Sonnet 5+.
 		{"claude-sonnet-5", true},
 		{"claude-sonnet-5-20260101", true},
@@ -2658,13 +2701,17 @@ func TestSupportsMidConversationSystem(t *testing.T) {
 		model    string
 		expected bool
 	}{
-		// Supported: Anthropic provider + Opus 4.8.
+		// Supported: Anthropic provider + Opus 4.8 (and Opus 5).
 		{schemas.Anthropic, "claude-opus-4-8", true},
 		{schemas.Anthropic, "claude-opus-4.8-20260601", true},
 		{schemas.Anthropic, "claude-opus-4-8-20260601", true},
-		// Not supported: Bedrock and Vertex even with Opus 4.8.
+		{schemas.Anthropic, "claude-opus-5", true},
+		{schemas.Anthropic, "claude-opus-5-20260601", true},
+		// Not supported: Bedrock and Vertex even with Opus 4.8 / Opus 5.
 		{schemas.Bedrock, "global.anthropic.claude-opus-4-8", false},
 		{schemas.Vertex, "claude-opus-4-8", false},
+		{schemas.Bedrock, "global.anthropic.claude-opus-5", false},
+		{schemas.Vertex, "claude-opus-5", false},
 		// Not supported: Anthropic but Opus 4.7 (feature is 4.8+ only).
 		{schemas.Anthropic, "claude-opus-4-7", false},
 		{schemas.Anthropic, "claude-opus-4.7-20260401", false},
@@ -2707,10 +2754,14 @@ func TestSupportsFastMode(t *testing.T) {
 		{"claude-opus-4.7-20260401", true},
 		{"claude-opus-4-8", true},
 		{"claude-opus-4.8-20260601", true},
+		// Opus 5: fast mode via IsOpus47Plus.
+		{"claude-opus-5", true},
+		{"claude-opus-5-20260601", true},
 		// Bedrock / Vertex prefixed IDs.
 		{"global.anthropic.claude-opus-4-6", true},
 		{"global.anthropic.claude-opus-4-7", true},
 		{"global.anthropic.claude-opus-4-8", true},
+		{"global.anthropic.claude-opus-5", true},
 		// Not supported — other model families.
 		{"claude-sonnet-4-6", false},
 		{"claude-haiku-4-5", false},
@@ -2750,6 +2801,9 @@ func TestSupportsEffortParameter(t *testing.T) {
 		{"global.anthropic.claude-fable-5", true},
 		{"claude-opus-4-8", true},
 		{"claude-opus-4.8-20260601", true},
+		{"claude-opus-5", true},
+		{"claude-opus-5-20260601", true},
+		{"global.anthropic.claude-opus-5", true},
 		{"claude-opus-4-7", true},
 		{"claude-opus-4.7-20260401", true},
 		{"claude-opus-4-6", true},
@@ -3242,6 +3296,10 @@ func TestComputerUseGeneration(t *testing.T) {
 		{"Claude-Opus-4-7", ComputerUseGen20251124},
 		{"claude-opus-4-7-20260321", ComputerUseGen20251124},
 		{"claude-opus-4-6", ComputerUseGen20251124},
+		// Opus 5 uses the new generation, like Opus 4.8.
+		{"claude-opus-5", ComputerUseGen20251124},
+		{"claude-opus-5-20260601", ComputerUseGen20251124},
+		{"global.anthropic.claude-opus-5", ComputerUseGen20251124},
 		{"claude-sonnet-4-6", ComputerUseGen20251124},
 		{"claude-sonnet-4.6", ComputerUseGen20251124},
 		// Sonnet 5+ uses the new generation (same tool surface as Sonnet 4.6).


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 5 across the Anthropic provider utility functions. Opus 5 shares the same request surface as Opus 4.8 — adaptive-only thinking, no `temperature`/`top_p`/`top_k`, and support for fast mode, the effort parameter, and mid-conversation system messages.

## Changes

- Introduces `IsOpus5Plus` predicate that matches `"opus-5"` as a substring, correctly excluding `"opus-4-5"` and `"opus-4.5"` while matching Bedrock/Vertex/date-suffixed model IDs.
- Extends `IsOpus47Plus` to delegate to `IsOpus5Plus`, so Opus 5 inherits the adaptive-only thinking and sampling-parameter restrictions.
- `SupportsEffortParameter` now returns `true` for Opus 5 via `IsOpus5Plus`.
- `SupportsMidConversationSystem` now returns `true` for Opus 5 on the Anthropic provider (Bedrock and Vertex remain unsupported).
- `SupportsFastMode` picks up Opus 5 through the updated `IsOpus47Plus` path.
- Computer use generation for Opus 5 resolves to `ComputerUseGen20251124`, matching Opus 4.8.
- Tests added for `IsOpus5Plus` and all affected capability predicates covering plain, date-suffixed, Bedrock-prefixed, and Vertex-prefixed model ID forms.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
```

Key test functions to verify:
- `TestIsOpus5Plus` — validates the new predicate matches Opus 5 variants and rejects Opus 4.5 and other families.
- `TestIsOpus47Plus` / `TestIsAdaptiveOnlyThinkingModel` — confirms Opus 5 is included in the adaptive-only surface.
- `TestSupportsMidConversationSystem` — confirms Opus 5 on Anthropic returns `true`; Bedrock/Vertex return `false`.
- `TestSupportsFastMode` / `TestSupportsEffortParameter` — confirms Opus 5 is supported.
- `TestComputerUseGeneration` — confirms Opus 5 resolves to `ComputerUseGen20251124`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable