### PR TITLE
chore: refactor overhead duration export for connectors

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780965770,
-        "narHash": "sha256-g13MEx3zFQG2HiYiEuM3QzLvGwnYiCuzRrIVYrTeSro=",
+        "lastModified": 1784875910,
+        "narHash": "sha256-UfxGmmJheitip1PVQHHJC3bIicCuVRxjAxB/Bis2kgI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6a817a86f2e8684a19f9982b4598b3b65a3d38e6",
+        "rev": "a0f7233e070eb72d7f415eda943a1aa2290427c5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,13 @@
         "aarch64-darwin" # 64-bit ARM macOS
       ];
 
-      # Temporary workaround until nixpkgs includes Go 1.26.4.
-      go_1_26_4_overlay = final: prev: {
+      # Temporary workaround until nixpkgs includes Go 1.26.5.
+      go_1_26_5_overlay = final: prev: {
         go_1_26 = prev.go_1_26.overrideAttrs (oldAttrs: rec {
-          version = "1.26.4";
+          version = "1.26.5";
           src = final.fetchurl {
             url = "https://go.dev/dl/go${version}.src.tar.gz";
-            sha256 = "0bb089d2bfszfc8r4cra94qsdb8x5y69dyw1m3k344gwzcr8lrjg";
+            sha256 = "495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42";
           };
         });
         go = final.go_1_26;
@@ -39,7 +39,7 @@
             # Provides a system-specific, configured Nixpkgs
             pkgs = import inputs.nixpkgs {
               inherit system;
-              overlays = [ go_1_26_4_overlay ];
+              overlays = [ go_1_26_5_overlay ];
               # Enable using unfree packages
               config.allowUnfree = true;
             };

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -150,8 +150,6 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 					kvStr(schemas.AttrBifrostRequestID, requestID),
 				)
 			}
-			// Overhead is stamped on the snapshot's root span by the tracer, so it
-			// flows through convertAttributesToKeyValues above like any other attr.
 			if len(p.instanceAttrs) > 0 {
 				otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
 			}
@@ -225,6 +223,11 @@ func convertAttributesToKeyValues(attrs map[string]any, disableContentLogging bo
 	kvs := make([]*KeyValue, 0, len(attrs))
 	for k, v := range attrs {
 		if disableContentLogging && schemas.IsContentAttribute(k) {
+			continue
+		}
+		// Overhead is not exported to connectors; it is still computed and stored in
+		// the logs DB. Skip it here so it does not ride the exported span.
+		if k == schemas.AttrBifrostOverheadDurationMs {
 			continue
 		}
 		kv := anyToKeyValue(k, v)

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -751,37 +751,6 @@ func getFloat64Attr(attrs map[string]any, key string) float64 {
 // is a meaningful value distinct from "absent" — an upstream total of 0 (a cache
 // hit, or a request rejected before any provider call) means all of the elapsed
 // time was Bifrost's, whereas a missing attribute means it was never measured.
-// overheadSecondsFromTrace reads Bifrost's own cost off the root span, where the
-// tracer stamps it as AttrBifrostOverheadDurationMs (root duration minus the
-// upstream total). Reading the stamped value rather than recomputing keeps the
-// overhead metric and the span attribute in lockstep. Returns false when the
-// request carried no measurement; absent must not be reported as zero overhead.
-func overheadSecondsFromTrace(trace *schemas.Trace) (float64, bool) {
-	if trace == nil || trace.RootSpan == nil {
-		return 0, false
-	}
-	overheadMs, ok := getFloat64AttrOK(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
-	if !ok {
-		return 0, false
-	}
-	return overheadMs / 1000.0, true
-}
-
-func getFloat64AttrOK(attrs map[string]any, key string) (float64, bool) {
-	if attrs == nil {
-		return 0, false
-	}
-	switch v := attrs[key].(type) {
-	case float64:
-		return v, true
-	case int:
-		return float64(v), true
-	case int64:
-		return float64(v), true
-	}
-	return 0, false
-}
-
 // buildSpanAttrs extracts metric dimension attrs from a single attempt span.
 func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	attrs := span.Attributes
@@ -941,21 +910,6 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 		if finalSpan == nil || span.EndTime.After(finalSpan.EndTime) {
 			finalSpan = span
 		}
-	}
-
-	// Bifrost's own overhead. Derived once per trace from the root span, which is
-	// the only span whose duration covers the whole request — including queue
-	// wait, plugin hooks and transport work that no llm.call span sees.
-	//
-	// Labelled off the final attempt span so provider/model dimensions match the
-	// other per-request metrics (retries, tokens, cost). The root span carries
-	// only HTTP attributes.
-	if overheadSeconds, ok := overheadSecondsFromTrace(trace); ok {
-		labelSpan := finalSpan
-		if labelSpan == nil {
-			labelSpan = trace.RootSpan
-		}
-		exporter.RecordOverheadLatency(ctx, overheadSeconds, buildSpanAttrs(labelSpan)...)
 	}
 
 	if finalSpan == nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -55,7 +55,6 @@ type MetricsExporter struct {
 
 	// Bifrost metrics - histograms
 	upstreamLatencySeconds         *syncFloat64Histogram
-	overheadLatencySeconds         *syncFloat64Histogram
 	streamFirstTokenLatencySeconds *syncFloat64Histogram
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
@@ -132,17 +131,6 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
-	}
-
-	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
-	// blocked on upstream sockets. A different scale entirely from upstream latency —
-	// healthy values are sub-millisecond to low tens of ms, dominated by request and
-	// response marshalling. Reusing upstreamLatencyBuckets would pile almost every
-	// request into the first two buckets and make regressions invisible. The long
-	// tail up to 30s exists to catch queue saturation and pathological payloads.
-	overheadLatencyBuckets = []float64{
-		.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1,
-		.25, .5, 1, 2.5, 5, 10, 30,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -404,14 +392,6 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: upstreamLatencyBuckets,
 	}
 
-	m.overheadLatencySeconds = &syncFloat64Histogram{
-		name:       "bifrost_overhead_latency_seconds",
-		desc:       "Latency added by Bifrost itself: total request time minus time blocked on upstream providers",
-		unit:       "s",
-		meter:      m.meter,
-		boundaries: overheadLatencyBuckets,
-	}
-
 	m.streamFirstTokenLatencySeconds = &syncFloat64Histogram{
 		name:       "bifrost_stream_first_token_latency_seconds",
 		desc:       "Latency of the first token of a stream response",
@@ -544,13 +524,6 @@ func (m *MetricsExporter) RecordCost(ctx context.Context, cost float64, attrs ..
 // RecordUpstreamLatency records upstream latency metric
 func (m *MetricsExporter) RecordUpstreamLatency(ctx context.Context, latencySeconds float64, attrs ...attribute.KeyValue) {
 	m.upstreamLatencySeconds.Record(ctx, latencySeconds, metric.WithAttributes(attrs...))
-}
-
-// RecordOverheadLatency records the latency Bifrost itself added to a request.
-// Recorded once per trace (off the root span), not once per attempt — the
-// underlying accumulator already spans every retry and fallback.
-func (m *MetricsExporter) RecordOverheadLatency(ctx context.Context, overheadSeconds float64, attrs ...attribute.KeyValue) {
-	m.overheadLatencySeconds.Record(ctx, overheadSeconds, metric.WithAttributes(attrs...))
 }
 
 // RecordStreamFirstTokenLatency records first token latency metric

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,11 +34,6 @@ const (
 	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
 	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
 	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
-
-	// Overhead is measured across the transport hooks rather than the LLM hooks,
-	// so the window matches the OTEL root span. See recordOverhead.
-	transportStartTimeKey schemas.BifrostContextKey = "bf-prom-transport-start-time"
-	overheadLabelsKey     schemas.BifrostContextKey = "bf-prom-overhead-labels"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -166,7 +160,6 @@ type PrometheusPlugin struct {
 	HTTPResponseSizeBytes          *prometheus.HistogramVec
 	UpstreamRequestsTotal          *prometheus.CounterVec
 	UpstreamLatencySeconds         *prometheus.HistogramVec
-	OverheadLatencySeconds         *prometheus.HistogramVec
 	SuccessRequestsTotal           *prometheus.CounterVec
 	ErrorRequestsTotal             *prometheus.CounterVec
 	InputTokensTotal               *prometheus.CounterVec
@@ -220,17 +213,6 @@ var (
 	upstreamLatencyBuckets = []float64{
 		.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5,
 		10, 15, 30, 45, 60, 90, 120, 180, 300, 600, 900,
-	}
-
-	// overheadLatencyBuckets: Bifrost's own processing cost, i.e. total minus time
-	// blocked on upstream sockets. A different scale entirely from upstream latency —
-	// healthy values are sub-millisecond to low tens of ms, dominated by request and
-	// response marshalling. Reusing upstreamLatencyBuckets would pile almost every
-	// request into the first two buckets and make regressions invisible. The long
-	// tail up to 30s exists to catch queue saturation and pathological payloads.
-	overheadLatencyBuckets = []float64{
-		.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1,
-		.25, .5, 1, 2.5, 5, 10, 30,
 	}
 
 	// firstTokenLatencyBuckets: TTFT. Bimodal - sub-second for fast streaming
@@ -405,18 +387,6 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(append(defaultBifrostLabels, "is_success"), filteredCustomLabels...),
 	)
 
-	// Labelled without is_success: unlike upstream latency, overhead is dominated by
-	// payload marshalling and is not expected to differ between success and failure,
-	// and a failed request often has no response to marshal at all.
-	bifrostOverheadLatencySeconds := factory.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:    "bifrost_overhead_latency_seconds",
-			Help:    "Latency added by Bifrost itself: total request time minus time blocked on upstream providers.",
-			Buckets: overheadLatencyBuckets,
-		},
-		append(defaultBifrostLabels, filteredCustomLabels...),
-	)
-
 	bifrostSuccessRequestsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_success_requests_total",
@@ -580,7 +550,6 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		HTTPResponseSizeBytes:          httpResponseSizeBytes,
 		UpstreamRequestsTotal:          bifrostUpstreamRequestsTotal,
 		UpstreamLatencySeconds:         bifrostUpstreamLatencySeconds,
-		OverheadLatencySeconds:         bifrostOverheadLatencySeconds,
 		SuccessRequestsTotal:           bifrostSuccessRequestsTotal,
 		ErrorRequestsTotal:             bifrostErrorRequestsTotal,
 		InputTokensTotal:               bifrostInputTokensTotal,
@@ -687,41 +656,12 @@ func (p *PrometheusPlugin) RedactConfig(raw map[string]any) (map[string]any, err
 
 // HTTPTransportPreHook is not used for this plugin
 func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
-	ctx.SetValue(transportStartTimeKey, time.Now())
 	return nil, nil
 }
 
-// HTTPTransportPostHook records Bifrost's own overhead.
-//
-// This is the widest window the plugin can see — the middleware order is
-// Tracing.pre → TransportInterceptor.pre → handler → TransportInterceptor.post
-// → Tracing.defer — so it brackets request parsing, the full core pipeline and
-// response marshalling, matching what OTEL derives from the root span. Measuring
-// across PreLLMHook/PostLLMHook instead would miss the transport work, and
-// marshalling a large response body is a real part of the cost.
-//
-// Running here also makes the observation once-per-request rather than
-// once-per-attempt, so a retried request no longer contributes several times.
+// HTTPTransportPostHook is not used for this plugin
 func (p *PrometheusPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
-	start, ok := ctx.Value(transportStartTimeKey).(time.Time)
-	if !ok {
-		return nil
-	}
-	p.recordOverhead(ctx, time.Since(start))
 	return nil
-}
-
-// recordOverhead observes total-minus-upstream against the labels the LLM hook
-// resolved. Silent when either is missing: no accumulator means upstream was
-// never measured, and reporting the full duration as overhead would be wrong.
-func (p *PrometheusPlugin) recordOverhead(ctx *schemas.BifrostContext, total time.Duration) {
-	labels, ok := ctx.Value(overheadLabelsKey).([]string)
-	if !ok || len(labels) == 0 {
-		return
-	}
-	if overhead, ok := schemas.CalculateOverhead(ctx, total); ok {
-		p.OverheadLatencySeconds.WithLabelValues(labels...).Observe(overhead.Seconds())
-	}
 }
 
 // HTTPTransportStreamChunkHook passes through streaming chunks unchanged
@@ -978,13 +918,6 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
-	// Labels for HTTPTransportPostHook, which observes overhead. Written before
-	// the goroutine launches so the transport hook can't race it; on a retry the
-	// final attempt's labels win.
-	if isStreamFinal {
-		ctx.SetValue(overheadLabelsKey, slices.Clone(promLabelValues))
-	}
-
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
 	go func() {
 		// For streaming requests, handle per-token metrics for intermediate chunks
@@ -1042,11 +975,6 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		latencyLabelValues = append(latencyLabelValues, strconv.FormatBool(bifrostErr == nil))            // is_success
 		latencyLabelValues = append(latencyLabelValues, promLabelValues[len(p.defaultBifrostLabels):]...) // then custom labels
 		p.UpstreamLatencySeconds.WithLabelValues(latencyLabelValues...).Observe(duration)
-
-		// SDK caller — no transport hooks, so this window is all there is.
-		if _, viaTransport := ctx.Value(transportStartTimeKey).(time.Time); !viaTransport {
-			p.recordOverhead(ctx, time.Since(startTime))
-		}
 
 		// Record cost using the dedicated cost counter
 		if cost > 0 {


### PR DESCRIPTION
## Summary

Removes the `bifrost_overhead_latency_seconds` metric from both the Prometheus and OpenTelemetry plugins. The overhead duration attribute (`AttrBifrostOverheadDurationMs`) is still computed and stored in the logs database, but it is no longer exported to connectors via span attributes or recorded as a histogram metric.

## Changes

- Removed the `bifrost_overhead_latency_seconds` histogram from the Prometheus plugin, including its registration, label keys, bucket definitions, and all recording logic (`recordOverhead`, `overheadSecondsFromTrace`, `getFloat64AttrOK`).
- Removed the `transportStartTimeKey` and `overheadLabelsKey` context keys and the associated pre/post transport hook logic that measured and propagated overhead labels.
- Removed the `RecordOverheadLatency` method and `overheadLatencySeconds` histogram from the OTel metrics exporter.
- Filtered `AttrBifrostOverheadDurationMs` out of exported OTEL span attributes in `convertAttributesToKeyValues` so the value does not ride outbound spans to downstream connectors.
- Moved the stale comment about overhead stamping to the correct location in `convertAttributesToKeyValues`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/otel/...
go test ./plugins/telemetry/...
```

Verify that after the change:
- No `bifrost_overhead_latency_seconds` metric appears in the Prometheus scrape endpoint.
- No `bifrost.overhead_duration_ms` attribute appears on spans exported to an OTEL collector.
- The attribute is still present in the internal logs database.

## Breaking changes

- [x] Yes
- [ ] No

The `bifrost_overhead_latency_seconds` Prometheus metric and the `bifrost_overhead_latency_seconds` OTEL histogram are removed. Any dashboards, alerts, or queries targeting these metrics will need to be updated or removed.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable