### PR TITLE
fixes live reload nuking model list before sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,10 @@ make test-mcp                            # All MCP tests
 make test-mcp TESTCASE=TestAgentLoop     # Specific test
 make test-mcp TYPE=agent                 # By category (agent|tool|connection|codemode)
 
+# Framework tests (require local backing services — bring them up FIRST)
+docker compose -f tests/docker-compose.yml up -d   # postgres, weaviate, qdrant, pinecone, and the 4 redis variants
+make test-framework                                # All framework packages
+
 # Plugin tests
 make test-plugins                        # All plugins
 make test-governance                     # Governance plugin specifically
@@ -501,6 +505,31 @@ E2E tests depend on `data-testid` attributes. Convention: `data-testid="<entity>
 ### 18. E2E Tests — Never Marshal Payloads to Maps
 
 In `tests/e2e/core/`, **never marshal API payloads to a `Record`/`Map`/plain-object and then re-serialize**. Field ordering matters for backend validation and snapshot comparisons. Construct payloads as object literals with fields in the intended order and pass directly to Playwright's `request.post({ data })`. Avoid `Object.fromEntries()`, `JSON.parse(JSON.stringify(...))` round-trips, or destructuring into an intermediate `Record<string, unknown>` — these can silently reorder fields.
+
+### 19. Framework Tests Need `tests/docker-compose.yml`, Not `framework/docker-compose.yml`
+
+`make test-framework` fails ~30 tests in `framework/vectorstore` with no services running. Bring the stack up first:
+
+```bash
+docker compose -f tests/docker-compose.yml up -d
+```
+
+Two compose files define overlapping services on the **same host ports** (9000, 6379, 6334, 5081), so only one can run at a time. Use the `tests/` one:
+
+| | `tests/docker-compose.yml` | `framework/docker-compose.yml` |
+|---|---|---|
+| Redis | plain 6379, **TLS 6380, cluster 7000, cluster-TLS 7100** | plain 6379 only |
+| TLS certs | `redis-certs-init` writes `tests/redis-certs/` | none |
+| Weaviate | 1.32.4, pins `CLUSTER_ADVERTISE_ADDR` | 1.25.0, no advertise addr |
+
+The differences are load-bearing, not cosmetic:
+
+- `redis_test.go` dials **6380** and **7100** for the TLS and TLS-cluster client tests, and `readTestCACert` reads `tests/redis-certs/ca.crt`. The `framework/` file provides neither, so 5 tests fail against it.
+- Weaviate's memberlist aborts startup with `Failed to get final advertise address: No private IP address found` unless `CLUSTER_ADVERTISE_ADDR` is set ([weaviate#7474](https://github.com/weaviate/weaviate/issues/7474)). The `tests/` file pins a static IP; the `framework/` file does not, so its Weaviate crash-loops and 4 more tests fail.
+
+Note that `qdrant` and `pinecone` report `(unhealthy)` in `docker compose ps` under the `framework/` file because those images have no `wget` for the healthcheck. The services themselves are fine, so ignore that specific signal and probe the port instead.
+
+Only `framework/vectorstore` needs any of this. Every other framework package passes with nothing running.
 
 ---
 

--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -75,6 +75,30 @@ func (s *Store) InvalidateProvider(provider schemas.ModelProvider) {
 	s.mu.Unlock()
 }
 
+// RetainKeys drops the provider's entries whose KeyID is absent from keep,
+// in both filtered and unfiltered modes, and leaves the rest untouched. It is
+// the narrow counterpart to InvalidateProvider: callers about to re-fetch use
+// it to prune keys that were removed or disabled while letting the surviving
+// keys' last-known-good entries stand until a successful Upsert replaces them.
+// A key named in keep that has no entry is a no-op, so callers can pass their
+// whole configured key set without first checking what is cached.
+//
+// keep is read-only and is not retained by the store. A nil or empty keep is
+// equivalent to InvalidateProvider.
+func (s *Store) RetainKeys(provider schemas.ModelProvider, keep map[string]struct{}) {
+	s.mu.Lock()
+	for k := range s.entries {
+		if k.Provider != provider {
+			continue
+		}
+		if _, ok := keep[k.KeyID]; ok {
+			continue
+		}
+		delete(s.entries, k)
+	}
+	s.mu.Unlock()
+}
+
 // ModelsForProvider returns the union of filtered entries for the provider,
 // sorted. Filtered entries are pre-gated so this is the effective allowed set
 // across the provider's keys.

--- a/framework/modelcatalog/live/store_test.go
+++ b/framework/modelcatalog/live/store_test.go
@@ -2,6 +2,7 @@ package live
 
 import (
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -85,6 +86,165 @@ func TestInvalidateProviderDropsEverything(t *testing.T) {
 	}
 	if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-3-5-sonnet"}) {
 		t.Errorf("anthropic untouched = %v, want [claude-3-5-sonnet]", got)
+	}
+}
+
+func TestRetainKeysDropsOnlyMissingKeys(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertUnfiltered(s, openai, "k1", []string{"gpt-4o", "gpt-4o-mini"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+	upsertUnfiltered(s, openai, "k2", []string{"o1", "o1-mini"})
+	upsertFiltered(s, openai, "k3", []string{"o3"})
+	upsertFiltered(s, anthropic, "k9", []string{"claude-3-5-sonnet"})
+
+	s.RetainKeys(openai, map[string]struct{}{"k1": {}, "k3": {}})
+
+	// k2 is gone in both modes; k1 and k3 survive in both.
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o", "o3"}) {
+		t.Errorf("filtered after RetainKeys = %v, want [gpt-4o o3]", got)
+	}
+	if got := s.UnfilteredModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o", "gpt-4o-mini"}) {
+		t.Errorf("unfiltered after RetainKeys = %v, want [gpt-4o gpt-4o-mini]", got)
+	}
+	if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-3-5-sonnet"}) {
+		t.Errorf("other provider must be untouched, got %v", got)
+	}
+}
+
+func TestRetainKeysEmptyKeepSetDropsAll(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		keep map[string]struct{}
+	}{
+		{"nil keep set", nil},
+		{"empty keep set", map[string]struct{}{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(nil)
+			upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+			upsertFiltered(s, anthropic, "k9", []string{"claude-3-5-sonnet"})
+
+			s.RetainKeys(openai, tt.keep)
+
+			if got := s.ModelsForProvider(openai); len(got) != 0 {
+				t.Errorf("openai after empty RetainKeys = %v, want empty", got)
+			}
+			if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-3-5-sonnet"}) {
+				t.Errorf("other provider must be untouched, got %v", got)
+			}
+		})
+	}
+}
+
+// TestRetainKeysKeylessSentinel pins the "" key ID (used by keyless providers
+// such as Vertex and Bedrock) as an ordinary retainable member of the keep
+// set, not a wildcard or an absent entry.
+func TestRetainKeysKeylessSentinel(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, schemas.Vertex, "", []string{"gemini-2.0-flash"})
+	upsertFiltered(s, schemas.Vertex, "stale-key", []string{"gemini-1.0-pro"})
+
+	s.RetainKeys(schemas.Vertex, map[string]struct{}{"": {}})
+
+	if got := s.ModelsForProvider(schemas.Vertex); !slices.Equal(got, []string{"gemini-2.0-flash"}) {
+		t.Errorf("keyless retain = %v, want [gemini-2.0-flash]", got)
+	}
+}
+
+// TestRetainKeysUnknownKeepEntriesAreHarmless covers the reload race where a
+// key is in the config but was never successfully fetched: naming it in the
+// keep set must not fabricate an entry or disturb the others.
+func TestRetainKeysUnknownKeepEntriesAreHarmless(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+
+	s.RetainKeys(openai, map[string]struct{}{"k1": {}, "never-fetched": {}})
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("after RetainKeys with unknown member = %v, want [gpt-4o]", got)
+	}
+	if n := len(s.Snapshot()); n != 1 {
+		t.Errorf("Snapshot has %d entries, want 1 (no entry fabricated)", n)
+	}
+}
+
+// TestRetainKeysIsRaceFreeUnderConcurrentAccess exercises RetainKeys against
+// every other mutator and reader on the store at once. RetainKeys is the only
+// method that both iterates the map and deletes from it, so it is the one most
+// likely to be written without the write lock, and a map iteration racing a
+// concurrent write is a runtime throw rather than a silent corruption. Run
+// under -race to catch the unsynchronized case even when the scheduler happens
+// not to interleave them.
+func TestRetainKeysIsRaceFreeUnderConcurrentAccess(t *testing.T) {
+	s := New(nil)
+	const goroutines = 8
+	const iterations = 200
+
+	providers := []schemas.ModelProvider{openai, anthropic}
+	keyIDs := []string{"", "k1", "k2", "k3"}
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			p := providers[g%len(providers)]
+			for i := range iterations {
+				keyID := keyIDs[i%len(keyIDs)]
+				switch g % 4 {
+				case 0:
+					s.Upsert(p, keyID, i%2 == 0, []string{"model-a", "model-b"})
+				case 1:
+					// Alternate the retained set so entries are constantly
+					// being pruned and repopulated underneath the readers.
+					keep := map[string]struct{}{keyID: {}}
+					if i%3 == 0 {
+						keep["k1"] = struct{}{}
+					}
+					s.RetainKeys(p, keep)
+				case 2:
+					_ = s.ModelsForProvider(p)
+					_ = s.UnfilteredModelsForProvider(p)
+				case 3:
+					if i%5 == 0 {
+						s.Invalidate(p, keyID)
+					}
+					_ = s.Snapshot()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Sanity check that the store is still coherent rather than merely
+	// race-free: a final retain must leave a readable, well-formed view.
+	s.Upsert(openai, "k1", false, []string{"model-a"})
+	s.RetainKeys(openai, map[string]struct{}{"k1": {}})
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"model-a"}) {
+		t.Fatalf("store incoherent after concurrent access: %v", got)
+	}
+}
+
+// TestRetainKeysDoesNotRetainCallerMap pins the ownership half of the
+// concurrency contract: the store must not hold a reference to the caller's
+// keep map, or a caller reusing or mutating that map after the call would be
+// racing the store's internals.
+func TestRetainKeysDoesNotRetainCallerMap(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+	upsertFiltered(s, openai, "k2", []string{"o1"})
+
+	keep := map[string]struct{}{"k1": {}}
+	s.RetainKeys(openai, keep)
+
+	// Mutating the caller's map afterwards must not retroactively change what
+	// the store kept.
+	keep["k2"] = struct{}{}
+	delete(keep, "k1")
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Fatalf("store observed post-call mutation of the keep map: %v, want [gpt-4o]", got)
 	}
 }
 

--- a/framework/modelcatalog/pool.go
+++ b/framework/modelcatalog/pool.go
@@ -35,6 +35,13 @@ func (mc *ModelCatalog) InvalidateLiveProvider(provider schemas.ModelProvider) {
 	mc.live.InvalidateProvider(provider)
 }
 
+// RetainLiveKeys prunes the provider's live entries down to the keys in keep,
+// leaving those keys' cached models in place. Used before a re-fetch so a
+// failed list-models call cannot empty a catalog that was valid a moment ago.
+func (mc *ModelCatalog) RetainLiveKeys(provider schemas.ModelProvider, keep map[string]struct{}) {
+	mc.live.RetainKeys(provider, keep)
+}
+
 // SetKeyConfigForProvider replaces the keyconfig snapshot for one provider.
 func (mc *ModelCatalog) SetKeyConfigForProvider(provider schemas.ModelProvider, keys []schemas.Key) {
 	mc.keyconf.SetProvider(provider, keys)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -668,13 +668,43 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 	isKeylessProvider := providerInfo.CustomProviderConfig != nil && providerInfo.CustomProviderConfig.IsKeyLess
 	hasNoKeys := len(inMemoryKeys) == 0 && !isKeylessProvider
 
-	// Refresh keyconfig from the current key list, then drop any stale live
-	// entries (for keys removed in this update) before refetching per-key.
+	// Refresh keyconfig from the current key list, then reconcile the live
+	// entries against it before refetching per-key.
 	s.Config.ModelCatalog.SetKeyConfigForProvider(provider, inMemoryKeys)
-	s.Config.ModelCatalog.InvalidateLiveProvider(provider)
 	if hasNoKeys {
+		// Nothing left to route through, and nothing will ever refresh these
+		// entries, so no cached response is still meaningful.
+		s.Config.ModelCatalog.InvalidateLiveProvider(provider)
 		logger.Warn("model discovery skipped for provider %s: no keys configured", provider)
 	} else {
+		// Prune only the keys that are gone or disabled and leave the
+		// survivors' entries in place for the refetch below to overwrite.
+		// FetchAndStoreLiveForKey writes nothing when the upstream call fails,
+		// so wiping the provider up front turned any transient list-models
+		// failure (5xx, rate limit, timeout, a restarting gateway) into an
+		// empty catalog for a provider that was perfectly healthy a moment
+		// earlier, with no background refresher to heal it.
+		//
+		// The trade is deliberate: entries survive a failed refetch even when
+		// this reload changed base_url or the custom provider config, so they
+		// can briefly describe the previous upstream. That is strictly the
+		// smaller blast radius, since an emptied catalog makes every model
+		// unroutable rather than just the ones that moved.
+		keep := make(map[string]struct{}, len(inMemoryKeys)+1)
+		if isKeylessProvider {
+			// Keyless providers cache under the empty-string sentinel, which
+			// is also what the OnKey* helpers write under for this provider.
+			keep[""] = struct{}{}
+		}
+		for _, key := range inMemoryKeys {
+			// Mirror RefreshLiveModelsForProvider's skip rule: a disabled key
+			// is never refetched, so retaining its entries would serve models
+			// for a key core rejects at routing time.
+			if keyEnabled(key) {
+				keep[key.ID] = struct{}{}
+			}
+		}
+		s.Config.ModelCatalog.RetainLiveKeys(provider, keep)
 		s.RefreshLiveModelsForProvider(ctx, provider, inMemoryKeys)
 	}
 	return updatedProvider, nil

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"context"
+	"slices"
+	"sync"
 	"testing"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
@@ -238,6 +242,228 @@ func TestOnKeyUpdated_DisabledKeySkipsFetchButInvalidatesCache(t *testing.T) {
 
 	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) != 0 {
 		t.Fatalf("expected InvalidateLive to drop the disabled key's cached models, got %v", models)
+	}
+}
+
+// reloadProviderConfigStore is the minimum ConfigStore ReloadProvider needs:
+// it only ever calls GetProvider before touching the model catalog.
+type reloadProviderConfigStore struct {
+	configstore.ConfigStore
+	provider *configstoreTables.TableProvider
+}
+
+func (s *reloadProviderConfigStore) GetProvider(context.Context, schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+	return s.provider, nil
+}
+
+// newReloadProviderServer builds a BifrostHTTPServer wired for ReloadProvider
+// with model discovery guaranteed to write nothing.
+//
+// Disabling list_models via AllowedRequests makes FetchAndStoreLiveForKey
+// return before it issues a request, which is the same observable outcome as
+// the transient failures this suite is about (upstream 5xx, rate limit,
+// timeout, refused connection): that function writes to the catalog only on a
+// successful response, so every failure mode is indistinguishable from here.
+// It also lets Client stay a bare non-nil pointer, so any regression that does
+// attempt a fetch panics instead of silently reaching the network.
+// The custom provider config is set on both the stored row and the in-memory
+// config on purpose: ReloadProvider reads the keyless flag off the row it
+// loads from the config store, while the isKeylessProvider helper that
+// RefreshLiveModelsForProvider and the OnKey* handlers use reads the in-memory
+// copy. A fixture that populated only one would exercise a state the running
+// server never has.
+func newReloadProviderServer(catalog *modelcatalog.ModelCatalog, provider schemas.ModelProvider, keys []schemas.Key, keyless bool) *BifrostHTTPServer {
+	customProviderConfig := &schemas.CustomProviderConfig{
+		IsKeyLess:       keyless,
+		AllowedRequests: &schemas.AllowedRequests{ListModels: false},
+	}
+	return &BifrostHTTPServer{
+		Ctx:    schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+		Client: &bifrost.Bifrost{},
+		Config: &lib.Config{
+			ConfigStore: &reloadProviderConfigStore{provider: &configstoreTables.TableProvider{
+				Name:                 string(provider),
+				CustomProviderConfig: customProviderConfig,
+			}},
+			ModelCatalog: catalog,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				provider: {
+					Keys:                 keys,
+					CustomProviderConfig: customProviderConfig,
+				},
+			},
+		},
+	}
+}
+
+// TestReloadProvider_FailedRefetchKeepsPreviousCatalog is the regression guard
+// for issue #5554: ReloadProvider used to wipe the provider's whole live
+// catalog before re-fetching, so a re-fetch that wrote nothing left the
+// provider with no live models at all. Editing an unrelated provider field
+// while the upstream was briefly unhealthy therefore emptied GET /v1/models
+// until a later edit or a restart repaired it.
+func TestReloadProvider_FailedRefetchKeepsPreviousCatalog(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("custom-provider", "key-1", false, []string{"some-model"})
+	catalog.UpsertLive("custom-provider", "key-1", true, []string{"some-model", "unlisted-model"})
+
+	server := newReloadProviderServer(catalog, "custom-provider", []schemas.Key{{ID: "key-1"}}, false)
+
+	if _, err := server.ReloadProvider(context.Background(), "custom-provider"); err != nil {
+		t.Fatalf("ReloadProvider returned unexpected error: %v", err)
+	}
+
+	if got := catalog.GetModelsForProvider("custom-provider"); !slices.Equal(got, []string{"some-model"}) {
+		t.Errorf("filtered catalog after failed refetch = %v, want [some-model] retained", got)
+	}
+	if got := catalog.GetUnfilteredModelsForProvider("custom-provider"); !slices.Equal(got, []string{"some-model", "unlisted-model"}) {
+		t.Errorf("unfiltered catalog after failed refetch = %v, want [some-model unlisted-model] retained", got)
+	}
+}
+
+// TestReloadProvider_PrunesRemovedAndDisabledKeys pins the half of the old
+// invalidate that must survive the fix. Retaining is not "skip the cleanup":
+// keys that left the provider's set, and keys that are still configured but
+// disabled, must still lose their cached entries. Disabled keys matter because
+// RefreshLiveModelsForProvider never re-fetches for them, so a retained entry
+// would be served indefinitely for a key core rejects at routing time.
+func TestReloadProvider_PrunesRemovedAndDisabledKeys(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("custom-provider", "key-enabled", false, []string{"kept-model"})
+	catalog.UpsertLive("custom-provider", "key-disabled", false, []string{"disabled-model"})
+	catalog.UpsertLive("custom-provider", "key-removed", false, []string{"removed-model"})
+	catalog.UpsertLive("custom-provider", "key-removed", true, []string{"removed-model"})
+
+	keys := []schemas.Key{
+		{ID: "key-enabled"},
+		{ID: "key-disabled", Enabled: schemas.Ptr(false)},
+	}
+	server := newReloadProviderServer(catalog, "custom-provider", keys, false)
+
+	if _, err := server.ReloadProvider(context.Background(), "custom-provider"); err != nil {
+		t.Fatalf("ReloadProvider returned unexpected error: %v", err)
+	}
+
+	if got := catalog.GetModelsForProvider("custom-provider"); !slices.Equal(got, []string{"kept-model"}) {
+		t.Errorf("filtered catalog = %v, want only [kept-model] (disabled and removed keys pruned)", got)
+	}
+	if got := catalog.GetUnfilteredModelsForProvider("custom-provider"); len(got) != 0 {
+		t.Errorf("unfiltered catalog = %v, want empty (only the removed key had an unfiltered entry)", got)
+	}
+}
+
+// TestReloadProvider_KeylessProviderRetainsSentinelEntry covers keyless
+// providers (Vertex workload identity, Bedrock IAM, custom keyless), whose
+// entries are cached under the "" key ID rather than a real key ID. The retain
+// set has to name that sentinel explicitly or the fix would still empty every
+// keyless provider's catalog on a failed refetch.
+func TestReloadProvider_KeylessProviderRetainsSentinelEntry(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("keyless-provider", "", false, []string{"keyless-model"})
+
+	server := newReloadProviderServer(catalog, "keyless-provider", nil, true)
+
+	if _, err := server.ReloadProvider(context.Background(), "keyless-provider"); err != nil {
+		t.Fatalf("ReloadProvider returned unexpected error: %v", err)
+	}
+
+	if got := catalog.GetModelsForProvider("keyless-provider"); !slices.Equal(got, []string{"keyless-model"}) {
+		t.Errorf("keyless catalog after failed refetch = %v, want [keyless-model] retained", got)
+	}
+}
+
+// TestReloadProvider_NoKeysDropsEverything pins the branch that must keep
+// wiping: a keyed provider with no keys left can serve nothing, so no cached
+// entry is still meaningful and none will ever be refreshed.
+func TestReloadProvider_NoKeysDropsEverything(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("custom-provider", "key-1", false, []string{"orphaned-model"})
+
+	server := newReloadProviderServer(catalog, "custom-provider", nil, false)
+
+	if _, err := server.ReloadProvider(context.Background(), "custom-provider"); err != nil {
+		t.Fatalf("ReloadProvider returned unexpected error: %v", err)
+	}
+
+	if got := catalog.GetModelsForProvider("custom-provider"); len(got) != 0 {
+		t.Errorf("catalog for keyless-less provider = %v, want empty", got)
+	}
+}
+
+// TestReloadProvider_ConcurrentReloadsAndReadsAreRaceFree covers the layer
+// above the store. ReloadProvider's catalog work is three separate store calls
+// (SetKeyConfigForProvider, RetainLiveKeys, then the per-key upserts inside
+// RefreshLiveModelsForProvider), so it is atomic per call but not as a
+// sequence. Two provider edits landing at once, or an edit landing while
+// GET /v1/models is being served, must stay race-free and leave the catalog
+// coherent even though the interleaving of those three steps is unspecified.
+//
+// The keep map is built fresh inside each ReloadProvider call and never
+// escapes it, which is what keeps concurrent callers from sharing it.
+func TestReloadProvider_ConcurrentReloadsAndReadsAreRaceFree(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	catalog := modelcatalog.NewTestCatalog(nil)
+	catalog.UpsertLive("custom-provider", "key-1", false, []string{"some-model"})
+	catalog.UpsertLive("custom-provider", "key-1", true, []string{"some-model", "unlisted-model"})
+
+	server := newReloadProviderServer(catalog, "custom-provider", []schemas.Key{{ID: "key-1"}}, false)
+
+	const reloaders = 4
+	const readers = 4
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	for range reloaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				if _, err := server.ReloadProvider(context.Background(), "custom-provider"); err != nil {
+					t.Errorf("concurrent ReloadProvider returned error: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = catalog.GetModelsForProvider("custom-provider")
+				_ = catalog.GetUnfilteredModelsForProvider("custom-provider")
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Retention is not just race-free but stable under repetition: no
+	// interleaving of concurrent reloads may drop an entry whose key is
+	// present and enabled in every one of them.
+	if got := catalog.GetModelsForProvider("custom-provider"); !slices.Equal(got, []string{"some-model"}) {
+		t.Errorf("filtered catalog after concurrent reloads = %v, want [some-model] retained", got)
+	}
+	if got := catalog.GetUnfilteredModelsForProvider("custom-provider"); !slices.Equal(got, []string{"some-model", "unlisted-model"}) {
+		t.Errorf("unfiltered catalog after concurrent reloads = %v, want both entries retained", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

`ReloadProvider` previously called `InvalidateLiveProvider` unconditionally before re-fetching per-key model lists. Because `FetchAndStoreLiveForKey` writes to the catalog only on a successful upstream response, any transient failure (5xx, rate limit, timeout, restarting gateway) during the refetch left the provider with a completely empty live catalog — making every model unroutable until a subsequent edit or restart repaired it. This PR replaces the blanket wipe with a targeted prune that removes only the entries for keys that were removed or disabled, leaving surviving keys' cached entries in place for the refetch to overwrite. Closes #5554

## Changes

- Added `RetainKeys` to `framework/modelcatalog/live/store.go`: iterates the entry map under the write lock and deletes only entries whose key ID is absent from the caller's keep set. A nil or empty keep set is equivalent to the old `InvalidateProvider`. The caller's map is not retained by the store.
- Exposed `RetainLiveKeys` on `ModelCatalog` as a thin wrapper around `store.RetainKeys`.
- Changed `ReloadProvider` in `server.go` to build a keep set from the current enabled keys (plus the `""` sentinel for keyless providers) and call `RetainLiveKeys` instead of `InvalidateLiveProvider`. The full `InvalidateLiveProvider` path is preserved for the no-keys branch, where no entry will ever be refreshed and none is still meaningful.
- Added comprehensive tests for `RetainKeys` covering: partial pruning, empty/nil keep sets, the keyless `""` sentinel, unknown keys in the keep set being harmless, race safety under concurrent access, and the store not retaining a reference to the caller's map.
- Added `ReloadProvider` integration tests covering: failed-refetch retention, pruning of removed and disabled keys, keyless provider sentinel retention, the no-keys full-wipe branch, and concurrent reloads racing concurrent reads.
- Updated `AGENTS.md` to document that `make test-framework` requires `cd tests && docker compose up -d` first, explain why `tests/docker-compose.yml` must be used instead of `framework/docker-compose.yml`, and detail the specific port and feature differences between the two files.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
# Store-level unit tests
go test ./framework/modelcatalog/live/... -race -count=1

# Server-level integration tests (no external services needed)
go test ./transports/bifrost-http/server/... -race -count=1 -run TestReloadProvider

# Full transport suite
go test ./transports/bifrost-http/... -race -count=1
```

To reproduce the original bug before this fix: seed a provider's live catalog, trigger a `ReloadProvider` while the upstream model-list endpoint is unavailable (or with `AllowedRequests.ListModels: false`), and observe `GET /v1/models` returning an empty list. After this fix the pre-reload entries are preserved.

## Breaking changes

- [x] No

## Related issues

Closes #5554

## Security considerations

None. The change is confined to in-memory catalog bookkeeping; no credentials, secrets, or external interfaces are affected.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable