### PR TITLE
fix: default fallback mode in anthropic

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -389,6 +389,11 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		if fbVal, exists := bifrostReq.Params.ExtraParams["fallbacks"]; exists {
 			var natives []AnthropicNativeFallback
 			switch v := fbVal.(type) {
+			case string:
+				// fallbacks:"default" (Opus 5 default fallback routing) — promote onto the
+				// typed field so it marshals natively and drives the -07-01 header.
+				delete(anthropicReq.ExtraParams, "fallbacks")
+				anthropicReq.Fallbacks = &AnthropicFallbacks{Preset: v}
 			case []AnthropicNativeFallback:
 				natives = v
 			default:
@@ -403,7 +408,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					n := natives[i]
 					entries[i] = AnthropicFallbackEntry{Native: &n}
 				}
-				anthropicReq.Fallbacks = entries
+				anthropicReq.Fallbacks = &AnthropicFallbacks{Entries: entries}
 			}
 		}
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3335,8 +3335,14 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 
 	// Anthropic native server-side fallback ("fallbacks" objects) is forwarded to
 	// the provider verbatim, distinct from Bifrost cross-provider fallback above.
+	// The bare-string preset (fallbacks:"default", Opus 5 default routing) is
+	// forwarded the same way so the rebuild re-adds it and injects the -2026-07-01
+	// beta header; without this the preset is lost and Anthropic 400s the array-only
+	// wire form.
 	if native := req.nativeFallbacks(); len(native) > 0 {
 		params.ExtraParams["fallbacks"] = native
+	} else if req.Fallbacks != nil && req.Fallbacks.Preset != "" {
+		params.ExtraParams["fallbacks"] = req.Fallbacks.Preset
 	}
 
 	// Fallback credit token — carried verbatim so the retry can redeem it.
@@ -3826,6 +3832,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				delete(anthropicReq.ExtraParams, "fallbacks")
 				var natives []AnthropicNativeFallback
 				switch v := fbVal.(type) {
+				case string:
+					// fallbacks:"default" (Opus 5 default fallback routing) — promote onto
+					// the typed field so it marshals natively and drives the -07-01 header.
+					anthropicReq.Fallbacks = &AnthropicFallbacks{Preset: v}
 				case []AnthropicNativeFallback:
 					natives = v
 				default:
@@ -3839,7 +3849,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						n := natives[i]
 						entries[i] = AnthropicFallbackEntry{Native: &n}
 					}
-					anthropicReq.Fallbacks = entries
+					anthropicReq.Fallbacks = &AnthropicFallbacks{Entries: entries}
 				}
 			}
 			// Fallback credit token: promote onto the typed field so it marshals

--- a/core/providers/anthropic/serversidefallback_test.go
+++ b/core/providers/anthropic/serversidefallback_test.go
@@ -1331,7 +1331,7 @@ func TestFallbackEntrySpeed_InjectsFastModeBetaHeader(t *testing.T) {
 			Model:     "claude-fable-5",
 			MaxTokens: 64,
 			Messages:  []AnthropicMessage{{Role: "user", Content: AnthropicContent{ContentStr: schemas.Ptr("hi")}}},
-			Fallbacks: []AnthropicFallbackEntry{{Native: &entry}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{Native: &entry}}},
 		}
 	}
 	hasFastMode := func(t *testing.T, req *AnthropicMessageRequest, provider schemas.ModelProvider) bool {
@@ -1415,5 +1415,148 @@ func TestFallbacksArray_RoutedByEntryShape(t *testing.T) {
 				t.Errorf("native fallbacks forwarded = %v, want %v", gotNative, tc.wantNative)
 			}
 		})
+	}
+}
+
+// TestFallbacksDefault_RoundTrip pins the Opus 5 fallbacks:"default" form: it parses
+// as a preset (not an array), fallbacksDefaultRouting() reports it, and it re-marshals
+// back to the bare string rather than an array.
+func TestFallbacksDefault_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	body := `{"model":"claude-opus-5","max_tokens":64,` +
+		`"messages":[{"role":"user","content":"hi"}],"fallbacks":"default"}`
+	var req AnthropicMessageRequest
+	if err := sonic.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if req.Fallbacks == nil || req.Fallbacks.Preset != "default" || len(req.Fallbacks.Entries) != 0 {
+		t.Fatalf("expected preset=\"default\" with no entries, got %+v", req.Fallbacks)
+	}
+	if !req.fallbacksDefaultRouting() {
+		t.Error("fallbacksDefaultRouting() = false, want true")
+	}
+
+	out, err := sonic.Marshal(&req)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if fb := gjson.GetBytes(out, "fallbacks"); fb.Type != gjson.String || fb.String() != "default" {
+		t.Errorf(`re-marshalled fallbacks = %s, want "default"`, fb.Raw)
+	}
+}
+
+// TestFallbacksDefault_IntegrationRoundTrip reproduces the /anthropic/v1/messages
+// typed path (AnthropicMessageRequest → ToBifrostResponsesRequest → rebuild): the
+// "default" preset must survive the Bifrost round-trip and re-emit with the superset
+// beta header, otherwise Anthropic 400s ("fallbacks: Input should be a valid array").
+func TestFallbacksDefault_IntegrationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	body := `{"model":"claude-opus-5","max_tokens":1024,"fallbacks":"default",` +
+		`"messages":[{"role":"user","content":"hi"}],"output_config":{"effort":"xhigh"},` +
+		`"thinking":{"type":"adaptive"}}`
+	var req AnthropicMessageRequest
+	if err := sonic.Unmarshal([]byte(body), &req); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	// AnthropicMessageRequest → BifrostResponsesRequest must preserve the preset.
+	bifrostReq := req.ToBifrostResponsesRequest(ctx)
+	if got, _ := bifrostReq.Params.ExtraParams["fallbacks"].(string); got != "default" {
+		t.Fatalf(`bifrost ExtraParams["fallbacks"] = %#v, want "default"`, bifrostReq.Params.ExtraParams["fallbacks"])
+	}
+
+	// Rebuild → the typed field is restored...
+	rebuilt, err := ToAnthropicResponsesRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("rebuild failed: %v", err)
+	}
+	if !rebuilt.fallbacksDefaultRouting() {
+		t.Fatalf("rebuilt.fallbacksDefaultRouting() = false, want true (Fallbacks=%+v)", rebuilt.Fallbacks)
+	}
+
+	// ...it re-marshals to the bare string...
+	out, err := sonic.Marshal(rebuilt)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if fb := gjson.GetBytes(out, "fallbacks"); fb.Type != gjson.String || fb.String() != "default" {
+		t.Errorf(`rebuilt fallbacks = %s, want "default"`, fb.Raw)
+	}
+
+	// ...and the superset beta header is injected (this is what was missing).
+	if err := AddMissingBetaHeadersToContext(ctx, rebuilt, schemas.Anthropic); err != nil {
+		t.Fatalf("AddMissingBetaHeadersToContext failed: %v", err)
+	}
+	hdrs, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !slices.Contains(hdrs[AnthropicBetaHeader], AnthropicServerSideFallbackDefaultBetaHeader) {
+		t.Errorf("expected %q injected, got %v", AnthropicServerSideFallbackDefaultBetaHeader, hdrs[AnthropicBetaHeader])
+	}
+}
+
+// TestFallbacksDefault_BetaHeader verifies default routing drives the superset
+// -2026-07-01 beta header (not -06-01) on Anthropic, and is gated off where
+// server-side fallback is unsupported.
+func TestFallbacksDefault_BetaHeader(t *testing.T) {
+	t.Parallel()
+
+	newReq := func() *AnthropicMessageRequest {
+		return &AnthropicMessageRequest{
+			Model:     "claude-opus-5",
+			MaxTokens: 64,
+			Messages:  []AnthropicMessage{{Role: "user", Content: AnthropicContent{ContentStr: schemas.Ptr("hi")}}},
+			Fallbacks: &AnthropicFallbacks{Preset: "default"},
+		}
+	}
+	has := func(t *testing.T, provider schemas.ModelProvider, header string) bool {
+		t.Helper()
+		ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+		defer cancel()
+		if err := AddMissingBetaHeadersToContext(ctx, newReq(), provider); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		hdrs, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+		return slices.Contains(hdrs[AnthropicBetaHeader], header)
+	}
+
+	if !has(t, schemas.Anthropic, AnthropicServerSideFallbackDefaultBetaHeader) {
+		t.Errorf("expected %q on Anthropic", AnthropicServerSideFallbackDefaultBetaHeader)
+	}
+	if has(t, schemas.Anthropic, AnthropicServerSideFallbackBetaHeader) {
+		t.Error("did not expect the -06-01 header for default routing")
+	}
+	if has(t, schemas.Vertex, AnthropicServerSideFallbackDefaultBetaHeader) {
+		t.Error("did not expect the default-routing header on Vertex (server-side fallback unsupported)")
+	}
+}
+
+// TestStripBifrostFallbacks_DefaultString verifies the "default" string form survives
+// body stripping on providers that support server-side fallback and is dropped
+// fail-closed elsewhere (matching the native-object gating).
+func TestStripBifrostFallbacks_DefaultString(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"claude-opus-5","fallbacks":"default"}`)
+
+	got, err := stripBifrostFallbacksFromBody(body, schemas.Anthropic)
+	if err != nil {
+		t.Fatalf("strip (anthropic) failed: %v", err)
+	}
+	if fb := gjson.GetBytes(got, "fallbacks"); fb.Type != gjson.String || fb.String() != "default" {
+		t.Errorf("anthropic: fallbacks = %s, want kept \"default\"", fb.Raw)
+	}
+
+	for _, p := range []schemas.ModelProvider{schemas.Bedrock, schemas.Vertex} {
+		got, err := stripBifrostFallbacksFromBody(body, p)
+		if err != nil {
+			t.Fatalf("strip (%s) failed: %v", p, err)
+		}
+		if gjson.GetBytes(got, "fallbacks").Exists() {
+			t.Errorf("%s: expected fallbacks stripped, got %s", p, got)
+		}
 	}
 }

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -69,6 +69,10 @@ const (
 	// AnthropicServerSideFallbackBetaHeader is required for the native "fallbacks"
 	// request field (server-side refusal fallback). Anthropic API only.
 	AnthropicServerSideFallbackBetaHeader = "server-side-fallback-2026-06-01"
+	// AnthropicServerSideFallbackDefaultBetaHeader is the superset header required for
+	// the fallbacks:"default" form (Opus 5 default fallback routing); it also accepts
+	// the explicit-list form. Shares the server-side-fallback- prefix for dedup/filter.
+	AnthropicServerSideFallbackDefaultBetaHeader = "server-side-fallback-2026-07-01"
 	// AnthropicFallbackCreditBetaHeader is required to receive fallback_credit_token
 	// on a refusal and to redeem it on the retry. Unlike server-side fallback this is
 	// supported on every Anthropic-family surface — but AWS ships it under its own date.
@@ -77,6 +81,11 @@ const (
 	// AWS-operated surfaces (Bedrock Converse and Bedrock Mantle), which are a
 	// release behind the Claude API. See betaHeaderProviderVersion in utils.go.
 	AnthropicFallbackCreditBetaHeaderAWS = "fallback-credit-2026-06-09"
+	// AnthropicMidConversationToolChangesBetaHeader enables tool_addition / tool_removal
+	// blocks inside mid_conv_system messages, so tools can be offered/withdrawn mid-turn
+	// while the tools array (and the cached prefix) stays fixed. Native Anthropic surface
+	// (Claude API direct + Claude in Amazon Bedrock via Mantle); Bedrock is Opus 5 only.
+	AnthropicMidConversationToolChangesBetaHeader = "mid-conversation-tool-changes-2026-07-01"
 
 	// AnthropicComputerUseBetaHeader is required for computer use (version-specific).
 	// computer_20251124 (Opus 4.6, Sonnet 4.6, Opus 4.5) uses the newer beta header.
@@ -105,6 +114,8 @@ const (
 	AnthropicAdvisorBetaHeaderPrefix             = "advisor-tool-"
 	AnthropicServerSideFallbackBetaHeaderPrefix  = "server-side-fallback-"
 	AnthropicFallbackCreditBetaHeaderPrefix      = "fallback-credit-"
+	// Mid-conversation tool changes (Opus 5).
+	AnthropicMidConversationToolChangesBetaHeaderPrefix = "mid-conversation-tool-changes-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
@@ -159,6 +170,7 @@ type ProviderFeatureSupport struct {
 	Diagnostics            bool // diagnostics request field — cache diagnostics (cache-diagnosis-2026-04-07 beta, diagnostics.previous_message_id). Claude API only per docs ("not supported on Amazon Bedrock or Vertex AI"); stripped elsewhere fail-closed. Azure rejects it.
 	ServerSideFallback     bool // native "fallbacks" request field — server-side-fallback-2026-06-01. Claude API only per docs ("not available on Amazon Bedrock, Google Cloud, or Microsoft Foundry").
 	FallbackCredit         bool // fallback_credit_token request field + stop_details credit fields — fallback-credit-2026-06-01 (AWS surfaces: -2026-06-09). Documented on the Claude API, Amazon Bedrock, Google Cloud and Microsoft Foundry, i.e. the inverse of ServerSideFallback.
+	MidConvToolChanges     bool // tool_addition/tool_removal blocks — mid-conversation-tool-changes-2026-07-01. Native Anthropic surface (Claude API + Bedrock Mantle); Bedrock is Opus 5 only, enforced upstream.
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -180,6 +192,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		Diagnostics:        true, // cache-diagnosis-2026-04-07 — Claude API only; only this provider keeps diagnostics.previous_message_id.
 		ServerSideFallback: true, // server-side-fallback-2026-06-01 — Claude API only.
 		FallbackCredit:     true, // fallback-credit-2026-06-01.
+		MidConvToolChanges: true, // mid-conversation-tool-changes-2026-07-01.
 	},
 	// Google Vertex AI — cite: A (overview table) and V-platform.
 	// Notably NOT supported: MCP (MCP-excl), Skills/container.skills,
@@ -266,6 +279,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		InputExamples:          true,
 		ServiceTier:            true,
 		FallbackCredit:         true, // fallback-credit-2026-06-09 (AWS date) per the Bedrock userguide
+		MidConvToolChanges:     true, // mid-conversation-tool-changes-2026-07-01 — Opus 5 on Bedrock, enforced upstream.
 	},
 	// Microsoft Azure AI Foundry — cite: A (most features azureAiBeta) +
 	// Az-platform ("supports most of Claude's features"). Excluded per
@@ -447,10 +461,11 @@ type AnthropicMessageRequest struct {
 	// Extra params for advanced use cases
 	ExtraParams map[string]interface{} `json:"-"`
 
-	// Fallbacks is the overloaded request-level "fallbacks" field. Its entries are
-	// either Bifrost cross-provider fallback strings ("provider/model") or Anthropic
-	// native server-side fallback objects ({"model": ...}); see AnthropicFallbackEntry.
-	Fallbacks []AnthropicFallbackEntry `json:"fallbacks,omitempty"`
+	// Fallbacks is the overloaded request-level "fallbacks" field, either an array of
+	// entries (Bifrost "provider/model" strings and/or native {"model": ...} objects)
+	// or the bare string preset "default" (Opus 5 default fallback routing). See
+	// AnthropicFallbacks, which models both shapes behind one type.
+	Fallbacks *AnthropicFallbacks `json:"fallbacks,omitempty"`
 
 	// Internal field to track whether to strip scope from cache control blocks (for Vertex + prompt caching scope)
 	stripCacheControlScope bool `json:"-"`
@@ -513,10 +528,44 @@ func (e AnthropicFallbackEntry) MarshalJSON() ([]byte, error) {
 	return sonic.Marshal(e.BifrostModel)
 }
 
+// AnthropicFallbacks models the overloaded request-level "fallbacks" field, which is
+// either an array of entries (AnthropicFallbackEntry) or a bare string preset —
+// currently only "default" (Opus 5 default fallback routing, which needs the superset
+// server-side-fallback-2026-07-01 beta header). Exactly one form is set; the custom
+// (Un)MarshalJSON lets it sit in the request struct and (de)serialize natively,
+// dispatching on wire shape the same way AnthropicFallbackEntry does per element.
+type AnthropicFallbacks struct {
+	Entries []AnthropicFallbackEntry // the array form
+	Preset  string                   // the bare-string form, e.g. "default"
+}
+
+// UnmarshalJSON dispatches on shape: a JSON string is a preset, an array is entries.
+func (f *AnthropicFallbacks) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		return nil
+	}
+	if trimmed[0] == '"' {
+		return sonic.Unmarshal(trimmed, &f.Preset)
+	}
+	return sonic.Unmarshal(trimmed, &f.Entries)
+}
+
+// MarshalJSON re-emits whichever form is set (preset wins if both are somehow set).
+func (f AnthropicFallbacks) MarshalJSON() ([]byte, error) {
+	if f.Preset != "" {
+		return sonic.Marshal(f.Preset)
+	}
+	return sonic.Marshal(f.Entries)
+}
+
 // bifrostFallbackModels returns the Bifrost cross-provider fallback "provider/model" strings.
 func (req *AnthropicMessageRequest) bifrostFallbackModels() []string {
 	var out []string
-	for _, f := range req.Fallbacks {
+	if req.Fallbacks == nil {
+		return out
+	}
+	for _, f := range req.Fallbacks.Entries {
 		if f.Native == nil && f.BifrostModel != "" {
 			out = append(out, f.BifrostModel)
 		}
@@ -527,12 +576,22 @@ func (req *AnthropicMessageRequest) bifrostFallbackModels() []string {
 // nativeFallbacks returns the Anthropic native server-side fallback entries.
 func (req *AnthropicMessageRequest) nativeFallbacks() []AnthropicNativeFallback {
 	var out []AnthropicNativeFallback
-	for _, f := range req.Fallbacks {
+	if req.Fallbacks == nil {
+		return out
+	}
+	for _, f := range req.Fallbacks.Entries {
 		if f.Native != nil {
 			out = append(out, *f.Native)
 		}
 	}
 	return out
+}
+
+// fallbacksDefaultRouting reports whether the request uses the fallbacks:"default"
+// form (Opus 5 default fallback routing), which needs the superset
+// server-side-fallback-2026-07-01 beta header rather than -2026-06-01.
+func (req *AnthropicMessageRequest) fallbacksDefaultRouting() bool {
+	return req.Fallbacks != nil && req.Fallbacks.Preset == "default"
 }
 
 // SetStripCacheControlScope sets the stripCacheControlScope flag

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1274,6 +1274,12 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			headers = appendUniqueHeader(headers, AnthropicServerSideFallbackBetaHeader)
 		}
 	}
+	// Default fallback routing (fallbacks:"default", Opus 5) needs the superset header.
+	if req.fallbacksDefaultRouting() {
+		if !hasProvider || features.ServerSideFallback {
+			headers = appendUniqueHeader(headers, AnthropicServerSideFallbackDefaultBetaHeader)
+		}
+	}
 	// Check for fallback credit redemption (fallback_credit_token present). The
 	// canonical date is added here; FilterBetaHeadersForProvider rewrites it to the
 	// AWS date on Bedrock/Mantle.
@@ -1384,6 +1390,7 @@ var betaHeaderPrefixKnown = []string{
 	AnthropicCacheDiagnosisBetaHeaderPrefix,
 	AnthropicServerSideFallbackBetaHeaderPrefix,
 	AnthropicFallbackCreditBetaHeaderPrefix,
+	AnthropicMidConversationToolChangesBetaHeaderPrefix,
 }
 
 // betaHeaderProviderVersion rewrites a beta header's version date on providers
@@ -1412,6 +1419,16 @@ func stripBifrostFallbacksFromBody(jsonBody []byte, provider schemas.ModelProvid
 		return jsonBody, nil
 	}
 	if !fb.IsArray() {
+		// Non-array "fallbacks": the string form (currently "default", Opus 5 default
+		// fallback routing) is kept on providers that support server-side fallback and
+		// stripped fail-closed elsewhere — mirroring the native-object gating below.
+		// Any other scalar shape is dropped (upstream would reject it).
+		if fb.Type == gjson.String {
+			features, known := ProviderFeatures[provider]
+			if !known || features.ServerSideFallback {
+				return jsonBody, nil
+			}
+		}
 		return sjson.DeleteBytes(jsonBody, "fallbacks")
 	}
 	// Unknown/custom providers keep native entries, mirroring the
@@ -1765,6 +1782,8 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	AnthropicCacheDiagnosisBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.Diagnostics },
 	AnthropicServerSideFallbackBetaHeaderPrefix:  func(f ProviderFeatureSupport) bool { return f.ServerSideFallback },
 	AnthropicFallbackCreditBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.FallbackCredit },
+	// Long key kept in its own group so gofmt doesn't realign the block above.
+	AnthropicMidConversationToolChangesBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.MidConvToolChanges },
 }
 
 // MergeBetaHeaders collects anthropic-beta values from provider ExtraHeaders and

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2283,7 +2283,7 @@ func TestToBifrostResponsesRequest_FallbacksRouting(t *testing.T) {
 		req := &AnthropicMessageRequest{
 			Model:     "claude-fable-5",
 			MaxTokens: 1024,
-			Fallbacks: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}}},
 		}
 		out := req.ToBifrostResponsesRequest(nil)
 		if len(out.Fallbacks) != 0 {
@@ -2298,7 +2298,7 @@ func TestToBifrostResponsesRequest_FallbacksRouting(t *testing.T) {
 	t.Run("bifrost strings go to Fallbacks", func(t *testing.T) {
 		req := &AnthropicMessageRequest{
 			Model:     "anthropic/claude-sonnet-4-5",
-			Fallbacks: []AnthropicFallbackEntry{{BifrostModel: "openai/gpt-4o"}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{BifrostModel: "openai/gpt-4o"}}},
 		}
 		out := req.ToBifrostResponsesRequest(nil)
 		if len(out.Fallbacks) != 1 || out.Fallbacks[0].Provider != schemas.OpenAI || out.Fallbacks[0].Model != "gpt-4o" {
@@ -2317,7 +2317,7 @@ func TestAddMissingBetaHeadersToContext_ServerSideFallback(t *testing.T) {
 	t.Run("anthropic adds the beta header", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		req := &AnthropicMessageRequest{
-			Fallbacks: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}}},
 		}
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
 		extraHeaders, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -2329,7 +2329,7 @@ func TestAddMissingBetaHeadersToContext_ServerSideFallback(t *testing.T) {
 	t.Run("vertex does not add the beta header", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		req := &AnthropicMessageRequest{
-			Fallbacks: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{Native: &AnthropicNativeFallback{Model: "claude-opus-4-8"}}}},
 		}
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Vertex)
 		extraHeaders, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -2341,7 +2341,7 @@ func TestAddMissingBetaHeadersToContext_ServerSideFallback(t *testing.T) {
 	t.Run("bifrost string fallbacks do not add the beta header", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 		req := &AnthropicMessageRequest{
-			Fallbacks: []AnthropicFallbackEntry{{BifrostModel: "openai/gpt-4o"}},
+			Fallbacks: &AnthropicFallbacks{Entries: []AnthropicFallbackEntry{{BifrostModel: "openai/gpt-4o"}}},
 		}
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
 		extraHeaders, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -4060,5 +4060,33 @@ func TestConvertChatResponseFormatToTool_OrderedMapSchema(t *testing.T) {
 	}
 	if _, hasAnyOf := normalizedText.Get("anyOf"); !hasAnyOf {
 		t.Fatal("nested multi-type union must be normalized to anyOf (recursion must descend into OrderedMap values)")
+	}
+}
+
+// TestMidConversationToolChangesBetaHeaderRouting pins the Opus 5
+// mid-conversation-tool-changes beta header: forwarded on the native Anthropic
+// surfaces (Claude API + Bedrock Mantle) and dropped where the feature is
+// unsupported (Bedrock Converse, Vertex, Azure).
+func TestMidConversationToolChangesBetaHeaderRouting(t *testing.T) {
+	t.Parallel()
+
+	hdr := AnthropicMidConversationToolChangesBetaHeader
+	for _, tc := range []struct {
+		provider schemas.ModelProvider
+		want     bool
+	}{
+		{schemas.Anthropic, true},
+		{schemas.BedrockMantle, true},
+		{schemas.Bedrock, false},
+		{schemas.Vertex, false},
+		{schemas.Azure, false},
+	} {
+		t.Run(string(tc.provider), func(t *testing.T) {
+			t.Parallel()
+			got := FilterBetaHeadersForProvider([]string{hdr}, tc.provider)
+			if kept := slices.Contains(got, hdr); kept != tc.want {
+				t.Errorf("FilterBetaHeadersForProvider(%q) kept=%v, want %v (got %v)", tc.provider, kept, tc.want, got)
+			}
+		})
 	}
 }

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -452,7 +452,9 @@ func TestDeepCopyResponsesMessagePreservesToolSearchFields(t *testing.T) {
 	}
 	if copied.Execution == nil || *copied.Execution != execution {
 		t.Fatalf("expected execution to survive copy, got %#v", copied.ResponsesToolMessage)
-=======
+	}
+}
+
 // TestResponsesMessagePreservesAdditionalTools verifies that codex
 // `additional_tools` input items (sent for code-mode models such as
 // gpt-5.6-sol) round-trip byte-identically. These items carry a `tools` array


### PR DESCRIPTION
## Summary

Anthropic's `fallbacks:"default"` preset (Opus 5 default fallback routing) was being lost during the Bifrost round-trip, causing Anthropic to 400 with "Input should be a valid array". This PR fixes the handling of the bare-string `fallbacks` field by introducing `AnthropicFallbacks`, a wrapper type that models both the array and string-preset wire shapes behind a single struct with custom `(Un)MarshalJSON`. It also adds support for the `mid-conversation-tool-changes-2026-07-01` beta header and its associated `MidConvToolChanges` feature flag.

## Changes

- Introduced `AnthropicFallbacks` struct to replace the previous `[]AnthropicFallbackEntry` field on `AnthropicMessageRequest`, dispatching on wire shape (JSON string → `Preset`, JSON array → `Entries`) via custom marshal/unmarshal logic.
- Added `fallbacksDefaultRouting()` helper that reports when `fallbacks:"default"` is active, used to gate injection of the superset `server-side-fallback-2026-07-01` beta header.
- Added `AnthropicServerSideFallbackDefaultBetaHeader` constant (`server-side-fallback-2026-07-01`) and wired it into `AddMissingBetaHeadersToContext` so the correct header is injected for default-routing requests.
- Preserved the `"default"` preset through `ToBifrostResponsesRequest` → `ToAnthropicResponsesRequest` round-trips by storing it in `ExtraParams["fallbacks"]` as a string and re-promoting it to the typed field on rebuild.
- Updated `stripBifrostFallbacksFromBody` to keep the string-form `fallbacks` on providers that support server-side fallback and strip it fail-closed elsewhere, matching the existing native-object gating.
- Added `AnthropicMidConversationToolChangesBetaHeader` and `AnthropicMidConversationToolChangesBetaHeaderPrefix` constants, a `MidConvToolChanges` feature flag on `ProviderFeatureSupport`, and enabled it for `Anthropic` and `BedrockMantle` providers.
- Updated all existing test fixtures from `[]AnthropicFallbackEntry{...}` to `&AnthropicFallbacks{Entries: ...}` to match the new type.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... -run TestFallbacksDefault
go test ./core/providers/anthropic/... -run TestStripBifrostFallbacks_DefaultString
go test ./core/providers/anthropic/... -run TestMidConversationToolChangesBetaHeaderRouting
go test ./core/providers/anthropic/... -run TestFallbackEntrySpeed_InjectsFastModeBetaHeader
go test ./core/providers/anthropic/...
go test ./...
```

Expected: all tests pass. The `TestFallbacksDefault_IntegrationRoundTrip` test specifically validates that `fallbacks:"default"` survives the full Bifrost round-trip and that the `server-side-fallback-2026-07-01` beta header is injected on the rebuilt request.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

The `Fallbacks` field on `AnthropicMessageRequest` changed from `[]AnthropicFallbackEntry` to `*AnthropicFallbacks`. Any code constructing this struct directly (outside of Bifrost internals) will need to wrap entries in `&AnthropicFallbacks{Entries: ...}`.

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing implications. The change is scoped to request serialization and beta header injection for Anthropic API calls.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable