### PR TITLE
adds EOF handler support to all providers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -957,6 +957,9 @@ func HandleAnthropicChatCompletionStreaming(
 		// Per-response tool-call index state
 		streamState := NewAnthropicStreamState()
 
+		// True once message_stop arrives — Anthropic's only completion signal.
+		sawTerminalEvent := false
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -1154,7 +1157,9 @@ func HandleAnthropicChatCompletionStreaming(
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			if response != nil {
 				response.ExtraFields = schemas.BifrostResponseExtraFields{
@@ -1179,9 +1184,26 @@ func HandleAnthropicChatCompletionStreaming(
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
 			if isLastChunk {
+				sawTerminalEvent = true
 				break
 			}
 		}
+
+		// Anthropic signals completion with a message_stop event and never sends a
+		// [DONE] marker, so message_stop is the only terminal signal available. A
+		// dying upstream closes on a chunk boundary, which surfaces as a plain
+		// io.EOF — indistinguishable from a healthy close — so without the terminal
+		// event the synthesized final chunk below would present a truncated stream
+		// to the client as a clean stop.
+		if !sawTerminalEvent {
+			// Fold cached tokens in before billing: SendStreamTruncatedError snapshots
+			// the accumulated usage handle, so a fold after the send never reaches the
+			// billed copy. Guarded, so the healthy path below stays unaffected.
+			normalizeUsage()
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		normalizeUsage()
 		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, modelName, 0)
 		if postResponseConverter != nil {
@@ -1581,6 +1603,9 @@ func HandleAnthropicResponsesStream(
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					logger.Warn("Error reading %s stream: %v", providerName, readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// Already reported; returning (rather than breaking) keeps the
+					// post-loop truncation check from reporting the same stream twice.
+					return
 				}
 				break
 			}
@@ -1648,7 +1673,9 @@ func HandleAnthropicResponsesStream(
 				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 
 			// Attach the upstream raw to exactly one bifrost response. Default to the last,
@@ -1716,6 +1743,17 @@ func HandleAnthropicResponsesStream(
 			}
 
 		}
+
+		// The loop returns as soon as the terminal chunk is emitted, so falling out
+		// of it means the body ended before message_stop. A plain io.EOF cannot
+		// distinguish that from a healthy close, so surface it rather than closing
+		// the channel silently.
+		//
+		// Fold cached tokens in first: SendStreamTruncatedError snapshots the
+		// accumulated usage handle, so a fold after the send never reaches the billed
+		// copy. Guarded, so the ctx.Err() defer above stays a no-op after this.
+		normalizeBilledUsage()
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil

--- a/core/providers/anthropic/streamtruncation_test.go
+++ b/core/providers/anthropic/streamtruncation_test.go
@@ -1,0 +1,374 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic's Messages stream carries no [DONE] sentinel: message_stop is the
+// only completion signal. An upstream that dies closes on a chunk boundary,
+// which fasthttp reports as a plain io.EOF — the same read result as a healthy
+// close — so a stream cut short before message_stop must be surfaced rather
+// than finished off with a synthesized final chunk.
+// See https://github.com/maximhq/bifrost/issues/5546.
+
+type truncationTestLogger struct{}
+
+func (truncationTestLogger) Debug(string, ...any)                   {}
+func (truncationTestLogger) Info(string, ...any)                    {}
+func (truncationTestLogger) Warn(string, ...any)                    {}
+func (truncationTestLogger) Error(string, ...any)                   {}
+func (truncationTestLogger) Fatal(string, ...any)                   {}
+func (truncationTestLogger) SetLevel(schemas.LogLevel)              {}
+func (truncationTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (truncationTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+// anthropicSSEServer serves prelude and then either ends cleanly or kills the
+// connection mid-response. panic(http.ErrAbortHandler) is net/http's documented
+// way to drop a connection without the terminating chunk, reproducing what an
+// upstream whose generator died does on the wire.
+func anthropicSSEServer(t *testing.T, prelude string, truncate bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server ResponseWriter is not an http.Flusher")
+			return
+		}
+		flusher.Flush()
+		if prelude != "" {
+			if _, err := w.Write([]byte(prelude)); err != nil {
+				t.Errorf("failed writing SSE prelude: %v", err)
+				return
+			}
+			flusher.Flush()
+		}
+		if truncate {
+			panic(http.ErrAbortHandler)
+		}
+	}))
+}
+
+func newTruncationTestProvider(baseURL string) *AnthropicProvider {
+	return NewAnthropicProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+	}, truncationTestLogger{})
+}
+
+func truncationPassthroughPostHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return resp, err
+}
+
+func collectTruncationChunks(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostStreamChunk {
+	t.Helper()
+	var chunks []*schemas.BifrostStreamChunk
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return chunks
+			}
+			if chunk != nil {
+				chunks = append(chunks, chunk)
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for the provider stream to close")
+			return chunks
+		}
+	}
+}
+
+func assertAnthropicTruncationError(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error, got nil")
+	}
+	if err.IsBifrostError {
+		t.Error("truncation error must have IsBifrostError=false so the retry loop does not break early")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 502 {
+		t.Errorf("expected StatusCode 502, got %v", err.StatusCode)
+	}
+	if err.Error == nil || err.Error.Message != schemas.ErrProviderStreamTruncated {
+		t.Errorf("expected message %q, got %+v", schemas.ErrProviderStreamTruncated, err.Error)
+	}
+}
+
+func truncationChatRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-repro",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+const anthropicMessageStart = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_repro","type":"message","role":"assistant","model":"claude-repro","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
+
+// anthropicPartialText is the one text delta the fixtures emit. Derived into the
+// SSE payload rather than duplicated, so the assertion cannot drift from the wire.
+const anthropicPartialText = "partial answer"
+
+const anthropicTextDelta = "event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"` + anthropicPartialText + `"}}` + "\n\n"
+
+const anthropicMessageStop = "event: content_block_stop\n" +
+	`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+	"event: message_delta\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}` + "\n\n" +
+	"event: message_stop\n" +
+	`data: {"type":"message_stop"}` + "\n\n"
+
+// Pre-first-byte death: the error must be the stream's first chunk so
+// CheckFirstStreamChunkForError can turn it into a synchronous, retryable error.
+func TestAnthropicChatStreamTruncatedPreFirstByte(t *testing.T) {
+	server := anthropicSSEServer(t, "", true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) != 1 {
+		t.Fatalf("expected exactly one chunk (the error), got %d: %+v", len(chunks), chunks)
+	}
+	assertAnthropicTruncationError(t, chunks[0].BifrostError)
+	if chunks[0].BifrostChatResponse != nil {
+		t.Error("no synthetic chat chunk may be emitted for a truncated stream")
+	}
+}
+
+// Mid-stream death: forwarded content stays, then the error frame lands, and no
+// content-free terminal chunk is appended.
+func TestAnthropicChatStreamTruncatedMidStream(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the forwarded content chunk followed by the error, got %d chunk(s)", len(chunks))
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	for i, chunk := range chunks[:len(chunks)-1] {
+		if chunk.BifrostError != nil {
+			t.Errorf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	// Detecting truncation must not cost the client the content that did arrive:
+	// the text delta forwarded before the connection died has to survive.
+	if !chunksContainContent(chunks[:len(chunks)-1], anthropicPartialText) {
+		t.Errorf("expected a pre-error chunk carrying %q; content forwarded before the truncation was dropped", anthropicPartialText)
+	}
+}
+
+// chunksContainContent reports whether any chunk carried the given delta text.
+func chunksContainContent(chunks []*schemas.BifrostStreamChunk, want string) bool {
+	for _, chunk := range chunks {
+		if chunk.BifrostChatResponse == nil {
+			continue
+		}
+		for _, choice := range chunk.BifrostChatResponse.Choices {
+			if choice.ChatStreamResponseChoice == nil || choice.ChatStreamResponseChoice.Delta == nil {
+				continue
+			}
+			if content := choice.ChatStreamResponseChoice.Delta.Content; content != nil && *content == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Guard against false positives: a stream that reaches message_stop is complete
+// and must still receive its synthesized final chunk, with no error.
+func TestAnthropicChatStreamCompleteUnaffected(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicMessageStart+anthropicTextDelta+anthropicMessageStop, false)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a well-formed stream")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	// A plain text delta is also a non-nil BifrostChatResponse, so identity has to be
+	// checked on properties only the synthesized terminal chunk carries: usage,
+	// a finish reason, and an empty delta.
+	final := chunks[len(chunks)-1].BifrostChatResponse
+	if final == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", chunks[len(chunks)-1])
+	}
+	if final.Usage == nil {
+		t.Fatal("terminal chunk must carry the accumulated usage; it is the only chunk the cost calculation can bill on")
+	}
+	// message_start reports input_tokens 5, message_delta reports a cumulative
+	// output_tokens 3 (https://platform.claude.com/docs/en/build-with-claude/streaming).
+	if final.Usage.PromptTokens != 5 || final.Usage.CompletionTokens != 3 || final.Usage.TotalTokens != 8 {
+		t.Errorf("terminal usage = prompt %d / completion %d / total %d, want 5 / 3 / 8",
+			final.Usage.PromptTokens, final.Usage.CompletionTokens, final.Usage.TotalTokens)
+	}
+	if len(final.Choices) != 1 {
+		t.Fatalf("expected exactly one choice on the terminal chunk, got %d", len(final.Choices))
+	}
+	choice := final.Choices[0]
+	if choice.FinishReason == nil {
+		t.Fatal("terminal chunk must carry a finish reason; content deltas never do")
+	}
+	if *choice.FinishReason != "stop" {
+		t.Errorf("finish reason = %q, want %q (mapped from Anthropic end_turn)", *choice.FinishReason, "stop")
+	}
+	if choice.ChatStreamResponseChoice == nil || choice.ChatStreamResponseChoice.Delta == nil {
+		t.Fatal("terminal chunk must still carry a stream choice with an empty delta")
+	}
+	if content := choice.ChatStreamResponseChoice.Delta.Content; content != nil && *content != "" {
+		t.Errorf("terminal chunk delta must be empty, got %q", *content)
+	}
+	// The content that arrived mid-stream is still expected to have been forwarded.
+	if !chunksContainContent(chunks[:len(chunks)-1], anthropicPartialText) {
+		t.Errorf("expected an earlier chunk carrying %q", anthropicPartialText)
+	}
+}
+
+// Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
+// exclusive of input_tokens - total input is the sum of all three
+// (https://platform.claude.com/docs/en/build-with-claude/prompt-caching). The
+// stream accumulator therefore folds the cache counters into PromptTokens/
+// TotalTokens exactly once at stream end. SendStreamTruncatedError snapshots the
+// usage handle when it bills, so the fold must happen before the send: otherwise a
+// cache-heavy request that dies mid-stream bills only the post-breakpoint tokens.
+
+const (
+	truncationCacheInputTokens  = 5
+	truncationCacheReadTokens   = 100
+	truncationCacheWriteTokens  = 20
+	truncationCacheFoldedTokens = truncationCacheInputTokens + truncationCacheReadTokens + truncationCacheWriteTokens
+)
+
+const anthropicCachedMessageStart = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_repro","type":"message","role":"assistant","model":"claude-repro","content":[],` +
+	`"usage":{"input_tokens":5,"output_tokens":0,"cache_read_input_tokens":100,"cache_creation_input_tokens":20}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
+
+// assertCacheFoldedBilledUsage pins the billed snapshot carried by a truncation
+// error: the cache counters must survive intact *and* already be folded into the
+// top-level prompt/total, which is what the cost calculation downstream charges on.
+func assertCacheFoldedBilledUsage(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error carrying billed usage, got nil")
+	}
+	billed := err.ExtraFields.BilledUsage
+	if billed == nil {
+		t.Fatal("truncated stream must bill for tokens the provider already reported")
+	}
+	if billed.PromptTokens != truncationCacheFoldedTokens {
+		t.Errorf("PromptTokens = %d, want %d (input %d + cache read %d + cache write %d)",
+			billed.PromptTokens, truncationCacheFoldedTokens,
+			truncationCacheInputTokens, truncationCacheReadTokens, truncationCacheWriteTokens)
+	}
+	if billed.TotalTokens != truncationCacheFoldedTokens {
+		t.Errorf("TotalTokens = %d, want %d", billed.TotalTokens, truncationCacheFoldedTokens)
+	}
+	if billed.PromptTokensDetails == nil {
+		t.Fatal("expected the cache breakdown to survive onto the billed snapshot")
+	}
+	if billed.PromptTokensDetails.CachedReadTokens != truncationCacheReadTokens {
+		t.Errorf("CachedReadTokens = %d, want %d", billed.PromptTokensDetails.CachedReadTokens, truncationCacheReadTokens)
+	}
+	if billed.PromptTokensDetails.CachedWriteTokens != truncationCacheWriteTokens {
+		t.Errorf("CachedWriteTokens = %d, want %d", billed.PromptTokensDetails.CachedWriteTokens, truncationCacheWriteTokens)
+	}
+}
+
+func TestAnthropicChatStreamTruncatedBillsCachedTokens(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicCachedMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	assertCacheFoldedBilledUsage(t, final.BifrostError)
+}
+
+func TestAnthropicResponsesStreamTruncatedBillsCachedTokens(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicCachedMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-repro",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	assertCacheFoldedBilledUsage(t, final.BifrostError)
+}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1005,8 +1005,12 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 			finalResponse.BackfillParams(request)
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, &finalResponse, nil, nil), responseChan, postHookSpanFinalizer)
-		} else if chunkIndex >= 0 && !doneReceived {
-			provider.logger.Warn("Stream ended without receiving [DONE] marker after %d chunks", chunkIndex+1)
+		} else if !doneReceived {
+			// The audio stream ended without its only completion signal, so the
+			// bytes already forwarded are a truncated clip. A server-side warning
+			// alone left the caller unable to tell that from a complete one, so
+			// surface it on the stream too.
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 		}
 
 		// Response is released via deferred ReleaseStreamingResponse(resp) above.

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -580,7 +580,9 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			if response != nil {
 				response.ID = responseID
@@ -608,11 +610,17 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 					response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
-					break
+					return
 				}
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
 		}
+
+		// Cohere terminates the stream with a message-end event, which the loop
+		// returns on. Falling out of the loop means the body ended before it — a
+		// plain io.EOF, indistinguishable from a healthy close — so surface it
+		// rather than closing the channel silently.
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil
@@ -857,7 +865,9 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			// Handle each response in the slice
 			for i, response := range responses {
@@ -890,6 +900,11 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 				}
 			}
 		}
+
+		// See the chat stream above: falling out of the loop means the body ended
+		// before the terminal event, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -532,6 +532,15 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 				break
 			}
 		}
+
+		// The loop only exits cleanly once a terminal event has been handled (the
+		// indicator is also set by the read-error path above, so an already-reported
+		// failure stays quiet here). Without it the body ended early — a plain
+		// io.EOF, indistinguishable from a healthy close — leaving the caller with a
+		// silently truncated transcript.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil)
+		}
 	}()
 
 	return responseChan, nil

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -2593,6 +2593,15 @@ func HandleOpenAISpeechStreamRequest(
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, &response, nil, nil), responseChan, postHookSpanFinalizer)
 		}
+
+		// The loop returns on speech.audio.done (the usage-bearing terminal event),
+		// so falling out means the body ended early — a plain io.EOF that cannot be
+		// told from a healthy close. Without this the caller receives a silently
+		// truncated audio clip. Stay quiet when a read error was already reported
+		// (it sets the indicator) or when the provider at least sent [DONE].
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+		}
 	}()
 
 	return responseChan, nil
@@ -3110,6 +3119,15 @@ func HandleOpenAITranscriptionStreamRequest(
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, response, nil), responseChan, postHookSpanFinalizer)
 		}
+
+		// The loop returns on transcript.text.done (or the usage-bearing chunk), so
+		// falling out means the body ended early — a plain io.EOF that cannot be told
+		// from a healthy close, leaving the caller with a silently truncated
+		// transcript. No raw request is attached: this endpoint sends multipart form
+		// data, not JSON.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, nil)
+		}
 	}()
 
 	return responseChan, nil
@@ -3481,7 +3499,13 @@ func HandleOpenAIImageGenerationStreaming(
 					return
 				}
 				if readErr != io.EOF {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -3665,6 +3689,14 @@ func HandleOpenAIImageGenerationStreaming(
 			if isCompleted {
 				return
 			}
+		}
+
+		// The loop returns on image_generation.completed, so falling out means the
+		// body ended early — a plain io.EOF that cannot be told from a healthy
+		// close. Without this the caller keeps only the partial images and never
+		// learns the final one is missing.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 		}
 	}()
 
@@ -4966,8 +4998,13 @@ func HandleOpenAIImageEditStreamRequest(
 					return
 				}
 				if readErr != io.EOF {
-					logger.Warn(fmt.Sprintf("Error reading stream: %v", readErr))
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -5147,6 +5184,15 @@ func HandleOpenAIImageEditStreamRequest(
 			if isCompleted {
 				return
 			}
+		}
+
+		// The loop returns on image_edit.completed, so falling out means the body
+		// ended early — a plain io.EOF that cannot be told from a healthy close.
+		// Without this the caller keeps only the partial images and never learns the
+		// final one is missing. No raw request is attached: this endpoint sends
+		// multipart form data, not JSON.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, nil)
 		}
 	}()
 

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -2,11 +2,14 @@ package openai
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -318,4 +321,121 @@ func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
 		t.Fatal("expected at least the error chunk")
 	}
 	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
+}
+
+// A non-EOF read error is already a reported failure. The truncation guard that
+// follows the read loop must not fire a second time for the same dead stream, or
+// the client sees two errors for one request and the retryable 502 synthesized by
+// SendStreamTruncatedError muddies which failure the retry logic reacted to. The
+// handler signals "already reported" by latching BifrostContextKeyStreamEndIndicator.
+
+// failingSSEDataReader yields queued data lines and then a non-EOF error,
+// reproducing an upstream whose SSE framing breaks mid-body (what bufio.Scanner
+// surfaces when a line exceeds its ceiling). It deliberately implements
+// SSEStreamTerminator returning false, so the post-loop truncation guard is live -
+// that is precisely the condition under which a handler that forgets to latch the
+// end indicator emits a duplicate.
+type failingSSEDataReader struct {
+	lines [][]byte
+	err   error
+}
+
+func (r *failingSSEDataReader) ReadDataLine() ([]byte, error) {
+	if len(r.lines) == 0 {
+		return nil, r.err
+	}
+	line := r.lines[0]
+	r.lines = r.lines[1:]
+	return line, nil
+}
+
+func (r *failingSSEDataReader) SawDoneMarker() bool { return false }
+
+// contextWithFailingSSEReader injects a reader that replays lines then fails.
+// BifrostContextKeySSEReaderFactory is the same seam enterprise uses to swap in a
+// streaming reader, so this drives the real handler loop rather than a stub of it.
+func contextWithFailingSSEReader(lines ...string) *schemas.BifrostContext {
+	ctx := newStreamTestContext()
+	payloads := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		payloads = append(payloads, []byte(line))
+	}
+	ctx.SetValue(schemas.BifrostContextKeySSEReaderFactory, &providerUtils.SSEReaderFactory{
+		NewDataReader: func(io.Reader) providerUtils.SSEDataReader {
+			return &failingSSEDataReader{
+				lines: payloads,
+				err:   errors.New("sse framing error"),
+			}
+		},
+	})
+	return ctx
+}
+
+// assertSingleReadError checks the stream carried exactly one error, and that it
+// is the read error rather than the synthesized truncation 502.
+func assertSingleReadError(t *testing.T, chunks []*schemas.BifrostStreamChunk) {
+	t.Helper()
+	var errored []*schemas.BifrostError
+	for _, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			errored = append(errored, chunk.BifrostError)
+		}
+	}
+	if len(errored) != 1 {
+		for i, err := range errored {
+			t.Logf("error %d: %+v", i, err.Error)
+		}
+		t.Fatalf("expected exactly one error for one dead stream, got %d", len(errored))
+	}
+	if errored[0].Error == nil {
+		t.Fatal("error chunk carried no error field")
+	}
+	if errored[0].Error.Message == schemas.ErrProviderStreamTruncated {
+		t.Error("expected the read error to be reported, not the synthesized truncation error")
+	}
+}
+
+const openAIPartialImageEvent = `{"type":"image_generation.partial_image","b64_json":"aGk=","partial_image_index":0,"sequence_number":1}`
+
+const openAIPartialImageEditEvent = `{"type":"image_edit.partial_image","b64_json":"aGk=","partial_image_index":0,"sequence_number":1}`
+
+func TestImageGenerationStreamReadErrorReportsOnce(t *testing.T) {
+	server := completeSSEServer(t, "data: "+openAIPartialImageEvent+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostImageGenerationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input:    &schemas.ImageGenerationInput{Prompt: "a cat"},
+	}
+	stream, bifrostErr := provider.ImageGenerationStream(
+		contextWithFailingSSEReader(openAIPartialImageEvent), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	assertSingleReadError(t, collectChunks(t, stream))
+}
+
+func TestImageEditStreamReadErrorReportsOnce(t *testing.T) {
+	server := completeSSEServer(t, "data: "+openAIPartialImageEditEvent+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostImageEditRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: &schemas.ImageEditInput{
+			Prompt: "make it blue",
+			Images: []schemas.ImageInput{{Image: []byte("fake-png-bytes")}},
+		},
+	}
+	stream, bifrostErr := provider.ImageEditStream(
+		contextWithFailingSSEReader(openAIPartialImageEditEvent), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	assertSingleReadError(t, collectChunks(t, stream))
 }

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -762,6 +762,14 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 				return
 			}
 		}
+
+		// Replicate terminates a prediction stream with a `done` event, which every
+		// branch of the loop returns on. Falling out means the body ended first — a
+		// plain io.EOF, indistinguishable from a healthy close. The read-error path
+		// above sets the indicator, so an already-reported failure stays quiet here.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -1118,6 +1126,13 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 				resp.CloseBodyStream()
 				return
 			}
+		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
 		}
 	}()
 
@@ -1693,6 +1708,13 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 				}
 			}
 		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -2137,6 +2159,13 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 				return
 			}
 		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -2523,6 +2552,13 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
 				return
 			}
+		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
 		}
 	}()
 

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -763,6 +763,15 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, &response, nil), responseChan, postHookSpanFinalizer)
 			}
+
+			// The loop returns once the terminal chunk (done / usage) is emitted, so
+			// falling out of it means the body ended early — a plain io.EOF, which is
+			// indistinguishable from a healthy close. Stay quiet when something was
+			// already reported (the read-error path sets the indicator) or when the
+			// provider at least sent [DONE].
+			if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+				providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, body.Bytes())
+			}
 		}()
 
 		return responseChan, nil


### PR DESCRIPTION
## Summary

Streaming providers that die mid-response close the connection with a plain `io.EOF`, which is indistinguishable from a healthy close at the transport layer. Previously, Bifrost would silently synthesize a terminal chunk and close the channel, presenting a truncated stream to the caller as if it had completed normally. This PR detects the missing terminal event (e.g., `message_stop` for Anthropic, `[DONE]` for OpenAI-compatible providers, `done` for Replicate) and surfaces a `502` truncation error on the stream instead, allowing retry logic to act on it.

## Changes

- **Anthropic chat and responses streams**: Track whether `message_stop` was received. If the loop falls through without it, emit a truncation error instead of the synthesized final chunk. Error paths now `return` rather than `break` to prevent the post-loop check from double-reporting.
- **Cohere chat and responses streams**: Same `return`-instead-of-`break` fix on error paths, plus a post-loop truncation check since Cohere's terminal event is the only completion signal.
- **Azure speech stream**: Replace the server-side-only warning with a `SendStreamTruncatedError` call so the caller can observe the truncation.
- **Mistral transcription stream**: Post-loop truncation check guarded by the existing `BifrostContextKeyStreamEndIndicator` so already-reported read errors stay quiet.
- **OpenAI speech, transcription, image generation, and image edit streams**: Post-loop truncation checks using both the stream-end indicator and `SSEStreamEndedOnMarker` to avoid false positives when `[DONE]` was received.
- **Replicate text completion, chat, responses, image generation, and image edit streams**: Post-loop truncation checks guarded by the stream-end indicator, consistent with the `done`-event contract.
- **vLLM transcription stream**: Post-loop truncation check using both the indicator and `SSEStreamEndedOnMarker`.
- **Tests**: Three new tests for the Anthropic chat stream covering pre-first-byte death, mid-stream death, and a complete stream that must still receive its synthesized final chunk without error.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... -run TestAnthropicChatStream
go test ./...
```

The three new Anthropic truncation tests spin up an in-process `httptest.Server` that either drops the connection mid-stream (`panic(http.ErrAbortHandler)`) or completes normally, and assert that:
- A pre-first-byte drop produces exactly one chunk carrying a `502` truncation error.
- A mid-stream drop forwards the partial content and appends a `502` truncation error as the final chunk.
- A fully completed stream produces no error and includes the synthesized final chunk.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5546

## Security considerations

None. The change only affects error reporting on the stream channel; no secrets or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable