### PR TITLE
fix: merge additional tools into tools for bedrock mantle

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -35,6 +35,51 @@ func (resp *OpenAIResponsesRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	}
 }
 
+// ResponsesFeatureSupport describes which OpenAI Responses wire extensions an
+// OpenAI-compatible backend accepts. Providers absent from ProviderFeatures keep
+// everything (safe default for custom providers), matching the Anthropic matrix.
+type ResponsesFeatureSupport struct {
+	// AdditionalToolsItem reports whether the backend accepts codex
+	// `additional_tools` input items; when false their tools are hoisted into
+	// the top-level tools param instead.
+	AdditionalToolsItem bool
+}
+
+// ProviderFeatures maps each OpenAI-compatible provider to its supported
+// Responses wire extensions. Only providers with a known deviation are listed.
+var ProviderFeatures = map[schemas.ModelProvider]ResponsesFeatureSupport{
+	schemas.OpenAI: {AdditionalToolsItem: true},
+	// Bedrock Mantle validates `input` against the standard union and rejects
+	// additional_tools with "Invalid 'input': value did not match any expected
+	// variant", but accepts the same tools at the top level.
+	schemas.Bedrock:       {AdditionalToolsItem: false},
+	schemas.BedrockMantle: {AdditionalToolsItem: false},
+}
+
+// supportsAdditionalToolsItem reports whether provider accepts codex
+// additional_tools input items. Unlisted providers are assumed to.
+func supportsAdditionalToolsItem(provider schemas.ModelProvider) bool {
+	features, ok := ProviderFeatures[provider]
+	if !ok {
+		return true
+	}
+	return features.AdditionalToolsItem
+}
+
+// hoistAdditionalTools decodes the tools carried by a codex additional_tools item.
+// The entries are ResponsesTool-shaped but live in the item's preserved raw bytes,
+// so they are decoded here rather than read off the typed message.
+func hoistAdditionalTools(message schemas.ResponsesMessage) []schemas.ResponsesTool {
+	if len(message.AdditionalTools) == 0 {
+		return nil
+	}
+	var tools []schemas.ResponsesTool
+	if err := schemas.Unmarshal(message.AdditionalTools, &tools); err != nil {
+		return nil
+	}
+	return tools
+}
+
 // ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
 func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
@@ -49,7 +94,15 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 	// OpenAI also doesn't support compaction content blocks, so we need to convert them to text blocks,
 	// nor Anthropic's server-side fallback boundary markers, which are dropped outright.
 	messages = make([]schemas.ResponsesMessage, 0, len(bifrostReq.Input))
+	// Tools lifted out of codex additional_tools items for providers that reject them.
+	var hoistedTools []schemas.ResponsesTool
+	keepAdditionalTools := supportsAdditionalToolsItem(bifrostReq.Provider)
 	for _, message := range bifrostReq.Input {
+		if !keepAdditionalTools && message.Type != nil &&
+			*message.Type == schemas.ResponsesMessageTypeAdditionalTools {
+			hoistedTools = append(hoistedTools, hoistAdditionalTools(message)...)
+			continue
+		}
 		// First, check if message has compaction/fallback content blocks and rewrite them
 		if message.Content != nil && len(message.Content.ContentBlocks) > 0 {
 			needsRewrite := false
@@ -314,33 +367,40 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 				req.ResponsesParameters.TopP = nil
 			}
 		}
-
-		// Normalize function tool parameters for deterministic JSON serialization, and
-		// default a nil strict to false — OpenAI resolves null to false anyway, while
-		// strict-pydantic upstreams (e.g. sglang) reject the explicit null outright.
-		// We must copy the Tools slice since it shares the backing array with bifrostReq.Params.Tools.
-		if len(req.Tools) > 0 {
-			normalizedTools := make([]schemas.ResponsesTool, len(req.Tools))
-			copy(normalizedTools, req.Tools)
-			for i, tool := range normalizedTools {
-				if tool.Type == schemas.ResponsesToolTypeFunction &&
-					tool.ResponsesToolFunction != nil {
-					funcCopy := *tool.ResponsesToolFunction
-					if funcCopy.Parameters != nil {
-						funcCopy.Parameters = funcCopy.Parameters.Normalized()
-					}
-					if funcCopy.Strict == nil {
-						funcCopy.Strict = new(false)
-					}
-					normalizedTools[i].ResponsesToolFunction = &funcCopy
-				}
-			}
-			req.Tools = normalizedTools
-		}
-
-		// Filter out tools that OpenAI doesn't support
-		req.filterUnsupportedTools()
 	}
+
+	// Append tools hoisted out of additional_tools items. Runs after the params
+	// assignment above, which would otherwise clobber Tools, and before the
+	// normalization below so hoisted function tools get the same treatment.
+	if len(hoistedTools) > 0 {
+		req.Tools = append(append(make([]schemas.ResponsesTool, 0, len(req.Tools)+len(hoistedTools)), req.Tools...), hoistedTools...)
+	}
+
+	// Normalize function tool parameters for deterministic JSON serialization, and
+	// default a nil strict to false — OpenAI resolves null to false anyway, while
+	// strict-pydantic upstreams (e.g. sglang) reject the explicit null outright.
+	// We must copy the Tools slice since it shares the backing array with bifrostReq.Params.Tools.
+	if len(req.Tools) > 0 {
+		normalizedTools := make([]schemas.ResponsesTool, len(req.Tools))
+		copy(normalizedTools, req.Tools)
+		for i, tool := range normalizedTools {
+			if tool.Type == schemas.ResponsesToolTypeFunction &&
+				tool.ResponsesToolFunction != nil {
+				funcCopy := *tool.ResponsesToolFunction
+				if funcCopy.Parameters != nil {
+					funcCopy.Parameters = funcCopy.Parameters.Normalized()
+				}
+				if funcCopy.Strict == nil {
+					funcCopy.Strict = new(false)
+				}
+				normalizedTools[i].ResponsesToolFunction = &funcCopy
+			}
+		}
+		req.Tools = normalizedTools
+	}
+
+	// Filter out tools that OpenAI doesn't support
+	req.filterUnsupportedTools()
 
 	if bifrostReq.Params != nil {
 		req.ExtraParams = bifrostReq.Params.ExtraParams

--- a/core/providers/openai/tool_search_roundtrip_test.go
+++ b/core/providers/openai/tool_search_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/tidwall/gjson"
 )
 
@@ -100,4 +101,112 @@ func TestResponsesInputRoundTripsAdditionalToolsItems(t *testing.T) {
 		t.Fatalf("plain user message broke: %q", got)
 	}
 	t.Logf("round-trip OK:\n%s", out)
+}
+
+// codexAdditionalToolsInput is the shape codex sends on its first request for
+// code-mode models: every tool it owns is declared inside the input array.
+const codexAdditionalToolsInput = `[
+	{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec","description":"Run JavaScript","format":{"type":"grammar","syntax":"lark","definition":"start: pragma_source"}},{"type":"function","name":"wait","description":"Waits on a cell","parameters":{"type":"object","properties":{"cell_id":{"type":"string"}},"required":["cell_id"],"additionalProperties":false}},{"type":"namespace","name":"collaboration","description":"Sub-agent tools","tools":[{"type":"function","name":"spawn_agent","description":"Spawn an agent","parameters":{"type":"object","properties":{"task_name":{"type":"string"}},"required":["task_name"]}}]}]},
+	{"role":"user","content":[{"type":"input_text","text":"Reply exactly with OK."}]}
+]`
+
+func codexAdditionalToolsRequest(t *testing.T, provider schemas.ModelProvider) []byte {
+	t.Helper()
+
+	var input OpenAIResponsesRequestInput
+	if err := input.UnmarshalJSON([]byte(codexAdditionalToolsInput)); err != nil {
+		t.Fatalf("unmarshal input: %v", err)
+	}
+
+	req := ToOpenAIResponsesRequest(nil, &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    "gpt-5.6-sol",
+		Input:    input.OpenAIResponsesRequestInputArray,
+	})
+	if req == nil {
+		t.Fatal("ToOpenAIResponsesRequest returned nil")
+	}
+	out, err := req.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	return out
+}
+
+// TestBedrockMantleHoistsAdditionalTools verifies that codex `additional_tools`
+// items are lifted into the top-level tools param for Bedrock Mantle, which
+// rejects the item type with "Invalid 'input': value did not match any expected
+// variant", and that the nested tool shapes survive the hoist intact.
+func TestBedrockMantleHoistsAdditionalTools(t *testing.T) {
+	for _, provider := range []schemas.ModelProvider{schemas.Bedrock, schemas.BedrockMantle} {
+		t.Run(string(provider), func(t *testing.T) {
+			out := codexAdditionalToolsRequest(t, provider)
+
+			// The rejected item must be gone, leaving only the user message.
+			if got := gjson.GetBytes(out, "input.#").Int(); got != 1 {
+				t.Fatalf("expected 1 input item after hoist, got %d: %s", got, gjson.GetBytes(out, "input").Raw)
+			}
+			if got := gjson.GetBytes(out, "input.0.role").String(); got != "user" {
+				t.Fatalf("wrong item survived: %s", gjson.GetBytes(out, "input.0").Raw)
+			}
+
+			// All three tools must land at the top level with their discriminators.
+			if got := gjson.GetBytes(out, "tools.#").Int(); got != 3 {
+				t.Fatalf("expected 3 hoisted tools, got %d: %s", got, gjson.GetBytes(out, "tools").Raw)
+			}
+			for i, want := range []string{"custom", "function", "namespace"} {
+				if got := gjson.GetBytes(out, fmt.Sprintf("tools.%d.type", i)).String(); got != want {
+					t.Fatalf("tools[%d].type = %q, want %q (full: %s)", i, got, want, gjson.GetBytes(out, "tools").Raw)
+				}
+			}
+			// The custom tool's lark grammar must survive.
+			if got := gjson.GetBytes(out, "tools.0.format.syntax").String(); got != "lark" {
+				t.Fatalf("custom tool grammar lost: %s", gjson.GetBytes(out, "tools.0").Raw)
+			}
+			// Function parameters must survive, and strict must be false, not null —
+			// strict-pydantic upstreams reject an explicit null.
+			if !gjson.GetBytes(out, "tools.1.parameters").IsObject() {
+				t.Fatalf("function parameters lost: %s", gjson.GetBytes(out, "tools.1").Raw)
+			}
+			if got := gjson.GetBytes(out, "tools.1.strict"); got.Type != gjson.False {
+				t.Fatalf("hoisted function strict = %s, want false", got.Raw)
+			}
+			// The namespace's nested tool list must survive.
+			if got := gjson.GetBytes(out, "tools.2.tools.#").Int(); got != 1 {
+				t.Fatalf("namespace nested tools lost: %s", gjson.GetBytes(out, "tools.2").Raw)
+			}
+		})
+	}
+}
+
+// TestOpenAIKeepsAdditionalToolsItem guards the native path: OpenAI accepts the
+// item, so it must stay in input verbatim and must not be hoisted.
+func TestOpenAIKeepsAdditionalToolsItem(t *testing.T) {
+	out := codexAdditionalToolsRequest(t, schemas.OpenAI)
+
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 2 {
+		t.Fatalf("expected 2 input items, got %d: %s", got, gjson.GetBytes(out, "input").Raw)
+	}
+	if got := gjson.GetBytes(out, "input.0.type").String(); got != "additional_tools" {
+		t.Fatalf("additional_tools item not preserved: %s", gjson.GetBytes(out, "input.0").Raw)
+	}
+	if got := gjson.GetBytes(out, "input.0.tools.#").Int(); got != 3 {
+		t.Fatalf("nested tools not preserved verbatim: %s", gjson.GetBytes(out, "input.0").Raw)
+	}
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("tools must not be hoisted for OpenAI: %s", gjson.GetBytes(out, "tools").Raw)
+	}
+}
+
+// TestUnlistedProviderKeepsAdditionalToolsItem verifies the fail-open default:
+// providers absent from ProviderFeatures are left untouched.
+func TestUnlistedProviderKeepsAdditionalToolsItem(t *testing.T) {
+	out := codexAdditionalToolsRequest(t, schemas.Groq)
+
+	if got := gjson.GetBytes(out, "input.#").Int(); got != 2 {
+		t.Fatalf("expected 2 input items for unlisted provider, got %d", got)
+	}
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("unlisted provider must not hoist: %s", gjson.GetBytes(out, "tools").Raw)
+	}
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1235,6 +1235,10 @@ type ResponsesMessage struct {
 	// not ResponsesMCPListTools.Tools, because the entries are ResponsesTool-shaped.
 	ToolSearchOutputTools json.RawMessage `json:"-"`
 
+	// Tools declared by a codex additional_tools item, surfaced so providers that
+	// reject the item type can hoist them into the top-level tools param.
+	AdditionalTools json.RawMessage `json:"-"`
+
 	*ResponsesToolMessage // For Tool calls and outputs
 
 	CacheControl *CacheControl `json:"cache_control,omitempty"` // Carries cache_control for function_call and function_call_output message types
@@ -1304,6 +1308,12 @@ func (m *ResponsesMessage) UnmarshalJSON(data []byte) error {
 		if t == string(ResponsesMessageTypeToolSearchOutput) {
 			if tools := gjson.GetBytes(data, "tools"); tools.IsArray() {
 				m.ToolSearchOutputTools = json.RawMessage(tools.Raw)
+			}
+		}
+		// additional_tools carries the codex tool declarations; same rationale.
+		if t == string(ResponsesMessageTypeAdditionalTools) {
+			if tools := gjson.GetBytes(data, "tools"); tools.IsArray() {
+				m.AdditionalTools = json.RawMessage(tools.Raw)
 			}
 		}
 		m.rawPreserved = append([]byte(nil), data...)

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -423,6 +423,26 @@ func TestResponsesMessageMarshalsToolSearchOutputArgumentsAsObject(t *testing.T)
 	}
 }
 
+// TestDeepCopyResponsesMessagePreservesRawPreserved verifies that a raw-preserved
+// item survives the copy. rawPreserved is unexported, so a copy that misses it
+// re-marshals field-by-field and reduces the item to just its type.
+func TestDeepCopyResponsesMessagePreservesRawPreserved(t *testing.T) {
+	raw := `{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec","format":{"type":"grammar","syntax":"lark","definition":"start: x"}}]}`
+
+	var msg ResponsesMessage
+	if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	encoded, err := DeepCopyResponsesMessage(msg).MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal copy: %v", err)
+	}
+	if string(encoded) != raw {
+		t.Fatalf("copy did not round-trip verbatim:\n got: %s\nwant: %s", encoded, raw)
+	}
+}
+
 func TestDeepCopyResponsesMessagePreservesToolSearchFields(t *testing.T) {
 	toolSearchOutputType := ResponsesMessageTypeToolSearchOutput
 	callID := "call_1"

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1287,6 +1287,14 @@ func DeepCopyResponsesMessage(original ResponsesMessage) ResponsesMessage {
 	if original.ToolSearchOutputTools != nil {
 		copy.ToolSearchOutputTools = append(json.RawMessage(nil), original.ToolSearchOutputTools...)
 	}
+	if original.AdditionalTools != nil {
+		copy.AdditionalTools = append(json.RawMessage(nil), original.AdditionalTools...)
+	}
+	// Raw-preserved items re-marshal from these bytes; without them the copy
+	// falls back to a field-by-field encode and loses the item's payload.
+	if original.rawPreserved != nil {
+		copy.rawPreserved = append([]byte(nil), original.rawPreserved...)
+	}
 
 	if original.Content != nil {
 		copy.Content = &ResponsesMessageContent{}

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -239,6 +239,7 @@ func deepCopyResponsesMessage(original schemas.ResponsesMessage) schemas.Respons
 	// do not expose every Responses API field, so newer fields are copied by name
 	// when a workspace build provides them.
 	copyRawMessageFieldByName(&copy, original, "ToolSearchOutputTools")
+	copyRawMessageFieldByName(&copy, original, "AdditionalTools")
 
 	// Deep copy ResponsesReasoning if present
 	if original.ResponsesReasoning != nil {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -73,7 +73,8 @@
           "        hasContent = true;",
           "    } else if (Array.isArray(j.output) && j.output.length > 0) {",
           "        shape = 'openai-responses-output';",
-          "        hasContent = j.output.some(function (o) { return o && (o.type === 'message' || o.type === 'tool_call' || o.type === 'function_call' || (o.content && o.content.length)); });",
+          "        // Responses tool-use items are all typed <tool>_call (function_call, tool_search_call, custom_tool_call, mcp_call, local_shell_call, ...). A client-execution call is a valid TERMINAL output: the model emits the call and stops, waiting for the matching *_output, so no text accompanies it.",
+          "        hasContent = j.output.some(function (o) { return o && (o.type === 'message' || /_call$/.test(o.type || '') || (o.content && o.content.length)); });",
           "    } else if (j.output && j.output.message && j.output.message.content) {",
           "        shape = 'bedrock-converse';",
           "        hasContent = j.output.message.content.length > 0;",
@@ -42558,6 +42559,304 @@
                   "});",
                   "pm.test('genai tool combination: functionDeclarations survive the round-trip alongside googleSearch (regression PR #5576)', function () {",
                   "  pm.expect(calls.length, 'no get_weather functionCall - toolConfig.includeServerSideToolInvocations was dropped and declarations stripped: ' + pm.response.text()).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "33. Codex additional_tools hoist + tool_search wire shapes (Bedrock Mantle)",
+      "description": "Codex code-mode models (gpt-5.6-sol, tool_mode=code_mode / use_responses_lite=true) declare their tools inside the input array as an `additional_tools` developer item rather than in the top-level `tools` param. api.openai.com accepts that item natively; Bedrock Mantle's OpenAI-compatible surface (bedrock-mantle.<region>.api.aws/openai/v1/responses) validates `input` against the standard union and rejects the whole request with 400 \"invalid request body: Invalid 'input': value did not match any expected variant\".\n\nBifrost resolves this in ToOpenAIResponsesRequest: for providers whose ResponsesFeatureSupport.AdditionalToolsItem is false (bedrock, bedrock_mantle), the item's tools are hoisted into the top-level `tools` param and the item is dropped from `input`. OpenAI keeps the item verbatim via ResponsesMessage.rawPreserved.\n\nThe nested tools are the fragile part: each entry carries its own `type` discriminator, and custom tools carry a lark `format` while namespace tools carry a nested `tools` list. A typed decode strips those, which is why the item round-trips through rawPreserved rather than a typed model.\n\nCases 33.1-33.3 pin the hoist (a 400 here means it stopped running). 33.4 pins that OpenAI still receives the item natively. 33.5-33.6 pin the sibling raw-preserved items: tool_search_call `arguments` must stay a JSON object (function_call uses a string) and tool_search_output `tools[].type` must survive replay.",
+      "item": [
+        {
+          "name": "33.1 bedrock/openai.gpt-5.6-sol additional_tools hoisted to top-level tools (no Invalid input 400)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/openai.gpt-5.6-sol\",\n  \"input\": [\n    {\n      \"type\": \"additional_tools\",\n      \"role\": \"developer\",\n      \"tools\": [\n        {\n          \"type\": \"custom\",\n          \"name\": \"exec\",\n          \"description\": \"Run JavaScript code to orchestrate/compose tool calls.\",\n          \"format\": {\n            \"type\": \"grammar\",\n            \"syntax\": \"lark\",\n            \"definition\": \"start: SOURCE\\nSOURCE: /[\\\\s\\\\S]+/\\n\"\n          }\n        },\n        {\n          \"type\": \"function\",\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city.\",\n          \"strict\": false,\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name.\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ],\n            \"additionalProperties\": false\n          }\n        },\n        {\n          \"type\": \"namespace\",\n          \"name\": \"collaboration\",\n          \"description\": \"Tools for spawning and managing sub-agents.\",\n          \"tools\": [\n            {\n              \"type\": \"function\",\n              \"name\": \"spawn_agent\",\n              \"description\": \"Spawn a sub-agent for a bounded subtask.\",\n              \"strict\": false,\n              \"parameters\": {\n                \"type\": \"object\",\n                \"properties\": {\n                  \"task_name\": {\n                    \"type\": \"string\"\n                  }\n                },\n                \"required\": [\n                  \"task_name\"\n                ],\n                \"additionalProperties\": false\n              }\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with exactly: OK\"\n        }\n      ]\n    }\n  ],\n  \"max_output_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var body = pm.response.text();",
+                  "pm.test('bedrock additional_tools: additional_tools not rejected by the provider', function () {",
+                  "  pm.expect(body, 'provider rejected the additional_tools input item - the hoist did not run: ' + body).to.not.include('did not match any expected variant');",
+                  "  pm.expect(body, 'provider rejected the input array: ' + body).to.not.include(\"Invalid 'input'\");",
+                  "});",
+                  "pm.test('bedrock additional_tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + body).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "33.2 bedrock_mantle/openai.gpt-5.6-sol additional_tools hoisted to top-level tools",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock_mantle/openai.gpt-5.6-sol\",\n  \"input\": [\n    {\n      \"type\": \"additional_tools\",\n      \"role\": \"developer\",\n      \"tools\": [\n        {\n          \"type\": \"custom\",\n          \"name\": \"exec\",\n          \"description\": \"Run JavaScript code to orchestrate/compose tool calls.\",\n          \"format\": {\n            \"type\": \"grammar\",\n            \"syntax\": \"lark\",\n            \"definition\": \"start: SOURCE\\nSOURCE: /[\\\\s\\\\S]+/\\n\"\n          }\n        },\n        {\n          \"type\": \"function\",\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city.\",\n          \"strict\": false,\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name.\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ],\n            \"additionalProperties\": false\n          }\n        },\n        {\n          \"type\": \"namespace\",\n          \"name\": \"collaboration\",\n          \"description\": \"Tools for spawning and managing sub-agents.\",\n          \"tools\": [\n            {\n              \"type\": \"function\",\n              \"name\": \"spawn_agent\",\n              \"description\": \"Spawn a sub-agent for a bounded subtask.\",\n              \"strict\": false,\n              \"parameters\": {\n                \"type\": \"object\",\n                \"properties\": {\n                  \"task_name\": {\n                    \"type\": \"string\"\n                  }\n                },\n                \"required\": [\n                  \"task_name\"\n                ],\n                \"additionalProperties\": false\n              }\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with exactly: OK\"\n        }\n      ]\n    }\n  ],\n  \"max_output_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var body = pm.response.text();",
+                  "pm.test('bedrock_mantle additional_tools: additional_tools not rejected by the provider', function () {",
+                  "  pm.expect(body, 'provider rejected the additional_tools input item - the hoist did not run: ' + body).to.not.include('did not match any expected variant');",
+                  "  pm.expect(body, 'provider rejected the input array: ' + body).to.not.include(\"Invalid 'input'\");",
+                  "});",
+                  "pm.test('bedrock_mantle additional_tools: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + body).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "33.3 bedrock_mantle/openai.gpt-5.6-sol additional_tools streaming (responses_stream prod path)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock_mantle/openai.gpt-5.6-sol\",\n  \"stream\": true,\n  \"input\": [\n    {\n      \"type\": \"additional_tools\",\n      \"role\": \"developer\",\n      \"tools\": [\n        {\n          \"type\": \"custom\",\n          \"name\": \"exec\",\n          \"description\": \"Run JavaScript code to orchestrate/compose tool calls.\",\n          \"format\": {\n            \"type\": \"grammar\",\n            \"syntax\": \"lark\",\n            \"definition\": \"start: SOURCE\\nSOURCE: /[\\\\s\\\\S]+/\\n\"\n          }\n        },\n        {\n          \"type\": \"function\",\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city.\",\n          \"strict\": false,\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name.\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ],\n            \"additionalProperties\": false\n          }\n        },\n        {\n          \"type\": \"namespace\",\n          \"name\": \"collaboration\",\n          \"description\": \"Tools for spawning and managing sub-agents.\",\n          \"tools\": [\n            {\n              \"type\": \"function\",\n              \"name\": \"spawn_agent\",\n              \"description\": \"Spawn a sub-agent for a bounded subtask.\",\n              \"strict\": false,\n              \"parameters\": {\n                \"type\": \"object\",\n                \"properties\": {\n                  \"task_name\": {\n                    \"type\": \"string\"\n                  }\n                },\n                \"required\": [\n                  \"task_name\"\n                ],\n                \"additionalProperties\": false\n              }\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with exactly: OK\"\n        }\n      ]\n    }\n  ],\n  \"max_output_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var body = pm.response.text();",
+                  "pm.test('bedrock_mantle additional_tools streaming: additional_tools not rejected by the provider', function () {",
+                  "  pm.expect(body, 'provider rejected the additional_tools input item - the hoist did not run: ' + body).to.not.include('did not match any expected variant');",
+                  "  pm.expect(body, 'provider rejected the input array: ' + body).to.not.include(\"Invalid 'input'\");",
+                  "});",
+                  "pm.test('bedrock_mantle additional_tools streaming: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + body).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('bedrock_mantle additional_tools streaming: SSE stream produced events', function () {",
+                  "  pm.expect(pm.response.text(), 'no SSE events: ' + pm.response.text()).to.include('data:');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "33.4 openai/gpt-5.6-sol additional_tools preserved natively on /openai/v1/responses (not hoisted)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"gpt-5.6-sol\",\n  \"input\": [\n    {\n      \"type\": \"additional_tools\",\n      \"role\": \"developer\",\n      \"tools\": [\n        {\n          \"type\": \"custom\",\n          \"name\": \"exec\",\n          \"description\": \"Run JavaScript code to orchestrate/compose tool calls.\",\n          \"format\": {\n            \"type\": \"grammar\",\n            \"syntax\": \"lark\",\n            \"definition\": \"start: SOURCE\\nSOURCE: /[\\\\s\\\\S]+/\\n\"\n          }\n        },\n        {\n          \"type\": \"function\",\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city.\",\n          \"strict\": false,\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\",\n                \"description\": \"City name.\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ],\n            \"additionalProperties\": false\n          }\n        },\n        {\n          \"type\": \"namespace\",\n          \"name\": \"collaboration\",\n          \"description\": \"Tools for spawning and managing sub-agents.\",\n          \"tools\": [\n            {\n              \"type\": \"function\",\n              \"name\": \"spawn_agent\",\n              \"description\": \"Spawn a sub-agent for a bounded subtask.\",\n              \"strict\": false,\n              \"parameters\": {\n                \"type\": \"object\",\n                \"properties\": {\n                  \"task_name\": {\n                    \"type\": \"string\"\n                  }\n                },\n                \"required\": [\n                  \"task_name\"\n                ],\n                \"additionalProperties\": false\n              }\n            }\n          ]\n        }\n      ]\n    },\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with exactly: OK\"\n        }\n      ]\n    }\n  ],\n  \"max_output_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var body = pm.response.text();",
+                  "pm.test('openai additional_tools native: additional_tools not rejected by the provider', function () {",
+                  "  pm.expect(body, 'provider rejected the additional_tools input item - the hoist did not run: ' + body).to.not.include('did not match any expected variant');",
+                  "  pm.expect(body, 'provider rejected the input array: ' + body).to.not.include(\"Invalid 'input'\");",
+                  "});",
+                  "pm.test('openai additional_tools native: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + body).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "pm.test('openai additional_tools native: response has output', function () {",
+                  "  var out = (pm.response.json() || {}).output || [];",
+                  "  pm.expect(out.length, 'empty output: ' + pm.response.text()).to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "33.5 openai/gpt-5.6-sol tool_search client execution keeps arguments as a JSON object",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"input\": [\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Find a tool that reports the weather, then use it for Paris.\"\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"type\": \"tool_search\",\n      \"execution\": \"client\",\n      \"description\": \"Find project-specific tools needed to complete the task.\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"goal\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"goal\"\n        ],\n        \"additionalProperties\": false\n      }\n    }\n  ],\n  \"max_output_tokens\": 128\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('openai tool_search client: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var output = (pm.response.json() || {}).output || [];",
+                  "var calls = output.filter(function (o) { return o.type === 'tool_search_call'; });",
+                  "// The model decides whether to search, so an empty result is not a failure.",
+                  "// When it does search, the wire shape is what this case pins.",
+                  "if (calls.length === 0) { pm.test.skip('openai tool_search client: model emitted no tool_search_call'); return; }",
+                  "pm.test('openai tool_search client: arguments is a JSON object, not a stringified one', function () {",
+                  "  calls.forEach(function (c) {",
+                  "    pm.expect(c.arguments, 'tool_search_call.arguments was stringified: ' + JSON.stringify(c)).to.be.an('object');",
+                  "  });",
+                  "});",
+                  "pm.test('openai tool_search client: execution preserved as client', function () {",
+                  "  calls.forEach(function (c) {",
+                  "    pm.expect(c.execution, 'execution lost: ' + JSON.stringify(c)).to.eql('client');",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "33.6 openai/gpt-5.6-sol tool_search_call + tool_search_output replay round-trip",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"input\": [\n    {\n      \"type\": \"message\",\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Use the discovered tool to report the weather in Paris.\"\n        }\n      ]\n    },\n    {\n      \"type\": \"tool_search_call\",\n      \"call_id\": \"ts_harness_1\",\n      \"execution\": \"client\",\n      \"status\": \"completed\",\n      \"arguments\": {\n        \"goal\": \"weather\"\n      }\n    },\n    {\n      \"type\": \"tool_search_output\",\n      \"call_id\": \"ts_harness_1\",\n      \"execution\": \"client\",\n      \"status\": \"completed\",\n      \"tools\": [\n        {\n          \"type\": \"function\",\n          \"name\": \"get_weather\",\n          \"description\": \"Get the current weather for a city.\",\n          \"parameters\": {\n            \"type\": \"object\",\n            \"properties\": {\n              \"city\": {\n                \"type\": \"string\"\n              }\n            },\n            \"required\": [\n              \"city\"\n            ],\n            \"additionalProperties\": false\n          }\n        }\n      ]\n    }\n  ],\n  \"tools\": [\n    {\n      \"type\": \"tool_search\",\n      \"execution\": \"client\",\n      \"description\": \"Find project-specific tools needed to complete the task.\",\n      \"parameters\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"goal\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"goal\"\n        ],\n        \"additionalProperties\": false\n      }\n    }\n  ],\n  \"max_output_tokens\": 64\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var body = pm.response.text();",
+                  "pm.test('openai tool_search replay: raw-preserved items accepted on replay', function () {",
+                  "  pm.expect(body, 'provider rejected the replayed tool_search items: ' + body).to.not.include(\"Invalid 'input'\");",
+                  "  pm.expect(body, 'tool_search_call arguments were stringified on replay: ' + body).to.not.include('Mismatch type string with value object');",
+                  "  pm.expect(body, 'tool_search_output tools lost their type discriminator: ' + body).to.not.include(\"input[1].tools[0].type\");",
+                  "});",
+                  "pm.test('openai tool_search replay: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + body).to.be.below(400);",
                   "});"
                 ]
               }


### PR DESCRIPTION
## Summary

Bedrock and Bedrock Mantle reject codex `additional_tools` input items with `"Invalid 'input': value did not match any expected variant"` because their Responses API wire validation only accepts the standard input union. This PR adds provider-aware handling that hoists the tools declared inside an `additional_tools` item into the top-level `tools` param for providers that don't support the item type, while leaving the item untouched for OpenAI and any unlisted provider (fail-open default).

## Changes

- Introduced `ResponsesFeatureSupport` and `ProviderFeatures` to track which OpenAI-compatible backends accept Responses wire extensions. `Bedrock` and `BedrockMantle` are marked as not supporting `AdditionalToolsItem`; `OpenAI` is marked as supporting it; all other providers default to supported.
- Added `supportsAdditionalToolsItem` and `hoistAdditionalTools` helpers. During request conversion, `additional_tools` items are intercepted for unsupported providers, their tool list is decoded and accumulated, and the item itself is dropped from the input array.
- Hoisted tools are appended to `req.Tools` after the params assignment (which would otherwise clobber them) and before the normalization pass, so hoisted function tools receive the same `strict`/`parameters` normalization as any other tool.
- Moved tool normalization and `filterUnsupportedTools` outside the params `if` block so they apply unconditionally, including to hoisted tools.
- Added `AdditionalTools json.RawMessage` to `ResponsesMessage`, populated during `UnmarshalJSON` when the message type is `additional_tools`, following the same pattern as `ToolSearchOutputTools`.
- Propagated `AdditionalTools` through `DeepCopyResponsesMessage` and the streaming `deepCopyResponsesMessage` reflection helper.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestBedrockMantleHoistsAdditionalTools
go test ./core/providers/openai/... -run TestOpenAIKeepsAdditionalToolsItem
go test ./core/providers/openai/... -run TestUnlistedProviderKeepsAdditionalToolsItem
go test ./...
```

`TestBedrockMantleHoistsAdditionalTools` verifies that for both `Bedrock` and `BedrockMantle`:
- The `additional_tools` item is removed from `input`, leaving only the user message.
- All three tool shapes (`custom`, `function`, `namespace`) appear at the top level with their discriminators and nested fields intact.
- Hoisted function tools have `strict: false` rather than `null`.

`TestOpenAIKeepsAdditionalToolsItem` verifies that for `OpenAI` the item stays in `input` verbatim and nothing is hoisted into `tools`.

`TestUnlistedProviderKeepsAdditionalToolsItem` verifies the fail-open default for providers absent from `ProviderFeatures` (e.g. `Groq`).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes Bedrock/Bedrock Mantle rejections when routing codex requests that include `additional_tools` input items.

## Security considerations

No auth, secrets, or PII implications. The hoist only repackages tool metadata already present in the request.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable