### PR TITLE
feat: add `CopyableId` component to customer, team, and virtual key detail sheets

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/user-groups/sheets/customerDetailSheet.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/sheets/customerDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { CopyableId } from "@/components/copyableId";
 import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { resetDurationLabels } from "@/lib/constants/governance";
@@ -97,7 +98,10 @@ export function CustomerDetailSheet({ customer, open, onOpenChange }: Props) {
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="max-w-[700px] overflow-y-auto p-0 pt-4">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 px-8 sticky -top-4 bg-card z-10">
-					<SheetTitle className="text-lg">{customer?.name || "Customer Details"}</SheetTitle>
+					<div className="flex min-w-0 items-center gap-1">
+						<SheetTitle className="truncate text-lg">{customer?.name || "Customer Details"}</SheetTitle>
+						{customer?.id && <CopyableId id={customer.id} entityLabel="Customer" />}
+					</div>
 					<SheetDescription>Usage details for this customer.</SheetDescription>
 				</SheetHeader>
 

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -8,6 +8,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { CopyableId } from "@/components/copyableId";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -274,7 +275,10 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="max-w-[900px] p-0 pt-4 sm:max-w-2xl" data-testid="customer-dialog-content">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Customer" : "Create Customer"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">
+						{isEditing ? "Edit Customer" : "Create Customer"}
+						{customer?.id && <CopyableId id={customer.id} entityLabel="Customer" />}
+					</SheetTitle>
 					<SheetDescription>
 						{isEditing
 							? "Update the customer information and settings."

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -9,6 +9,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { CopyableId } from "@/components/copyableId";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -320,7 +321,10 @@ export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 				onEscapeKeyDown={() => onCancel()}
 			>
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Create Team"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">
+						{isEditing ? "Edit Team" : "Create Team"}
+						{team?.id && <CopyableId id={team.id} entityLabel="Team" />}
+					</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the team information and settings." : "Create a new team to organize users and manage shared resources."}
 					</SheetDescription>

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -1,4 +1,5 @@
 import { BudgetOverrideDialog } from "@/components/budgetOverrideDialog";
+import { CopyableId } from "@/components/copyableId";
 import { SheetNavigationButtons } from "@/components/sheetNavigationButtons";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -120,8 +121,11 @@ export default function VirtualKeyDetailSheet({
 					className="flex flex-row items-center justify-between px-0 py-4"
 					headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8"
 				>
-					<div className="flex flex-col items-start">
-						<SheetTitle>{virtualKey.name}</SheetTitle>
+					<div className="flex min-w-0 flex-col items-start">
+						<div className="flex min-w-0 items-center gap-1">
+							<SheetTitle className="truncate">{virtualKey.name}</SheetTitle>
+							<CopyableId id={virtualKey.id} entityLabel="Virtual key" />
+						</div>
 						<SheetDescription>{virtualKey.description || "Virtual key details and usage information"}</SheetDescription>
 					</div>
 					<SheetNavigationButtons
@@ -226,8 +230,7 @@ export default function VirtualKeyDetailSheet({
 													<span className="font-medium">{ProviderLabels[config.provider as ProviderName] || config.provider}</span>
 												</div>
 												<Badge variant="outline" className="font-mono text-xs">
-													Weight:{" "}
-													{config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
+													Weight: {config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
 												</Badge>
 											</div>
 

--- a/ui/components/copyableId.tsx
+++ b/ui/components/copyableId.tsx
@@ -1,0 +1,50 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { cn } from "@/lib/utils";
+import { Check, Copy } from "lucide-react";
+
+interface CopyableIdProps {
+	id: string | number;
+	/** Entity name used in the toast, tooltip, and aria-label, e.g. "Team" -> "Copy team ID". */
+	entityLabel?: string;
+	className?: string;
+}
+
+/**
+ * Icon-only click-to-copy control for an entity id, sized to sit inline beside a
+ * sheet title. The full id lives in the tooltip so it never competes with the name.
+ */
+export function CopyableId({ id, entityLabel, className }: CopyableIdProps) {
+	const value = String(id ?? "");
+	const noun = entityLabel ? `${entityLabel.toLowerCase()} ID` : "ID";
+	const { copy, copied } = useCopyToClipboard({
+		successMessage: `${entityLabel ? `${entityLabel} ID` : "ID"} copied`,
+	});
+
+	if (!value) return null;
+
+	return (
+		<Tooltip delayDuration={0}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						copy(value);
+					}}
+					aria-label={`Copy ${noun}`}
+					className={cn(
+						"text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded transition-colors",
+						className,
+					)}
+				>
+					{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="flex flex-col items-start gap-0.5 px-2 py-1">
+				<span className="text-xs">Copy {noun}</span>
+				<span className="font-mono text-xs opacity-80">{value}</span>
+			</TooltipContent>
+		</Tooltip>
+	);
+}


### PR DESCRIPTION
## Summary

Adds a reusable `CopyableId` component that lets users copy entity IDs directly from sheet headers. This makes it easier to grab IDs for customers, teams, and virtual keys without needing to dig through network requests or other tooling.

## Changes

- Introduces `CopyableId`, an icon-only click-to-copy button that displays the full ID in a tooltip and shows a checkmark on successful copy. It is sized to sit inline beside sheet titles without competing visually with the entity name.
- Adds `CopyableId` to the Customer detail sheet (fallback), Customer sheet, Team sheet, and Virtual Key detail sheet — appearing only when an ID is present.
- Wraps sheet titles that now share a row with `CopyableId` in a flex container with `min-w-0` and `truncate` to prevent overflow when names are long.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open any Customer, Team, or Virtual Key sheet for an existing entity.
2. Verify a small copy icon appears inline next to the entity name in the sheet header.
3. Hover over the icon — the tooltip should display "Copy [entity] ID" and the ID value.
4. Click the icon — the ID should be copied to the clipboard and the icon should briefly change to a checkmark.
5. Confirm the icon does not appear when creating a new entity (no ID yet).

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots showing the copy icon in the sheet header._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No sensitive data is introduced. The copied value is the entity ID, which is already visible to the authenticated user viewing the sheet.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable