### PR TITLE
feat: add user-scoped pricing overrides with pluggable enterprise user picker

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/registrations/userPicker.ts
+++ b/ui/app/_fallbacks/enterprise/lib/registrations/userPicker.ts
@@ -1,0 +1,8 @@
+// OSS-build fallback for the enterprise user picker registration.
+//
+// Side-effect imports of this module from OSS code (the pricing override
+// and routing rule sheets) compile to a no-op when the @enterprise alias
+// resolves to _fallbacks/. The enterprise build replaces this module with
+// one that registers the async user picker, which is what reveals the
+// "User" scope options.
+export {};

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -18,6 +18,7 @@ import {
 	useUpdatePricingOverrideMutation,
 } from "@/lib/store";
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
+import { getUserPicker } from "@/lib/registries/userPicker";
 import { ModelProvider, RequestType } from "@/lib/types/config";
 import {
 	CreatePricingOverrideRequest,
@@ -32,6 +33,8 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useS
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { PricingFieldSelector } from "./pricingFieldSelector";
+// Side-effect import: registers the enterprise user picker (no-op in OSS builds).
+import "@enterprise/lib/registrations/userPicker";
 
 export const REQUEST_TYPE_GROUPS = [
 	{
@@ -295,11 +298,12 @@ export const PRICING_FIELDS = [
 export type PricingFieldKey = (typeof PRICING_FIELDS)[number]["key"];
 export type FieldErrors = Partial<Record<PricingFieldKey | "name" | "scope" | "pattern" | "patch", string>>;
 
-type ScopeRoot = "global" | "virtual_key";
+type ScopeRoot = "global" | "virtual_key" | "user";
 
 export interface FormState {
 	name: string;
 	scopeRoot: ScopeRoot;
+	userID: string;
 	virtualKeyID: string;
 	providerID: string;
 	providerKeyID: string;
@@ -312,6 +316,7 @@ export interface FormState {
 export const defaultFormState: FormState = {
 	name: "",
 	scopeRoot: "global",
+	userID: "",
 	virtualKeyID: "",
 	providerID: "",
 	providerKeyID: "",
@@ -380,11 +385,14 @@ function toFormState(override: PricingOverride): FormState {
 	const scopeRoot: ScopeRoot =
 		scopeKind === "virtual_key" || scopeKind === "virtual_key_provider" || scopeKind === "virtual_key_provider_key"
 			? "virtual_key"
-			: "global";
+			: scopeKind === "user" || scopeKind === "user_provider" || scopeKind === "user_provider_key"
+				? "user"
+				: "global";
 
 	return {
 		name: override.name ?? "",
 		scopeRoot,
+		userID: override.user_id ?? "",
 		virtualKeyID: override.virtual_key_id ?? "",
 		providerID: override.provider_id ?? "",
 		providerKeyID: override.provider_key_id ?? "",
@@ -402,7 +410,10 @@ function resolveScopeKind(override: PricingOverride): PricingOverrideScopeKind {
 		override.scope_kind === "provider_key" ||
 		override.scope_kind === "virtual_key" ||
 		override.scope_kind === "virtual_key_provider" ||
-		override.scope_kind === "virtual_key_provider_key"
+		override.scope_kind === "virtual_key_provider_key" ||
+		override.scope_kind === "user" ||
+		override.scope_kind === "user_provider" ||
+		override.scope_kind === "user_provider_key"
 	) {
 		return override.scope_kind;
 	}
@@ -410,6 +421,11 @@ function resolveScopeKind(override: PricingOverride): PricingOverrideScopeKind {
 		if (override.provider_key_id) return "virtual_key_provider_key";
 		if (override.provider_id) return "virtual_key_provider";
 		return "virtual_key";
+	}
+	if (override.user_id) {
+		if (override.provider_key_id) return "user_provider_key";
+		if (override.provider_id) return "user_provider";
+		return "user";
 	}
 	if (override.provider_key_id) return "provider_key";
 	if (override.provider_id) return "provider";
@@ -421,6 +437,11 @@ function deriveScopeKind(form: FormState): PricingOverrideScopeKind {
 		if (form.providerKeyID) return "virtual_key_provider_key";
 		if (form.providerID) return "virtual_key_provider";
 		return "virtual_key";
+	}
+	if (form.scopeRoot === "user") {
+		if (form.providerKeyID) return "user_provider_key";
+		if (form.providerID) return "user_provider";
+		return "user";
 	}
 	if (form.providerKeyID) return "provider_key";
 	if (form.providerID) return "provider";
@@ -480,6 +501,7 @@ interface PricingOverrideDrawerProps {
 	editingOverride?: PricingOverride | null;
 	scopeLock?: {
 		scopeKind: PricingOverrideScopeKind;
+		userID?: string;
 		virtualKeyID?: string;
 		providerID?: string;
 		providerKeyID?: string;
@@ -503,6 +525,12 @@ function isCompleteScopeLock(scopeLock?: PricingOverrideDrawerProps["scopeLock"]
 			return Boolean(scopeLock.virtualKeyID && scopeLock.providerID);
 		case "virtual_key_provider_key":
 			return Boolean(scopeLock.virtualKeyID && scopeLock.providerID && scopeLock.providerKeyID);
+		case "user":
+			return Boolean(scopeLock.userID);
+		case "user_provider":
+			return Boolean(scopeLock.userID && scopeLock.providerID);
+		case "user_provider_key":
+			return Boolean(scopeLock.userID && scopeLock.providerID && scopeLock.providerKeyID);
 		default:
 			return false;
 	}
@@ -532,11 +560,16 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const providerID = watch("providerID");
 	const providerKeyID = watch("providerKeyID");
 	const virtualKeyID = watch("virtualKeyID");
+	const userID = watch("userID");
 	const matchType = watch("matchType");
 	const requestTypes = watch("requestTypes");
 	const pricingValues = watch("pricingValues");
 
 	const shouldLockScope = useMemo(() => !editingOverride && isCompleteScopeLock(scopeLock), [editingOverride, scopeLock]);
+
+	// Registered by the downstream build at module load; undefined in builds
+	// without a user directory, which hides the "User" scope root.
+	const UserPicker = getUserPicker();
 
 	const providerKeyOptions = useMemo(
 		() =>
@@ -576,15 +609,18 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		if (shouldLockScope && scopeLock) {
 			reset({
 				...defaultFormState,
+				userID: scopeLock.userID ?? "",
 				virtualKeyID: scopeLock.virtualKeyID ?? "",
 				providerID: scopeLock.providerID ?? "",
 				providerKeyID: scopeLock.providerKeyID ?? "",
 				scopeRoot:
 					scopeLock.scopeKind === "virtual_key" ||
-					scopeLock.scopeKind === "virtual_key_provider" ||
-					scopeLock.scopeKind === "virtual_key_provider_key"
+						scopeLock.scopeKind === "virtual_key_provider" ||
+						scopeLock.scopeKind === "virtual_key_provider_key"
 						? "virtual_key"
-						: "global",
+						: scopeLock.scopeKind === "user" || scopeLock.scopeKind === "user_provider" || scopeLock.scopeKind === "user_provider_key"
+							? "user"
+							: "global",
 			});
 			return;
 		}
@@ -612,6 +648,11 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		if (shouldLockScope) return scopeLock?.virtualKeyID;
 		return scopeRoot === "virtual_key" ? virtualKeyID || undefined : undefined;
 	}, [scopeLock, shouldLockScope, scopeRoot, virtualKeyID]);
+
+	const resolvedUserID = useMemo(() => {
+		if (shouldLockScope) return scopeLock?.userID;
+		return scopeRoot === "user" ? userID.trim() || undefined : undefined;
+	}, [scopeLock, shouldLockScope, scopeRoot, userID]);
 
 	const resolvedProviderID = useMemo(() => {
 		if (shouldLockScope) return scopeLock?.providerID;
@@ -704,6 +745,15 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 			hasErrors = true;
 		}
 
+		if (
+			!shouldLockScope &&
+			(resolvedScopeKind === "user" || resolvedScopeKind === "user_provider" || resolvedScopeKind === "user_provider_key") &&
+			!resolvedUserID
+		) {
+			setError("userID", { message: "User ID is required" });
+			hasErrors = true;
+		}
+
 		const pError = patternError(data.matchType, data.pattern);
 		if (pError) {
 			setError("pattern", { message: pError });
@@ -729,6 +779,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		if (hasErrors || jsonError) return;
 
 		const { patch } = buildPatchFromForm(data);
+		let scopedUserID: string | undefined;
 		let scopedVirtualKeyID: string | undefined;
 		let scopedProviderID: string | undefined;
 		let scopedProviderKeyID: string | undefined;
@@ -754,11 +805,24 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 				scopedProviderID = resolvedProviderID;
 				scopedProviderKeyID = resolvedProviderKeyID;
 				break;
+			case "user":
+				scopedUserID = resolvedUserID;
+				break;
+			case "user_provider":
+				scopedUserID = resolvedUserID;
+				scopedProviderID = resolvedProviderID;
+				break;
+			case "user_provider_key":
+				scopedUserID = resolvedUserID;
+				scopedProviderID = resolvedProviderID;
+				scopedProviderKeyID = resolvedProviderKeyID;
+				break;
 		}
 
 		const requestPayload: CreatePricingOverrideRequest = {
 			name: data.name.trim(),
 			scope_kind: resolvedScopeKind,
+			user_id: scopedUserID,
 			virtual_key_id: scopedVirtualKeyID,
 			provider_id: scopedProviderID,
 			provider_key_id: scopedProviderKeyID,
@@ -834,7 +898,9 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 														onValueChange={(value: ScopeRoot) => {
 															field.onChange(value);
 															setValue("virtualKeyID", "");
+															setValue("userID", "");
 															clearErrors("virtualKeyID");
+															clearErrors("userID");
 														}}
 													>
 														<FormControl>
@@ -845,11 +911,53 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 														<SelectContent>
 															<SelectItem value="global">Global</SelectItem>
 															<SelectItem value="virtual_key">Virtual key</SelectItem>
+															{(UserPicker || scopeRoot === "user") && <SelectItem value="user">User</SelectItem>}
 														</SelectContent>
 													</Select>
 												</FormItem>
 											)}
 										/>
+
+										{scopeRoot === "user" && (
+											<FormField
+												control={control}
+												name="userID"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>
+															User <span className="text-red-500">*</span>
+														</FormLabel>
+														<FormControl>
+															{UserPicker ? (
+																<UserPicker
+																	value={field.value}
+																	onChange={(value) => {
+																		field.onChange(value);
+																		clearErrors("userID");
+																	}}
+																	fallbackOption={
+																		editingOverride?.user_id ? { value: editingOverride.user_id, label: editingOverride.user_id } : null
+																	}
+																/>
+															) : (
+																// No user directory in this build: keep a plain input so
+																// existing user-scoped overrides remain editable.
+																<Input
+																	data-testid="pricing-override-user-id-input"
+																	placeholder="Governance user ID"
+																	{...field}
+																	onChange={(e) => {
+																		field.onChange(e);
+																		clearErrors("userID");
+																	}}
+																/>
+															)}
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										)}
 
 										{scopeRoot === "virtual_key" && (
 											<FormField

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -97,18 +97,24 @@ function parseScopeKind(value: string | null): ScopeFilter {
 		value === "provider_key" ||
 		value === "virtual_key" ||
 		value === "virtual_key_provider" ||
-		value === "virtual_key_provider_key"
+		value === "virtual_key_provider_key" ||
+		value === "user" ||
+		value === "user_provider" ||
+		value === "user_provider_key"
 	) {
 		return value;
 	}
 	return "all";
 }
 
-// Returns the top-level scope label: "Global" or the virtual key name.
+// Returns the top-level scope label: "Global", "Virtual Key", or "User".
 function scopeLabel(override: PricingOverride, _virtualKeyMap: Map<string, string>): string {
 	const scopeKind = resolveScopeKind(override);
 	if (override.virtual_key_id && scopeKind.startsWith("virtual_key")) {
 		return "Virtual Key";
+	}
+	if (override.user_id && scopeKind.startsWith("user")) {
+		return "User";
 	}
 	return "Global";
 }
@@ -128,9 +134,11 @@ function providerLabel(override: PricingOverride, providerMap: Map<string, strin
 	switch (scopeKind) {
 		case "provider":
 		case "virtual_key_provider":
+		case "user_provider":
 			return providerMap.get(override.provider_id || "") || override.provider_id || "-";
 		case "provider_key":
-		case "virtual_key_provider_key": {
+		case "virtual_key_provider_key":
+		case "user_provider_key": {
 			const keyID = override.provider_key_id || "";
 			return providerMap.get(keyProviderMap.get(keyID) || "") || keyProviderMap.get(keyID) || "-";
 		}
@@ -146,7 +154,10 @@ function resolveScopeKind(override: PricingOverride): PricingOverrideScopeKind {
 		override.scope_kind === "provider_key" ||
 		override.scope_kind === "virtual_key" ||
 		override.scope_kind === "virtual_key_provider" ||
-		override.scope_kind === "virtual_key_provider_key"
+		override.scope_kind === "virtual_key_provider_key" ||
+		override.scope_kind === "user" ||
+		override.scope_kind === "user_provider" ||
+		override.scope_kind === "user_provider_key"
 	) {
 		return override.scope_kind;
 	}
@@ -154,6 +165,11 @@ function resolveScopeKind(override: PricingOverride): PricingOverrideScopeKind {
 		if (override.provider_key_id) return "virtual_key_provider_key";
 		if (override.provider_id) return "virtual_key_provider";
 		return "virtual_key";
+	}
+	if (override.user_id) {
+		if (override.provider_key_id) return "user_provider_key";
+		if (override.provider_id) return "user_provider";
+		return "user";
 	}
 	if (override.provider_key_id) return "provider_key";
 	if (override.provider_id) return "provider";
@@ -167,6 +183,7 @@ export default function ScopedPricingOverridesView() {
 	const searchParams = useMemo(() => new URLSearchParams(location.searchStr), [location.searchStr]);
 
 	const [scopeKind, setScopeKind] = useState<ScopeFilter>(() => parseScopeKind(searchParams.get("scope_kind")));
+	const [userID, setUserID] = useState(() => (searchParams.get("user_id") || "").trim());
 	const [virtualKeyID, setVirtualKeyID] = useState(() => (searchParams.get("virtual_key_id") || "").trim());
 	const [providerID, setProviderID] = useState(() => (searchParams.get("provider_id") || "").trim());
 	const [providerKeyID, setProviderKeyID] = useState(() => (searchParams.get("provider_key_id") || "").trim());
@@ -177,6 +194,7 @@ export default function ScopedPricingOverridesView() {
 
 	useEffect(() => {
 		setScopeKind(parseScopeKind(searchParams.get("scope_kind")));
+		setUserID((searchParams.get("user_id") || "").trim());
 		setVirtualKeyID((searchParams.get("virtual_key_id") || "").trim());
 		setProviderID((searchParams.get("provider_id") || "").trim());
 		setProviderKeyID((searchParams.get("provider_key_id") || "").trim());
@@ -185,11 +203,12 @@ export default function ScopedPricingOverridesView() {
 	// Reset to first page when filters or search change
 	useEffect(() => {
 		setOffset(0);
-	}, [scopeKind, virtualKeyID, providerID, providerKeyID, debouncedSearch]);
+	}, [scopeKind, userID, virtualKeyID, providerID, providerKeyID, debouncedSearch]);
 
 	const queryArgs = useMemo(
 		() => ({
 			scopeKind: scopeKind === "all" ? undefined : scopeKind,
+			userID: userID || undefined,
 			virtualKeyID: virtualKeyID || undefined,
 			providerID: providerID || undefined,
 			providerKeyID: providerKeyID || undefined,
@@ -197,7 +216,7 @@ export default function ScopedPricingOverridesView() {
 			offset,
 			search: debouncedSearch || undefined,
 		}),
-		[scopeKind, virtualKeyID, providerID, providerKeyID, offset, debouncedSearch],
+		[scopeKind, userID, virtualKeyID, providerID, providerKeyID, offset, debouncedSearch],
 	);
 
 	const { data, isLoading, error } = useGetPricingOverridesQuery(queryArgs);
@@ -251,12 +270,13 @@ export default function ScopedPricingOverridesView() {
 		if (scopeKind === "all") return undefined;
 		return {
 			scopeKind,
+			userID: userID || undefined,
 			virtualKeyID: virtualKeyID || undefined,
 			providerID: providerID || undefined,
 			providerKeyID: providerKeyID || undefined,
-			label: `${scopeKind}${virtualKeyID || providerID || providerKeyID ? " (filtered)" : ""}`,
+			label: `${scopeKind}${userID || virtualKeyID || providerID || providerKeyID ? " (filtered)" : ""}`,
 		};
-	}, [scopeKind, virtualKeyID, providerID, providerKeyID]);
+	}, [scopeKind, userID, virtualKeyID, providerID, providerKeyID]);
 
 	const openCreateDrawer = () => {
 		setEditingOverride(null);
@@ -279,7 +299,7 @@ export default function ScopedPricingOverridesView() {
 		}
 	};
 
-	const hasActiveFilters = debouncedSearch || scopeKind !== "all" || virtualKeyID || providerID || providerKeyID;
+	const hasActiveFilters = debouncedSearch || scopeKind !== "all" || userID || virtualKeyID || providerID || providerKeyID;
 
 	if (!isLoading && !error && totalCount === 0 && !hasActiveFilters) {
 		return (
@@ -301,7 +321,7 @@ export default function ScopedPricingOverridesView() {
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Overrides</h2>
 					<p className="text-muted-foreground text-sm">
-						Set custom rates for any model across global or virtual key scopes, optionally narrowed to a specific provider or key
+						Set custom rates for any model across global, virtual key, or user scopes, optionally narrowed to a specific provider or key
 					</p>
 				</div>
 				<Button data-testid="pricing-override-create-btn" onClick={openCreateDrawer} className="gap-2">

--- a/ui/lib/registries/userPicker.tsx
+++ b/ui/lib/registries/userPicker.tsx
@@ -1,0 +1,36 @@
+// Runtime registry for the governance user picker.
+//
+// OSS has no user directory, so the base build registers nothing and
+// consumers (pricing overrides, routing rules) hide their "User" scope
+// options. Downstream builds (enterprise) register a picker by importing
+// their registration module via the @enterprise alias; see
+// ui/app/_fallbacks/enterprise/lib/registrations/userPicker.ts for the
+// OSS-build fallback.
+
+import type { ComponentType } from "react";
+
+export interface UserPickerProps {
+	value: string;
+	onChange: (value: string) => void;
+	disabled?: boolean;
+	// Optional fallback option to guarantee the currently-selected user is
+	// always selectable, even if it falls outside the page fetched by the
+	// picker. Callers pass the edited row's own user id when editing an
+	// existing row.
+	fallbackOption?: { value: string; label: string } | null;
+}
+
+let userPicker: ComponentType<UserPickerProps> | undefined;
+
+/**
+ * Registers (or replaces) the user picker. Intended to be called at module
+ * load, once, before the first render that reads the registry.
+ */
+export function registerUserPicker(component: ComponentType<UserPickerProps>): void {
+	userPicker = component;
+}
+
+/** Returns the registered user picker, or undefined in builds without one. */
+export function getUserPicker(): ComponentType<UserPickerProps> | undefined {
+	return userPicker;
+}

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -46,6 +46,7 @@ import { baseApi } from "./baseApi";
 
 type PricingOverrideQueryArgs = {
 	scopeKind?: string;
+	userID?: string;
 	virtualKeyID?: string;
 	providerID?: string;
 	providerKeyID?: string;
@@ -652,6 +653,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: "/governance/pricing-overrides",
 				params: {
 					scope_kind: params?.scopeKind,
+					user_id: params?.userID,
 					virtual_key_id: params?.virtualKeyID,
 					provider_id: params?.providerID,
 					provider_key_id: params?.providerKeyID,
@@ -679,6 +681,7 @@ export const governanceApi = baseApi.injectEndpoints({
 						const args: PricingOverrideQueryArgs = entry.originalArgs ?? {};
 						const matchesQuery =
 							(!args.scopeKind || args.scopeKind === created.scope_kind) &&
+							(!args.userID || args.userID === created.user_id) &&
 							(!args.virtualKeyID || args.virtualKeyID === created.virtual_key_id) &&
 							(!args.providerID || args.providerID === created.provider_id) &&
 							(!args.providerKeyID || args.providerKeyID === created.provider_key_id) &&
@@ -722,6 +725,7 @@ export const governanceApi = baseApi.injectEndpoints({
 						const args: PricingOverrideQueryArgs = entry.originalArgs ?? {};
 						const matchesQuery =
 							(!args.scopeKind || args.scopeKind === updated.scope_kind) &&
+							(!args.userID || args.userID === updated.user_id) &&
 							(!args.virtualKeyID || args.virtualKeyID === updated.virtual_key_id) &&
 							(!args.providerID || args.providerID === updated.provider_id) &&
 							(!args.providerKeyID || args.providerKeyID === updated.provider_key_id);

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -426,7 +426,10 @@ export type PricingOverrideScopeKind =
 	| "provider_key"
 	| "virtual_key"
 	| "virtual_key_provider"
-	| "virtual_key_provider_key";
+	| "virtual_key_provider_key"
+	| "user"
+	| "user_provider"
+	| "user_provider_key";
 export type PricingOverrideMatchType = "exact" | "wildcard";
 
 export interface PricingOverridePatch {
@@ -519,6 +522,7 @@ export interface PricingOverride {
 	id: string;
 	name: string;
 	scope_kind: PricingOverrideScopeKind;
+	user_id?: string;
 	virtual_key_id?: string;
 	provider_id?: string;
 	provider_key_id?: string;
@@ -534,6 +538,7 @@ export interface PricingOverride {
 export interface CreatePricingOverrideRequest {
 	name: string;
 	scope_kind: PricingOverrideScopeKind;
+	user_id?: string;
 	virtual_key_id?: string;
 	provider_id?: string;
 	provider_key_id?: string;
@@ -546,6 +551,7 @@ export interface CreatePricingOverrideRequest {
 export interface UpdatePricingOverrideRequest {
 	name?: string;
 	scope_kind?: PricingOverrideScopeKind;
+	user_id?: string;
 	virtual_key_id?: string;
 	provider_id?: string;
 	provider_key_id?: string;


### PR DESCRIPTION
## Summary

Adds user-scoped pricing overrides, allowing custom rates to be applied at the individual user level in addition to the existing global and virtual key scopes. The implementation uses a runtime registry pattern so that the user picker UI component can be injected by enterprise builds while OSS builds gracefully degrade to either a plain text input or hide the "User" scope option entirely.

## Changes

- Added `user`, `user_provider`, and `user_provider_key` to the `PricingOverrideScopeKind` type and updated all scope resolution/derivation logic to handle these new kinds.
- Added `user_id` to `PricingOverride`, `CreatePricingOverrideRequest`, and `UpdatePricingOverrideRequest` types.
- Introduced a `userPicker` runtime registry (`ui/lib/registries/userPicker.tsx`) that allows enterprise builds to register an async user picker component at module load time. OSS builds register nothing, which hides the "User" scope option unless an existing user-scoped override is being edited (in which case a plain text input is shown to preserve editability).
- Added an OSS-build fallback module (`ui/app/_fallbacks/enterprise/lib/registrations/userPicker.ts`) that compiles to a no-op, with the enterprise build replacing it with a module that registers the actual picker.
- Updated the pricing override sheet to render the `UserPicker` (or plain input fallback) when the "User" scope root is selected, with validation requiring a user ID before submission.
- Updated `ScopedPricingOverridesView` to support filtering by `user_id` via URL search params and query args.
- Updated the governance API query to pass `user_id` as a filter parameter and to match it correctly in cache invalidation logic for create and update mutations.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Navigate to the custom pricing overrides page.
2. Click "Create" to open the pricing override sheet.
3. Verify the scope dropdown shows "Global" and "Virtual key" but not "User" in an OSS build.
4. Select "Virtual key" and confirm the virtual key selector appears as before.
5. In an enterprise build (with the user picker registered), verify "User" appears in the scope dropdown and selecting it renders the user picker component.
6. In an OSS build, if editing an existing user-scoped override, verify the "User" option appears and a plain text input is shown for the user ID.
7. Attempt to submit a user-scoped override without a user ID and confirm the validation error appears.
8. Confirm that filtering the overrides list by `user_id` via URL params correctly scopes the results.

## Screenshots/Recordings

_Add before/after screenshots showing the scope dropdown with and without the "User" option, and the user picker/plain input rendered in the sheet._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

User IDs are passed as query parameters and request payload fields. No new authentication or authorization surface is introduced beyond what already exists for virtual key scoped overrides.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable