### PR TITLE
feat: drive model limit edit sheet from URL query param with fallback fetch for off-page configs

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -38269,7 +38269,7 @@
       "put": {
         "operationId": "updateTeam",
         "summary": "Update team",
-        "description": "Updates a team. Note that renaming teams is not allowed.",
+        "description": "Updates a team. Note that renaming teams is not allowed.\nAccepts customer_id / customer_ids to attach customers to the team via the team <-> customer many-to-many association, the same association exposed by POST /api/teams/{id}/customers. Attachment is additive and does not detach existing customers.",
         "tags": [
           "Teams"
         ],
@@ -38291,9 +38291,20 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "description": {
+                  "name": {
                     "type": "string",
-                    "description": "Updated team description"
+                    "description": "Team name. Renaming is not allowed - sending a value different from the team's current name returns 400."
+                  },
+                  "customer_id": {
+                    "type": "string",
+                    "description": "Customer to attach to this team. Additive: the customer is attached and any customers already attached are left in place. Re-sending an already-attached customer is a no-op. To detach, use DELETE /api/teams/{id}/customers/{customerId}.\nThis is the team <-> customer many-to-many association that drives governance and DAC customer derivation. It is distinct from the customer_id on PUT /api/governance/teams/{team_id}, which sets the team's budget-hierarchy parent and is not modified by this endpoint."
+                  },
+                  "customer_ids": {
+                    "type": "array",
+                    "description": "Customers to attach to this team, same semantics as customer_id. May be combined with customer_id; the two sets are merged.",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }
@@ -38318,6 +38329,17 @@
                     },
                     "name": {
                       "type": "string"
+                    },
+                    "attached_customer_ids": {
+                      "type": "array",
+                      "description": "Customers attached by this request. Omitted when the request carried no customer_id or customer_ids.",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "warning": {
+                      "type": "string",
+                      "description": "Present only when the attachment was persisted but refreshing the cached team scope failed. The association is durable; the derived customer scope may lag until the next reload."
                     }
                   }
                 }
@@ -38335,7 +38357,7 @@
             }
           },
           "404": {
-            "description": "Team not found",
+            "description": "Team or customer not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi/paths/management/users.yaml
+++ b/docs/openapi/paths/management/users.yaml
@@ -417,7 +417,13 @@ teams-by-id:
   put:
     operationId: updateTeam
     summary: Update team
-    description: Updates a team. Note that renaming teams is not allowed.
+    description: >-
+      Updates a team. Note that renaming teams is not allowed.
+
+      Accepts customer_id / customer_ids to attach customers to the team via the
+      team <-> customer many-to-many association, the same association exposed by
+      POST /api/teams/{id}/customers. Attachment is additive and does not detach
+      existing customers.
     tags:
       - Teams
     parameters:
@@ -441,7 +447,7 @@ teams-by-id:
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/users.yaml#/CreateTeamResponse'
+              $ref: '../../schemas/management/users.yaml#/UpdateTeamResponse'
       '400':
         description: Bad request (e.g. renaming not allowed)
         content:
@@ -449,7 +455,7 @@ teams-by-id:
             schema:
               $ref: '../../schemas/management/common.yaml#/ErrorResponse'
       '404':
-        description: Team not found
+        description: Team or customer not found
         content:
           application/json:
             schema:

--- a/docs/openapi/schemas/management/users.yaml
+++ b/docs/openapi/schemas/management/users.yaml
@@ -230,9 +230,30 @@ CreateTeamRequest:
 UpdateTeamRequest:
   type: object
   properties:
-    description:
+    name:
       type: string
-      description: Updated team description
+      description: >-
+        Team name. Renaming is not allowed - sending a value different from the
+        team's current name returns 400.
+    customer_id:
+      type: string
+      description: >-
+        Customer to attach to this team. Additive: the customer is attached and
+        any customers already attached are left in place. Re-sending an
+        already-attached customer is a no-op. To detach, use
+        DELETE /api/teams/{id}/customers/{customerId}.
+
+        This is the team <-> customer many-to-many association that drives
+        governance and DAC customer derivation. It is distinct from the
+        customer_id on PUT /api/governance/teams/{team_id}, which sets the
+        team's budget-hierarchy parent and is not modified by this endpoint.
+    customer_ids:
+      type: array
+      description: >-
+        Customers to attach to this team, same semantics as customer_id. May be
+        combined with customer_id; the two sets are merged.
+      items:
+        type: string
 
 CreateTeamResponse:
   type: object
@@ -241,6 +262,27 @@ CreateTeamResponse:
       type: string
     name:
       type: string
+
+UpdateTeamResponse:
+  type: object
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    attached_customer_ids:
+      type: array
+      description: >-
+        Customers attached by this request. Omitted when the request carried no
+        customer_id or customer_ids.
+      items:
+        type: string
+    warning:
+      type: string
+      description: >-
+        Present only when the attachment was persisted but refreshing the cached
+        team scope failed. The association is durable; the derived customer scope
+        may lag until the next reload.
 
 ListTeamsResponse:
   type: object

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -20,7 +20,7 @@ import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
-import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
+import { getErrorMessage, useDeleteModelConfigMutation, useGetModelConfigQuery } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
@@ -28,7 +28,8 @@ import { formatCurrency } from "@/lib/utils/governance";
 import { getScopeLabel } from "@/lib/utils/labels";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { ArrowUpRight, ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useQueryState } from "nuqs";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 import { ModelLimitsEmptyState } from "./modelLimitsEmptyState";
@@ -144,15 +145,41 @@ export default function ModelLimitsTable({
 	isLoading = false,
 }: ModelLimitsTableProps) {
 	const navigate = useNavigate();
-	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
-	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
+	// The edit sheet is driven entirely by the URL: /workspace/model-limits?edit=<model-config-id>.
+	// Clicking Edit writes the param, closing it clears the param — so the open
+	// sheet is always shareable/refreshable, and back/forward behave sanely.
+	const [editParam, setEditParam] = useQueryState("edit");
+	const [isCreatingModelLimit, setIsCreatingModelLimit] = useState(false);
 	const [deleteModelConfigId, setDeleteModelConfigId] = useState<string | null>(null);
 
-	// Derive editingModelConfig from props so it stays in sync with RTK cache updates
-	const editingModelConfig = useMemo(
+	const editingModelConfigId = editParam?.trim() || null;
+
+	// Prefer the row from props so it stays in sync with RTK cache updates
+	const editingModelConfigInList = useMemo(
 		() => (editingModelConfigId ? (modelConfigs.find((mc) => mc.id === editingModelConfigId) ?? null) : null),
 		[editingModelConfigId, modelConfigs],
 	);
+
+	// The linked config may not be on the current page/filter, so fetch it by id as a fallback.
+	const needsEditFetch = !!editingModelConfigId && !editingModelConfigInList;
+	const {
+		data: fetchedModelConfigData,
+		error: fetchedModelConfigError,
+		isLoading: isFetchingEditingModelConfig,
+	} = useGetModelConfigQuery(editingModelConfigId ?? "", { skip: !needsEditFetch });
+	const editingModelConfig = editingModelConfigInList ?? (needsEditFetch ? (fetchedModelConfigData?.model_config ?? null) : null);
+
+	// Param pointed at a model limit that no longer exists (or isn't readable).
+	useEffect(() => {
+		if (!fetchedModelConfigError) return;
+		toast.error(`Failed to load model limit: ${getErrorMessage(fetchedModelConfigError)}`);
+		void setEditParam(null);
+	}, [fetchedModelConfigError, setEditParam]);
+
+	// Don't flash the sheet in "create" mode while a linked config is loading.
+	const isResolvingEditParam = needsEditFetch && (isFetchingEditingModelConfig || (!editingModelConfig && !fetchedModelConfigError));
+	const isSheetOpen = (isCreatingModelLimit || !!editingModelConfigId) && !isResolvingEditParam;
+
 	const deletingModelConfig = useMemo(
 		() => (deleteModelConfigId ? (modelConfigs.find((mc) => mc.id === deleteModelConfigId) ?? null) : null),
 		[deleteModelConfigId, modelConfigs],
@@ -175,18 +202,18 @@ export default function ModelLimitsTable({
 	};
 
 	const handleAddModelLimit = () => {
-		setEditingModelConfigId(null);
-		setShowModelLimitSheet(true);
+		void setEditParam(null);
+		setIsCreatingModelLimit(true);
 	};
 
 	const handleEditModelLimit = (config: ModelConfig) => {
-		setEditingModelConfigId(config.id);
-		setShowModelLimitSheet(true);
+		setIsCreatingModelLimit(false);
+		void setEditParam(config.id);
 	};
 
-	const handleModelLimitSaved = () => {
-		setShowModelLimitSheet(false);
-		setEditingModelConfigId(null);
+	const closeModelLimitSheet = () => {
+		setIsCreatingModelLimit(false);
+		void setEditParam(null);
 	};
 
 	const hasActiveFilters = debouncedSearch || scope || provider;
@@ -197,9 +224,7 @@ export default function ModelLimitsTable({
 	if (totalCount === 0 && !hasActiveFilters && !isLoading) {
 		return (
 			<>
-				{showModelLimitSheet && (
-					<ModelLimitSheet modelConfig={editingModelConfig} onSave={handleModelLimitSaved} onCancel={() => setShowModelLimitSheet(false)} />
-				)}
+				{isSheetOpen && <ModelLimitSheet modelConfig={editingModelConfig} onSave={closeModelLimitSheet} onCancel={closeModelLimitSheet} />}
 				<ModelLimitsEmptyState onAddClick={handleAddModelLimit} canCreate={hasCreateAccess} />
 			</>
 		);
@@ -207,9 +232,7 @@ export default function ModelLimitsTable({
 
 	return (
 		<>
-			{showModelLimitSheet && (
-				<ModelLimitSheet modelConfig={editingModelConfig} onSave={handleModelLimitSaved} onCancel={() => setShowModelLimitSheet(false)} />
-			)}
+			{isSheetOpen && <ModelLimitSheet modelConfig={editingModelConfig} onSave={closeModelLimitSheet} onCancel={closeModelLimitSheet} />}
 			<AlertDialog open={!!deletingModelConfig} onOpenChange={(open) => !open && setDeleteModelConfigId(null)}>
 				<AlertDialogContent>
 					<AlertDialogHeader>


### PR DESCRIPTION
## Summary

The model limit edit sheet is now driven by the URL via a `?edit=<model-config-id>` query parameter instead of local React state. This makes the edit sheet shareable and refreshable — navigating directly to a URL with the `edit` param will open the correct sheet, and browser back/forward behave correctly.

## Changes

- Replaced `showModelLimitSheet` and `editingModelConfigId` local state with a `useQueryState("edit")` param from `nuqs`, so the open sheet is reflected in the URL.
- Added a fallback fetch via `useGetModelConfigQuery` for cases where the linked model config is not present in the current page or filter results (e.g., when navigating directly to a deep-linked URL).
- Added an error handler that clears the `edit` param and shows a toast if the linked model config cannot be loaded (deleted or inaccessible).
- Prevented a flash of the sheet in "create" mode while a deep-linked config is still being resolved.
- Unified `handleModelLimitSaved` and the cancel handler into a single `closeModelLimitSheet` function that clears both the `edit` param and the `isCreatingModelLimit` flag.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to `/workspace/model-limits`.
2. Click **Edit** on any model limit — confirm the URL updates to include `?edit=<id>` and the sheet opens.
3. Close the sheet — confirm the `edit` param is removed from the URL.
4. Directly navigate to `/workspace/model-limits?edit=<id>` — confirm the sheet opens for the correct model limit even if it is not on the current page.
5. Navigate to `/workspace/model-limits?edit=nonexistent-id` — confirm a toast error appears and the param is cleared.
6. Use browser back/forward while the sheet is open — confirm navigation behaves correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Edit sheet state was local; refreshing or sharing the URL would not reopen the sheet.

After: The `?edit=<id>` param persists in the URL, making the sheet deep-linkable and refresh-safe.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth or data access is introduced. The fallback fetch uses the existing `useGetModelConfigQuery` endpoint, which respects the same RBAC controls as the list view.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable