### PR TITLE
feat: add user scope to routing rules with pluggable user picker registry

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1061,7 +1061,7 @@ func (s *BifrostHTTPServer) UpdateSyncConfig(ctx context.Context) error {
 	// The live model refresher reads its interval from the same framework
 	// config block, so pick up a changed (or newly disabled) value here rather
 	// than waiting for a restart.
-	s.restartLiveModelRefresher(s.backgroundCtx())
+	s.RestartLiveModelRefresher(s.backgroundCtx())
 	return s.Config.ModelCatalog.UpdateSyncConfig(ctx, pricing)
 }
 
@@ -1190,11 +1190,13 @@ func (s *BifrostHTTPServer) startLiveModelRefresher(ctx context.Context, interva
 	return cancel
 }
 
-// restartLiveModelRefresher stops any running refresher and starts a new one
+// RestartLiveModelRefresher stops any running refresher and starts a new one
 // at the currently configured interval. Called at boot and again whenever the
 // framework config changes, so a disabled-to-enabled edit (or vice versa)
-// takes effect without a restart.
-func (s *BifrostHTTPServer) restartLiveModelRefresher(ctx context.Context) {
+// takes effect without a restart. Exported so servers that replace the boot
+// path can start the refresher with its stop handle registered for the shared
+// cleanup and config-change restarts.
+func (s *BifrostHTTPServer) RestartLiveModelRefresher(ctx context.Context) {
 	s.liveModelRefresherMu.Lock()
 	defer s.liveModelRefresherMu.Unlock()
 	if s.liveModelRefresherStop != nil {
@@ -2360,7 +2362,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// Keep the live model catalog current after boot. Without this, a model an
 	// upstream starts serving mid-uptime stays invisible until a restart or a
 	// key edit, since nothing else re-fetches list-models.
-	s.restartLiveModelRefresher(s.Ctx)
+	s.RestartLiveModelRefresher(s.Ctx)
 	return nil
 }
 

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -15,6 +15,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
+import { getUserPicker } from "@/lib/registries/userPicker";
 import { getErrorMessage } from "@/lib/store";
 import { useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store/apis/governanceApi";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
@@ -35,6 +36,8 @@ import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { RuleGroupType } from "react-querybuilder";
 import { toast } from "sonner";
+// Side-effect import: registers the enterprise user picker (no-op in OSS builds).
+import "@enterprise/lib/registrations/userPicker";
 
 interface RoutingRuleDialogProps {
 	open: boolean;
@@ -117,6 +120,10 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	const chainRule = watch("chain_rule");
 	const scope = watch("scope");
 	const scopeId = watch("scope_id");
+
+	// Registered by the downstream build at module load; undefined in builds
+	// without a user directory, which hides the "User" scope option.
+	const UserPicker = getUserPicker();
 	const fallbacks = watch("fallbacks");
 
 	// Get available providers from configured providers, plus any provider already
@@ -212,7 +219,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 
 		// Validate scope_id is required when scope is not global
 		if (data.scope !== "global" && !data.scope_id?.trim()) {
-			toast.error(`${data.scope === "team" ? "Team" : data.scope === "customer" ? "Customer" : "Virtual Key"} is required`);
+			toast.error(
+				`${data.scope === "team" ? "Team" : data.scope === "customer" ? "Customer" : data.scope === "user" ? "User" : "Virtual Key"} is required`,
+			);
 			return;
 		}
 
@@ -278,9 +287,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		const submitPromise =
 			isEditing && editingRule
 				? updateRoutingRule({
-						id: editingRule.id,
-						data: payload,
-					}).unwrap()
+					id: editingRule.id,
+					data: payload,
+				}).unwrap()
 				: createRoutingRule(payload).unwrap();
 
 		submitPromise
@@ -395,6 +404,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 												{scopeOption.label}
 											</SelectItem>
 										))}
+										{(UserPicker || scope === "user") && <SelectItem value="user">User</SelectItem>}
 									</SelectContent>
 								</Select>
 							</div>
@@ -423,7 +433,8 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 						{scope !== "global" && (
 							<div className="space-y-2">
 								<Label htmlFor="scope_id">
-									{scope === "team" ? "Team" : scope === "customer" ? "Customer" : "Virtual Key"} <span className="text-red-500">*</span>
+									{scope === "team" ? "Team" : scope === "customer" ? "Customer" : scope === "user" ? "User" : "Virtual Key"}{" "}
+									<span className="text-red-500">*</span>
 								</Label>
 								{scope === "team" && teamsData.teams.length > 0 && (
 									<ComboboxSelect
@@ -452,13 +463,35 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 										noPortal
 									/>
 								)}
+								{scope === "user" &&
+									(UserPicker ? (
+										<UserPicker
+											value={scopeId || ""}
+											onChange={(value) => setValue("scope_id", value)}
+											fallbackOption={
+												editingRule?.scope === "user" && editingRule.scope_id
+													? { value: editingRule.scope_id, label: editingRule.scope_id }
+													: null
+											}
+										/>
+									) : (
+										// No user directory in this build: keep a plain input so
+										// existing user-scoped rules remain editable.
+										<Input
+											id="scope_id"
+											data-testid="routing-rule-scope-user-input"
+											placeholder="Governance user ID"
+											value={scopeId || ""}
+											onChange={(e) => setValue("scope_id", e.target.value)}
+										/>
+									))}
 								{((scope === "team" && teamsData.teams.length === 0) ||
 									(scope === "customer" && customersData.customers.length === 0) ||
 									(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
-									<p className="text-muted-foreground text-sm">
-										No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
-									</p>
-								)}
+										<p className="text-muted-foreground text-sm">
+											No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
+										</p>
+									)}
 								{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
 							</div>
 						)}

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -19,7 +19,7 @@ export interface RoutingRule {
 	cel_expression: string;
 	targets: RoutingTarget[];
 	fallbacks?: string[];
-	scope: "global" | "team" | "customer" | "virtual_key";
+	scope: "global" | "team" | "customer" | "virtual_key" | "user";
 	scope_id?: string;
 	priority: number;
 	enabled: boolean;
@@ -92,6 +92,9 @@ export enum RoutingRuleScope {
 	Team = "team",
 	Customer = "customer",
 	VirtualKey = "virtual_key",
+	// Not part of ROUTING_RULE_SCOPES: the sheet offers it only when a user
+	// picker is registered (builds with a user directory).
+	User = "user",
 }
 
 export const ROUTING_RULE_SCOPES = [

--- a/ui/lib/utils/labels.ts
+++ b/ui/lib/utils/labels.ts
@@ -15,6 +15,7 @@ export function getScopeLabel(scope: string): string {
 	const legacy: Record<string, string> = {
 		team: "Team",
 		customer: "Customer",
+		user: "User",
 	};
 	return legacy[scope] || scope;
 }


### PR DESCRIPTION
## Summary

Adds a `user` scope to routing rules, allowing rules to be targeted at individual users. The "User" scope option is only surfaced in the UI when a user picker component is registered (i.e., in enterprise/builds with a user directory). In OSS builds, the option is hidden, but existing user-scoped rules remain editable via a plain text input fallback.

## Changes

- Added `"user"` to the `RoutingRule` scope type union and introduced `RoutingRuleScope.User` enum value.
- The "User" `SelectItem` is conditionally rendered in the scope dropdown only when a `UserPicker` component is registered or the rule already has a `user` scope.
- When `scope === "user"`, the sheet renders the registered `UserPicker` if available, or falls back to a plain `Input` accepting a governance user ID directly.
- Validation and label logic updated to handle the `user` scope alongside existing scopes.
- `getScopeLabel` updated to return `"User"` for the `user` scope string.
- The enterprise user picker registration is imported as a side-effect, making it a no-op in OSS builds.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. In an OSS build, open the routing rules sheet and confirm the "User" scope option does not appear in the dropdown.
2. In an enterprise build with a user directory registered, open the routing rules sheet and confirm the "User" scope option appears and renders the user picker component.
3. Create a routing rule with `scope: "user"` and a valid user ID, and confirm it saves and displays correctly.
4. Load an existing user-scoped rule in an OSS build and confirm the plain text input is rendered and the rule remains editable.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

User IDs entered via the plain text fallback input are not validated against a directory. Operators should ensure only trusted users can create or edit routing rules.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable