### PR TITLE
override count fixes for multinode setup

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -454,7 +454,8 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_oauth_config_resource_column"}, run: migrationAddOauthConfigResourceColumn},
 	{IDs: []string{"add_use_anthropic_endpoints_column"}, run: migrationAddUseAnthropicEndpointsColumn},
 	{IDs: []string{"add_bedrock_batch_role_arn_column"}, run: migrationAddBedrockBatchRoleARNColumn},
-  {IDs: []string{"add_budget_override_columns"}, run: migrationAddBudgetOverrideColumns},
+	{IDs: []string{"add_budget_override_columns"}, run: migrationAddBudgetOverrideColumns},
+	{IDs: []string{"add_budget_override_anchor_columns"}, run: migrationAddBudgetOverrideAnchorColumns},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -3198,6 +3199,59 @@ func migrationAddBudgetOverrideColumns(ctx context.Context, db *gorm.DB, logger 
 		},
 		Rollback: func(tx *gorm.DB) error {
 			return fmt.Errorf("add_budget_override_columns is non-rollbackable: dropping the override columns would permanently destroy saved budget override state; the columns are additive and older binaries safely ignore them")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}
+
+// migrationAddBudgetOverrideAnchorColumns adds the immutable grant columns that
+// make finite budget-override consumption a derived value rather than mutable
+// state, and adopts every already-active finite override into that model.
+//
+// Without a grant, the remaining-cycle count is independently mutable, so every
+// cluster node keeps its own tally while only the leader persists one, and any
+// config reload replaying a pre-reset row hands back a cycle the reset path had
+// already spent. Deriving the count from (anchor, total, last_reset) removes both
+// failure modes because all three inputs are either immutable or monotonic.
+func migrationAddBudgetOverrideAnchorColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_budget_override_anchor_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableBudget{}, "override_cycles_total"); err != nil {
+				return fmt.Errorf("failed to add override_cycles_total column: %w", err)
+			}
+			if err := addColumnIfNotExists(tx, logger, &tables.TableBudget{}, "override_anchor_reset"); err != nil {
+				return fmt.Errorf("failed to add override_anchor_reset column: %w", err)
+			}
+			// Adopt active finite overrides: re-anchor each at its current window
+			// and re-grant its remaining count from there. Without knowing when the
+			// grant was originally written this is the only available reading, and
+			// it can only be generous by less than one window.
+			//
+			// Required, not optional: validateOverride rejects a cycles override
+			// with no anchor, so an unadopted row would be treated as having no
+			// lifecycle at all.
+			if err := tx.Exec(`
+				UPDATE governance_budgets
+				SET override_cycles_total = override_cycles_remaining,
+				    override_anchor_reset = last_reset
+				WHERE override_mode = 'cycles'
+				  AND override_cycles_remaining > 0
+				  AND override_anchor_reset IS NULL
+			`).Error; err != nil {
+				return fmt.Errorf("failed to backfill budget override grants: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return fmt.Errorf("add_budget_override_anchor_columns is non-rollbackable: dropping the grant columns would strip every active finite override of the state its remaining-cycle count is derived from; the columns are additive and older binaries safely ignore them")
 		},
 	}})
 	if err := m.Migrate(); err != nil {

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2854,3 +2854,86 @@ func TestMigrationAddBudgetOverrideColumns(t *testing.T) {
 	require.NoError(t, migrationAddBudgetOverrideColumns(ctx, db, testMigrationLogger),
 		"re-running the migration should be idempotent")
 }
+
+// TestMigrationAddBudgetOverrideAnchorColumns verifies the grant columns are added
+// and that every already-active finite override is adopted into the derived model.
+// Adoption is required rather than cosmetic: validateOverride rejects a cycles
+// override with no anchor, so an unadopted row would be treated as having no
+// lifecycle at all.
+func TestMigrationAddBudgetOverrideAnchorColumns(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.AutoMigrate(&tables.TableBudget{}))
+	lastReset := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+
+	// An active finite override, a forever override, and a plain budget with no
+	// override. Only the first should be adopted.
+	seeds := []*tables.TableBudget{
+		{ID: "cycles-budget", MaxLimit: 100, ResetDuration: "1h", LastReset: lastReset},
+		{ID: "forever-budget", MaxLimit: 100, ResetDuration: "1h", LastReset: lastReset},
+		{ID: "plain-budget", MaxLimit: 100, ResetDuration: "1h", LastReset: lastReset},
+	}
+	for _, seed := range seeds {
+		require.NoError(t, db.Session(&gorm.Session{SkipHooks: true}).Create(seed).Error)
+	}
+	// Set override state directly so the pre-migration shape is reproduced without
+	// going through validation, which now requires a grant.
+	require.NoError(t, db.Exec(`UPDATE governance_budgets
+		SET override_amount = 25, override_mode = 'cycles', override_cycles_remaining = 2
+		WHERE id = 'cycles-budget'`).Error)
+	require.NoError(t, db.Exec(`UPDATE governance_budgets
+		SET override_amount = 50, override_mode = 'forever'
+		WHERE id = 'forever-budget'`).Error)
+
+	for _, column := range []string{"override_anchor_reset", "override_cycles_total"} {
+		require.NoError(t, db.Migrator().DropColumn(&tables.TableBudget{}, column))
+		require.False(t, db.Migrator().HasColumn(&tables.TableBudget{}, column),
+			"precondition: %s must be absent to reproduce the upgrade path", column)
+	}
+
+	require.NoError(t, migrationAddBudgetOverrideAnchorColumns(ctx, db, testMigrationLogger))
+
+	for _, column := range []string{"override_cycles_total", "override_anchor_reset"} {
+		require.True(t, db.Migrator().HasColumn(&tables.TableBudget{}, column),
+			"migration should have added %s", column)
+	}
+
+	readGrant := func(id string) (int, *time.Time) {
+		var got struct {
+			OverrideCyclesTotal int
+			OverrideAnchorReset *time.Time
+		}
+		require.NoError(t, db.Table("governance_budgets").
+			Select("override_cycles_total, override_anchor_reset").
+			Where("id = ?", id).
+			Scan(&got).Error)
+		return got.OverrideCyclesTotal, got.OverrideAnchorReset
+	}
+
+	// The active finite override is adopted: granted its remaining count from its
+	// current boundary, which can only be generous by less than one window.
+	total, anchor := readGrant("cycles-budget")
+	assert.Equal(t, 2, total, "adopted grant total should match the remaining count")
+	require.NotNil(t, anchor, "an active finite override must end up anchored")
+	assert.True(t, anchor.UTC().Equal(lastReset), "adopted grant should anchor at the budget's current boundary")
+
+	// A forever override has no cycle lifecycle, so it must stay unanchored.
+	total, anchor = readGrant("forever-budget")
+	assert.Zero(t, total)
+	assert.Nil(t, anchor)
+
+	total, anchor = readGrant("plain-budget")
+	assert.Zero(t, total)
+	assert.Nil(t, anchor)
+
+	require.NoError(t, migrationAddBudgetOverrideAnchorColumns(ctx, db, testMigrationLogger),
+		"re-running the migration should be idempotent")
+
+	// Idempotence must not re-adopt: the backfill is scoped to rows with no anchor,
+	// so a row that already had one keeps its original grant.
+	total, anchor = readGrant("cycles-budget")
+	assert.Equal(t, 2, total, "re-running must not change an already adopted grant")
+	require.NotNil(t, anchor)
+	assert.True(t, anchor.UTC().Equal(lastReset))
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4463,9 +4463,14 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 		}
 		// Overrides are managed by the dedicated override path, not UpdateBudget;
 		// carry them forward so partial updates can't wipe an active override.
+		// The grant columns must travel with the derived remaining count: dropping
+		// the anchor would leave a cycles override with no lifecycle, which
+		// validateOverride rejects outright.
 		budget.OverrideAmount = existing.OverrideAmount
 		budget.OverrideMode = existing.OverrideMode
 		budget.OverrideCyclesRemaining = existing.OverrideCyclesRemaining
+		budget.OverrideCyclesTotal = existing.OverrideCyclesTotal
+		budget.OverrideAnchorReset = existing.OverrideAnchorReset
 	}
 	if err := txDB.WithContext(ctx).Save(budget).Error; err != nil {
 		return s.parseGormError(err)
@@ -4474,12 +4479,17 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 }
 
 // UpdateBudgetOverride atomically updates only override columns so concurrent usage changes are preserved.
-func (s *RDBConfigStore) UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesRemaining int, tx ...*gorm.DB) (*tables.TableBudget, error) {
+//
+// The grant is anchored at the budget's current window boundary rather than at
+// the persisted last_reset. Those differ by up to one reset-ticker interval,
+// because a node advances last_reset in memory before the next dump flushes it,
+// and anchoring one window behind would silently grant an extra window.
+func (s *RDBConfigStore) UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesTotal int, calendarAligned bool, tx ...*gorm.DB) (*tables.TableBudget, error) {
 	if len(tx) == 0 {
 		var updated *tables.TableBudget
 		err := s.DB().WithContext(ctx).Transaction(func(transaction *gorm.DB) error {
 			var err error
-			updated, err = s.UpdateBudgetOverride(ctx, id, amount, mode, cyclesRemaining, transaction)
+			updated, err = s.UpdateBudgetOverride(ctx, id, amount, mode, cyclesTotal, calendarAligned, transaction)
 			return err
 		})
 		return updated, err
@@ -4493,7 +4503,10 @@ func (s *RDBConfigStore) UpdateBudgetOverride(ctx context.Context, id string, am
 		}
 		return nil, err
 	}
-	if err := budget.SetOverride(amount, mode, cyclesRemaining); err != nil {
+	// IsCalendarAligned is not persisted on the budget row and a bare First does
+	// not fire the owner's AfterFind, so the caller has to supply it.
+	budget.IsCalendarAligned = calendarAligned
+	if err := budget.SetOverrideAt(amount, mode, cyclesTotal, budget.WindowStart(time.Now())); err != nil {
 		return nil, err
 	}
 	if err := txDB.Session(&gorm.Session{SkipHooks: true}).Model(&tables.TableBudget{}).
@@ -4502,6 +4515,8 @@ func (s *RDBConfigStore) UpdateBudgetOverride(ctx context.Context, id string, am
 			"override_amount":           budget.OverrideAmount,
 			"override_mode":             budget.OverrideMode,
 			"override_cycles_remaining": budget.OverrideCyclesRemaining,
+			"override_cycles_total":     budget.OverrideCyclesTotal,
+			"override_anchor_reset":     budget.OverrideAnchorReset,
 			"updated_at":                time.Now(),
 		}).Error; err != nil {
 		return nil, s.parseGormError(err)

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -752,14 +752,21 @@ func TestUpdateBudget(t *testing.T) {
 func TestCreateBudgetWithOverride(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
+	// A finite grant must carry its anchor and total, which is what the remaining
+	// count is derived from. A cycles override without them is rejected by
+	// validation rather than persisted as a lifecycle-less override.
+	grantAnchor := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 	tests := []*tables.TableBudget{
 		{
 			ID:                      "budget-override-cycles",
 			MaxLimit:                100,
 			ResetDuration:           "1h",
+			LastReset:               grantAnchor,
 			OverrideAmount:          25,
 			OverrideMode:            tables.BudgetOverrideModeCycles,
 			OverrideCyclesRemaining: 4,
+			OverrideCyclesTotal:     4,
+			OverrideAnchorReset:     &grantAnchor,
 		},
 		{
 			ID:             "budget-override-forever",
@@ -777,6 +784,14 @@ func TestCreateBudgetWithOverride(t *testing.T) {
 		assert.Equal(t, budget.OverrideAmount, got.OverrideAmount)
 		assert.Equal(t, budget.OverrideMode, got.OverrideMode)
 		assert.Equal(t, budget.OverrideCyclesRemaining, got.OverrideCyclesRemaining)
+		assert.Equal(t, budget.OverrideCyclesTotal, got.OverrideCyclesTotal)
+		if budget.OverrideAnchorReset == nil {
+			assert.Nil(t, got.OverrideAnchorReset)
+			continue
+		}
+		require.NotNil(t, got.OverrideAnchorReset)
+		assert.True(t, got.OverrideAnchorReset.Equal(*budget.OverrideAnchorReset),
+			"grant anchor did not round-trip: got %s, want %s", got.OverrideAnchorReset.UTC(), budget.OverrideAnchorReset.UTC())
 	}
 }
 
@@ -792,7 +807,7 @@ func TestUpdateBudgetOverridePreservesBudgetState(t *testing.T) {
 	}
 	require.NoError(t, store.CreateBudget(ctx, budget))
 
-	updated, err := store.UpdateBudgetOverride(ctx, budget.ID, 25, tables.BudgetOverrideModeCycles, 4)
+	updated, err := store.UpdateBudgetOverride(ctx, budget.ID, 25, tables.BudgetOverrideModeCycles, 4, false)
 	require.NoError(t, err)
 	assert.Equal(t, 100.0, updated.MaxLimit)
 	assert.Equal(t, "1d", updated.ResetDuration)
@@ -800,14 +815,70 @@ func TestUpdateBudgetOverridePreservesBudgetState(t *testing.T) {
 	assert.Equal(t, 25.0, updated.OverrideAmount)
 	assert.Equal(t, tables.BudgetOverrideModeCycles, updated.OverrideMode)
 	assert.Equal(t, 4, updated.OverrideCyclesRemaining)
+	assert.Equal(t, 4, updated.OverrideCyclesTotal)
+	require.NotNil(t, updated.OverrideAnchorReset, "a finite grant must be anchored so its remaining count can be derived")
 
-	cleared, err := store.UpdateBudgetOverride(ctx, budget.ID, 0, "", 0)
+	cleared, err := store.UpdateBudgetOverride(ctx, budget.ID, 0, "", 0, false)
 	require.NoError(t, err)
 	assert.Equal(t, 100.0, cleared.MaxLimit)
 	assert.Equal(t, 40.0, cleared.CurrentUsage)
 	assert.Zero(t, cleared.OverrideAmount)
 	assert.Empty(t, cleared.OverrideMode)
 	assert.Zero(t, cleared.OverrideCyclesRemaining)
+	assert.Zero(t, cleared.OverrideCyclesTotal)
+	assert.Nil(t, cleared.OverrideAnchorReset, "clearing must drop the grant so it cannot be re-derived")
+}
+
+// TestUpdateBudgetOverrideAnchorsAtCurrentWindow verifies a rolling grant is
+// anchored on the budget's CreatedAt lattice, so every node derives the same
+// remaining count from it.
+func TestUpdateBudgetOverrideAnchorsAtCurrentWindow(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	created := time.Now().UTC().Add(-10 * time.Hour).Truncate(time.Second)
+	budget := &tables.TableBudget{
+		ID:            "budget-override-rolling-anchor",
+		MaxLimit:      100,
+		ResetDuration: "1h",
+		CreatedAt:     created,
+		LastReset:     created,
+	}
+	require.NoError(t, store.CreateBudget(ctx, budget))
+
+	updated, err := store.UpdateBudgetOverride(ctx, budget.ID, 25, tables.BudgetOverrideModeCycles, 2, false)
+	require.NoError(t, err)
+	require.NotNil(t, updated.OverrideAnchorReset)
+
+	// The anchor must be a lattice point: an exact number of windows past the
+	// budget's creation instant, not the wall clock at grant time.
+	offset := updated.OverrideAnchorReset.Sub(updated.CreatedAt)
+	assert.Zero(t, offset%time.Hour,
+		"grant anchor is not lattice aligned: %s past CreatedAt is not a whole number of 1h windows", offset)
+}
+
+// TestUpdateBudgetOverrideAnchorsAtCalendarPeriodStart verifies a calendar-aligned
+// grant is anchored on the calendar boundary rather than the rolling lattice.
+func TestUpdateBudgetOverrideAnchorsAtCalendarPeriodStart(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	created := time.Now().UTC().AddDate(0, 0, -10).Truncate(time.Second)
+	budget := &tables.TableBudget{
+		ID:            "budget-override-calendar-anchor",
+		MaxLimit:      100,
+		ResetDuration: "1d",
+		CreatedAt:     created,
+		LastReset:     created,
+	}
+	require.NoError(t, store.CreateBudget(ctx, budget))
+
+	updated, err := store.UpdateBudgetOverride(ctx, budget.ID, 25, tables.BudgetOverrideModeCycles, 2, true)
+	require.NoError(t, err)
+	require.NotNil(t, updated.OverrideAnchorReset)
+
+	wantAnchor := tables.GetCalendarPeriodStart("1d", time.Now())
+	assert.True(t, updated.OverrideAnchorReset.Equal(wantAnchor),
+		"calendar-aligned grant anchor should be midnight UTC today: got %s, want %s",
+		updated.OverrideAnchorReset.UTC(), wantAnchor.UTC())
 }
 
 func TestGetBudgets(t *testing.T) {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -354,7 +354,13 @@ type ConfigStore interface {
 	CreateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	UpdateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	// UpdateBudgetOverride updates only the override state and returns the refreshed budget.
-	UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesRemaining int, tx ...*gorm.DB) (*tables.TableBudget, error)
+	//
+	// A finite grant is anchored at the budget's current window boundary so every
+	// cluster node derives the same remaining-cycle count from it. calendarAligned
+	// must come from the owning entity (virtual key, team, customer or access
+	// profile) because the budget row does not persist it, and getting it wrong
+	// anchors the grant on the wrong lattice.
+	UpdateBudgetOverride(ctx context.Context, id string, amount float64, mode tables.BudgetOverrideMode, cyclesTotal int, calendarAligned bool, tx ...*gorm.DB) (*tables.TableBudget, error)
 	UpdateBudgets(ctx context.Context, budgets []*tables.TableBudget, tx ...*gorm.DB) error
 	DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error
 	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64, tx ...*gorm.DB) error

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -31,7 +31,39 @@ type TableBudget struct {
 	// OverrideMode distinguishes finite cycle-based overrides from permanent overrides.
 	OverrideMode BudgetOverrideMode `gorm:"type:varchar(20);not null;default:''" json:"override_mode,omitempty"`
 	// OverrideCyclesRemaining includes the current cycle and is positive only for cycle-based overrides.
+	//
+	// This is a materialized view of the immutable grant below, not independent
+	// state: RefreshOverrideCyclesRemaining recomputes it from
+	// (OverrideAnchorReset, OverrideCyclesTotal, LastReset) on every write that
+	// advances LastReset. It stays persisted and exposed so the API, the UI,
+	// HasActiveOverride and EffectiveMaxLimit are unchanged, but it must never be
+	// treated as the source of truth. Doing so is what let a config reload hand
+	// back a cycle the reset path had already spent.
 	OverrideCyclesRemaining int `gorm:"not null;default:0" json:"override_cycles_remaining,omitempty"`
+
+	// OverrideCyclesTotal is the number of budget windows the current finite
+	// override was granted for. Immutable for the life of a grant.
+	OverrideCyclesTotal int `gorm:"not null;default:0" json:"override_cycles_total,omitempty"`
+
+	// OverrideAnchorReset is the window boundary at which the current finite
+	// override was granted. Immutable for the life of a grant.
+	//
+	// Together with OverrideCyclesTotal it makes override consumption a pure
+	// function of persisted state, so every cluster node derives the same
+	// remaining count without coordinating, a reload that replays the grant
+	// cannot resurrect a spent cycle, and a node that was down for many windows
+	// lands on the correct count instead of catching up one window at a time.
+	//
+	// Nil only for a budget with no finite override. validateOverride rejects a
+	// cycles override without an anchor, so an unanchored grant cannot be persisted,
+	// and the backfill migration adopts any row written before these columns existed.
+	//
+	// Deliberately not indexed. Nothing filters, joins or orders by this column: it is
+	// written with the rest of the override state and read back as part of the row. The
+	// only predicate on it is the one-time backfill's IS NULL, which scans regardless.
+	// An index here would add write cost to every budget update, and DumpBudgets
+	// rewrites the whole table on its dump tick.
+	OverrideAnchorReset *time.Time `json:"override_anchor_reset,omitempty"`
 
 	// Owner FKs: a budget belongs to at most one Team, VK, ProviderConfig, ModelConfig, or Customer
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
@@ -64,6 +96,62 @@ type TableBudget struct {
 // TableName sets the table name for each model
 func (TableBudget) TableName() string { return "governance_budgets" }
 
+// WindowStart returns the budget's current reset-window boundary at or before
+// now: the calendar period for a calendar-aligned budget whose duration has a
+// calendar boundary, and the rolling lattice anchored on CreatedAt otherwise.
+//
+// This is the single definition of "when did the current window open", shared by
+// the reset path, the enforcement path and the override-grant anchor. Every node
+// derives the same instant from the same persisted row, which is what lets
+// budget resets and finite-override accounting agree across a cluster without
+// any coordination.
+//
+// Falls back to LastReset as the rolling anchor when CreatedAt is zero, which
+// happens for budgets that were loaded straight from a config file and never
+// round-tripped through the database. Such a budget still resets on a stable
+// cadence; it just anchors on its own last reset rather than its creation.
+// Returns LastReset unchanged when the duration is missing, unparseable or
+// non-positive, so callers comparing against LastReset see "not due".
+func (b *TableBudget) WindowStart(now time.Time) time.Time {
+	if b == nil {
+		return time.Time{}
+	}
+	if b.ResetDuration == "" {
+		return b.LastReset
+	}
+	if b.IsCalendarAligned && IsCalendarAlignableDuration(b.ResetDuration) {
+		return GetCalendarPeriodStart(b.ResetDuration, now)
+	}
+	duration, err := ParseDuration(b.ResetDuration)
+	if err != nil || duration <= 0 {
+		return b.LastReset
+	}
+	anchor := b.CreatedAt
+	if anchor.IsZero() {
+		anchor = b.LastReset
+	}
+	return RollingWindowStart(anchor, duration, now)
+}
+
+// StampCalendarAlignment copies an owner's calendar-alignment flag onto the
+// budgets and rate limit it owns.
+//
+// IsCalendarAligned is derived, never persisted on the budget or rate-limit row,
+// so every owner has to stamp it on load. Miss it and the governance reset path
+// silently takes the rolling branch, so a calendar-aligned owner's "1d" budget
+// resets on a rolling 24h clock instead of at midnight UTC. Every owner type
+// (virtual key, team, customer, model config, and the enterprise access profiles)
+// funnels through here so a new owner cannot reintroduce that bug by forgetting
+// one of the two field sets.
+func StampCalendarAlignment(calendarAligned bool, budgets []TableBudget, rateLimit *TableRateLimit) {
+	for i := range budgets {
+		budgets[i].IsCalendarAligned = calendarAligned
+	}
+	if rateLimit != nil {
+		rateLimit.IsCalendarAligned = calendarAligned
+	}
+}
+
 // HasActiveOverride reports whether the budget currently has a valid configured override.
 func (b *TableBudget) HasActiveOverride() bool {
 	if b == nil || b.OverrideAmount <= 0 {
@@ -84,27 +172,61 @@ func (b *TableBudget) EffectiveMaxLimit() float64 {
 	return b.MaxLimit + b.OverrideAmount
 }
 
-// SetOverride replaces the budget's current override after validating the complete state.
+// SetOverride replaces the budget's current override after validating the
+// complete state, anchoring a finite grant at the budget's current window
+// boundary (LastReset).
+//
+// LastReset is the right anchor for a clock-free caller because it already is
+// the current window's boundary. Callers that hold a clock and may be looking at
+// a row whose boundary has not been flushed yet should use SetOverrideAt with
+// WindowStart(now) instead, so the grant is not anchored one window behind.
 func (b *TableBudget) SetOverride(amount float64, mode BudgetOverrideMode, cyclesRemaining int) error {
+	if b == nil {
+		return fmt.Errorf("budget is required")
+	}
+	return b.SetOverrideAt(amount, mode, cyclesRemaining, b.LastReset)
+}
+
+// SetOverrideAt replaces the budget's current override and anchors a finite grant
+// at the given window boundary, so that every node derives the same remaining
+// count from the same immutable grant. anchor is ignored for forever-mode and
+// cleared overrides, which have no cycle lifecycle. Validation matches
+// SetOverride, and a rejected change leaves every override field untouched.
+func (b *TableBudget) SetOverrideAt(amount float64, mode BudgetOverrideMode, cyclesTotal int, anchor time.Time) error {
 	if b == nil {
 		return fmt.Errorf("budget is required")
 	}
 	previousAmount := b.OverrideAmount
 	previousMode := b.OverrideMode
 	previousCyclesRemaining := b.OverrideCyclesRemaining
+	previousCyclesTotal := b.OverrideCyclesTotal
+	previousAnchor := b.OverrideAnchorReset
+
 	b.OverrideAmount = amount
 	b.OverrideMode = mode
-	b.OverrideCyclesRemaining = cyclesRemaining
+	b.OverrideCyclesRemaining = cyclesTotal
+	if mode == BudgetOverrideModeCycles {
+		b.OverrideCyclesTotal = cyclesTotal
+		anchoredAt := anchor
+		b.OverrideAnchorReset = &anchoredAt
+	} else {
+		b.OverrideCyclesTotal = 0
+		b.OverrideAnchorReset = nil
+	}
+
 	if err := b.validateOverride(); err != nil {
 		b.OverrideAmount = previousAmount
 		b.OverrideMode = previousMode
 		b.OverrideCyclesRemaining = previousCyclesRemaining
+		b.OverrideCyclesTotal = previousCyclesTotal
+		b.OverrideAnchorReset = previousAnchor
 		return err
 	}
 	return nil
 }
 
-// ClearOverride removes any finite or permanent override from the budget.
+// ClearOverride removes any finite or permanent override from the budget,
+// including the immutable grant, so a cleared override cannot be re-derived.
 func (b *TableBudget) ClearOverride() {
 	if b == nil {
 		return
@@ -112,18 +234,86 @@ func (b *TableBudget) ClearOverride() {
 	b.OverrideAmount = 0
 	b.OverrideMode = ""
 	b.OverrideCyclesRemaining = 0
+	b.OverrideCyclesTotal = 0
+	b.OverrideAnchorReset = nil
 }
 
-// ConsumeOverrideCycle advances a finite override by one completed budget reset cycle.
-func (b *TableBudget) ConsumeOverrideCycle() {
-	if b == nil || b.OverrideMode != BudgetOverrideModeCycles || !b.HasActiveOverride() {
+// boundaryJitterTolerance absorbs sub-millisecond noise when counting whole
+// windows between two boundaries.
+//
+// Both the grant anchor and LastReset are lattice points, so their difference is
+// an exact multiple of the window and sits exactly on a truncation edge. Any
+// positive error on the anchor would therefore truncate to one window fewer and
+// silently grant an extra window. Such error is unavoidable: boundaries cross the
+// cluster as JSON numbers, and a nanosecond epoch (around 1.8e18) exceeds
+// float64's exact-integer range of 2^53, so it round-trips with roughly 256ns of
+// error. One millisecond is four orders of magnitude above that noise and three
+// below the smallest sensible reset window, so it cannot mask a real window.
+const boundaryJitterTolerance = time.Millisecond
+
+// WindowsSinceAnchor returns how many reset windows have closed between the
+// current finite override's anchor and LastReset. Returns 0 when there is no
+// anchored grant or when LastReset has not advanced past the anchor, so a node
+// whose LastReset briefly lags the anchor never reports negative consumption.
+func (b *TableBudget) WindowsSinceAnchor() int {
+	if b == nil || b.OverrideAnchorReset == nil || b.ResetDuration == "" {
+		return 0
+	}
+	anchor := *b.OverrideAnchorReset
+	if !b.LastReset.After(anchor.Add(boundaryJitterTolerance)) {
+		return 0
+	}
+	if b.IsCalendarAligned && IsCalendarAlignableDuration(b.ResetDuration) {
+		// Both ends are nudged past the tolerance before the period count, for the
+		// same reason the rolling branch adds it below. A grant anchor and a LastReset
+		// are both period starts, so each sits exactly on a calendar boundary, and a
+		// negative sub-microsecond shift from a JSON round trip drops it into the
+		// previous period. That silently changed the count by one whole period, which
+		// on a daily budget means the override expires a day early or lives a day too
+		// long. Nudging forward keeps both ends inside their true period for any
+		// error smaller than the tolerance.
+		return CountCalendarPeriods(
+			b.ResetDuration,
+			anchor.Add(boundaryJitterTolerance),
+			b.LastReset.Add(boundaryJitterTolerance),
+		)
+	}
+	duration, err := ParseDuration(b.ResetDuration)
+	if err != nil || duration <= 0 {
+		return 0
+	}
+	return int((b.LastReset.Sub(anchor) + boundaryJitterTolerance) / duration)
+}
+
+// RefreshOverrideCyclesRemaining recomputes OverrideCyclesRemaining from the
+// immutable grant (OverrideAnchorReset, OverrideCyclesTotal) and the current
+// LastReset, clearing the override once every granted window has closed.
+//
+// This is the single point where a finite override advances. Deriving the count
+// rather than decrementing it once per observer is what makes the lifecycle
+// correct in a cluster:
+//   - every node derives the same count without any coordination, where
+//     decrementing locally left each node holding its own tally that only the
+//     leader ever persisted;
+//   - a config reload that replays the grant cannot resurrect a spent cycle,
+//     because replaying an immutable value changes nothing;
+//   - a node down for many windows lands directly on the correct count instead of
+//     needing to replay one decrement per elapsed window.
+//
+// A cycles-mode budget with no anchor is not a supported state: validateOverride
+// rejects it, so it cannot be persisted. Should one be constructed in memory it
+// clears here, which is the safe direction (no unearned headroom) and surfaces
+// immediately rather than silently granting extra windows.
+func (b *TableBudget) RefreshOverrideCyclesRemaining() {
+	if b == nil || b.OverrideMode != BudgetOverrideModeCycles {
 		return
 	}
-	if b.OverrideCyclesRemaining == 1 {
+	remaining := b.OverrideCyclesTotal - b.WindowsSinceAnchor()
+	if remaining <= 0 {
 		b.ClearOverride()
 		return
 	}
-	b.OverrideCyclesRemaining--
+	b.OverrideCyclesRemaining = remaining
 }
 
 // validateOverride checks that the persisted override fields form one unambiguous state.
@@ -136,6 +326,9 @@ func (b *TableBudget) validateOverride() error {
 		if b.OverrideAmount != 0 || b.OverrideCyclesRemaining != 0 {
 			return fmt.Errorf("budget override fields require override_mode")
 		}
+		if b.OverrideCyclesTotal != 0 || b.OverrideAnchorReset != nil {
+			return fmt.Errorf("budget override grant fields require override_mode")
+		}
 	case BudgetOverrideModeCycles:
 		if b.OverrideAmount <= 0 {
 			return fmt.Errorf("budget override_amount must be > 0 for cycles mode")
@@ -143,12 +336,24 @@ func (b *TableBudget) validateOverride() error {
 		if b.OverrideCyclesRemaining <= 0 {
 			return fmt.Errorf("budget override_cycles_remaining must be > 0 for cycles mode")
 		}
+		// The grant is what the remaining count is derived from, so a cycles
+		// override without one has no lifecycle at all. Requiring it here means
+		// an unanchored grant can never reach the database.
+		if b.OverrideAnchorReset == nil {
+			return fmt.Errorf("budget override_anchor_reset is required for cycles mode")
+		}
+		if b.OverrideCyclesTotal < b.OverrideCyclesRemaining {
+			return fmt.Errorf("budget override_cycles_total must be >= override_cycles_remaining for cycles mode")
+		}
 	case BudgetOverrideModeForever:
 		if b.OverrideAmount <= 0 {
 			return fmt.Errorf("budget override_amount must be > 0 for forever mode")
 		}
 		if b.OverrideCyclesRemaining != 0 {
 			return fmt.Errorf("budget override_cycles_remaining must be 0 for forever mode")
+		}
+		if b.OverrideCyclesTotal != 0 || b.OverrideAnchorReset != nil {
+			return fmt.Errorf("budget override grant fields must be empty for forever mode")
 		}
 	default:
 		return fmt.Errorf("invalid budget override_mode: %s", b.OverrideMode)

--- a/framework/configstore/tables/budget_test.go
+++ b/framework/configstore/tables/budget_test.go
@@ -3,6 +3,7 @@ package tables
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,24 +41,69 @@ func TestTableBudgetSetOverrideRestoresPreviousState(t *testing.T) {
 	assert.Equal(t, 2, budget.OverrideCyclesRemaining)
 }
 
-// TestTableBudgetConsumeOverrideCycle verifies finite overrides expire while permanent overrides survive resets.
-func TestTableBudgetConsumeOverrideCycle(t *testing.T) {
-	finite := &TableBudget{MaxLimit: 100}
+// TestTableBudgetRefreshOverrideCyclesRemaining verifies finite overrides expire
+// as windows close while permanent overrides survive resets. The remaining count
+// is derived from the grant and LastReset, so advancing LastReset is what spends
+// a cycle.
+func TestTableBudgetRefreshOverrideCyclesRemaining(t *testing.T) {
+	grantedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	finite := &TableBudget{MaxLimit: 100, ResetDuration: "1h", LastReset: grantedAt}
 	require.NoError(t, finite.SetOverride(25, BudgetOverrideModeCycles, 2))
+	assert.Equal(t, 2, finite.OverrideCyclesTotal)
+	require.NotNil(t, finite.OverrideAnchorReset)
+	assert.True(t, finite.OverrideAnchorReset.Equal(grantedAt))
 
-	finite.ConsumeOverrideCycle()
+	finite.LastReset = grantedAt.Add(time.Hour)
+	finite.RefreshOverrideCyclesRemaining()
 	assert.Equal(t, 1, finite.OverrideCyclesRemaining)
 	assert.Equal(t, 125.0, finite.EffectiveMaxLimit())
 
-	finite.ConsumeOverrideCycle()
+	finite.LastReset = grantedAt.Add(2 * time.Hour)
+	finite.RefreshOverrideCyclesRemaining()
 	assert.False(t, finite.HasActiveOverride())
 	assert.Equal(t, 100.0, finite.EffectiveMaxLimit())
 
-	permanent := &TableBudget{MaxLimit: 100}
+	permanent := &TableBudget{MaxLimit: 100, ResetDuration: "1h", LastReset: grantedAt}
 	require.NoError(t, permanent.SetOverride(50, BudgetOverrideModeForever, 0))
-	permanent.ConsumeOverrideCycle()
+	permanent.LastReset = grantedAt.Add(5 * time.Hour)
+	permanent.RefreshOverrideCyclesRemaining()
 	assert.True(t, permanent.HasActiveOverride())
 	assert.Equal(t, 150.0, permanent.EffectiveMaxLimit())
+}
+
+// TestTableBudgetRefreshOverrideCyclesRemainingIsIdempotent verifies that
+// refreshing repeatedly at a fixed LastReset does not spend extra cycles. This is
+// the property that makes it safe for every node, the ticker, the request path and
+// every config reload to all call it freely.
+func TestTableBudgetRefreshOverrideCyclesRemainingIsIdempotent(t *testing.T) {
+	grantedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	budget := &TableBudget{MaxLimit: 100, ResetDuration: "1h", LastReset: grantedAt}
+	require.NoError(t, budget.SetOverride(25, BudgetOverrideModeCycles, 3))
+
+	budget.LastReset = grantedAt.Add(time.Hour)
+	for i := 0; i < 10; i++ {
+		budget.RefreshOverrideCyclesRemaining()
+	}
+	assert.Equal(t, 2, budget.OverrideCyclesRemaining, "repeated refreshes at one boundary must spend exactly one cycle")
+}
+
+// TestTableBudgetRefreshOverrideCyclesRemainingSpendsWholeGrantAfterLongGap
+// verifies a multi-window gap collapses to the correct count in one call rather
+// than needing one call per elapsed window.
+func TestTableBudgetRefreshOverrideCyclesRemainingSpendsWholeGrantAfterLongGap(t *testing.T) {
+	grantedAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	budget := &TableBudget{MaxLimit: 100, ResetDuration: "1h", LastReset: grantedAt}
+	require.NoError(t, budget.SetOverride(25, BudgetOverrideModeCycles, 3))
+
+	budget.LastReset = grantedAt.Add(240 * time.Hour)
+	budget.RefreshOverrideCyclesRemaining()
+	assert.False(t, budget.HasActiveOverride(), "a 3 cycle grant must be fully spent after 240 elapsed windows")
+}
+
+// overrideAnchor returns a fixed grant anchor for validation table cases.
+func overrideAnchor() *time.Time {
+	anchor := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	return &anchor
 }
 
 // TestTableBudgetValidateOverride verifies that persisted override fields cannot form an ambiguous state.
@@ -81,7 +127,54 @@ func TestTableBudgetValidateOverride(t *testing.T) {
 				OverrideAmount:          25,
 				OverrideMode:            BudgetOverrideModeCycles,
 				OverrideCyclesRemaining: 3,
+				OverrideCyclesTotal:     3,
+				OverrideAnchorReset:     overrideAnchor(),
 			},
+		},
+		{
+			name: "finite override partway through its grant",
+			budget: TableBudget{
+				OverrideAmount:          25,
+				OverrideMode:            BudgetOverrideModeCycles,
+				OverrideCyclesRemaining: 1,
+				OverrideCyclesTotal:     3,
+				OverrideAnchorReset:     overrideAnchor(),
+			},
+		},
+		{
+			name: "cycles mode without an anchor",
+			budget: TableBudget{
+				OverrideAmount:          25,
+				OverrideMode:            BudgetOverrideModeCycles,
+				OverrideCyclesRemaining: 3,
+				OverrideCyclesTotal:     3,
+			},
+			wantError: true,
+		},
+		{
+			name: "cycles mode with total below remaining",
+			budget: TableBudget{
+				OverrideAmount:          25,
+				OverrideMode:            BudgetOverrideModeCycles,
+				OverrideCyclesRemaining: 4,
+				OverrideCyclesTotal:     3,
+				OverrideAnchorReset:     overrideAnchor(),
+			},
+			wantError: true,
+		},
+		{
+			name: "forever mode with a grant anchor",
+			budget: TableBudget{
+				OverrideAmount:      25,
+				OverrideMode:        BudgetOverrideModeForever,
+				OverrideAnchorReset: overrideAnchor(),
+			},
+			wantError: true,
+		},
+		{
+			name:      "no mode with a grant anchor",
+			budget:    TableBudget{OverrideAnchorReset: overrideAnchor()},
+			wantError: true,
 		},
 		{name: "amount without mode", budget: TableBudget{OverrideAmount: 25}, wantError: true},
 		{name: "cycles without mode", budget: TableBudget{OverrideCyclesRemaining: 1}, wantError: true},

--- a/framework/configstore/tables/budgetwindow_test.go
+++ b/framework/configstore/tables/budgetwindow_test.go
@@ -1,0 +1,245 @@
+package tables
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// utcDate builds a UTC instant for the calendar-period tables below.
+func utcDate(year int, month time.Month, day, hour int) time.Time {
+	return time.Date(year, month, day, hour, 0, 0, 0, time.UTC)
+}
+
+// TestCountCalendarPeriods verifies the override-cycle counter counts exactly the
+// boundaries GetCalendarPeriodStart produces.
+//
+// The two must agree or a finite override on a calendar-aligned budget drifts away
+// from the cadence the budget actually resets on: WindowsSinceAnchor uses this to
+// decide how many granted windows have closed, while the reset path uses
+// GetCalendarPeriodStart to decide when a window closes.
+func TestCountCalendarPeriods(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration string
+		from     time.Time
+		to       time.Time
+		want     int
+	}{
+		{name: "same day is zero", duration: "1d", from: utcDate(2026, time.March, 10, 1), to: utcDate(2026, time.March, 10, 23), want: 0},
+		{name: "one day boundary", duration: "1d", from: utcDate(2026, time.March, 10, 23), to: utcDate(2026, time.March, 11, 1), want: 1},
+		{name: "three day boundaries", duration: "1d", from: utcDate(2026, time.March, 10, 0), to: utcDate(2026, time.March, 13, 0), want: 3},
+		{name: "day across month end", duration: "1d", from: utcDate(2026, time.March, 31, 12), to: utcDate(2026, time.April, 2, 1), want: 2},
+		{name: "day across year end", duration: "1d", from: utcDate(2025, time.December, 31, 12), to: utcDate(2026, time.January, 1, 1), want: 1},
+
+		// Weeks are counted from Monday, matching GetCalendarPeriodStart's snap.
+		{name: "same week is zero", duration: "1w", from: utcDate(2026, time.March, 10, 0), to: utcDate(2026, time.March, 14, 0), want: 0},
+		{name: "one week boundary", duration: "1w", from: utcDate(2026, time.March, 10, 0), to: utcDate(2026, time.March, 17, 0), want: 1},
+
+		{name: "same month is zero", duration: "1M", from: utcDate(2026, time.March, 1, 0), to: utcDate(2026, time.March, 31, 23), want: 0},
+		{name: "one month boundary", duration: "1M", from: utcDate(2026, time.March, 31, 23), to: utcDate(2026, time.April, 1, 0), want: 1},
+		{name: "months across year end", duration: "1M", from: utcDate(2025, time.November, 15, 0), to: utcDate(2026, time.February, 3, 0), want: 3},
+
+		{name: "same year is zero", duration: "1Y", from: utcDate(2026, time.January, 1, 0), to: utcDate(2026, time.December, 31, 23), want: 0},
+		{name: "one year boundary", duration: "1Y", from: utcDate(2025, time.December, 31, 23), to: utcDate(2026, time.January, 1, 0), want: 1},
+
+		// Not calendar suffixes, so there is no calendar boundary to count.
+		{name: "hours are not a calendar period", duration: "1h", from: utcDate(2026, time.March, 10, 1), to: utcDate(2026, time.March, 12, 1), want: 0},
+		{name: "reversed range is zero", duration: "1d", from: utcDate(2026, time.March, 12, 0), to: utcDate(2026, time.March, 10, 0), want: 0},
+		{name: "empty duration is zero", duration: "", from: utcDate(2026, time.March, 10, 0), to: utcDate(2026, time.March, 12, 0), want: 0},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, CountCalendarPeriods(testCase.duration, testCase.from, testCase.to))
+		})
+	}
+}
+
+// TestCountCalendarPeriodsIgnoresDurationMultiplier pins a surprising inherited
+// behaviour rather than silently diverging from it.
+//
+// GetCalendarPeriodStart ignores the numeric prefix: "7d" snaps to midnight today,
+// so a calendar-aligned "7d" budget actually resets daily, not weekly. This counter
+// must reproduce that exactly, because a mismatch would make a finite override count
+// windows at a different rate than the budget resets at. Changing either one without
+// the other is the bug this test exists to catch, so a deliberate fix to the
+// multiplier must update both and edit this test.
+func TestCountCalendarPeriodsIgnoresDurationMultiplier(t *testing.T) {
+	from := utcDate(2026, time.March, 10, 0)
+	to := utcDate(2026, time.March, 13, 0)
+
+	assert.Equal(t, 3, CountCalendarPeriods("7d", from, to),
+		`"7d" must count days, matching GetCalendarPeriodStart which snaps "7d" to midnight today`)
+	assert.Equal(t, CountCalendarPeriods("1d", from, to), CountCalendarPeriods("7d", from, to),
+		`"1d" and "7d" must agree because GetCalendarPeriodStart treats them identically`)
+
+	// The reset path's view, asserted directly so the two cannot drift apart.
+	assert.True(t, GetCalendarPeriodStart("7d", to).Equal(GetCalendarPeriodStart("1d", to)),
+		`GetCalendarPeriodStart must treat "7d" and "1d" identically for this counter to be correct`)
+}
+
+// TestRollingWindowStart verifies the rolling lattice is a pure function of
+// (anchor, duration, now) and always lands on a lattice point.
+func TestRollingWindowStart(t *testing.T) {
+	anchor := utcDate(2026, time.March, 10, 0)
+	hour := time.Hour
+
+	assert.True(t, RollingWindowStart(anchor, hour, anchor).Equal(anchor), "now at the anchor stays on the anchor")
+	assert.True(t, RollingWindowStart(anchor, hour, anchor.Add(59*time.Minute)).Equal(anchor), "inside the first window stays on the anchor")
+	assert.True(t, RollingWindowStart(anchor, hour, anchor.Add(hour)).Equal(anchor.Add(hour)), "exactly on a boundary lands on it")
+	assert.True(t, RollingWindowStart(anchor, hour, anchor.Add(90*time.Minute)).Equal(anchor.Add(hour)), "mid second window snaps back")
+
+	// A long gap collapses to the current lattice point in one step rather than
+	// requiring one call per elapsed window.
+	assert.True(t, RollingWindowStart(anchor, hour, anchor.Add(240*hour+17*time.Minute)).Equal(anchor.Add(240*hour)),
+		"a ten day gap lands on the current window boundary")
+
+	// Clock skew and misconfiguration must never produce a target before the anchor
+	// or a perpetually-due target.
+	assert.True(t, RollingWindowStart(anchor, hour, anchor.Add(-time.Hour)).Equal(anchor), "now before the anchor clamps to the anchor")
+	assert.True(t, RollingWindowStart(anchor, 0, anchor.Add(time.Hour)).Equal(anchor), "zero duration returns the anchor")
+	assert.True(t, RollingWindowStart(anchor, -time.Hour, anchor.Add(time.Hour)).Equal(anchor), "negative duration returns the anchor")
+}
+
+// TestWindowStartCalendarAlignedSubDayUsesRollingLattice pins the case that was
+// silently broken: a calendar-aligned budget whose duration is shorter than a day.
+//
+// IsCalendarAlignableDuration only accepts d/w/M/Y, so a calendar-aligned "1h" budget
+// falls through to the rolling branch. Before the lattice that branch stamped each
+// node's own clock, so these budgets diverged across a cluster exactly like plain
+// rolling ones, despite the operator having asked for alignment.
+func TestWindowStartCalendarAlignedSubDayUsesRollingLattice(t *testing.T) {
+	created := utcDate(2026, time.March, 10, 0)
+	budget := &TableBudget{
+		ResetDuration:     "1h",
+		CreatedAt:         created,
+		LastReset:         created,
+		IsCalendarAligned: true,
+	}
+
+	// Two different observation instants inside the same window must agree, which is
+	// what makes two nodes with out-of-phase tickers agree.
+	first := budget.WindowStart(created.Add(90 * time.Minute))
+	second := budget.WindowStart(created.Add(119 * time.Minute))
+	assert.True(t, first.Equal(second), "two instants in one window must give the same boundary: %s vs %s", first, second)
+	assert.True(t, first.Equal(created.Add(time.Hour)), "boundary must be a lattice point past CreatedAt, got %s", first)
+}
+
+// TestWindowStartCalendarAlignedDayUsesCalendarBoundary verifies a calendar-aligned
+// budget with a calendar-scale duration snaps to midnight UTC rather than to the
+// CreatedAt lattice, which is what the flag is for.
+func TestWindowStartCalendarAlignedDayUsesCalendarBoundary(t *testing.T) {
+	// Deliberately created mid-afternoon so the CreatedAt lattice and the calendar
+	// boundary cannot coincide by accident.
+	created := utcDate(2026, time.March, 10, 15)
+	budget := &TableBudget{
+		ResetDuration:     "1d",
+		CreatedAt:         created,
+		LastReset:         created,
+		IsCalendarAligned: true,
+	}
+
+	now := utcDate(2026, time.March, 12, 9)
+	got := budget.WindowStart(now)
+	assert.True(t, got.Equal(utcDate(2026, time.March, 12, 0)),
+		"calendar-aligned daily budget should snap to midnight UTC, got %s", got)
+}
+
+// TestCalendarAlignedOverrideSpansExactlyGrantedPeriods verifies a finite override on
+// a calendar-aligned budget expires after exactly the granted number of calendar
+// periods, using the calendar counter rather than rolling arithmetic.
+func TestCalendarAlignedOverrideSpansExactlyGrantedPeriods(t *testing.T) {
+	// Granted mid-afternoon; the anchor is the calendar period start, as
+	// UpdateBudgetOverride computes it via WindowStart.
+	grantDay := utcDate(2026, time.March, 10, 0)
+	budget := &TableBudget{
+		MaxLimit:          100,
+		ResetDuration:     "1d",
+		CreatedAt:         utcDate(2026, time.March, 1, 15),
+		LastReset:         grantDay,
+		IsCalendarAligned: true,
+	}
+	require.NoError(t, budget.SetOverrideAt(25, BudgetOverrideModeCycles, 3, grantDay))
+	require.Equal(t, 3, budget.OverrideCyclesRemaining)
+	require.Equal(t, 125.0, budget.EffectiveMaxLimit())
+
+	// Each midnight closes one granted period.
+	for day, wantRemaining := range map[int]int{11: 2, 12: 1} {
+		budget.LastReset = utcDate(2026, time.March, day, 0)
+		budget.RefreshOverrideCyclesRemaining()
+		assert.Equal(t, wantRemaining, budget.OverrideCyclesRemaining, "after midnight on March %d", day)
+		assert.True(t, budget.HasActiveOverride(), "override should still be active on March %d", day)
+	}
+
+	// The third midnight exhausts the grant.
+	budget.LastReset = utcDate(2026, time.March, 13, 0)
+	budget.RefreshOverrideCyclesRemaining()
+	assert.False(t, budget.HasActiveOverride(), "a 3 period grant must be spent after 3 midnights")
+	assert.Equal(t, 100.0, budget.EffectiveMaxLimit())
+}
+
+// TestCalendarAlignedOverrideSurvivesConfigReload verifies a config reload replaying
+// the persisted grant cannot hand back a spent period on a calendar-aligned budget.
+func TestCalendarAlignedOverrideSurvivesConfigReload(t *testing.T) {
+	grantDay := utcDate(2026, time.March, 10, 0)
+	budget := &TableBudget{
+		MaxLimit:          100,
+		ResetDuration:     "1d",
+		CreatedAt:         utcDate(2026, time.March, 1, 15),
+		LastReset:         grantDay,
+		IsCalendarAligned: true,
+	}
+	require.NoError(t, budget.SetOverrideAt(25, BudgetOverrideModeCycles, 3, grantDay))
+
+	// Snapshot as the database holds it at grant time.
+	pristine := *budget
+
+	budget.LastReset = utcDate(2026, time.March, 12, 0)
+	budget.RefreshOverrideCyclesRemaining()
+	require.Equal(t, 1, budget.OverrideCyclesRemaining, "two midnights closed, so one period should remain")
+
+	// The reload replays the pristine grant onto the advanced boundary, exactly as
+	// UpsertBudgetConfig does: grant from config, LastReset preserved, then derive.
+	reloaded := pristine
+	reloaded.LastReset = budget.LastReset
+	reloaded.RefreshOverrideCyclesRemaining()
+	assert.Equal(t, 1, reloaded.OverrideCyclesRemaining,
+		"reload resurrected a spent calendar period: %d remaining, want 1", reloaded.OverrideCyclesRemaining)
+}
+
+// TestCalendarAlignedOverrideToleratesWireJitter verifies a sub-microsecond shift in
+// either boundary cannot change the calendar period count.
+//
+// This is not a theoretical concern. A grant anchor and a LastReset are both period
+// starts, so each sits exactly on midnight, and a JSON round trip shifts a nanosecond
+// timestamp by a few hundred nanoseconds. A negative shift drops the value into the
+// previous day, which changed the count by a whole period: on a daily budget the
+// override expired a day early. The calendar path needs the same tolerance the rolling
+// path does, for exactly the same edge-of-truncation reason.
+func TestCalendarAlignedOverrideToleratesWireJitter(t *testing.T) {
+	grantDay := utcDate(2026, time.March, 10, 0)
+	resetDay := utcDate(2026, time.March, 12, 0)
+	jitters := []time.Duration{-500 * time.Nanosecond, -1 * time.Nanosecond, 0, time.Nanosecond, 500 * time.Nanosecond}
+
+	for _, anchorJitter := range jitters {
+		for _, resetJitter := range jitters {
+			shiftedAnchor := grantDay.Add(anchorJitter)
+			budget := &TableBudget{
+				MaxLimit:            100,
+				ResetDuration:       "1d",
+				CreatedAt:           utcDate(2026, time.March, 1, 15),
+				LastReset:           resetDay.Add(resetJitter),
+				IsCalendarAligned:   true,
+				OverrideAmount:      25,
+				OverrideMode:        BudgetOverrideModeCycles,
+				OverrideCyclesTotal: 3,
+				OverrideAnchorReset: &shiftedAnchor,
+			}
+			budget.RefreshOverrideCyclesRemaining()
+			assert.Equal(t, 1, budget.OverrideCyclesRemaining,
+				"anchor %s / reset %s jitter changed the calendar period count", anchorJitter, resetJitter)
+		}
+	}
+}

--- a/framework/configstore/tables/customer.go
+++ b/framework/configstore/tables/customer.go
@@ -37,11 +37,6 @@ func (TableCustomer) TableName() string { return "governance_customers" }
 // AfterFind stamps IsCalendarAligned on owned budgets and rate limit so the
 // reset path (which reads the derived field off those objects) sees the correct value.
 func (c *TableCustomer) AfterFind(tx *gorm.DB) error {
-	for i := range c.Budgets {
-		c.Budgets[i].IsCalendarAligned = c.CalendarAligned
-	}
-	if c.RateLimit != nil {
-		c.RateLimit.IsCalendarAligned = c.CalendarAligned
-	}
+	StampCalendarAlignment(c.CalendarAligned, c.Budgets, c.RateLimit)
 	return nil
 }

--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -107,9 +107,7 @@ func (TableModelConfig) TableName() string {
 // the stamped value off each budget. Mirrors TableTeam/TableVirtualKey. The governance
 // store's Update*InMemory paths re-stamp on every model-config update.
 func (mc *TableModelConfig) AfterFind(tx *gorm.DB) error {
-	for i := range mc.Budgets {
-		mc.Budgets[i].IsCalendarAligned = mc.CalendarAligned
-	}
+	StampCalendarAlignment(mc.CalendarAligned, mc.Budgets, nil)
 	return nil
 }
 

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -107,11 +107,6 @@ func (t *TableTeam) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 	}
-	for i := range t.Budgets {
-		t.Budgets[i].IsCalendarAligned = t.CalendarAligned
-	}
-	if t.RateLimit != nil {
-		t.RateLimit.IsCalendarAligned = t.CalendarAligned
-	}
+	StampCalendarAlignment(t.CalendarAligned, t.Budgets, t.RateLimit)
 	return nil
 }

--- a/framework/configstore/tables/utils.go
+++ b/framework/configstore/tables/utils.go
@@ -53,6 +53,71 @@ func GetCalendarPeriodStart(duration string, t time.Time) time.Time {
 	}
 }
 
+// RollingWindowStart returns the most recent rolling-window boundary at or
+// before now for a window of the given duration anchored at anchor. The result
+// is always a lattice point anchor + k*duration for some integer k >= 0.
+//
+// This is what makes rolling resets agree across a cluster. anchor is a
+// persisted, immutable value (a row's CreatedAt), so the returned boundary is a
+// pure function of (anchor, duration, now) and every node computes the identical
+// instant no matter when its own reset ticker happened to fire. Stamping
+// time.Now() instead makes each node's boundary a function of its ticker phase,
+// and because that stamp becomes the origin of the node's next window the error
+// compounds every cycle and no two nodes ever agree on when a window closed.
+//
+// Quantizing now also bounds clock skew: a node whose clock runs fast notices
+// the boundary early but still writes the same lattice point, so skew has to
+// exceed a full duration before it can shift which boundary gets written.
+//
+// A now before anchor (clock skew or a rollback) clamps to anchor, and a
+// non-positive duration returns anchor unchanged, so a caller can never build a
+// perpetually-due target (issue #4851 class).
+func RollingWindowStart(anchor time.Time, duration time.Duration, now time.Time) time.Time {
+	if duration <= 0 {
+		return anchor
+	}
+	elapsed := now.Sub(anchor)
+	if elapsed < 0 {
+		return anchor
+	}
+	return anchor.Add((elapsed / duration) * duration)
+}
+
+// CountCalendarPeriods returns how many calendar-period boundaries the interval
+// (from, to] crosses for the given duration suffix. It counts exactly the
+// boundaries GetCalendarPeriodStart would produce, so "d" counts UTC days, "w"
+// counts Mondays, "M" counts months and "Y" counts years.
+//
+// Like GetCalendarPeriodStart this deliberately ignores the numeric multiplier,
+// so "7d" counts days rather than seven-day blocks. The two must agree: a
+// mismatch would make a finite override's derived cycle count drift away from
+// the cadence at which the budget actually resets.
+//
+// Returns 0 for a non-calendar suffix and whenever to is not after from.
+func CountCalendarPeriods(duration string, from, to time.Time) int {
+	if duration == "" || !to.After(from) {
+		return 0
+	}
+	from = from.UTC()
+	to = to.UTC()
+	switch duration[len(duration)-1:] {
+	case "d":
+		fromDay := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, time.UTC)
+		toDay := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, time.UTC)
+		return int(toDay.Sub(fromDay) / (24 * time.Hour))
+	case "w":
+		fromWeek := GetCalendarPeriodStart("1w", from)
+		toWeek := GetCalendarPeriodStart("1w", to)
+		return int(toWeek.Sub(fromWeek) / (7 * 24 * time.Hour))
+	case "M":
+		return (to.Year()-from.Year())*12 + int(to.Month()) - int(from.Month())
+	case "Y":
+		return to.Year() - from.Year()
+	default:
+		return 0
+	}
+}
+
 // ParseDuration function to parse duration strings
 func ParseDuration(duration string) (time.Duration, error) {
 	if duration == "" {

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -341,20 +341,10 @@ func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
 		}
 	}
-	for i := range vk.Budgets {
-		vk.Budgets[i].IsCalendarAligned = vk.CalendarAligned
-	}
-	if vk.RateLimit != nil {
-		vk.RateLimit.IsCalendarAligned = vk.CalendarAligned
-	}
+	StampCalendarAlignment(vk.CalendarAligned, vk.Budgets, vk.RateLimit)
 	for i := range vk.ProviderConfigs {
 		pc := &vk.ProviderConfigs[i]
-		for j := range pc.Budgets {
-			pc.Budgets[j].IsCalendarAligned = vk.CalendarAligned
-		}
-		if pc.RateLimit != nil {
-			pc.RateLimit.IsCalendarAligned = vk.CalendarAligned
-		}
+		StampCalendarAlignment(vk.CalendarAligned, pc.Budgets, pc.RateLimit)
 	}
 	return nil
 }

--- a/plugins/governance/budgetcycle_test.go
+++ b/plugins/governance/budgetcycle_test.go
@@ -1,0 +1,540 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cycleTestWindow is the reset duration every budget-cycle test uses. One
+// minute is short enough to walk many windows with a simulated clock and long
+// enough that the jitter offsets below stay well inside a single window.
+const cycleTestWindow = time.Minute
+
+// cycleTestDuration is cycleTestWindow rendered the way ResetDuration expects.
+const cycleTestDuration = "1m"
+
+// cycleTestAnchor is the fixed creation instant every budget-cycle test anchors
+// on. It is a lattice point for every duration these tests use, so expected
+// boundaries are exact multiples of the window away from it.
+func cycleTestAnchor() time.Time {
+	return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// newCycleTestBudget builds a budget whose creation instant and last reset both
+// sit on cycleTestAnchor, which is the state a freshly created budget has in the
+// database. Tests drive it forward with a simulated clock rather than sleeping.
+func newCycleTestBudget(id string, maxLimit, currentUsage float64) *configstoreTables.TableBudget {
+	anchor := cycleTestAnchor()
+	budget := buildBudgetWithUsage(id, maxLimit, currentUsage, cycleTestDuration)
+	budget.CreatedAt = anchor
+	budget.UpdatedAt = anchor
+	budget.LastReset = anchor
+	return budget
+}
+
+// sweepBudgetAt runs one reset sweep for a single budget against a simulated
+// clock, mirroring what the 10s ticker does on a real node. Returns the reset
+// snapshot, or nil when the budget was not due at that instant.
+func sweepBudgetAt(t *testing.T, store *LocalGovernanceStore, budgetID string, now time.Time) *configstoreTables.TableBudget {
+	t.Helper()
+	ctx := context.Background()
+	current := store.LoadBudget(ctx, budgetID)
+	if current == nil {
+		t.Fatalf("budget %s missing from store", budgetID)
+	}
+	return store.resetExpiredBudgetFromSnapshot(ctx, current, now)
+}
+
+// TestBudgetResetTargetIsDeterministicAcrossNodes proves two nodes holding the
+// same budget row converge on the same reset boundary even though their reset
+// tickers fire at different phases.
+//
+// This is the core cluster defect: the rolling branch of budgetResetTarget
+// writes time.Now(), so LastReset becomes a function of whichever instant that
+// node's ticker happened to fire. Each node then measures its next window from
+// its own stamp, so the phase error compounds every cycle and no two nodes ever
+// agree on when a window closed. Overrides sit on top of that disagreement,
+// which is why a cycles override grants a different number of windows per node.
+func TestBudgetResetTargetIsDeterministicAcrossNodes(t *testing.T) {
+	anchor := cycleTestAnchor()
+	// Two independent nodes, identical starting row, tickers ~7s out of phase.
+	nodeA := newStandaloneStore(t)
+	nodeB := newStandaloneStore(t)
+	nodeA.budgets.Store("shared-budget", newCycleTestBudget("shared-budget", 100, 10))
+	nodeB.budgets.Store("shared-budget", newCycleTestBudget("shared-budget", 100, 10))
+
+	// Node A's ticker lands 1s into each window, node B's lands 8s in.
+	phaseA := []time.Duration{61 * time.Second, 125 * time.Second, 181 * time.Second}
+	phaseB := []time.Duration{68 * time.Second, 133 * time.Second, 188 * time.Second}
+	for i := range phaseA {
+		sweepBudgetAt(t, nodeA, "shared-budget", anchor.Add(phaseA[i]))
+		sweepBudgetAt(t, nodeB, "shared-budget", anchor.Add(phaseB[i]))
+	}
+
+	ctx := context.Background()
+	gotA := nodeA.LoadBudget(ctx, "shared-budget")
+	gotB := nodeB.LoadBudget(ctx, "shared-budget")
+	require.NotNil(t, gotA)
+	require.NotNil(t, gotB)
+
+	assert.True(t, gotA.LastReset.Equal(gotB.LastReset),
+		"nodes disagree on the window boundary: node A at %s, node B at %s (%s apart)",
+		gotA.LastReset.UTC(), gotB.LastReset.UTC(), gotB.LastReset.Sub(gotA.LastReset))
+
+	// The boundary must also be a lattice point, not a ticker timestamp, so the
+	// cadence stays exactly one window instead of window plus ticker jitter.
+	wantBoundary := anchor.Add(3 * cycleTestWindow)
+	assert.True(t, gotA.LastReset.Equal(wantBoundary),
+		"boundary is not lattice aligned: got %s, want %s", gotA.LastReset.UTC(), wantBoundary.UTC())
+}
+
+// TestBudgetResetCadenceIsExactlyOneWindow proves consecutive boundaries differ
+// by exactly the reset duration. Today each boundary is the ticker instant, so
+// successive boundaries differ by the duration plus that tick's jitter, and the
+// budget window silently runs long every single cycle.
+func TestBudgetResetCadenceIsExactlyOneWindow(t *testing.T) {
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+	store.budgets.Store("cadence-budget", newCycleTestBudget("cadence-budget", 100, 10))
+
+	// Deliberately ragged tick offsets inside each window, as a real 10s ticker
+	// produces.
+	offsets := []time.Duration{
+		63 * time.Second,
+		127 * time.Second,
+		188 * time.Second,
+		247 * time.Second,
+		309 * time.Second,
+	}
+	var boundaries []time.Time
+	for _, offset := range offsets {
+		if reset := sweepBudgetAt(t, store, "cadence-budget", anchor.Add(offset)); reset != nil {
+			boundaries = append(boundaries, reset.LastReset)
+		}
+	}
+
+	require.GreaterOrEqual(t, len(boundaries), 2, "expected at least two resets, got %d", len(boundaries))
+	for i := 1; i < len(boundaries); i++ {
+		gap := boundaries[i].Sub(boundaries[i-1])
+		assert.Equal(t, cycleTestWindow, gap,
+			"boundary %d to %d gap is %s, want exactly %s (boundaries: %v)",
+			i-1, i, gap, cycleTestWindow, boundaries)
+	}
+}
+
+// TestUpsertBudgetConfigDoesNotResurrectOverrideCycles proves a config reload
+// cannot hand back a cycle the reset path already spent.
+//
+// UpsertBudgetConfig preserves CurrentUsage and LastReset from the live snapshot
+// but takes the override fields wholesale from the incoming config. Every reload
+// path funnels through it, so a reload carrying the database's pre-reset row
+// restores the old cycle count while LastReset stays advanced. That window's
+// cycle can never be spent again, so the override outlives the grant it was
+// given, and it does so by a different amount on every node.
+func TestUpsertBudgetConfigDoesNotResurrectOverrideCycles(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+
+	budget := newCycleTestBudget("resurrect-budget", 100, 75)
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 3))
+	store.budgets.Store(budget.ID, budget)
+
+	// The snapshot a reload would carry: read before the reset, so it still
+	// holds the pre-reset cycle count. This is exactly what a database row looks
+	// like between the in-memory reset and the leader's next dump.
+	stale := store.LoadBudget(ctx, budget.ID)
+	require.NotNil(t, stale)
+	staleCycles := stale.OverrideCyclesRemaining
+	require.Equal(t, 3, staleCycles)
+
+	reset := sweepBudgetAt(t, store, budget.ID, anchor.Add(61*time.Second))
+	require.NotNil(t, reset, "budget should have been due one window after the anchor")
+	require.Equal(t, 2, reset.OverrideCyclesRemaining, "one window closed, so one cycle should be spent")
+
+	// Now the reload lands, carrying the stale pre-reset override state.
+	store.UpsertBudgetConfig(ctx, budget.ID, stale)
+
+	got := store.LoadBudget(ctx, budget.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, 2, got.OverrideCyclesRemaining,
+		"config reload resurrected a spent override cycle: %d remaining after reload, want 2", got.OverrideCyclesRemaining)
+}
+
+// TestBudgetCycleSurvivesInterleavedConfigReload proves an N cycle override
+// grants exactly N windows even when a config reload fires inside every window.
+//
+// This is the end to end shape of the reported bug. With the override count held
+// as independently mutable state, a reload mid window replays the pre-reset
+// count and the override never converges on its grant.
+func TestBudgetCycleSurvivesInterleavedConfigReload(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+
+	const grantedCycles = 3
+	budget := newCycleTestBudget("reload-race-budget", 100, 0)
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, grantedCycles))
+	store.budgets.Store(budget.ID, budget)
+
+	// The pristine row as the database holds it at grant time. A reload replays
+	// this same config every time, which is what makes the race reproducible.
+	pristine := *budget
+
+	// Walk well past the grant so an override that fails to expire is caught.
+	activeWindows := 0
+	for window := 1; window <= grantedCycles+3; window++ {
+		tick := anchor.Add(time.Duration(window)*cycleTestWindow + time.Second)
+		if reset := sweepBudgetAt(t, store, budget.ID, tick); reset != nil && reset.HasActiveOverride() {
+			activeWindows++
+		}
+		// A config reload lands mid window, carrying the pristine grant.
+		reloaded := pristine
+		store.UpsertBudgetConfig(ctx, budget.ID, &reloaded)
+	}
+
+	got := store.LoadBudget(ctx, budget.ID)
+	require.NotNil(t, got)
+	assert.False(t, got.HasActiveOverride(),
+		"override outlived its %d cycle grant: mode=%q remaining=%d", grantedCycles, got.OverrideMode, got.OverrideCyclesRemaining)
+	assert.Equal(t, grantedCycles-1, activeWindows,
+		"override stayed active across %d post reset windows, want %d", activeWindows, grantedCycles-1)
+}
+
+// TestBudgetCycleGrantsExactlyNWindows pins the single node baseline: without
+// any reload or cluster interference an N cycle override must span exactly N
+// windows and then clear itself.
+func TestBudgetCycleGrantsExactlyNWindows(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+
+	const grantedCycles = 3
+	budget := newCycleTestBudget("exact-cycles-budget", 100, 0)
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, grantedCycles))
+	store.budgets.Store(budget.ID, budget)
+
+	for window := 1; window <= grantedCycles+2; window++ {
+		sweepBudgetAt(t, store, budget.ID, anchor.Add(time.Duration(window)*cycleTestWindow+time.Second))
+	}
+
+	got := store.LoadBudget(ctx, budget.ID)
+	require.NotNil(t, got)
+	assert.False(t, got.HasActiveOverride(), "override should have cleared after %d windows", grantedCycles)
+	assert.Equal(t, 100.0, got.EffectiveMaxLimit(), "limit should be back to the base max after expiry")
+}
+
+// TestBudgetCycleLongIdleSkipsToCurrentWindow proves a long outage collapses to
+// a single reset that lands on the current window, and spends the whole override
+// grant rather than replaying one cycle per elapsed window.
+//
+// Consuming one cycle per elapsed window would let an operator extend an
+// override by stopping a node, and catching up 240 windows one at a time would
+// either spin the sweep or leave the budget perpetually due.
+func TestBudgetCycleLongIdleSkipsToCurrentWindow(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+
+	budget := newCycleTestBudget("long-idle-budget", 100, 90)
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 3))
+	store.budgets.Store(budget.ID, budget)
+
+	// Ten days of downtime on a one minute window: 14400 windows elapsed.
+	const idleWindows = 14400
+	resumeAt := anchor.Add(idleWindows*cycleTestWindow + 17*time.Second)
+	reset := sweepBudgetAt(t, store, budget.ID, resumeAt)
+	require.NotNil(t, reset, "budget should be due after a long outage")
+
+	assert.Zero(t, reset.CurrentUsage, "usage should be zeroed by the catch up reset")
+	assert.True(t, reset.LastReset.Equal(anchor.Add(idleWindows*cycleTestWindow)),
+		"catch up reset should land on the current window boundary: got %s", reset.LastReset.UTC())
+	assert.False(t, reset.HasActiveOverride(),
+		"a 3 cycle override should be fully spent after %d elapsed windows, got remaining=%d", idleWindows, reset.OverrideCyclesRemaining)
+
+	// A second sweep at the same instant must be a no-op, proving the target
+	// converged in one application instead of staying perpetually due.
+	assert.Nil(t, sweepBudgetAt(t, store, budget.ID, resumeAt), "budget should not still be due after the catch up reset")
+
+	_ = ctx
+}
+
+// TestCheckBudgetHonoursResetSemantics proves the enforcement path agrees with
+// the reset path about whether a window has closed.
+//
+// CheckBudget open-codes its own expiry predicate instead of reusing
+// budgetResetTarget, and the two disagree in both directions. It ignores
+// IsCalendarAligned, so a calendar aligned budget is judged on a rolling clock
+// for enforcement while it resets on the calendar. It also has no guard against
+// a non-positive duration, and because time.Since is always at least zero such
+// a budget is skipped past enforcement forever, which is unlimited spend.
+func TestCheckBudgetHonoursResetSemantics(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-positive duration still enforces", func(t *testing.T) {
+		store := newStandaloneStore(t)
+		budget := buildBudgetWithUsage("zero-duration-budget", 10, 50, "0s")
+		budget.CreatedAt = cycleTestAnchor()
+		budget.LastReset = time.Now()
+		store.budgets.Store(budget.ID, budget)
+
+		decision, err := store.CheckBudget(ctx, EntityWiseBudgets{
+			"virtual_key": {budget},
+		}, nil)
+		assert.Equal(t, DecisionBudgetExceeded, decision,
+			"a budget with a non-positive reset duration must still be enforced, got %v", decision)
+		assert.Error(t, err, "an over-limit budget should report why it was blocked")
+	})
+
+	t.Run("calendar aligned budget expires on the calendar boundary", func(t *testing.T) {
+		now := time.Now().UTC()
+		periodStart := configstoreTables.GetCalendarPeriodStart("1Y", now)
+		// Guard against the final hours of the year, where the rolling
+		// approximation of a year coincides with the calendar boundary and the
+		// two predicates would agree by accident.
+		if now.Sub(periodStart) > 300*24*time.Hour {
+			t.Skip("too close to the year boundary for the two predicates to disagree")
+		}
+
+		store := newStandaloneStore(t)
+		budget := buildBudgetWithUsage("calendar-budget", 10, 50, "1Y")
+		budget.CreatedAt = periodStart.AddDate(-1, 0, 0)
+		// One second before this year's boundary: the calendar period has
+		// rolled over, so the budget is expired and must not be enforced.
+		budget.LastReset = periodStart.Add(-time.Second)
+		budget.IsCalendarAligned = true
+		store.budgets.Store(budget.ID, budget)
+
+		decision, _ := store.CheckBudget(ctx, EntityWiseBudgets{
+			"virtual_key": {budget},
+		}, nil)
+		assert.Equal(t, DecisionAllow, decision,
+			"calendar aligned budget crossed its period boundary and must be treated as expired, got %v", decision)
+	})
+}
+
+// TestResetExpiredRateLimitsPersistsLastResetUnderTraffic proves a rate-limit
+// reset advances the persisted boundary even when a request bumps the counter
+// back above zero before the write lands.
+//
+// ResetExpiredRateLimits decides what to write by testing whether the in-memory
+// counter is still zero. Under sustained traffic it never is, so the whole field
+// pair is dropped, including the boundary column. The database boundary then
+// never advances and the counter reads as perpetually due on the next restart.
+func TestResetExpiredRateLimitsPersistsLastResetUnderTraffic(t *testing.T) {
+	ctx := context.Background()
+	logger := NewMockLogger()
+	configStore, err := configstore.NewConfigStore(ctx, &configstore.Config{
+		Enabled: true,
+		Type:    configstore.ConfigStoreTypeSQLite,
+		Config:  &configstore.SQLiteConfig{Path: t.TempDir() + "/ratelimitreset.db"},
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, configStore.Close(ctx)) })
+
+	anchor := cycleTestAnchor()
+	rateLimit := buildRateLimitWithUsage("traffic-rate-limit", 1000, 900, 1000, 900)
+	rateLimit.CreatedAt = anchor
+	rateLimit.TokenLastReset = anchor
+	rateLimit.RequestLastReset = anchor
+	require.NoError(t, configStore.CreateRateLimit(ctx, rateLimit))
+
+	store, err := NewLocalGovernanceStore(ctx, logger, configStore, nil, nil)
+	require.NoError(t, err)
+
+	boundary := anchor.Add(cycleTestWindow)
+	reset, ok := store.ResetRateLimitAt(ctx, rateLimit.ID, &boundary, &boundary)
+	require.True(t, ok, "rate limit should have been resettable one window after the anchor")
+
+	// A request lands between the in-memory reset and the database write, which
+	// is the normal case for any rate limit that is actually carrying traffic.
+	raced := *reset
+	raced.TokenCurrentUsage = 5
+	raced.RequestCurrentUsage = 1
+	require.NoError(t, store.ResetExpiredRateLimits(ctx, []*configstoreTables.TableRateLimit{&raced}))
+
+	persisted, err := configStore.GetRateLimit(ctx, rateLimit.ID)
+	require.NoError(t, err)
+	assert.True(t, persisted.TokenLastReset.Equal(boundary),
+		"token boundary was not persisted: got %s, want %s", persisted.TokenLastReset.UTC(), boundary.UTC())
+	assert.True(t, persisted.RequestLastReset.Equal(boundary),
+		"request boundary was not persisted: got %s, want %s", persisted.RequestLastReset.UTC(), boundary.UTC())
+}
+
+// TestVirtualKeyReloadDoesNotResurrectOverrideCycles proves the virtual-key reload
+// path cannot hand back an override cycle the reset path already spent.
+//
+// This is the hole the in-process budget tests missed and a live cluster run found.
+// UpsertBudgetConfig was documented as the single funnel for installing a budget, but
+// UpdateVirtualKeyInMemory (which every VK reload goes through) wrote into the budgets
+// map directly. It hand-rolled the CurrentUsage and LastReset preservation and so
+// looked correct, but it never re-derived the override lifecycle, meaning the persisted
+// row's stale cycle count won and the override outlived its grant.
+func TestVirtualKeyReloadDoesNotResurrectOverrideCycles(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+	store := newStandaloneStore(t)
+
+	budget := newCycleTestBudget("vk-reload-budget", 100, 0)
+	require.NoError(t, budget.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 3))
+	vk := buildVirtualKeyWithMultiBudgets("vk-reload", "sk-bf-vk-reload", "VK Reload", []configstoreTables.TableBudget{*budget})
+	store.CreateVirtualKeyInMemory(ctx, vk)
+
+	// The snapshot a reload carries: the row as the database holds it before the
+	// leader has flushed the spent cycle.
+	pristine := buildVirtualKeyWithMultiBudgets(vk.ID, "sk-bf-vk-reload", vk.Name, []configstoreTables.TableBudget{*budget})
+
+	reset := sweepBudgetAt(t, store, budget.ID, anchor.Add(61*time.Second))
+	require.NotNil(t, reset, "budget should be due one window after the anchor")
+	require.Equal(t, 2, reset.OverrideCyclesRemaining, "one window closed, so one cycle should be spent")
+
+	// A virtual-key reload lands, replaying the pristine grant.
+	store.UpdateVirtualKeyInMemory(ctx, pristine, nil, nil, nil)
+
+	got := store.LoadBudget(ctx, budget.ID)
+	require.NotNil(t, got)
+	assert.Equal(t, 2, got.OverrideCyclesRemaining,
+		"virtual key reload resurrected a spent override cycle: %d remaining after reload, want 2", got.OverrideCyclesRemaining)
+	assert.True(t, got.LastReset.Equal(anchor.Add(time.Minute)),
+		"virtual key reload should preserve the advanced boundary, got %s", got.LastReset.UTC())
+}
+
+// TestUpsertBudgetConfigDoesNotAliasOrMutateCallerConfig proves the store never
+// mutates the budget it is handed, and never publishes it as the live map entry.
+//
+// Both first-write branches used to refresh the caller's struct in place and then
+// store that same pointer. Callers legitimately pass a pointer into a slice they keep
+// using (BulkLoadUserAccessProfiles passes &p.Budgets[j]), so the caller's copy would
+// be silently rewritten and any later write through it would race BumpBudgetUsage's
+// clone-and-CAS. sync.Map makes the map operation atomic, not the pointed-to struct.
+func TestUpsertBudgetConfigDoesNotAliasOrMutateCallerConfig(t *testing.T) {
+	ctx := context.Background()
+	anchor := cycleTestAnchor()
+
+	for _, testCase := range []struct {
+		name string
+		// seed installs a pre-existing entry so the second branch is exercised.
+		seed func(store *LocalGovernanceStore, budgetID string)
+	}{
+		{name: "first write", seed: func(*LocalGovernanceStore, string) {}},
+		{name: "replacing an unusable entry", seed: func(store *LocalGovernanceStore, budgetID string) {
+			// A non-budget value forces the type-assertion branch.
+			store.budgets.Store(budgetID, "not a budget")
+		}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := newStandaloneStore(t)
+
+			// Three windows have closed since the grant, so a refresh would drop the
+			// remaining count from 3 to 1 and be plainly visible on the caller's copy.
+			caller := newCycleTestBudget("alias-budget", 100, 0)
+			require.NoError(t, caller.SetOverride(25, configstoreTables.BudgetOverrideModeCycles, 3))
+			caller.LastReset = anchor.Add(2 * cycleTestWindow)
+			testCase.seed(store, caller.ID)
+
+			before := *caller
+			store.UpsertBudgetConfig(ctx, caller.ID, caller)
+
+			assert.Equal(t, before.OverrideCyclesRemaining, caller.OverrideCyclesRemaining,
+				"UpsertBudgetConfig rewrote the caller's remaining count in place")
+			assert.True(t, before.LastReset.Equal(caller.LastReset),
+				"UpsertBudgetConfig rewrote the caller's boundary in place")
+
+			stored := store.LoadBudget(ctx, caller.ID)
+			require.NotNil(t, stored)
+			assert.NotSame(t, caller, stored,
+				"the caller's pointer became the live map entry, so caller-side writes would race the usage CAS")
+			// The stored copy is the one that carries the derived count.
+			assert.Equal(t, 1, stored.OverrideCyclesRemaining,
+				"stored budget should have two of three granted windows spent")
+		})
+	}
+}
+
+// TestDumpBudgetsPersistsUsageAndNeverRewindsBoundary covers both directions of the
+// dump guard.
+//
+// The usage statement writes last_reset, and the derived override count is a function
+// of (anchor, last_reset), so a stale snapshot must not move the persisted boundary
+// backwards: that re-opens a window the cluster already spent. Reachable on leader
+// change, when a follower still on the older boundary takes over and dumps before its
+// own sweep catches up. Equally important is the other direction, which is why the
+// guard is <= and not <: in steady state the persisted boundary equals the in-memory
+// one, and a < guard would match zero rows and stop persisting usage entirely.
+//
+// Boundaries here are anchored on the present, not on cycleTestAnchor, so the budget is
+// never already due and no sweep moves the boundary out from under the assertions.
+func TestDumpBudgetsPersistsUsageAndNeverRewindsBoundary(t *testing.T) {
+	ctx := context.Background()
+	logger := NewMockLogger()
+	const window = 24 * time.Hour
+	now := time.Now().UTC().Truncate(time.Second)
+
+	newStore := func(t *testing.T, seeded *configstoreTables.TableBudget) (*LocalGovernanceStore, configstore.ConfigStore) {
+		t.Helper()
+		configStore, err := configstore.NewConfigStore(ctx, &configstore.Config{
+			Enabled: true,
+			Type:    configstore.ConfigStoreTypeSQLite,
+			Config:  &configstore.SQLiteConfig{Path: t.TempDir() + "/dump.db"},
+		}, logger)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, configStore.Close(ctx)) })
+		require.NoError(t, configStore.CreateBudget(ctx, seeded))
+		store, err := NewLocalGovernanceStore(ctx, logger, configStore, nil, nil)
+		require.NoError(t, err)
+		return store, configStore
+	}
+
+	// seedBudget builds a budget whose current window opened at now, so WindowStart(now)
+	// equals LastReset and nothing is due.
+	seedBudget := func(id string) *configstoreTables.TableBudget {
+		budget := buildBudgetWithUsage(id, 1000, 0, "24h")
+		budget.CreatedAt = now
+		budget.UpdatedAt = now
+		budget.LastReset = now
+		return budget
+	}
+
+	t.Run("unchanged boundary still persists usage", func(t *testing.T) {
+		seeded := seedBudget("dump-steady-budget")
+		store, configStore := newStore(t, seeded)
+
+		require.NoError(t, store.BumpBudgetUsage(ctx, seeded.ID, 12.5))
+		live := store.LoadBudget(ctx, seeded.ID)
+		require.NotNil(t, live)
+		require.True(t, live.LastReset.Equal(now), "precondition: no sweep should have moved the boundary")
+		require.NoError(t, store.DumpBudgets(ctx, nil))
+
+		persisted, err := configStore.GetBudget(ctx, seeded.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 12.5, persisted.CurrentUsage,
+			"usage must persist when the boundary has not moved: a < guard would match zero rows here")
+	})
+
+	t.Run("stale boundary cannot rewind the persisted one", func(t *testing.T) {
+		// The database already holds the current boundary, as an earlier leader left it.
+		seeded := seedBudget("dump-rewind-budget")
+		store, configStore := newStore(t, seeded)
+
+		// This node is a window behind and has not swept yet.
+		stale := store.LoadBudget(ctx, seeded.ID)
+		require.NotNil(t, stale)
+		rewound := *stale
+		rewound.LastReset = now.Add(-window)
+		rewound.CurrentUsage = 5
+		store.budgets.Store(seeded.ID, &rewound)
+
+		require.NoError(t, store.DumpBudgets(ctx, nil))
+
+		persisted, err := configStore.GetBudget(ctx, seeded.ID)
+		require.NoError(t, err)
+		assert.True(t, persisted.LastReset.UTC().Equal(now),
+			"a stale snapshot rewound the persisted boundary to %s, re-opening a spent window", persisted.LastReset.UTC())
+	})
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -277,6 +277,27 @@ func (gs *LocalGovernanceStore) LoadBudget(ctx context.Context, budgetID string)
 	return nil
 }
 
+// storeBudget publishes a budget into the shared budgets map after re-deriving its
+// finite-override lifecycle from the immutable grant.
+//
+// Every path that installs a budget funnels through here, which is what makes the
+// derived override count safe. It is a pure function of (OverrideAnchorReset,
+// OverrideCyclesTotal, LastReset), so deriving it at the moment of storage means no
+// caller can install a stale count by accident: a config reload replaying a persisted
+// row, an admin edit, access-profile propagation and the initial load from the database
+// all converge on the same answer. It also means a restarting node recomputes the count
+// rather than trusting whatever was last persisted.
+//
+// Callers stay responsible for preserving CurrentUsage and LastReset, since LastReset
+// is what decides which window the derivation is relative to.
+func (gs *LocalGovernanceStore) storeBudget(budgetID string, budget *configstoreTables.TableBudget) {
+	if budget == nil {
+		return
+	}
+	budget.RefreshOverrideCyclesRemaining()
+	gs.budgets.Store(budgetID, budget)
+}
+
 // UpsertBudgetConfig publishes a budget config under budgetID, preserving the
 // in-memory CurrentUsage and LastReset from any prior snapshot so a concurrent
 // BumpBudgetUsage or ResetBudgetAt is never clobbered by a config replacement.
@@ -288,6 +309,16 @@ func (gs *LocalGovernanceStore) LoadBudget(ctx context.Context, budgetID string)
 // a budget — whether fresh load or config replacement — should funnel through
 // here so counters are never clobbered by an admin edit racing with a usage
 // increment.
+//
+// The override grant (OverrideAmount / OverrideMode / OverrideCyclesTotal /
+// OverrideAnchorReset) is taken from the incoming config, which is safe because a
+// grant is immutable for its life: a reload carrying a stale row replays the same
+// values, and RefreshOverrideCyclesRemaining then re-derives the spent count from
+// the preserved LastReset. That is what stops a reload from handing back a cycle
+// the reset path already spent. Previously the mutable remaining count came
+// straight from the incoming config while LastReset stayed advanced, so the
+// window's cycle could never be spent again and the override outlived its grant
+// by a different amount on every node.
 func (gs *LocalGovernanceStore) UpsertBudgetConfig(ctx context.Context, budgetID string, config *configstoreTables.TableBudget) {
 	if config == nil {
 		return
@@ -295,19 +326,31 @@ func (gs *LocalGovernanceStore) UpsertBudgetConfig(ctx context.Context, budgetID
 	for {
 		raw, exists := gs.budgets.Load(budgetID)
 		if !exists {
-			if _, loaded := gs.budgets.LoadOrStore(budgetID, config); !loaded {
+			// Publish a copy, never the caller's struct. Storing config directly would
+			// mutate it in place via the refresh and then alias it as the live map
+			// entry, so any later caller-side write would race BumpBudgetUsage's
+			// clone-and-CAS. Callers legitimately pass a pointer into a slice they keep
+			// using (BulkLoadUserAccessProfiles passes &p.Budgets[j]), so the copy has
+			// to happen here rather than relying on every caller to make one.
+			fresh := *config
+			fresh.RefreshOverrideCyclesRemaining()
+			if _, loaded := gs.budgets.LoadOrStore(budgetID, &fresh); !loaded {
 				return
 			}
 			continue
 		}
 		old, ok := raw.(*configstoreTables.TableBudget)
 		if !ok || old == nil {
-			gs.budgets.Store(budgetID, config)
+			// Same reasoning as the not-exists branch above: storeBudget refreshes and
+			// stores what it is given, so hand it a copy.
+			replacement := *config
+			gs.storeBudget(budgetID, &replacement)
 			return
 		}
 		merged := *config
 		merged.CurrentUsage = old.CurrentUsage
 		merged.LastReset = old.LastReset
+		merged.RefreshOverrideCyclesRemaining()
 		if gs.budgets.CompareAndSwap(budgetID, raw, &merged) {
 			return
 		}
@@ -445,10 +488,18 @@ func (gs *LocalGovernanceStore) BumpBudgetUsage(ctx context.Context, budgetID st
 			// resetExpiredBudgetFromSnapshot so DB delta folding stays
 			// consistent. Only the reset hook (DB persistence of LastReset)
 			// is skipped on the request path.
+			//
+			// budgetResetTarget returns a window boundary, so applying it makes
+			// the next evaluation return nil and this branch is unreachable for
+			// any valid duration. It survives purely as a termination guard.
+			//
+			// Skipping the hook is safe for the override lifecycle: the remaining
+			// count is derived from the grant and LastReset, so nothing needs
+			// persisting here beyond LastReset itself, which the next dump writes.
 			gs.logger.Error("budget %s reset target not converging after %d resets; applying inline reset to avoid request-path spin", budgetID, resetAttempts)
 			clone.CurrentUsage = 0
 			clone.LastReset = *target
-			clone.ConsumeOverrideCycle()
+			clone.RefreshOverrideCyclesRemaining()
 			gs.LastDBUsagesBudgetsMu.Lock()
 			gs.LastDBUsagesBudgets[budgetID] = 0
 			gs.LastDBUsagesBudgetsMu.Unlock()
@@ -575,7 +626,7 @@ func (gs *LocalGovernanceStore) ResetBudgetAt(ctx context.Context, budgetID stri
 		clone := *old
 		clone.CurrentUsage = 0
 		clone.LastReset = newLastReset
-		clone.ConsumeOverrideCycle()
+		clone.RefreshOverrideCyclesRemaining()
 		if gs.budgets.CompareAndSwap(budgetID, raw, &clone) {
 			return &clone, true
 		}
@@ -617,6 +668,73 @@ func (gs *LocalGovernanceStore) ResetRateLimitAt(ctx context.Context, rateLimitI
 		}
 		if !didReset {
 			return nil, false
+		}
+		if gs.rateLimits.CompareAndSwap(rateLimitID, raw, &clone) {
+			return &clone, true
+		}
+	}
+}
+
+// RebaseBudget atomically installs a cluster-authoritative usage value and, when
+// newLastReset is non-nil, raises LastReset toward it. Returns the rebased
+// snapshot and true when the swap landed; (nil, false) when the budget is absent.
+//
+// LastReset is never moved backward. A leader state sync that arrives after this
+// node already crossed a boundary must not reopen the window it closed: with
+// boundaries deterministic, the leader is publishing a value this node already
+// holds, so a backward move could only ever un-spend an override cycle. The
+// derived override count is refreshed inside the same clone, so remaining and
+// LastReset can never be observed out of step.
+//
+// Callers applying remote state must funnel through here rather than mutating the
+// pointer returned by GetGovernanceData, which is a live entry in the budgets
+// sync.Map: writing through it races BumpBudgetUsage's clone-and-CAS and can drop
+// a concurrent usage increment.
+func (gs *LocalGovernanceStore) RebaseBudget(ctx context.Context, budgetID string, newUsage float64, newLastReset *time.Time) (*configstoreTables.TableBudget, bool) {
+	for {
+		raw, exists := gs.budgets.Load(budgetID)
+		if !exists || raw == nil {
+			return nil, false
+		}
+		old, ok := raw.(*configstoreTables.TableBudget)
+		if !ok || old == nil {
+			return nil, false
+		}
+		clone := *old
+		clone.CurrentUsage = newUsage
+		if newLastReset != nil && clone.LastReset.Before(*newLastReset) {
+			clone.LastReset = *newLastReset
+		}
+		clone.RefreshOverrideCyclesRemaining()
+		if gs.budgets.CompareAndSwap(budgetID, raw, &clone) {
+			return &clone, true
+		}
+	}
+}
+
+// RebaseRateLimit atomically installs cluster-authoritative token and request
+// usage values and raises each dimension's LastReset toward the supplied target
+// when it is non-nil and strictly newer. Each dimension is rebased independently,
+// and neither boundary is ever moved backward. Same contract and rationale as
+// RebaseBudget. Returns the rebased snapshot and true when the swap landed.
+func (gs *LocalGovernanceStore) RebaseRateLimit(ctx context.Context, rateLimitID string, newTokens, newRequests int64, tokenLastReset, requestLastReset *time.Time) (*configstoreTables.TableRateLimit, bool) {
+	for {
+		raw, exists := gs.rateLimits.Load(rateLimitID)
+		if !exists || raw == nil {
+			return nil, false
+		}
+		old, ok := raw.(*configstoreTables.TableRateLimit)
+		if !ok || old == nil {
+			return nil, false
+		}
+		clone := *old
+		clone.TokenCurrentUsage = newTokens
+		clone.RequestCurrentUsage = newRequests
+		if tokenLastReset != nil && clone.TokenLastReset.Before(*tokenLastReset) {
+			clone.TokenLastReset = *tokenLastReset
+		}
+		if requestLastReset != nil && clone.RequestLastReset.Before(*requestLastReset) {
+			clone.RequestLastReset = *requestLastReset
 		}
 		if gs.rateLimits.CompareAndSwap(rateLimitID, raw, &clone) {
 			return &clone, true
@@ -1055,17 +1173,24 @@ func (gs *LocalGovernanceStore) CheckRateLimit(ctx context.Context, entityWiseRa
 // The idea is to keep this as a common method for checking all budgets. The entire business logic resides in here
 func (gs *LocalGovernanceStore) CheckBudget(ctx context.Context, entityWiseBudgets EntityWiseBudgets, baselines map[string]float64) (Decision, error) {
 	// Check each budget in hierarchy order using in-memory data
+	now := time.Now()
 	for entity, budgets := range entityWiseBudgets {
-		for _, budget := range budgets { // Check if budget needs reset (in-memory check)
-			if budget.ResetDuration != "" {
-				if duration, err := configstoreTables.ParseDuration(budget.ResetDuration); err == nil {
-					if time.Since(budget.LastReset) >= duration {
-						// Budget expired but hasn't been reset yet - treat as reset
-						// Note: actual reset will happen in post-hook via AtomicBudgetUpdate
-						gs.logger.Debug("LocalStore CheckBudget: Budget %s (%s) expired, skipping check", budget.ID, entity)
-						continue // Skip budget check for expired budgets
-					}
-				}
+		for _, budget := range budgets {
+			// Whether the window has closed must be decided by exactly the same
+			// predicate the reset path uses. Open-coding it here previously
+			// disagreed with budgetResetTarget in two ways: it ignored
+			// IsCalendarAligned, so a calendar-aligned budget was judged on a
+			// rolling clock for enforcement while resetting on the calendar; and
+			// it had no non-positive-duration guard, so because time.Since is
+			// always at least zero such a budget skipped enforcement forever,
+			// which is unlimited spend.
+			//
+			// An expired-but-unswept budget is skipped rather than denied: the
+			// reset lands on the next sweep or in the post-request usage bump,
+			// and skipping errs permissive for at most one ticker interval.
+			if gs.budgetResetTarget(budget, now) != nil {
+				gs.logger.Debug("LocalStore CheckBudget: Budget %s (%s) expired, skipping check", budget.ID, entity)
+				continue
 			}
 			baseline, exists := baselines[budget.ID]
 			if !exists {
@@ -1836,32 +1961,44 @@ func (gs *LocalGovernanceStore) UpdateUserRateLimitUsageInMemory(ctx context.Con
 	return nil
 }
 
-// budgetResetTarget returns the LastReset value to write when budget is expired.
+// budgetResetTarget returns the LastReset value to write when budget is expired,
+// or nil when the current window is still open.
+//
+// The returned value is always a window boundary from TableBudget.WindowStart,
+// never the caller's wall clock. That distinction is the whole point: a boundary
+// is a pure function of the persisted row, so every node in a cluster writes the
+// identical value and the LastReset guards in ResetBudgetAt and in the reset SQL
+// collapse duplicate work instead of each node advancing to its own timestamp.
+// Stamping now() instead makes LastReset a function of ticker phase, which then
+// becomes the origin of that node's next window, so the phase error compounds
+// every cycle. LastReset is only ever read here to decide whether to write; it
+// never influences what gets written.
+//
+// A gap of many windows collapses to a single reset at the current boundary
+// rather than replaying one reset per elapsed window, and applying the returned
+// target makes an immediate re-evaluation return nil, so a target can never be
+// perpetually due (issue #4851 class).
 func (gs *LocalGovernanceStore) budgetResetTarget(budget *configstoreTables.TableBudget, now time.Time) *time.Time {
 	if budget == nil || budget.ResetDuration == "" {
 		return nil
 	}
 	// Sub-day durations have no calendar boundary; see rateLimitResetTarget.
-	if budget.IsCalendarAligned && configstoreTables.IsCalendarAlignableDuration(budget.ResetDuration) {
-		currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
-		if currentPeriodStart.After(budget.LastReset) {
-			return &currentPeriodStart
+	// WindowStart applies the same guard, so validation here exists purely to
+	// surface a misconfigured duration in the logs.
+	if !budget.IsCalendarAligned || !configstoreTables.IsCalendarAlignableDuration(budget.ResetDuration) {
+		duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
+		if err != nil {
+			gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
+			return nil
 		}
-		return nil
+		if duration <= 0 {
+			gs.logger.Error("non-positive budget reset duration %s: budget will not auto-reset", budget.ResetDuration)
+			return nil
+		}
 	}
-	duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
-	if err != nil {
-		gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
-		return nil
-	}
-	// A non-positive duration would be perpetually due, spinning BumpBudgetUsage
-	// forever (issue #4851 class); treat it as invalid, same as unparseable.
-	if duration <= 0 {
-		gs.logger.Error("non-positive budget reset duration %s: budget will not auto-reset", budget.ResetDuration)
-		return nil
-	}
-	if now.Sub(budget.LastReset) >= duration {
-		return &now
+	target := budget.WindowStart(now)
+	if target.After(budget.LastReset) {
+		return &target
 	}
 	return nil
 }
@@ -1932,7 +2069,12 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context,
 // calendar-aligned, mirroring the handler-side snap logic. Without this guard
 // GetCalendarPeriodStart returns now for sub-day durations, making the reset
 // target perpetually due and spinning BumpRateLimitUsage forever (issue #4851).
-func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, calendarAligned bool, lastReset time.Time, now time.Time) *time.Time {
+// The returned value is a window boundary anchored on the rate limit's
+// CreatedAt, never the caller's wall clock, so every cluster node computes the
+// same instant from the same persisted row. See budgetResetTarget for why that
+// matters; the two must stay in step because a rate limit and a budget on the
+// same owner are expected to roll over together.
+func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, calendarAligned bool, anchor, lastReset time.Time, now time.Time) *time.Time {
 	if resetDuration == nil {
 		return nil
 	}
@@ -1954,19 +2096,27 @@ func (gs *LocalGovernanceStore) rateLimitResetTarget(resetDuration *string, cale
 		gs.logger.Error("non-positive rate limit reset duration %s: counter will not auto-reset", *resetDuration)
 		return nil
 	}
-	if now.Sub(lastReset) >= duration {
-		return &now
+	if anchor.IsZero() {
+		anchor = lastReset
+	}
+	target := configstoreTables.RollingWindowStart(anchor, duration, now)
+	if target.After(lastReset) {
+		return &target
 	}
 	return nil
 }
 
 // rateLimitResetTargets returns reset targets for the token and request counters.
+// Both dimensions share the rate limit's CreatedAt as their lattice anchor, so
+// they stay phase-locked to each other as well as across nodes.
 func (gs *LocalGovernanceStore) rateLimitResetTargets(rateLimit *configstoreTables.TableRateLimit, now time.Time) (*time.Time, *time.Time) {
 	if rateLimit == nil {
 		return nil, nil
 	}
 	calendarAligned := rateLimit.IsCalendarAligned
-	return gs.rateLimitResetTarget(rateLimit.TokenResetDuration, calendarAligned, rateLimit.TokenLastReset, now), gs.rateLimitResetTarget(rateLimit.RequestResetDuration, calendarAligned, rateLimit.RequestLastReset, now)
+	anchor := rateLimit.CreatedAt
+	return gs.rateLimitResetTarget(rateLimit.TokenResetDuration, calendarAligned, anchor, rateLimit.TokenLastReset, now),
+		gs.rateLimitResetTarget(rateLimit.RequestResetDuration, calendarAligned, anchor, rateLimit.RequestLastReset, now)
 }
 
 // resetExpiredRateLimitFromSnapshot applies the local side effects for an expired rate-limit snapshot.
@@ -2053,6 +2203,8 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgets(ctx context.Context, resetBu
 						"override_amount":           budget.OverrideAmount,
 						"override_mode":             budget.OverrideMode,
 						"override_cycles_remaining": budget.OverrideCyclesRemaining,
+						"override_cycles_total":     budget.OverrideCyclesTotal,
+						"override_anchor_reset":     budget.OverrideAnchorReset,
 					})
 
 				if overrideResult.Error != nil {
@@ -2064,10 +2216,17 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgets(ctx context.Context, resetBu
 
 				// Direct UPDATE only resets current_usage and last_reset
 				// This prevents overwriting max_limit or reset_duration that may have been changed by other nodes/requests
+				//
+				// Guarded on last_reset for the same reason as the override write
+				// above, and the two guards must match: without it a snapshot
+				// that lost the override race still advanced last_reset, leaving
+				// the row with a newer boundary but older override state, which
+				// is precisely the split that lets a window's override cycle go
+				// unspent. Either both statements land or neither does.
 				result := tx.WithContext(ctx).
 					Session(&gorm.Session{SkipHooks: true}).
 					Model(&configstoreTables.TableBudget{}).
-					Where("id = ?", budget.ID).
+					Where("id = ? AND last_reset < ?", budget.ID, budget.LastReset).
 					Updates(map[string]interface{}{
 						"current_usage": budget.CurrentUsage,
 						"last_reset":    budget.LastReset,
@@ -2091,31 +2250,44 @@ func (gs *LocalGovernanceStore) ResetExpiredRateLimits(ctx context.Context, rese
 	if len(resetRateLimits) > 0 && gs.configStore != nil {
 		if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 			for _, rateLimit := range resetRateLimits {
-				// Build update map with only the fields that were reset
-				updates := make(map[string]interface{})
-
-				// Check which fields were reset by comparing with current values
-				if rateLimit.TokenCurrentUsage == 0 && rateLimit.TokenResetDuration != nil {
-					updates["token_current_usage"] = 0
-					updates["token_last_reset"] = rateLimit.TokenLastReset
-				}
-				if rateLimit.RequestCurrentUsage == 0 && rateLimit.RequestResetDuration != nil {
-					updates["request_current_usage"] = 0
-					updates["request_last_reset"] = rateLimit.RequestLastReset
-				}
-
-				if len(updates) > 0 {
+				// Each dimension is written by its own statement guarded on its
+				// own boundary column. Deciding what to write by testing whether
+				// the in-memory counter is still zero was wrong: under sustained
+				// traffic a request bumps the counter back above zero between the
+				// in-memory reset and this write, so the whole field pair was
+				// dropped, including the boundary column. The database boundary
+				// then never advanced and the counter read as perpetually due on
+				// the next restart.
+				//
+				// The boundary guard is the correct expression of "this snapshot
+				// advanced the window", and it holds regardless of racing usage.
+				// A dimension that was not reset in this sweep is a no-op because
+				// its in-memory boundary already equals the persisted one.
+				writeDimension := func(durationSet bool, usageColumn, boundaryColumn string, boundary time.Time) error {
+					if !durationSet {
+						return nil
+					}
 					// Direct UPDATE only resets usage and last_reset fields
 					// This prevents overwriting max_limit or reset_duration that may have been changed by other nodes/requests
 					result := tx.WithContext(ctx).
 						Session(&gorm.Session{SkipHooks: true}).
 						Model(&configstoreTables.TableRateLimit{}).
-						Where("id = ?", rateLimit.ID).
-						Updates(updates)
-
+						Where("id = ? AND "+boundaryColumn+" < ?", rateLimit.ID, boundary).
+						Updates(map[string]interface{}{
+							usageColumn:    0,
+							boundaryColumn: boundary,
+						})
 					if result.Error != nil {
-						return fmt.Errorf("failed to reset rate limit %s: %w", rateLimit.ID, result.Error)
+						return fmt.Errorf("failed to reset rate limit %s %s: %w", rateLimit.ID, boundaryColumn, result.Error)
 					}
+					return nil
+				}
+
+				if err := writeDimension(rateLimit.TokenResetDuration != nil, "token_current_usage", "token_last_reset", rateLimit.TokenLastReset); err != nil {
+					return err
+				}
+				if err := writeDimension(rateLimit.RequestResetDuration != nil, "request_current_usage", "request_last_reset", rateLimit.RequestLastReset); err != nil {
+					return err
 				}
 			}
 			return nil
@@ -2253,13 +2425,17 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 					newUsage += baseline
 				}
 
-				// The override trio mutated by ConsumeOverrideCycle is flushed first
-				// under a monotonic last_reset guard: it only fires when this node
-				// performed a reset the database has not seen, which is exactly when
-				// its override snapshot is authoritative. An unguarded write would let
-				// a node with a stale in-memory override clobber a newer admin update
-				// every dump cycle. This must run BEFORE the usage write below, which
-				// advances last_reset and would close the guard within this transaction.
+				// The override state is flushed first under a monotonic last_reset
+				// guard: it only fires when this node performed a reset the database
+				// has not seen, which is exactly when its override snapshot is
+				// authoritative. An unguarded write would let a node with a stale
+				// in-memory override clobber a newer admin update every dump cycle.
+				// This must run BEFORE the usage write below, which advances
+				// last_reset and would close the guard within this transaction.
+				//
+				// The grant columns travel with the derived remaining count so a
+				// reader can never see one without the other, which would let it
+				// re-derive a different count from a half-written row.
 				overrideResult := tx.WithContext(ctx).
 					Session(&gorm.Session{SkipHooks: true}).
 					Model(&configstoreTables.TableBudget{}).
@@ -2268,6 +2444,8 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 						"override_amount":           inMemoryBudget.OverrideAmount,
 						"override_mode":             inMemoryBudget.OverrideMode,
 						"override_cycles_remaining": inMemoryBudget.OverrideCyclesRemaining,
+						"override_cycles_total":     inMemoryBudget.OverrideCyclesTotal,
+						"override_anchor_reset":     inMemoryBudget.OverrideAnchorReset,
 					})
 
 				if overrideResult.Error != nil {
@@ -2276,10 +2454,24 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 
 				// Direct UPDATE avoids read-then-write lock escalation that causes deadlocks
 				// Use Session with SkipHooks to avoid triggering BeforeSave hook validation
+				//
+				// Guarded so a stale snapshot cannot move the persisted boundary
+				// backwards. This statement writes last_reset, and the derived override
+				// count is a function of (anchor, last_reset), so a rewind re-opens a
+				// window the cluster already spent. Reachable on leader change: the old
+				// leader dumps boundary N+1, dies, and a follower still on N takes over
+				// and dumps before its own sweep catches up.
+				//
+				// The comparison must be <=, not <. In steady state the persisted
+				// boundary equals the in-memory one, so < would match zero rows and
+				// usage would never be persisted at all. <= lets an unchanged boundary
+				// through while still rejecting a rewind. A skipped write costs one dump
+				// tick: usage stays in memory and in the gossip baselines, and the next
+				// tick persists it once this node has swept to the newer boundary.
 				result := tx.WithContext(ctx).
 					Session(&gorm.Session{SkipHooks: true}).
 					Model(&configstoreTables.TableBudget{}).
-					Where("id = ?", inMemoryBudget.ID).
+					Where("id = ? AND last_reset <= ?", inMemoryBudget.ID, inMemoryBudget.LastReset).
 					Updates(map[string]interface{}{
 						"current_usage": newUsage,
 						"last_reset":    inMemoryBudget.LastReset,
@@ -2544,7 +2736,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 	// Build budgets map
 	for i := range budgets {
 		budget := &budgets[i]
-		gs.budgets.Store(budget.ID, budget)
+		gs.storeBudget(budget.ID, budget)
 	}
 
 	// Build rate limits map
@@ -2572,7 +2764,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 		// Mirrors how VK/team budgets are stamped from their owner.
 		for j := range mc.Budgets {
 			mc.Budgets[j].IsCalendarAligned = mc.CalendarAligned
-			gs.budgets.Store(mc.Budgets[j].ID, &mc.Budgets[j])
+			gs.storeBudget(mc.Budgets[j].ID, &mc.Budgets[j])
 		}
 		if mc.RateLimit != nil {
 			mc.RateLimit.IsCalendarAligned = mc.CalendarAligned
@@ -2605,7 +2797,7 @@ func (gs *LocalGovernanceStore) rebuildInMemoryStructures(ctx context.Context, c
 		customer := &customers[i]
 		for j := range customer.Budgets {
 			customer.Budgets[j].IsCalendarAligned = customer.CalendarAligned
-			gs.budgets.Store(customer.Budgets[j].ID, &customer.Budgets[j])
+			gs.storeBudget(customer.Budgets[j].ID, &customer.Budgets[j])
 		}
 		if customer.RateLimitID != nil {
 			if raw, ok := gs.rateLimits.Load(*customer.RateLimitID); ok {
@@ -3028,7 +3220,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 	// Store budgets
 	for i := range clone.Budgets {
 		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
-		gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
+		gs.storeBudget(clone.Budgets[i].ID, &clone.Budgets[i])
 	}
 
 	// Create associated rate limit if exists
@@ -3043,7 +3235,7 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 			pc := &clone.ProviderConfigs[i]
 			for j := range pc.Budgets {
 				pc.Budgets[j].IsCalendarAligned = clone.CalendarAligned
-				gs.budgets.Store(pc.Budgets[j].ID, &pc.Budgets[j])
+				gs.storeBudget(pc.Budgets[j].ID, &pc.Budgets[j])
 			}
 			if pc.RateLimit != nil {
 				pc.RateLimit.IsCalendarAligned = clone.CalendarAligned
@@ -3114,7 +3306,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 				}
 			}
 			clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
-			gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
+			gs.storeBudget(clone.Budgets[i].ID, &clone.Budgets[i])
 		}
 		// Delete removed multi-budgets
 		for _, oldBudget := range existingVK.Budgets {
@@ -3201,7 +3393,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 						}
 					}
 					b.IsCalendarAligned = clone.CalendarAligned
-					gs.budgets.Store(b.ID, b)
+					gs.storeBudget(b.ID, b)
 				}
 				// Delete removed multi-budgets for this provider config
 				if existingPC, exists := existingProviderConfigs[pc.ID]; exists {
@@ -3326,7 +3518,7 @@ func (gs *LocalGovernanceStore) CreateTeamInMemory(ctx context.Context, team *co
 	for i := range clone.Budgets {
 		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
 		b := clone.Budgets[i]
-		gs.budgets.Store(b.ID, &b)
+		gs.storeBudget(b.ID, &b)
 	}
 
 	// Create associated rate limit if exists
@@ -3373,7 +3565,7 @@ func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *co
 				}
 			}
 			b.IsCalendarAligned = clone.CalendarAligned
-			gs.budgets.Store(b.ID, b)
+			gs.storeBudget(b.ID, b)
 		}
 		for id := range existingBudgetIDs {
 			if _, stillThere := nextBudgetIDs[id]; !stillThere {
@@ -3457,7 +3649,7 @@ func (gs *LocalGovernanceStore) CreateCustomerInMemory(ctx context.Context, cust
 	clone := *customer
 	for i := range clone.Budgets {
 		clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
-		gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
+		gs.storeBudget(clone.Budgets[i].ID, &clone.Budgets[i])
 	}
 	if clone.RateLimit != nil {
 		clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
@@ -3491,7 +3683,7 @@ func (gs *LocalGovernanceStore) UpdateCustomerInMemory(ctx context.Context, cust
 					b.LastReset = existingBudget.LastReset
 				}
 			}
-			gs.budgets.Store(b.ID, b)
+			gs.storeBudget(b.ID, b)
 			newBudgetIDs[b.ID] = true
 		}
 		for _, existing := range existingCustomer.Budgets {
@@ -3630,7 +3822,7 @@ func (gs *LocalGovernanceStore) UpdateModelConfigInMemory(ctx context.Context, m
 				b.LastReset = eb.LastReset
 			}
 		}
-		gs.budgets.Store(b.ID, b)
+		gs.storeBudget(b.ID, b)
 	}
 
 	// Store associated rate limit if exists, preserving existing in-memory usage and
@@ -3739,7 +3931,7 @@ func (gs *LocalGovernanceStore) UpdateProviderInMemory(ctx context.Context, prov
 				clone.Budget.CurrentUsage = eb.CurrentUsage
 			}
 		}
-		gs.budgets.Store(clone.Budget.ID, clone.Budget)
+		gs.storeBudget(clone.Budget.ID, clone.Budget)
 	}
 
 	// Store associated rate limit if exists, preserving existing in-memory usage

--- a/plugins/governance/storeconcurrency_test.go
+++ b/plugins/governance/storeconcurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,16 +95,18 @@ func TestBumpRateLimitUsage_NoLostIncrements(t *testing.T) {
 func TestResetBudgetAt_ConcurrentResettersCollapse(t *testing.T) {
 	store := newStandaloneStore(t)
 	budgetID := "reset-collapse"
-	old := buildBudget(budgetID, 1000, "1h")
-	old.LastReset = time.Now().Add(-2 * time.Hour)
-	old.CurrentUsage = 999
-	old.OverrideAmount = 25
-	old.OverrideMode = "cycles"
-	old.OverrideCyclesRemaining = 5
-	store.budgets.Store(budgetID, old)
-
 	const goroutines = 128
-	newLastReset := time.Now()
+	// Exactly one window between the grant anchor and the reset target, so the
+	// derived remaining count is unambiguous: 5 granted minus 1 window closed.
+	newLastReset := time.Now().Truncate(time.Second)
+	grantAnchor := newLastReset.Add(-time.Hour)
+
+	old := buildBudget(budgetID, 1000, "1h")
+	old.CreatedAt = grantAnchor
+	old.LastReset = grantAnchor
+	old.CurrentUsage = 999
+	require.NoError(t, old.SetOverrideAt(25, configstoreTables.BudgetOverrideModeCycles, 5, grantAnchor))
+	store.budgets.Store(budgetID, old)
 
 	var successes atomic.Int64
 	var wg sync.WaitGroup

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1591,12 +1591,16 @@ func (h *GovernanceHandler) mutateVirtualKeyBudgetOverride(ctx *fasthttp.Request
 		}
 	}
 
+	// IsCalendarAligned was stamped onto the budget by the virtual key's AfterFind
+	// during loadVirtualKeyBudget, and the store needs it to anchor a finite grant
+	// on the same lattice the budget actually resets on.
 	budget, err = h.configStore.UpdateBudgetOverride(
 		ctx,
 		budget.ID,
 		budget.OverrideAmount,
 		budget.OverrideMode,
 		budget.OverrideCyclesRemaining,
+		budget.IsCalendarAligned,
 	)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {


### PR DESCRIPTION
## Summary

Finite budget overrides previously tracked remaining cycles as independently mutable state. This caused two failure modes in a cluster: each node maintained its own tally (only the leader ever persisted one), and a config reload replaying a pre-reset row could hand back a cycle the reset path had already spent. This PR replaces the mutable decrement model with an immutable grant anchored at the window boundary where the override was created, making the remaining cycle count a pure function of `(OverrideAnchorReset, OverrideCyclesTotal, LastReset)`.

## Changes

- **Immutable grant columns**: Added `override_cycles_total` and `override_anchor_reset` to `TableBudget`. The anchor is the window boundary at grant time; the total is the number of windows granted. Both are immutable for the life of a grant.

- **Derived remaining count**: `ConsumeOverrideCycle` (decrement-per-reset) is replaced by `RefreshOverrideCyclesRemaining`, which derives the count from `OverrideCyclesTotal - WindowsSinceAnchor()`. Every node computes the same value from the same persisted row without coordination.

- **`WindowStart` and `RollingWindowStart`**: A new `WindowStart(now)` method on `TableBudget` returns the current window boundary as a pure function of the persisted row, shared by the reset path, the enforcement path, and the override-grant anchor. `RollingWindowStart` computes the lattice point for rolling budgets anchored on `CreatedAt` rather than the ticker's wall clock.

- **`CountCalendarPeriods`**: A new utility counts calendar-period boundaries between two instants using the same suffix logic as `GetCalendarPeriodStart`, so the override cycle counter and the reset path agree on the cadence.

- **`storeBudget`**: All paths that install a budget into the in-memory map now funnel through `storeBudget`, which calls `RefreshOverrideCyclesRemaining` before storing. This means a config reload replaying a stale row re-derives the correct count from the preserved `LastReset` rather than trusting the persisted remaining count.

- **`UpdateBudgetOverride` signature change**: Now accepts `cyclesTotal` and `calendarAligned` instead of `cyclesRemaining`. The grant is anchored at `WindowStart(now)` so it is never one window behind a boundary that has advanced in memory but not yet been flushed.

- **`budgetResetTarget` and `rateLimitResetTarget`**: Both now return a window boundary (lattice point) rather than `time.Now()`, so every node writes the identical `LastReset` value. Rate limit targets are anchored on `CreatedAt` to match budget behaviour.

- **`CheckBudget`**: The expiry predicate now delegates to `budgetResetTarget` instead of open-coding its own, fixing two prior disagreements: calendar-aligned budgets were judged on a rolling clock for enforcement while resetting on the calendar, and a non-positive duration skipped enforcement entirely.

- **`ResetExpiredRateLimits`**: The decision of what to write is now based on the boundary column rather than whether the in-memory counter is still zero. Under sustained traffic a request bumps the counter back above zero before the write lands, previously causing the boundary column to never advance.

- **Database writes**: `last_reset` guards are added to the budget reset SQL so duplicate resets from multiple nodes collapse correctly. Grant columns are written atomically with the derived remaining count in both `DumpBudgets` and `ResetExpiredBudgets`.

- **`StampCalendarAlignment`**: Extracted from the four `AfterFind` implementations into a single shared helper to prevent a new owner type from silently taking the rolling branch.

- **Backfill migration** (`add_budget_override_anchor_columns`): Adopts every already-active finite override by anchoring it at its current `last_reset` and granting its remaining count from there. `validateOverride` rejects a cycles override with no anchor, so an unadopted row would be treated as having no lifecycle.

- **`RebaseBudget` / `RebaseRateLimit`**: New methods for applying cluster-authoritative state that never move boundaries backward and always re-derive the override count inside the same clone.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/configstore/tables/...
go test ./plugins/governance/...
```

Key test scenarios covered:

- `TestBudgetResetTargetIsDeterministicAcrossNodes`: two nodes with out-of-phase tickers converge on the same `LastReset` boundary.
- `TestBudgetCycleSurvivesInterleavedConfigReload`: an N-cycle override grants exactly N windows even when a config reload fires inside every window.
- `TestUpsertBudgetConfigDoesNotResurrectOverrideCycles`: a reload carrying a pre-reset row cannot hand back a spent cycle.
- `TestVirtualKeyReloadDoesNotResurrectOverrideCycles`: the virtual-key reload path cannot resurrect a spent cycle.
- `TestBudgetCycleLongIdleSkipsToCurrentWindow`: a long outage collapses to a single reset at the current boundary.
- `TestCalendarAlignedOverrideToleratesWireJitter`: sub-microsecond boundary shifts from JSON round-trips do not change the calendar period count.
- `TestMigrationAddBudgetOverrideAnchorColumns`: migration is idempotent and adopts only active finite overrides.

## Breaking changes

- [x] Yes

`UpdateBudgetOverride` now takes `cyclesTotal int` and `calendarAligned bool` instead of `cyclesRemaining int`. Any caller implementing the `ConfigStore` interface must update its signature. The `ConsumeOverrideCycle` method is removed; callers should use `RefreshOverrideCyclesRemaining` instead.

A cycles override without `override_anchor_reset` is now rejected by `validateOverride`. The backfill migration adopts existing rows automatically, but any out-of-band row insertion that omits the anchor will be refused.

## Related issues

Closes #4851

## Security considerations

None beyond the governance correctness fix. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable