### PR TITLE
feat: add `customer_id`/`customer_ids` attachment and `UpdateTeamResponse` schema to `updateTeam`

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -38269,7 +38269,7 @@
       "put": {
         "operationId": "updateTeam",
         "summary": "Update team",
-        "description": "Updates a team. Note that renaming teams is not allowed.",
+        "description": "Updates a team. Note that renaming teams is not allowed.\nAccepts customer_id / customer_ids to attach customers to the team via the team <-> customer many-to-many association, the same association exposed by POST /api/teams/{id}/customers. Attachment is additive and does not detach existing customers.",
         "tags": [
           "Teams"
         ],
@@ -38291,9 +38291,20 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "description": {
+                  "name": {
                     "type": "string",
-                    "description": "Updated team description"
+                    "description": "Team name. Renaming is not allowed - sending a value different from the team's current name returns 400."
+                  },
+                  "customer_id": {
+                    "type": "string",
+                    "description": "Customer to attach to this team. Additive: the customer is attached and any customers already attached are left in place. Re-sending an already-attached customer is a no-op. To detach, use DELETE /api/teams/{id}/customers/{customerId}.\nThis is the team <-> customer many-to-many association that drives governance and DAC customer derivation. It is distinct from the customer_id on PUT /api/governance/teams/{team_id}, which sets the team's budget-hierarchy parent and is not modified by this endpoint."
+                  },
+                  "customer_ids": {
+                    "type": "array",
+                    "description": "Customers to attach to this team, same semantics as customer_id. May be combined with customer_id; the two sets are merged.",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -38318,6 +38329,17 @@
                     },
                     "name": {
                       "type": "string"
+                    },
+                    "attached_customer_ids": {
+                      "type": "array",
+                      "description": "Customers attached by this request. Omitted when the request carried no customer_id or customer_ids.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "warning": {
+                      "type": "string",
+                      "description": "Present only when the attachment was persisted but refreshing the cached team scope failed. The association is durable; the derived customer scope may lag until the next reload."
                     }
                   }
                 }
@@ -38335,7 +38357,7 @@
             }
           },
           "404": {
-            "description": "Team not found",
+            "description": "Team or customer not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi/paths/management/users.yaml
+++ b/docs/openapi/paths/management/users.yaml
@@ -417,7 +417,13 @@ teams-by-id:
   put:
     operationId: updateTeam
     summary: Update team
-    description: Updates a team. Note that renaming teams is not allowed.
+    description: >-
+      Updates a team. Note that renaming teams is not allowed.
+
+      Accepts customer_id / customer_ids to attach customers to the team via the
+      team <-> customer many-to-many association, the same association exposed by
+      POST /api/teams/{id}/customers. Attachment is additive and does not detach
+      existing customers.
     tags:
       - Teams
     parameters:
@@ -441,7 +447,7 @@ teams-by-id:
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/users.yaml#/CreateTeamResponse'
+              $ref: '../../schemas/management/users.yaml#/UpdateTeamResponse'
       '400':
         description: Bad request (e.g. renaming not allowed)
         content:
@@ -449,7 +455,7 @@ teams-by-id:
             schema:
               $ref: '../../schemas/management/common.yaml#/ErrorResponse'
       '404':
-        description: Team not found
+        description: Team or customer not found
         content:
           application/json:
             schema:

--- a/docs/openapi/schemas/management/users.yaml
+++ b/docs/openapi/schemas/management/users.yaml
@@ -230,9 +230,30 @@ CreateTeamRequest:
 UpdateTeamRequest:
   type: object
   properties:
-    description:
+    name:
       type: string
-      description: Updated team description
+      description: >-
+        Team name. Renaming is not allowed - sending a value different from the
+        team's current name returns 400.
+    customer_id:
+      type: string
+      description: >-
+        Customer to attach to this team. Additive: the customer is attached and
+        any customers already attached are left in place. Re-sending an
+        already-attached customer is a no-op. To detach, use
+        DELETE /api/teams/{id}/customers/{customerId}.
+
+        This is the team <-> customer many-to-many association that drives
+        governance and DAC customer derivation. It is distinct from the
+        customer_id on PUT /api/governance/teams/{team_id}, which sets the
+        team's budget-hierarchy parent and is not modified by this endpoint.
+    customer_ids:
+      type: array
+      description: >-
+        Customers to attach to this team, same semantics as customer_id. May be
+        combined with customer_id; the two sets are merged.
+      items:
+        type: string
 
 CreateTeamResponse:
   type: object
@@ -241,6 +262,27 @@ CreateTeamResponse:
       type: string
     name:
       type: string
+
+UpdateTeamResponse:
+  type: object
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    attached_customer_ids:
+      type: array
+      description: >-
+        Customers attached by this request. Omitted when the request carried no
+        customer_id or customer_ids.
+      items:
+        type: string
+    warning:
+      type: string
+      description: >-
+        Present only when the attachment was persisted but refreshing the cached
+        team scope failed. The association is durable; the derived customer scope
+        may lag until the next reload.
 
 ListTeamsResponse:
   type: object


### PR DESCRIPTION
## Summary

Extends the `PUT /api/teams/{id}` endpoint to support attaching customers to a team directly, exposing the same team ↔ customer many-to-many association previously only available via `POST /api/teams/{id}/customers`. This allows callers to update a team and associate customers in a single request.

## Changes

- Added `customer_id` and `customer_ids` fields to `UpdateTeamRequest`, allowing one or more customers to be attached to a team in a single call. Attachment is additive — existing customer associations are preserved, and re-sending an already-attached customer is a no-op.
- Introduced a dedicated `UpdateTeamResponse` schema (previously reusing `CreateTeamResponse`) that includes an `attached_customer_ids` field listing the customers attached by the request. This field is omitted when no `customer_id` or `customer_ids` was provided.
- Replaced the `description` field in `UpdateTeamRequest` with `name`, clarifying that while the field is accepted, sending a name different from the team's current name returns a 400.
- Updated the 404 response description from "Team not found" to "Team or customer not found" to reflect that a missing customer also triggers this response.
- Updated the endpoint description to clarify the distinction between this association and the `customer_id` on `PUT /api/governance/teams/{team_id}`, which controls the budget-hierarchy parent and is unaffected by this endpoint.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Attach a customer to a team via the updated endpoint and verify the response includes `attached_customer_ids`:

```sh
curl -X PUT /api/teams/{id} \
  -H "Content-Type: application/json" \
  -d '{"customer_id": "<customer_id>"}'
# Expected: 200 with attached_customer_ids in response body

curl -X PUT /api/teams/{id} \
  -H "Content-Type: application/json" \
  -d '{"customer_ids": ["<id1>", "<id2>"]}'
# Expected: 200 with both IDs in attached_customer_ids

curl -X PUT /api/teams/{id} \
  -H "Content-Type: application/json" \
  -d '{"customer_id": "<nonexistent_id>"}'
# Expected: 404 with error response
```

## Breaking changes

- [x] Yes
- [ ] No

The `UpdateTeamRequest` schema previously exposed a `description` field; this has been replaced with `name`. Callers sending `description` will no longer have it recognized. The response schema has also changed from `CreateTeamResponse` to `UpdateTeamResponse`, which adds `attached_customer_ids`.

## Related issues

## Security considerations

The `customer_id` / `customer_ids` fields drive governance and DAC customer derivation. Ensure that authorization checks are enforced on the calling identity before allowing customer associations to be modified via this endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable