### PR TITLE
adds ssetruncation interface for handling EOF cases

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -735,6 +735,14 @@ func HandleOpenAITextCompletionStreaming(
 			}
 		}
 
+		// See HandleOpenAIChatCompletionStreaming: a plain io.EOF cannot distinguish a
+		// finished provider from a dead connection, so a terminal marker is required
+		// before synthesizing the final chunk.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) && finishReason == nil {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.TextCompletionStreamRequest, request.Model, created)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)
@@ -1411,6 +1419,24 @@ func HandleOpenAIChatCompletionStreaming(
 			}
 		}
 
+		// A dying upstream closes the connection on a chunk boundary, which fasthttp
+		// reports as a plain io.EOF — the same read result as a properly terminated
+		// body. Truncation is therefore only detectable semantically: require an
+		// explicit [DONE], a finish_reason, or (on the fallback path) a terminal
+		// Responses event before synthesizing a final chunk. Without one, emitting
+		// the synthetic chunk would hand the client a clean, content-free completion
+		// that is indistinguishable from a provider that generated zero tokens.
+		terminalSignalSeen := providerUtils.SSEStreamEndedOnMarker(sseReader)
+		if isResponsesToChatCompletionsFallback {
+			terminalSignalSeen = terminalSignalSeen || pendingFinalEvent != nil
+		} else {
+			terminalSignalSeen = terminalSignalSeen || finishReason != nil
+		}
+		if !terminalSignalSeen {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		if isResponsesToChatCompletionsFallback {
 			if pendingFinalEvent != nil {
 				if usageSeen && pendingFinalEvent.Response != nil {
@@ -1864,6 +1890,10 @@ func HandleOpenAIResponsesStreaming(
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -1977,6 +2007,15 @@ func HandleOpenAIResponsesStreaming(
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// The loop returns as soon as a terminal event (completed / incomplete /
+		// failed / error) arrives, so falling out of it means the body ended without
+		// one. A plain io.EOF cannot distinguish that from a healthy close, so
+		// surface it rather than closing the channel silently — a silent close is
+		// indistinguishable to the client from a stream that just stopped emitting.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 		}
 	}()
 

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -298,6 +298,9 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					provider.logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, provider.logger, postHookSpanFinalizer)
+					// Already reported; returning keeps the post-loop truncation check
+					// from reporting the same dead stream twice.
+					return
 				}
 				break
 			}
@@ -369,6 +372,13 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// Falling out of the loop means the body ended without a terminal event.
+		// A plain io.EOF cannot distinguish that from a healthy close, so surface it
+		// instead of closing the channel silently.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil)
 		}
 	}()
 

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -1,0 +1,321 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// An upstream that dies mid-SSE closes its connection on a chunk boundary, which
+// fasthttp reports as a plain io.EOF — byte-for-byte the same read result as a
+// properly terminated body. These tests pin the semantic detection that replaces
+// the impossible transport-level check: without a terminal marker
+// ([DONE] / finish_reason / a terminal Responses event), the stream is truncated
+// and must surface as an error instead of a synthetic clean completion.
+// See https://github.com/maximhq/bifrost/issues/5546.
+
+// truncatingSSEServer serves one streaming response that writes prelude (already
+// SSE-framed) and then kills the connection without the terminating chunk.
+// panic(http.ErrAbortHandler) is net/http's documented way to drop a connection
+// mid-response without logging a stack trace, reproducing what an upstream whose
+// generator raised does on the wire.
+func truncatingSSEServer(t *testing.T, prelude string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server ResponseWriter is not an http.Flusher")
+			return
+		}
+		flusher.Flush()
+		if prelude != "" {
+			if _, err := w.Write([]byte(prelude)); err != nil {
+				t.Errorf("failed writing SSE prelude: %v", err)
+				return
+			}
+			flusher.Flush()
+		}
+		panic(http.ErrAbortHandler)
+	}))
+}
+
+// completeSSEServer serves a full, well-formed SSE stream.
+func completeSSEServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("failed writing SSE body: %v", err)
+		}
+	}))
+}
+
+func newStreamTestProvider(baseURL string) *OpenAIProvider {
+	return NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+	}, testNoopLogger{})
+}
+
+// passthroughPostHook is the identity post-hook: streaming helpers require a
+// runner, and these tests assert on what the provider produced, not on plugins.
+func passthroughPostHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return resp, err
+}
+
+func newStreamTestContext() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func testKey() schemas.Key {
+	return schemas.Key{Value: *schemas.NewSecretVar("test-key")}
+}
+
+// collectChunks drains a provider stream, failing the test if it does not close
+// in time (a stuck stream is itself a regression worth surfacing loudly).
+func collectChunks(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostStreamChunk {
+	t.Helper()
+	var chunks []*schemas.BifrostStreamChunk
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return chunks
+			}
+			if chunk != nil {
+				chunks = append(chunks, chunk)
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for the provider stream to close")
+			return chunks
+		}
+	}
+}
+
+// assertTruncationError checks the error carries the retryable upstream-connection
+// shape. IsBifrostError must stay false and the status 502 so that
+// executeRequestWithRetries retries / falls back instead of breaking out early.
+func assertTruncationError(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error, got nil")
+	}
+	if err.IsBifrostError {
+		t.Error("truncation error must have IsBifrostError=false so the retry loop does not break early")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 502 {
+		t.Errorf("expected StatusCode 502, got %v", err.StatusCode)
+	}
+	if err.Error == nil || err.Error.Message != schemas.ErrProviderStreamTruncated {
+		t.Errorf("expected message %q, got %+v", schemas.ErrProviderStreamTruncated, err.Error)
+	}
+	if err.Error != nil && (err.Error.Type == nil || *err.Error.Type != schemas.ProviderConnectionFailed) {
+		t.Errorf("expected error type %q, got %v", schemas.ProviderConnectionFailed, err.Error.Type)
+	}
+}
+
+func basicChatRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+func chatChunk(content string, finishReason *string) string {
+	delta := `{}`
+	if content != "" {
+		delta = `{"content":"` + content + `"}`
+	}
+	finish := "null"
+	if finishReason != nil {
+		finish = `"` + *finishReason + `"`
+	}
+	return `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":` + delta + `,"finish_reason":` + finish + `}]}` + "\n\n"
+}
+
+// Pre-first-byte death: nothing has reached the client yet, so the error must be
+// the very first chunk. That is what lets CheckFirstStreamChunkForError convert it
+// into a synchronous error and give the transport a real non-2xx status.
+func TestChatStreamTruncatedPreFirstByte(t *testing.T) {
+	server := truncatingSSEServer(t, "")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) != 1 {
+		t.Fatalf("expected exactly one chunk (the error), got %d: %+v", len(chunks), chunks)
+	}
+	assertTruncationError(t, chunks[0].BifrostError)
+	if chunks[0].BifrostChatResponse != nil {
+		t.Error("no synthetic chat chunk may be emitted for a truncated stream")
+	}
+}
+
+// Mid-stream death: already-forwarded content stays, then the error frame lands.
+// Bifrost must not append the content-free terminal chunk that made the failure
+// look like a normal short completion.
+func TestChatStreamTruncatedMidStream(t *testing.T) {
+	server := truncatingSSEServer(t, chatChunk("partial answer", nil))
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) != 2 {
+		t.Fatalf("expected the content chunk plus one error chunk, got %d: %+v", len(chunks), chunks)
+	}
+	if chunks[0].BifrostChatResponse == nil {
+		t.Fatalf("expected the first chunk to be the forwarded content, got %+v", chunks[0])
+	}
+	assertTruncationError(t, chunks[1].BifrostError)
+}
+
+// Guard against false positives: a well-formed stream must still get its
+// synthesized terminal chunk and no error.
+func TestChatStreamCleanDoneUnaffected(t *testing.T) {
+	stop := "stop"
+	server := completeSSEServer(t, chatChunk("hello", nil)+chatChunk("", &stop)+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a well-formed stream")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	final := chunks[len(chunks)-1]
+	if final.BifrostChatResponse == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", final)
+	}
+	if len(final.BifrostChatResponse.Choices) == 0 ||
+		final.BifrostChatResponse.Choices[0].FinishReason == nil ||
+		*final.BifrostChatResponse.Choices[0].FinishReason != stop {
+		t.Errorf("expected the final chunk to carry finish_reason %q, got %+v", stop, final.BifrostChatResponse.Choices)
+	}
+}
+
+// [DONE] is a terminal marker in its own right: a provider that ends the stream
+// properly but never sets finish_reason is not truncated.
+func TestChatStreamDoneWithoutFinishReasonIsNotTruncated(t *testing.T) {
+	server := completeSSEServer(t, chatChunk("hello", nil)+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	for i, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+}
+
+// finish_reason alone is terminal too — providers listed as not sending [DONE]
+// (Cerebras, Perplexity, HuggingFace, Bedrock mantle) rely on exactly this.
+func TestChatStreamFinishReasonWithoutDoneIsNotTruncated(t *testing.T) {
+	stop := "stop"
+	server := completeSSEServer(t, chatChunk("hello", nil)+chatChunk("", &stop))
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	for i, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+}
+
+func TestTextCompletionStreamTruncated(t *testing.T) {
+	server := truncatingSSEServer(t, `data: {"id":"cmpl-repro","object":"text_completion","created":1,"model":"repro-model","choices":[{"index":0,"text":"partial"}]}`+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostTextCompletionRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input:    &schemas.TextCompletionInput{PromptStr: schemas.Ptr("hi")},
+	}
+	stream, bifrostErr := provider.TextCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertTruncationError(t, final.BifrostError)
+	if final.BifrostTextCompletionResponse != nil {
+		t.Error("no synthetic text completion chunk may be emitted for a truncated stream")
+	}
+}
+
+// The Responses loop returns as soon as a terminal event arrives, so a stream
+// that ends without one previously closed the channel silently — indistinguishable
+// to the client from a stream that simply stopped emitting events.
+func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
+	server := truncatingSSEServer(t, "event: response.output_text.delta\n"+
+		`data: {"type":"response.output_text.delta","sequence_number":1,"delta":"partial"}`+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
+}

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -29,6 +29,26 @@ type SSEEventReader interface {
 	ReadEvent() (eventType string, data []byte, err error)
 }
 
+// SSEStreamTerminator is optionally implemented by SSE readers that can report
+// whether the stream ended on an explicit terminal marker ("data: [DONE]")
+// rather than a plain body EOF. ReadDataLine returns io.EOF for both, so
+// without this a provider loop cannot tell a provider that finished cleanly
+// from an upstream connection that died mid-stream.
+type SSEStreamTerminator interface {
+	SawDoneMarker() bool
+}
+
+// SSEStreamEndedOnMarker reports whether r ended on an explicit [DONE] marker.
+// Readers that do not implement SSEStreamTerminator (e.g. an enterprise-injected
+// SSEReaderFactory) return true: with no signal available we assume the stream
+// terminated normally rather than misreport a healthy stream as truncated.
+func SSEStreamEndedOnMarker(r SSEDataReader) bool {
+	if t, ok := r.(SSEStreamTerminator); ok {
+		return t.SawDoneMarker()
+	}
+	return true
+}
+
 // SSEReaderFactory creates SSE readers for streaming response processing.
 // Enterprise injects this via BifrostContextKeySSEReaderFactory to replace
 // the default bufio.Scanner-based implementations with streaming readers.
@@ -75,7 +95,11 @@ var (
 type defaultSSEDataReader struct {
 	scanner *bufio.Scanner
 	pending []byte // line carried over from an aborted multi-line JSON accumulation
+	sawDone bool   // stream ended on "data: [DONE]" rather than a bare body EOF
 }
+
+// SawDoneMarker implements SSEStreamTerminator.
+func (r *defaultSSEDataReader) SawDoneMarker() bool { return r.sawDone }
 
 func newDefaultSSEDataReader(reader io.Reader) *defaultSSEDataReader {
 	scanner := bufio.NewScanner(reader)
@@ -104,6 +128,7 @@ func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
 				continue
 			}
 			if bytes.Equal(data, sseDoneMarker) {
+				r.sawDone = true
 				return nil, io.EOF
 			}
 			// Copy to decouple from scanner's internal buffer

--- a/core/providers/utils/sse_test.go
+++ b/core/providers/utils/sse_test.go
@@ -34,6 +34,57 @@ func TestSSEDataReader_DataLinesAndDone(t *testing.T) {
 	}
 }
 
+// [DONE] and a bare body EOF both surface as io.EOF from ReadDataLine, so the
+// reader must record which one it was — that flag is the only way a provider
+// loop can tell a finished stream from a dead upstream connection.
+func TestSSEDataReader_SawDoneMarkerOnDone(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader("data: {\"a\":1}\n\ndata: [DONE]\n\n"))
+	drainSSEDataReader(t, reader)
+	if !reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be true after reading [DONE]")
+	}
+	if !SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be true after reading [DONE]")
+	}
+}
+
+// A stream that just stops (upstream connection died on a chunk boundary) ends
+// with the same io.EOF but no marker.
+func TestSSEDataReader_SawDoneMarkerAbsentOnBareEOF(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader("data: {\"a\":1}\n\n"))
+	drainSSEDataReader(t, reader)
+	if reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be false when the body ended without [DONE]")
+	}
+	if SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be false when the body ended without [DONE]")
+	}
+}
+
+// A reader with no bytes at all (upstream died before its first byte) must also
+// report no marker.
+func TestSSEDataReader_SawDoneMarkerAbsentOnEmptyStream(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader(""))
+	drainSSEDataReader(t, reader)
+	if SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be false for an empty stream")
+	}
+}
+
+// stubSSEDataReader stands in for an enterprise-injected reader that predates
+// SSEStreamTerminator.
+type stubSSEDataReader struct{}
+
+func (stubSSEDataReader) ReadDataLine() ([]byte, error) { return nil, io.EOF }
+
+// Readers that cannot report a marker must be assumed to have terminated
+// normally: reporting them as truncated would fail every enterprise stream.
+func TestSSEStreamEndedOnMarker_UnknownReaderDefaultsTrue(t *testing.T) {
+	if !SSEStreamEndedOnMarker(stubSSEDataReader{}) {
+		t.Error("expected SSEStreamEndedOnMarker to default to true for readers without SSEStreamTerminator")
+	}
+}
+
 func TestSSEDataReader_SingleLineRawJSONFallback(t *testing.T) {
 	stream := `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}` + "\n"
 	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2839,6 +2839,44 @@ func ProcessAndSendError(
 	GateSendChunk(ctx, streamResponse, responseChan)
 }
 
+// SendStreamTruncatedError surfaces an upstream stream that ended without a
+// terminal marker (no "data: [DONE]", no finish_reason / completion event) as a
+// client-visible error instead of letting the caller synthesize a clean final
+// chunk. A dying upstream typically closes the connection on a chunk boundary,
+// which fasthttp reports as a plain io.EOF — indistinguishable at the transport
+// layer from a properly terminated body — so truncation can only be detected
+// semantically, by the absence of a terminal marker.
+//
+// The error is deliberately built as a retryable upstream connection failure
+// (502, IsBifrostError=false): when nothing has been forwarded yet this becomes
+// the stream's first chunk, so CheckFirstStreamChunkForError converts it into a
+// synchronous error and executeRequestWithRetries can retry or fall back. An
+// IsBifrostError=true error would break that retry loop instead (see #4496).
+func SendStreamTruncatedError(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	responseChan chan *schemas.BifrostStreamChunk,
+	logger schemas.Logger,
+	postHookSpanFinalizer func(context.Context),
+	jsonBody []byte,
+) {
+	if logger != nil {
+		logger.Warn("Stream ended without a terminal marker; treating as truncated upstream stream")
+	}
+
+	truncatedErr := NewBifrostUpstreamConnectionError(schemas.ErrProviderStreamTruncated, io.ErrUnexpectedEOF)
+
+	if ShouldSendBackRawRequest(ctx, false) && len(jsonBody) > 0 {
+		truncatedErr.ExtraFields.RawRequest = compactRawJSON(jsonBody)
+	}
+
+	// Bill for tokens the provider already produced before the stream died.
+	attachBilledUsageFromContext(ctx, truncatedErr)
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	ProcessAndSendBifrostError(ctx, postHookRunner, truncatedErr, responseChan, logger, postHookSpanFinalizer)
+}
+
 // CreateBifrostTextCompletionChunkResponse creates a bifrost text completion chunk response.
 func CreateBifrostTextCompletionChunkResponse(
 	id string,

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -41,6 +41,7 @@ const (
 	ErrProviderRawRequestUnmarshal  = "failed to unmarshal raw request from provider API"
 	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
 	ErrProviderResponseDecompress   = "failed to decompress provider's response"
+	ErrProviderStreamTruncated      = "provider closed the stream before sending a completion marker (upstream connection ended mid-stream)"
 )
 
 // NetworkConfig represents the network configuration for provider connections.


### PR DESCRIPTION
## Summary

When an upstream provider dies mid-stream, it closes the TCP connection on a chunk boundary. fasthttp (and net/http) report this as a plain `io.EOF` — byte-for-byte identical to a properly terminated response body. Previously, Bifrost could not distinguish the two cases and would synthesize a clean, content-free terminal chunk, making a broken stream look like a valid zero-token completion to the client.

This PR introduces semantic truncation detection: if a stream ends without an explicit terminal marker (`data: [DONE]`, a `finish_reason`, or a terminal Responses API event), it is treated as a truncated upstream connection and surfaced as a retryable 502 error instead of a silent clean close.



Closes #5546

## Changes

- **`core/providers/utils/sse.go`**: Added `SSEStreamTerminator` interface with `SawDoneMarker()` and a helper `SSEStreamEndedOnMarker()`. The default `defaultSSEDataReader` now sets a `sawDone` flag when it encounters `data: [DONE]`. Readers that do not implement the interface (e.g. enterprise-injected factories) default to `true` to avoid false positives.
- **`core/providers/utils/utils.go`**: Added `SendStreamTruncatedError`, which emits a retryable upstream connection error (`IsBifrostError=false`, status 502, message `ErrProviderStreamTruncated`). This shape allows `CheckFirstStreamChunkForError` to convert it into a synchronous error and lets `executeRequestWithRetries` retry or fall back rather than breaking out early.
- **`core/providers/openai/openai.go`**: Added post-loop truncation checks to `HandleOpenAIChatCompletionStreaming`, `HandleOpenAITextCompletionStreaming`, and `HandleOpenAIResponsesStreaming`. Each handler now calls `SendStreamTruncatedError` when the loop exits without a terminal signal. The Responses handler also returns immediately on a mid-stream read error to prevent double-reporting.
- **`core/providers/openai/responseslifecycle.go`**: Applied the same truncation check and early-return fix to `ResponsesRetrieveStream`.
- **`core/schemas/provider.go`**: Added the `ErrProviderStreamTruncated` error constant.
- **`core/providers/openai/streamtruncation_test.go`**: New test file covering pre-first-byte death, mid-stream death, clean `[DONE]` streams, `[DONE]` without `finish_reason`, `finish_reason` without `[DONE]`, text completion truncation, and Responses API truncation. Tests use `httptest.Server` with `panic(http.ErrAbortHandler)` to reproduce a real dropped connection.
- **`core/providers/utils/sse_test.go`**: Added unit tests for `SawDoneMarker` on `[DONE]`, bare EOF, empty stream, and the fallback behaviour for readers that do not implement `SSEStreamTerminator`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/openai/... -run TestChatStream -v
go test ./core/providers/openai/... -run TestTextCompletion -v
go test ./core/providers/openai/... -run TestResponses -v
go test ./core/providers/utils/... -run TestSSE -v
go test ./...
```

The truncation tests spin up local `httptest.Server` instances that drop the connection mid-response via `panic(http.ErrAbortHandler)`. Each test asserts that the final chunk carries a `BifrostError` with `IsBifrostError=false`, `StatusCode=502`, and `Message=ErrProviderStreamTruncated`, and that no synthetic clean completion chunk is emitted.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5546

## Security considerations

None. The change only affects how stream termination is classified; no auth, secrets, or PII handling is modified.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable