### PR TITLE
fix done marker for error frame

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -947,6 +947,9 @@ func HandleAnthropicChatCompletionStreaming(
 		// Per-response tool-call index state
 		streamState := NewAnthropicStreamState()
 
+		// True once message_stop arrives — Anthropic's only completion signal.
+		sawTerminalEvent := false
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -1144,7 +1147,9 @@ func HandleAnthropicChatCompletionStreaming(
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			if response != nil {
 				response.ExtraFields = schemas.BifrostResponseExtraFields{
@@ -1169,9 +1174,26 @@ func HandleAnthropicChatCompletionStreaming(
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
 			if isLastChunk {
+				sawTerminalEvent = true
 				break
 			}
 		}
+
+		// Anthropic signals completion with a message_stop event and never sends a
+		// [DONE] marker, so message_stop is the only terminal signal available. A
+		// dying upstream closes on a chunk boundary, which surfaces as a plain
+		// io.EOF — indistinguishable from a healthy close — so without the terminal
+		// event the synthesized final chunk below would present a truncated stream
+		// to the client as a clean stop.
+		if !sawTerminalEvent {
+			// Fold cached tokens in before billing: SendStreamTruncatedError snapshots
+			// the accumulated usage handle, so a fold after the send never reaches the
+			// billed copy. Guarded, so the healthy path below stays unaffected.
+			normalizeUsage()
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		normalizeUsage()
 		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, modelName, 0)
 		if postResponseConverter != nil {
@@ -1571,6 +1593,9 @@ func HandleAnthropicResponsesStream(
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					logger.Warn("Error reading %s stream: %v", providerName, readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// Already reported; returning (rather than breaking) keeps the
+					// post-loop truncation check from reporting the same stream twice.
+					return
 				}
 				break
 			}
@@ -1638,7 +1663,9 @@ func HandleAnthropicResponsesStream(
 				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 
 			// Attach the upstream raw to exactly one bifrost response. Default to the last,
@@ -1706,6 +1733,17 @@ func HandleAnthropicResponsesStream(
 			}
 
 		}
+
+		// The loop returns as soon as the terminal chunk is emitted, so falling out
+		// of it means the body ended before message_stop. A plain io.EOF cannot
+		// distinguish that from a healthy close, so surface it rather than closing
+		// the channel silently.
+		//
+		// Fold cached tokens in first: SendStreamTruncatedError snapshots the
+		// accumulated usage handle, so a fold after the send never reaches the billed
+		// copy. Guarded, so the ctx.Err() defer above stays a no-op after this.
+		normalizeBilledUsage()
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil

--- a/core/providers/anthropic/streamtruncation_test.go
+++ b/core/providers/anthropic/streamtruncation_test.go
@@ -1,0 +1,374 @@
+package anthropic
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic's Messages stream carries no [DONE] sentinel: message_stop is the
+// only completion signal. An upstream that dies closes on a chunk boundary,
+// which fasthttp reports as a plain io.EOF — the same read result as a healthy
+// close — so a stream cut short before message_stop must be surfaced rather
+// than finished off with a synthesized final chunk.
+// See https://github.com/maximhq/bifrost/issues/5546.
+
+type truncationTestLogger struct{}
+
+func (truncationTestLogger) Debug(string, ...any)                   {}
+func (truncationTestLogger) Info(string, ...any)                    {}
+func (truncationTestLogger) Warn(string, ...any)                    {}
+func (truncationTestLogger) Error(string, ...any)                   {}
+func (truncationTestLogger) Fatal(string, ...any)                   {}
+func (truncationTestLogger) SetLevel(schemas.LogLevel)              {}
+func (truncationTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (truncationTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+// anthropicSSEServer serves prelude and then either ends cleanly or kills the
+// connection mid-response. panic(http.ErrAbortHandler) is net/http's documented
+// way to drop a connection without the terminating chunk, reproducing what an
+// upstream whose generator died does on the wire.
+func anthropicSSEServer(t *testing.T, prelude string, truncate bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server ResponseWriter is not an http.Flusher")
+			return
+		}
+		flusher.Flush()
+		if prelude != "" {
+			if _, err := w.Write([]byte(prelude)); err != nil {
+				t.Errorf("failed writing SSE prelude: %v", err)
+				return
+			}
+			flusher.Flush()
+		}
+		if truncate {
+			panic(http.ErrAbortHandler)
+		}
+	}))
+}
+
+func newTruncationTestProvider(baseURL string) *AnthropicProvider {
+	return NewAnthropicProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+	}, truncationTestLogger{})
+}
+
+func truncationPassthroughPostHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return resp, err
+}
+
+func collectTruncationChunks(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostStreamChunk {
+	t.Helper()
+	var chunks []*schemas.BifrostStreamChunk
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return chunks
+			}
+			if chunk != nil {
+				chunks = append(chunks, chunk)
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for the provider stream to close")
+			return chunks
+		}
+	}
+}
+
+func assertAnthropicTruncationError(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error, got nil")
+	}
+	if err.IsBifrostError {
+		t.Error("truncation error must have IsBifrostError=false so the retry loop does not break early")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 502 {
+		t.Errorf("expected StatusCode 502, got %v", err.StatusCode)
+	}
+	if err.Error == nil || err.Error.Message != schemas.ErrProviderStreamTruncated {
+		t.Errorf("expected message %q, got %+v", schemas.ErrProviderStreamTruncated, err.Error)
+	}
+}
+
+func truncationChatRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-repro",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+const anthropicMessageStart = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_repro","type":"message","role":"assistant","model":"claude-repro","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
+
+// anthropicPartialText is the one text delta the fixtures emit. Derived into the
+// SSE payload rather than duplicated, so the assertion cannot drift from the wire.
+const anthropicPartialText = "partial answer"
+
+const anthropicTextDelta = "event: content_block_delta\n" +
+	`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"` + anthropicPartialText + `"}}` + "\n\n"
+
+const anthropicMessageStop = "event: content_block_stop\n" +
+	`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+	"event: message_delta\n" +
+	`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}` + "\n\n" +
+	"event: message_stop\n" +
+	`data: {"type":"message_stop"}` + "\n\n"
+
+// Pre-first-byte death: the error must be the stream's first chunk so
+// CheckFirstStreamChunkForError can turn it into a synchronous, retryable error.
+func TestAnthropicChatStreamTruncatedPreFirstByte(t *testing.T) {
+	server := anthropicSSEServer(t, "", true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) != 1 {
+		t.Fatalf("expected exactly one chunk (the error), got %d: %+v", len(chunks), chunks)
+	}
+	assertAnthropicTruncationError(t, chunks[0].BifrostError)
+	if chunks[0].BifrostChatResponse != nil {
+		t.Error("no synthetic chat chunk may be emitted for a truncated stream")
+	}
+}
+
+// Mid-stream death: forwarded content stays, then the error frame lands, and no
+// content-free terminal chunk is appended.
+func TestAnthropicChatStreamTruncatedMidStream(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) < 2 {
+		t.Fatalf("expected the forwarded content chunk followed by the error, got %d chunk(s)", len(chunks))
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	for i, chunk := range chunks[:len(chunks)-1] {
+		if chunk.BifrostError != nil {
+			t.Errorf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	// Detecting truncation must not cost the client the content that did arrive:
+	// the text delta forwarded before the connection died has to survive.
+	if !chunksContainContent(chunks[:len(chunks)-1], anthropicPartialText) {
+		t.Errorf("expected a pre-error chunk carrying %q; content forwarded before the truncation was dropped", anthropicPartialText)
+	}
+}
+
+// chunksContainContent reports whether any chunk carried the given delta text.
+func chunksContainContent(chunks []*schemas.BifrostStreamChunk, want string) bool {
+	for _, chunk := range chunks {
+		if chunk.BifrostChatResponse == nil {
+			continue
+		}
+		for _, choice := range chunk.BifrostChatResponse.Choices {
+			if choice.ChatStreamResponseChoice == nil || choice.ChatStreamResponseChoice.Delta == nil {
+				continue
+			}
+			if content := choice.ChatStreamResponseChoice.Delta.Content; content != nil && *content == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Guard against false positives: a stream that reaches message_stop is complete
+// and must still receive its synthesized final chunk, with no error.
+func TestAnthropicChatStreamCompleteUnaffected(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicMessageStart+anthropicTextDelta+anthropicMessageStop, false)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a well-formed stream")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	// A plain text delta is also a non-nil BifrostChatResponse, so identity has to be
+	// checked on properties only the synthesized terminal chunk carries: usage,
+	// a finish reason, and an empty delta.
+	final := chunks[len(chunks)-1].BifrostChatResponse
+	if final == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", chunks[len(chunks)-1])
+	}
+	if final.Usage == nil {
+		t.Fatal("terminal chunk must carry the accumulated usage; it is the only chunk the cost calculation can bill on")
+	}
+	// message_start reports input_tokens 5, message_delta reports a cumulative
+	// output_tokens 3 (https://platform.claude.com/docs/en/build-with-claude/streaming).
+	if final.Usage.PromptTokens != 5 || final.Usage.CompletionTokens != 3 || final.Usage.TotalTokens != 8 {
+		t.Errorf("terminal usage = prompt %d / completion %d / total %d, want 5 / 3 / 8",
+			final.Usage.PromptTokens, final.Usage.CompletionTokens, final.Usage.TotalTokens)
+	}
+	if len(final.Choices) != 1 {
+		t.Fatalf("expected exactly one choice on the terminal chunk, got %d", len(final.Choices))
+	}
+	choice := final.Choices[0]
+	if choice.FinishReason == nil {
+		t.Fatal("terminal chunk must carry a finish reason; content deltas never do")
+	}
+	if *choice.FinishReason != "stop" {
+		t.Errorf("finish reason = %q, want %q (mapped from Anthropic end_turn)", *choice.FinishReason, "stop")
+	}
+	if choice.ChatStreamResponseChoice == nil || choice.ChatStreamResponseChoice.Delta == nil {
+		t.Fatal("terminal chunk must still carry a stream choice with an empty delta")
+	}
+	if content := choice.ChatStreamResponseChoice.Delta.Content; content != nil && *content != "" {
+		t.Errorf("terminal chunk delta must be empty, got %q", *content)
+	}
+	// The content that arrived mid-stream is still expected to have been forwarded.
+	if !chunksContainContent(chunks[:len(chunks)-1], anthropicPartialText) {
+		t.Errorf("expected an earlier chunk carrying %q", anthropicPartialText)
+	}
+}
+
+// Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
+// exclusive of input_tokens - total input is the sum of all three
+// (https://platform.claude.com/docs/en/build-with-claude/prompt-caching). The
+// stream accumulator therefore folds the cache counters into PromptTokens/
+// TotalTokens exactly once at stream end. SendStreamTruncatedError snapshots the
+// usage handle when it bills, so the fold must happen before the send: otherwise a
+// cache-heavy request that dies mid-stream bills only the post-breakpoint tokens.
+
+const (
+	truncationCacheInputTokens  = 5
+	truncationCacheReadTokens   = 100
+	truncationCacheWriteTokens  = 20
+	truncationCacheFoldedTokens = truncationCacheInputTokens + truncationCacheReadTokens + truncationCacheWriteTokens
+)
+
+const anthropicCachedMessageStart = "event: message_start\n" +
+	`data: {"type":"message_start","message":{"id":"msg_repro","type":"message","role":"assistant","model":"claude-repro","content":[],` +
+	`"usage":{"input_tokens":5,"output_tokens":0,"cache_read_input_tokens":100,"cache_creation_input_tokens":20}}}` + "\n\n" +
+	"event: content_block_start\n" +
+	`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"
+
+// assertCacheFoldedBilledUsage pins the billed snapshot carried by a truncation
+// error: the cache counters must survive intact *and* already be folded into the
+// top-level prompt/total, which is what the cost calculation downstream charges on.
+func assertCacheFoldedBilledUsage(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error carrying billed usage, got nil")
+	}
+	billed := err.ExtraFields.BilledUsage
+	if billed == nil {
+		t.Fatal("truncated stream must bill for tokens the provider already reported")
+	}
+	if billed.PromptTokens != truncationCacheFoldedTokens {
+		t.Errorf("PromptTokens = %d, want %d (input %d + cache read %d + cache write %d)",
+			billed.PromptTokens, truncationCacheFoldedTokens,
+			truncationCacheInputTokens, truncationCacheReadTokens, truncationCacheWriteTokens)
+	}
+	if billed.TotalTokens != truncationCacheFoldedTokens {
+		t.Errorf("TotalTokens = %d, want %d", billed.TotalTokens, truncationCacheFoldedTokens)
+	}
+	if billed.PromptTokensDetails == nil {
+		t.Fatal("expected the cache breakdown to survive onto the billed snapshot")
+	}
+	if billed.PromptTokensDetails.CachedReadTokens != truncationCacheReadTokens {
+		t.Errorf("CachedReadTokens = %d, want %d", billed.PromptTokensDetails.CachedReadTokens, truncationCacheReadTokens)
+	}
+	if billed.PromptTokensDetails.CachedWriteTokens != truncationCacheWriteTokens {
+		t.Errorf("CachedWriteTokens = %d, want %d", billed.PromptTokensDetails.CachedWriteTokens, truncationCacheWriteTokens)
+	}
+}
+
+func TestAnthropicChatStreamTruncatedBillsCachedTokens(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicCachedMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, truncationChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	assertCacheFoldedBilledUsage(t, final.BifrostError)
+}
+
+func TestAnthropicResponsesStreamTruncatedBillsCachedTokens(t *testing.T) {
+	server := anthropicSSEServer(t, anthropicCachedMessageStart+anthropicTextDelta, true)
+	defer server.Close()
+
+	provider := newTruncationTestProvider(server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-repro",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(ctx, truncationPassthroughPostHook, nil,
+		schemas.Key{Value: *schemas.NewSecretVar("test-key")}, request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectTruncationChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertAnthropicTruncationError(t, final.BifrostError)
+	assertCacheFoldedBilledUsage(t, final.BifrostError)
+}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1005,8 +1005,12 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 			finalResponse.BackfillParams(request)
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, &finalResponse, nil, nil), responseChan, postHookSpanFinalizer)
-		} else if chunkIndex >= 0 && !doneReceived {
-			provider.logger.Warn("Stream ended without receiving [DONE] marker after %d chunks", chunkIndex+1)
+		} else if !doneReceived {
+			// The audio stream ended without its only completion signal, so the
+			// bytes already forwarded are a truncated clip. A server-side warning
+			// alone left the caller unable to tell that from a complete one, so
+			// surface it on the stream too.
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 		}
 
 		// Response is released via deferred ReleaseStreamingResponse(resp) above.

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -580,7 +580,9 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			if response != nil {
 				response.ID = responseID
@@ -608,11 +610,17 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 					response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
-					break
+					return
 				}
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil), responseChan, postHookSpanFinalizer)
 			}
 		}
+
+		// Cohere terminates the stream with a message-end event, which the loop
+		// returns on. Falling out of the loop means the body ended before it — a
+		// plain io.EOF, indistinguishable from a healthy close — so surface it
+		// rather than closing the channel silently.
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil
@@ -857,7 +865,9 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			if bifrostErr != nil {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
-				break
+				// Already reported; returning (rather than breaking) keeps the
+				// post-loop truncation check from reporting the same stream twice.
+				return
 			}
 			// Handle each response in the slice
 			for i, response := range responses {
@@ -890,6 +900,11 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 				}
 			}
 		}
+
+		// See the chat stream above: falling out of the loop means the body ended
+		// before the terminal event, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonBody)
 	}()
 
 	return responseChan, nil

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -532,6 +532,15 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 				break
 			}
 		}
+
+		// The loop only exits cleanly once a terminal event has been handled (the
+		// indicator is also set by the read-error path above, so an already-reported
+		// failure stays quiet here). Without it the body ended early — a plain
+		// io.EOF, indistinguishable from a healthy close — leaving the caller with a
+		// silently truncated transcript.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil)
+		}
 	}()
 
 	return responseChan, nil

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -2593,6 +2593,15 @@ func HandleOpenAISpeechStreamRequest(
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, &response, nil, nil), responseChan, postHookSpanFinalizer)
 		}
+
+		// The loop returns on speech.audio.done (the usage-bearing terminal event),
+		// so falling out means the body ended early — a plain io.EOF that cannot be
+		// told from a healthy close. Without this the caller receives a silently
+		// truncated audio clip. Stay quiet when a read error was already reported
+		// (it sets the indicator) or when the provider at least sent [DONE].
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+		}
 	}()
 
 	return responseChan, nil
@@ -3110,6 +3119,15 @@ func HandleOpenAITranscriptionStreamRequest(
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, response, nil), responseChan, postHookSpanFinalizer)
 		}
+
+		// The loop returns on transcript.text.done (or the usage-bearing chunk), so
+		// falling out means the body ended early — a plain io.EOF that cannot be told
+		// from a healthy close, leaving the caller with a silently truncated
+		// transcript. No raw request is attached: this endpoint sends multipart form
+		// data, not JSON.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, nil)
+		}
 	}()
 
 	return responseChan, nil
@@ -3481,7 +3499,13 @@ func HandleOpenAIImageGenerationStreaming(
 					return
 				}
 				if readErr != io.EOF {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -3665,6 +3689,14 @@ func HandleOpenAIImageGenerationStreaming(
 			if isCompleted {
 				return
 			}
+		}
+
+		// The loop returns on image_generation.completed, so falling out means the
+		// body ended early — a plain io.EOF that cannot be told from a healthy
+		// close. Without this the caller keeps only the partial images and never
+		// learns the final one is missing.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 		}
 	}()
 
@@ -4966,8 +4998,13 @@ func HandleOpenAIImageEditStreamRequest(
 					return
 				}
 				if readErr != io.EOF {
-					logger.Warn(fmt.Sprintf("Error reading stream: %v", readErr))
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -5147,6 +5184,15 @@ func HandleOpenAIImageEditStreamRequest(
 			if isCompleted {
 				return
 			}
+		}
+
+		// The loop returns on image_edit.completed, so falling out means the body
+		// ended early — a plain io.EOF that cannot be told from a healthy close.
+		// Without this the caller keeps only the partial images and never learns the
+		// final one is missing. No raw request is attached: this endpoint sends
+		// multipart form data, not JSON.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, nil)
 		}
 	}()
 

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -735,6 +735,14 @@ func HandleOpenAITextCompletionStreaming(
 			}
 		}
 
+		// See HandleOpenAIChatCompletionStreaming: a plain io.EOF cannot distinguish a
+		// finished provider from a dead connection, so a terminal marker is required
+		// before synthesizing the final chunk.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) && finishReason == nil {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.TextCompletionStreamRequest, request.Model, created)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)
@@ -1411,6 +1419,24 @@ func HandleOpenAIChatCompletionStreaming(
 			}
 		}
 
+		// A dying upstream closes the connection on a chunk boundary, which fasthttp
+		// reports as a plain io.EOF — the same read result as a properly terminated
+		// body. Truncation is therefore only detectable semantically: require an
+		// explicit [DONE], a finish_reason, or (on the fallback path) a terminal
+		// Responses event before synthesizing a final chunk. Without one, emitting
+		// the synthetic chunk would hand the client a clean, content-free completion
+		// that is indistinguishable from a provider that generated zero tokens.
+		terminalSignalSeen := providerUtils.SSEStreamEndedOnMarker(sseReader)
+		if isResponsesToChatCompletionsFallback {
+			terminalSignalSeen = terminalSignalSeen || pendingFinalEvent != nil
+		} else {
+			terminalSignalSeen = terminalSignalSeen || finishReason != nil
+		}
+		if !terminalSignalSeen {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			return
+		}
+
 		if isResponsesToChatCompletionsFallback {
 			if pendingFinalEvent != nil {
 				if usageSeen && pendingFinalEvent.Response != nil {
@@ -1864,6 +1890,10 @@ func HandleOpenAIResponsesStreaming(
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
+					// The read error is already reported; returning (rather than
+					// breaking) keeps the post-loop truncation check from reporting
+					// the same dead stream a second time.
+					return
 				}
 				break
 			}
@@ -1977,6 +2007,15 @@ func HandleOpenAIResponsesStreaming(
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// The loop returns as soon as a terminal event (completed / incomplete /
+		// failed / error) arrives, so falling out of it means the body ended without
+		// one. A plain io.EOF cannot distinguish that from a healthy close, so
+		// surface it rather than closing the channel silently — a silent close is
+		// indistinguishable to the client from a stream that just stopped emitting.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
 		}
 	}()
 

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -298,6 +298,9 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					provider.logger.Warn("Error reading stream: %v", readErr)
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, provider.logger, postHookSpanFinalizer)
+					// Already reported; returning keeps the post-loop truncation check
+					// from reporting the same dead stream twice.
+					return
 				}
 				break
 			}
@@ -369,6 +372,13 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 			lastChunkTime = time.Now()
 
 			providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, &response, nil, nil, nil), responseChan, postHookSpanFinalizer)
+		}
+
+		// Falling out of the loop means the body ended without a terminal event.
+		// A plain io.EOF cannot distinguish that from a healthy close, so surface it
+		// instead of closing the channel silently.
+		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil)
 		}
 	}()
 

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -1,0 +1,321 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// An upstream that dies mid-SSE closes its connection on a chunk boundary, which
+// fasthttp reports as a plain io.EOF — byte-for-byte the same read result as a
+// properly terminated body. These tests pin the semantic detection that replaces
+// the impossible transport-level check: without a terminal marker
+// ([DONE] / finish_reason / a terminal Responses event), the stream is truncated
+// and must surface as an error instead of a synthetic clean completion.
+// See https://github.com/maximhq/bifrost/issues/5546.
+
+// truncatingSSEServer serves one streaming response that writes prelude (already
+// SSE-framed) and then kills the connection without the terminating chunk.
+// panic(http.ErrAbortHandler) is net/http's documented way to drop a connection
+// mid-response without logging a stack trace, reproducing what an upstream whose
+// generator raised does on the wire.
+func truncatingSSEServer(t *testing.T, prelude string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("test server ResponseWriter is not an http.Flusher")
+			return
+		}
+		flusher.Flush()
+		if prelude != "" {
+			if _, err := w.Write([]byte(prelude)); err != nil {
+				t.Errorf("failed writing SSE prelude: %v", err)
+				return
+			}
+			flusher.Flush()
+		}
+		panic(http.ErrAbortHandler)
+	}))
+}
+
+// completeSSEServer serves a full, well-formed SSE stream.
+func completeSSEServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("failed writing SSE body: %v", err)
+		}
+	}))
+}
+
+func newStreamTestProvider(baseURL string) *OpenAIProvider {
+	return NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+	}, testNoopLogger{})
+}
+
+// passthroughPostHook is the identity post-hook: streaming helpers require a
+// runner, and these tests assert on what the provider produced, not on plugins.
+func passthroughPostHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return resp, err
+}
+
+func newStreamTestContext() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func testKey() schemas.Key {
+	return schemas.Key{Value: *schemas.NewSecretVar("test-key")}
+}
+
+// collectChunks drains a provider stream, failing the test if it does not close
+// in time (a stuck stream is itself a regression worth surfacing loudly).
+func collectChunks(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostStreamChunk {
+	t.Helper()
+	var chunks []*schemas.BifrostStreamChunk
+	timeout := time.NewTimer(20 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return chunks
+			}
+			if chunk != nil {
+				chunks = append(chunks, chunk)
+			}
+		case <-timeout.C:
+			t.Fatal("timed out waiting for the provider stream to close")
+			return chunks
+		}
+	}
+}
+
+// assertTruncationError checks the error carries the retryable upstream-connection
+// shape. IsBifrostError must stay false and the status 502 so that
+// executeRequestWithRetries retries / falls back instead of breaking out early.
+func assertTruncationError(t *testing.T, err *schemas.BifrostError) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a truncation error, got nil")
+	}
+	if err.IsBifrostError {
+		t.Error("truncation error must have IsBifrostError=false so the retry loop does not break early")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 502 {
+		t.Errorf("expected StatusCode 502, got %v", err.StatusCode)
+	}
+	if err.Error == nil || err.Error.Message != schemas.ErrProviderStreamTruncated {
+		t.Errorf("expected message %q, got %+v", schemas.ErrProviderStreamTruncated, err.Error)
+	}
+	if err.Error != nil && (err.Error.Type == nil || *err.Error.Type != schemas.ProviderConnectionFailed) {
+		t.Errorf("expected error type %q, got %v", schemas.ProviderConnectionFailed, err.Error.Type)
+	}
+}
+
+func basicChatRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+func chatChunk(content string, finishReason *string) string {
+	delta := `{}`
+	if content != "" {
+		delta = `{"content":"` + content + `"}`
+	}
+	finish := "null"
+	if finishReason != nil {
+		finish = `"` + *finishReason + `"`
+	}
+	return `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":` + delta + `,"finish_reason":` + finish + `}]}` + "\n\n"
+}
+
+// Pre-first-byte death: nothing has reached the client yet, so the error must be
+// the very first chunk. That is what lets CheckFirstStreamChunkForError convert it
+// into a synchronous error and give the transport a real non-2xx status.
+func TestChatStreamTruncatedPreFirstByte(t *testing.T) {
+	server := truncatingSSEServer(t, "")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) != 1 {
+		t.Fatalf("expected exactly one chunk (the error), got %d: %+v", len(chunks), chunks)
+	}
+	assertTruncationError(t, chunks[0].BifrostError)
+	if chunks[0].BifrostChatResponse != nil {
+		t.Error("no synthetic chat chunk may be emitted for a truncated stream")
+	}
+}
+
+// Mid-stream death: already-forwarded content stays, then the error frame lands.
+// Bifrost must not append the content-free terminal chunk that made the failure
+// look like a normal short completion.
+func TestChatStreamTruncatedMidStream(t *testing.T) {
+	server := truncatingSSEServer(t, chatChunk("partial answer", nil))
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) != 2 {
+		t.Fatalf("expected the content chunk plus one error chunk, got %d: %+v", len(chunks), chunks)
+	}
+	if chunks[0].BifrostChatResponse == nil {
+		t.Fatalf("expected the first chunk to be the forwarded content, got %+v", chunks[0])
+	}
+	assertTruncationError(t, chunks[1].BifrostError)
+}
+
+// Guard against false positives: a well-formed stream must still get its
+// synthesized terminal chunk and no error.
+func TestChatStreamCleanDoneUnaffected(t *testing.T) {
+	stop := "stop"
+	server := completeSSEServer(t, chatChunk("hello", nil)+chatChunk("", &stop)+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a well-formed stream")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	final := chunks[len(chunks)-1]
+	if final.BifrostChatResponse == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", final)
+	}
+	if len(final.BifrostChatResponse.Choices) == 0 ||
+		final.BifrostChatResponse.Choices[0].FinishReason == nil ||
+		*final.BifrostChatResponse.Choices[0].FinishReason != stop {
+		t.Errorf("expected the final chunk to carry finish_reason %q, got %+v", stop, final.BifrostChatResponse.Choices)
+	}
+}
+
+// [DONE] is a terminal marker in its own right: a provider that ends the stream
+// properly but never sets finish_reason is not truncated.
+func TestChatStreamDoneWithoutFinishReasonIsNotTruncated(t *testing.T) {
+	server := completeSSEServer(t, chatChunk("hello", nil)+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	for i, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+}
+
+// finish_reason alone is terminal too — providers listed as not sending [DONE]
+// (Cerebras, Perplexity, HuggingFace, Bedrock mantle) rely on exactly this.
+func TestChatStreamFinishReasonWithoutDoneIsNotTruncated(t *testing.T) {
+	stop := "stop"
+	server := completeSSEServer(t, chatChunk("hello", nil)+chatChunk("", &stop))
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	for i, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+}
+
+func TestTextCompletionStreamTruncated(t *testing.T) {
+	server := truncatingSSEServer(t, `data: {"id":"cmpl-repro","object":"text_completion","created":1,"model":"repro-model","choices":[{"index":0,"text":"partial"}]}`+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostTextCompletionRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input:    &schemas.TextCompletionInput{PromptStr: schemas.Ptr("hi")},
+	}
+	stream, bifrostErr := provider.TextCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	final := chunks[len(chunks)-1]
+	assertTruncationError(t, final.BifrostError)
+	if final.BifrostTextCompletionResponse != nil {
+		t.Error("no synthetic text completion chunk may be emitted for a truncated stream")
+	}
+}
+
+// The Responses loop returns as soon as a terminal event arrives, so a stream
+// that ends without one previously closed the channel silently — indistinguishable
+// to the client from a stream that simply stopped emitting events.
+func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
+	server := truncatingSSEServer(t, "event: response.output_text.delta\n"+
+		`data: {"type":"response.output_text.delta","sequence_number":1,"delta":"partial"}`+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least the error chunk")
+	}
+	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
+}

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -2,11 +2,14 @@ package openai
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -318,4 +321,121 @@ func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
 		t.Fatal("expected at least the error chunk")
 	}
 	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
+}
+
+// A non-EOF read error is already a reported failure. The truncation guard that
+// follows the read loop must not fire a second time for the same dead stream, or
+// the client sees two errors for one request and the retryable 502 synthesized by
+// SendStreamTruncatedError muddies which failure the retry logic reacted to. The
+// handler signals "already reported" by latching BifrostContextKeyStreamEndIndicator.
+
+// failingSSEDataReader yields queued data lines and then a non-EOF error,
+// reproducing an upstream whose SSE framing breaks mid-body (what bufio.Scanner
+// surfaces when a line exceeds its ceiling). It deliberately implements
+// SSEStreamTerminator returning false, so the post-loop truncation guard is live -
+// that is precisely the condition under which a handler that forgets to latch the
+// end indicator emits a duplicate.
+type failingSSEDataReader struct {
+	lines [][]byte
+	err   error
+}
+
+func (r *failingSSEDataReader) ReadDataLine() ([]byte, error) {
+	if len(r.lines) == 0 {
+		return nil, r.err
+	}
+	line := r.lines[0]
+	r.lines = r.lines[1:]
+	return line, nil
+}
+
+func (r *failingSSEDataReader) SawDoneMarker() bool { return false }
+
+// contextWithFailingSSEReader injects a reader that replays lines then fails.
+// BifrostContextKeySSEReaderFactory is the same seam enterprise uses to swap in a
+// streaming reader, so this drives the real handler loop rather than a stub of it.
+func contextWithFailingSSEReader(lines ...string) *schemas.BifrostContext {
+	ctx := newStreamTestContext()
+	payloads := make([][]byte, 0, len(lines))
+	for _, line := range lines {
+		payloads = append(payloads, []byte(line))
+	}
+	ctx.SetValue(schemas.BifrostContextKeySSEReaderFactory, &providerUtils.SSEReaderFactory{
+		NewDataReader: func(io.Reader) providerUtils.SSEDataReader {
+			return &failingSSEDataReader{
+				lines: payloads,
+				err:   errors.New("sse framing error"),
+			}
+		},
+	})
+	return ctx
+}
+
+// assertSingleReadError checks the stream carried exactly one error, and that it
+// is the read error rather than the synthesized truncation 502.
+func assertSingleReadError(t *testing.T, chunks []*schemas.BifrostStreamChunk) {
+	t.Helper()
+	var errored []*schemas.BifrostError
+	for _, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			errored = append(errored, chunk.BifrostError)
+		}
+	}
+	if len(errored) != 1 {
+		for i, err := range errored {
+			t.Logf("error %d: %+v", i, err.Error)
+		}
+		t.Fatalf("expected exactly one error for one dead stream, got %d", len(errored))
+	}
+	if errored[0].Error == nil {
+		t.Fatal("error chunk carried no error field")
+	}
+	if errored[0].Error.Message == schemas.ErrProviderStreamTruncated {
+		t.Error("expected the read error to be reported, not the synthesized truncation error")
+	}
+}
+
+const openAIPartialImageEvent = `{"type":"image_generation.partial_image","b64_json":"aGk=","partial_image_index":0,"sequence_number":1}`
+
+const openAIPartialImageEditEvent = `{"type":"image_edit.partial_image","b64_json":"aGk=","partial_image_index":0,"sequence_number":1}`
+
+func TestImageGenerationStreamReadErrorReportsOnce(t *testing.T) {
+	server := completeSSEServer(t, "data: "+openAIPartialImageEvent+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostImageGenerationRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input:    &schemas.ImageGenerationInput{Prompt: "a cat"},
+	}
+	stream, bifrostErr := provider.ImageGenerationStream(
+		contextWithFailingSSEReader(openAIPartialImageEvent), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	assertSingleReadError(t, collectChunks(t, stream))
+}
+
+func TestImageEditStreamReadErrorReportsOnce(t *testing.T) {
+	server := completeSSEServer(t, "data: "+openAIPartialImageEditEvent+"\n\n")
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostImageEditRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: &schemas.ImageEditInput{
+			Prompt: "make it blue",
+			Images: []schemas.ImageInput{{Image: []byte("fake-png-bytes")}},
+		},
+	}
+	stream, bifrostErr := provider.ImageEditStream(
+		contextWithFailingSSEReader(openAIPartialImageEditEvent), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	assertSingleReadError(t, collectChunks(t, stream))
 }

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -762,6 +762,14 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 				return
 			}
 		}
+
+		// Replicate terminates a prediction stream with a `done` event, which every
+		// branch of the loop returns on. Falling out means the body ended first — a
+		// plain io.EOF, indistinguishable from a healthy close. The read-error path
+		// above sets the indicator, so an already-reported failure stays quiet here.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -1118,6 +1126,13 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 				resp.CloseBodyStream()
 				return
 			}
+		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
 		}
 	}()
 
@@ -1693,6 +1708,13 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 				}
 			}
 		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -2137,6 +2159,13 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 				return
 			}
 		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
+		}
 	}()
 
 	return responseChan, nil
@@ -2523,6 +2552,13 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger, postHookSpanFinalizer)
 				return
 			}
+		}
+
+		// See TextCompletionStream: no `done` event means the body ended before the
+		// prediction finished, which a plain io.EOF cannot distinguish from a
+		// healthy close.
+		if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended {
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, jsonData)
 		}
 	}()
 

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -29,6 +29,26 @@ type SSEEventReader interface {
 	ReadEvent() (eventType string, data []byte, err error)
 }
 
+// SSEStreamTerminator is optionally implemented by SSE readers that can report
+// whether the stream ended on an explicit terminal marker ("data: [DONE]")
+// rather than a plain body EOF. ReadDataLine returns io.EOF for both, so
+// without this a provider loop cannot tell a provider that finished cleanly
+// from an upstream connection that died mid-stream.
+type SSEStreamTerminator interface {
+	SawDoneMarker() bool
+}
+
+// SSEStreamEndedOnMarker reports whether r ended on an explicit [DONE] marker.
+// Readers that do not implement SSEStreamTerminator (e.g. an enterprise-injected
+// SSEReaderFactory) return true: with no signal available we assume the stream
+// terminated normally rather than misreport a healthy stream as truncated.
+func SSEStreamEndedOnMarker(r SSEDataReader) bool {
+	if t, ok := r.(SSEStreamTerminator); ok {
+		return t.SawDoneMarker()
+	}
+	return true
+}
+
 // SSEReaderFactory creates SSE readers for streaming response processing.
 // Enterprise injects this via BifrostContextKeySSEReaderFactory to replace
 // the default bufio.Scanner-based implementations with streaming readers.
@@ -75,7 +95,11 @@ var (
 type defaultSSEDataReader struct {
 	scanner *bufio.Scanner
 	pending []byte // line carried over from an aborted multi-line JSON accumulation
+	sawDone bool   // stream ended on "data: [DONE]" rather than a bare body EOF
 }
+
+// SawDoneMarker implements SSEStreamTerminator.
+func (r *defaultSSEDataReader) SawDoneMarker() bool { return r.sawDone }
 
 func newDefaultSSEDataReader(reader io.Reader) *defaultSSEDataReader {
 	scanner := bufio.NewScanner(reader)
@@ -104,6 +128,7 @@ func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
 				continue
 			}
 			if bytes.Equal(data, sseDoneMarker) {
+				r.sawDone = true
 				return nil, io.EOF
 			}
 			// Copy to decouple from scanner's internal buffer

--- a/core/providers/utils/sse_test.go
+++ b/core/providers/utils/sse_test.go
@@ -34,6 +34,57 @@ func TestSSEDataReader_DataLinesAndDone(t *testing.T) {
 	}
 }
 
+// [DONE] and a bare body EOF both surface as io.EOF from ReadDataLine, so the
+// reader must record which one it was — that flag is the only way a provider
+// loop can tell a finished stream from a dead upstream connection.
+func TestSSEDataReader_SawDoneMarkerOnDone(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader("data: {\"a\":1}\n\ndata: [DONE]\n\n"))
+	drainSSEDataReader(t, reader)
+	if !reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be true after reading [DONE]")
+	}
+	if !SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be true after reading [DONE]")
+	}
+}
+
+// A stream that just stops (upstream connection died on a chunk boundary) ends
+// with the same io.EOF but no marker.
+func TestSSEDataReader_SawDoneMarkerAbsentOnBareEOF(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader("data: {\"a\":1}\n\n"))
+	drainSSEDataReader(t, reader)
+	if reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be false when the body ended without [DONE]")
+	}
+	if SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be false when the body ended without [DONE]")
+	}
+}
+
+// A reader with no bytes at all (upstream died before its first byte) must also
+// report no marker.
+func TestSSEDataReader_SawDoneMarkerAbsentOnEmptyStream(t *testing.T) {
+	reader := newDefaultSSEDataReader(strings.NewReader(""))
+	drainSSEDataReader(t, reader)
+	if SSEStreamEndedOnMarker(reader) {
+		t.Error("expected SSEStreamEndedOnMarker to be false for an empty stream")
+	}
+}
+
+// stubSSEDataReader stands in for an enterprise-injected reader that predates
+// SSEStreamTerminator.
+type stubSSEDataReader struct{}
+
+func (stubSSEDataReader) ReadDataLine() ([]byte, error) { return nil, io.EOF }
+
+// Readers that cannot report a marker must be assumed to have terminated
+// normally: reporting them as truncated would fail every enterprise stream.
+func TestSSEStreamEndedOnMarker_UnknownReaderDefaultsTrue(t *testing.T) {
+	if !SSEStreamEndedOnMarker(stubSSEDataReader{}) {
+		t.Error("expected SSEStreamEndedOnMarker to default to true for readers without SSEStreamTerminator")
+	}
+}
+
 func TestSSEDataReader_SingleLineRawJSONFallback(t *testing.T) {
 	stream := `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}` + "\n"
 	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(strings.NewReader(stream)))

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2839,6 +2839,44 @@ func ProcessAndSendError(
 	GateSendChunk(ctx, streamResponse, responseChan)
 }
 
+// SendStreamTruncatedError surfaces an upstream stream that ended without a
+// terminal marker (no "data: [DONE]", no finish_reason / completion event) as a
+// client-visible error instead of letting the caller synthesize a clean final
+// chunk. A dying upstream typically closes the connection on a chunk boundary,
+// which fasthttp reports as a plain io.EOF — indistinguishable at the transport
+// layer from a properly terminated body — so truncation can only be detected
+// semantically, by the absence of a terminal marker.
+//
+// The error is deliberately built as a retryable upstream connection failure
+// (502, IsBifrostError=false): when nothing has been forwarded yet this becomes
+// the stream's first chunk, so CheckFirstStreamChunkForError converts it into a
+// synchronous error and executeRequestWithRetries can retry or fall back. An
+// IsBifrostError=true error would break that retry loop instead (see #4496).
+func SendStreamTruncatedError(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	responseChan chan *schemas.BifrostStreamChunk,
+	logger schemas.Logger,
+	postHookSpanFinalizer func(context.Context),
+	jsonBody []byte,
+) {
+	if logger != nil {
+		logger.Warn("Stream ended without a terminal marker; treating as truncated upstream stream")
+	}
+
+	truncatedErr := NewBifrostUpstreamConnectionError(schemas.ErrProviderStreamTruncated, io.ErrUnexpectedEOF)
+
+	if ShouldSendBackRawRequest(ctx, false) && len(jsonBody) > 0 {
+		truncatedErr.ExtraFields.RawRequest = compactRawJSON(jsonBody)
+	}
+
+	// Bill for tokens the provider already produced before the stream died.
+	attachBilledUsageFromContext(ctx, truncatedErr)
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	ProcessAndSendBifrostError(ctx, postHookRunner, truncatedErr, responseChan, logger, postHookSpanFinalizer)
+}
+
 // CreateBifrostTextCompletionChunkResponse creates a bifrost text completion chunk response.
 func CreateBifrostTextCompletionChunkResponse(
 	id string,

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -763,6 +763,15 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, &response, nil), responseChan, postHookSpanFinalizer)
 			}
+
+			// The loop returns once the terminal chunk (done / usage) is emitted, so
+			// falling out of it means the body ended early — a plain io.EOF, which is
+			// indistinguishable from a healthy close. Stay quiet when something was
+			// already reported (the read-error path sets the indicator) or when the
+			// provider at least sent [DONE].
+			if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
+				providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, body.Bytes())
+			}
 		}()
 
 		return responseChan, nil

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -41,6 +41,7 @@ const (
 	ErrProviderRawRequestUnmarshal  = "failed to unmarshal raw request from provider API"
 	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
 	ErrProviderResponseDecompress   = "failed to decompress provider's response"
+	ErrProviderStreamTruncated      = "provider closed the stream before sending a completion marker (upstream connection ended mid-stream)"
 )
 
 // NetworkConfig represents the network configuration for provider connections.

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -2059,6 +2059,11 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 
 		var includeEventType bool
 		var skipDoneMarker bool
+		// Set once a hard error frame reaches the client. An error frame is a
+		// terminal signal in its own right, so appending [DONE] after it would tell
+		// a client keyed on the marker that the stream finished normally — the exact
+		// ambiguity that let truncated upstream streams look successful (#5546).
+		var sawErrorChunk bool
 
 		// Process streaming responses
 		for chunk := range stream {
@@ -2121,6 +2126,12 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 				continue
 			}
 
+			// Checked after marshalling so a chunk that never reaches the wire does
+			// not suppress the marker.
+			if chunk.BifrostError != nil {
+				sawErrorChunk = true
+			}
+
 			// Format and send as SSE data
 			var eventType string
 			if includeEventType {
@@ -2152,7 +2163,12 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 		// once they see [DONE], so they'd be silently dropped.
 		runCompleter(true)
 
-		if !includeEventType && !skipDoneMarker {
+		// A stream that ended on an error frame is already terminated for the client;
+		// only a clean run gets the marker. Note this deliberately ignores an error
+		// from runCompleter above: that reports a post-processing/plugin failure, not
+		// an incomplete stream, so [DONE] remains an accurate statement about the
+		// stream data itself.
+		if !includeEventType && !skipDoneMarker && !sawErrorChunk {
 			// Send the [DONE] marker to indicate the end of the stream (only for non-responses/image-gen APIs)
 			if !reader.SendDone() {
 				cancel()

--- a/transports/bifrost-http/handlers/streamdonemarker_test.go
+++ b/transports/bifrost-http/handlers/streamdonemarker_test.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// A "data: [DONE]" marker states that the stream finished normally. Emitting it
+// after an error frame reproduces, one layer up, the same ambiguity that made
+// truncated upstream streams look successful: a client keyed on the marker sees
+// a clean end either way. See https://github.com/maximhq/bifrost/issues/5546.
+
+// serveStreamingResponse runs handleStreamingResponse against an in-process
+// connection and returns the raw SSE body the client would receive.
+func serveStreamingResponse(t *testing.T, chunks []*schemas.BifrostStreamChunk) string {
+	t.Helper()
+
+	handler := func(reqCtx *fasthttp.RequestCtx) {
+		// A zero Config loads no transport plugins, so no chunk interceptor runs.
+		h := &CompletionHandler{config: &lib.Config{}}
+
+		base, cancel := context.WithCancel(context.Background())
+		bifrostCtx := schemas.NewBifrostContext(base, schemas.NoDeadline)
+
+		getStream := func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+			stream := make(chan *schemas.BifrostStreamChunk, len(chunks))
+			for _, chunk := range chunks {
+				stream <- chunk
+			}
+			close(stream)
+			return stream, nil
+		}
+
+		h.handleStreamingResponse(reqCtx, bifrostCtx, schemas.ChatCompletionStreamRequest, getStream, cancel)
+	}
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	go func() {
+		_ = fasthttp.ServeConn(serverConn, handler)
+	}()
+
+	if err := clientConn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatalf("failed to set deadline: %v", err)
+	}
+	if _, err := clientConn.Write([]byte("POST /v1/chat/completions HTTP/1.1\r\nHost: test\r\n\r\n")); err != nil {
+		t.Fatalf("failed to write request: %v", err)
+	}
+
+	br := bufio.NewReader(clientConn)
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("failed to read response header: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break
+		}
+	}
+
+	var body strings.Builder
+	for {
+		sizeLine, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("failed to read chunk size: %v", err)
+		}
+		var chunkSize int
+		if _, err := fmt.Sscanf(strings.TrimSpace(sizeLine), "%x", &chunkSize); err != nil {
+			t.Fatalf("failed to parse chunk size %q: %v", sizeLine, err)
+		}
+		if chunkSize == 0 {
+			break
+		}
+		data := make([]byte, chunkSize+2) // +2 for the trailing CRLF
+		for n := 0; n < len(data); {
+			nn, err := br.Read(data[n:])
+			if err != nil {
+				t.Fatalf("failed to read chunk data: %v", err)
+			}
+			n += nn
+		}
+		body.Write(data[:chunkSize])
+	}
+	return body.String()
+}
+
+func contentChunk(text string) *schemas.BifrostStreamChunk {
+	return &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{
+			ID:     "chatcmpl-repro",
+			Object: "chat.completion.chunk",
+			Model:  "repro-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				Index: 0,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{Content: schemas.Ptr(text)},
+				},
+			}},
+		},
+	}
+}
+
+func truncationErrorChunk() *schemas.BifrostStreamChunk {
+	statusCode := 502
+	errorType := schemas.ProviderConnectionFailed
+	return &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &statusCode,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderStreamTruncated,
+				Type:    &errorType,
+			},
+		},
+	}
+}
+
+// A stream that ends on an error frame is already terminated for the client;
+// appending [DONE] would report it as a clean finish.
+func TestStreamingResponseSkipsDoneAfterErrorChunk(t *testing.T) {
+	body := serveStreamingResponse(t, []*schemas.BifrostStreamChunk{
+		contentChunk("partial answer"),
+		truncationErrorChunk(),
+	})
+
+	if !strings.Contains(body, schemas.ErrProviderStreamTruncated) {
+		t.Errorf("expected the error frame to reach the client, got:\n%s", body)
+	}
+	if strings.Contains(body, "data: [DONE]") {
+		t.Errorf("[DONE] must not follow an error frame, got:\n%s", body)
+	}
+}
+
+// Guard against over-suppression: a clean stream still gets its marker.
+func TestStreamingResponseSendsDoneOnCleanStream(t *testing.T) {
+	body := serveStreamingResponse(t, []*schemas.BifrostStreamChunk{
+		contentChunk("hello"),
+		contentChunk(" world"),
+	})
+
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Errorf("expected [DONE] to terminate a clean stream, got:\n%s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a bug where a `data: [DONE]` marker was emitted after an error frame in a streaming response, causing clients keyed on that marker to interpret a failed or truncated stream as a clean, successful completion. This was the root ambiguity behind truncated upstream streams appearing successful (issue #5546).

## Changes

- Introduced a `sawErrorChunk` boolean in `handleStreamingResponse` that is set when a chunk carrying a `BifrostError` is written to the wire. If this flag is set, the `[DONE]` marker is suppressed at the end of the stream, since the error frame already serves as a terminal signal.
- The flag is checked after marshalling to avoid suppressing the marker for chunks that never actually reach the client.
- `runCompleter` errors are intentionally not factored into this decision — those reflect post-processing or plugin failures, not an incomplete stream, so `[DONE]` remains accurate in that case.
- Added `streamdonemarker_test.go` with two regression tests: one asserting `[DONE]` is absent after an error frame, and one guarding against over-suppression by confirming clean streams still receive the marker.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

`TestStreamingResponseSkipsDoneAfterErrorChunk` verifies that a stream ending with an error frame does not emit `[DONE]`.  
`TestStreamingResponseSendsDoneOnCleanStream` verifies that a clean stream still receives `[DONE]`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5546

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable