### PR TITLE
fix: follow redirects for download in genai passthrough

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -45,9 +45,20 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 				return nil, err
 			}
 
-			// Convert tool choice to tool config
+			// Convert tool choice if present, but only when function declarations exist.
+			// Gemini rejects functionCallingConfig without function_declarations
+			// (e.g. a tools list holding only non-function types yields no declarations).
 			if bifrostReq.Params.ToolChoice != nil {
-				geminiReq.ToolConfig = convertToolChoiceToToolConfig(bifrostReq.Params.ToolChoice)
+				hasFunctionDeclarations := false
+				for _, tool := range geminiReq.Tools {
+					if len(tool.FunctionDeclarations) > 0 {
+						hasFunctionDeclarations = true
+						break
+					}
+				}
+				if hasFunctionDeclarations {
+					geminiReq.ToolConfig = convertToolChoiceToToolConfig(bifrostReq.Params.ToolChoice)
+				}
 			}
 		}
 
@@ -64,6 +75,10 @@ func ToGeminiChatCompletionRequestWithImageURLSchemes(ctx *schemas.BifrostContex
 				}
 			}
 			geminiReq.Tools = append(geminiReq.Tools, Tool{GoogleSearch: googleSearch})
+		}
+
+		if bifrostReq.Params.IncludeServerSideToolInvocations != nil && *bifrostReq.Params.IncludeServerSideToolInvocations {
+			applyServerSideToolInvocations(geminiReq)
 		}
 
 		if bifrostReq.Params.ServiceTier != nil {
@@ -311,6 +326,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 
 	// Set usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
+	applyGeminiSearchQueryChatUsage(bifrostResp.Usage, candidate.GroundingMetadata, response.ModelVersion)
 
 	if response.UsageMetadata != nil {
 		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
@@ -546,6 +562,7 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 	// Add usage information if this is the last chunk
 	if isLastChunk && response.UsageMetadata != nil {
 		streamResponse.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
+		applyGeminiSearchQueryChatUsage(streamResponse.Usage, candidate.GroundingMetadata, response.ModelVersion)
 		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
 			streamResponse.ServiceTier = t
 		} else if response.UsageMetadata.ServiceTier != "" {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -4086,7 +4086,16 @@ func (provider *GeminiProvider) Passthrough(
 
 	fasthttpReq.SetBody(req.Body)
 
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	var latency time.Duration
+	var bifrostErr *schemas.BifrostError
+	var wait func()
+	// Google redirects file downloads to /download/v1beta, and only Bifrost holds
+	// the API key that the redirect target requires — so follow it here.
+	if req.Method == http.MethodGet && strings.Contains(req.Path, ":download") {
+		latency, bifrostErr, wait = providerUtils.MakeRequestWithContextFollowRedirects(ctx, provider.client, fasthttpReq, resp, 5)
+	} else {
+		latency, bifrostErr, wait = providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	}
 	defer wait()
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -4746,3 +4746,429 @@ func TestGroundingMetadataToChatAnnotations(t *testing.T) {
 		assert.Empty(t, bifrostResp.Choices[0].ChatStreamResponseChoice.Delta.Annotations)
 	})
 }
+
+// TestIncludeServerSideToolInvocations covers Gemini's tool-combination opt-in:
+// without it Gemini rejects function declarations sent alongside Google Search, so
+// the declarations are dropped; with it both go on the wire.
+func TestIncludeServerSideToolInvocations(t *testing.T) {
+	responsesReq := func(include *bool) *schemas.BifrostResponsesRequest {
+		return &schemas.BifrostResponsesRequest{
+			Model: "gemini-3.6-flash",
+			Input: []schemas.ResponsesMessage{
+				{Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser), Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("weather in tokyo?")}},
+			},
+			Params: &schemas.ResponsesParameters{
+				IncludeServerSideToolInvocations: include,
+				Tools: []schemas.ResponsesTool{
+					{Type: schemas.ResponsesToolTypeWebSearch, ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{}},
+					{
+						Type:                  schemas.ResponsesToolTypeFunction,
+						Name:                  schemas.Ptr("get_weather"),
+						ResponsesToolFunction: &schemas.ResponsesToolFunction{Parameters: &schemas.ToolFunctionParameters{Type: "object"}},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("flag absent drops function declarations (unchanged behaviour)", func(t *testing.T) {
+		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(nil))
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
+		assert.NotNil(t, out.Tools[0].GoogleSearch)
+		assert.Empty(t, out.Tools[0].FunctionDeclarations)
+		assert.Nil(t, out.ToolConfig)
+	})
+
+	t.Run("flag false drops function declarations", func(t *testing.T) {
+		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(schemas.Ptr(false)))
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 1)
+		assert.NotNil(t, out.Tools[0].GoogleSearch)
+		assert.Nil(t, out.ToolConfig)
+	})
+
+	t.Run("flag true sends both as separate tool entries", func(t *testing.T) {
+		out, err := gemini.ToGeminiResponsesRequest(nil, responsesReq(schemas.Ptr(true)))
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 2)
+		require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+		assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+		assert.NotNil(t, out.Tools[1].GoogleSearch)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.IncludeServerSideToolInvocations)
+		assert.True(t, *out.ToolConfig.IncludeServerSideToolInvocations)
+	})
+
+	t.Run("flag true promotes auto tool choice to VALIDATED", func(t *testing.T) {
+		req := responsesReq(schemas.Ptr(true))
+		req.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("auto")}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, gemini.FunctionCallingConfigModeValidated, out.ToolConfig.FunctionCallingConfig.Mode)
+	})
+
+	t.Run("flag true leaves an explicit required tool choice alone", func(t *testing.T) {
+		req := responsesReq(schemas.Ptr(true))
+		req.Params.ToolChoice = &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")}
+		out, err := gemini.ToGeminiResponsesRequest(nil, req)
+		require.NoError(t, err)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, gemini.FunctionCallingConfigModeAny, out.ToolConfig.FunctionCallingConfig.Mode)
+	})
+
+	t.Run("chat path sets the flag on toolConfig", func(t *testing.T) {
+		out, err := gemini.ToGeminiChatCompletionRequest(nil, &schemas.BifrostChatRequest{
+			Model: "gemini-3.6-flash",
+			Input: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("weather in tokyo?")}},
+			},
+			Params: &schemas.ChatParameters{
+				IncludeServerSideToolInvocations: schemas.Ptr(true),
+				WebSearchOptions:                 &schemas.ChatWebSearchOptions{},
+				Tools: []schemas.ChatTool{
+					{Type: schemas.ChatToolTypeFunction, Function: &schemas.ChatToolFunction{Name: "get_weather", Parameters: &schemas.ToolFunctionParameters{Type: "object"}}},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Tools, 2)
+		assert.NotEmpty(t, out.Tools[0].FunctionDeclarations)
+		assert.NotNil(t, out.Tools[1].GoogleSearch)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.IncludeServerSideToolInvocations)
+		assert.True(t, *out.ToolConfig.IncludeServerSideToolInvocations)
+	})
+}
+
+// TestIncludeServerSideToolInvocationsGenAIRoundTrip verifies the native genai path
+// (/v1beta/models/*:generateContent) preserves the flag through the Bifrost Responses
+// schema, in both camelCase and snake_case spellings.
+func TestIncludeServerSideToolInvocationsGenAIRoundTrip(t *testing.T) {
+	bodyTemplate := `{
+		"contents": [{"role": "user", "parts": [{"text": "weather in tokyo?"}]}],
+		"tools": [
+			{"functionDeclarations": [{"name": "get_weather", "parametersJsonSchema": {"type": "object"}}]},
+			{"googleSearch": {}}
+		],
+		"toolConfig": {%s}
+	}`
+
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "camelCase", body: fmt.Sprintf(bodyTemplate, `"includeServerSideToolInvocations": true`), want: true},
+		{name: "snake_case", body: fmt.Sprintf(bodyTemplate, `"include_server_side_tool_invocations": true`), want: true},
+		{name: "explicitly false", body: fmt.Sprintf(bodyTemplate, `"includeServerSideToolInvocations": false`), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var req gemini.GeminiGenerationRequest
+			require.NoError(t, sonic.Unmarshal([]byte(tt.body), &req))
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			bifrostReq := req.ToBifrostResponsesRequest(ctx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params.IncludeServerSideToolInvocations)
+			assert.Equal(t, tt.want, *bifrostReq.Params.IncludeServerSideToolInvocations)
+
+			out, err := gemini.ToGeminiResponsesRequest(ctx, bifrostReq)
+			require.NoError(t, err)
+
+			if !tt.want {
+				// Combination not requested: today's behaviour keeps search, drops declarations.
+				require.Len(t, out.Tools, 1)
+				assert.NotNil(t, out.Tools[0].GoogleSearch)
+				return
+			}
+
+			require.Len(t, out.Tools, 2)
+			require.Len(t, out.Tools[0].FunctionDeclarations, 1)
+			assert.Equal(t, "get_weather", out.Tools[0].FunctionDeclarations[0].Name)
+			assert.NotNil(t, out.Tools[1].GoogleSearch)
+			require.NotNil(t, out.ToolConfig)
+			require.NotNil(t, out.ToolConfig.IncludeServerSideToolInvocations)
+			assert.True(t, *out.ToolConfig.IncludeServerSideToolInvocations)
+		})
+	}
+}
+
+// TestGroundingMultiSourceCitationsResponses covers the non-streaming Responses path
+// emitting one url_citation per (support, chunk) pair, matching the chat path, so a
+// segment backed by several sources keeps every source.
+func TestGroundingMultiSourceCitationsResponses(t *testing.T) {
+	response := &gemini.GenerateContentResponse{
+		ResponseID:   "grounding-multi",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*gemini.Candidate{{
+			FinishReason: gemini.FinishReasonStop,
+			Content: &gemini.Content{
+				Role:  "model",
+				Parts: []*gemini.Part{{Text: "Spain won Euro 2024"}},
+			},
+			GroundingMetadata: &gemini.GroundingMetadata{
+				WebSearchQueries: []string{"euro 2024 winner"},
+				GroundingChunks: []*gemini.GroundingChunk{
+					{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/spain", Title: "uefa.com"}},
+					{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/final", Title: "wikipedia.org"}},
+					{RetrievedContext: &gemini.GroundingChunkRetrievedContext{URI: "ctx://ignored"}}, // no Web — skipped
+					{Web: &gemini.GroundingChunkWeb{URI: ""}},                                        // empty URI — skipped
+				},
+				GroundingSupports: []*gemini.GroundingSupport{
+					{
+						Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 19, Text: "Spain won Euro 2024"},
+						GroundingChunkIndices: []int32{0, 1, 2, 3, 99, -1}, // 2/3 unusable, 99 and -1 out of range
+					},
+					{
+						GroundingChunkIndices: []int32{1}, // no segment — skipped
+					},
+				},
+			},
+		}},
+		UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{PromptTokenCount: 5, CandidatesTokenCount: 5, TotalTokenCount: 10},
+	}
+
+	bifrostResp := response.ToResponsesBifrostResponsesResponse()
+	require.NotNil(t, bifrostResp)
+
+	// Citations must land on the assistant text block they annotate — never on a
+	// separate empty message, whose text the segment offsets would not index into.
+	var annotations []schemas.ResponsesOutputMessageContentTextAnnotation
+	for _, msg := range bifrostResp.Output {
+		if msg.Content == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.ResponsesOutputMessageContentText == nil {
+				continue
+			}
+			if len(block.ResponsesOutputMessageContentText.Annotations) > 0 {
+				require.NotNil(t, block.Text)
+				assert.Equal(t, "Spain won Euro 2024", *block.Text,
+					"annotations must be attached to the block holding the annotated text")
+			}
+			annotations = append(annotations, block.ResponsesOutputMessageContentText.Annotations...)
+		}
+	}
+
+	for _, msg := range bifrostResp.Output {
+		if msg.Content == nil || msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeMessage {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Type == schemas.ResponsesOutputMessageContentTypeText && block.Text != nil {
+				assert.NotEmpty(t, *block.Text, "no empty phantom text message should be emitted")
+			}
+		}
+	}
+
+	require.Len(t, annotations, 2, "both usable chunks should produce a citation")
+	assert.Equal(t, "https://example.com/spain", *annotations[0].URL)
+	assert.Equal(t, "uefa.com", *annotations[0].Title)
+	assert.Equal(t, "https://example.com/final", *annotations[1].URL)
+	assert.Equal(t, "wikipedia.org", *annotations[1].Title)
+	// Both cite the same segment.
+	assert.Equal(t, 0, *annotations[0].StartIndex)
+	assert.Equal(t, 19, *annotations[1].EndIndex)
+}
+
+// TestGroundingAnnotationsFallbackWithoutText covers the edge case where a grounded
+// candidate produced no text part: the segment offsets index into nothing, so the
+// citations are kept on a standalone message rather than dropped.
+func TestGroundingAnnotationsFallbackWithoutText(t *testing.T) {
+	response := &gemini.GenerateContentResponse{
+		ResponseID:   "grounding-no-text",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*gemini.Candidate{{
+			FinishReason: gemini.FinishReasonStop,
+			Content: &gemini.Content{
+				Role: "model",
+				Parts: []*gemini.Part{{
+					FunctionCall: &gemini.FunctionCall{Name: "get_weather", Args: []byte(`{}`)},
+				}},
+			},
+			GroundingMetadata: &gemini.GroundingMetadata{
+				WebSearchQueries: []string{"euro 2024 winner"},
+				GroundingChunks: []*gemini.GroundingChunk{
+					{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/spain", Title: "uefa.com"}},
+				},
+				GroundingSupports: []*gemini.GroundingSupport{{
+					Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 19, Text: "Spain won Euro 2024"},
+					GroundingChunkIndices: []int32{0},
+				}},
+			},
+		}},
+	}
+
+	bifrostResp := response.ToResponsesBifrostResponsesResponse()
+	require.NotNil(t, bifrostResp)
+
+	var annotations []schemas.ResponsesOutputMessageContentTextAnnotation
+	for _, msg := range bifrostResp.Output {
+		if msg.Content == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if block.ResponsesOutputMessageContentText != nil {
+				annotations = append(annotations, block.ResponsesOutputMessageContentText.Annotations...)
+			}
+		}
+	}
+
+	require.Len(t, annotations, 1, "citations must survive even with no text block to attach to")
+	assert.Equal(t, "https://example.com/spain", *annotations[0].URL)
+}
+
+// TestGoogleSearchBillingUnits pins how Google Search grounding is metered. Google bills
+// Gemini 3+ per search query executed ($14/1K) and Gemini 2.5 and older per grounded
+// prompt ($35/1K), so NumSearchQueries — the multiplier CalculateCost applies against
+// search_context_cost_per_query — must differ by model generation.
+func TestGoogleSearchBillingUnits(t *testing.T) {
+	grounded := func(queries ...string) *gemini.GroundingMetadata {
+		return &gemini.GroundingMetadata{
+			WebSearchQueries: queries,
+			GroundingChunks: []*gemini.GroundingChunk{
+				{Web: &gemini.GroundingChunkWeb{URI: "https://example.com/a", Title: "example.com"}},
+			},
+			GroundingSupports: []*gemini.GroundingSupport{{
+				Segment:               &gemini.Segment{StartIndex: 0, EndIndex: 5, Text: "hello"},
+				GroundingChunkIndices: []int32{0},
+			}},
+		}
+	}
+
+	response := func(model string, metadata *gemini.GroundingMetadata) *gemini.GenerateContentResponse {
+		return &gemini.GenerateContentResponse{
+			ResponseID:   "billing",
+			ModelVersion: model,
+			Candidates: []*gemini.Candidate{{
+				FinishReason:      gemini.FinishReasonStop,
+				GroundingMetadata: metadata,
+				Content: &gemini.Content{
+					Role:  "model",
+					Parts: []*gemini.Part{{Text: "hello"}},
+				},
+			}},
+			UsageMetadata: &gemini.GenerateContentResponseUsageMetadata{
+				PromptTokenCount: 5, CandidatesTokenCount: 5, TotalTokenCount: 10,
+			},
+		}
+	}
+
+	chatQueries := func(r *gemini.GenerateContentResponse) *int {
+		u := r.ToBifrostChatResponse().Usage
+		if u == nil || u.CompletionTokensDetails == nil {
+			return nil
+		}
+		return u.CompletionTokensDetails.NumSearchQueries
+	}
+	responsesQueries := func(r *gemini.GenerateContentResponse) *int {
+		u := r.ToResponsesBifrostResponsesResponse().Usage
+		if u == nil || u.OutputTokensDetails == nil {
+			return nil
+		}
+		return u.OutputTokensDetails.NumSearchQueries
+	}
+
+	t.Run("gemini 3 bills per search query executed", func(t *testing.T) {
+		r := response("gemini-3.6-flash", grounded("euro 2024 winner", "euro 2024 final score"))
+		require.NotNil(t, chatQueries(r))
+		assert.Equal(t, 2, *chatQueries(r))
+		require.NotNil(t, responsesQueries(r))
+		assert.Equal(t, 2, *responsesQueries(r))
+	})
+
+	t.Run("gemini 2.5 bills once per grounded prompt regardless of query count", func(t *testing.T) {
+		r := response("gemini-2.5-flash", grounded("euro 2024 winner", "euro 2024 final score"))
+		require.NotNil(t, chatQueries(r))
+		assert.Equal(t, 1, *chatQueries(r))
+		require.NotNil(t, responsesQueries(r))
+		assert.Equal(t, 1, *responsesQueries(r))
+	})
+
+	t.Run("empty and duplicate queries are not billed twice", func(t *testing.T) {
+		r := response("gemini-3.6-flash", grounded("euro 2024 winner", "", "  ", "euro 2024 winner"))
+		require.NotNil(t, chatQueries(r))
+		assert.Equal(t, 1, *chatQueries(r))
+	})
+
+	t.Run("ungrounded response is not billed for search", func(t *testing.T) {
+		assert.Nil(t, chatQueries(response("gemini-3.6-flash", nil)))
+		assert.Nil(t, responsesQueries(response("gemini-3.6-flash", nil)))
+		// Grounding metadata present but no queries executed (e.g. url_context only).
+		assert.Nil(t, chatQueries(response("gemini-3.6-flash", grounded())))
+	})
+
+	t.Run("chat streaming bills on the finish chunk", func(t *testing.T) {
+		state := gemini.NewGeminiStreamState()
+		chunks := []*gemini.GenerateContentResponse{
+			{
+				ResponseID: "billing", ModelVersion: "gemini-3.6-flash",
+				Candidates: []*gemini.Candidate{{
+					Content: &gemini.Content{Role: "model", Parts: []*gemini.Part{{Text: "hello"}}},
+				}},
+			},
+			response("gemini-3.6-flash", grounded("q1", "q2", "q3")),
+		}
+
+		var billed *int
+		for _, chunk := range chunks {
+			resp, bifrostErr, _ := chunk.ToBifrostChatCompletionStream(state)
+			require.Nil(t, bifrostErr)
+			if resp != nil && resp.Usage != nil && resp.Usage.CompletionTokensDetails != nil &&
+				resp.Usage.CompletionTokensDetails.NumSearchQueries != nil {
+				billed = resp.Usage.CompletionTokensDetails.NumSearchQueries
+			}
+		}
+		require.NotNil(t, billed, "streaming must bill search queries on the finish chunk")
+		assert.Equal(t, 3, *billed)
+	})
+}
+
+// TestChatToolConfigRequiresFunctionDeclarations pins that a Gemini chat request only
+// carries functionCallingConfig when function declarations were actually produced.
+// Gemini rejects the config on its own, and a tools list holding only non-function
+// types yields no declarations. Mirrors the guard on the Responses path.
+func TestChatToolConfigRequiresFunctionDeclarations(t *testing.T) {
+	baseReq := func(tools []schemas.ChatTool) *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Model: "gemini-2.5-flash",
+			Input: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+			},
+			Params: &schemas.ChatParameters{
+				Tools:      tools,
+				ToolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("auto")},
+			},
+		}
+	}
+
+	t.Run("function tool produces tool config", func(t *testing.T) {
+		out, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq([]schemas.ChatTool{
+			{Type: schemas.ChatToolTypeFunction, Function: &schemas.ChatToolFunction{
+				Name:       "get_weather",
+				Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+			}},
+		}))
+		require.NoError(t, err)
+		require.NotEmpty(t, out.Tools)
+		require.NotNil(t, out.ToolConfig)
+		require.NotNil(t, out.ToolConfig.FunctionCallingConfig)
+		assert.Equal(t, gemini.FunctionCallingConfigModeAuto, out.ToolConfig.FunctionCallingConfig.Mode)
+	})
+
+	t.Run("non-function tool yields no orphan tool config", func(t *testing.T) {
+		out, err := gemini.ToGeminiChatCompletionRequest(nil, baseReq([]schemas.ChatTool{
+			{Type: schemas.ChatToolTypeCustom, Custom: &schemas.ChatToolCustom{}},
+		}))
+		require.NoError(t, err)
+		assert.Empty(t, out.Tools, "custom tools produce no Gemini declarations")
+		assert.Nil(t, out.ToolConfig, "functionCallingConfig without function_declarations is rejected by Gemini")
+	})
+}

