### PR TITLE
fix: vllm stream truncation

### DIFF
--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -770,7 +770,7 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 			// already reported (the read-error path sets the indicator) or when the
 			// provider at least sent [DONE].
 			if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); !ended && !providerUtils.SSEStreamEndedOnMarker(sseReader) {
-				providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, body.Bytes())
+				providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, nil)
 			}
 		}()
 


### PR DESCRIPTION
## Summary

Fixes an issue in the vLLM provider's `TranscriptionStream` where a non-nil byte buffer was being passed to `SendStreamTruncatedError` when a stream is detected as truncated. Passing `nil` instead ensures consistent behavior and avoids potentially sending stale or partial buffer contents as part of the truncation error.

## Changes

- In the truncation detection path of `TranscriptionStream`, the `body.Bytes()` argument passed to `SendStreamTruncatedError` is replaced with `nil`, aligning with the intended contract for that error path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a transcription stream request against a vLLM backend that terminates without sending `[DONE]` and verify that the truncation error is surfaced correctly without any partial body data being included.

```sh
go test ./core/providers/vllm/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The change removes the forwarding of potentially partial response body bytes in an error path, which reduces the risk of leaking incomplete data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable