### PR TITLE
lifts chat-completions function wrapper in responses tool unmarshal

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -2678,6 +2678,39 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 		if err := Unmarshal(data, &funcTool); err != nil {
 			return err
 		}
+		// Chat Completions format nests the definition under "function":
+		//   {"type":"function","function":{"name":...,"parameters":...}}
+		// Clients like Cursor send this shape to Responses endpoints; without
+		// lifting the nested fields the tool parses with a nil name and
+		// providers that require one (e.g. Bedrock) reject the request.
+		// Top-level (Responses format) fields win when both are present.
+		if _, hasWrapper := raw["function"]; hasWrapper {
+			var wrapper struct {
+				Function *struct {
+					Name        *string                 `json:"name"`
+					Description *string                 `json:"description"`
+					Parameters  *ToolFunctionParameters `json:"parameters"`
+					Strict      *bool                   `json:"strict"`
+				} `json:"function"`
+			}
+			if err := Unmarshal(data, &wrapper); err != nil {
+				return fmt.Errorf("invalid 'function' object in ResponsesTool: %w", err)
+			}
+			if wrapper.Function != nil {
+				if t.Name == nil {
+					t.Name = wrapper.Function.Name
+				}
+				if t.Description == nil {
+					t.Description = wrapper.Function.Description
+				}
+				if funcTool.Parameters == nil {
+					funcTool.Parameters = wrapper.Function.Parameters
+				}
+				if funcTool.Strict == nil {
+					funcTool.Strict = wrapper.Function.Strict
+				}
+			}
+		}
 		t.ResponsesToolFunction = &funcTool
 
 	case ResponsesToolTypeFileSearch:

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -52,6 +52,136 @@ func TestBifrostResponsesStreamResponsePreservesOpenAIStreamMetadata(t *testing.
 	}
 }
 
+// Cursor (and other Chat Completions clients) send function tools nested under
+// a "function" wrapper. The unmarshal must lift name/description/parameters so
+// providers that require a top-level name (e.g. Bedrock) don't reject the tool.
+func TestResponsesToolUnmarshalLiftsChatCompletionsFunctionWrapper(t *testing.T) {
+	raw := []byte(`{
+		"type": "function",
+		"function": {
+			"name": "read_file",
+			"description": "Reads a file",
+			"parameters": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]},
+			"strict": true
+		}
+	}`)
+
+	var tool ResponsesTool
+	if err := Unmarshal(raw, &tool); err != nil {
+		t.Fatalf("unmarshal chat-completions-format tool: %v", err)
+	}
+
+	if tool.Name == nil || *tool.Name != "read_file" {
+		t.Fatalf("expected name lifted from function wrapper, got %#v", tool.Name)
+	}
+	if tool.Description == nil || *tool.Description != "Reads a file" {
+		t.Fatalf("expected description lifted from function wrapper, got %#v", tool.Description)
+	}
+	if tool.ResponsesToolFunction == nil || tool.ResponsesToolFunction.Parameters == nil {
+		t.Fatalf("expected parameters lifted from function wrapper, got %#v", tool.ResponsesToolFunction)
+	}
+	if len(tool.ResponsesToolFunction.Parameters.Required) != 1 || tool.ResponsesToolFunction.Parameters.Required[0] != "path" {
+		t.Fatalf("expected parameters schema to survive, got %#v", tool.ResponsesToolFunction.Parameters)
+	}
+	if tool.ResponsesToolFunction.Strict == nil || !*tool.ResponsesToolFunction.Strict {
+		t.Fatalf("expected strict lifted from function wrapper, got %#v", tool.ResponsesToolFunction.Strict)
+	}
+}
+
+func TestResponsesToolUnmarshalTopLevelFieldsWinOverFunctionWrapper(t *testing.T) {
+	tests := []struct {
+		name            string
+		raw             string
+		wantName        string
+		wantDescription string
+		wantStrict      *bool
+		wantParamKey    string
+	}{
+		{
+			name: "name_and_parameters",
+			raw: `{
+				"type": "function",
+				"name": "top_level_name",
+				"parameters": {"type": "object", "properties": {"a": {"type": "string"}}},
+				"function": {
+					"name": "nested_name",
+					"parameters": {"type": "object", "properties": {"b": {"type": "string"}}}
+				}
+			}`,
+			wantName:     "top_level_name",
+			wantParamKey: "a",
+		},
+		{
+			name: "description",
+			raw: `{
+				"type": "function",
+				"name": "top_level_name",
+				"description": "top-level description",
+				"function": {"name": "nested_name", "description": "nested description"}
+			}`,
+			wantName:        "top_level_name",
+			wantDescription: "top-level description",
+		},
+		{
+			name: "explicit_strict_false",
+			raw: `{
+				"type": "function",
+				"strict": false,
+				"function": {"name": "nested_name", "strict": true}
+			}`,
+			// Name is still lifted from the wrapper; the explicit top-level
+			// strict:false must not be overwritten by the nested strict:true.
+			wantName:   "nested_name",
+			wantStrict: Ptr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tool ResponsesTool
+			if err := Unmarshal([]byte(tt.raw), &tool); err != nil {
+				t.Fatalf("unmarshal mixed-format tool: %v", err)
+			}
+
+			if tool.Name == nil || *tool.Name != tt.wantName {
+				t.Fatalf("expected name %q, got %#v", tt.wantName, tool.Name)
+			}
+			if tool.ResponsesToolFunction == nil {
+				t.Fatalf("expected function tool payload, got nil")
+			}
+			if tt.wantDescription != "" && (tool.Description == nil || *tool.Description != tt.wantDescription) {
+				t.Fatalf("expected description %q, got %#v", tt.wantDescription, tool.Description)
+			}
+			if tt.wantStrict != nil {
+				if tool.ResponsesToolFunction.Strict == nil || *tool.ResponsesToolFunction.Strict != *tt.wantStrict {
+					t.Fatalf("expected strict %v, got %#v", *tt.wantStrict, tool.ResponsesToolFunction.Strict)
+				}
+			}
+			if tt.wantParamKey != "" {
+				if tool.ResponsesToolFunction.Parameters == nil || tool.ResponsesToolFunction.Parameters.Properties == nil {
+					t.Fatalf("expected parameters present, got %#v", tool.ResponsesToolFunction)
+				}
+				if _, ok := tool.ResponsesToolFunction.Parameters.Properties.Get(tt.wantParamKey); !ok {
+					t.Fatalf("expected top-level parameters to win, got %#v", tool.ResponsesToolFunction.Parameters)
+				}
+			}
+		})
+	}
+}
+
+func TestResponsesToolUnmarshalRejectsMalformedFunctionWrapper(t *testing.T) {
+	raw := []byte(`{"type": "function", "function": "not_an_object"}`)
+
+	var tool ResponsesTool
+	err := Unmarshal(raw, &tool)
+	if err == nil {
+		t.Fatalf("expected error for malformed function wrapper, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid 'function' object") {
+		t.Fatalf("expected contextual error, got %v", err)
+	}
+}
+
 func TestBifrostResponsesResponseUnmarshalTimestamps(t *testing.T) {
 	t.Run("float created_at is truncated to int", func(t *testing.T) {
 		raw := []byte(`{"object":"response","model":"m","created_at":1716000000.5,"output":[]}`)

--- a/plugins/governance/complexityextract.go
+++ b/plugins/governance/complexityextract.go
@@ -214,10 +214,16 @@ func isChatTextBlock(block schemas.ChatContentBlock) bool {
 	return block.Type == "" || block.Type == schemas.ChatContentBlockTypeText
 }
 
-// isResponsesInputTextBlock reports whether a Responses content block is input
+// isResponsesInputTextBlock reports whether a Responses content block is plain
 // text, treating an empty type as text for compatibility with normalized input.
+// output_text is accepted alongside input_text because the Anthropic→Responses
+// conversion tags user text blocks as output_text for bedrock/-prefixed models
+// (keepToolsGrouped path); rejecting them would silently disable complexity
+// routing for those clients.
 func isResponsesInputTextBlock(block schemas.ResponsesMessageContentBlock) bool {
-	return block.Type == "" || block.Type == schemas.ResponsesInputMessageContentBlockTypeText
+	return block.Type == "" ||
+		block.Type == schemas.ResponsesInputMessageContentBlockTypeText ||
+		block.Type == schemas.ResponsesOutputMessageContentTypeText
 }
 
 // appendText joins adjacent text fragments with one separating space while

--- a/plugins/governance/complexityextract_test.go
+++ b/plugins/governance/complexityextract_test.go
@@ -185,6 +185,37 @@ func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
 	}
 }
 
+// The Anthropic→Responses conversion tags user text blocks as output_text for
+// bedrock/-prefixed models (keepToolsGrouped path), emitting one message per
+// text block. Complexity extraction must still treat these as text, otherwise
+// Claude Code traffic using a bedrock/ alias never classifies and always falls
+// through to the default routing rule.
+func TestBuildComplexityInput_ResponsesOutputTextTypedUserBlocks(t *testing.T) {
+	systemRole := schemas.ResponsesInputMessageRoleSystem
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{
+					Role:    &systemRole,
+					Content: complexityResponsesBlocks(complexityResponsesTextBlock("You are a coding agent")),
+				},
+				{
+					Role:    &userRole,
+					Content: complexityResponsesBlocks(complexityResponsesOutputTextBlock("Explain encryption")),
+				},
+			},
+		},
+	}
+
+	input, ok := buildComplexityInput(req)
+	require.True(t, ok)
+	assert.Equal(t, "Explain encryption", input.LastUserText)
+	assert.Equal(t, "You are a coding agent", input.SystemText)
+}
+
 func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(t *testing.T) {
 	userRole := schemas.ResponsesInputMessageRoleUser
 	req := &schemas.BifrostRequest{


### PR DESCRIPTION
## Summary

Clients like Cursor send function tools to the Responses API using the Chat Completions format, where the tool definition is nested under a `"function"` key (e.g. `{"type":"function","function":{"name":...,"parameters":...}}`). The Responses API expects these fields at the top level, so without lifting them, the tool is parsed with a `nil` name and providers that require one (e.g. Bedrock) reject the request.

## Changes

- `ResponsesTool.UnmarshalJSON` now detects the presence of a `"function"` wrapper and promotes `name`, `description`, `parameters`, and `strict` from the nested object into the top-level struct fields, matching the Responses format.
- Top-level fields always take precedence over the nested wrapper when both are present, preserving correct behavior for well-formed Responses API payloads.
- Two new tests cover the lifting behavior and the precedence rule.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestResponsesTool
```

Expected: both `TestResponsesToolUnmarshalLiftsChatCompletionsFunctionWrapper` and `TestResponsesToolUnmarshalTopLevelFieldsWinOverFunctionWrapper` pass.

To reproduce the original issue, send a Chat Completions-format function tool (with a nested `"function"` object) to a Responses endpoint backed by Bedrock and confirm the request is no longer rejected due to a missing tool name.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The change only affects JSON deserialization of tool definitions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable