### PR TITLE
fix: convert strict null to false for sdk compatibility

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -315,17 +315,23 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			}
 		}
 
-		// Normalize function tool parameters for deterministic JSON serialization.
+		// Normalize function tool parameters for deterministic JSON serialization, and
+		// default a nil strict to false — OpenAI resolves null to false anyway, while
+		// strict-pydantic upstreams (e.g. sglang) reject the explicit null outright.
 		// We must copy the Tools slice since it shares the backing array with bifrostReq.Params.Tools.
 		if len(req.Tools) > 0 {
 			normalizedTools := make([]schemas.ResponsesTool, len(req.Tools))
 			copy(normalizedTools, req.Tools)
 			for i, tool := range normalizedTools {
 				if tool.Type == schemas.ResponsesToolTypeFunction &&
-					tool.ResponsesToolFunction != nil &&
-					tool.ResponsesToolFunction.Parameters != nil {
+					tool.ResponsesToolFunction != nil {
 					funcCopy := *tool.ResponsesToolFunction
-					funcCopy.Parameters = tool.ResponsesToolFunction.Parameters.Normalized()
+					if funcCopy.Parameters != nil {
+						funcCopy.Parameters = funcCopy.Parameters.Normalized()
+					}
+					if funcCopy.Strict == nil {
+						funcCopy.Strict = new(false)
+					}
 					normalizedTools[i].ResponsesToolFunction = &funcCopy
 				}
 			}

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -2245,6 +2245,66 @@ func TestToOpenAIResponsesRequest_DefaultsImageDetail(t *testing.T) {
 	}
 }
 
+// TestToOpenAIResponsesRequest_DefaultsStrictOnFunctionTools verifies function tools
+// leave with an explicit strict rather than null. OpenAI resolves a null strict to
+// false, but strict-pydantic upstreams (sglang's ResponseTool.strict is a non-Optional
+// bool) reject the null with a bool_type validation error. Explicit caller values are
+// preserved and the caller's tools are never mutated.
+func TestToOpenAIResponsesRequest_DefaultsStrictOnFunctionTools(t *testing.T) {
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Model: "glm-5.2",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{
+					Type: schemas.ResponsesToolTypeFunction,
+					Name: schemas.Ptr("Bash"),
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{
+						Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+					},
+				},
+				{
+					Type: schemas.ResponsesToolTypeFunction,
+					Name: schemas.Ptr("Grep"),
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{
+						Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+						Strict:     schemas.Ptr(true),
+					},
+				},
+			},
+		},
+	}
+
+	req := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if req == nil {
+		t.Fatal("converted request is nil")
+	}
+
+	if req.Tools[0].ResponsesToolFunction.Strict == nil || *req.Tools[0].ResponsesToolFunction.Strict {
+		t.Errorf("nil strict not defaulted to false: %v", req.Tools[0].ResponsesToolFunction.Strict)
+	}
+	if req.Tools[1].ResponsesToolFunction.Strict == nil || !*req.Tools[1].ResponsesToolFunction.Strict {
+		t.Errorf("explicit strict not preserved: %v", req.Tools[1].ResponsesToolFunction.Strict)
+	}
+
+	// Wire-level: no tool may carry a null strict.
+	data, err := sonic.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal converted request: %v", err)
+	}
+	if strings.Contains(string(data), `"strict":null`) {
+		t.Errorf("wire JSON carries a null strict: %s", data)
+	}
+
+	// Caller's tools must remain untouched.
+	if bifrostReq.Params.Tools[0].ResponsesToolFunction.Strict != nil {
+		t.Error("caller's tools were mutated")
+	}
+}
+
 // TestToOpenAIResponsesRequest_FallbackBlockDropped verifies that Anthropic's
 // server-side fallback boundary marker never reaches OpenAI. Unlike a compaction
 // block (which is promoted to text), it carries no user content, so it is dropped.


### PR DESCRIPTION
## Summary

Function tools with a `nil` `strict` field were being serialized as `"strict": null` in the wire JSON. OpenAI silently resolves `null` to `false`, but strict-pydantic upstreams such as sglang define `strict` as a non-optional `bool` and reject the explicit `null` with a validation error. This PR defaults a `nil` strict to `false` before serialization, while preserving any explicitly set caller value and ensuring the caller's original tools slice is never mutated.

## Changes

- When converting function tools in `ToOpenAIResponsesRequest`, a `nil` `Strict` field is now defaulted to `false` (via a new `bool` pointer) so the wire JSON always carries an explicit boolean rather than `null`.
- The parameter normalization block was restructured so that a function tool with `nil` parameters still receives the `Strict` defaulting — previously the entire copy was skipped if `Parameters` was `nil`.
- A test (`TestToOpenAIResponsesRequest_DefaultsStrictOnFunctionTools`) was added to verify: `nil` strict is defaulted to `false`, explicitly set values are preserved, the wire JSON never contains `"strict":null`, and the caller's original tools are not mutated.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_DefaultsStrictOnFunctionTools -v
go test ./...
```

The new test validates three things:
1. A tool with no `strict` set serializes with `"strict": false` (not `null`).
2. A tool with `strict: true` retains that value.
3. The original `bifrostReq.Params.Tools` slice is not modified.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable