### PR TITLE
accepts output_text user blocks in complexity extraction

### DIFF
--- a/plugins/governance/complexityextract.go
+++ b/plugins/governance/complexityextract.go
@@ -214,10 +214,16 @@ func isChatTextBlock(block schemas.ChatContentBlock) bool {
 	return block.Type == "" || block.Type == schemas.ChatContentBlockTypeText
 }
 
-// isResponsesInputTextBlock reports whether a Responses content block is input
+// isResponsesInputTextBlock reports whether a Responses content block is plain
 // text, treating an empty type as text for compatibility with normalized input.
+// output_text is accepted alongside input_text because the Anthropic→Responses
+// conversion tags user text blocks as output_text for bedrock/-prefixed models
+// (keepToolsGrouped path); rejecting them would silently disable complexity
+// routing for those clients.
 func isResponsesInputTextBlock(block schemas.ResponsesMessageContentBlock) bool {
-	return block.Type == "" || block.Type == schemas.ResponsesInputMessageContentBlockTypeText
+	return block.Type == "" ||
+		block.Type == schemas.ResponsesInputMessageContentBlockTypeText ||
+		block.Type == schemas.ResponsesOutputMessageContentTypeText
 }
 
 // appendText joins adjacent text fragments with one separating space while

--- a/plugins/governance/complexityextract_test.go
+++ b/plugins/governance/complexityextract_test.go
@@ -185,6 +185,37 @@ func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
 	}
 }
 
+// The Anthropic→Responses conversion tags user text blocks as output_text for
+// bedrock/-prefixed models (keepToolsGrouped path), emitting one message per
+// text block. Complexity extraction must still treat these as text, otherwise
+// Claude Code traffic using a bedrock/ alias never classifies and always falls
+// through to the default routing rule.
+func TestBuildComplexityInput_ResponsesOutputTextTypedUserBlocks(t *testing.T) {
+	systemRole := schemas.ResponsesInputMessageRoleSystem
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{
+					Role:    &systemRole,
+					Content: complexityResponsesBlocks(complexityResponsesTextBlock("You are a coding agent")),
+				},
+				{
+					Role:    &userRole,
+					Content: complexityResponsesBlocks(complexityResponsesOutputTextBlock("Explain encryption")),
+				},
+			},
+		},
+	}
+
+	input, ok := buildComplexityInput(req)
+	require.True(t, ok)
+	assert.Equal(t, "Explain encryption", input.LastUserText)
+	assert.Equal(t, "You are a coding agent", input.SystemText)
+}
+
 func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(t *testing.T) {
 	userRole := schemas.ResponsesInputMessageRoleUser
 	req := &schemas.BifrostRequest{


### PR DESCRIPTION
## Summary

The Anthropic→Responses conversion path tags user text blocks as `output_text` (rather than `input_text`) when routing through bedrock/-prefixed models via the `keepToolsGrouped` path. Previously, `isResponsesInputTextBlock` only accepted empty or `input_text` typed blocks, causing complexity extraction to silently skip these blocks and fall through to the default routing rule — effectively disabling complexity-based routing for Claude Code traffic using a bedrock/ alias.

## Changes

- `isResponsesInputTextBlock` now also accepts `output_text`-typed blocks so that user text arriving via the Anthropic→Responses conversion is correctly treated as plain text during complexity extraction.
- A regression test covering this scenario was added: a Responses request with a user message block typed as `output_text` must still yield a valid `LastUserText` and `SystemText` from `buildComplexityInput`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

The new test `TestBuildComplexityInput_ResponsesOutputTextTypedUserBlocks` should pass, confirming that `output_text`-typed user blocks are correctly extracted as `LastUserText` during complexity classification.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This change only affects how content block types are interpreted during complexity routing classification.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable