### PR TITLE
fix: copy url for skills repo marketplace fix

### DIFF
--- a/ui/app/workspace/skills-repo/components/skillListView.tsx
+++ b/ui/app/workspace/skills-repo/components/skillListView.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/lib/store/apis/skillsApi";
 import { AllSkillsVersionBump, SkillListItem } from "@/lib/types/skills";
 import { cn } from "@/lib/utils";
-import { getApiBaseUrl } from "@/lib/utils/port";
+import { getApiBaseUrl, getExampleBaseUrl } from "@/lib/utils/port";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import {
 	ArrowDown,
@@ -63,7 +63,7 @@ const SKILLS_REPOSITORY_DOCS_URL = "https://docs.getbifrost.ai/features/skills-r
 function MarketplacePopover() {
 	const [copiedKey, setCopiedKey] = useState<string | null>(null);
 	const [open, setOpen] = useState(false);
-	const marketplaceBaseUrl = getApiBaseUrl();
+	const marketplaceBaseUrl = `${getExampleBaseUrl()}/api`;
 
 	const items = [
 		{


### PR DESCRIPTION
## Summary

The marketplace base URL in the Skills Repository was incorrectly using the API
base URL instead of the example base URL. This fixes the URL construction so the
marketplace popover references the correct endpoint.

## Changes

- Replaced `getApiBaseUrl()` with `` `${getExampleBaseUrl()}/api` `` for
  `marketplaceBaseUrl` in `MarketplacePopover`, ensuring the marketplace URL is
  derived from the example base URL rather than the API base URL.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Skills Repository in the workspace.
2. Open the Marketplace popover.
3. Verify that the displayed or copied marketplace URL correctly reflects the
   example base URL with `/api` appended, rather than the standalone API base
   URL.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
