### PR TITLE
fix: return closed non-nil channel for empty streams instead of (nil, nil)

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6189,6 +6189,7 @@ func executeRequestWithRetries[T any](
 		// is actually an error (e.g., rate limits sent as SSE events in HTTP 200).
 		// This enables retries and fallbacks for providers that embed errors in
 		// the SSE stream instead of returning proper HTTP error status codes.
+		emptyStream := false
 		if bifrostError == nil {
 			if streamChan, ok := any(result).(chan *schemas.BifrostStreamChunk); ok {
 				checkedStream, drainDone, firstChunkErr := providerUtils.CheckFirstStreamChunkForError(ctx, streamChan)
@@ -6201,6 +6202,21 @@ func executeRequestWithRetries[T any](
 					// closed and fail every read with ErrStreamClosed.
 					ctx.ClearValue(schemas.BifrostContextKeyConnectionClosed)
 					bifrostError = firstChunkErr
+				} else if checkedStream == nil {
+					// Empty stream (zero chunks before close — includes the large-payload
+					// passthrough placeholder). Substitute a closed, non-nil channel:
+					// this result becomes the public *StreamRequest return value, and a
+					// nil channel with a nil error makes callers that range/receive on
+					// it block forever (a nil-channel receive never returns). A closed
+					// channel preserves zero-chunk semantics (range exits immediately,
+					// receive yields (nil, false)). The span is still completed
+					// synchronously below (emptyStream keeps isStreamChan false): the
+					// provider goroutine has already exited, so nothing is left to
+					// complete a deferred span.
+					emptyStream = true
+					closedCh := make(chan *schemas.BifrostStreamChunk)
+					close(closedCh)
+					result = any(closedCh).(T)
 				} else {
 					result = any(checkedStream).(T)
 				}
@@ -6208,9 +6224,11 @@ func executeRequestWithRetries[T any](
 		}
 
 		// Check if result is a streaming channel - if so, defer span completion
-		// Only defer for successful stream setup; error paths must end the span synchronously
+		// Only defer for successful stream setup; error paths must end the span
+		// synchronously. An empty stream is also ended synchronously: its
+		// provider goroutine is gone, so a deferred span would never complete.
 		isStreamChan := false
-		if bifrostError == nil {
+		if bifrostError == nil && !emptyStream {
 			if ch, ok := any(result).(chan *schemas.BifrostStreamChunk); ok && ch != nil {
 				isStreamChan = true
 			}

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3025,3 +3025,56 @@ func TestReleaseChannelMessage_ClearsPooledReferences_Streaming(t *testing.T) {
 	default:
 	}
 }
+
+// TestExecuteRequestWithRetries_EmptyStreamReturnsClosedChannel pins the public
+// streaming contract for zero-chunk streams: when the provider's channel closes
+// before the first chunk, the caller must receive a NON-nil, closed channel with
+// a nil error — not (nil, nil). A nil channel with a nil error makes integrators
+// that range/receive on the result block forever, since a receive from a nil
+// channel never returns.
+func TestExecuteRequestWithRetries_EmptyStreamReturnsClosedChannel(t *testing.T) {
+	config := createTestConfig(1, 10*time.Millisecond, 100*time.Millisecond)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	logger := NewDefaultLogger(schemas.LogLevelError)
+	ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+
+	handler := func(_ schemas.Key) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+		ch := make(chan *schemas.BifrostStreamChunk)
+		close(ch) // provider stream ends before emitting any chunk
+		return ch, nil
+	}
+
+	stream, err := executeRequestWithRetries(
+		ctx,
+		config,
+		handler,
+		nil,
+		schemas.ChatCompletionStreamRequest,
+		schemas.OpenAI,
+		"gpt-4",
+		nil,
+		logger,
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if stream == nil {
+		t.Fatal("Expected non-nil closed channel for an empty stream; a nil channel with a nil error hangs consumers on a nil-channel receive")
+	}
+	select {
+	case _, ok := <-stream:
+		if ok {
+			t.Error("Expected zero chunks from an empty stream")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Receive on the returned channel blocked; expected a closed channel")
+	}
+	count := 0
+	for range stream {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("Expected range over empty stream to yield 0 chunks, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the public streaming API returning `(nil, nil)` for empty streams. When a provider's chunk channel closes before the first chunk, `CheckFirstStreamChunkForError` returns a nil channel with a nil error, and `executeRequestWithRetries` assigned that straight into the public `*StreamRequest` result — so integrators received a nil channel with no error and blocked forever on the receive (a nil-channel receive never returns).

Closes #5555.

## Changes

- `core/bifrost.go` (`executeRequestWithRetries`): when the checked stream comes back nil (empty stream), substitute a **closed, non-nil** channel as the result. Zero-chunk semantics are preserved — `range` exits immediately, a receive yields `(nil, false)` — while the implicit contract "nil error ⇒ usable channel" now holds.
- The substitution deliberately happens **at the call site, not inside `CheckFirstStreamChunkForError`**, and the empty case keeps `isStreamChan == false`, for two reasons:
  1. **Span lifecycle**: an empty stream has no surviving provider goroutine to complete a deferred span. Keeping the synchronous span-completion path (pre-existing behavior) avoids stranding a deferred span in the TraceStore or racing the provider goroutine's finalizer.
  2. **Large-payload passthrough**: `SetupStreamingPassthrough` providers intentionally return an already-closed placeholder channel; changing the helper's return would have silently moved every passthrough request onto the deferred-span path with no completer.
- `CheckFirstStreamChunkForError` itself is unchanged — its nil return is now genuinely consumed by the caller as the empty-stream signal, matching its doc comment.

Behavior note (intended): through the HTTP transport, an empty stream previously hit the `stream == nil` guard and produced an error response; it now returns a well-formed SSE stream with zero data events, which is the truthful representation of "the provider ended the stream without chunks".

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
cd core
go test -run 'TestExecuteRequestWithRetries_EmptyStreamReturnsClosedChannel' .
go test ./providers/utils/
go build ./...
```

`TestExecuteRequestWithRetries_EmptyStreamReturnsClosedChannel` is a caller-level regression test: it fails on the previous behavior (nil channel) and passes with this change. Existing `TestCheckFirstStreamChunk_*` tests are untouched and still green.

## Breaking changes

- [x] No

## Related issues

Closes #5555

## Security considerations

None. One extra channel allocation only on the empty-stream path.