--- a/core/providers/gemini/passthrough_test.go
+++ b/core/providers/gemini/passthrough_test.go
@@ -1,0 +1,96 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPassthroughFollowsFileDownloadRedirect covers Google's file-download flow:
+// /v1beta/files/{id}:download answers 302 to /download/v1beta, and only Bifrost
+// holds the API key that target requires. Everything else must keep receiving
+// redirects untouched — notably resumable uploads, whose 308 "Resume Incomplete"
+// carries no Location and would break a redirect-following client.
+func TestPassthroughFollowsFileDownloadRedirect(t *testing.T) {
+	const videoBytes = "fake-mp4-bytes"
+
+	var sawAPIKeyOnRedirect string
+	mux := http.NewServeMux()
+	// The versioned surface redirects, exactly as generativelanguage does.
+	mux.HandleFunc("/v1beta/files/abc:download", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/download/v1beta/files/abc:download?alt=media", http.StatusFound)
+	})
+	// The redirect target requires the key.
+	mux.HandleFunc("/download/v1beta/files/abc:download", func(w http.ResponseWriter, r *http.Request) {
+		sawAPIKeyOnRedirect = r.Header.Get("x-goog-api-key")
+		if sawAPIKeyOnRedirect == "" {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":{"code":403,"message":"Method doesn't allow unregistered callers"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "video/mp4")
+		_, _ = w.Write([]byte(videoBytes))
+	})
+	// A resumable upload chunk: 308 with no Location header.
+	mux.HandleFunc("/upload/v1beta/files", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Goog-Upload-Status", "active")
+		w.WriteHeader(http.StatusPermanentRedirect)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	provider := NewGeminiProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL + "/v1beta"},
+	}, testNoopLogger{})
+	key := schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}
+
+	t.Run("download follows the redirect and returns the bytes", func(t *testing.T) {
+		sawAPIKeyOnRedirect = ""
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		resp, bifrostErr := provider.Passthrough(ctx, key, &schemas.BifrostPassthroughRequest{
+			Provider: schemas.Gemini,
+			Method:   http.MethodGet,
+			Path:     "/files/abc:download",
+			RawQuery: "alt=media",
+		})
+
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "client should get the bytes, not the 302")
+		assert.Equal(t, videoBytes, string(resp.Body))
+		assert.Equal(t, "dummy-key", sawAPIKeyOnRedirect, "api key must survive onto the redirect hop")
+	})
+
+	t.Run("resumable upload 308 is forwarded, not followed", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		resp, bifrostErr := provider.Passthrough(ctx, key, &schemas.BifrostPassthroughRequest{
+			Provider: schemas.Gemini,
+			Method:   http.MethodPost,
+			Path:     "/upload/v1beta/files",
+			RawQuery: "upload_id=xyz",
+		})
+
+		require.Nil(t, bifrostErr, "a Location-less 308 must not surface as a redirect error")
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusPermanentRedirect, resp.StatusCode)
+	})
+
+	t.Run("ordinary calls are unaffected", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		resp, bifrostErr := provider.Passthrough(ctx, key, &schemas.BifrostPassthroughRequest{
+			Provider: schemas.Gemini,
+			Method:   http.MethodGet,
+			Path:     "/files/abc",
+		})
+
+		require.Nil(t, bifrostErr)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode, "unregistered path, but no redirect handling either")
+	})
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -54,8 +54,11 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 		params.Tools = convertGeminiToolsToResponsesTools(request.Tools)
 	}
 
-	if request.ToolConfig != nil && request.ToolConfig.FunctionCallingConfig != nil {
-		params.ToolChoice = convertGeminiToolConfigToToolChoice(request.ToolConfig)
+	if request.ToolConfig != nil {
+		if request.ToolConfig.FunctionCallingConfig != nil {
+			params.ToolChoice = convertGeminiToolConfigToToolChoice(request.ToolConfig)
+		}
+		params.IncludeServerSideToolInvocations = request.ToolConfig.IncludeServerSideToolInvocations
 	}
 
 	if request.SafetySettings != nil {
@@ -105,9 +108,10 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 			return nil, err
 		}
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
+		includeServerSideToolInvocations := bifrostReq.Params.IncludeServerSideToolInvocations != nil && *bifrostReq.Params.IncludeServerSideToolInvocations
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
-			geminiReq.Tools, err = convertResponsesToolsToGemini(bifrostReq.Params.Tools)
+			geminiReq.Tools, err = convertResponsesToolsToGemini(bifrostReq.Params.Tools, includeServerSideToolInvocations)
 			if err != nil {
 				return nil, err
 			}
@@ -127,6 +131,10 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 					geminiReq.ToolConfig = convertResponsesToolChoiceToGemini(bifrostReq.Params.ToolChoice)
 				}
 			}
+		}
+
+		if includeServerSideToolInvocations {
+			applyServerSideToolInvocations(geminiReq)
 		}
 
 		if bifrostReq.Params.ServiceTier != nil {
@@ -191,6 +199,9 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 
 	// Convert usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToResponsesUsage(response.UsageMetadata)
+	if len(response.Candidates) > 0 && response.Candidates[0] != nil {
+		applyGeminiSearchQueryResponsesUsage(bifrostResp.Usage, response.Candidates[0].GroundingMetadata, response.ModelVersion)
+	}
 
 	if response.UsageMetadata != nil {
 		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
@@ -1875,6 +1886,9 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 
 	// Emit response.completed with usage
 	bifrostUsage := ConvertGeminiUsageMetadataToResponsesUsage(usage)
+	if state.Model != nil {
+		applyGeminiSearchQueryResponsesUsage(bifrostUsage, groundingMetadata, *state.Model)
+	}
 
 	completedResp := &schemas.BifrostResponsesResponse{
 		ID:        state.MessageID,
@@ -2401,6 +2415,21 @@ func convertGeminiToolConfigToToolChoice(toolConfig *ToolConfig) *schemas.Respon
 	}
 }
 
+// textBlockOf returns the text content block of messages[idx], or nil when idx is
+// out of range or the message carries no text block.
+func textBlockOf(messages []schemas.ResponsesMessage, idx int) *schemas.ResponsesOutputMessageContentText {
+	if idx < 0 || idx >= len(messages) || messages[idx].Content == nil {
+		return nil
+	}
+	for i := range messages[idx].Content.ContentBlocks {
+		block := &messages[idx].Content.ContentBlocks[i]
+		if block.Type == schemas.ResponsesOutputMessageContentTypeText && block.ResponsesOutputMessageContentText != nil {
+			return block.ResponsesOutputMessageContentText
+		}
+	}
+	return nil
+}
+
 // Helper functions for Responses conversion
 // convertGeminiCandidatesToResponsesOutput converts Gemini candidates to Responses output messages
 func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas.ResponsesMessage {
@@ -2410,6 +2439,10 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 		if candidate.Content == nil || len(candidate.Content.Parts) == 0 {
 			continue
 		}
+
+		// Index into messages of this candidate's first text message; grounding
+		// annotations are attached to it once all parts have been converted.
+		textMessageIdx := -1
 
 		for _, part := range candidate.Content.Parts {
 			// Handle different types of parts
@@ -2458,6 +2491,9 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 					msg.Content.ContentBlocks[len(msg.Content.ContentBlocks)-1].Signature = &thoughtSig
 				}
 				messages = append(messages, msg)
+				if textMessageIdx < 0 {
+					textMessageIdx = len(messages) - 1
+				}
 
 			case part.FunctionCall != nil:
 				// Function call message
@@ -2686,49 +2722,55 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 			if len(candidate.GroundingMetadata.GroundingSupports) > 0 {
 				annotations := []schemas.ResponsesOutputMessageContentTextAnnotation{}
 				for _, support := range candidate.GroundingMetadata.GroundingSupports {
-					if support.Segment != nil {
+					if support.Segment == nil {
+						continue
+					}
+					// One annotation per (support, chunk) pair so multi-source segments keep every source.
+					for _, chunkIdx := range support.GroundingChunkIndices {
+						if chunkIdx < 0 || int(chunkIdx) >= len(candidate.GroundingMetadata.GroundingChunks) {
+							continue
+						}
+						chunk := candidate.GroundingMetadata.GroundingChunks[chunkIdx]
+						if chunk.Web == nil || chunk.Web.URI == "" {
+							continue
+						}
 						annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
 							Type:       "url_citation",
 							Text:       schemas.Ptr(support.Segment.Text),
 							StartIndex: schemas.Ptr(int(support.Segment.StartIndex)),
 							EndIndex:   schemas.Ptr(int(support.Segment.EndIndex)),
+							URL:        schemas.Ptr(chunk.Web.URI),
 						}
-
-						// Look up URL from grounding chunks
-						if len(support.GroundingChunkIndices) > 0 {
-							chunkIdx := support.GroundingChunkIndices[0]
-							if chunkIdx >= 0 && int(chunkIdx) < len(candidate.GroundingMetadata.GroundingChunks) {
-								chunk := candidate.GroundingMetadata.GroundingChunks[chunkIdx]
-								if chunk.Web != nil {
-									annotation.URL = schemas.Ptr(chunk.Web.URI)
-									if chunk.Web.Title != "" {
-										annotation.Title = schemas.Ptr(chunk.Web.Title)
-									}
-								}
-							}
+						if chunk.Web.Title != "" {
+							annotation.Title = schemas.Ptr(chunk.Web.Title)
 						}
-
-						if annotation.URL != nil {
-							annotations = append(annotations, annotation)
-						}
+						annotations = append(annotations, annotation)
 					}
 				}
-				annotationsMessage := schemas.ResponsesMessage{
-					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-					Status: schemas.Ptr("completed"),
-					Content: &schemas.ResponsesMessageContent{
-						ContentBlocks: []schemas.ResponsesMessageContentBlock{
-							{
-								Type: schemas.ResponsesOutputMessageContentTypeText,
-								Text: schemas.Ptr(""),
-								ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-									Annotations: annotations,
+				// Attach to the candidate's text block: segment offsets index into that text,
+				// and it is where the streaming path puts them. Only when the candidate
+				// produced no text (offsets would reference nothing) fall back to a
+				// standalone message so the citations are not dropped.
+				if block := textBlockOf(messages, textMessageIdx); block != nil {
+					block.Annotations = append(block.Annotations, annotations...)
+				} else if len(annotations) > 0 {
+					messages = append(messages, schemas.ResponsesMessage{
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Status: schemas.Ptr("completed"),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeText,
+									Text: schemas.Ptr(""),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+										Annotations: annotations,
+									},
 								},
 							},
 						},
-					},
+					})
 				}
-				messages = append(messages, annotationsMessage)
 			}
 
 			// Emit rendered content if present
@@ -2961,9 +3003,12 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 	return config, nil
 }
 
-// convertResponsesToolsToGemini converts Responses tools to Gemini tools
-func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) ([]Tool, error) {
-	geminiTool := Tool{}
+// convertResponsesToolsToGemini converts Responses tools to Gemini tools.
+// includeServerSideToolInvocations opts into Gemini's tool combination mode; without it
+// Gemini rejects function declarations sent alongside Google Search, so they are dropped.
+func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerSideToolInvocations bool) ([]Tool, error) {
+	var functionDeclarations []*FunctionDeclaration
+	var googleSearch *GoogleSearch
 
 	hasWebSearchTool := false
 
@@ -2974,9 +3019,10 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) ([]Tool, error
 		}
 	}
 
+	dropFunctionDeclarations := hasWebSearchTool && !includeServerSideToolInvocations
+
 	for _, tool := range tools {
-		// you cant use function declarations and google search together
-		if tool.Type == schemas.ResponsesToolTypeFunction && !hasWebSearchTool {
+		if tool.Type == schemas.ResponsesToolTypeFunction && !dropFunctionDeclarations {
 			// Extract function information from ResponsesExtendedTool
 			if tool.ResponsesToolFunction != nil {
 				if tool.Name != nil && tool.ResponsesToolFunction != nil {
@@ -2996,30 +3042,38 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) ([]Tool, error
 						}
 						funcDecl.ParametersJSONSchema = json.RawMessage(raw)
 					}
-					geminiTool.FunctionDeclarations = append(geminiTool.FunctionDeclarations, funcDecl)
+					functionDeclarations = append(functionDeclarations, funcDecl)
 				}
 			}
 		}
 		if tool.Type == schemas.ResponsesToolTypeWebSearch {
-			geminiTool.GoogleSearch = &GoogleSearch{}
+			googleSearch = &GoogleSearch{}
 			if tool.ResponsesToolWebSearch != nil && tool.ResponsesToolWebSearch.Filters != nil {
 				if tool.ResponsesToolWebSearch.Filters.TimeRangeFilter != nil {
-					geminiTool.GoogleSearch.TimeRangeFilter = &Interval{
+					googleSearch.TimeRangeFilter = &Interval{
 						StartTime: tool.ResponsesToolWebSearch.Filters.TimeRangeFilter.StartTime,
 						EndTime:   tool.ResponsesToolWebSearch.Filters.TimeRangeFilter.EndTime,
 					}
 				}
 				if len(tool.ResponsesToolWebSearch.Filters.BlockedDomains) > 0 {
-					geminiTool.GoogleSearch.ExcludeDomains = tool.ResponsesToolWebSearch.Filters.BlockedDomains
+					googleSearch.ExcludeDomains = tool.ResponsesToolWebSearch.Filters.BlockedDomains
 				}
 			}
 		}
 	}
 
-	if len(geminiTool.FunctionDeclarations) > 0 || geminiTool.GoogleSearch != nil {
-		return []Tool{geminiTool}, nil
+	// One Tool entry per tool type, matching Google's documented tool-combination shape.
+	var geminiTools []Tool
+	if len(functionDeclarations) > 0 {
+		geminiTools = append(geminiTools, Tool{FunctionDeclarations: functionDeclarations})
 	}
-	return []Tool{}, nil
+	if googleSearch != nil {
+		geminiTools = append(geminiTools, Tool{GoogleSearch: googleSearch})
+	}
+	if len(geminiTools) == 0 {
+		return []Tool{}, nil
+	}
+	return geminiTools, nil
 }
 
 // convertResponsesToolChoiceToGemini converts Responses tool choice to Gemini tool config
@@ -3828,12 +3882,29 @@ func emitWebSearchFromGroundingMetadata(
 			},
 		})
 
-		// output_item.done for rendered content
+		// output_item.done for rendered content. It must repeat the item: output_item.done
+		// carries the completed item, and consumers that rebuild Gemini's searchEntryPoint
+		// read the rendered content off this event.
 		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 			Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
 			SequenceNumber: sequenceNumber + len(responses),
 			OutputIndex:    &renderedIndex,
 			ItemID:         &renderedItemID,
+			Item: &schemas.ResponsesMessage{
+				ID:     &renderedItemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Status: schemas.Ptr("completed"),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeRenderedContent,
+							ResponsesOutputMessageContentRenderedContent: &schemas.ResponsesOutputMessageContentRenderedContent{
+								RenderedContent: metadata.SearchEntryPoint.RenderedContent,
+							},
+						},
+					},
+				},
+			},
 		})
 	}
 
@@ -3861,46 +3932,41 @@ func emitAnnotationsFromGroundingSupports(
 			continue
 		}
 
-		annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
-			Type: "url_citation",
-		}
-
-		// Set text and indices
-		if support.Segment.Text != "" {
-			annotation.Text = &support.Segment.Text
-		}
-		annotation.StartIndex = schemas.Ptr(int(support.Segment.StartIndex))
-		annotation.EndIndex = schemas.Ptr(int(support.Segment.EndIndex))
-
-		// Find URL and title from chunk indices
-		if len(support.GroundingChunkIndices) > 0 {
-			chunkIdx := support.GroundingChunkIndices[0]
-			if int(chunkIdx) < len(metadata.GroundingChunks) {
-				chunk := metadata.GroundingChunks[chunkIdx]
-				if chunk.Web != nil {
-					annotation.URL = &chunk.Web.URI
-					if chunk.Web.Title != "" {
-						annotation.Title = &chunk.Web.Title
-					}
-				}
+		// One annotation per (support, chunk) pair so multi-source segments keep every source.
+		for _, chunkIdx := range support.GroundingChunkIndices {
+			if chunkIdx < 0 || int(chunkIdx) >= len(metadata.GroundingChunks) {
+				continue
 			}
-		}
+			chunk := metadata.GroundingChunks[chunkIdx]
+			if chunk.Web == nil || chunk.Web.URI == "" {
+				continue
+			}
 
-		if annotation.URL == nil {
-			continue
-		}
+			annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
+				Type: "url_citation",
+				URL:  &chunk.Web.URI,
+			}
+			if support.Segment.Text != "" {
+				annotation.Text = &support.Segment.Text
+			}
+			annotation.StartIndex = schemas.Ptr(int(support.Segment.StartIndex))
+			annotation.EndIndex = schemas.Ptr(int(support.Segment.EndIndex))
+			if chunk.Web.Title != "" {
+				annotation.Title = &chunk.Web.Title
+			}
 
-		// Emit annotation.added event
-		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
-			Type:            schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
-			SequenceNumber:  sequenceNumber + len(responses),
-			OutputIndex:     &state.TextOutputIndex,
-			ItemID:          &itemID,
-			ContentIndex:    schemas.Ptr(0),
-			Annotation:      &annotation,
-			AnnotationIndex: &emmitedIndex,
-		})
-		emmitedIndex++
+			// Emit annotation.added event
+			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+				Type:            schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
+				SequenceNumber:  sequenceNumber + len(responses),
+				OutputIndex:     &state.TextOutputIndex,
+				ItemID:          &itemID,
+				ContentIndex:    schemas.Ptr(0),
+				Annotation:      &annotation,
+				AnnotationIndex: schemas.Ptr(emmitedIndex),
+			})
+			emmitedIndex++
+		}
 	}
 
 	return responses

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -251,6 +251,40 @@ type ToolConfig struct {
 	FunctionCallingConfig *FunctionCallingConfig `json:"functionCallingConfig,omitempty"`
 	// Optional. Retrieval config.
 	RetrievalConfig *RetrievalConfig `json:"retrievalConfig,omitempty"`
+	// Optional. Allows built-in server-side tools (e.g. Google Search) to run in the
+	// same turn as function declarations. Gemini 3+ rejects the combination without it.
+	IncludeServerSideToolInvocations *bool `json:"includeServerSideToolInvocations,omitempty"`
+}
+
+// UnmarshalJSON handles both camelCase and snake_case
+func (t *ToolConfig) UnmarshalJSON(data []byte) error {
+	type Alias ToolConfig
+	aux := &struct {
+		*Alias
+		// snake_case alternatives
+		FunctionCallingConfigSnake            *FunctionCallingConfig `json:"function_calling_config,omitempty"`
+		RetrievalConfigSnake                  *RetrievalConfig       `json:"retrieval_config,omitempty"`
+		IncludeServerSideToolInvocationsSnake *bool                  `json:"include_server_side_tool_invocations,omitempty"`
+	}{
+		Alias: (*Alias)(t),
+	}
+
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Use snake_case if camelCase wasn't provided
+	if t.FunctionCallingConfig == nil && aux.FunctionCallingConfigSnake != nil {
+		t.FunctionCallingConfig = aux.FunctionCallingConfigSnake
+	}
+	if t.RetrievalConfig == nil && aux.RetrievalConfigSnake != nil {
+		t.RetrievalConfig = aux.RetrievalConfigSnake
+	}
+	if t.IncludeServerSideToolInvocations == nil && aux.IncludeServerSideToolInvocationsSnake != nil {
+		t.IncludeServerSideToolInvocations = aux.IncludeServerSideToolInvocationsSnake
+	}
+
+	return nil
 }
 
 // FunctionDeclaration defines a function that the model can generate JSON inputs for.

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1798,6 +1798,75 @@ func convertToolChoiceToToolConfig(toolChoice *schemas.ChatToolChoice) *ToolConf
 	return config
 }
 
+// countGeminiSearchQueries returns the number of billable Google Search units for a
+// grounded response, or nil when the response was not grounded. Gemini 3+ is billed per
+// search query the model executed; Gemini 2.5 and older are billed per grounded prompt
+// however many queries ran. Empty queries are not billable and duplicates count once.
+func countGeminiSearchQueries(metadata *GroundingMetadata, model string) *int {
+	if metadata == nil {
+		return nil
+	}
+	unique := make(map[string]struct{}, len(metadata.WebSearchQueries))
+	for _, query := range metadata.WebSearchQueries {
+		if trimmed := strings.TrimSpace(query); trimmed != "" {
+			unique[trimmed] = struct{}{}
+		}
+	}
+	if len(unique) == 0 {
+		return nil
+	}
+	if !isGemini3Plus(model) {
+		return new(1)
+	}
+	return new(len(unique))
+}
+
+// applyGeminiSearchQueryChatUsage records billable Google Search units on chat usage so
+// CalculateCost can charge the per-query search fee.
+func applyGeminiSearchQueryChatUsage(usage *schemas.BifrostLLMUsage, metadata *GroundingMetadata, model string) {
+	count := countGeminiSearchQueries(metadata, model)
+	if usage == nil || count == nil {
+		return
+	}
+	if usage.CompletionTokensDetails == nil {
+		usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+	}
+	usage.CompletionTokensDetails.NumSearchQueries = count
+}
+
+// applyGeminiSearchQueryResponsesUsage is the Responses-shaped counterpart of
+// applyGeminiSearchQueryChatUsage.
+func applyGeminiSearchQueryResponsesUsage(usage *schemas.ResponsesResponseUsage, metadata *GroundingMetadata, model string) {
+	count := countGeminiSearchQueries(metadata, model)
+	if usage == nil || count == nil {
+		return
+	}
+	if usage.OutputTokensDetails == nil {
+		usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{}
+	}
+	usage.OutputTokensDetails.NumSearchQueries = count
+}
+
+// applyServerSideToolInvocations opts the request into Gemini's tool combination mode,
+// which is what lets built-in tools (Google Search) run in the same turn as function
+// declarations. Gemini rejects AUTO in this mode, so an existing AUTO (or unset, which
+// the server treats as AUTO) is promoted to VALIDATED. A functionCallingConfig is never
+// synthesized here — Gemini rejects one without function declarations.
+func applyServerSideToolInvocations(req *GeminiGenerationRequest) {
+	if req == nil {
+		return
+	}
+	if req.ToolConfig == nil {
+		req.ToolConfig = &ToolConfig{}
+	}
+	req.ToolConfig.IncludeServerSideToolInvocations = schemas.Ptr(true)
+	if fc := req.ToolConfig.FunctionCallingConfig; fc != nil {
+		if fc.Mode == FunctionCallingConfigModeAuto || fc.Mode == "" {
+			fc.Mode = FunctionCallingConfigModeValidated
+		}
+	}
+}
+
 // addSpeechConfigToGenerationConfig adds speech configuration to the generation config
 func addSpeechConfigToGenerationConfig(config *GenerationConfig, voiceConfig *schemas.SpeechVoiceInput) {
 	speechConfig := SpeechConfig{}

--- a/core/providers/gemini/websearchstreamstate_test.go
+++ b/core/providers/gemini/websearchstreamstate_test.go
@@ -135,3 +135,122 @@ func TestGeminiResponsesStreamWebSearchEmittedAfterStateRecycle(t *testing.T) {
 	require.Len(t, action.Sources, 1)
 	assert.Equal(t, "https://vertexaisearch.cloud.google.com/grounding-api-redirect/example", action.Sources[0].URL)
 }
+
+// multiSourceGroundedStreamChunks mirrors groundedStreamChunks but cites one segment
+// from two different sources, plus entries that must be skipped.
+func multiSourceGroundedStreamChunks() []*GenerateContentResponse {
+	return []*GenerateContentResponse{
+		{
+			ResponseID:   "resp-multi",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				Content: &Content{
+					Role:  "model",
+					Parts: []*Part{{Text: "Spain won Euro 2024"}},
+				},
+			}},
+		},
+		{
+			ResponseID:   "resp-multi",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				FinishReason: FinishReasonStop,
+				GroundingMetadata: &GroundingMetadata{
+					WebSearchQueries: []string{"euro 2024 winner"},
+					GroundingChunks: []*GroundingChunk{
+						{Web: &GroundingChunkWeb{URI: "https://example.com/spain", Title: "uefa.com"}},
+						{Web: &GroundingChunkWeb{URI: "https://example.com/final", Title: "wikipedia.org"}},
+						{RetrievedContext: &GroundingChunkRetrievedContext{URI: "ctx://ignored"}}, // no Web — skipped
+						{Web: &GroundingChunkWeb{URI: ""}},                                        // empty URI — skipped
+					},
+					GroundingSupports: []*GroundingSupport{{
+						Segment:               &Segment{StartIndex: 0, EndIndex: 19, Text: "Spain won Euro 2024"},
+						GroundingChunkIndices: []int32{0, 1, 2, 3, 99, -1}, // 2/3 unusable, 99 and -1 out of range
+					}},
+				},
+			}},
+			UsageMetadata: &GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     5,
+				CandidatesTokenCount: 5,
+				TotalTokenCount:      10,
+			},
+		},
+	}
+}
+
+// TestGeminiResponsesStreamMultiSourceAnnotations asserts the streaming Responses path
+// emits one annotation per (support, chunk) pair, with a distinct AnnotationIndex per
+// event rather than a shared pointer into the loop counter.
+func TestGeminiResponsesStreamMultiSourceAnnotations(t *testing.T) {
+	state := &GeminiResponsesStreamState{}
+	state.flush()
+
+	var annotations []*schemas.BifrostResponsesStreamResponse
+	seq := 0
+	for _, chunk := range multiSourceGroundedStreamChunks() {
+		responses, bifrostErr := chunk.ToBifrostResponsesStream(seq, state)
+		require.Nil(t, bifrostErr, "unexpected conversion error")
+		seq += len(responses)
+		for _, r := range responses {
+			if r.Type == schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded {
+				annotations = append(annotations, r)
+			}
+		}
+	}
+
+	require.Len(t, annotations, 2, "both usable chunks should emit an annotation event")
+	assert.Equal(t, "https://example.com/spain", *annotations[0].Annotation.URL)
+	assert.Equal(t, "uefa.com", *annotations[0].Annotation.Title)
+	assert.Equal(t, "https://example.com/final", *annotations[1].Annotation.URL)
+	assert.Equal(t, "wikipedia.org", *annotations[1].Annotation.Title)
+
+	// Each event must carry its own index; a shared pointer would read 2 for both.
+	require.NotNil(t, annotations[0].AnnotationIndex)
+	require.NotNil(t, annotations[1].AnnotationIndex)
+	assert.Equal(t, 0, *annotations[0].AnnotationIndex)
+	assert.Equal(t, 1, *annotations[1].AnnotationIndex)
+}
+
+// TestGeminiGroundedStreamRoundTripKeepsSearchEntryPoint drives the genai passthrough
+// loop — Gemini stream -> Bifrost Responses stream -> Gemini stream — and asserts the
+// searchEntryPoint survives. It is rebuilt from the rendered-content output_item.done
+// event, so that event must carry its item.
+func TestGeminiGroundedStreamRoundTripKeepsSearchEntryPoint(t *testing.T) {
+	forward := &GeminiResponsesStreamState{}
+	forward.flush()
+	reverse := NewBifrostToGeminiStreamState()
+
+	var grounded []*GroundingMetadata
+	seq := 0
+	for _, chunk := range groundedStreamChunks() {
+		events, bifrostErr := chunk.ToBifrostResponsesStream(seq, forward)
+		require.Nil(t, bifrostErr, "unexpected forward conversion error")
+		seq += len(events)
+
+		for _, event := range events {
+			out := ToGeminiResponsesStreamResponse(event, reverse)
+			if out == nil {
+				continue
+			}
+			for _, candidate := range out.Candidates {
+				if candidate.GroundingMetadata != nil {
+					grounded = append(grounded, candidate.GroundingMetadata)
+				}
+			}
+		}
+	}
+
+	require.Len(t, grounded, 1, "grounding metadata must be rebuilt exactly once")
+	metadata := grounded[0]
+
+	require.NotNil(t, metadata.SearchEntryPoint,
+		"searchEntryPoint must survive the round trip; Google's terms require rendering Search Suggestions")
+	assert.Equal(t, "<div>Google Search Suggestions</div>", metadata.SearchEntryPoint.RenderedContent)
+
+	// The rest of the grounding payload must still round-trip alongside it.
+	assert.Equal(t, []string{"eiffel tower height"}, metadata.WebSearchQueries)
+	require.Len(t, metadata.GroundingChunks, 1)
+	assert.Equal(t, "https://vertexaisearch.cloud.google.com/grounding-api-redirect/example",
+		metadata.GroundingChunks[0].Web.URI)
+	require.Len(t, metadata.GroundingSupports, 1)
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -235,6 +235,11 @@ type ChatParameters struct {
 	TaskBudget        *ChatTaskBudget `json:"task_budget,omitempty"`        // Anthropic output_config.task_budget (task-budgets-2026-03-13 beta)
 	ContextManagement json.RawMessage `json:"context_management,omitempty"` // Anthropic context_management — complex union, passed as raw JSON to the provider layer
 
+	// Opts into running built-in server-side tools (e.g. Google Search) in the same
+	// turn as function declarations. Required by Gemini 3+, which otherwise rejects
+	// the combination; providers without the concept ignore it.
+	IncludeServerSideToolInvocations *bool `json:"include_server_side_tool_invocations,omitempty"`
+
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -522,6 +522,12 @@ type ResponsesParameters struct {
 	Tools                []ResponsesTool               `json:"tools,omitempty"`       // Tools to use
 	Truncation           *string                       `json:"truncation,omitempty"`
 	User                 *string                       `json:"user,omitempty"`
+
+	// Opts into running built-in server-side tools (e.g. Google Search) in the same
+	// turn as function declarations. Required by Gemini 3+, which otherwise rejects
+	// the combination; providers without the concept ignore it.
+	IncludeServerSideToolInvocations *bool `json:"include_server_side_tool_invocations,omitempty"`
+
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -5690,6 +5690,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "description": "When `true`, replays the stored response as SSE events instead of a single JSON object",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -5699,6 +5707,817 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "object",
+                  "description": "Streaming responses API response (SSE format)",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "response.ping",
+                        "response.created",
+                        "response.in_progress",
+                        "response.completed",
+                        "response.failed",
+                        "response.incomplete",
+                        "response.output_item.added",
+                        "response.output_item.done",
+                        "response.content_part.added",
+                        "response.content_part.done",
+                        "response.output_text.delta",
+                        "response.output_text.done",
+                        "response.refusal.delta",
+                        "response.refusal.done",
+                        "response.function_call_arguments.delta",
+                        "response.function_call_arguments.done",
+                        "response.file_search_call.in_progress",
+                        "response.file_search_call.searching",
+                        "response.file_search_call.results.added",
+                        "response.file_search_call.results.completed",
+                        "response.web_search_call.in_progress",
+                        "response.web_search_call.searching",
+                        "response.web_search_call.completed",
+                        "response.web_search_call.results.added",
+                        "response.web_search_call.results.completed",
+                        "response.web_fetch_call.in_progress",
+                        "response.web_fetch_call.fetching",
+                        "response.web_fetch_call.completed",
+                        "response.reasoning_summary_part.added",
+                        "response.reasoning_summary_part.done",
+                        "response.reasoning_summary_text.delta",
+                        "response.reasoning_summary_text.done",
+                        "response.image_generation_call.completed",
+                        "response.image_generation_call.generating",
+                        "response.image_generation_call.in_progress",
+                        "response.image_generation_call.partial_image",
+                        "response.mcp_call_arguments.delta",
+                        "response.mcp_call_arguments.done",
+                        "response.mcp_call.completed",
+                        "response.mcp_call.failed",
+                        "response.mcp_call.in_progress",
+                        "response.mcp_list_tools.completed",
+                        "response.mcp_list_tools.failed",
+                        "response.mcp_list_tools.in_progress",
+                        "response.code_interpreter_call.in_progress",
+                        "response.code_interpreter_call.interpreting",
+                        "response.code_interpreter_call.completed",
+                        "response.code_interpreter_call_code.delta",
+                        "response.code_interpreter_call_code.done",
+                        "response.output_text.annotation.added",
+                        "response.output_text.annotation.done",
+                        "response.queued",
+                        "response.custom_tool_call_input.delta",
+                        "response.custom_tool_call_input.done",
+                        "error"
+                      ]
+                    },
+                    "sequence_number": {
+                      "type": "integer"
+                    },
+                    "response": {
+                      "$ref": "#/components/schemas/ResponsesResponse"
+                    },
+                    "output_index": {
+                      "type": "integer"
+                    },
+                    "item": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "message",
+                            "file_search_call",
+                            "computer_call",
+                            "computer_call_output",
+                            "web_search_call",
+                            "web_fetch_call",
+                            "function_call",
+                            "function_call_output",
+                            "code_interpreter_call",
+                            "local_shell_call",
+                            "local_shell_call_output",
+                            "mcp_call",
+                            "custom_tool_call",
+                            "custom_tool_call_output",
+                            "image_generation_call",
+                            "mcp_list_tools",
+                            "mcp_approval_request",
+                            "mcp_approval_responses",
+                            "reasoning",
+                            "item_reference",
+                            "refusal"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "in_progress",
+                            "completed",
+                            "incomplete",
+                            "interpreting",
+                            "failed"
+                          ]
+                        },
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
+                        },
+                        "content": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "call_id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "arguments": {
+                          "type": "string"
+                        },
+                        "output": {
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "queries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "results": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "summary": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "text"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "summary_text"
+                                ]
+                              },
+                              "text": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "encrypted_content": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content_index": {
+                      "type": "integer"
+                    },
+                    "item_id": {
+                      "type": "string"
+                    },
+                    "part": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "input_text",
+                            "input_image",
+                            "input_file",
+                            "input_audio",
+                            "output_text",
+                            "refusal",
+                            "reasoning_text"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "signature": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "detail": {
+                          "type": "string"
+                        },
+                        "file_data": {
+                          "type": "string"
+                        },
+                        "file_url": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "file_type": {
+                          "type": "string"
+                        },
+                        "input_audio": {
+                          "type": "object",
+                          "required": [
+                            "format",
+                            "data"
+                          ],
+                          "properties": {
+                            "format": {
+                              "type": "string",
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
+                            },
+                            "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "annotations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "file_citation",
+                                  "url_citation",
+                                  "container_file_citation",
+                                  "file_path"
+                                ]
+                              },
+                              "index": {
+                                "type": "integer"
+                              },
+                              "file_id": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "start_index": {
+                                "type": "integer"
+                              },
+                              "end_index": {
+                                "type": "integer"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "container_id": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "logprobs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "bytes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer"
+                                }
+                              },
+                              "logprob": {
+                                "type": "number"
+                              },
+                              "token": {
+                                "type": "string"
+                              },
+                              "top_logprobs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "logprob": {
+                                      "type": "number"
+                                    },
+                                    "token": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "refusal": {
+                          "type": "string"
+                        },
+                        "cache_control": {
+                          "$ref": "#/components/schemas/CacheControl"
+                        }
+                      }
+                    },
+                    "delta": {
+                      "type": "string"
+                    },
+                    "signature": {
+                      "type": "string"
+                    },
+                    "logprobs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bytes": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "logprob": {
+                            "type": "number"
+                          },
+                          "token": {
+                            "type": "string"
+                          },
+                          "top_logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "refusal": {
+                      "type": "string"
+                    },
+                    "arguments": {
+                      "type": "string"
+                    },
+                    "partial_image_b64": {
+                      "type": "string"
+                    },
+                    "partial_image_index": {
+                      "type": "integer"
+                    },
+                    "annotation": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "file_citation",
+                            "url_citation",
+                            "container_file_citation",
+                            "file_path"
+                          ]
+                        },
+                        "index": {
+                          "type": "integer"
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "start_index": {
+                          "type": "integer"
+                        },
+                        "end_index": {
+                          "type": "integer"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "container_id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "annotation_index": {
+                      "type": "integer"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "param": {
+                      "type": "string"
+                    },
+                    "extra_fields": {
+                      "$ref": "#/components/schemas/BifrostResponseExtraFields"
+                    }
+                  }
                 }
               }
             }
@@ -13612,6 +14431,14 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "stream",
+            "in": "query",
+            "description": "When `true`, replays the stored response as SSE events instead of a single JSON object",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -13621,6 +14448,817 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResponsesResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "object",
+                  "description": "Streaming responses API response (SSE format)",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "response.ping",
+                        "response.created",
+                        "response.in_progress",
+                        "response.completed",
+                        "response.failed",
+                        "response.incomplete",
+                        "response.output_item.added",
+                        "response.output_item.done",
+                        "response.content_part.added",
+                        "response.content_part.done",
+                        "response.output_text.delta",
+                        "response.output_text.done",
+                        "response.refusal.delta",
+                        "response.refusal.done",
+                        "response.function_call_arguments.delta",
+                        "response.function_call_arguments.done",
+                        "response.file_search_call.in_progress",
+                        "response.file_search_call.searching",
+                        "response.file_search_call.results.added",
+                        "response.file_search_call.results.completed",
+                        "response.web_search_call.in_progress",
+                        "response.web_search_call.searching",
+                        "response.web_search_call.completed",
+                        "response.web_search_call.results.added",
+                        "response.web_search_call.results.completed",
+                        "response.web_fetch_call.in_progress",
+                        "response.web_fetch_call.fetching",
+                        "response.web_fetch_call.completed",
+                        "response.reasoning_summary_part.added",
+                        "response.reasoning_summary_part.done",
+                        "response.reasoning_summary_text.delta",
+                        "response.reasoning_summary_text.done",
+                        "response.image_generation_call.completed",
+                        "response.image_generation_call.generating",
+                        "response.image_generation_call.in_progress",
+                        "response.image_generation_call.partial_image",
+                        "response.mcp_call_arguments.delta",
+                        "response.mcp_call_arguments.done",
+                        "response.mcp_call.completed",
+                        "response.mcp_call.failed",
+                        "response.mcp_call.in_progress",
+                        "response.mcp_list_tools.completed",
+                        "response.mcp_list_tools.failed",
+                        "response.mcp_list_tools.in_progress",
+                        "response.code_interpreter_call.in_progress",
+                        "response.code_interpreter_call.interpreting",
+                        "response.code_interpreter_call.completed",
+                        "response.code_interpreter_call_code.delta",
+                        "response.code_interpreter_call_code.done",
+                        "response.output_text.annotation.added",
+                        "response.output_text.annotation.done",
+                        "response.queued",
+                        "response.custom_tool_call_input.delta",
+                        "response.custom_tool_call_input.done",
+                        "error"
+                      ]
+                    },
+                    "sequence_number": {
+                      "type": "integer"
+                    },
+                    "response": {
+                      "$ref": "#/components/schemas/ResponsesResponse"
+                    },
+                    "output_index": {
+                      "type": "integer"
+                    },
+                    "item": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "message",
+                            "file_search_call",
+                            "computer_call",
+                            "computer_call_output",
+                            "web_search_call",
+                            "web_fetch_call",
+                            "function_call",
+                            "function_call_output",
+                            "code_interpreter_call",
+                            "local_shell_call",
+                            "local_shell_call_output",
+                            "mcp_call",
+                            "custom_tool_call",
+                            "custom_tool_call_output",
+                            "image_generation_call",
+                            "mcp_list_tools",
+                            "mcp_approval_request",
+                            "mcp_approval_responses",
+                            "reasoning",
+                            "item_reference",
+                            "refusal"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "in_progress",
+                            "completed",
+                            "incomplete",
+                            "interpreting",
+                            "failed"
+                          ]
+                        },
+                        "role": {
+                          "type": "string",
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
+                        },
+                        "content": {
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "call_id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "arguments": {
+                          "type": "string"
+                        },
+                        "output": {
+                          "description": "Tool call output. A plain string for function/custom/local-shell tool\noutputs, an array of content blocks for structured function tool\noutputs, or a computer-tool screenshot object for computer_call_output.\n",
+                          "oneOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "type": {
+                                    "type": "string",
+                                    "enum": [
+                                      "input_text",
+                                      "input_image",
+                                      "input_file",
+                                      "input_audio",
+                                      "output_text",
+                                      "refusal",
+                                      "reasoning_text"
+                                    ]
+                                  },
+                                  "file_id": {
+                                    "type": "string"
+                                  },
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "signature": {
+                                    "type": "string"
+                                  },
+                                  "image_url": {
+                                    "type": "string"
+                                  },
+                                  "detail": {
+                                    "type": "string"
+                                  },
+                                  "file_data": {
+                                    "type": "string"
+                                  },
+                                  "file_url": {
+                                    "type": "string"
+                                  },
+                                  "filename": {
+                                    "type": "string"
+                                  },
+                                  "file_type": {
+                                    "type": "string"
+                                  },
+                                  "input_audio": {
+                                    "type": "object",
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
+                                    "properties": {
+                                      "format": {
+                                        "type": "string",
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
+                                      },
+                                      "data": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "annotations": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "enum": [
+                                            "file_citation",
+                                            "url_citation",
+                                            "container_file_citation",
+                                            "file_path"
+                                          ]
+                                        },
+                                        "index": {
+                                          "type": "integer"
+                                        },
+                                        "file_id": {
+                                          "type": "string"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "start_index": {
+                                          "type": "integer"
+                                        },
+                                        "end_index": {
+                                          "type": "integer"
+                                        },
+                                        "filename": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        },
+                                        "container_id": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "logprobs": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "bytes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "logprob": {
+                                          "type": "number"
+                                        },
+                                        "token": {
+                                          "type": "string"
+                                        },
+                                        "top_logprobs": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "bytes": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "integer"
+                                                }
+                                              },
+                                              "logprob": {
+                                                "type": "number"
+                                              },
+                                              "token": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "refusal": {
+                                    "type": "string"
+                                  },
+                                  "cache_control": {
+                                    "$ref": "#/components/schemas/CacheControl"
+                                  }
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "description": "Computer tool call output (computer_screenshot).",
+                              "properties": {
+                                "type": {
+                                  "type": "string",
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
+                                },
+                                "file_id": {
+                                  "type": "string"
+                                },
+                                "image_url": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        },
+                        "error": {
+                          "type": "string"
+                        },
+                        "queries": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "results": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "summary": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "type",
+                              "text"
+                            ],
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "summary_text"
+                                ]
+                              },
+                              "text": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "encrypted_content": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "content_index": {
+                      "type": "integer"
+                    },
+                    "item_id": {
+                      "type": "string"
+                    },
+                    "part": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "input_text",
+                            "input_image",
+                            "input_file",
+                            "input_audio",
+                            "output_text",
+                            "refusal",
+                            "reasoning_text"
+                          ]
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "signature": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "detail": {
+                          "type": "string"
+                        },
+                        "file_data": {
+                          "type": "string"
+                        },
+                        "file_url": {
+                          "type": "string"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "file_type": {
+                          "type": "string"
+                        },
+                        "input_audio": {
+                          "type": "object",
+                          "required": [
+                            "format",
+                            "data"
+                          ],
+                          "properties": {
+                            "format": {
+                              "type": "string",
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
+                            },
+                            "data": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "annotations": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "file_citation",
+                                  "url_citation",
+                                  "container_file_citation",
+                                  "file_path"
+                                ]
+                              },
+                              "index": {
+                                "type": "integer"
+                              },
+                              "file_id": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "start_index": {
+                                "type": "integer"
+                              },
+                              "end_index": {
+                                "type": "integer"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "url": {
+                                "type": "string"
+                              },
+                              "container_id": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "logprobs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "bytes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "integer"
+                                }
+                              },
+                              "logprob": {
+                                "type": "number"
+                              },
+                              "token": {
+                                "type": "string"
+                              },
+                              "top_logprobs": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "logprob": {
+                                      "type": "number"
+                                    },
+                                    "token": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "refusal": {
+                          "type": "string"
+                        },
+                        "cache_control": {
+                          "$ref": "#/components/schemas/CacheControl"
+                        }
+                      }
+                    },
+                    "delta": {
+                      "type": "string"
+                    },
+                    "signature": {
+                      "type": "string"
+                    },
+                    "logprobs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bytes": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer"
+                            }
+                          },
+                          "logprob": {
+                            "type": "number"
+                          },
+                          "token": {
+                            "type": "string"
+                          },
+                          "top_logprobs": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "bytes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "logprob": {
+                                  "type": "number"
+                                },
+                                "token": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "refusal": {
+                      "type": "string"
+                    },
+                    "arguments": {
+                      "type": "string"
+                    },
+                    "partial_image_b64": {
+                      "type": "string"
+                    },
+                    "partial_image_index": {
+                      "type": "integer"
+                    },
+                    "annotation": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "file_citation",
+                            "url_citation",
+                            "container_file_citation",
+                            "file_path"
+                          ]
+                        },
+                        "index": {
+                          "type": "integer"
+                        },
+                        "file_id": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "start_index": {
+                          "type": "integer"
+                        },
+                        "end_index": {
+                          "type": "integer"
+                        },
+                        "filename": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "container_id": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "annotation_index": {
+                      "type": "integer"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "param": {
+                      "type": "string"
+                    },
+                    "extra_fields": {
+                      "$ref": "#/components/schemas/BifrostResponseExtraFields"
+                    }
+                  }
                 }
               }
             }

--- a/docs/openapi/paths/inference/responses.yaml
+++ b/docs/openapi/paths/inference/responses.yaml
@@ -116,6 +116,11 @@ responses-by-id:
       description: Whether to include obfuscation on the response
       schema:
         type: boolean
+    - name: stream
+      in: query
+      description: When `true`, replays the stored response as SSE events instead of a single JSON object
+      schema:
+        type: boolean
     responses:
       '200':
         description: Successful response
@@ -123,6 +128,9 @@ responses-by-id:
           application/json:
             schema:
               $ref: '../../schemas/inference/responses.yaml#/ResponsesResponse'
+          text/event-stream:
+            schema:
+              $ref: '../../schemas/inference/responses.yaml#/ResponsesStreamResponse'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '404':

--- a/docs/openapi/paths/integrations/openai/responses.yaml
+++ b/docs/openapi/paths/integrations/openai/responses.yaml
@@ -215,6 +215,11 @@ responses-by-id:
       description: Whether to include obfuscation on the response
       schema:
         type: boolean
+    - name: stream
+      in: query
+      description: When `true`, replays the stored response as SSE events instead of a single JSON object
+      schema:
+        type: boolean
     responses:
       '200':
         description: Successful response
@@ -222,6 +227,9 @@ responses-by-id:
           application/json:
             schema:
               $ref: '../../../schemas/integrations/openai/responses.yaml#/OpenAIResponsesResponse'
+          text/event-stream:
+            schema:
+              $ref: '../../../schemas/integrations/openai/responses.yaml#/OpenAIResponsesStreamResponse'
       '400':
         $ref: '../../../openapi.yaml#/components/responses/BadRequest'
       '404':

--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -14,7 +14,7 @@ OpenAI is the **baseline schema** for Bifrost. When using OpenAI directly, param
 |-----------|---------------|-----------|----------|
 | Chat Completions | ✅ | ✅ | `/v1/chat/completions` |
 | Responses API | ✅ | ✅ | `/v1/responses` |
-| Responses Lifecycle | ✅ | - | `/v1/responses/{response_id}` |
+| Responses Lifecycle | ✅ | ✅ | `/v1/responses/{response_id}` |
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | Embeddings | ✅ | - | `/v1/embeddings` |
 | Speech (TTS) | ✅ | ✅ | `/v1/audio/speech` |
@@ -229,8 +229,9 @@ GET `/v1/responses/{response_id}` - Retrieve a stored response ([docs](https://p
 | `include` | array | ❌ | Additional fields to include (repeat the parameter for multiple values) |
 | `starting_after` | int | ❌ | Sequence number of the event after which to start the response |
 | `include_obfuscation` | bool | ❌ | Whether to include obfuscation on the response |
+| `stream` | bool | ❌ | When `true`, replays the stored response as SSE events |
 
-**Response:** The full response object, same shape as `POST /v1/responses`.
+**Response:** The full response object, same shape as `POST /v1/responses`. With `stream=true`, the same SSE event stream as `POST /v1/responses` with `stream: true`.
 
 ### Delete Response
 

--- a/tests/cmd/e2eseed/go.mod
+++ b/tests/cmd/e2eseed/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
-	github.com/maximhq/bifrost/core v1.7.3 // indirect
+	github.com/maximhq/bifrost/core v1.7.4 // indirect
 	github.com/maximhq/bifrost/framework v1.3.16 // indirect
 	github.com/paulmach/orb v0.11.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect

--- a/tests/cmd/seed/go.mod
+++ b/tests/cmd/seed/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/maximhq/bifrost/core v1.7.3
+	github.com/maximhq/bifrost/core v1.7.4
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0

--- a/tests/cmd/seedvks/go.mod
+++ b/tests/cmd/seedvks/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.7.3
+	github.com/maximhq/bifrost/core v1.7.4
 	github.com/maximhq/bifrost/framework v1.3.16
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -42309,6 +42309,262 @@
           }
         }
       ]
+    },
+    {
+      "name": "32. Gemini Google Search grounding + tool combination (PR #5576)",
+      "description": "PR #5576 (Gemini Google Search grounding + tool combination). Four regressions, all of which return 200 when broken, so a status assertion alone cannot pin them:\n\n1. Grounding annotations on /v1/responses were emitted on a SEPARATE message item whose output_text was \"\" , while the real assistant text carried annotations: []. Segment start_index/end_index index into the real text, so the offsets pointed at a different item entirely. Annotations must now sit on the text block they annotate, and no empty-text message may be emitted.\n2. Only the first entry of groundingSupports[].groundingChunkIndices was read on the Responses path, so a segment backed by several sources kept one citation. Every (support, chunk) pair now yields a url_citation.\n3. Gemini rejects function declarations sent alongside googleSearch unless toolConfig.includeServerSideToolInvocations is set (Gemini 3+). Bifrost had no way to express the flag, so it silently DROPPED the caller function declarations whenever web search was present - the model could never call them. The neutral include_server_side_tool_invocations param now maps to toolConfig.includeServerSideToolInvocations, and an AUTO/unset functionCallingConfig is promoted to VALIDATED (AUTO is unsupported in that mode).\n4. On the streaming genai passthrough, groundingMetadata.searchEntryPoint was lost: the rendered-content output_item.done event carried no item, so the reverse conversion never rebuilt it. Google requires rendering Search Suggestions, so its loss is a compliance issue, not cosmetic.\n\nCases 32.3/32.4 use gemini-3.6-flash because tool combination is Gemini 3+ only.",
+      "item": [
+        {
+          "name": "gemini/gemini-3.6-flash google_search annotations on assistant text block, no phantom message (/v1/responses) - PR #5576",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini-3.6-flash\",\n  \"input\": \"Who won UEFA Euro 2024? Answer in two short sentences using Google Search.\",\n  \"tools\": [\n    {\n      \"type\": \"web_search\"\n    }\n  ],\n  \"max_output_tokens\": 2000\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('responses google_search: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var output = (pm.response.json() || {}).output || [];",
+                  "var textBlocks = [];",
+                  "output.forEach(function (item) {",
+                  "  if (item.type !== 'message' || !item.content) { return; }",
+                  "  item.content.forEach(function (block) {",
+                  "    if (block.type === 'output_text') { textBlocks.push(block); }",
+                  "  });",
+                  "});",
+                  "pm.test('responses google_search: at least one output_text block', function () {",
+                  "  pm.expect(textBlocks.length, 'no output_text block: ' + pm.response.text()).to.be.above(0);",
+                  "});",
+                  "pm.test('responses google_search: no phantom empty-text message (regression PR #5576)', function () {",
+                  "  textBlocks.forEach(function (b) {",
+                  "    pm.expect(b.text, 'empty output_text block emitted - annotations were split onto a phantom message: ' + JSON.stringify(b)).to.be.a('string').and.not.empty;",
+                  "  });",
+                  "});",
+                  "var annotated = textBlocks.filter(function (b) { return b.annotations && b.annotations.length; });",
+                  "pm.test('responses google_search: url_citation annotations present', function () {",
+                  "  pm.expect(annotated.length, 'no annotations on any output_text block: ' + pm.response.text()).to.be.above(0);",
+                  "});",
+                  "pm.test('responses google_search: annotations attached to the annotated text (regression PR #5576)', function () {",
+                  "  annotated.forEach(function (b) {",
+                  "    pm.expect(b.text, 'annotations sit on an empty text block').to.be.a('string').and.not.empty;",
+                  "    b.annotations.forEach(function (a) {",
+                  "      pm.expect(a.type, 'unexpected annotation type: ' + JSON.stringify(a)).to.eql('url_citation');",
+                  "      pm.expect(a.url, 'annotation missing url: ' + JSON.stringify(a)).to.be.a('string').and.not.empty;",
+                  "      pm.expect(a.end_index, 'annotation missing end_index: ' + JSON.stringify(a)).to.be.a('number');",
+                  "    });",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "gemini/gemini-3.6-flash streaming googleSearch keeps searchEntryPoint (/genai SSE) - PR #5576",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Who won UEFA Euro 2024? Answer in one short sentence using Google Search.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"googleSearch\": {}\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini-3.6-flash:streamGenerateContent?alt=sse",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "gemini-3.6-flash:streamGenerateContent"
+              ],
+              "query": [
+                {
+                  "key": "alt",
+                  "value": "sse"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('genai stream googleSearch: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var raw = pm.response.text();",
+                  "var chunks = [];",
+                  "raw.split('\\n').forEach(function (line) {",
+                  "  var t = line.trim();",
+                  "  if (t.indexOf('data:') !== 0) { return; }",
+                  "  var payload = t.slice(5).trim();",
+                  "  if (!payload || payload === '[DONE]') { return; }",
+                  "  try { chunks.push(JSON.parse(payload)); } catch (e) {}",
+                  "});",
+                  "pm.test('genai stream googleSearch: SSE chunks parsed', function () {",
+                  "  pm.expect(chunks.length, 'no SSE data chunks: ' + raw.slice(0, 500)).to.be.above(0);",
+                  "});",
+                  "var queries = [];",
+                  "var rendered = '';",
+                  "chunks.forEach(function (c) {",
+                  "  (c.candidates || []).forEach(function (cand) {",
+                  "    var gm = cand.groundingMetadata;",
+                  "    if (!gm) { return; }",
+                  "    if (gm.webSearchQueries) { queries = queries.concat(gm.webSearchQueries); }",
+                  "    if (gm.searchEntryPoint && gm.searchEntryPoint.renderedContent) { rendered = gm.searchEntryPoint.renderedContent; }",
+                  "  });",
+                  "});",
+                  "pm.test('genai stream googleSearch: groundingMetadata present in stream', function () {",
+                  "  pm.expect(queries.length, 'no webSearchQueries in stream: ' + raw.slice(0, 800)).to.be.above(0);",
+                  "});",
+                  "pm.test('genai stream googleSearch: searchEntryPoint.renderedContent survives streaming (regression PR #5576)', function () {",
+                  "  pm.expect(rendered, 'searchEntryPoint missing from streamed groundingMetadata - Google requires rendering Search Suggestions').to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "gemini/gemini-3.6-flash include_server_side_tool_invocations keeps function tools with google_search (/v1/responses) - PR #5576",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gemini-3.6-flash\",\n  \"input\": \"Call the get_weather function for Tokyo. You must use the function to answer.\",\n  \"tools\": [\n    {\n      \"type\": \"web_search\"\n    },\n    {\n      \"type\": \"function\",\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a city\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"city\": {\n            \"type\": \"string\",\n            \"description\": \"City name\"\n          }\n        },\n        \"required\": [\n          \"city\"\n        ]\n      }\n    }\n  ],\n  \"include_server_side_tool_invocations\": true,\n  \"max_output_tokens\": 2000\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('responses tool combination: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var output = (pm.response.json() || {}).output || [];",
+                  "var calls = output.filter(function (item) {",
+                  "  return item.type === 'function_call' && item.name === 'get_weather';",
+                  "});",
+                  "pm.test('responses tool combination: function declarations survive alongside google_search (regression PR #5576)', function () {",
+                  "  pm.expect(calls.length, 'no get_weather function_call - declarations were dropped when web_search was present: ' + pm.response.text()).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "gemini/gemini-3.6-flash genai toolConfig.includeServerSideToolInvocations round-trip (/genai generateContent) - PR #5576",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contents\": [\n    {\n      \"role\": \"user\",\n      \"parts\": [\n        {\n          \"text\": \"Call the get_weather function for Tokyo. You must use the function to answer.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"functionDeclarations\": [\n        {\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ]\n          }\n        }\n      ]\n    },\n    {\n      \"googleSearch\": {}\n    }\n  ],\n  \"toolConfig\": {\n    \"includeServerSideToolInvocations\": true\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/genai/v1beta/models/gemini-3.6-flash:generateContent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "genai",
+                "v1beta",
+                "models",
+                "gemini-3.6-flash:generateContent"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('genai tool combination: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var candidates = (pm.response.json() || {}).candidates || [];",
+                  "var calls = [];",
+                  "candidates.forEach(function (cand) {",
+                  "  var parts = (cand.content && cand.content.parts) || [];",
+                  "  parts.forEach(function (p) {",
+                  "    if (p.functionCall && p.functionCall.name === 'get_weather') { calls.push(p.functionCall); }",
+                  "  });",
+                  "});",
+                  "pm.test('genai tool combination: functionDeclarations survive the round-trip alongside googleSearch (regression PR #5576)', function () {",
+                  "  pm.expect(calls.length, 'no get_weather functionCall - toolConfig.includeServerSideToolInvocations was dropped and declarations stripped: ' + pm.response.text()).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -153,6 +153,8 @@ var chatParamsKnownFields = map[string]bool{
 	"truncation":             true,
 	"user":                   true,
 	"verbosity":              true,
+
+	"include_server_side_tool_invocations": true,
 }
 
 var responsesParamsKnownFields = map[string]bool{
@@ -183,6 +185,8 @@ var responsesParamsKnownFields = map[string]bool{
 	"tool_choice":            true,
 	"tools":                  true,
 	"truncation":             true,
+
+	"include_server_side_tool_invocations": true,
 }
 
 var compactionParamsKnownFields = map[string]bool{


### PR DESCRIPTION
## Summary

When a client requests a Gemini file download via `GET /files/{id}:download`, Google's API responds with a `302` redirect to `/download/v1beta/...`. The redirect target requires the API key, but since Bifrost is the only party holding it, the redirect was previously not followed — resulting in a `403` from Google. This PR fixes that by transparently following redirects (up to 5 hops) for `:download` GET requests while leaving all other passthrough calls unaffected.

## Changes

- For `GET` requests whose path contains `:download`, the Gemini passthrough now calls `MakeRequestWithContextFollowRedirects` instead of `MakeRequestWithContext`, ensuring the API key is forwarded to the redirect target.
- All other requests (e.g. resumable upload `308` responses with no `Location` header) continue to use the non-redirect-following path, preventing breakage of those flows.
- Added `passthrough_test.go` covering three cases: the download redirect is followed and bytes are returned, a resumable upload `308` is forwarded as-is, and ordinary calls are unaffected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
```

The new tests spin up a local HTTP server that mimics Google's redirect behaviour. Expected outcomes:
- `download follows the redirect and returns the bytes` — status `200`, body contains the file bytes, and the API key is present on the redirect hop.
- `resumable upload 308 is forwarded, not followed` — status `308`, no error.
- `ordinary calls are unaffected` — status `404`, no redirect handling triggered.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The API key is intentionally forwarded to the redirect target (`/download/v1beta/...`), which is a first-party Google endpoint. The redirect-following logic is scoped strictly to `:download` GET requests to prevent the key from being forwarded to arbitrary third-party redirect destinations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable