### PR TITLE
feat: add partitioned sidekiq job claiming with FIFO ordering per key

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -443,6 +443,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_vertex_force_single_region_column"}, run: migrationAddVertexForceSingleRegionColumn},
 	{IDs: []string{"add_sidekiq_table"}, run: migrationAddSidekiqTable},
 	{IDs: []string{"add_sidekiq_kind_status_created_index"}, run: migrationAddSidekiqKindStatusCreatedIndex},
+	{IDs: []string{"add_sidekiq_partitioning_key_column"}, run: migrationAddSidekiqPartitioningKeyColumn},
 	{IDs: []string{"add_fast_mode_cache_pricing_columns"}, run: migrationAddFastModeCachePricingColumns},
 	{IDs: []string{"add_inference_geo_multiplier_column"}, run: migrationAddInferenceGeoMultiplierColumn},
 	{IDs: []string{"repair_bare_wildcard_allowed_models"}, run: migrationRepairBareWildcardAllowedModels},
@@ -10678,6 +10679,32 @@ func migrationAddMCPClientToolExecutionTimeoutColumn(ctx context.Context, db *go
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 			return dropColumnIfExists(tx, logger, &tables.TableMCPClient{}, "tool_execution_timeout")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}
+
+// migrationAddSidekiqPartitioningKeyColumn adds the nullable partitioning_key column and
+// its index, enabling cluster-wide FIFO-ordered job execution per key.
+func migrationAddSidekiqPartitioningKeyColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_sidekiq_partitioning_key_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableSidekiqJob{}, "partitioning_key"); err != nil {
+				return err
+			}
+			return tx.Exec(`CREATE INDEX IF NOT EXISTS idx_sidekiq_partitioning_key ON sidekiq (partitioning_key)`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &tables.TableSidekiqJob{}, "partitioning_key")
 		},
 	}})
 	if err := m.Migrate(); err != nil {

--- a/framework/configstore/sidekiq.go
+++ b/framework/configstore/sidekiq.go
@@ -87,6 +87,46 @@ func (s *RDBConfigStore) ClaimSidekiqJob(ctx context.Context, id, runnerID strin
 	return res.RowsAffected == 1, nil
 }
 
+// ClaimPartitionedSidekiqJob is ClaimSidekiqJob for jobs carrying a partitioning key.
+// On top of the base claimable condition it enforces, atomically, that the job is
+// next in line for its key:
+//   - G1: no OTHER job with the same key is running under a live owner
+//     (updated_at >= staleBefore, i.e. not itself stale), and
+//   - G2: no OLDER pending job with the same key exists (FIFO by created_at, id).
+//
+// Together these give at-most-one-running plus FIFO execution per key, cluster-wide,
+// while distinct keys stay parallel. A blocked job yields RowsAffected == 0 (not
+// claimed) and is retried on the next dispatch tick. A stale (dead-owner) running
+// job does not block its key, so a crashed node cannot deadlock the queue.
+func (s *RDBConfigStore) ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, partitioningKey string, createdAt time.Time) (bool, error) {
+	now := time.Now()
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableSidekiqJob{}).
+		Where("id = ? AND (status = ? OR (status = ? AND updated_at < ?))",
+			id,
+			tables.SidekiqStatusPending,
+			tables.SidekiqStatusRunning, staleBefore).
+		// G1: mutual exclusion — no other same-key job running under a live owner.
+		Where("NOT EXISTS (SELECT 1 FROM sidekiq r WHERE r.partitioning_key = ? AND r.id <> ? AND r.status = ? AND r.updated_at >= ?)",
+			partitioningKey, id, tables.SidekiqStatusRunning, staleBefore).
+		// G2: FIFO — no OLDER pending job for the same key. Excludes the row itself
+		// (o.id <> id): the claim's createdAt (in-memory, nanosecond) can exceed the
+		// truncated persisted created_at, which would else block the job on itself.
+		Where("NOT EXISTS (SELECT 1 FROM sidekiq o WHERE o.partitioning_key = ? AND o.id <> ? AND o.status = ? AND (o.created_at < ? OR (o.created_at = ? AND o.id < ?)))",
+			partitioningKey, id, tables.SidekiqStatusPending, createdAt, createdAt, id).
+		Updates(map[string]any{
+			"status":     tables.SidekiqStatusRunning,
+			"runner_id":  runnerID,
+			"started_at": gorm.Expr("COALESCE(started_at, ?)", now),
+			"updated_at": now,
+			"attempts":   gorm.Expr("attempts + 1"),
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
 // HeartbeatSidekiqJob bumps the heartbeat (updated_at) for a job the caller still
 // owns and is still running. Called on a fixed interval by the owning runner so a
 // slow-but-alive job (one whose handler has not checkpointed recently) is not

--- a/framework/configstore/sidekiq_test.go
+++ b/framework/configstore/sidekiq_test.go
@@ -25,6 +25,14 @@ func setUpdatedAt(t *testing.T, store *RDBConfigStore, id string, ts time.Time) 
 		Where("id = ?", id).Update("updated_at", ts).Error)
 }
 
+// setCreatedAt forces a job's created_at so FIFO ordering can be exercised
+// deterministically without relying on insert-time clock resolution.
+func setCreatedAt(t *testing.T, store *RDBConfigStore, id string, ts time.Time) {
+	t.Helper()
+	require.NoError(t, store.DB().Model(&tables.TableSidekiqJob{}).
+		Where("id = ?", id).Update("created_at", ts).Error)
+}
+
 func getJob(t *testing.T, store *RDBConfigStore, id string) *tables.TableSidekiqJob {
 	t.Helper()
 	job, err := store.GetSidekiqJob(context.Background(), id)
@@ -440,4 +448,99 @@ func TestMarkStaleSidekiqJobsFailed(t *testing.T) {
 	assert.NotEmpty(t, getJob(t, store, "stale").LastError)
 	assert.Equal(t, tables.SidekiqStatusRunning, getJob(t, store, "fresh").Status)
 	assert.Equal(t, tables.SidekiqStatusPending, getJob(t, store, "pending").Status)
+}
+
+// TestClaimPartitionedSidekiqJobFIFOAndExclusion verifies that jobs sharing a
+// partitioning key run one-at-a-time in FIFO order, while a distinct key runs in
+// parallel: the newer job cannot claim before the older pending one; while the
+// older runs the newer stays blocked; only once the older completes does the
+// newer claim.
+func TestClaimPartitionedSidekiqJobFIFOAndExclusion(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+	const runner = "node-1"
+	stale := time.Now().Add(-30 * time.Second) // fresh running jobs block
+
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "j1", Kind: "sync", PartitioningKey: "g"}))
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "j2", Kind: "sync", PartitioningKey: "g"}))
+	base := time.Now().Add(-time.Hour)
+	setCreatedAt(t, store, "j1", base)
+	setCreatedAt(t, store, "j2", base.Add(time.Minute)) // j2 strictly newer
+
+	j1, j2 := getJob(t, store, "j1"), getJob(t, store, "j2")
+
+	// Newer job must not jump the queue while the older is still pending (FIFO).
+	claimed, err := store.ClaimPartitionedSidekiqJob(ctx, "j2", runner, stale, "g", j2.CreatedAt)
+	require.NoError(t, err)
+	assert.False(t, claimed, "newer job claimed before older pending job")
+
+	// Oldest pending job claims.
+	claimed, err = store.ClaimPartitionedSidekiqJob(ctx, "j1", runner, stale, "g", j1.CreatedAt)
+	require.NoError(t, err)
+	assert.True(t, claimed, "oldest pending job should claim")
+
+	// Newer job stays blocked while the older one runs (mutual exclusion).
+	claimed, err = store.ClaimPartitionedSidekiqJob(ctx, "j2", runner, stale, "g", j2.CreatedAt)
+	require.NoError(t, err)
+	assert.False(t, claimed, "job claimed while same-key job running")
+
+	// A distinct key runs in parallel.
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "k1", Kind: "sync", PartitioningKey: "h"}))
+	k1 := getJob(t, store, "k1")
+	claimed, err = store.ClaimPartitionedSidekiqJob(ctx, "k1", runner, stale, "h", k1.CreatedAt)
+	require.NoError(t, err)
+	assert.True(t, claimed, "distinct partitioning key should run in parallel")
+
+	// Once the predecessor completes, the next in line claims.
+	require.NoError(t, store.CompleteSidekiqJob(ctx, "j1", runner, "{}"))
+	claimed, err = store.ClaimPartitionedSidekiqJob(ctx, "j2", runner, stale, "g", j2.CreatedAt)
+	require.NoError(t, err)
+	assert.True(t, claimed, "next-in-line should claim after predecessor completes")
+}
+
+// TestClaimPartitionedSidekiqJobSelfNotBlockedByPrecisionSkew: a claim timestamp
+// newer than the persisted created_at (the eager-spawn nanosecond-vs-truncated
+// skew) must not make the sole pending job block itself in the FIFO subquery.
+func TestClaimPartitionedSidekiqJobSelfNotBlockedByPrecisionSkew(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+	const runner = "node-1"
+	stale := time.Now().Add(-30 * time.Second)
+
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "j1", Kind: "sync", PartitioningKey: "g"}))
+	persisted := time.Now().Add(-time.Hour)
+	setCreatedAt(t, store, "j1", persisted)
+
+	// Claim with a timestamp strictly newer than the persisted value, as the
+	// truncation-losing eager spawn would; the only pending job must still claim.
+	claimed, err := store.ClaimPartitionedSidekiqJob(ctx, "j1", runner, stale, "g", persisted.Add(time.Microsecond))
+	require.NoError(t, err)
+	assert.True(t, claimed, "sole pending job must not block itself on a newer claim timestamp")
+}
+
+// TestClaimPartitionedSidekiqJobStaleRunnerDoesNotBlock verifies a dead owner's
+// stale running job does not deadlock its key: a newer job becomes claimable once
+// the running one is past the stale horizon.
+func TestClaimPartitionedSidekiqJobStaleRunnerDoesNotBlock(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+	const runner = "node-1"
+
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "j1", Kind: "sync", PartitioningKey: "g"}))
+	require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "j2", Kind: "sync", PartitioningKey: "g"}))
+	base := time.Now().Add(-time.Hour)
+	setCreatedAt(t, store, "j1", base)
+	setCreatedAt(t, store, "j2", base.Add(time.Minute))
+
+	stale := time.Now().Add(-30 * time.Second)
+	claimed, err := store.ClaimPartitionedSidekiqJob(ctx, "j1", runner, stale, "g", getJob(t, store, "j1").CreatedAt)
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	// Simulate a dead owner: push j1's heartbeat before the stale horizon.
+	setUpdatedAt(t, store, "j1", time.Now().Add(-2*time.Minute))
+
+	claimed, err = store.ClaimPartitionedSidekiqJob(ctx, "j2", runner, stale, "g", getJob(t, store, "j2").CreatedAt)
+	require.NoError(t, err)
+	assert.True(t, claimed, "stale (dead-owner) running job must not block its key")
 }

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -686,6 +686,7 @@ type ConfigStore interface {
 	CreateSidekiqJob(ctx context.Context, job *tables.TableSidekiqJob) error
 	GetSidekiqJob(ctx context.Context, id string) (*tables.TableSidekiqJob, error)
 	ClaimSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time) (bool, error)
+	ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, partitioningKey string, createdAt time.Time) (bool, error)
 	HeartbeatSidekiqJob(ctx context.Context, id, runnerID string) (bool, error)
 	UpdateSidekiqJobProgress(ctx context.Context, id, runnerID, metadata string) error
 	CompleteSidekiqJob(ctx context.Context, id, runnerID, metadata string) error

--- a/framework/configstore/tables/sidekiq.go
+++ b/framework/configstore/tables/sidekiq.go
@@ -19,19 +19,23 @@ const (
 // resume cursor, running counts, errors) in the Metadata JSON blob. The runner only
 // reads Status and UpdatedAt; everything else is opaque to it.
 type TableSidekiqJob struct {
-	ID          string     `gorm:"column:id;primaryKey;type:text" json:"id"`
-	Kind        string     `gorm:"column:kind;not null;type:text;index:idx_sidekiq_status_updated,priority:3;index:idx_sidekiq_kind_status_created,priority:1" json:"kind"`
-	Status      string     `gorm:"column:status;not null;default:pending;type:text;index:idx_sidekiq_status_updated,priority:1;index:idx_sidekiq_kind_status_created,priority:2" json:"status"`
+	ID     string `gorm:"column:id;primaryKey;type:text" json:"id"`
+	Kind   string `gorm:"column:kind;not null;type:text;index:idx_sidekiq_status_updated,priority:3;index:idx_sidekiq_kind_status_created,priority:1" json:"kind"`
+	Status string `gorm:"column:status;not null;default:pending;type:text;index:idx_sidekiq_status_updated,priority:1;index:idx_sidekiq_kind_status_created,priority:2" json:"status"`
 	// RunnerID identifies the runner process that currently owns (claimed) this job.
 	// Empty in OSS (single-node) mode; set to the node ID in enterprise cluster mode.
 	// Progress/complete/fail/heartbeat writes are fenced on this value so a revived
 	// stale node cannot stomp a job another node has re-claimed.
-	RunnerID    string     `gorm:"column:runner_id;type:text;index" json:"runner_id,omitempty"`
-	Metadata    string     `gorm:"column:metadata;type:text;default:'{}'" json:"metadata"`
-	Attempts    int        `gorm:"column:attempts;not null;default:0" json:"attempts"`
-	LastError   string     `gorm:"column:last_error;type:text" json:"last_error,omitempty"`
-	CreatedAt   time.Time  `gorm:"column:created_at;not null;index:idx_sidekiq_kind_status_created,priority:3" json:"created_at"`
-	UpdatedAt   time.Time  `gorm:"column:updated_at;not null;index:idx_sidekiq_status_updated,priority:2" json:"updated_at"`
+	RunnerID string `gorm:"column:runner_id;type:text;index" json:"runner_id,omitempty"`
+	// PartitioningKey groups jobs that must run one-at-a-time in FIFO (created_at)
+	// order across the cluster. Empty (default) = unconstrained; distinct keys
+	// still run in parallel. Enforced by ClaimPartitionedSidekiqJob.
+	PartitioningKey string     `gorm:"column:partitioning_key;type:text;index:idx_sidekiq_partitioning_key" json:"partitioning_key,omitempty"`
+	Metadata        string     `gorm:"column:metadata;type:text;default:'{}'" json:"metadata"`
+	Attempts        int        `gorm:"column:attempts;not null;default:0" json:"attempts"`
+	LastError       string     `gorm:"column:last_error;type:text" json:"last_error,omitempty"`
+	CreatedAt       time.Time  `gorm:"column:created_at;not null;index:idx_sidekiq_kind_status_created,priority:3" json:"created_at"`
+	UpdatedAt       time.Time  `gorm:"column:updated_at;not null;index:idx_sidekiq_status_updated,priority:2" json:"updated_at"`
 	StartedAt       *time.Time `gorm:"column:started_at" json:"started_at,omitempty"`
 	CreatedByUserID *string    `gorm:"column:created_by_user_id;type:varchar(255)" json:"created_by_user_id,omitempty"`
 	CompletedAt     *time.Time `gorm:"column:completed_at" json:"completed_at,omitempty"`

--- a/framework/sidekiq/sidekiq.go
+++ b/framework/sidekiq/sidekiq.go
@@ -17,6 +17,9 @@ type Store interface {
 	GetSidekiqJob(ctx context.Context, id string) (*tables.TableSidekiqJob, error)
 	// ClaimSidekiqJob atomically claims a job for runnerID; returns true only for the winner.
 	ClaimSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time) (bool, error)
+	// ClaimPartitionedSidekiqJob claims a partitioning-keyed job only when it is next in
+	// line for its key (no other same-key job running, no older same-key job pending).
+	ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, partitioningKey string, createdAt time.Time) (bool, error)
 	// HeartbeatSidekiqJob bumps updated_at for a job still owned by runnerID; returns false on lost ownership.
 	HeartbeatSidekiqJob(ctx context.Context, id, runnerID string) (bool, error)
 	UpdateSidekiqJobProgress(ctx context.Context, id, runnerID, metadata string) error
@@ -110,14 +113,24 @@ func (r *Runner) handlerFor(kind string) (HandlerFunc, bool) {
 // Enqueue persists a new pending job and starts it as soon as a concurrency slot is free.
 // Returns once the DB row is committed so the caller can respond immediately.
 func (r *Runner) Enqueue(ctx context.Context, id, kind, metadata, createdBy string) error {
+	return r.EnqueuePartitioned(ctx, id, kind, "", metadata, createdBy)
+}
+
+// EnqueuePartitioned is Enqueue for a job that must run serially within partitioningKey:
+// jobs sharing a non-empty key run one-at-a-time in FIFO (created_at) order across
+// the cluster (see ClaimPartitionedSidekiqJob). An empty key behaves exactly like
+// Enqueue. The eager spawn is safe either way — a not-yet-runnable partitioned job
+// simply fails to claim and is picked up later by the dispatcher.
+func (r *Runner) EnqueuePartitioned(ctx context.Context, id, kind, partitioningKey, metadata, createdBy string) error {
 	if _, ok := r.handlerFor(kind); !ok {
 		return fmt.Errorf("sidekiq: no handler registered for kind %q", kind)
 	}
 	job := &tables.TableSidekiqJob{
-		ID:       id,
-		Kind:     kind,
-		Status:   tables.SidekiqStatusPending,
-		Metadata: metadata,
+		ID:              id,
+		Kind:            kind,
+		Status:          tables.SidekiqStatusPending,
+		Metadata:        metadata,
+		PartitioningKey: partitioningKey,
 	}
 	if createdBy != "" {
 		job.CreatedByUserID = &createdBy
@@ -191,7 +204,15 @@ func (r *Runner) execute(job tables.TableSidekiqJob) {
 		}
 	}()
 
-	claimed, err := r.store.ClaimSidekiqJob(r.baseCtx, job.ID, r.runnerID, r.staleBefore())
+	var claimed bool
+	var err error
+	if job.PartitioningKey != "" {
+		// Partitioned jobs claim only when next in line for their key; a blocked one
+		// stays pending and is retried on a later dispatch tick.
+		claimed, err = r.store.ClaimPartitionedSidekiqJob(r.baseCtx, job.ID, r.runnerID, r.staleBefore(), job.PartitioningKey, job.CreatedAt)
+	} else {
+		claimed, err = r.store.ClaimSidekiqJob(r.baseCtx, job.ID, r.runnerID, r.staleBefore())
+	}
 	if err != nil {
 		r.logger.Error("sidekiq: failed to claim job %s: %v", job.ID, err)
 		return

--- a/framework/sidekiq/sidekiq_test.go
+++ b/framework/sidekiq/sidekiq_test.go
@@ -97,6 +97,13 @@ func (f *fakeStore) ClaimSidekiqJob(_ context.Context, id, runnerID string, stal
 	return true, nil
 }
 
+// ClaimPartitionedSidekiqJob: the fake ignores the partitioning guards (no runner
+// test here exercises them) and behaves like ClaimSidekiqJob. The FIFO/exclusion
+// logic is covered against the real store in configstore/sidekiq_test.go.
+func (f *fakeStore) ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, _ string, _ time.Time) (bool, error) {
+	return f.ClaimSidekiqJob(ctx, id, runnerID, staleBefore)
+}
+
 func (f *fakeStore) HeartbeatSidekiqJob(_ context.Context, id, runnerID string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -462,8 +469,8 @@ func TestConcurrencySemaphoreBound(t *testing.T) {
 	var inFlight sync.WaitGroup
 
 	r.Register("k", func(_ context.Context, _ tables.TableSidekiqJob, _ ProgressFunc) (string, error) {
-		inFlight.Done()   // signal that we entered the handler
-		<-gate            // block until the test releases us
+		inFlight.Done() // signal that we entered the handler
+		<-gate          // block until the test releases us
 		return "", nil
 	})
 
@@ -518,10 +525,10 @@ func TestInflightDedupPreventsDoubleSpawn(t *testing.T) {
 
 	// Release blocker and wait for its slot to free before dispatching again.
 	close(gate)
-	waitTerminal(t, store) // blocker done
+	waitTerminal(t, store)            // blocker done
 	time.Sleep(10 * time.Millisecond) // let deferred semaphore release run
 
-	r.dispatchOnce() // slot is now free — picks up waiter
+	r.dispatchOnce()       // slot is now free — picks up waiter
 	waitTerminal(t, store) // waiter done
 
 	store.mu.Lock()

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -275,6 +275,9 @@ func (s *fakeSidekiqStore) GetInFlightSidekiqJobByKind(ctx context.Context, kind
 func (s *fakeSidekiqStore) ClaimSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time) (bool, error) {
 	return true, nil
 }
+func (s *fakeSidekiqStore) ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, partitioningKey string, createdAt time.Time) (bool, error) {
+	return true, nil
+}
 func (s *fakeSidekiqStore) HeartbeatSidekiqJob(ctx context.Context, id, runnerID string) (bool, error) {
 	return true, nil
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1601,6 +1601,10 @@ func (m *MockConfigStore) ClaimSidekiqJob(ctx context.Context, id, runnerID stri
 	return false, nil
 }
 
+func (m *MockConfigStore) ClaimPartitionedSidekiqJob(ctx context.Context, id, runnerID string, staleBefore time.Time, partitioningKey string, createdAt time.Time) (bool, error) {
+	return false, nil
+}
+
 func (m *MockConfigStore) HeartbeatSidekiqJob(ctx context.Context, id, runnerID string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
### TL;DR

Adds partitioned job execution to Sidekiq, enabling cluster-wide FIFO-ordered, mutually exclusive job processing per partitioning key.

### What changed?

A nullable `partitioning_key` column and its index have been added to the `sidekiq` table via a new migration. Jobs assigned a non-empty partitioning key are governed by two atomically enforced guarantees during claim:

- **G1 (mutual exclusion):** No other job with the same key may be actively running under a live owner.
- **G2 (FIFO ordering):** No older pending job with the same key may exist ahead in the queue.

A new `ClaimPartitionedSidekiqJob` method on the store implements these guards in a single atomic `UPDATE ... WHERE NOT EXISTS` query. A stale (dead-owner) running job is explicitly excluded from the blocking condition, preventing a crashed node from deadlocking its key indefinitely.

`Runner.Enqueue` now delegates to a new `EnqueuePartitioned` method, which accepts an optional `partitioningKey`. An empty key preserves the existing unconstrained behavior. During execution, the runner automatically routes to `ClaimPartitionedSidekiqJob` or `ClaimSidekiqJob` based on whether the job carries a key. A blocked partitioned job simply fails to claim and is retried on the next dispatch tick.

### How to test?

Two new integration tests run against the real store:

- `TestClaimPartitionedSidekiqJobFIFOAndExclusion` — verifies that a newer job cannot jump the queue while an older pending job exists, that a running job blocks its key, that distinct keys run in parallel, and that the next job claims once its predecessor completes.
- `TestClaimPartitionedSidekiqJobStaleRunnerDoesNotBlock` — verifies that a job whose owner has gone stale (heartbeat past the stale horizon) does not prevent the next job in its key from being claimed.

### Why make this change?

Some job kinds require strict serial execution within a logical group (e.g., per-resource or per-tenant operations) without sacrificing parallelism across unrelated groups. The existing `ClaimSidekiqJob` provides only cluster-wide mutual exclusion via optimistic locking with no ordering guarantees. Partitioned claiming adds the missing FIFO-per-key primitive at the database layer, where it can be enforced atomically across all nodes without additional coordination infrastructure.