### PR TITLE
feat(vertex): allow Flex PayGo for gemini-3.5-flash-lite

### DIFF
--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -244,6 +244,7 @@ var vertexFlexModels = []string{
 	"gemini-3.1-flash-lite",
 	"gemini-3.1-flash-image-preview",
 	"gemini-3.1-pro-preview",
+	"gemini-3.5-flash-lite",
 	"gemini-3-flash-preview",
 	"gemini-3-pro-image-preview",
 }

--- a/core/providers/vertex/utils_test.go
+++ b/core/providers/vertex/utils_test.go
@@ -627,3 +627,15 @@ func TestGeminiImageURLSchemesContract(t *testing.T) {
 		t.Fatalf("geminiImageURLSchemes = %v, want %v", geminiImageURLSchemes, want)
 	}
 }
+
+func TestVertexServiceTierHeaderValue_Gemini35FlashLiteFlex(t *testing.T) {
+	t.Parallel()
+
+	flex := schemas.BifrostServiceTierFlex
+	if got := vertexServiceTierHeaderValue("global", "gemini-3.5-flash-lite", flex); got != "flex" {
+		t.Fatalf("expected flex header for gemini-3.5-flash-lite on global, got %q", got)
+	}
+	if got := vertexServiceTierHeaderValue("us-central1", "gemini-3.5-flash-lite", flex); got != "" {
+		t.Fatalf("expected no flex header outside global region, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `gemini-3.5-flash-lite` to `vertexFlexModels` so `service_tier: flex` sets `X-Vertex-AI-LLM-Shared-Request-Type: flex` on the Vertex **global** endpoint (PERF-939 / Talisman spike).

## Changes

- Add `gemini-3.5-flash-lite` to the Vertex Flex model allowlist in `core/providers/vertex/utils.go`
- Add unit test ensuring the flex header is set for `global` and not for regional endpoints (e.g. `us-central1`)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/vertex/ -run TestVertexServiceTierHeaderValue_Gemini35FlashLiteFlex -v
```

Expected: test passes.

After release/deploy: Bifrost spike `vertex/gemini-3.5-flash-lite` with `service_tier: flex` returns `service_tier: flex` in the response.

## Screenshots/Recordings

N/A (no UI).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Talisman spike: PERF-939 (internal).

## Security considerations

No auth/secrets changes; only extends an existing model allowlist for an existing header behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI) — `go test` for affected package
- [ ] I verified the CI pipeline passes locally if applicable