### PR TITLE
fix: apply `ScopedDB` to `FindMCPToolLog` for query-scope enforcement

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -4000,10 +4000,12 @@ func (s *RDBLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Context, ent
 	}).Create(&entries).Error
 }
 
-// FindMCPToolLog retrieves a single MCP tool log entry by its ID.
+// FindMCPToolLog retrieves a single MCP tool log entry by its ID. When ctx
+// carries a QueryScope, ScopedDB applies it so out-of-scope IDs return
+// ErrNotFound. Contexts without a QueryScope stay unscoped as before.
 func (s *RDBLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error) {
 	var log MCPToolLog
-	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&log).Error; err != nil {
+	if err := s.ScopedDB(ctx).Where("id = ?", id).First(&log).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}

--- a/framework/logstore/scopeddb_test.go
+++ b/framework/logstore/scopeddb_test.go
@@ -117,3 +117,42 @@ func TestFindByIDUsesScopedDB(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hidden-log", hidden.ID)
 }
+
+// TestFindMCPToolLogUsesScopedDB verifies MCP tool log point lookups honor
+// caller-supplied row visibility, matching FindByID on the logs table.
+func TestFindMCPToolLogUsesScopedDB(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	visibleUserID := "user-visible"
+	hiddenUserID := "user-hidden"
+
+	require.NoError(t, store.CreateMCPToolLog(ctx, &MCPToolLog{
+		ID:        "visible-mcp-log",
+		Timestamp: time.Now().UTC(),
+		ToolName:  "echo",
+		Status:    "success",
+		UserID:    &visibleUserID,
+	}))
+	require.NoError(t, store.CreateMCPToolLog(ctx, &MCPToolLog{
+		ID:        "hidden-mcp-log",
+		Timestamp: time.Now().UTC(),
+		ToolName:  "echo",
+		Status:    "success",
+		UserID:    &hiddenUserID,
+	}))
+
+	scopedCtx := queryscope.WithQueryScope(ctx, func(db *gorm.DB) *gorm.DB {
+		return db.Where("user_id = ?", visibleUserID)
+	})
+
+	visible, err := store.FindMCPToolLog(scopedCtx, "visible-mcp-log")
+	require.NoError(t, err)
+	require.Equal(t, "visible-mcp-log", visible.ID)
+
+	_, err = store.FindMCPToolLog(scopedCtx, "hidden-mcp-log")
+	require.ErrorIs(t, err, ErrNotFound)
+
+	hidden, err := store.FindMCPToolLog(ctx, "hidden-mcp-log")
+	require.NoError(t, err)
+	require.Equal(t, "hidden-mcp-log", hidden.ID)
+}


### PR DESCRIPTION
## Summary

`FindMCPToolLog` was querying the database directly without respecting any `QueryScope` attached to the context, meaning callers had no way to restrict row visibility for point lookups on MCP tool logs. This brings `FindMCPToolLog` in line with `FindByID` by routing the query through `ScopedDB`.

## Changes

- `FindMCPToolLog` now calls `s.ScopedDB(ctx)` instead of `s.db.WithContext(ctx)`, so a `QueryScope` carried in the context is applied before the query executes. Contexts without a `QueryScope` remain unscoped and behave identically to before.
- Added `TestFindMCPToolLogUsesScopedDB` to confirm that a scoped context returns `ErrNotFound` for out-of-scope IDs while an unscoped context can still retrieve them.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestFindMCPToolLogUsesScopedDB -v
```

The test creates two MCP tool log entries owned by different users, applies a `QueryScope` that filters to one user, and asserts that:
- The in-scope log is returned successfully.
- The out-of-scope log returns `ErrNotFound`.
- An unscoped context can still retrieve the out-of-scope log directly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This fix ensures that row-level visibility constraints expressed via `QueryScope` are consistently enforced for MCP tool log lookups, preventing callers from inadvertently reading log entries outside their permitted scope.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable