### PR TITLE
`refactor: export RestartLiveModelRefresher for external boot path access`

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1061,7 +1061,7 @@ func (s *BifrostHTTPServer) UpdateSyncConfig(ctx context.Context) error {
 	// The live model refresher reads its interval from the same framework
 	// config block, so pick up a changed (or newly disabled) value here rather
 	// than waiting for a restart.
-	s.restartLiveModelRefresher(s.backgroundCtx())
+	s.RestartLiveModelRefresher(s.backgroundCtx())
 	return s.Config.ModelCatalog.UpdateSyncConfig(ctx, pricing)
 }
 
@@ -1190,11 +1190,13 @@ func (s *BifrostHTTPServer) startLiveModelRefresher(ctx context.Context, interva
 	return cancel
 }
 
-// restartLiveModelRefresher stops any running refresher and starts a new one
+// RestartLiveModelRefresher stops any running refresher and starts a new one
 // at the currently configured interval. Called at boot and again whenever the
 // framework config changes, so a disabled-to-enabled edit (or vice versa)
-// takes effect without a restart.
-func (s *BifrostHTTPServer) restartLiveModelRefresher(ctx context.Context) {
+// takes effect without a restart. Exported so servers that replace the boot
+// path can start the refresher with its stop handle registered for the shared
+// cleanup and config-change restarts.
+func (s *BifrostHTTPServer) RestartLiveModelRefresher(ctx context.Context) {
 	s.liveModelRefresherMu.Lock()
 	defer s.liveModelRefresherMu.Unlock()
 	if s.liveModelRefresherStop != nil {
@@ -2360,7 +2362,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// Keep the live model catalog current after boot. Without this, a model an
 	// upstream starts serving mid-uptime stays invisible until a restart or a
 	// key edit, since nothing else re-fetches list-models.
-	s.restartLiveModelRefresher(s.Ctx)
+	s.RestartLiveModelRefresher(s.Ctx)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Exports `restartLiveModelRefresher` as `RestartLiveModelRefresher` so that servers which replace the standard boot path can invoke the refresher directly, ensuring its stop handle is properly registered for shared cleanup and config-change restarts.

## Changes

- Renamed `restartLiveModelRefresher` to `RestartLiveModelRefresher` to make it part of the exported API on `BifrostHTTPServer`.
- Updated all internal call sites (`UpdateSyncConfig` and `Bootstrap`) to use the new exported name.
- Extended the method's doc comment to explain why it is exported: external servers that bypass the default boot path need access to start the live model refresher with its cancellation handle wired into the shared lifecycle.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Verify that the live model refresher still starts correctly at boot and restarts when framework config changes (e.g., toggling the refresh interval on/off) without requiring a server restart.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. This change only affects method visibility; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable