### PR TITLE
fix: bedrock mantle set structured outputs to false for claude models

### DIFF
--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -133,6 +133,9 @@ const (
 //	     https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
 //	Advisor-excl = Advisor tool Claude-API-only:
 //	     https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
+//	SO-mantle-excl = Structured outputs unsupported on the bedrock-mantle
+//	     Messages API, per the "Supported APIs or features" table:
+//	     https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html
 type ProviderFeatureSupport struct {
 	WebSearch              bool // web_search server tool (cite: A)
 	WebSearchNova          bool // web_search via nova_grounding — Bedrock Responses path only, not Chat/Converse
@@ -266,10 +269,17 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	// code_interpreter tool that the endpoint rejects. Mantle's native surface
 	// does not support the Anthropic web_search / code_execution server tools
 	// either, so both stay false (no WebSearch / CodeExecution).
+	//
+	// StructuredOutputs is OFF (cite: SO-mantle-excl). AWS marks the whole
+	// feature unsupported on this endpoint — both output_config.format (which is
+	// why ToAnthropicChat/ResponsesRequest route this provider through the
+	// synthetic bf_so_* tool) and strict tool use, which 400s with
+	// "tools.0.custom.strict: Extra inputs are not permitted". Structured
+	// outputs on AWS require Converse/InvokeModel on bedrock-runtime, i.e.
+	// schemas.Bedrock, which keeps the flag on.
 	schemas.BedrockMantle: {
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		ContainerBasic:         true,
-		StructuredOutputs:      true,
 		Compaction:             true,
 		ContextEditing:         true,
 		ContextManagementField: true,

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1275,6 +1275,13 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("BedrockMantle/drops_structured_outputs_header", func(t *testing.T) {
+		result := FilterBetaHeadersForProvider([]string{AnthropicStructuredOutputsBetaHeader}, schemas.BedrockMantle)
+		if len(result) != 0 {
+			t.Errorf("expected %q to be dropped for Bedrock Mantle, got %v", AnthropicStructuredOutputsBetaHeader, result)
+		}
+	})
+
 	t.Run("Azure/drops_unsupported_headers", func(t *testing.T) {
 		unsupported := []string{
 			AnthropicFastModeBetaHeader,
@@ -1631,6 +1638,26 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 		}
 	})
 
+	t.Run("bedrock_mantle_strips_strict_keeps_input_examples", func(t *testing.T) {
+		// Mantle's native Anthropic surface rejects the structured-outputs beta:
+		// tools[].strict 400s with "tools.0.custom.strict: Extra inputs are not
+		// permitted". input_examples (tool-examples-2025-10-29) is unaffected.
+		input := []byte(`{
+			"model":"claude-opus-4-8",
+			"tools":[{"name":"t1","strict":false,"input_examples":[{"input":{"a":1}}]}]
+		}`)
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.BedrockMantle, "claude-opus-4-8")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if providerUtils.JSONFieldExists(result, "tools.0.strict") {
+			t.Errorf("expected tools[0].strict to be stripped for Bedrock Mantle, got: %s", string(result))
+		}
+		if !providerUtils.JSONFieldExists(result, "tools.0.input_examples") {
+			t.Errorf("expected tools[0].input_examples to survive on Bedrock Mantle, got: %s", string(result))
+		}
+	})
+
 	t.Run("bedrock_keeps_input_examples_via_standalone_flag", func(t *testing.T) {
 		// Bedrock has InputExamples=true via tool-examples-2025-10-29 but
 		// AdvancedToolUse=false. input_examples should be KEPT; defer_loading
@@ -1865,6 +1892,39 @@ func TestStripUnsupportedAnthropicFields_ContainerSkillsGating(t *testing.T) {
 		}
 		if req.Container.ContainerObject.Skills == nil {
 			t.Errorf("expected empty skills preserved on Skills=true provider (not nilled)")
+		}
+	})
+}
+
+// TestStripUnsupportedAnthropicFields_StrictGating covers the typed path for
+// tools[].strict. Mantle's native Anthropic surface rejects the field outright
+// ("tools.0.custom.strict: Extra inputs are not permitted"), including the
+// strict:false the AI SDK emits, so both values must be cleared there.
+func TestStripUnsupportedAnthropicFields_StrictGating(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		t.Run(fmt.Sprintf("bedrock_mantle_strips_strict_%t", strict), func(t *testing.T) {
+			req := &AnthropicMessageRequest{
+				Model: "claude-opus-4-8",
+				Tools: []AnthropicTool{{Name: "t1", Strict: schemas.Ptr(strict)}},
+			}
+			stripUnsupportedAnthropicFields(req, schemas.BedrockMantle, "claude-opus-4-8")
+			if req.Tools[0].Strict != nil {
+				t.Errorf("expected strict cleared for Bedrock Mantle, got %v", *req.Tools[0].Strict)
+			}
+			if req.Tools[0].Name != "t1" {
+				t.Errorf("expected tool otherwise untouched, got %+v", req.Tools[0])
+			}
+		})
+	}
+
+	t.Run("anthropic_keeps_strict", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-opus-4-8",
+			Tools: []AnthropicTool{{Name: "t1", Strict: schemas.Ptr(true)}},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Anthropic, "claude-opus-4-8")
+		if req.Tools[0].Strict == nil || !*req.Tools[0].Strict {
+			t.Errorf("expected strict preserved on StructuredOutputs=true provider, got %v", req.Tools[0].Strict)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

AWS Bedrock Mantle's native Anthropic Messages API surface does not support structured outputs. The `tools[].strict` field causes a 400 error (`tools.0.custom.strict: Extra inputs are not permitted`), and the `output_config.format` path is similarly unsupported. This PR disables `StructuredOutputs` for `schemas.BedrockMantle` and ensures the `strict` field is stripped from tool definitions before requests are sent to that endpoint.

## Changes

- `StructuredOutputs` is set to `false` for `schemas.BedrockMantle` in `ProviderFeatures`, with a citation (`SO-mantle-excl`) referencing the AWS Bedrock structured output support table.
- `StripUnsupportedFieldsFromRawBody` and `stripUnsupportedAnthropicFields` now strip `tools[].strict` (both `true` and `false` values) for Bedrock Mantle, since the field is rejected outright regardless of value.
- The `AnthropicStructuredOutputsBetaHeader` is dropped for Bedrock Mantle via `FilterBetaHeadersForProvider`.
- `input_examples` (from the `tool-examples-2025-10-29` beta) is intentionally preserved on Bedrock Mantle, as it is unaffected by this restriction.
- Tests cover: the beta header being dropped, `strict` being stripped in both the raw-body and typed paths, `input_examples` surviving, and `strict` being preserved on providers that do support structured outputs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
```

Verify that:
- `BedrockMantle/drops_structured_outputs_header` passes — the structured outputs beta header is not forwarded.
- `bedrock_mantle_strips_strict_keeps_input_examples` passes — `tools[].strict` is removed and `tools[].input_examples` is retained.
- `TestStripUnsupportedAnthropicFields_StrictGating` passes — `strict` is cleared for Bedrock Mantle for both `true` and `false` values, and preserved for `schemas.Anthropic`.

## Breaking changes

- [x] No

Requests to Bedrock Mantle that previously included `tools[].strict` or the structured outputs beta header will now have those fields silently stripped rather than forwarded (where they would cause a 400).

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable