### PR TITLE
[fix]: MCP code mode - propagate nested tool errors

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: propagate nested Starlark tool errors [@eddiewang](https://github.com/eddiewang)

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -149,6 +149,10 @@ func (s *StarlarkCodeMode) handleExecuteToolCode(ctx *schemas.BifrostContext, to
 			strings.Join(result.Environment.ServerKeys, ", "),
 		)
 		s.logger.Debug("%s Error response formatted. Response length: %d chars", codemcp.CodeModeLogPrefix, len(responseText))
+		// Code-mode execution failures are tool failures, not successful text values. Returning
+		// the formatted diagnostic as an error lets the outer MCP bridge set IsError=true while
+		// preserving the sandbox kind, hints, print output, and server-key context for the agent.
+		return nil, fmt.Errorf("%s", responseText)
 	} else {
 		hasLogs := len(result.Logs) > 0
 		hasResult := result.Result != nil
@@ -540,11 +544,11 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 			return nil, fmt.Errorf("tool call failed for %s.%s: %v", clientName, effectiveToolName, callErr)
 		}
 
-		rawResult := extractTextFromMCPResponse(toolResponse, effectiveToolName)
-		if after, ok := strings.CutPrefix(rawResult, "Error: "); ok {
-			s.logger.Debug("%s Tool returned error result: %s.%s - %s", codemcp.CodeModeLogPrefix, clientName, effectiveToolName, after)
-			appendLog(fmt.Sprintf("[TOOL] %s.%s error result: %s", clientName, effectiveToolName, after))
-			return nil, fmt.Errorf("%s", after)
+		rawResult, resultErr := nestedMCPToolResult(toolResponse, effectiveToolName)
+		if resultErr != nil {
+			s.logger.Debug("%s Tool returned error result: %s.%s - %s", codemcp.CodeModeLogPrefix, clientName, effectiveToolName, resultErr)
+			appendLog(fmt.Sprintf("[TOOL] %s.%s error result: %s", clientName, effectiveToolName, resultErr))
+			return nil, resultErr
 		}
 
 		resultStr := formatResultForLog(rawResult)
@@ -587,4 +591,89 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	}
 
 	return nil, fmt.Errorf("plugin post-hooks returned invalid response")
+}
+
+// nestedMCPToolResult converts a nested MCP result into either successful text or an
+// execution error. IsError is authoritative; the Error: prefix remains as a compatibility
+// fallback for older result producers that do not set IsError.
+func nestedMCPToolResult(toolResponse *mcp.CallToolResult, toolName string) (string, error) {
+	if toolResponse != nil && toolResponse.IsError {
+		errorText := extractContentFromMCPResponse(toolResponse)
+		if errorText == "" {
+			errorText = fmt.Sprintf("MCP tool '%s' returned an error without content", toolName)
+		}
+		return "", fmt.Errorf("%s", collapseRepeatedMCPErrorPrefixes(errorText))
+	}
+
+	rawResult := extractTextFromMCPResponse(toolResponse, toolName)
+	if after, ok := strings.CutPrefix(rawResult, "Error: "); ok {
+		return "", fmt.Errorf("%s", after)
+	}
+	return rawResult, nil
+}
+
+// collapseRepeatedMCPErrorPrefixes reduces a run of identical leading
+// "MCP error <signed integer>:" prefixes to one. Distinct adjacent prefixes are
+// preserved because they may describe separate proxy hops.
+func collapseRepeatedMCPErrorPrefixes(text string) string {
+	prefixStart := 0
+	for prefixStart < len(text) && isMCPErrorPrefixWhitespace(text[prefixStart]) {
+		prefixStart++
+	}
+
+	code, next, ok := parseMCPErrorPrefix(text, prefixStart)
+	if !ok {
+		return text
+	}
+
+	lastIdenticalStart := -1
+	for {
+		nextCode, nextEnd, nextOK := parseMCPErrorPrefix(text, next)
+		if !nextOK || nextCode != code {
+			break
+		}
+		lastIdenticalStart = next
+		next = nextEnd
+	}
+	if lastIdenticalStart < 0 {
+		return text
+	}
+
+	return text[:prefixStart] + text[lastIdenticalStart:]
+}
+
+func parseMCPErrorPrefix(text string, start int) (code string, end int, ok bool) {
+	const marker = "MCP error "
+	if start < 0 || start > len(text) || !strings.HasPrefix(text[start:], marker) {
+		return "", start, false
+	}
+
+	codeStart := start + len(marker)
+	cursor := codeStart
+	if cursor < len(text) && (text[cursor] == '+' || text[cursor] == '-') {
+		cursor++
+	}
+	digitStart := cursor
+	for cursor < len(text) && text[cursor] >= '0' && text[cursor] <= '9' {
+		cursor++
+	}
+	if cursor == digitStart || cursor >= len(text) || text[cursor] != ':' {
+		return "", start, false
+	}
+
+	code = text[codeStart:cursor]
+	cursor++
+	for cursor < len(text) && isMCPErrorPrefixWhitespace(text[cursor]) {
+		cursor++
+	}
+	return code, cursor, true
+}
+
+func isMCPErrorPrefixWhitespace(char byte) bool {
+	switch char {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
 }

--- a/core/mcp/codemode/starlark/starlark_test.go
+++ b/core/mcp/codemode/starlark/starlark_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	codemcp "github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 	"go.starlark.net/starlark"
@@ -19,6 +21,7 @@ import (
 type testClientManager struct {
 	clients map[string]*schemas.MCPClientState
 	tools   map[string][]schemas.ChatTool
+	conn    *client.Client
 }
 
 func (m *testClientManager) GetClientForTool(toolName string) *schemas.MCPClientState {
@@ -46,7 +49,7 @@ func (m *testClientManager) GetPluginPipeline() codemcp.PluginPipeline {
 
 func (m *testClientManager) ReleasePluginPipeline(pipeline codemcp.PluginPipeline) {}
 func (m *testClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
-	return nil, func() {}, nil
+	return m.conn, func() {}, nil
 }
 func (m *testClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op codemcp.MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
 	resp, err := op(req)
@@ -54,6 +57,130 @@ func (m *testClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, r
 		return nil, &schemas.BifrostError{IsBifrostError: false, Error: &schemas.ErrorField{Message: err.Error()}}
 	}
 	return resp, nil
+}
+
+func TestNestedMCPToolResult(t *testing.T) {
+	t.Run("IsError text fails", func(t *testing.T) {
+		result := mcp.NewToolResultError("MCP error -32603: upstream failed")
+		value, err := nestedMCPToolResult(result, "fail")
+		if err == nil || err.Error() != "MCP error -32603: upstream failed" {
+			t.Fatalf("expected upstream error, got value=%v err=%v", value, err)
+		}
+	})
+
+	t.Run("identical prefixes collapse", func(t *testing.T) {
+		result := mcp.NewToolResultError("MCP error -32603:  MCP error -32603:\tupstream failed")
+		_, err := nestedMCPToolResult(result, "fail")
+		if err == nil || err.Error() != "MCP error -32603:\tupstream failed" {
+			t.Fatalf("unexpected normalized error: %v", err)
+		}
+	})
+
+	t.Run("distinct prefixes remain", func(t *testing.T) {
+		text := "MCP error -32603: MCP error +7: upstream failed"
+		result := mcp.NewToolResultError(text)
+		_, err := nestedMCPToolResult(result, "fail")
+		if err == nil || err.Error() != text {
+			t.Fatalf("distinct prefixes were rewritten: %v", err)
+		}
+	})
+
+	t.Run("empty error uses fallback without metadata", func(t *testing.T) {
+		result := &mcp.CallToolResult{
+			IsError:           true,
+			StructuredContent: map[string]interface{}{"secret": "do not expose"},
+		}
+		_, err := nestedMCPToolResult(result, "fail")
+		if err == nil || err.Error() != "MCP tool 'fail' returned an error without content" {
+			t.Fatalf("unexpected empty-result error: %v", err)
+		}
+		if strings.Contains(err.Error(), "do not expose") {
+			t.Fatalf("structured metadata leaked into error: %v", err)
+		}
+	})
+
+	t.Run("non-error remains successful", func(t *testing.T) {
+		value, err := nestedMCPToolResult(mcp.NewToolResultText("ok"), "succeed")
+		if err != nil || value != "ok" {
+			t.Fatalf("expected successful result, got value=%v err=%v", value, err)
+		}
+	})
+
+	t.Run("legacy Error prefix fails", func(t *testing.T) {
+		result := mcp.NewToolResultText("Error: legacy failure")
+		value, err := nestedMCPToolResult(result, "legacy")
+		if err == nil || err.Error() != "legacy failure" {
+			t.Fatalf("expected legacy error, got value=%v err=%v", value, err)
+		}
+	})
+}
+
+func TestHandleExecuteToolCodeReportsNestedMCPIsError(t *testing.T) {
+	mcpServer := server.NewMCPServer("nested-error-test", "1.0.0", server.WithToolCapabilities(true))
+	mcpServer.AddTool(mcp.NewTool("fail"), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultError("nested execution failed"), nil
+	})
+
+	conn, err := client.NewInProcessClient(mcpServer)
+	if err != nil {
+		t.Fatalf("create in-process client: %v", err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Initialize(context.Background(), mcp.InitializeRequest{Params: mcp.InitializeParams{
+		ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+		Capabilities:    mcp.ClientCapabilities{},
+		ClientInfo:      mcp.Implementation{Name: "starlark-test", Version: "1.0.0"},
+	}})
+	if err != nil {
+		t.Fatalf("initialize in-process client: %v", err)
+	}
+
+	const clientName = "testServer"
+	mode := NewStarlarkCodeMode(&codemcp.CodeModeConfig{
+		BindingLevel:         schemas.CodeModeBindingLevelTool,
+		ToolExecutionTimeout: time.Second,
+	}, nil)
+	mode.clientManager = &testClientManager{
+		conn: conn,
+		clients: map[string]*schemas.MCPClientState{
+			clientName: {
+				Name: clientName,
+				ExecutionConfig: &schemas.MCPClientConfig{
+					Name:             clientName,
+					IsCodeModeClient: true,
+				},
+			},
+		},
+		tools: map[string][]schemas.ChatTool{
+			clientName: {{Function: &schemas.ChatToolFunction{Name: clientName + "-fail"}}},
+		},
+	}
+
+	msg, err := mode.handleExecuteToolCode(
+		schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+		schemas.ChatAssistantMessageToolCall{
+			ID: schemas.Ptr("call-1"),
+			Function: schemas.ChatAssistantMessageToolCallFunction{
+				Name:      schemas.Ptr(codemcp.ToolTypeExecuteToolCode),
+				Arguments: `{"code":"result = testServer.fail()"}`,
+			},
+		},
+	)
+	if err == nil {
+		t.Fatalf("expected code-mode execution error, got message: %#v", msg)
+	}
+	if msg != nil {
+		t.Fatalf("failed code-mode execution returned a success message: %#v", msg)
+	}
+
+	content := err.Error()
+	if !strings.Contains(content, "Execution runtime error") || !strings.Contains(content, "nested execution failed") {
+		t.Fatalf("expected nested failure in outer error, got:\n%s", content)
+	}
+	if strings.Contains(content, "Execution completed successfully") {
+		t.Fatalf("nested failure was reported as success:\n%s", content)
+	}
 }
 
 func TestStarlarkToGo(t *testing.T) {

--- a/core/mcp/codemode/starlark/utils.go
+++ b/core/mcp/codemode/starlark/utils.go
@@ -261,8 +261,17 @@ func generatePythonErrorHints(errorMessage string, serverKeys []string) []string
 
 // extractTextFromMCPResponse extracts text content from an MCP tool response.
 func extractTextFromMCPResponse(toolResponse *mcp.CallToolResult, toolName string) string {
+	if content := extractContentFromMCPResponse(toolResponse); content != "" {
+		return content
+	}
+	return fmt.Sprintf("MCP tool '%s' executed successfully", toolName)
+}
+
+// extractContentFromMCPResponse flattens only the response content blocks. It deliberately
+// excludes top-level structured content and metadata, which should not be exposed in errors.
+func extractContentFromMCPResponse(toolResponse *mcp.CallToolResult) string {
 	if toolResponse == nil {
-		return fmt.Sprintf("MCP tool '%s' executed successfully", toolName)
+		return ""
 	}
 
 	var result strings.Builder
@@ -293,10 +302,7 @@ func extractTextFromMCPResponse(toolResponse *mcp.CallToolResult, toolName strin
 		}
 	}
 
-	if result.Len() > 0 {
-		return strings.TrimSpace(result.String())
-	}
-	return fmt.Sprintf("MCP tool '%s' executed successfully", toolName)
+	return strings.TrimSpace(result.String())
 }
 
 // createToolResponseMessage creates a tool response message with the execution result.


### PR DESCRIPTION
## Summary

Fixes Starlark code mode so nested MCP tool failures remain failures instead of successful script values. Closes #5571.

## Changes

- Treat `CallToolResult.IsError` as authoritative while retaining the legacy `Error: ` text-prefix fallback.
- Collapse only repeated identical leading `MCP error <code>:` prefixes; preserve distinct proxy-hop codes.
- Read error text only from MCP content blocks and use a bounded fallback when error content is empty, avoiding structured metadata disclosure.
- Return formatted Starlark execution failures as actual tool errors so outer MCP responses carry `isError`.
- Add focused helper and in-process nested-execution regressions.
- Add the required core changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test -count=1 ./mcp/codemode/starlark
go vet ./mcp/codemode/starlark
```

Both commands complete successfully. The regression covers `IsError`, legacy prefixes, repeated/distinct forwarded prefixes, empty error content, successful results, and the complete nested in-process Starlark path.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5571.

## Security considerations

The empty-error fallback intentionally excludes top-level structured content and metadata, preventing those fields from becoming an error-text disclosure channel.

## Checklist

- [x] I read the contribution guidelines and followed them
- [x] I added/updated tests where appropriate
- [x] I updated the core changelog
- [ ] I verified the complete repository build and UI
- [x] I verified the focused Go tests and vet checks
