### PR TITLE
models list backend changes

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -218,14 +218,15 @@ Full documentation: [Storage](/deployment-guides/config-json/storage).
 
 ## `framework`
 
-Controls model pricing catalog sync:
+Controls model pricing catalog sync and background model discovery:
 
 ```json
 {
   "framework": {
     "pricing": {
       "pricing_url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
-      "pricing_sync_interval": 86400
+      "pricing_sync_interval": 86400,
+      "live_models_sync_interval": 3600
     }
   }
 }
@@ -235,6 +236,24 @@ Controls model pricing catalog sync:
 |-------|---------|-------------|
 | `pricing.pricing_url` | LiteLLM catalog | URL of a model pricing JSON file |
 | `pricing.pricing_sync_interval` | `86400` | Sync interval in seconds (minimum: `3600`) |
+| `pricing.live_models_sync_interval` | `3600` | How often each provider's model list is re-fetched, in seconds. `0` disables it (minimum when enabled: `60`) |
+
+### Background model discovery
+
+Each provider's model list is fetched at startup and whenever you add, edit, or
+delete a key. `live_models_sync_interval` additionally re-fetches it on a timer,
+so a model a provider starts serving after the gateway booted becomes routable
+without a restart.
+
+Every node runs its own refresh, because the model list is cached in process
+memory rather than in the database. Each pass costs two `list models` calls per
+enabled key, per provider, so raise the interval if a provider meters that
+endpoint. The interval is jittered by ±10% to keep replicas that booted together
+from calling every upstream at the same instant.
+
+Set it to `0` to turn the timer off entirely. Model discovery then happens only
+at startup and on key edits, and you can trigger it on demand from the
+**Providers** page.
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1047,6 +1047,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.32",
               "changelogs/helm-v2.1.31",
               "changelogs/helm-v2.1.30",
               "changelogs/helm-v2.1.29",

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1622,10 +1622,16 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 }
 
 // frameworkConfigHashPayload holds the config.json-sourced fields used for hashing.
+//
+// LiveModelsSyncInterval carries omitempty deliberately: a nil pointer must
+// marshal to exactly the bytes this struct produced before the field existed,
+// so hashes already persisted in framework_configs stay valid and no upgraded
+// deployment sees a spurious "file changed" override on first boot.
 type frameworkConfigHashPayload struct {
-	PricingURL          *string `json:"pricing_url"`
-	ModelParametersURL  *string `json:"model_parameters_url"`
-	PricingSyncInterval *int64  `json:"pricing_sync_interval"`
+	PricingURL             *string `json:"pricing_url"`
+	ModelParametersURL     *string `json:"model_parameters_url"`
+	PricingSyncInterval    *int64  `json:"pricing_sync_interval"`
+	LiveModelsSyncInterval *int64  `json:"live_models_sync_interval,omitempty"`
 }
 
 type frameworkConfigHashPayloadWithMCP struct {
@@ -1634,6 +1640,7 @@ type frameworkConfigHashPayloadWithMCP struct {
 	PricingSyncInterval    *int64  `json:"pricing_sync_interval"`
 	MCPLibraryURL          *string `json:"mcp_library_url"`
 	MCPLibrarySyncInterval *int64  `json:"mcp_library_sync_interval"`
+	LiveModelsSyncInterval *int64  `json:"live_models_sync_interval,omitempty"`
 }
 
 // FrameworkConfigHashOptions adds optional framework config fields to the
@@ -1642,6 +1649,7 @@ type frameworkConfigHashPayloadWithMCP struct {
 type FrameworkConfigHashOptions struct {
 	MCPLibraryURL          *string
 	MCPLibrarySyncInterval *int64
+	LiveModelsSyncInterval *int64
 }
 
 // GenerateFrameworkConfigHash generates a SHA256 hash for a framework config.
@@ -1650,13 +1658,26 @@ func GenerateFrameworkConfigHash(pricingURL *string, modelParametersURL *string,
 	var data []byte
 	var err error
 	if len(opts) > 0 {
-		data, err = sonic.Marshal(frameworkConfigHashPayloadWithMCP{
-			PricingURL:             pricingURL,
-			ModelParametersURL:     modelParametersURL,
-			PricingSyncInterval:    pricingSyncInterval,
-			MCPLibraryURL:          opts[0].MCPLibraryURL,
-			MCPLibrarySyncInterval: opts[0].MCPLibrarySyncInterval,
-		})
+		if opts[0].MCPLibraryURL == nil && opts[0].MCPLibrarySyncInterval == nil {
+			// Only live-models config was supplied. Staying on the pricing-only
+			// payload keeps the digest identical to a pre-MCP deployment's when
+			// the live interval is also nil.
+			data, err = sonic.Marshal(frameworkConfigHashPayload{
+				PricingURL:             pricingURL,
+				ModelParametersURL:     modelParametersURL,
+				PricingSyncInterval:    pricingSyncInterval,
+				LiveModelsSyncInterval: opts[0].LiveModelsSyncInterval,
+			})
+		} else {
+			data, err = sonic.Marshal(frameworkConfigHashPayloadWithMCP{
+				PricingURL:             pricingURL,
+				ModelParametersURL:     modelParametersURL,
+				PricingSyncInterval:    pricingSyncInterval,
+				MCPLibraryURL:          opts[0].MCPLibraryURL,
+				MCPLibrarySyncInterval: opts[0].MCPLibrarySyncInterval,
+				LiveModelsSyncInterval: opts[0].LiveModelsSyncInterval,
+			})
+		}
 	} else {
 		data, err = sonic.Marshal(frameworkConfigHashPayload{
 			PricingURL:          pricingURL,

--- a/framework/configstore/frameworkconfighash_test.go
+++ b/framework/configstore/frameworkconfighash_test.go
@@ -1,0 +1,86 @@
+package configstore
+
+import (
+	"testing"
+)
+
+// TestGenerateFrameworkConfigHash_NilLiveIntervalPreservesLegacyDigest pins the
+// back-compat contract for adding fields to the framework config hash.
+//
+// The hash is how ResolveFrameworkPricingConfig decides whether config.json
+// changed since it was last applied. If adding a field shifted the digest for
+// deployments that do not set it, every upgraded gateway would see a spurious
+// "file changed" on first boot and let config.json stomp values the operator
+// had edited through the UI. LiveModelsSyncInterval carries `omitempty` so a
+// nil pointer marshals to exactly the bytes the struct produced before the
+// field existed.
+//
+// The literals below are deliberately hardcoded rather than recomputed: a test
+// that derives the expected value from the same code it is testing would
+// happily follow a regression.
+func TestGenerateFrameworkConfigHash_NilLiveIntervalPreservesLegacyDigest(t *testing.T) {
+	pricingURL := "https://example.com/pricing.json"
+	modelParamsURL := "https://example.com/params.json"
+	syncInterval := int64(86400)
+
+	t.Run("pricing-only payload", func(t *testing.T) {
+		got, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval)
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		const want = "4ee61c7fef9dfd0036fbe7973584297c2ed00b9d8c3a5a05ba0e10d34340209d"
+		if got != want {
+			t.Fatalf("pricing-only digest changed.\n got: %s\nwant: %s\n\nAdding a field to frameworkConfigHashPayload without `omitempty` (or removing it) breaks config.json change detection for every existing deployment.", got, want)
+		}
+	})
+
+	t.Run("explicit nil live interval matches the no-options form", func(t *testing.T) {
+		withoutOpts, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval)
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		withNilOpts, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval, FrameworkConfigHashOptions{})
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		if withoutOpts != withNilOpts {
+			t.Fatalf("an all-nil options struct must hash identically to omitting options entirely:\n  without: %s\n  with:    %s", withoutOpts, withNilOpts)
+		}
+	})
+
+	t.Run("mcp payload is unchanged by a nil live interval", func(t *testing.T) {
+		mcpURL := "https://example.com/mcp.json"
+		mcpInterval := int64(86400)
+
+		mcpOnly, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval, FrameworkConfigHashOptions{
+			MCPLibraryURL:          &mcpURL,
+			MCPLibrarySyncInterval: &mcpInterval,
+		})
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		const want = "8dbe17439dad62ba0ac9d63bd2dbe6413ad46749c7d18739887c29a6a7cb5652"
+		if mcpOnly != want {
+			t.Fatalf("mcp payload digest changed.\n got: %s\nwant: %s\n\nExisting deployments with mcp_library_* in config.json rely on this digest staying stable.", mcpOnly, want)
+		}
+	})
+
+	t.Run("setting the live interval does change the digest", func(t *testing.T) {
+		// The flip side of the contract: an operator editing the value in
+		// config.json must be detected as a file change.
+		base, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval)
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		liveInterval := int64(900)
+		withLive, err := GenerateFrameworkConfigHash(&pricingURL, &modelParamsURL, &syncInterval, FrameworkConfigHashOptions{
+			LiveModelsSyncInterval: &liveInterval,
+		})
+		if err != nil {
+			t.Fatalf("GenerateFrameworkConfigHash returned error: %v", err)
+		}
+		if base == withLive {
+			t.Fatal("expected setting live_models_sync_interval to change the digest; a config.json edit would otherwise go undetected")
+		}
+	})
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -456,6 +456,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_bedrock_batch_role_arn_column"}, run: migrationAddBedrockBatchRoleARNColumn},
 	{IDs: []string{"add_budget_override_columns"}, run: migrationAddBudgetOverrideColumns},
 	{IDs: []string{"add_budget_override_anchor_columns"}, run: migrationAddBudgetOverrideAnchorColumns},
+	{IDs: []string{"add_live_models_sync_interval_column"}, run: migrationAddLiveModelsSyncIntervalColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10423,6 +10424,37 @@ func migrationAddMCPLibraryConfigColumns(ctx context.Context, db *gorm.DB, logge
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_library_config_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddLiveModelsSyncIntervalColumn adds the live_models_sync_interval
+// column to framework_configs. It stores how often each provider's list-models
+// response is re-fetched in the background, in seconds, with 0 meaning the
+// refresher is disabled. Idempotent via HasColumn guards.
+func migrationAddLiveModelsSyncIntervalColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_live_models_sync_interval_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableFrameworkConfig{}, "LiveModelsSyncInterval"); err != nil {
+				return fmt.Errorf("add live_models_sync_interval column: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := dropColumnIfExists(tx, logger, &tables.TableFrameworkConfig{}, "LiveModelsSyncInterval"); err != nil {
+				return fmt.Errorf("drop live_models_sync_interval column: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_live_models_sync_interval_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/framework.go
+++ b/framework/configstore/tables/framework.go
@@ -12,7 +12,10 @@ type TableFrameworkConfig struct {
 	// PricingURL: the default ships out of the box and the user can override it.
 	MCPLibraryURL          *string `gorm:"type:text" json:"mcp_library_url"`
 	MCPLibrarySyncInterval *int64  `gorm:"" json:"mcp_library_sync_interval"`
-	ConfigHash             string  `gorm:"type:text" json:"config_hash"`
+	// LiveModelsSyncInterval is how often each provider's list-models response
+	// is re-fetched in the background, in seconds. 0 disables the refresher.
+	LiveModelsSyncInterval *int64 `gorm:"" json:"live_models_sync_interval"`
+	ConfigHash             string `gorm:"type:text" json:"config_hash"`
 }
 
 // TableName sets the table name for each model

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -12,6 +12,20 @@ const (
 	DefaultSyncInterval           = datasheet.DefaultSyncInterval
 	MinimumPricingSyncIntervalSec = int64(3600)
 
+	// DefaultLiveModelsSyncInterval is how often the gateway re-fetches each
+	// provider's list-models response in the background.
+	DefaultLiveModelsSyncInterval = 60 * time.Minute
+	// MinimumLiveModelsSyncIntervalSec is the floor for a non-zero live models
+	// sync interval. Deliberately far below MinimumPricingSyncIntervalSec:
+	// pricing is a single shared datasheet fetch on a 24h cadence, whereas an
+	// operator fronting a fast-moving aggregator may legitimately want model
+	// discovery to run every few minutes.
+	MinimumLiveModelsSyncIntervalSec = int64(60)
+	// LiveModelsSyncDisabled is the sentinel for "never refresh in the
+	// background". Distinct from a negative value, which is treated as
+	// corrupted config and falls back to the default.
+	LiveModelsSyncDisabled = int64(0)
+
 	ConfigLastPricingSyncKey    = "LastModelPricingSync"
 	ConfigLastParamsSyncKey     = "LastModelParametersSync"
 	ConfigLastMCPLibrarySyncKey = "LastMCPLibrarySync"
@@ -28,6 +42,18 @@ type Config struct {
 	// default ships out of the box and the user can point it at a custom source.
 	MCPLibraryURL          *string `json:"mcp_library_url,omitempty"`
 	MCPLibrarySyncInterval *int64  `json:"mcp_library_sync_interval,omitempty"` // seconds
+
+	// LiveModelsSyncInterval is how often each provider's list-models response
+	// is re-fetched in the background, in seconds. Nil uses
+	// DefaultLiveModelsSyncInterval; LiveModelsSyncDisabled (0) turns the
+	// background refresher off entirely.
+	//
+	// Unlike the sync intervals above, nothing in this package acts on it: the
+	// live model cache is per-process and the refresh has to go through the
+	// Bifrost routing pipeline, so the HTTP server owns that ticker. This field
+	// is the transport's configuration channel, carried here to keep every
+	// catalog cadence in one place.
+	LiveModelsSyncInterval *int64 `json:"live_models_sync_interval,omitempty"` // seconds
 }
 
 // Type re-exports so external callers can continue importing the legacy

--- a/framework/modelcatalog/live/store.go
+++ b/framework/modelcatalog/live/store.go
@@ -4,9 +4,15 @@
 // callers reading filtered entries MUST NOT reapply that gate elsewhere or
 // alias-backfill rows will be dropped.
 //
-// The store is passive — it never calls the network. Callers (the HTTP server
-// after key add/update, or a future background refresher) decide when to
-// fetch and push results in via Upsert.
+// The store is passive: it never calls the network. Callers decide when to
+// fetch and push results in via Upsert. Today those are the HTTP server's
+// bootstrap seed, its key add/update handlers, the on-demand refresh
+// endpoints, and BifrostHTTPServer.startLiveModelRefresher, which re-fetches
+// every provider on the configured live_models_sync_interval unless that
+// interval is 0, which disables the refresher.
+//
+// Entries are per process and are never persisted, so every node refreshes its
+// own copy rather than electing one refresher.
 package live
 
 import (
@@ -33,17 +39,33 @@ type Entry struct {
 type Store struct {
 	mu      sync.RWMutex
 	entries map[Key]Entry
-	logger  schemas.Logger
+	// gen counts invalidations per provider so a fetch that was already in
+	// flight when its key was deleted or disabled, or its provider removed,
+	// cannot re-add the entry the invalidation just dropped. Fetchers capture
+	// Generation before issuing the upstream call and commit through
+	// UpsertIfCurrent, which compares under the same lock the bump takes.
+	//
+	// Never pruned. Dropping a provider's counter on delete would reset it to
+	// 0, and a fetch still holding a pre-delete generation of 0 would then
+	// look current again after the provider was re-added.
+	gen    map[schemas.ModelProvider]uint64
+	logger schemas.Logger
 }
 
 func New(logger schemas.Logger) *Store {
 	if logger == nil {
 		logger = bifrost.NewNoOpLogger()
 	}
-	return &Store{entries: make(map[Key]Entry), logger: logger}
+	return &Store{
+		entries: make(map[Key]Entry),
+		gen:     make(map[schemas.ModelProvider]uint64),
+		logger:  logger,
+	}
 }
 
-// Upsert stores a successful fetch.
+// Upsert stores a successful fetch unconditionally. Use it for writes with no
+// in-flight window to lose a race in (seeding, tests); anything that fetches
+// from an upstream first should go through Generation + UpsertIfCurrent.
 func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered bool, models []string) {
 	cp := make([]string, len(models))
 	copy(cp, models)
@@ -53,6 +75,46 @@ func (s *Store) Upsert(provider schemas.ModelProvider, keyID string, unfiltered 
 	s.mu.Unlock()
 }
 
+// Generation returns the provider's current invalidation counter. Read it
+// before starting a fetch and hand it back to UpsertIfCurrent.
+func (s *Store) Generation(provider schemas.ModelProvider) uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.gen[provider]
+}
+
+// UpsertIfCurrent stores a fetch only if nothing invalidated the provider
+// since gen was read, and reports whether it wrote.
+//
+// This is what keeps a deleted or disabled key's models from being resurrected
+// by a fetch that outlived it. The background refresher works from a key
+// snapshot taken at the top of a pass; by the time list-models answers, the key
+// may be gone. Its Invalidate already ran, and no later pass re-fetches or
+// prunes a key that is no longer configured, so an unguarded commit would
+// advertise that key's models until the process restarted.
+func (s *Store) UpsertIfCurrent(provider schemas.ModelProvider, keyID string, unfiltered bool, models []string, gen uint64) bool {
+	cp := make([]string, len(models))
+	copy(cp, models)
+	k := Key{Provider: provider, KeyID: keyID, Unfiltered: unfiltered}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.gen[provider] != gen {
+		return false
+	}
+	s.entries[k] = Entry{Models: cp}
+	return true
+}
+
+// bumpLocked invalidates every generation handed out for the provider so far.
+// Callers must hold mu for writing.
+//
+// Bumped unconditionally, even when the invalidation deleted no entry: the
+// write a pending fetch is about to make is exactly the case where there is
+// nothing cached yet, and that is the write this has to stop.
+func (s *Store) bumpLocked(provider schemas.ModelProvider) {
+	s.gen[provider]++
+}
+
 // Invalidate drops both filtered and unfiltered entries for one key. Called
 // when the key's credential value changes (cached models were computed
 // against the old credential) or when the key is deleted.
@@ -60,6 +122,7 @@ func (s *Store) Invalidate(provider schemas.ModelProvider, keyID string) {
 	s.mu.Lock()
 	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: false})
 	delete(s.entries, Key{Provider: provider, KeyID: keyID, Unfiltered: true})
+	s.bumpLocked(provider)
 	s.mu.Unlock()
 }
 
@@ -72,6 +135,7 @@ func (s *Store) InvalidateProvider(provider schemas.ModelProvider) {
 			delete(s.entries, k)
 		}
 	}
+	s.bumpLocked(provider)
 	s.mu.Unlock()
 }
 
@@ -85,6 +149,12 @@ func (s *Store) InvalidateProvider(provider schemas.ModelProvider) {
 //
 // keep is read-only and is not retained by the store. A nil or empty keep is
 // equivalent to InvalidateProvider.
+//
+// Bumps the provider's generation like the other invalidations, which costs the
+// caller nothing: every caller re-fetches straight afterwards and so captures
+// the new generation. A concurrent background pass loses that provider's
+// results for one cycle, which is the correct outcome — the caller's own
+// re-fetch replaces them, and the pass was working from the pre-prune key set.
 func (s *Store) RetainKeys(provider schemas.ModelProvider, keep map[string]struct{}) {
 	s.mu.Lock()
 	for k := range s.entries {
@@ -96,6 +166,7 @@ func (s *Store) RetainKeys(provider schemas.ModelProvider, keep map[string]struc
 		}
 		delete(s.entries, k)
 	}
+	s.bumpLocked(provider)
 	s.mu.Unlock()
 }
 

--- a/framework/modelcatalog/live/store_test.go
+++ b/framework/modelcatalog/live/store_test.go
@@ -299,3 +299,157 @@ func TestUpsertOverwritesSameKey(t *testing.T) {
 		t.Errorf("after re-Upsert = %v, want [o1] (overwrite, not append)", got)
 	}
 }
+
+// TestUpsertIfCurrentAcceptsUnchangedGeneration is the baseline: with nothing
+// invalidating the provider in between, a guarded commit behaves exactly like
+// a plain Upsert.
+func TestUpsertIfCurrentAcceptsUnchangedGeneration(t *testing.T) {
+	s := New(nil)
+	gen := s.Generation(openai)
+
+	if !s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen) {
+		t.Fatal("UpsertIfCurrent reported a dropped write with no intervening invalidation")
+	}
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("after guarded upsert = %v, want [gpt-4o]", got)
+	}
+}
+
+// TestUpsertIfCurrentDropsWriteAfterInvalidate is the core of the deleted-key
+// fix. It reproduces the ordering a background refresh hits: read generation,
+// start the (here, elided) upstream call, have the key deleted mid-flight, and
+// only then try to commit. The commit must not resurrect the entry Invalidate
+// just dropped, because nothing ever re-prunes a key that is no longer
+// configured.
+func TestUpsertIfCurrentDropsWriteAfterInvalidate(t *testing.T) {
+	s := New(nil)
+	upsertFiltered(s, openai, "k1", []string{"gpt-4o"})
+
+	gen := s.Generation(openai) // refresh pass starts here
+
+	s.Invalidate(openai, "k1") // key deleted while the fetch is in flight
+
+	if s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen) {
+		t.Fatal("UpsertIfCurrent committed a result fetched before the key was invalidated")
+	}
+	if got := s.ModelsForProvider(openai); len(got) != 0 {
+		t.Errorf("after dropped commit = %v, want [] (deleted key must stay gone)", got)
+	}
+}
+
+// TestInvalidateBumpsGenerationWithNoCachedEntry pins why the bump is
+// unconditional. The dangerous case is precisely the one where Invalidate
+// deletes nothing: the fetch it has to cancel has not written yet. Bumping only
+// when an entry existed would leave that write unguarded.
+func TestInvalidateBumpsGenerationWithNoCachedEntry(t *testing.T) {
+	s := New(nil)
+	gen := s.Generation(openai)
+
+	s.Invalidate(openai, "k1") // nothing cached for k1 yet
+
+	if s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen) {
+		t.Fatal("UpsertIfCurrent committed after an Invalidate that happened to delete nothing")
+	}
+}
+
+// TestInvalidateProviderAndRetainKeysBumpGeneration covers the other two
+// invalidation entrypoints: provider delete and the pre-refetch prune both
+// cancel in-flight fetches the same way Invalidate does.
+func TestInvalidateProviderAndRetainKeysBumpGeneration(t *testing.T) {
+	tests := []struct {
+		name       string
+		invalidate func(*Store)
+	}{
+		{"InvalidateProvider", func(s *Store) { s.InvalidateProvider(openai) }},
+		{"RetainKeys", func(s *Store) { s.RetainKeys(openai, map[string]struct{}{"k2": {}}) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(nil)
+			gen := s.Generation(openai)
+
+			tt.invalidate(s)
+
+			if s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen) {
+				t.Fatalf("UpsertIfCurrent committed a fetch that predates %s", tt.name)
+			}
+		})
+	}
+}
+
+// TestGenerationIsPerProvider makes sure the counter does not couple unrelated
+// providers: deleting a key on one must not throw away a healthy in-flight
+// refresh for another. Providers refresh concurrently, so a shared counter
+// would make every key edit anywhere cost a whole refresh cycle.
+func TestGenerationIsPerProvider(t *testing.T) {
+	s := New(nil)
+	gen := s.Generation(anthropic)
+
+	s.Invalidate(openai, "k1")
+
+	if !s.UpsertIfCurrent(anthropic, "k1", false, []string{"claude-sonnet"}, gen) {
+		t.Fatal("an OpenAI invalidation dropped an Anthropic commit")
+	}
+	if got := s.ModelsForProvider(anthropic); !slices.Equal(got, []string{"claude-sonnet"}) {
+		t.Errorf("Anthropic after unrelated invalidation = %v, want [claude-sonnet]", got)
+	}
+}
+
+// TestGenerationSurvivesProviderRemoval guards the decision not to prune the
+// gen map. Resetting a removed provider's counter to 0 would make a fetch that
+// captured 0 before the removal look current again once the provider was
+// re-added, which is the exact write the guard exists to stop.
+func TestGenerationSurvivesProviderRemoval(t *testing.T) {
+	s := New(nil)
+	gen := s.Generation(openai) // fetch starts against the original provider
+
+	s.InvalidateProvider(openai) // provider deleted...
+	upsertFiltered(s, openai, "k1", []string{"o1"})
+	s.InvalidateProvider(openai) // ...and re-added, then reloaded
+
+	if s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen) {
+		t.Fatal("a pre-removal fetch committed after the provider was recreated")
+	}
+}
+
+// TestUpsertIfCurrentCopiesInputSlice mirrors TestUpsertCopiesInputSlice: the
+// guarded path must not retain the caller's backing array either.
+func TestUpsertIfCurrentCopiesInputSlice(t *testing.T) {
+	s := New(nil)
+	input := []string{"gpt-4o"}
+	s.UpsertIfCurrent(openai, "k1", false, input, s.Generation(openai))
+
+	input[0] = "MUTATED"
+
+	if got := s.ModelsForProvider(openai); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("store mutated through input slice: %v", got)
+	}
+}
+
+// TestConcurrentInvalidateAndGuardedUpsertAreRaceFree runs the guard under -race
+// with invalidations and commits interleaving freely. The invariant is not which
+// writes land but that the store stays consistent and no commit outlives the
+// invalidation that followed its Generation read.
+func TestConcurrentInvalidateAndGuardedUpsertAreRaceFree(t *testing.T) {
+	s := New(nil)
+	const workers = 8
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for range iterations {
+				gen := s.Generation(openai)
+				if i%2 == 0 {
+					s.Invalidate(openai, "k1")
+					continue
+				}
+				s.UpsertIfCurrent(openai, "k1", false, []string{"gpt-4o"}, gen)
+				_ = s.ModelsForProvider(openai)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/framework/modelcatalog/pool.go
+++ b/framework/modelcatalog/pool.go
@@ -25,6 +25,26 @@ func (mc *ModelCatalog) UpsertLiveFromResponse(provider schemas.ModelProvider, k
 	mc.live.Upsert(provider, keyID, unfiltered, extractModelIDs(resp, provider))
 }
 
+// LiveGeneration returns the live cache's invalidation counter for the
+// provider. Read it before issuing a list-models fetch and pass it back to
+// UpsertLiveFromResponseIfCurrent when the response lands.
+func (mc *ModelCatalog) LiveGeneration(provider schemas.ModelProvider) uint64 {
+	return mc.live.Generation(provider)
+}
+
+// UpsertLiveFromResponseIfCurrent is UpsertLiveFromResponse with a staleness
+// guard: the write is dropped, and false returned, if the provider was
+// invalidated (key deleted or disabled, provider removed, entries pruned)
+// after gen was read. A nil resp is a no-op and also reports false, matching
+// UpsertLiveFromResponse's "never clear a cache entry with a missing
+// response" contract.
+func (mc *ModelCatalog) UpsertLiveFromResponseIfCurrent(provider schemas.ModelProvider, keyID string, unfiltered bool, resp *schemas.BifrostListModelsResponse, gen uint64) bool {
+	if resp == nil {
+		return false
+	}
+	return mc.live.UpsertIfCurrent(provider, keyID, unfiltered, extractModelIDs(resp, provider), gen)
+}
+
 // InvalidateLive drops both filtered + unfiltered live entries for one key.
 func (mc *ModelCatalog) InvalidateLive(provider schemas.ModelProvider, keyID string) {
 	mc.live.Invalidate(provider, keyID)

--- a/framework/modelcatalog/pool_test.go
+++ b/framework/modelcatalog/pool_test.go
@@ -320,3 +320,62 @@ func TestInvalidateLiveProvider_DropsAcrossKeys(t *testing.T) {
 		t.Errorf("Anthropic after InvalidateLiveProvider(OpenAI) = %v, want [claude-sonnet]", got)
 	}
 }
+
+// TestUpsertLiveFromResponseIfCurrent_DropsStaleFetch covers the forwarder for
+// the deleted-key race the server hits: a background refresh reads the
+// generation, the key is deleted while list-models is in flight (dropping its
+// entries), and the response then arrives. No later pass fetches or prunes a
+// key that is no longer configured, so committing here would advertise the
+// deleted key's models until the process restarted.
+func TestUpsertLiveFromResponseIfCurrent_DropsStaleFetch(t *testing.T) {
+	mc := NewTestCatalog(nil)
+	mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"gpt-4o"})
+
+	gen := mc.LiveGeneration(schemas.OpenAI)
+	resp := &schemas.BifrostListModelsResponse{Data: []schemas.Model{{ID: "openai/gpt-4o"}}}
+
+	mc.InvalidateLive(schemas.OpenAI, "k1")
+
+	if mc.UpsertLiveFromResponseIfCurrent(schemas.OpenAI, "k1", false, resp, gen) {
+		t.Fatal("committed a list-models response fetched before the key was deleted")
+	}
+	if got := mc.GetModelsForProvider(schemas.OpenAI); len(got) != 0 {
+		t.Errorf("GetModelsForProvider after dropped commit = %v, want [] (deleted key stays gone)", got)
+	}
+}
+
+// TestUpsertLiveFromResponseIfCurrent_CommitsWhenUnchanged is the happy path:
+// the guard must not cost the ordinary refresh anything, so an uncontended
+// commit lands the same models UpsertLiveFromResponse would.
+func TestUpsertLiveFromResponseIfCurrent_CommitsWhenUnchanged(t *testing.T) {
+	mc := NewTestCatalog(nil)
+	gen := mc.LiveGeneration(schemas.OpenAI)
+	resp := &schemas.BifrostListModelsResponse{
+		Data: []schemas.Model{{ID: "openai/gpt-4o"}, {ID: "openai/o1"}},
+	}
+
+	if !mc.UpsertLiveFromResponseIfCurrent(schemas.OpenAI, "k1", false, resp, gen) {
+		t.Fatal("uncontended guarded commit was dropped")
+	}
+
+	got := mc.GetModelsForProvider(schemas.OpenAI)
+	slices.Sort(got)
+	if want := []string{"gpt-4o", "o1"}; !slices.Equal(got, want) {
+		t.Errorf("GetModelsForProvider = %v, want %v", got, want)
+	}
+}
+
+// TestUpsertLiveFromResponseIfCurrent_NilRespIsNoop keeps the guarded variant
+// on the same contract as UpsertLiveFromResponse: a missing response must never
+// be able to clear a healthy entry.
+func TestUpsertLiveFromResponseIfCurrent_NilRespIsNoop(t *testing.T) {
+	mc := NewTestCatalog(nil)
+	mc.UpsertLive(schemas.OpenAI, "k1", false, []string{"gpt-4o"})
+
+	if mc.UpsertLiveFromResponseIfCurrent(schemas.OpenAI, "k1", false, nil, mc.LiveGeneration(schemas.OpenAI)) {
+		t.Error("nil resp reported as a committed write")
+	}
+	if got := mc.GetModelsForProvider(schemas.OpenAI); !slices.Equal(got, []string{"gpt-4o"}) {
+		t.Errorf("after nil-resp guarded upsert = %v, want [gpt-4o] (entry must survive)", got)
+	}
+}

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.31
+version: 2.1.32
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.31
+**Latest Version:** 2.1.32
 
 ## Changelog
+
+### Upcoming
+
+- Added `bifrost.framework.pricing.liveModelsSyncInterval` (default `3600` seconds, minimum `60`, `0` disables) to control how often each provider's list-models response is re-fetched in the background. Renders into `framework.pricing.live_models_sync_interval`.
 
 ### 2.1.31
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -384,7 +384,11 @@ false
 {{- if .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
 {{- $_ := set $pricing "mcp_library_sync_interval" .Values.bifrost.framework.pricing.mcpLibrarySyncInterval }}
 {{- end }}
-{{- if or $pricing.pricing_url $pricing.model_parameters_url $pricing.pricing_sync_interval $pricing.mcp_library_url $pricing.mcp_library_sync_interval }}
+{{- /* nil-aware: 0 is a meaningful value here (disables the background refresh) */ -}}
+{{- if not (kindIs "invalid" .Values.bifrost.framework.pricing.liveModelsSyncInterval) }}
+{{- $_ := set $pricing "live_models_sync_interval" .Values.bifrost.framework.pricing.liveModelsSyncInterval }}
+{{- end }}
+{{- if or $pricing.pricing_url $pricing.model_parameters_url $pricing.pricing_sync_interval $pricing.mcp_library_url $pricing.mcp_library_sync_interval (hasKey $pricing "live_models_sync_interval") }}
 {{- $_ := set $framework "pricing" $pricing }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -654,6 +654,15 @@
                   "description": "MCP library sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
                   "default": 86400,
                   "minimum": 3600
+                },
+                "liveModelsSyncInterval": {
+                  "type": "integer",
+                  "description": "How often each provider's list-models response is re-fetched in the background, in seconds. Set to 0 to disable background refresh. Default is 3600 (1 hour); minimum when enabled is 60 seconds.",
+                  "default": 3600,
+                  "anyOf": [
+                    {"const": 0},
+                    {"minimum": 60}
+                  ]
                 }
               },
               "additionalProperties": false

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -355,6 +355,9 @@ bifrost:
       # mcpLibraryUrl: ""
       # MCP library sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
       # mcpLibrarySyncInterval: 86400
+      # How often each provider's model list is re-fetched in the background, in seconds
+      # (default: 3600 = 1 hour, minimum: 60; set to 0 to disable background refresh)
+      # liveModelsSyncInterval: 3600
 
   # Provider configurations (add your provider keys here)
   # You can specify API keys directly or use env.VAR_NAME syntax to reference environment variables

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -158,7 +158,12 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		mapConfig["framework_config"] = *normalizedFrameworkConfig
 	} else {
 		mapConfig["client_config"] = h.store.ClientConfig.Redacted()
-		normalizedFrameworkConfig, _, _ := lib.ResolveFrameworkPricingConfig(nil, h.store.FrameworkConfig)
+		// Snapshot under the read lock; updateConfig swaps this pointer from
+		// another request goroutine.
+		h.store.Mu.RLock()
+		storedFrameworkConfig := h.store.FrameworkConfig
+		h.store.Mu.RUnlock()
+		normalizedFrameworkConfig, _, _ := lib.ResolveFrameworkPricingConfig(nil, storedFrameworkConfig)
 		mapConfig["framework_config"] = *normalizedFrameworkConfig
 	}
 	if h.store.ConfigStore != nil {
@@ -337,6 +342,21 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		logger.Warn("MCP library sync interval must be greater than 0")
 		SendError(ctx, fasthttp.StatusBadRequest, "MCP library sync interval must be greater than 0")
 		return
+	}
+	// Checking the live models sync interval. Unlike the intervals above, 0 is
+	// accepted: it is the documented way to turn the background refresher off.
+	if payload.FrameworkConfig.LiveModelsSyncInterval != nil {
+		interval := *payload.FrameworkConfig.LiveModelsSyncInterval
+		if interval < 0 {
+			logger.Warn("live models sync interval cannot be negative")
+			SendError(ctx, fasthttp.StatusBadRequest, "live models sync interval cannot be negative (use 0 to disable background refresh)")
+			return
+		}
+		if interval > 0 && interval < modelcatalog.MinimumLiveModelsSyncIntervalSec {
+			logger.Warn("live models sync interval is below the minimum of %d seconds", modelcatalog.MinimumLiveModelsSyncIntervalSec)
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("live models sync interval must be 0 (disabled) or at least %d seconds", modelcatalog.MinimumLiveModelsSyncIntervalSec))
+			return
+		}
 	}
 
 	// Get current config with proper locking
@@ -664,6 +684,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			ModelParametersURL:     bifrost.Ptr(modelcatalog.DefaultModelParametersURL),
 			MCPLibraryURL:          bifrost.Ptr(modelcatalog.DefaultMCPLibraryURL),
 			MCPLibrarySyncInterval: bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds())),
+			LiveModelsSyncInterval: bifrost.Ptr(int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds())),
 		}
 	}
 	// Handling individual nil cases
@@ -681,6 +702,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 	if frameworkConfig.MCPLibrarySyncInterval == nil {
 		frameworkConfig.MCPLibrarySyncInterval = bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds()))
+	}
+	if frameworkConfig.LiveModelsSyncInterval == nil {
+		frameworkConfig.LiveModelsSyncInterval = bifrost.Ptr(int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds()))
 	}
 	// Updating framework config
 	shouldReloadFrameworkConfig := false
@@ -734,6 +758,13 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			shouldReloadFrameworkConfig = true
 		}
 	}
+	if payload.FrameworkConfig.LiveModelsSyncInterval != nil {
+		syncInterval := *payload.FrameworkConfig.LiveModelsSyncInterval
+		if frameworkConfig.LiveModelsSyncInterval == nil || syncInterval != *frameworkConfig.LiveModelsSyncInterval {
+			frameworkConfig.LiveModelsSyncInterval = &syncInterval
+			shouldReloadFrameworkConfig = true
+		}
+	}
 	// Reload config if required
 	if shouldReloadFrameworkConfig {
 		var syncSeconds int64
@@ -742,15 +773,25 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		} else {
 			syncSeconds = int64(modelcatalog.DefaultSyncInterval.Seconds())
 		}
-		h.store.FrameworkConfig = &framework.FrameworkConfig{
+		updatedFrameworkConfig := &framework.FrameworkConfig{
 			Pricing: &modelcatalog.Config{
 				PricingURL:             frameworkConfig.PricingURL,
 				PricingSyncInterval:    &syncSeconds,
 				ModelParametersURL:     frameworkConfig.ModelParametersURL,
 				MCPLibraryURL:          frameworkConfig.MCPLibraryURL,
 				MCPLibrarySyncInterval: frameworkConfig.MCPLibrarySyncInterval,
+				LiveModelsSyncInterval: frameworkConfig.LiveModelsSyncInterval,
 			},
 		}
+		// Publish the new config under the write lock: other request goroutines
+		// read this pointer through LiveModelsSyncInterval and UpdateSyncConfig.
+		// A whole new struct is swapped in rather than mutated in place, which is
+		// what lets readers use the pointer after releasing the lock. Scoped to
+		// the assignment alone — the store write and reload below take the read
+		// lock themselves, and sync.RWMutex is not reentrant.
+		h.store.Mu.Lock()
+		h.store.FrameworkConfig = updatedFrameworkConfig
+		h.store.Mu.Unlock()
 		// Saving framework config
 		if err := h.store.ConfigStore.UpdateFrameworkConfig(ctx, frameworkConfig); err != nil {
 			logger.Warn("failed to save framework configuration: %v", err)

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -302,8 +302,13 @@ func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
 	} else {
 		// Resolve the effective MCP library URL from framework config (DB → file → default).
 		mcpLibraryURL := modelcatalog.DefaultMCPLibraryURL
-		if h.store.FrameworkConfig != nil && h.store.FrameworkConfig.Pricing != nil && h.store.FrameworkConfig.Pricing.MCPLibraryURL != nil {
-			if u := *h.store.FrameworkConfig.Pricing.MCPLibraryURL; u != "" {
+		// Snapshot under the read lock; updateConfig swaps this pointer from
+		// another request goroutine.
+		h.store.Mu.RLock()
+		storedFrameworkConfig := h.store.FrameworkConfig
+		h.store.Mu.RUnlock()
+		if storedFrameworkConfig != nil && storedFrameworkConfig.Pricing != nil && storedFrameworkConfig.Pricing.MCPLibraryURL != nil {
+			if u := *storedFrameworkConfig.Pricing.MCPLibraryURL; u != "" {
 				mcpLibraryURL = u
 			}
 		}

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -314,6 +314,88 @@ func (h *ProviderHandler) deleteProviderKey(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, redactedKey)
 }
 
+// refreshProviderModels handles POST /api/providers/{provider}/refresh-models.
+// Re-runs list-models across every enabled key of the provider and returns the
+// provider's keys with their freshly resolved discovery status.
+func (h *ProviderHandler) refreshProviderModels(ctx *fasthttp.RequestCtx) {
+	provider, err := getProviderFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid provider: %v", err))
+		return
+	}
+
+	if _, err := h.inMemoryStore.GetProviderConfigRaw(provider); err != nil {
+		if errors.Is(err, lib.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider not found: %v", err))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider config: %v", err))
+		return
+	}
+
+	if err := h.modelsManager.RefreshLiveModelsForAllKeys(ctx, provider); err != nil {
+		if errors.Is(err, ErrRefreshInProgress) {
+			SendError(ctx, fasthttp.StatusConflict, err.Error())
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to refresh models: %v", err))
+		return
+	}
+
+	// Read back after the refresh so the caller sees the statuses this pass
+	// produced rather than the ones it started from.
+	keys, err := h.inMemoryStore.GetProviderKeysRedacted(provider)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider keys: %v", err))
+		return
+	}
+
+	SendJSON(ctx, ListProviderKeysResponse{Keys: keys, Total: len(keys)})
+}
+
+// refreshProviderKeyModels handles
+// POST /api/providers/{provider}/keys/{key_id}/refresh-models. Re-runs
+// list-models for one key and returns it with its freshly resolved status.
+func (h *ProviderHandler) refreshProviderKeyModels(ctx *fasthttp.RequestCtx) {
+	provider, err := getProviderFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid provider: %v", err))
+		return
+	}
+
+	keyID, err := getKeyIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if _, err := h.inMemoryStore.GetProviderKeyRedacted(provider, keyID); err != nil {
+		if errors.Is(err, lib.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider key not found: %v", err))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider key: %v", err))
+		return
+	}
+
+	if err := h.modelsManager.RefreshLiveModelsForKey(ctx, provider, keyID); err != nil {
+		if errors.Is(err, ErrRefreshInProgress) {
+			SendError(ctx, fasthttp.StatusConflict, err.Error())
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to refresh models: %v", err))
+		return
+	}
+
+	refreshedKey, err := h.inMemoryStore.GetProviderKeyRedacted(provider, keyID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider key: %v", err))
+		return
+	}
+
+	SendJSON(ctx, refreshedKey)
+}
+
 // mergeUpdatedKey merges an updated key with the old raw version, preserving
 // stored values for masked placeholders. A placeholder without a stored
 // counterpart is rejected so it can never reach persistence.

--- a/transports/bifrost-http/handlers/provider_keys_test.go
+++ b/transports/bifrost-http/handlers/provider_keys_test.go
@@ -287,6 +287,103 @@ func TestValidateProviderKeyRequiredNestedFields(t *testing.T) {
 	}
 }
 
+// refreshHandlerForTest builds a ProviderHandler with one keyed provider and a
+// recording models manager.
+func refreshHandlerForTest(mgr *mockModelsManager) *ProviderHandler {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+	return &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"openai": {Keys: []schemas.Key{{ID: "key-1"}}},
+			},
+		},
+		modelsManager: mgr,
+	}
+}
+
+func TestRefreshProviderModels_DelegatesToModelsManager(t *testing.T) {
+	mgr := &mockModelsManager{}
+	h := refreshHandlerForTest(mgr)
+
+	ctx := newTestRequestCtx("")
+	ctx.SetUserValue("provider", "openai")
+	h.refreshProviderModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("status got %d, want 200; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(mgr.refreshProviderCalls) != 1 || mgr.refreshProviderCalls[0] != "openai" {
+		t.Fatalf("expected one provider-level refresh for openai, got %v", mgr.refreshProviderCalls)
+	}
+}
+
+func TestRefreshProviderKeyModels_DelegatesToModelsManager(t *testing.T) {
+	mgr := &mockModelsManager{}
+	h := refreshHandlerForTest(mgr)
+
+	ctx := newTestRequestCtx("")
+	ctx.SetUserValue("provider", "openai")
+	ctx.SetUserValue("key_id", "key-1")
+	h.refreshProviderKeyModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("status got %d, want 200; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(mgr.refreshKeyCalls) != 1 || mgr.refreshKeyCalls[0].keyID != "key-1" {
+		t.Fatalf("expected one refresh for key-1, got %v", mgr.refreshKeyCalls)
+	}
+}
+
+// A refresh already running for the provider must surface as 409 rather than
+// stacking another (enabled keys x 2) burst of upstream calls, so the UI can
+// tell the user to wait instead of silently doubling the load.
+func TestRefreshProviderModels_InFlightReturns409(t *testing.T) {
+	mgr := &mockModelsManager{refreshErr: ErrRefreshInProgress}
+	h := refreshHandlerForTest(mgr)
+
+	ctx := newTestRequestCtx("")
+	ctx.SetUserValue("provider", "openai")
+	h.refreshProviderModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusConflict {
+		t.Fatalf("status got %d, want 409; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+}
+
+func TestRefreshProviderKeyModels_UnknownKeyReturns404(t *testing.T) {
+	mgr := &mockModelsManager{}
+	h := refreshHandlerForTest(mgr)
+
+	ctx := newTestRequestCtx("")
+	ctx.SetUserValue("provider", "openai")
+	ctx.SetUserValue("key_id", "does-not-exist")
+	h.refreshProviderKeyModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("status got %d, want 404; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(mgr.refreshKeyCalls) != 0 {
+		t.Fatalf("expected no upstream refresh for an unknown key, got %v", mgr.refreshKeyCalls)
+	}
+}
+
+func TestRefreshProviderModels_UnknownProviderReturns404(t *testing.T) {
+	mgr := &mockModelsManager{}
+	h := refreshHandlerForTest(mgr)
+
+	ctx := newTestRequestCtx("")
+	ctx.SetUserValue("provider", "does-not-exist")
+	h.refreshProviderModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("status got %d, want 404; body=%s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if len(mgr.refreshProviderCalls) != 0 {
+		t.Fatalf("expected no upstream refresh for an unknown provider, got %v", mgr.refreshProviderCalls)
+	}
+}
+
 // Regression for the custom-provider path: required-field validation must run
 // against the resolved BASE provider, not the custom route name, or a custom
 // provider based on Bedrock would skip the region requirement entirely.

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -34,7 +34,21 @@ type ModelsManager interface {
 	OnKeyAdded(ctx context.Context, provider schemas.ModelProvider, key schemas.Key) error
 	OnKeyUpdated(ctx context.Context, provider schemas.ModelProvider, key schemas.Key) error
 	OnKeyDeleted(ctx context.Context, provider schemas.ModelProvider, keyID string) error
+	// RefreshLiveModelsForKey re-fetches list-models for a single key on
+	// demand. Returns ErrRefreshInProgress when the provider is already being
+	// refreshed.
+	RefreshLiveModelsForKey(ctx context.Context, provider schemas.ModelProvider, keyID string) error
+	// RefreshLiveModelsForAllKeys re-fetches list-models across every enabled
+	// key of the provider on demand. Returns ErrRefreshInProgress when the
+	// provider is already being refreshed.
+	RefreshLiveModelsForAllKeys(ctx context.Context, provider schemas.ModelProvider) error
 }
+
+// ErrRefreshInProgress is returned by the on-demand model refresh entrypoints
+// when a refresh for the same provider is already running. Repeated presses of
+// the UI refresh button collapse into the in-flight pass rather than each
+// spawning their own (enabled keys x 2) burst of upstream calls.
+var ErrRefreshInProgress = errors.New("model refresh already in progress for this provider")
 
 // ModelPricingAttributesEntry is the wire shape for PUT /api/models/catalog.
 // (model, provider) is the natural key on governance_model_pricing.
@@ -135,6 +149,11 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.PUT("/api/providers/{provider}/keys/{key_id}", lib.ChainMiddlewares(h.updateProviderKey, middlewares...))
 	r.DELETE("/api/providers/{provider}", lib.ChainMiddlewares(h.deleteProvider, middlewares...))
 	r.DELETE("/api/providers/{provider}/keys/{key_id}", lib.ChainMiddlewares(h.deleteProviderKey, middlewares...))
+	// On-demand model discovery. The catalog otherwise refreshes on the
+	// configured live_models_sync_interval, so these let an operator pick up a
+	// newly served model (or re-check a failing key) without waiting.
+	r.POST("/api/providers/{provider}/refresh-models", lib.ChainMiddlewares(h.refreshProviderModels, middlewares...))
+	r.POST("/api/providers/{provider}/keys/{key_id}/refresh-models", lib.ChainMiddlewares(h.refreshProviderKeyModels, middlewares...))
 	r.GET("/api/keys", lib.ChainMiddlewares(h.listKeys, middlewares...))
 	r.GET("/api/models", lib.ChainMiddlewares(h.listModels, middlewares...))
 	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -21,11 +21,20 @@ import (
 )
 
 // mockModelsManager returns stable filtered and unfiltered model lists for handler tests.
+// providerKeyRef records a (provider, keyID) pair a refresh was requested for.
+type providerKeyRef struct {
+	provider schemas.ModelProvider
+	keyID    string
+}
+
 type mockModelsManager struct {
-	filtered    map[schemas.ModelProvider][]string
-	unfiltered  map[schemas.ModelProvider][]string
-	reloadCalls []schemas.ModelProvider
-	reloadErr   error
+	filtered             map[schemas.ModelProvider][]string
+	unfiltered           map[schemas.ModelProvider][]string
+	reloadCalls          []schemas.ModelProvider
+	reloadErr            error
+	refreshKeyCalls      []providerKeyRef
+	refreshProviderCalls []schemas.ModelProvider
+	refreshErr           error
 }
 
 func (m *mockModelsManager) ReloadProvider(_ context.Context, provider schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
@@ -68,6 +77,16 @@ func (m *mockModelsManager) OnKeyUpdated(_ context.Context, _ schemas.ModelProvi
 
 func (m *mockModelsManager) OnKeyDeleted(_ context.Context, _ schemas.ModelProvider, _ string) error {
 	return nil
+}
+
+func (m *mockModelsManager) RefreshLiveModelsForKey(_ context.Context, provider schemas.ModelProvider, keyID string) error {
+	m.refreshKeyCalls = append(m.refreshKeyCalls, providerKeyRef{provider: provider, keyID: keyID})
+	return m.refreshErr
+}
+
+func (m *mockModelsManager) RefreshLiveModelsForAllKeys(_ context.Context, provider schemas.ModelProvider) error {
+	m.refreshProviderCalls = append(m.refreshProviderCalls, provider)
+	return m.refreshErr
 }
 
 // providerHandlerForTest builds a handler with fixed provider config and model sets.

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4112,12 +4112,14 @@ func ResolveFrameworkPricingConfig(
 	defaultPricingURL := modelcatalog.DefaultPricingURL
 	defaultModelParametersURL := modelcatalog.DefaultModelParametersURL
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
+	defaultLiveModelsSyncSeconds := int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds())
 
 	filePricingURL := (*string)(nil)
 	fileModelParametersURL := (*string)(nil)
 	fileSyncSeconds := (*int64)(nil)
 	fileMCPLibraryURL := (*string)(nil)
 	fileMCPLibrarySyncSeconds := (*int64)(nil)
+	fileLiveModelsSyncSeconds := (*int64)(nil)
 	skipURLBackfill := false // prevent DB backfill of unresolved env references
 	skipModelParamsURLBackfill := false
 	skipMCPLibraryURLBackfill := false
@@ -4203,6 +4205,24 @@ func ResolveFrameworkPricingConfig(
 				fileMCPLibrarySyncSeconds = &val
 			}
 		}
+		if fileConfig.Pricing.LiveModelsSyncInterval != nil {
+			val := *fileConfig.Pricing.LiveModelsSyncInterval
+			switch {
+			case val == modelcatalog.LiveModelsSyncDisabled:
+				// Explicit opt-out, not corruption. Passed through untouched so
+				// Phase 3 does not "repair" it back to the default.
+				disabled := modelcatalog.LiveModelsSyncDisabled
+				fileLiveModelsSyncSeconds = &disabled
+			case val < 0:
+				logger.Warn("live_models_sync_interval in config.json is invalid (%d seconds), ignoring — using default (%d seconds)", val, defaultLiveModelsSyncSeconds)
+			case val < modelcatalog.MinimumLiveModelsSyncIntervalSec:
+				clamped := modelcatalog.MinimumLiveModelsSyncIntervalSec
+				logger.Warn("live_models_sync_interval in config.json is below minimum (%d seconds), clamping to %d seconds", val, clamped)
+				fileLiveModelsSyncSeconds = &clamped
+			default:
+				fileLiveModelsSyncSeconds = &val
+			}
+		}
 	}
 
 	// --- Phase 2: apply file config over defaults ---
@@ -4215,6 +4235,7 @@ func ResolveFrameworkPricingConfig(
 	defaultMCPLibrarySyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
 	resolvedMCPLibraryURL := &defaultMCPLibraryURL
 	resolvedMCPLibrarySyncInterval := &defaultMCPLibrarySyncSeconds
+	resolvedLiveModelsSyncInterval := &defaultLiveModelsSyncSeconds
 
 	if filePricingURL != nil {
 		resolvedPricingURL = filePricingURL
@@ -4238,6 +4259,10 @@ func ResolveFrameworkPricingConfig(
 	if fileMCPLibrarySyncSeconds != nil {
 		resolvedMCPLibrarySyncInterval = fileMCPLibrarySyncSeconds
 	}
+	if fileLiveModelsSyncSeconds != nil {
+		resolvedLiveModelsSyncInterval = fileLiveModelsSyncSeconds
+		logger.Debug("live_models_sync_interval resolved from file: %d seconds", *fileLiveModelsSyncSeconds)
+	}
 
 	// --- Phase 3: DB values applied; file wins on hash mismatch (file changed since last write) ---
 
@@ -4247,10 +4272,13 @@ func ResolveFrameworkPricingConfig(
 	// Hash the file-resolved values; skip if nothing valid survived Phase 1.
 	fileHash := ""
 	fileHasHashableMCPConfig := (fileMCPLibraryURL != nil && !skipMCPLibraryURLBackfill) || fileMCPLibrarySyncSeconds != nil
-	if fileConfig != nil && fileConfig.Pricing != nil && !skipURLBackfill && (filePricingURL != nil || (fileModelParametersURL != nil && !skipModelParamsURLBackfill) || fileSyncSeconds != nil || fileHasHashableMCPConfig) {
+	// Folded into the same predicate so a config.json edit that touches only
+	// live_models_sync_interval still registers as a file change.
+	fileHasHashableOptionalConfig := fileHasHashableMCPConfig || fileLiveModelsSyncSeconds != nil
+	if fileConfig != nil && fileConfig.Pricing != nil && !skipURLBackfill && (filePricingURL != nil || (fileModelParametersURL != nil && !skipModelParamsURLBackfill) || fileSyncSeconds != nil || fileHasHashableOptionalConfig) {
 		var h string
 		var err error
-		if fileHasHashableMCPConfig {
+		if fileHasHashableOptionalConfig {
 			mcpHashURL := fileMCPLibraryURL
 			if skipMCPLibraryURLBackfill {
 				mcpHashURL = nil
@@ -4258,6 +4286,7 @@ func ResolveFrameworkPricingConfig(
 			h, err = configstore.GenerateFrameworkConfigHash(filePricingURL, fileModelParametersURL, fileSyncSeconds, configstore.FrameworkConfigHashOptions{
 				MCPLibraryURL:          mcpHashURL,
 				MCPLibrarySyncInterval: fileMCPLibrarySyncSeconds,
+				LiveModelsSyncInterval: fileLiveModelsSyncSeconds,
 			})
 		} else {
 			h, err = configstore.GenerateFrameworkConfigHash(filePricingURL, fileModelParametersURL, fileSyncSeconds)
@@ -4362,6 +4391,41 @@ func ResolveFrameworkPricingConfig(
 		} else {
 			needsDBUpdate = true
 		}
+
+		// Live models refresh interval. Same hash-gated precedence as above,
+		// with one carve-out: 0 is a deliberate opt-out rather than corruption,
+		// so it is honoured instead of being backfilled with the default.
+		if dbConfig.LiveModelsSyncInterval != nil {
+			val := *dbConfig.LiveModelsSyncInterval
+			switch {
+			case val == modelcatalog.LiveModelsSyncDisabled:
+				if fileChanged && fileLiveModelsSyncSeconds != nil {
+					logger.Info("live_models_sync_interval from config.json overrides DB (file hash changed): file=%d db=disabled — updating DB", *fileLiveModelsSyncSeconds)
+					needsDBUpdate = true
+				} else {
+					resolvedLiveModelsSyncInterval = dbConfig.LiveModelsSyncInterval
+				}
+			case val < 0:
+				logger.Warn("live_models_sync_interval in DB is corrupted (%d seconds), ignoring — backfilling with %d seconds", val, *resolvedLiveModelsSyncInterval)
+				needsDBUpdate = true
+			case val < modelcatalog.MinimumLiveModelsSyncIntervalSec:
+				logger.Warn("live_models_sync_interval in DB is below minimum (%d seconds) — backfilling", val)
+				if !fileChanged || fileLiveModelsSyncSeconds == nil {
+					clamped := modelcatalog.MinimumLiveModelsSyncIntervalSec
+					resolvedLiveModelsSyncInterval = &clamped
+				}
+				needsDBUpdate = true
+			default:
+				if fileChanged && fileLiveModelsSyncSeconds != nil {
+					logger.Info("live_models_sync_interval from config.json overrides DB (file hash changed): file=%d db=%d seconds — updating DB", *fileLiveModelsSyncSeconds, val)
+					needsDBUpdate = true
+				} else {
+					resolvedLiveModelsSyncInterval = dbConfig.LiveModelsSyncInterval
+				}
+			}
+		} else {
+			needsDBUpdate = true
+		}
 	}
 
 	// --- Phase 4: nil guard ---
@@ -4383,6 +4447,9 @@ func ResolveFrameworkPricingConfig(
 	if resolvedMCPLibrarySyncInterval == nil {
 		resolvedMCPLibrarySyncInterval = &defaultMCPLibrarySyncSeconds
 	}
+	if resolvedLiveModelsSyncInterval == nil {
+		resolvedLiveModelsSyncInterval = &defaultLiveModelsSyncSeconds
+	}
 
 	// Only update the stored hash when the file actually changed; preserve the
 	// existing hash for correction-only DB updates (null backfill, corruption fix).
@@ -4401,6 +4468,7 @@ func ResolveFrameworkPricingConfig(
 			ModelParametersURL:     resolvedModelParametersURL,
 			MCPLibraryURL:          resolvedMCPLibraryURL,
 			MCPLibrarySyncInterval: resolvedMCPLibrarySyncInterval,
+			LiveModelsSyncInterval: resolvedLiveModelsSyncInterval,
 			ConfigHash:             persistedHash,
 		}, &modelcatalog.Config{
 			PricingURL:             resolvedPricingURL,
@@ -4408,6 +4476,7 @@ func ResolveFrameworkPricingConfig(
 			ModelParametersURL:     resolvedModelParametersURL,
 			MCPLibraryURL:          resolvedMCPLibraryURL,
 			MCPLibrarySyncInterval: resolvedMCPLibrarySyncInterval,
+			LiveModelsSyncInterval: resolvedLiveModelsSyncInterval,
 		}, needsDBUpdate
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -17634,6 +17634,7 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
 	defaultModelParamsURL := modelcatalog.DefaultModelParametersURL
 	defaultMCPLibraryURL := modelcatalog.DefaultMCPLibraryURL
+	defaultLiveModelsSyncSeconds := int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds())
 	fileURL := "https://example.com/pricing.json"
 	fileSyncSeconds := int64((12 * time.Hour).Seconds())
 	dbURL := "https://db.example.com/pricing.json"
@@ -17680,6 +17681,9 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 			ModelParametersURL:     &defaultModelParamsURL,
 			MCPLibraryURL:          &defaultMCPLibraryURL,
 			MCPLibrarySyncInterval: &defaultSyncSeconds,
+			// Populated so this stays a pure precedence test: a nil column is a
+			// backfill case and would set needsDBUpdate on its own.
+			LiveModelsSyncInterval: &defaultLiveModelsSyncSeconds,
 			ConfigHash:             storedHash, // hash of last file-applied values
 		}
 		fileConfig := &framework.FrameworkConfig{
@@ -17854,6 +17858,108 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 		require.Equal(t, defaultSyncSeconds, *normalizedModelCatalog.MCPLibrarySyncInterval)
 	})
 
+	t.Run("live models sync interval defaults when unset everywhere", func(t *testing.T) {
+		normalizedTable, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(nil, nil)
+		want := int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds())
+		require.Equal(t, want, *normalizedTable.LiveModelsSyncInterval)
+		require.Equal(t, want, *normalizedModelCatalog.LiveModelsSyncInterval)
+	})
+
+	t.Run("live models sync interval zero is an opt-out, not corruption", func(t *testing.T) {
+		// The sibling intervals treat <=0 as corrupted and backfill the
+		// default. 0 here means "never refresh in the background" and must
+		// survive both the file parse and the DB precedence pass.
+		disabled := modelcatalog.LiveModelsSyncDisabled
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{LiveModelsSyncInterval: &disabled},
+		}
+
+		_, fromFile, _ := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.Equal(t, modelcatalog.LiveModelsSyncDisabled, *fromFile.LiveModelsSyncInterval)
+
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     11,
+			PricingURL:             &defaultURL,
+			PricingSyncInterval:    &defaultSyncSeconds,
+			ModelParametersURL:     &defaultModelParamsURL,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &defaultSyncSeconds,
+			LiveModelsSyncInterval: &disabled,
+		}
+		_, fromDB, _ := ResolveFrameworkPricingConfig(dbConfig, nil)
+		require.Equal(t, modelcatalog.LiveModelsSyncDisabled, *fromDB.LiveModelsSyncInterval)
+	})
+
+	t.Run("live models sync interval negative falls back to default", func(t *testing.T) {
+		negative := int64(-30)
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{LiveModelsSyncInterval: &negative},
+		}
+
+		_, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.Equal(t, int64(modelcatalog.DefaultLiveModelsSyncInterval.Seconds()), *normalizedModelCatalog.LiveModelsSyncInterval)
+	})
+
+	t.Run("live models sync interval below minimum clamps up", func(t *testing.T) {
+		tooFast := modelcatalog.MinimumLiveModelsSyncIntervalSec - 1
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{LiveModelsSyncInterval: &tooFast},
+		}
+
+		_, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(nil, fileConfig)
+		require.Equal(t, modelcatalog.MinimumLiveModelsSyncIntervalSec, *normalizedModelCatalog.LiveModelsSyncInterval)
+	})
+
+	t.Run("live models sync interval db wins while the file is unchanged", func(t *testing.T) {
+		// Mirrors the UI-edit case for the sibling intervals: the operator's
+		// stored value must not be stomped by the file on every restart.
+		fileInterval := int64(900)
+		storedHash, err := configstore.GenerateFrameworkConfigHash(nil, nil, nil, configstore.FrameworkConfigHashOptions{
+			LiveModelsSyncInterval: &fileInterval,
+		})
+		require.NoError(t, err)
+
+		uiEdited := int64(1800)
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     12,
+			PricingURL:             &defaultURL,
+			PricingSyncInterval:    &defaultSyncSeconds,
+			ModelParametersURL:     &defaultModelParamsURL,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &defaultSyncSeconds,
+			LiveModelsSyncInterval: &uiEdited,
+			ConfigHash:             storedHash,
+		}
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{LiveModelsSyncInterval: &fileInterval},
+		}
+
+		_, normalizedModelCatalog, _ := ResolveFrameworkPricingConfig(dbConfig, fileConfig)
+		require.Equal(t, uiEdited, *normalizedModelCatalog.LiveModelsSyncInterval)
+	})
+
+	t.Run("live models sync interval file wins when the file changed", func(t *testing.T) {
+		fileInterval := int64(900)
+		uiEdited := int64(1800)
+		dbConfig := &tables.TableFrameworkConfig{
+			ID:                     13,
+			PricingURL:             &defaultURL,
+			PricingSyncInterval:    &defaultSyncSeconds,
+			ModelParametersURL:     &defaultModelParamsURL,
+			MCPLibraryURL:          &defaultMCPLibraryURL,
+			MCPLibrarySyncInterval: &defaultSyncSeconds,
+			LiveModelsSyncInterval: &uiEdited,
+			ConfigHash:             "stale-hash-from-a-previous-file",
+		}
+		fileConfig := &framework.FrameworkConfig{
+			Pricing: &modelcatalog.Config{LiveModelsSyncInterval: &fileInterval},
+		}
+
+		_, normalizedModelCatalog, needsDBUpdate := ResolveFrameworkPricingConfig(dbConfig, fileConfig)
+		require.True(t, needsDBUpdate)
+		require.Equal(t, fileInterval, *normalizedModelCatalog.LiveModelsSyncInterval)
+	})
+
 	t.Run("mcp library file values override defaults", func(t *testing.T) {
 		mcpURL := "https://example.com/mcp-library.json"
 		mcpSyncSeconds := int64((2 * time.Hour).Seconds())
@@ -17915,6 +18021,9 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 			ModelParametersURL:     &defaultModelParamsURL,
 			MCPLibraryURL:          &uiEditedMCPURL,
 			MCPLibrarySyncInterval: &uiEditedMCPSyncSeconds,
+			// Populated so this stays a pure precedence test: a nil column is a
+			// backfill case and would set needsDBUpdate on its own.
+			LiveModelsSyncInterval: &defaultLiveModelsSyncSeconds,
 			ConfigHash:             storedHash,
 		}
 		fileConfig := &framework.FrameworkConfig{

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"os"
 	"os/signal"
@@ -23,6 +24,7 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 	dynamicPlugins "github.com/maximhq/bifrost/framework/plugins"
 	"github.com/maximhq/bifrost/framework/sidekiq"
 	"github.com/maximhq/bifrost/framework/temptoken"
@@ -109,6 +111,8 @@ type ServerCallbacks interface {
 	OnKeyAdded(ctx context.Context, provider schemas.ModelProvider, key schemas.Key) error
 	OnKeyUpdated(ctx context.Context, provider schemas.ModelProvider, key schemas.Key) error
 	OnKeyDeleted(ctx context.Context, provider schemas.ModelProvider, keyID string) error
+	RefreshLiveModelsForKey(ctx context.Context, provider schemas.ModelProvider, keyID string) error
+	RefreshLiveModelsForAllKeys(ctx context.Context, provider schemas.ModelProvider) error
 	ReloadRoutingRule(ctx context.Context, id string) error
 	RemoveRoutingRule(ctx context.Context, id string) error
 	// Webhook related callbacks
@@ -186,6 +190,18 @@ type BifrostHTTPServer struct {
 
 	SidekiqRunner         *sidekiq.Runner
 	SidekiqDispatcherStop func()
+
+	// Background live model catalog refresher. Guarded because the framework
+	// config handler can restart it from a request goroutine while the boot
+	// path or shutdown is touching it.
+	liveModelRefresherMu   sync.Mutex
+	liveModelRefresherStop func()
+
+	// refreshInFlight coordinates on-demand model refreshes. Distinct keys for
+	// the same provider may refresh concurrently, while an all-keys refresh is
+	// exclusive with every key refresh for that provider.
+	refreshInFlightMu sync.Mutex
+	refreshInFlight   map[schemas.ModelProvider]*providerRefreshState
 
 	WebhookDispatcher *webhooks.Dispatcher
 
@@ -1028,10 +1044,277 @@ func (s *BifrostHTTPServer) UpdateSyncConfig(ctx context.Context) error {
 	if s.Config == nil || s.Config.ModelCatalog == nil {
 		return fmt.Errorf("pricing manager not found")
 	}
-	if s.Config.FrameworkConfig == nil || s.Config.FrameworkConfig.Pricing == nil {
+	// Snapshot the pricing pointer and release the read lock before restarting
+	// the refresher: that path takes Config.Mu.RLock again through
+	// LiveModelsSyncInterval, and sync.RWMutex read locks are not reentrant.
+	// Safe to use after unlocking because the config update path publishes a
+	// whole new FrameworkConfig rather than mutating this struct in place.
+	s.Config.Mu.RLock()
+	var pricing *modelcatalog.Config
+	if s.Config.FrameworkConfig != nil {
+		pricing = s.Config.FrameworkConfig.Pricing
+	}
+	s.Config.Mu.RUnlock()
+	if pricing == nil {
 		return fmt.Errorf("framework config not found")
 	}
-	return s.Config.ModelCatalog.UpdateSyncConfig(ctx, s.Config.FrameworkConfig.Pricing)
+	// The live model refresher reads its interval from the same framework
+	// config block, so pick up a changed (or newly disabled) value here rather
+	// than waiting for a restart.
+	s.restartLiveModelRefresher(s.backgroundCtx())
+	return s.Config.ModelCatalog.UpdateSyncConfig(ctx, pricing)
+}
+
+// backgroundCtx returns the server-lifetime context background workers should
+// hang off. Falls back to context.Background() before Bootstrap has set s.Ctx.
+func (s *BifrostHTTPServer) backgroundCtx() context.Context {
+	if s.Ctx != nil {
+		return s.Ctx
+	}
+	return context.Background()
+}
+
+// liveRefreshProviderConcurrency bounds how many providers a single
+// RefreshAllLiveModels pass fetches at once. The bootstrap seed could fan out
+// across every provider unbounded because nothing else was in flight yet; the
+// background pass runs alongside live inference traffic, and each provider it
+// picks up itself fans out to (enabled keys x 2) upstream calls.
+const liveRefreshProviderConcurrency = 4
+
+// RefreshAllLiveModels runs a full per-provider live model refresh.
+//
+// Safe to call while providers are being edited, unlike the bootstrap seed it
+// replaced: the provider set and each provider's keys are read through the
+// Config accessors, which take Config.Mu.RLock and hand back copies, rather
+// than ranging Config.Providers directly.
+//
+// Deliberately does not invalidate anything first. Key and provider removals
+// already prune the cache through the CRUD handlers, and
+// FetchAndStoreLiveForKey writes nothing when a fetch fails, so leaving
+// entries in place keeps last-known-good models routable across a transient
+// upstream error instead of emptying a catalog that was healthy a moment ago.
+func (s *BifrostHTTPServer) RefreshAllLiveModels(ctx context.Context) {
+	if s.Config == nil || s.Config.ModelCatalog == nil || s.Client == nil {
+		return
+	}
+
+	providers, err := s.Config.GetAllProviders()
+	if err != nil {
+		logger.Warn("live model refresh skipped: failed to list providers: %v", err)
+		return
+	}
+
+	sem := make(chan struct{}, liveRefreshProviderConcurrency)
+	var wg sync.WaitGroup
+	for _, provider := range providers {
+		keys, err := s.Config.GetProviderKeysRaw(provider)
+		if err != nil {
+			// Removed between GetAllProviders and this read. OnProviderRemoved
+			// has already dropped its live entries, so there is nothing to do.
+			continue
+		}
+		wg.Add(1)
+		go func(p schemas.ModelProvider, k []schemas.Key) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			s.RefreshLiveModelsForProvider(ctx, p, k)
+		}(provider, keys)
+	}
+	wg.Wait()
+}
+
+// liveRefreshJitterFraction spreads each refresh cycle over
+// interval * [1-f, 1+f]. Pods in a deployment start within seconds of each
+// other, so an exact interval would have every replica fan out to every
+// upstream at the same instant, on every cycle, forever.
+const liveRefreshJitterFraction = 0.1
+
+// jitteredInterval scales d by a uniform random factor around 1.
+func jitteredInterval(d time.Duration) time.Duration {
+	factor := 1 - liveRefreshJitterFraction + 2*liveRefreshJitterFraction*rand.Float64()
+	return time.Duration(float64(d) * factor)
+}
+
+// LiveModelsSyncInterval returns the configured background refresh interval.
+// A non-positive result means the refresher is disabled.
+func (s *BifrostHTTPServer) LiveModelsSyncInterval() time.Duration {
+	if s.Config == nil {
+		return modelcatalog.DefaultLiveModelsSyncInterval
+	}
+	// FrameworkConfig is swapped wholesale by the config update handler, so the
+	// pointer read needs Config.Mu like every other accessor on this struct.
+	s.Config.Mu.RLock()
+	defer s.Config.Mu.RUnlock()
+	if s.Config.FrameworkConfig == nil || s.Config.FrameworkConfig.Pricing == nil {
+		return modelcatalog.DefaultLiveModelsSyncInterval
+	}
+	configured := s.Config.FrameworkConfig.Pricing.LiveModelsSyncInterval
+	if configured == nil {
+		return modelcatalog.DefaultLiveModelsSyncInterval
+	}
+	return time.Duration(*configured) * time.Second
+}
+
+// startLiveModelRefresher runs RefreshAllLiveModels on a jittered interval and
+// returns a func that stops it. A non-positive interval disables the refresher
+// and returns a no-op, which is the documented opt-out.
+//
+// Deliberately takes no distributed lock, unlike the pricing sync worker: the
+// live model cache is per-process in-memory, so every node has to refresh its
+// own copy. Electing a single refresher would leave every other node serving
+// its boot-time snapshot indefinitely.
+func (s *BifrostHTTPServer) startLiveModelRefresher(ctx context.Context, interval time.Duration) func() {
+	if interval <= 0 {
+		logger.Info("background live model refresh is disabled")
+		return func() {}
+	}
+	logger.Info("background live model refresh every %v (jittered +/-%d%%)", interval, int(liveRefreshJitterFraction*100))
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		// A timer rather than a ticker: the delay is resampled every cycle, so
+		// replicas that happen to align on one cycle drift apart on the next.
+		timer := time.NewTimer(jitteredInterval(interval))
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				s.RefreshAllLiveModels(ctx)
+				timer.Reset(jitteredInterval(interval))
+			}
+		}
+	}()
+	return cancel
+}
+
+// restartLiveModelRefresher stops any running refresher and starts a new one
+// at the currently configured interval. Called at boot and again whenever the
+// framework config changes, so a disabled-to-enabled edit (or vice versa)
+// takes effect without a restart.
+func (s *BifrostHTTPServer) restartLiveModelRefresher(ctx context.Context) {
+	s.liveModelRefresherMu.Lock()
+	defer s.liveModelRefresherMu.Unlock()
+	if s.liveModelRefresherStop != nil {
+		s.liveModelRefresherStop()
+	}
+	s.liveModelRefresherStop = s.startLiveModelRefresher(ctx, s.LiveModelsSyncInterval())
+}
+
+// stopLiveModelRefresher halts the background refresher if one is running.
+func (s *BifrostHTTPServer) stopLiveModelRefresher() {
+	s.liveModelRefresherMu.Lock()
+	defer s.liveModelRefresherMu.Unlock()
+	if s.liveModelRefresherStop != nil {
+		s.liveModelRefresherStop()
+		s.liveModelRefresherStop = nil
+	}
+}
+
+type providerRefreshState struct {
+	allKeys bool
+	keys    map[string]struct{}
+}
+
+// beginKeyRefresh claims an on-demand refresh slot for one provider key.
+// Refreshes for distinct keys may run concurrently, but the same key is
+// deduplicated and no key refresh may overlap an all-keys refresh.
+func (s *BifrostHTTPServer) beginKeyRefresh(provider schemas.ModelProvider, keyID string) (release func(), ok bool) {
+	s.refreshInFlightMu.Lock()
+	defer s.refreshInFlightMu.Unlock()
+
+	if s.refreshInFlight == nil {
+		s.refreshInFlight = make(map[schemas.ModelProvider]*providerRefreshState)
+	}
+	state := s.refreshInFlight[provider]
+	if state == nil {
+		state = &providerRefreshState{keys: make(map[string]struct{})}
+		s.refreshInFlight[provider] = state
+	}
+	if state.allKeys {
+		return nil, false
+	}
+	if _, exists := state.keys[keyID]; exists {
+		return nil, false
+	}
+	state.keys[keyID] = struct{}{}
+
+	return func() {
+		s.refreshInFlightMu.Lock()
+		defer s.refreshInFlightMu.Unlock()
+		current := s.refreshInFlight[provider]
+		if current != state {
+			return
+		}
+		delete(state.keys, keyID)
+		if len(state.keys) == 0 {
+			delete(s.refreshInFlight, provider)
+		}
+	}, true
+}
+
+// beginAllKeysRefresh claims an exclusive on-demand refresh slot for a
+// provider. It conflicts with both another all-keys refresh and any active
+// per-key refresh for that provider.
+func (s *BifrostHTTPServer) beginAllKeysRefresh(provider schemas.ModelProvider) (release func(), ok bool) {
+	s.refreshInFlightMu.Lock()
+	defer s.refreshInFlightMu.Unlock()
+
+	if s.refreshInFlight == nil {
+		s.refreshInFlight = make(map[schemas.ModelProvider]*providerRefreshState)
+	}
+	if _, exists := s.refreshInFlight[provider]; exists {
+		return nil, false
+	}
+	state := &providerRefreshState{allKeys: true}
+	s.refreshInFlight[provider] = state
+
+	return func() {
+		s.refreshInFlightMu.Lock()
+		defer s.refreshInFlightMu.Unlock()
+		if s.refreshInFlight[provider] == state {
+			delete(s.refreshInFlight, provider)
+		}
+	}, true
+}
+
+// RefreshLiveModelsForKey re-fetches list-models for one key on demand. It is
+// the ModelsManager entrypoint behind the per-key refresh button.
+func (s *BifrostHTTPServer) RefreshLiveModelsForKey(ctx context.Context, provider schemas.ModelProvider, keyID string) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil || s.Client == nil {
+		return fmt.Errorf("model catalog is not initialized")
+	}
+	release, ok := s.beginKeyRefresh(provider, keyID)
+	if !ok {
+		return handlers.ErrRefreshInProgress
+	}
+	defer release()
+
+	s.FetchAndStoreLiveForKey(ctx, provider, keyID)
+	return nil
+}
+
+// RefreshLiveModelsForAllKeys re-fetches list-models across every enabled key
+// of the provider on demand. It is the ModelsManager entrypoint behind the
+// provider-level refresh button.
+func (s *BifrostHTTPServer) RefreshLiveModelsForAllKeys(ctx context.Context, provider schemas.ModelProvider) error {
+	if s.Config == nil || s.Config.ModelCatalog == nil || s.Client == nil {
+		return fmt.Errorf("model catalog is not initialized")
+	}
+	keys, err := s.Config.GetProviderKeysRaw(provider)
+	if err != nil {
+		return err
+	}
+	release, ok := s.beginAllKeysRefresh(provider)
+	if !ok {
+		return handlers.ErrRefreshInProgress
+	}
+	defer release()
+
+	s.RefreshLiveModelsForProvider(ctx, provider, keys)
+	return nil
 }
 
 // RefreshLiveModelsForProvider runs filtered + unfiltered list-models for the
@@ -1086,16 +1369,24 @@ func (s *BifrostHTTPServer) RefreshLiveModelsForProvider(ctx context.Context, pr
 // routing graph is the same at boot, after a key add, and after a reload —
 // stale-but-routable behavior would diverge otherwise.
 func (s *BifrostHTTPServer) FetchAndStoreLiveForKey(ctx context.Context, provider schemas.ModelProvider, keyID string) {
+	if s.Config == nil || s.Config.ModelCatalog == nil {
+		return
+	}
 	// Skip the fetch entirely when the provider has disabled list_models via
 	// allowed_requests — every per-(provider,keyID) call would just bounce with
 	// "operation not allowed", wasting two goroutines and one bfCtx per attempt.
-	if s.Config != nil {
-		if pc, err := s.Config.GetProviderConfigRaw(provider); err == nil && pc != nil &&
-			pc.CustomProviderConfig != nil &&
-			!pc.CustomProviderConfig.IsOperationAllowed(schemas.ListModelsRequest) {
-			return
-		}
+	if pc, err := s.Config.GetProviderConfigRaw(provider); err == nil && pc != nil &&
+		pc.CustomProviderConfig != nil &&
+		!pc.CustomProviderConfig.IsOperationAllowed(schemas.ListModelsRequest) {
+		return
 	}
+	// Captured before the upstream calls go out, and checked again by the
+	// catalog when each response commits. list-models can take seconds; a key
+	// deleted or disabled in that window has already had its entries dropped by
+	// the CRUD handler, and no later refresh pass fetches or prunes a key that
+	// is no longer configured — so an unguarded commit here would re-add that
+	// key's models and advertise them until the process restarted.
+	gen := s.Config.ModelCatalog.LiveGeneration(provider)
 	// One BifrostContext per goroutine. BifrostContext.SetValue mutates state
 	// in place, so the request-scoped metadata core sets during a routing pass
 	// (RequestID, FallbackIndex, span IDs, ...) would otherwise bleed between
@@ -1132,7 +1423,15 @@ func (s *BifrostHTTPServer) FetchAndStoreLiveForKey(ctx context.Context, provide
 		if resp == nil {
 			return
 		}
-		s.Config.ModelCatalog.UpsertLiveFromResponse(provider, keyID, false, resp)
+		if !s.Config.ModelCatalog.UpsertLiveFromResponseIfCurrent(provider, keyID, false, resp, gen) {
+			// The key or provider changed while this call was in flight, so the
+			// result describes a configuration that no longer exists. Dropping
+			// the key statuses with it is deliberate: they are keyed by the same
+			// key ID and would write validity back onto a row that was just
+			// deleted or replaced.
+			logger.Debug("discarding stale filtered list-models result for provider %s key %s: the provider's keys changed while the fetch was in flight", provider, keyID)
+			return
+		}
 		if len(resp.KeyStatuses) > 0 && s.Config.ConfigStore != nil {
 			s.updateKeyStatus(ctx, resp.KeyStatuses)
 		}
@@ -1153,7 +1452,9 @@ func (s *BifrostHTTPServer) FetchAndStoreLiveForKey(ctx context.Context, provide
 		if resp == nil {
 			return
 		}
-		s.Config.ModelCatalog.UpsertLiveFromResponse(provider, keyID, true, resp)
+		if !s.Config.ModelCatalog.UpsertLiveFromResponseIfCurrent(provider, keyID, true, resp, gen) {
+			logger.Debug("discarding stale unfiltered list-models result for provider %s key %s: the provider's keys changed while the fetch was in flight", provider, keyID)
+		}
 	}()
 	wg.Wait()
 }
@@ -1891,15 +2192,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		}
 		s.Config.ModelCatalog.ReplaceKeyConfig(snapshot)
 
-		var wg sync.WaitGroup
-		for provider, providerConfig := range s.Config.Providers {
-			wg.Add(1)
-			go func(p schemas.ModelProvider, keys []schemas.Key) {
-				defer wg.Done()
-				s.RefreshLiveModelsForProvider(ctx, p, keys)
-			}(provider, providerConfig.Keys)
-		}
-		wg.Wait()
+		s.RefreshAllLiveModels(ctx)
 	}
 	logger.Info("models added to catalog")
 	s.Config.SetBifrostClient(s.Client)
@@ -2064,6 +2357,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		ReadBufferSize:     s.Config.ServerConfig.ReadBufferSize,
 	}
 	startSkillsOrphanCleanupWorker(s.Ctx, s.Config)
+	// Keep the live model catalog current after boot. Without this, a model an
+	// upstream starts serving mid-uptime stays invisible until a restart or a
+	// key edit, since nothing else re-fetches list-models.
+	s.restartLiveModelRefresher(s.Ctx)
 	return nil
 }
 
@@ -2150,6 +2447,8 @@ func (s *BifrostHTTPServer) Start() error {
 				logger.Info("stopping sidekiq dispatcher...")
 				s.SidekiqDispatcherStop()
 			}
+			logger.Info("stopping live model refresher...")
+			s.stopLiveModelRefresher()
 			if s.SidekiqRunner != nil {
 				logger.Info("stopping sidekiq runner...")
 				s.SidekiqRunner.Shutdown()

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"runtime"
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -127,6 +129,291 @@ func TestUpdateKeyStatus_EmptyKeyIDDoesNotOverwriteKeyedProviderStatus(t *testin
 	if store.calls[0].Provider != "openai" || store.calls[0].KeyID != "" {
 		t.Fatalf("expected DB status update to retain empty key ID, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
 	}
+}
+
+// TestUpdateKeyStatus_SkipsWriteWhenUnchanged pins the write-gating that makes
+// the background refresher affordable: ConfigStore.UpdateStatus is an
+// unconditional SQL UPDATE, so a status that has not moved must not reach it.
+// Without this gate a 30-key deployment refreshing on an interval writes 30
+// no-op UPDATEs per pass, per node, forever.
+func TestUpdateKeyStatus_SkipsWriteWhenUnchanged(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"openai": {
+					Keys: []schemas.Key{{
+						ID:          "key-1",
+						Status:      schemas.KeyStatusListModelsFailed,
+						Description: "upstream 503",
+					}},
+				},
+			},
+		},
+	}
+
+	unchanged := []schemas.KeyStatus{{
+		Provider: "openai",
+		KeyID:    "key-1",
+		Status:   schemas.KeyStatusListModelsFailed,
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: "upstream 503"}},
+	}}
+
+	server.updateKeyStatus(context.Background(), unchanged)
+	server.updateKeyStatus(context.Background(), unchanged)
+
+	if len(store.calls) != 0 {
+		t.Fatalf("expected no status update calls for an unchanged status, got %d", len(store.calls))
+	}
+
+	// A genuine change must still get through, otherwise the gate would hide
+	// a key recovering or breaking.
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "openai",
+		KeyID:    "key-1",
+		Status:   schemas.KeyStatusSuccess,
+	}})
+
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one status update call after the status changed, got %d", len(store.calls))
+	}
+	if got := server.Config.Providers["openai"].Keys[0].Status; got != schemas.KeyStatusSuccess {
+		t.Fatalf("expected in-memory status to become success, got %q", got)
+	}
+	if got := server.Config.Providers["openai"].Keys[0].Description; got != "" {
+		t.Fatalf("expected in-memory description to be cleared, got %q", got)
+	}
+}
+
+// TestUpdateKeyStatus_WritesWhenKeyMissingFromMemory guards the fallback: with
+// nothing to compare against, the gate must let the write through rather than
+// silently swallowing it.
+func TestUpdateKeyStatus_WritesWhenKeyMissingFromMemory(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"openai": {Keys: []schemas.Key{{ID: "key-1"}}},
+			},
+		},
+	}
+
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "openai",
+		KeyID:    "key-unknown",
+		Status:   schemas.KeyStatusSuccess,
+	}})
+
+	if len(store.calls) != 1 {
+		t.Fatalf("expected the write to proceed for an unknown key, got %d calls", len(store.calls))
+	}
+}
+
+// TestRefreshAllLiveModels_NilClientIsNoop covers the boot-order guard: the
+// refresher can fire before or after the client exists, and dereferencing a
+// nil client would panic the background goroutine.
+func TestRefreshAllLiveModels_NilClientIsNoop(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalog(nil),
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"custom-provider": {Keys: []schemas.Key{{ID: "key-1"}}},
+			},
+		},
+	}
+
+	// Reaching the end without panicking is the assertion: s.Client is nil, so
+	// any scheduled fetch would dereference it.
+	server.RefreshAllLiveModels(context.Background())
+
+	if models := server.Config.ModelCatalog.GetModelsForProvider("custom-provider"); len(models) != 0 {
+		t.Fatalf("expected no live models to be written, got %v", models)
+	}
+}
+
+// TestRefreshAllLiveModels_SkipsProvidersWithNoEnabledKeys cross-checks that
+// the per-provider skip rules still apply when the fan-out is driven by the
+// background pass rather than the bootstrap loop.
+func TestRefreshAllLiveModels_SkipsProvidersWithNoEnabledKeys(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ModelCatalog: modelcatalog.NewTestCatalog(nil),
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"all-disabled": {Keys: []schemas.Key{
+					{ID: "key-1", Enabled: schemas.Ptr(false)},
+					{ID: "key-2", Enabled: schemas.Ptr(false)},
+				}},
+				"no-keys": {},
+			},
+		},
+	}
+	// Non-nil sentinel would be required for a fetch to be attempted; leaving
+	// Client nil means any scheduled fetch panics and fails this test.
+	server.RefreshAllLiveModels(context.Background())
+}
+
+// TestStartLiveModelRefresher_ZeroIntervalDisabled pins the opt-out: a
+// non-positive interval must spawn nothing and still return a usable stop func.
+func TestStartLiveModelRefresher_ZeroIntervalDisabled(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	server := &BifrostHTTPServer{}
+
+	for _, interval := range []time.Duration{0, -time.Second} {
+		before := runtime.NumGoroutine()
+		stop := server.startLiveModelRefresher(context.Background(), interval)
+		if stop == nil {
+			t.Fatalf("interval %v: expected a non-nil stop func", interval)
+		}
+		if after := runtime.NumGoroutine(); after > before {
+			t.Fatalf("interval %v: expected no goroutine to be spawned, went from %d to %d", interval, before, after)
+		}
+		stop() // must not panic
+	}
+}
+
+// TestStartLiveModelRefresher_StopsOnContextCancel makes sure the refresher
+// does not outlive the server: a leaked ticker would keep calling every
+// upstream forever after shutdown.
+func TestStartLiveModelRefresher_StopsOnContextCancel(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	server := &BifrostHTTPServer{}
+
+	baseline := runtime.NumGoroutine()
+	stop := server.startLiveModelRefresher(context.Background(), 10*time.Millisecond)
+
+	// Let it turn over a few cycles so we are stopping a running loop, not one
+	// that never started.
+	time.Sleep(50 * time.Millisecond)
+
+	stop()
+
+	// Poll rather than sleeping a fixed amount: goroutine teardown is not
+	// synchronous with cancel, and a generous window beats a flaky one.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("refresher goroutine still running 2s after stop: baseline %d, now %d", baseline, runtime.NumGoroutine())
+}
+
+// TestJitteredInterval_StaysWithinBounds pins the jitter window. Pods in a
+// deployment boot together, so this is what keeps their refresh cycles from
+// converging into a synchronized burst against every upstream.
+func TestJitteredInterval_StaysWithinBounds(t *testing.T) {
+	base := time.Hour
+	lower := time.Duration(float64(base) * (1 - liveRefreshJitterFraction))
+	upper := time.Duration(float64(base) * (1 + liveRefreshJitterFraction))
+
+	seen := make(map[time.Duration]struct{})
+	for range 1000 {
+		got := jitteredInterval(base)
+		if got < lower || got > upper {
+			t.Fatalf("jitteredInterval(%v) = %v, want within [%v, %v]", base, got, lower, upper)
+		}
+		seen[got] = struct{}{}
+	}
+	// A constant would satisfy the bounds check above but defeat the purpose.
+	if len(seen) < 2 {
+		t.Fatalf("expected jittered intervals to vary, got %d distinct value(s)", len(seen))
+	}
+}
+
+// TestBeginKeyRefresh_CoordinatesAtKeyGranularity covers the per-key in-flight
+// guard: duplicate key refreshes collapse, while distinct keys and providers
+// remain independent.
+func TestBeginKeyRefresh_CoordinatesAtKeyGranularity(t *testing.T) {
+	server := &BifrostHTTPServer{}
+
+	release, ok := server.beginKeyRefresh("openai", "key-1")
+	if !ok {
+		t.Fatal("expected the first claim to succeed")
+	}
+	if _, ok := server.beginKeyRefresh("openai", "key-1"); ok {
+		t.Fatal("expected a concurrent claim for the same key to be rejected")
+	}
+
+	otherKeyRelease, ok := server.beginKeyRefresh("openai", "key-2")
+	if !ok {
+		t.Fatal("expected a different key for the same provider to succeed")
+	}
+	otherKeyRelease()
+
+	otherProviderRelease, ok := server.beginKeyRefresh("anthropic", "key-1")
+	if !ok {
+		t.Fatal("expected a claim for a different provider to succeed")
+	}
+	otherProviderRelease()
+
+	release()
+	release, ok = server.beginKeyRefresh("openai", "key-1")
+	if !ok {
+		t.Fatal("expected the key to be claimable again after release")
+	}
+	release()
+}
+
+func TestBeginAllKeysRefresh_IsExclusiveWithinProvider(t *testing.T) {
+	server := &BifrostHTTPServer{}
+
+	keyRelease, ok := server.beginKeyRefresh("openai", "key-1")
+	if !ok {
+		t.Fatal("expected the key claim to succeed")
+	}
+	if _, ok := server.beginAllKeysRefresh("openai"); ok {
+		t.Fatal("expected all-keys refresh to conflict with an active key refresh")
+	}
+	keyRelease()
+
+	allRelease, ok := server.beginAllKeysRefresh("openai")
+	if !ok {
+		t.Fatal("expected all-keys refresh to succeed after the key refresh completed")
+	}
+	if _, ok := server.beginAllKeysRefresh("openai"); ok {
+		t.Fatal("expected a second all-keys refresh to be rejected")
+	}
+	if _, ok := server.beginKeyRefresh("openai", "key-2"); ok {
+		t.Fatal("expected key refresh to conflict with an active all-keys refresh")
+	}
+
+	otherProviderRelease, ok := server.beginKeyRefresh("anthropic", "key-1")
+	if !ok {
+		t.Fatal("expected another provider to remain independent")
+	}
+	otherProviderRelease()
+
+	allRelease()
+	allRelease, ok = server.beginAllKeysRefresh("openai")
+	if !ok {
+		t.Fatal("expected all-keys refresh to be claimable again after release")
+	}
+	allRelease()
 }
 
 func TestKeyEnabled(t *testing.T) {

--- a/transports/bifrost-http/server/utils.go
+++ b/transports/bifrost-http/server/utils.go
@@ -131,9 +131,47 @@ func MarshalPluginConfig[T any](source any) (*T, error) {
 	return nil, fmt.Errorf("invalid config type")
 }
 
+// currentKeyStatus returns the status and description currently held in memory
+// for the target of a KeyStatus update, and whether that target was found.
+//
+// A keyless provider is addressed by ks.KeyID == "" and carries its status on
+// the provider config; a keyed provider carries it on the matching key. found
+// is false when the provider is absent, when the key is absent, or when a
+// provider-level update arrives for a keyed provider — in every one of those
+// cases the caller has nothing to compare against and must not skip the write.
+func (s *BifrostHTTPServer) currentKeyStatus(ks schemas.KeyStatus) (status string, description string, found bool) {
+	s.Config.Mu.RLock()
+	defer s.Config.Mu.RUnlock()
+
+	providerConfig, exists := s.Config.Providers[ks.Provider]
+	if !exists {
+		return "", "", false
+	}
+
+	if ks.KeyID == "" {
+		if providerConfig.CustomProviderConfig == nil || !providerConfig.CustomProviderConfig.IsKeyLess {
+			return "", "", false
+		}
+		return providerConfig.Status, providerConfig.Description, true
+	}
+
+	for i := range providerConfig.Keys {
+		if providerConfig.Keys[i].ID == ks.KeyID {
+			return string(providerConfig.Keys[i].Status), providerConfig.Keys[i].Description, true
+		}
+	}
+	return "", "", false
+}
+
 // updateKeyStatus updates the model discovery status for keys or providers based on key statuses.
 // For keyed providers: updates individual key status
 // For keyless providers: updates provider-level status
+//
+// Statuses that match what is already stored are dropped before the write.
+// ConfigStore.UpdateStatus is an unconditional SQL UPDATE, and list-models runs
+// on a background interval on every node, so writing unconditionally would put
+// a steady keys x nodes x interval stream of no-op UPDATEs on the keys table
+// for rows whose values almost never change.
 func (s *BifrostHTTPServer) updateKeyStatus(
 	ctx context.Context,
 	keyStatuses []schemas.KeyStatus,
@@ -147,6 +185,13 @@ func (s *BifrostHTTPServer) updateKeyStatus(
 		errorMsg := ""
 		if ks.Error != nil && ks.Error.Error != nil {
 			errorMsg = ks.Error.Error.Message
+		}
+
+		// Compared before the DB write, not after: a status that has not moved
+		// needs neither the UPDATE nor the in-memory rewrite below.
+		if currentStatus, currentDesc, found := s.currentKeyStatus(ks); found &&
+			currentStatus == string(ks.Status) && currentDesc == errorMsg {
+			continue
 		}
 
 		if err := s.Config.ConfigStore.UpdateStatus(ctx, ks.Provider, ks.KeyID, string(ks.Status), errorMsg); err != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3612,6 +3612,13 @@
           "default": 86400,
           "optional": true,
           "minimum": 3600
+        },
+        "live_models_sync_interval": {
+          "type": "integer",
+          "description": "How often each provider's list-models response is re-fetched in the background, in seconds. Without this, a model an upstream starts serving after the gateway booted stays invisible until a restart or a key edit. Set to 0 to disable background refresh. Default is 1 hour; minimum when enabled is 60 seconds.",
+          "default": 3600,
+          "optional": true,
+          "anyOf": [{ "const": 0 }, { "minimum": 60 }]
         }
       },
       "additionalProperties": false

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -1031,3 +1031,38 @@ func TestSchemaBedrockKeyConfigSTSFields(t *testing.T) {
 		}
 	})
 }
+
+// TestSchemaLiveModelsSyncInterval pins the 0-or->=60 contract on
+// framework.pricing.live_models_sync_interval. This schema is the source of
+// truth users author against, so it has to reject the same values the config
+// API rejects (ConfigHandler.updateConfig) and the file resolver silently
+// clamps (ResolveFrameworkPricingConfig). A bare "minimum": 0 accepted 1-59
+// and left the user with a config that validated and then behaved as 60.
+func TestSchemaLiveModelsSyncInterval(t *testing.T) {
+	compiled := compileSchema(t)
+
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+	}{
+		{name: "zero disables the background refresh", value: "0"},
+		{name: "the minimum enabled interval is accepted", value: "60"},
+		{name: "the default is accepted", value: "3600"},
+		{name: "below the minimum but above zero is rejected", value: "59", wantError: true},
+		{name: "one second is rejected", value: "1", wantError: true},
+		{name: "negative is rejected", value: "-1", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := `{"framework":{"pricing":{"live_models_sync_interval":` + tt.value + `}}}`
+			err := validateConfig(t, compiled, config)
+			if tt.wantError && err == nil {
+				t.Errorf("live_models_sync_interval=%s should be rejected, got no error", tt.value)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("live_models_sync_interval=%s should be valid, got: %v", tt.value, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a configurable background timer that periodically re-fetches each provider's model list, so models an upstream starts serving after the gateway boots become routable without a restart or a key edit. Previously, model discovery only ran at startup and on key CRUD operations.

Closes maximhq/bifrost#5551 maximhq/bifrost#5552

## Changes

* Introduces `live_models_sync_interval` in the `framework.pricing` config block (default: 3600 s, minimum when enabled: 60 s, `0` disables). The interval is jittered by ±10% so replicas that boot together do not fan out to every upstream simultaneously on every cycle.
* Adds `BifrostHTTPServer.startLiveModelRefresher` / `restartLiveModelRefresher` / `stopLiveModelRefresher` to manage the background goroutine. The refresher is started at the end of `Bootstrap` and stopped during graceful shutdown. `UpdateSyncConfig` also restarts it so a config change takes effect without a restart.
* Replaces the bootstrap-time provider fan-out (which ranged `Config.Providers` directly) with `RefreshAllLiveModels`, which reads providers and keys through the thread-safe `Config` accessors and bounds concurrency to four providers at a time.
* Adds on-demand refresh endpoints (`POST /api/providers/{provider}/refresh-models` and `POST /api/providers/{provider}/keys/{key_id}/refresh-models`) backed by `RefreshLiveModelsForAllKeys` and `RefreshLiveModelsForKey`. Concurrent requests for the same provider collapse via a `sync.Map` in-flight guard and return HTTP 409 rather than stacking upstream fan-outs.
* Gates `updateKeyStatus` writes: statuses that match what is already in memory are dropped before the SQL `UPDATE`, preventing a steady stream of no-op writes from every node on every refresh cycle.
* Adds `live_models_sync_interval` to `TableFrameworkConfig` via a new migration and threads it through `ResolveFrameworkPricingConfig` with the same file-wins-on-hash-change / DB-wins-otherwise precedence as the sibling intervals. `0` is treated as a deliberate opt-out rather than corruption.
* Adds `LiveModelsSyncInterval` to `FrameworkConfigHashOptions` with `omitempty` so existing persisted hashes remain valid and upgraded deployments do not see a spurious "file changed" on first boot.
* Documents the new field in `docs/deployment-guides/config-json/schema-reference.mdx` and `transports/config.schema.json`.

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [X] Core (Go)
- [X] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [X] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/...
```

* Set `live_models_sync_interval` to a short value (e.g. `120`) in `config.json`, boot the gateway, and confirm log lines showing background refresh cycles appear at the configured cadence.
* Set `live_models_sync_interval: 0` and confirm no refresh goroutine is spawned and no background log lines appear.
* Hit `POST /api/providers/{provider}/refresh-models` twice in rapid succession and confirm the second request returns HTTP 409.
* Edit `live_models_sync_interval` via the config API and confirm the refresher restarts at the new interval without a gateway restart.
* Run the gateway with an existing DB (pre-migration) and confirm the migration applies cleanly and no spurious "file changed" override occurs on first boot.

## Breaking changes

- [ ] Yes
- [X] No

## Related issues

## Security considerations

On-demand refresh endpoints are gated behind the same middleware chain as the existing provider key endpoints. The in-flight guard prevents a user from amplifying upstream calls by repeatedly pressing the refresh button.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [X] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable