### PR TITLE
feat: add user-scoped routing rules with `user_id` CEL variable support

### DIFF
--- a/framework/configstore/tables/routingrules.go
+++ b/framework/configstore/tables/routingrules.go
@@ -28,7 +28,7 @@ type TableRoutingRule struct {
 	ParsedQuery map[string]any `gorm:"-" json:"query,omitempty"`
 
 	// Scope: where this rule applies
-	Scope   string  `gorm:"type:varchar(50);not null;uniqueIndex:idx_routing_rule_scope_name" json:"scope"` // "global" | "team" | "customer" | "virtual_key"
+	Scope   string  `gorm:"type:varchar(50);not null;uniqueIndex:idx_routing_rule_scope_name" json:"scope"` // "global" | "team" | "customer" | "virtual_key" | "user"
 	ScopeID *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_rule_scope_name" json:"scope_id"`      // nil for global, otherwise entity ID
 
 	// Chaining

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -728,6 +728,7 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 
 	routingCtx := &RoutingContext{
 		VirtualKey:               virtualKey,
+		UserID:                   bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID),
 		Provider:                 provider,
 		Model:                    model,
 		RequestType:              requestType,

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -39,6 +39,7 @@ type RoutingDecision struct {
 // Reuses existing configstore table types for VirtualKey, Team, Customer
 type RoutingContext struct {
 	VirtualKey               *configstoreTables.TableVirtualKey  // nil if no VK
+	UserID                   string                              // Resolved calling user id; empty when the request carries no user identity
 	Provider                 schemas.ModelProvider               // Current provider
 	Model                    string                              // Current model
 	RequestType              string                              // Normalized request type (e.g., "chat_completion", "embedding") from HTTP context
@@ -101,8 +102,9 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	// rules in the chain run, rather than halting with a cycle error.
 	visitedRuleIDs := map[string]struct{}{}
 
-	// Build scope chain once — it's based on the immutable VirtualKey and won't change across chain steps.
-	scopeChain := buildScopeChain(routingCtx.VirtualKey)
+	// Build scope chain once — it's based on the immutable VirtualKey and user
+	// identity and won't change across chain steps.
+	scopeChain := buildScopeChain(routingCtx.VirtualKey, routingCtx.UserID)
 
 	// Cache rules per scope upfront to avoid redundant store lookups when rules chain
 	// and we re-evaluate the scope hierarchy on subsequent steps.
@@ -350,8 +352,8 @@ func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (confi
 
 // buildScopeChain builds the scope evaluation chain based on organizational hierarchy
 // Returns scope levels in precedence order (highest to lowest)
-// VirtualKey > Team > Customer > Global
-func buildScopeChain(virtualKey *configstoreTables.TableVirtualKey) []ScopeLevel {
+// VirtualKey > User > Team > Customer > Global
+func buildScopeChain(virtualKey *configstoreTables.TableVirtualKey, userID string) []ScopeLevel {
 	var chain []ScopeLevel
 
 	// VirtualKey level (highest precedence)
@@ -360,7 +362,19 @@ func buildScopeChain(virtualKey *configstoreTables.TableVirtualKey) []ScopeLevel
 			ScopeName: "virtual_key",
 			ScopeID:   virtualKey.ID,
 		})
+	}
 
+	// User level: the resolved calling user. Independent of VK presence so
+	// session-authenticated requests without a virtual key still match
+	// user-scoped rules.
+	if userID != "" {
+		chain = append(chain, ScopeLevel{
+			ScopeName: "user",
+			ScopeID:   userID,
+		})
+	}
+
+	if virtualKey != nil {
 		// Team level
 		if virtualKey.Team != nil {
 			chain = append(chain, ScopeLevel{
@@ -476,6 +490,9 @@ func extractRoutingVariables(ctx *RoutingContext) (map[string]interface{}, error
 		variables["virtual_key_id"] = ""
 		variables["virtual_key_name"] = ""
 	}
+
+	// Resolved calling user id; empty when the request carries no user identity
+	variables["user_id"] = ctx.UserID
 
 	// Extract Team context if available (from VirtualKey)
 	if ctx.VirtualKey != nil && ctx.VirtualKey.Team != nil {
@@ -650,6 +667,7 @@ func createCELEnvironment() (*cel.Env, error) {
 		// VirtualKey/Team/Customer context
 		cel.Variable("virtual_key_id", cel.StringType),
 		cel.Variable("virtual_key_name", cel.StringType),
+		cel.Variable("user_id", cel.StringType),
 		cel.Variable("team_id", cel.StringType),
 		cel.Variable("team_name", cel.StringType),
 		cel.Variable("customer_id", cel.StringType),

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestBuildScopeChain_GlobalOnly tests scope chain with no VirtualKey
 func TestBuildScopeChain_GlobalOnly(t *testing.T) {
-	chain := buildScopeChain(nil)
+	chain := buildScopeChain(nil, "")
 
 	require.Equal(t, 1, len(chain))
 	assert.Equal(t, "global", chain[0].ScopeName)
@@ -32,7 +32,7 @@ func TestBuildScopeChain_VirtualKeyOnly(t *testing.T) {
 		Name: "test-vk",
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(vk, "")
 
 	require.Equal(t, 2, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -54,7 +54,7 @@ func TestBuildScopeChain_WithTeam(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(vk, "")
 
 	require.Equal(t, 3, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -83,7 +83,7 @@ func TestBuildScopeChain_FullHierarchy(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(vk, "")
 
 	require.Equal(t, 4, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -94,6 +94,36 @@ func TestBuildScopeChain_FullHierarchy(t *testing.T) {
 	assert.Equal(t, "cust-789", chain[2].ScopeID)
 	assert.Equal(t, "global", chain[3].ScopeName)
 	assert.Equal(t, "", chain[3].ScopeID)
+}
+
+// TestBuildScopeChain_UserOnly verifies a session-authenticated request with
+// no virtual key still gets a user level ahead of global.
+func TestBuildScopeChain_UserOnly(t *testing.T) {
+	chain := buildScopeChain(nil, "user-1")
+
+	require.Equal(t, 2, len(chain))
+	assert.Equal(t, "user", chain[0].ScopeName)
+	assert.Equal(t, "user-1", chain[0].ScopeID)
+	assert.Equal(t, "global", chain[1].ScopeName)
+}
+
+// TestBuildScopeChain_FullHierarchyWithUser verifies the user level slots
+// between virtual_key and team: VirtualKey > User > Team > Customer > Global.
+func TestBuildScopeChain_FullHierarchyWithUser(t *testing.T) {
+	customer := &configstoreTables.TableCustomer{ID: "cust-789", Name: "acme-corp"}
+	team := &configstoreTables.TableTeam{ID: "team-456", Name: "premium-team", Customer: customer}
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-123", Name: "test-vk", Team: team}
+
+	chain := buildScopeChain(vk, "user-1")
+
+	require.Equal(t, 5, len(chain))
+	assert.Equal(t, "virtual_key", chain[0].ScopeName)
+	assert.Equal(t, "vk-123", chain[0].ScopeID)
+	assert.Equal(t, "user", chain[1].ScopeName)
+	assert.Equal(t, "user-1", chain[1].ScopeID)
+	assert.Equal(t, "team", chain[2].ScopeName)
+	assert.Equal(t, "customer", chain[3].ScopeName)
+	assert.Equal(t, "global", chain[4].ScopeName)
 }
 
 // TestGetDefaultRouting tests getting default routing from context
@@ -1931,4 +1961,151 @@ func getDefaultRouting(ctx *RoutingContext) *RoutingDecision {
 		Fallbacks:     ctx.Fallbacks,
 		MatchedRuleID: "0",
 	}
+}
+
+// TestEvaluateRoutingRules_UserScopedRule verifies a user-scoped rule fires
+// only for the matching resolved user and is skipped for other users and for
+// requests carrying no user identity.
+func TestEvaluateRoutingRules_UserScopedRule(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "user-rule-1",
+		Name:          "User Rule",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "user",
+		ScopeID:  bifrost.Ptr("user-1"),
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(context.Background(), rule))
+
+	baseCtx := func(userID string) *RoutingContext {
+		return &RoutingContext{
+			Provider:    schemas.OpenAI,
+			Model:       "gpt-4o",
+			UserID:      userID,
+			Headers:     map[string]string{},
+			QueryParams: map[string]string{},
+		}
+	}
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, baseCtx("user-1"))
+	require.NoError(t, err)
+	require.NotNil(t, decision, "user-scoped rule must fire for the matching user")
+	assert.Equal(t, "user-rule-1", decision.MatchedRuleID)
+	assert.Equal(t, "azure", decision.Provider)
+
+	decision, err = engine.EvaluateRoutingRules(bgCtx, baseCtx("someone-else"))
+	require.NoError(t, err)
+	assert.Nil(t, decision, "user-scoped rule must not fire for a different user")
+
+	decision, err = engine.EvaluateRoutingRules(bgCtx, baseCtx(""))
+	require.NoError(t, err)
+	assert.Nil(t, decision, "user-scoped rule must not fire without user identity")
+}
+
+// TestEvaluateRoutingRules_VirtualKeyPreemptsUser verifies chain precedence:
+// when both a virtual_key-scoped and a user-scoped rule match, the VK rule wins.
+func TestEvaluateRoutingRules_VirtualKeyPreemptsUser(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	userRule := &configstoreTables.TableRoutingRule{
+		ID:            "user-rule",
+		Name:          "User Rule",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o-mini"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "user",
+		ScopeID:  bifrost.Ptr("user-1"),
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(context.Background(), userRule))
+
+	vkRule := &configstoreTables.TableRoutingRule{
+		ID:            "vk-rule",
+		Name:          "VK Rule",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "virtual_key",
+		ScopeID:  bifrost.Ptr("vk-123"),
+		Priority: 10,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(context.Background(), vkRule))
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, &RoutingContext{
+		VirtualKey:  &configstoreTables.TableVirtualKey{ID: "vk-123", Name: "test-vk"},
+		UserID:      "user-1",
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.Equal(t, "vk-rule", decision.MatchedRuleID,
+		"virtual_key scope must preempt user scope in the chain")
+}
+
+// TestEvaluateRoutingRules_UserIDCELVariable verifies rule CEL expressions can
+// target the resolved user via the user_id variable.
+func TestEvaluateRoutingRules_UserIDCELVariable(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	engine, err := NewRoutingEngine(store, NewMockLogger(), schemas.Ptr(10))
+	require.NoError(t, err)
+
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "cel-user-rule",
+		Name:          "CEL User Rule",
+		CelExpression: "user_id == 'user-1'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  bifrost.Ptr(true),
+		Scope:    "global",
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(context.Background(), rule))
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		UserID:      "user-1",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, decision, "user_id CEL predicate must match the resolved user")
+	assert.Equal(t, "cel-user-rule", decision.MatchedRuleID)
+
+	decision, err = engine.EvaluateRoutingRules(bgCtx, &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		UserID:      "someone-else",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, decision, "user_id CEL predicate must not match a different user")
 }

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -4740,6 +4740,7 @@ var validRoutingScopes = map[string]bool{
 	"team":        true,
 	"customer":    true,
 	"virtual_key": true,
+	"user":        true,
 }
 
 // errRoutingScopeIDNotFound marks a validateRoutingScopeID failure as a genuine
@@ -4775,6 +4776,10 @@ func (h *GovernanceHandler) validateRoutingScopeID(ctx context.Context, scope st
 			}
 			return fmt.Errorf("failed to verify customer: %w", err)
 		}
+	case "user":
+		// User ids live outside the config store (they arrive on requests via
+		// the resolved identity context), so existence cannot be verified
+		// here; the id is matched at eval time against the calling user.
 	}
 	return nil
 }
@@ -4797,7 +4802,7 @@ func validateRoutingScope(scope string) error {
 		return nil // Empty scope will default to "global" later
 	}
 	if !validRoutingScopes[scope] {
-		return fmt.Errorf("invalid scope %q: must be one of: global, team, customer, virtual_key", scope)
+		return fmt.Errorf("invalid scope %q: must be one of: global, team, customer, virtual_key, user", scope)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds `user` as a first-class routing rule scope, allowing rules to be targeted at a specific resolved calling user. This enables per-user routing policies that work independently of virtual key presence — session-authenticated requests without a virtual key can still match user-scoped rules.

## Changes

- Added `"user"` to the set of valid routing rule scopes in the config store table definition and the HTTP handler validation logic.
- Introduced `UserID` to `RoutingContext`, populated from the Bifrost context's user identity key when routing rules are applied.
- Updated `buildScopeChain` to insert a `user` scope level between `virtual_key` and `team`, establishing the precedence order: `VirtualKey > User > Team > Customer > Global`. The user level is added regardless of whether a virtual key is present, so session-authenticated requests are covered.
- Exposed `user_id` as a CEL variable in routing rule expressions, allowing global or other scoped rules to branch on the calling user's identity without requiring a dedicated user-scoped rule.
- Skipped existence validation for `user` scope IDs in `validateRoutingScopeID` since user identities are resolved at request time from the identity context rather than stored in the config store.
- Added tests covering: user-only scope chain, full hierarchy with user, user-scoped rule matching/non-matching, virtual key preempting user scope, and `user_id` CEL variable evaluation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run "TestBuildScopeChain|TestEvaluateRoutingRules_UserScoped|TestEvaluateRoutingRules_VirtualKeyPreemptsUser|TestEvaluateRoutingRules_UserIDCELVariable"
go test ./...
```

To validate end-to-end, create a routing rule with `scope: "user"` and `scope_id: "<your-user-id>"`. Issue requests with and without a matching resolved user identity and confirm the rule fires only for the matching user. Also verify that a `virtual_key`-scoped rule takes precedence over a `user`-scoped rule when both match.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

User scope IDs are matched at rule evaluation time against the resolved identity from the request context. No existence check is performed at rule creation time since user identities are not stored in the config store. Rule authors should ensure `scope_id` values correspond to valid, expected user identifiers to avoid unintended rule misses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable