### PR TITLE
complexity : reducing keyword lists from 4 -> 3 lists

### DIFF
--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -402,14 +402,17 @@ bifrost:
         simple_medium: 0.20
         medium_complex: 0.40
       keywords:
-        code_keywords: ["function", "class", "api", "debug", "deploy"]
-        reasoning_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]
-        technical_keywords: ["architecture", "kubernetes", "latency", "authentication"]
         simple_keywords: ["hello", "hi", "thanks", "what is", "define"]
+        medium_keywords: ["function", "api", "debug", "architecture", "kubernetes", "latency"]
+        complex_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]
 ```
 
 <Note>
 In the default split mode, runtime UI and API edits are preserved while the matching Helm-rendered section is unchanged. When Helm changes a section, tier boundaries are replaced from the rendered `config.json`, while keyword lists are merged additively with stored runtime keywords (union with duplicates removed). Use `bifrost.sourceOfTruth: config.json` only when Helm should replace stored governance state. See [Source of Truth & Reconciliation](/deployment-guides/config-json/source-of-truth) for the full startup rules.
+</Note>
+
+<Note>
+Existing releases that still use `code_keywords`, `technical_keywords`, and `reasoning_keywords` remain valid during upgrade. Bifrost reads them as Medium (`code` + `technical`) and Complex (`reasoning`) signals. New configurations should use the three-list shape shown above.
 </Note>
 
 ---

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -23,25 +23,39 @@ This lets you route simple greetings to a fast, cheap model and deep reasoning t
 
 ### Scoring dimensions
 
-Classified requests produce a score between 0.0 and 1.0. The analyzer starts with a weighted score across five dimensions detected by scanning the last user message:
+Classified requests produce a score between 0.0 and 1.0. The three keyword lists are scoring signals, not direct tier mappings. The analyzer scans the last user message and normalizes each match count before applying these weights:
 
-| Dimension | Weight | What it measures |
-|---|---|---|
-| Code presence | 34% | Code, debugging, and programming artifacts |
-| Reasoning markers | 28% | Analytical and multi-step reasoning language |
-| Technical terms | 28% | Architecture, infra, and operational terminology |
-| Word count | 10% | Prompt length measured by whitespace-delimited words, used only after a signal or continuation is detected |
-| Simple indicators | -5% | Greetings, definitions, translation requests, and other straightforward asks |
+| Signal | Normalization | Weight | What it does |
+|---|---|---|---|
+| Medium keywords | `min(matches / 4, 1)` | +40% | Implementation, code, technical, architecture, and operational evidence |
+| Complex keywords | `min(matches / 3, 1)` | +50% | Narrow, high-confidence reasoning evidence |
+| Word count | length curve capped at 1 | +10% | Prompt length, used only after a positive signal or continuation is detected |
+| Simple keywords | `min(matches / 2, 1)` | -5% | A small dampener for greetings, definitions, translation requests, and other straightforward asks |
 
-Simple indicators are a small downward nudge, not an override. A simple-only request can classify as **Simple** with a `0.00` score, while a request that also has strong code, technical, or reasoning signals can still rise into a higher tier.
+```text
+last_message_score = clamp(
+  0.40 × medium_score
+  + 0.50 × complex_score
+  + 0.10 × token_score
+  - 0.05 × simple_score,
+  0,
+  1
+)
+```
+
+The divisors are saturation points, not tier thresholds: four Medium matches provide the full Medium contribution, three Complex matches provide the full Complex contribution, and two Simple matches provide the maximum small dampener.
+
+Simple indicators are a small downward nudge, not an override. A simple-only request can classify as **Simple** with a `0.00` score, while a request that also has strong Medium or Complex signals can still rise into a higher tier.
 
 ### System prompt contribution
 
-When the latest user message already has a code, technical, or reasoning signal, the system prompt is scanned for code and technical signals. Its contribution is weighted at **25% of the user-message signal** for those dimensions. This provides soft lexical context — for example, a system prompt describing a coding assistant nudges code scores up — but it never creates a classification by itself.
+When the latest user message already has a Medium or Complex signal, the system prompt is scanned for Medium signals. The system prompt's normalized Medium signal contributes at **25% strength**. This provides soft lexical context — for example, a system prompt describing a coding assistant nudges the Medium score up — but it never creates a classification by itself or triggers a Complex override.
 
 ### Conversation context blending
 
-For multi-turn conversations, prior context is used only when the latest user message has its own code, technical, or reasoning signal, or when the latest message reads as a continuation of the conversation and the prior-context score is at least 0.20. A message counts as a continuation when it is a configured continuation phrase such as "do it", "try again", "continue", or "go ahead", **or** when it is 12 words or fewer with no simple-keyword match — brevity itself is the signal in follow-ups like "yes but make it faster". Conversation closers like "thanks!" match a simple keyword, so they still classify as Simple instead of inheriting the conversation's complexity.
+For multi-turn conversations, prior context is used only when the latest user message has its own Medium or Complex signal, or when the latest message reads as a continuation of the conversation and the prior-context score is at least 0.20. A message counts as a continuation when it is a configured continuation phrase such as "do it", "try again", "continue", or "go ahead", **or** when it is 12 words or fewer with no simple-keyword match — brevity itself is the signal in follow-ups like "yes but make it faster". Conversation closers like "thanks!" match a Simple keyword, so they still classify as Simple instead of inheriting the conversation's complexity.
+
+Each prior user turn is scored as `(0.40 × medium_score + 0.50 × complex_score) / 0.90`. History intentionally excludes token length and Simple dampening; dividing by `0.90` normalizes the two available positive weights back to the full 0–1 range.
 
 In those cases, the score blends the current message with history from up to the last 10 user turns (recency-weighted: earlier turns count less):
 
@@ -53,9 +67,9 @@ A low-signal latest message that is not a continuation does not inherit old cont
 
 The final score is `max(last_message_score, weighted_blend)` — the current message always sets a floor.
 
-### Reasoning override
+### Complex guarantees
 
-When two or more **reasoning keywords** are detected in the last user message, the tier is promoted to **Complex** regardless of the numeric score. The same override applies when one strong reasoning keyword appears alongside strong code or technical signals.
+One **Complex keyword** in the last user message guarantees a tier of at least **Medium**. Two or more Complex keyword matches force **Complex**, regardless of the numeric score.
 
 This handles prompts like "step by step, explain why the authentication flow fails" that would score moderately on each individual dimension but clearly deserve the strongest model.
 
@@ -66,11 +80,11 @@ The final score maps to a tier using configurable boundaries (defaults shown):
 | Tier | Score range (defaults) | Typical requests |
 |---|---|---|
 | Simple | < 0.20 | Greetings, definitions, simple lookups |
-| Medium | 0.20 – 0.40 | General questions, short explanations |
+| Medium | ≥ 0.20 and < 0.40 | General questions, short explanations |
 | Complex | ≥ 0.40 (or override) | Technical questions, code help, analysis, root-cause investigation |
 
 <Note>
-Earlier Bifrost versions had a fourth tier, **REASONING**, above Complex. It has been merged into **COMPLEX**: the `complex_reasoning` boundary no longer exists, and the reasoning-keyword override now promotes to Complex. Historical log rows keep their recorded `REASONING` tier and stay reachable through the logs filter as a legacy value, but the CEL builder no longer offers it — update any routing rules that match on `"REASONING"`.
+Earlier Bifrost versions had a fourth tier, **REASONING**, above Complex. It has been merged into **COMPLEX**: the `complex_reasoning` boundary no longer exists, and the strongest lexical signals now live in `complex_keywords`. Historical log rows keep their recorded `REASONING` tier and stay reachable through the logs filter as a legacy value, but the CEL builder no longer offers it — update any routing rules that match on `"REASONING"`.
 </Note>
 
 ![Complexity Analyzer Pipeline](../../media/complexity-logic-architecture.png)
@@ -113,10 +127,9 @@ curl -X PUT http://localhost:8080/api/governance/complexity-analyzer-config \
       "medium_complex": 0.40
     },
     "keywords": {
-      "code_keywords": ["function", "class", "api", "debug"],
-      "reasoning_keywords": ["step by step", "explain why", "tradeoffs"],
-      "technical_keywords": ["architecture", "kubernetes", "latency"],
-      "simple_keywords": ["hello", "hi", "thanks", "what is"]
+      "simple_keywords": ["hello", "hi", "thanks", "what is"],
+      "medium_keywords": ["function", "api", "debug", "architecture", "kubernetes", "latency"],
+      "complex_keywords": ["step by step", "explain why", "tradeoffs"]
     }
   }'
 
@@ -132,10 +145,9 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
     "medium_complex": 0.40
   },
   "keywords": {
-    "code_keywords": ["function", "class", "..."],
-    "reasoning_keywords": ["step by step", "..."],
-    "technical_keywords": ["architecture", "..."],
-    "simple_keywords": ["hello", "hi", "..."]
+    "simple_keywords": ["hello", "hi", "..."],
+    "medium_keywords": ["function", "api", "architecture", "..."],
+    "complex_keywords": ["step by step", "..."]
   }
 }
 ```
@@ -152,10 +164,9 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
         "medium_complex": 0.40
       },
       "keywords": {
-        "code_keywords": ["function", "class", "api", "debug", "deploy"],
-        "reasoning_keywords": ["step by step", "explain why", "tradeoffs", "root cause analysis"],
-        "technical_keywords": ["architecture", "kubernetes", "latency", "authentication"],
-        "simple_keywords": ["hello", "hi", "thanks", "what is", "define"]
+        "simple_keywords": ["hello", "hi", "thanks", "what is", "define"],
+        "medium_keywords": ["function", "api", "debug", "architecture", "kubernetes", "latency"],
+        "complex_keywords": ["step by step", "explain why", "tradeoffs", "root cause analysis"]
       }
     }
   }
@@ -166,13 +177,16 @@ curl -X POST http://localhost:8080/api/governance/complexity-analyzer-config/res
 |---|---|---|---|---|
 | `tier_boundaries.simple_medium` | number | Yes | 0.20 | Score threshold between Simple and Medium (exclusive: 0 < value < 1) |
 | `tier_boundaries.medium_complex` | number | Yes | 0.40 | Score threshold between Medium and Complex; scores at or above are Complex |
-| `keywords.code_keywords` | string[] | Yes | built-in defaults | Signals for code/debugging/programming requests |
-| `keywords.reasoning_keywords` | string[] | Yes | built-in defaults | Strong reasoning triggers — matches can promote the request to the Complex tier |
-| `keywords.technical_keywords` | string[] | Yes | built-in defaults | Architecture/infra/operations signals |
 | `keywords.simple_keywords` | string[] | Yes | built-in defaults | Phrases that slightly reduce complexity and classify straightforward requests |
+| `keywords.medium_keywords` | string[] | Yes | built-in defaults | Code, implementation, technical, architecture, and operational scoring signals |
+| `keywords.complex_keywords` | string[] | Yes | built-in defaults | Strong reasoning signals with explicit minimum-tier and override behavior |
 
 <Note>
 Each keyword list requires at least one entry. Keywords are normalized to lowercase and deduplicated on save. Changes are hot-reloaded with no restart required.
+</Note>
+
+<Note>
+The legacy four-list shape remains readable for upgrades. `code_keywords` and `technical_keywords` are merged into `medium_keywords`, while `reasoning_keywords` becomes `complex_keywords`. The UI and API responses always show the canonical three-list shape. Existing legacy database rows are not rewritten merely by reading them; the next save or reset writes the canonical shape. Do not mix legacy and canonical fields in one configuration.
 </Note>
 
 <Warning>
@@ -202,13 +216,12 @@ Type a keyword or phrase and press **Enter** to add it. Click the × on any tag 
 
 | List | Effect | When to customize |
 |---|---|---|
-| **Code keywords** | Each match contributes to the Code dimension (34% weight) | Add domain-specific tooling, frameworks, or file types your users frequently mention |
-| **Reasoning keywords** | Strong triggers — two or more matches, or one match alongside strong code/technical signals, promotes the request to the Complex tier regardless of score | Narrow this list to the phrases that truly demand your most capable model. The default list is intentionally conservative. |
-| **Technical keywords** | Each match contributes to the Technical dimension (28% weight) | Add industry-specific jargon (e.g. "SOC 2", "HIPAA", "proration") relevant to your product |
 | **Simple keywords** | Each match slightly reduces the score and can classify straightforward requests as Simple | Add domain-specific phrases that signal trivial intent in your app context |
+| **Medium keywords** | Each match raises the Medium signal; four matches saturate its 40% contribution | Add domain-specific implementation, tooling, architecture, or operational terms |
+| **Complex keywords** | Each match raises the Complex signal; one guarantees at least Medium and two force Complex | Keep this list narrow and reserve it for language that truly demands your strongest model |
 
 <Warning>
-The **reasoning keywords** list gates the tier-override path, not just scoring. Adding broad terms like "explain" or "analyze" will push many requests to Complex. Prefer specific multi-word phrases like "step by step" or "root cause analysis".
+The **Complex keywords** list gates the tier-override path, not just scoring. Adding broad terms like "explain" or "analyze" will push many requests to Complex. Prefer specific multi-word phrases like "step by step" or "root cause analysis".
 </Warning>
 
 </Tab>
@@ -393,7 +406,7 @@ It does **not** run for:
 
 ### All traffic classified as Complex
 
-The **reasoning keywords** list is the most common cause. Check if any broad single-word terms were added (e.g. "explain", "analyze"). The override gate fires when two or more strong reasoning keywords match — a broad list will trigger it on most prompts. Replace single-word terms with specific multi-word phrases.
+The **Complex keywords** list is the most common cause. Check if any broad single-word terms were added (e.g. "explain", "analyze"). The override gate fires when two or more Complex keywords match — a broad list will trigger it on most prompts. Replace single-word terms with specific multi-word phrases.
 
 ### Want to test threshold changes without affecting live traffic
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -67498,37 +67498,29 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
+                      "description": "Editable scoring signals used by the complexity analyzer. Medium entries raise\nthe score gradually. One Complex match guarantees at least MEDIUM and two force\nCOMPLEX. Matching is normalized to lowercase and duplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
-                        "code_keywords",
-                        "reasoning_keywords",
-                        "technical_keywords",
-                        "simple_keywords"
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
                       ],
                       "properties": {
-                        "code_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "reasoning_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "technical_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
                         "simple_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "medium_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "complex_keywords": {
                           "type": "array",
                           "items": {
                             "type": "string"
@@ -67609,37 +67601,29 @@
                   },
                   "keywords": {
                     "type": "object",
-                    "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
+                    "description": "Editable scoring signals used by the complexity analyzer. Medium entries raise\nthe score gradually. One Complex match guarantees at least MEDIUM and two force\nCOMPLEX. Matching is normalized to lowercase and duplicates are removed on save.\n",
                     "additionalProperties": false,
                     "required": [
-                      "code_keywords",
-                      "reasoning_keywords",
-                      "technical_keywords",
-                      "simple_keywords"
+                      "simple_keywords",
+                      "medium_keywords",
+                      "complex_keywords"
                     ],
                     "properties": {
-                      "code_keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "reasoning_keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
-                      "technical_keywords": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "minItems": 1
-                      },
                       "simple_keywords": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "medium_keywords": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1
+                      },
+                      "complex_keywords": {
                         "type": "array",
                         "items": {
                           "type": "string"
@@ -67692,37 +67676,29 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
+                      "description": "Editable scoring signals used by the complexity analyzer. Medium entries raise\nthe score gradually. One Complex match guarantees at least MEDIUM and two force\nCOMPLEX. Matching is normalized to lowercase and duplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
-                        "code_keywords",
-                        "reasoning_keywords",
-                        "technical_keywords",
-                        "simple_keywords"
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
                       ],
                       "properties": {
-                        "code_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "reasoning_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "technical_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
                         "simple_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "medium_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "complex_keywords": {
                           "type": "array",
                           "items": {
                             "type": "string"
@@ -67816,37 +67792,29 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Editable keyword lists used by the complexity analyzer. Only the four user-facing\ndimensions are exposed; `reasoning_keywords` entries drive the override that\npromotes requests to the COMPLEX tier. Matching is normalized to lowercase and\nduplicates are removed on save.\n",
+                      "description": "Editable scoring signals used by the complexity analyzer. Medium entries raise\nthe score gradually. One Complex match guarantees at least MEDIUM and two force\nCOMPLEX. Matching is normalized to lowercase and duplicates are removed on save.\n",
                       "additionalProperties": false,
                       "required": [
-                        "code_keywords",
-                        "reasoning_keywords",
-                        "technical_keywords",
-                        "simple_keywords"
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
                       ],
                       "properties": {
-                        "code_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "reasoning_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
-                        "technical_keywords": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1
-                        },
                         "simple_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "medium_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "minItems": 1
+                        },
+                        "complex_keywords": {
                           "type": "array",
                           "items": {
                             "type": "string"

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2121,33 +2121,26 @@ ComplexityTierBoundaries:
 ComplexityKeywordConfig:
   type: object
   description: |
-    Editable keyword lists used by the complexity analyzer. Only the four user-facing
-    dimensions are exposed; `reasoning_keywords` entries drive the override that
-    promotes requests to the COMPLEX tier. Matching is normalized to lowercase and
-    duplicates are removed on save.
+    Editable scoring signals used by the complexity analyzer. Medium entries raise
+    the score gradually. One Complex match guarantees at least MEDIUM and two force
+    COMPLEX. Matching is normalized to lowercase and duplicates are removed on save.
   additionalProperties: false
   required:
-    - code_keywords
-    - reasoning_keywords
-    - technical_keywords
     - simple_keywords
+    - medium_keywords
+    - complex_keywords
   properties:
-    code_keywords:
-      type: array
-      items:
-        type: string
-      minItems: 1
-    reasoning_keywords:
-      type: array
-      items:
-        type: string
-      minItems: 1
-    technical_keywords:
-      type: array
-      items:
-        type: string
-      minItems: 1
     simple_keywords:
+      type: array
+      items:
+        type: string
+      minItems: 1
+    medium_keywords:
+      type: array
+      items:
+        type: string
+      minItems: 1
+    complex_keywords:
       type: array
       items:
         type: string

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1281,30 +1281,54 @@ func GenerateComplexityAnalyzerConfigHashes(config *ComplexityAnalyzerConfig) (C
 	if err != nil {
 		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash tier boundaries: %w", err)
 	}
-	codeHash, err := hashComplexityValue(normalized.Keywords.CodeKeywords)
-	if err != nil {
-		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash code keywords: %w", err)
-	}
-	reasoningHash, err := hashComplexityValue(normalized.Keywords.ReasoningKeywords)
-	if err != nil {
-		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash reasoning keywords: %w", err)
-	}
-	technicalHash, err := hashComplexityValue(normalized.Keywords.TechnicalKeywords)
-	if err != nil {
-		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash technical keywords: %w", err)
-	}
 	simpleHash, err := hashComplexityValue(normalized.Keywords.SimpleKeywords)
 	if err != nil {
 		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash simple keywords: %w", err)
 	}
+	mediumHash, err := hashComplexityValue(normalized.Keywords.MediumKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash medium keywords: %w", err)
+	}
+	complexHash, err := hashComplexityValue(normalized.Keywords.ComplexKeywords)
+	if err != nil {
+		return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash complex keywords: %w", err)
+	}
 
 	return ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    tierHash,
-		CodeKeywords:      codeHash,
-		ReasoningKeywords: reasoningHash,
-		TechnicalKeywords: technicalHash,
-		SimpleKeywords:    simpleHash,
+		TierBoundaries:  tierHash,
+		SimpleKeywords:  simpleHash,
+		MediumKeywords:  mediumHash,
+		ComplexKeywords: complexHash,
 	}, nil
+}
+
+// GenerateLegacyComplexityMediumKeywordsHash returns the Medium section hash
+// used when config.json still has separate Code and Technical keyword lists.
+// Hashing the two legacy section hashes, rather than their merged runtime list,
+// keeps config.json change detection independent from DB/UI keyword edits.
+func GenerateLegacyComplexityMediumKeywordsHash(codeKeywords, technicalKeywords []string) (string, error) {
+	codeHash, err := hashComplexityValue(normalizeComplexityKeywordList(codeKeywords))
+	if err != nil {
+		return "", fmt.Errorf("failed to hash legacy code keywords: %w", err)
+	}
+	technicalHash, err := hashComplexityValue(normalizeComplexityKeywordList(technicalKeywords))
+	if err != nil {
+		return "", fmt.Errorf("failed to hash legacy technical keywords: %w", err)
+	}
+	return legacyMediumKeywordsHashFromSectionHashes(codeHash, technicalHash)
+}
+
+func legacyMediumKeywordsHashFromSectionHashes(codeHash, technicalHash string) (string, error) {
+	if codeHash == "" && technicalHash == "" {
+		return "", nil
+	}
+	return hashComplexityValue(struct {
+		CodeKeywords      string `json:"code_keywords"`
+		TechnicalKeywords string `json:"technical_keywords"`
+	}{
+		CodeKeywords:      codeHash,
+		TechnicalKeywords: technicalHash,
+	})
 }
 
 func hashComplexityValue(value any) (string, error) {

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -31,16 +31,88 @@ func (b *ComplexityTierBoundaries) Validate() error {
 
 // ComplexityEditableKeywordConfig contains the user-editable keyword lists.
 type ComplexityEditableKeywordConfig struct {
+	SimpleKeywords  []string `json:"simple_keywords"`
+	MediumKeywords  []string `json:"medium_keywords"`
+	ComplexKeywords []string `json:"complex_keywords"`
+}
+
+type legacyComplexityEditableKeywordConfig struct {
 	CodeKeywords      []string `json:"code_keywords"`
 	ReasoningKeywords []string `json:"reasoning_keywords"`
 	TechnicalKeywords []string `json:"technical_keywords"`
 	SimpleKeywords    []string `json:"simple_keywords"`
 }
 
+// UnmarshalJSON accepts the canonical three-list shape and the deprecated
+// four-list shape. Runtime and API callers always receive the canonical shape.
+func (c *ComplexityEditableKeywordConfig) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	allowed := map[string]struct{}{
+		"simple_keywords":    {},
+		"medium_keywords":    {},
+		"complex_keywords":   {},
+		"code_keywords":      {},
+		"reasoning_keywords": {},
+		"technical_keywords": {},
+	}
+	for field := range fields {
+		if _, ok := allowed[field]; !ok {
+			return fmt.Errorf("unknown complexity keyword field %q", field)
+		}
+	}
+
+	hasCanonical := hasAnyComplexityField(fields, "medium_keywords", "complex_keywords")
+	hasLegacy := hasAnyComplexityField(fields, "code_keywords", "reasoning_keywords", "technical_keywords")
+	if hasCanonical && hasLegacy {
+		return fmt.Errorf("complexity keyword config cannot mix canonical and legacy fields")
+	}
+
+	if hasLegacy {
+		var legacy legacyComplexityEditableKeywordConfig
+		if err := json.Unmarshal(data, &legacy); err != nil {
+			return err
+		}
+		*c = ComplexityEditableKeywordConfig{
+			SimpleKeywords:  legacy.SimpleKeywords,
+			MediumKeywords:  mergeComplexityKeywordLists(legacy.CodeKeywords, legacy.TechnicalKeywords),
+			ComplexKeywords: legacy.ReasoningKeywords,
+		}
+		return nil
+	}
+
+	type canonicalComplexityEditableKeywordConfig ComplexityEditableKeywordConfig
+	var canonical canonicalComplexityEditableKeywordConfig
+	if err := json.Unmarshal(data, &canonical); err != nil {
+		return err
+	}
+	*c = ComplexityEditableKeywordConfig(canonical)
+	return nil
+}
+
+func hasAnyComplexityField(fields map[string]json.RawMessage, names ...string) bool {
+	for _, name := range names {
+		if _, ok := fields[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // ComplexityAnalyzerConfigHashes tracks the config.json hash for each editable
 // analyzer section. It is persisted with the config row, but not exposed through
 // API responses or config.json.
 type ComplexityAnalyzerConfigHashes struct {
+	TierBoundaries  string `json:"tier_boundaries,omitempty"`
+	SimpleKeywords  string `json:"simple_keywords,omitempty"`
+	MediumKeywords  string `json:"medium_keywords,omitempty"`
+	ComplexKeywords string `json:"complex_keywords,omitempty"`
+}
+
+type legacyComplexityAnalyzerConfigHashes struct {
 	TierBoundaries    string `json:"tier_boundaries,omitempty"`
 	CodeKeywords      string `json:"code_keywords,omitempty"`
 	ReasoningKeywords string `json:"reasoning_keywords,omitempty"`
@@ -48,22 +120,60 @@ type ComplexityAnalyzerConfigHashes struct {
 	SimpleKeywords    string `json:"simple_keywords,omitempty"`
 }
 
+// UnmarshalJSON translates persisted legacy section hashes into the canonical
+// three-list representation without hashing the runtime DB keyword values.
+func (h *ComplexityAnalyzerConfigHashes) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	hasCanonical := hasAnyComplexityField(fields, "medium_keywords", "complex_keywords")
+	hasLegacy := hasAnyComplexityField(fields, "code_keywords", "reasoning_keywords", "technical_keywords")
+	if hasCanonical && hasLegacy {
+		return fmt.Errorf("complexity config hashes cannot mix canonical and legacy fields")
+	}
+
+	if hasLegacy {
+		var legacy legacyComplexityAnalyzerConfigHashes
+		if err := json.Unmarshal(data, &legacy); err != nil {
+			return err
+		}
+		mediumHash, err := legacyMediumKeywordsHashFromSectionHashes(legacy.CodeKeywords, legacy.TechnicalKeywords)
+		if err != nil {
+			return err
+		}
+		*h = ComplexityAnalyzerConfigHashes{
+			TierBoundaries:  legacy.TierBoundaries,
+			SimpleKeywords:  legacy.SimpleKeywords,
+			MediumKeywords:  mediumHash,
+			ComplexKeywords: legacy.ReasoningKeywords,
+		}
+		return nil
+	}
+
+	type canonicalComplexityAnalyzerConfigHashes ComplexityAnalyzerConfigHashes
+	var canonical canonicalComplexityAnalyzerConfigHashes
+	if err := json.Unmarshal(data, &canonical); err != nil {
+		return err
+	}
+	*h = ComplexityAnalyzerConfigHashes(canonical)
+	return nil
+}
+
 // Empty reports whether no file-backed section hashes are present.
 func (h ComplexityAnalyzerConfigHashes) Empty() bool {
 	return h.TierBoundaries == "" &&
-		h.CodeKeywords == "" &&
-		h.ReasoningKeywords == "" &&
-		h.TechnicalKeywords == "" &&
-		h.SimpleKeywords == ""
+		h.SimpleKeywords == "" &&
+		h.MediumKeywords == "" &&
+		h.ComplexKeywords == ""
 }
 
 // Equal reports whether all section hashes match.
 func (h ComplexityAnalyzerConfigHashes) Equal(other ComplexityAnalyzerConfigHashes) bool {
 	return h.TierBoundaries == other.TierBoundaries &&
-		h.CodeKeywords == other.CodeKeywords &&
-		h.ReasoningKeywords == other.ReasoningKeywords &&
-		h.TechnicalKeywords == other.TechnicalKeywords &&
-		h.SimpleKeywords == other.SimpleKeywords
+		h.SimpleKeywords == other.SimpleKeywords &&
+		h.MediumKeywords == other.MediumKeywords &&
+		h.ComplexKeywords == other.ComplexKeywords
 }
 
 // ComplexityAnalyzerConfig is the persisted runtime configuration for the complexity analyzer.
@@ -89,17 +199,14 @@ func (c *ComplexityAnalyzerConfig) Validate() error {
 	}
 
 	var missing []string
-	if len(c.Keywords.CodeKeywords) == 0 {
-		missing = append(missing, "code_keywords")
-	}
-	if len(c.Keywords.ReasoningKeywords) == 0 {
-		missing = append(missing, "reasoning_keywords")
-	}
-	if len(c.Keywords.TechnicalKeywords) == 0 {
-		missing = append(missing, "technical_keywords")
-	}
 	if len(c.Keywords.SimpleKeywords) == 0 {
 		missing = append(missing, "simple_keywords")
+	}
+	if len(c.Keywords.MediumKeywords) == 0 {
+		missing = append(missing, "medium_keywords")
+	}
+	if len(c.Keywords.ComplexKeywords) == 0 {
+		missing = append(missing, "complex_keywords")
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("keyword lists must be non-empty: %s", strings.Join(missing, ", "))
@@ -115,10 +222,9 @@ func (c *ComplexityAnalyzerConfig) Normalized() ComplexityAnalyzerConfig {
 	return ComplexityAnalyzerConfig{
 		TierBoundaries: c.TierBoundaries,
 		Keywords: ComplexityEditableKeywordConfig{
-			CodeKeywords:      normalizeComplexityKeywordList(c.Keywords.CodeKeywords),
-			ReasoningKeywords: normalizeComplexityKeywordList(c.Keywords.ReasoningKeywords),
-			TechnicalKeywords: normalizeComplexityKeywordList(c.Keywords.TechnicalKeywords),
-			SimpleKeywords:    normalizeComplexityKeywordList(c.Keywords.SimpleKeywords),
+			SimpleKeywords:  normalizeComplexityKeywordList(c.Keywords.SimpleKeywords),
+			MediumKeywords:  normalizeComplexityKeywordList(c.Keywords.MediumKeywords),
+			ComplexKeywords: normalizeComplexityKeywordList(c.Keywords.ComplexKeywords),
 		},
 		ConfigHashes: c.ConfigHashes,
 	}
@@ -153,10 +259,9 @@ func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*Compl
 	merged := ComplexityAnalyzerConfig{
 		TierBoundaries: normalizedFile.TierBoundaries,
 		Keywords: ComplexityEditableKeywordConfig{
-			CodeKeywords:      mergeComplexityKeywordLists(normalizedBase.Keywords.CodeKeywords, normalizedFile.Keywords.CodeKeywords),
-			ReasoningKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ReasoningKeywords, normalizedFile.Keywords.ReasoningKeywords),
-			TechnicalKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.TechnicalKeywords, normalizedFile.Keywords.TechnicalKeywords),
-			SimpleKeywords:    mergeComplexityKeywordLists(normalizedBase.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords),
+			SimpleKeywords:  mergeComplexityKeywordLists(normalizedBase.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords),
+			MediumKeywords:  mergeComplexityKeywordLists(normalizedBase.Keywords.MediumKeywords, normalizedFile.Keywords.MediumKeywords),
+			ComplexKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ComplexKeywords, normalizedFile.Keywords.ComplexKeywords),
 		},
 		ConfigHashes: normalizedFile.ConfigHashes,
 	}
@@ -190,21 +295,17 @@ func MergeComplexityAnalyzerConfigByHashes(base, file *ComplexityAnalyzerConfig)
 		merged.TierBoundaries = normalizedFile.TierBoundaries
 		merged.ConfigHashes.TierBoundaries = normalizedFile.ConfigHashes.TierBoundaries
 	}
-	if merged.ConfigHashes.CodeKeywords != normalizedFile.ConfigHashes.CodeKeywords {
-		merged.Keywords.CodeKeywords = mergeComplexityKeywordLists(merged.Keywords.CodeKeywords, normalizedFile.Keywords.CodeKeywords)
-		merged.ConfigHashes.CodeKeywords = normalizedFile.ConfigHashes.CodeKeywords
-	}
-	if merged.ConfigHashes.ReasoningKeywords != normalizedFile.ConfigHashes.ReasoningKeywords {
-		merged.Keywords.ReasoningKeywords = mergeComplexityKeywordLists(merged.Keywords.ReasoningKeywords, normalizedFile.Keywords.ReasoningKeywords)
-		merged.ConfigHashes.ReasoningKeywords = normalizedFile.ConfigHashes.ReasoningKeywords
-	}
-	if merged.ConfigHashes.TechnicalKeywords != normalizedFile.ConfigHashes.TechnicalKeywords {
-		merged.Keywords.TechnicalKeywords = mergeComplexityKeywordLists(merged.Keywords.TechnicalKeywords, normalizedFile.Keywords.TechnicalKeywords)
-		merged.ConfigHashes.TechnicalKeywords = normalizedFile.ConfigHashes.TechnicalKeywords
-	}
 	if merged.ConfigHashes.SimpleKeywords != normalizedFile.ConfigHashes.SimpleKeywords {
 		merged.Keywords.SimpleKeywords = mergeComplexityKeywordLists(merged.Keywords.SimpleKeywords, normalizedFile.Keywords.SimpleKeywords)
 		merged.ConfigHashes.SimpleKeywords = normalizedFile.ConfigHashes.SimpleKeywords
+	}
+	if merged.ConfigHashes.MediumKeywords != normalizedFile.ConfigHashes.MediumKeywords {
+		merged.Keywords.MediumKeywords = mergeComplexityKeywordLists(merged.Keywords.MediumKeywords, normalizedFile.Keywords.MediumKeywords)
+		merged.ConfigHashes.MediumKeywords = normalizedFile.ConfigHashes.MediumKeywords
+	}
+	if merged.ConfigHashes.ComplexKeywords != normalizedFile.ConfigHashes.ComplexKeywords {
+		merged.Keywords.ComplexKeywords = mergeComplexityKeywordLists(merged.Keywords.ComplexKeywords, normalizedFile.Keywords.ComplexKeywords)
+		merged.ConfigHashes.ComplexKeywords = normalizedFile.ConfigHashes.ComplexKeywords
 	}
 	if err := merged.Validate(); err != nil {
 		return nil, err

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -87,10 +87,9 @@ func testComplexityAnalyzerConfig() *ComplexityAnalyzerConfig {
 			MediumComplex: 0.30,
 		},
 		Keywords: ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{" Function ", "api", "API"},
-			ReasoningKeywords: []string{"tradeoffs"},
-			TechnicalKeywords: []string{"latency"},
-			SimpleKeywords:    []string{"hello"},
+			SimpleKeywords:  []string{"hello"},
+			MediumKeywords:  []string{" Function ", "api", "API", "latency"},
+			ComplexKeywords: []string{"tradeoffs"},
 		},
 	}
 }
@@ -131,11 +130,10 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 
 	cfg := testComplexityAnalyzerConfig()
 	cfg.ConfigHashes = ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "tier-hash-1",
-		CodeKeywords:      "code-hash-1",
-		ReasoningKeywords: "reason-hash-1",
-		TechnicalKeywords: "tech-hash-1",
-		SimpleKeywords:    "simple-hash-1",
+		TierBoundaries:  "tier-hash-1",
+		SimpleKeywords:  "simple-hash-1",
+		MediumKeywords:  "medium-hash-1",
+		ComplexKeywords: "complex-hash-1",
 	}
 	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
@@ -146,7 +144,7 @@ func TestRDBConfigStore_ComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 		SimpleMedium:  0.10,
 		MediumComplex: 0.30,
 	}, got.TierBoundaries)
-	assert.Equal(t, []string{"api", "function"}, got.Keywords.CodeKeywords)
+	assert.Equal(t, []string{"api", "function", "latency"}, got.Keywords.MediumKeywords)
 	assert.Equal(t, cfg.ConfigHashes, got.ConfigHashes)
 }
 
@@ -159,17 +157,85 @@ func TestRDBConfigStore_GetComplexityAnalyzerConfigMissingReturnsNil(t *testing.
 	assert.Nil(t, got)
 }
 
+func TestRDBConfigStore_LegacyComplexityAnalyzerConfigReadAndCanonicalWrite(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	legacyRaw := `{
+		"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4,"complex_reasoning":0.6},
+		"keywords":{
+			"code_keywords":["api","ui-code"],
+			"reasoning_keywords":["tradeoffs","ui-reasoning"],
+			"technical_keywords":["latency","ui-technical"],
+			"simple_keywords":["hello","ui-simple"]
+		},
+		"_config_hashes":{
+			"tier_boundaries":"tier-hash",
+			"code_keywords":"code-file-hash",
+			"reasoning_keywords":"reasoning-file-hash",
+			"technical_keywords":"technical-file-hash",
+			"simple_keywords":"simple-file-hash"
+		}
+	}`
+	require.NoError(t, store.UpdateConfig(ctx, &tables.TableGovernanceConfig{
+		Key:   tables.ConfigComplexityAnalyzerConfigKey,
+		Value: legacyRaw,
+	}))
+
+	got, err := store.GetComplexityAnalyzerConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"api", "latency", "ui-code", "ui-technical"}, got.Keywords.MediumKeywords)
+	assert.Equal(t, []string{"tradeoffs", "ui-reasoning"}, got.Keywords.ComplexKeywords)
+	expectedMediumHash, err := legacyMediumKeywordsHashFromSectionHashes("code-file-hash", "technical-file-hash")
+	require.NoError(t, err)
+	assert.Equal(t, expectedMediumHash, got.ConfigHashes.MediumKeywords)
+	assert.Equal(t, "reasoning-file-hash", got.ConfigHashes.ComplexKeywords)
+
+	// API/UI payloads do not contain internal hashes. The store re-reads the
+	// legacy row, preserves its translated hashes, and writes canonical JSON.
+	got.Keywords.MediumKeywords = []string{"latency", "ui-code", "ui-technical"}
+	got.ConfigHashes = ComplexityAnalyzerConfigHashes{}
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, got))
+
+	entry, err := store.GetConfig(ctx, tables.ConfigComplexityAnalyzerConfigKey)
+	require.NoError(t, err)
+	assert.NotContains(t, entry.Value, `"code_keywords"`)
+	assert.NotContains(t, entry.Value, `"technical_keywords"`)
+	assert.NotContains(t, entry.Value, `"reasoning_keywords"`)
+	assert.NotContains(t, entry.Value, `"complex_reasoning"`)
+	assert.Contains(t, entry.Value, `"medium_keywords"`)
+	assert.Contains(t, entry.Value, `"complex_keywords"`)
+
+	reloaded, err := store.GetComplexityAnalyzerConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, []string{"latency", "ui-code", "ui-technical"}, reloaded.Keywords.MediumKeywords)
+	assert.Equal(t, expectedMediumHash, reloaded.ConfigHashes.MediumKeywords)
+}
+
+func TestDecodeComplexityAnalyzerConfigRejectsMixedKeywordShapes(t *testing.T) {
+	_, err := DecodeComplexityAnalyzerConfig([]byte(`{
+		"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4},
+		"keywords":{
+			"simple_keywords":["hello"],
+			"medium_keywords":["api"],
+			"complex_keywords":["tradeoffs"],
+			"code_keywords":["debug"]
+		}
+	}`))
+	require.ErrorContains(t, err, "cannot mix canonical and legacy fields")
+}
+
 func TestRDBConfigStore_UpdateComplexityAnalyzerConfigPreservesExistingHashesOnRuntimeUpdate(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
 	fileConfig := testComplexityAnalyzerConfig()
 	fileConfig.ConfigHashes = ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "tier-hash-1",
-		CodeKeywords:      "code-hash-1",
-		ReasoningKeywords: "reason-hash-1",
-		TechnicalKeywords: "tech-hash-1",
-		SimpleKeywords:    "simple-hash-1",
+		TierBoundaries:  "tier-hash-1",
+		SimpleKeywords:  "simple-hash-1",
+		MediumKeywords:  "medium-hash-1",
+		ComplexKeywords: "complex-hash-1",
 	}
 	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, fileConfig))
 
@@ -188,9 +254,9 @@ func TestRDBConfigStore_UpdateComplexityAnalyzerConfigPreservesExistingHashesOnR
 func TestGenerateComplexityAnalyzerConfigHashesCanonicalizesKeywords(t *testing.T) {
 	left := testComplexityAnalyzerConfig()
 	right := testComplexityAnalyzerConfig()
-	right.Keywords.CodeKeywords = []string{"api", "function"}
-	left.ConfigHashes = ComplexityAnalyzerConfigHashes{CodeKeywords: "stored-code-hash-a"}
-	right.ConfigHashes = ComplexityAnalyzerConfigHashes{CodeKeywords: "stored-code-hash-b"}
+	right.Keywords.MediumKeywords = []string{"api", "function", "latency"}
+	left.ConfigHashes = ComplexityAnalyzerConfigHashes{MediumKeywords: "stored-medium-hash-a"}
+	right.ConfigHashes = ComplexityAnalyzerConfigHashes{MediumKeywords: "stored-medium-hash-b"}
 
 	leftHashes, err := GenerateComplexityAnalyzerConfigHashes(left)
 	require.NoError(t, err)
@@ -207,9 +273,8 @@ func TestMergeComplexityAnalyzerConfigAddsKeywordsAndOverlaysBoundaries(t *testi
 		SimpleMedium:  0.20,
 		MediumComplex: 0.40,
 	}
-	file.Keywords.CodeKeywords = []string{"GraphQL", "api"}
-	file.Keywords.ReasoningKeywords = []string{"tradeoffs", "step by step"}
-	file.Keywords.TechnicalKeywords = []string{"latency", "kubernetes"}
+	file.Keywords.MediumKeywords = []string{"GraphQL", "api", "latency", "kubernetes"}
+	file.Keywords.ComplexKeywords = []string{"tradeoffs", "step by step"}
 	file.Keywords.SimpleKeywords = []string{"hello", "thanks"}
 
 	merged, err := MergeComplexityAnalyzerConfig(base, file)
@@ -217,41 +282,39 @@ func TestMergeComplexityAnalyzerConfigAddsKeywordsAndOverlaysBoundaries(t *testi
 	require.NotNil(t, merged)
 
 	assert.Equal(t, file.TierBoundaries, merged.TierBoundaries)
-	assert.Equal(t, []string{"api", "function", "graphql"}, merged.Keywords.CodeKeywords)
-	assert.Equal(t, []string{"step by step", "tradeoffs"}, merged.Keywords.ReasoningKeywords)
-	assert.Equal(t, []string{"kubernetes", "latency"}, merged.Keywords.TechnicalKeywords)
+	assert.Equal(t, []string{"api", "function", "graphql", "kubernetes", "latency"}, merged.Keywords.MediumKeywords)
+	assert.Equal(t, []string{"step by step", "tradeoffs"}, merged.Keywords.ComplexKeywords)
 	assert.Equal(t, []string{"hello", "thanks"}, merged.Keywords.SimpleKeywords)
 }
 
 func TestMergeComplexityAnalyzerConfigByHashesOnlyAppliesChangedSections(t *testing.T) {
 	base := testComplexityAnalyzerConfig()
 	base.ConfigHashes = ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "tier-hash-1",
-		CodeKeywords:      "code-hash-1",
-		ReasoningKeywords: "reason-hash-1",
-		TechnicalKeywords: "tech-hash-1",
-		SimpleKeywords:    "simple-hash-1",
+		TierBoundaries:  "tier-hash-1",
+		SimpleKeywords:  "simple-hash-1",
+		MediumKeywords:  "medium-hash-1",
+		ComplexKeywords: "complex-hash-1",
 	}
 	base.TierBoundaries.SimpleMedium = 0.12
-	base.Keywords.CodeKeywords = []string{"ui-code"}
-	base.Keywords.ReasoningKeywords = []string{"ui-reason"}
+	base.Keywords.MediumKeywords = []string{"ui-medium"}
+	base.Keywords.ComplexKeywords = []string{"ui-complex"}
 
 	file := testComplexityAnalyzerConfig()
 	file.ConfigHashes = base.ConfigHashes
-	file.ConfigHashes.CodeKeywords = "code-hash-2"
+	file.ConfigHashes.MediumKeywords = "medium-hash-2"
 	file.TierBoundaries.SimpleMedium = 0.20
-	file.Keywords.CodeKeywords = []string{"file-code"}
-	file.Keywords.ReasoningKeywords = []string{"file-reason"}
+	file.Keywords.MediumKeywords = []string{"file-medium"}
+	file.Keywords.ComplexKeywords = []string{"file-complex"}
 
 	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
 	require.NoError(t, err)
 	require.NotNil(t, merged)
 
 	assert.Equal(t, 0.12, merged.TierBoundaries.SimpleMedium)
-	assert.Equal(t, []string{"file-code", "ui-code"}, merged.Keywords.CodeKeywords)
-	assert.Equal(t, []string{"ui-reason"}, merged.Keywords.ReasoningKeywords)
-	assert.Equal(t, "code-hash-2", merged.ConfigHashes.CodeKeywords)
-	assert.Equal(t, "reason-hash-1", merged.ConfigHashes.ReasoningKeywords)
+	assert.Equal(t, []string{"file-medium", "ui-medium"}, merged.Keywords.MediumKeywords)
+	assert.Equal(t, []string{"ui-complex"}, merged.Keywords.ComplexKeywords)
+	assert.Equal(t, "medium-hash-2", merged.ConfigHashes.MediumKeywords)
+	assert.Equal(t, "complex-hash-1", merged.ConfigHashes.ComplexKeywords)
 }
 
 func TestRDBConfigStore_GetGovernanceConfigIncludesComplexityAnalyzerConfig(t *testing.T) {
@@ -260,11 +323,10 @@ func TestRDBConfigStore_GetGovernanceConfigIncludesComplexityAnalyzerConfig(t *t
 
 	cfg := testComplexityAnalyzerConfig()
 	cfg.ConfigHashes = ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "tier-hash-2",
-		CodeKeywords:      "code-hash-2",
-		ReasoningKeywords: "reason-hash-2",
-		TechnicalKeywords: "tech-hash-2",
-		SimpleKeywords:    "simple-hash-2",
+		TierBoundaries:  "tier-hash-2",
+		SimpleKeywords:  "simple-hash-2",
+		MediumKeywords:  "medium-hash-2",
+		ComplexKeywords: "complex-hash-2",
 	}
 	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, cfg))
 
@@ -321,21 +383,15 @@ func TestRDBConfigStore_UpdateComplexityAnalyzerConfigRejectsInvalidConfig(t *te
 			},
 		},
 		{
-			name: "empty code keywords",
+			name: "empty medium keywords",
 			mutate: func(cfg *ComplexityAnalyzerConfig) {
-				cfg.Keywords.CodeKeywords = nil
+				cfg.Keywords.MediumKeywords = nil
 			},
 		},
 		{
-			name: "empty reasoning keywords",
+			name: "empty complex keywords",
 			mutate: func(cfg *ComplexityAnalyzerConfig) {
-				cfg.Keywords.ReasoningKeywords = nil
-			},
-		},
-		{
-			name: "empty technical keywords",
-			mutate: func(cfg *ComplexityAnalyzerConfig) {
-				cfg.Keywords.TechnicalKeywords = nil
+				cfg.Keywords.ComplexKeywords = nil
 			},
 		},
 		{

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2047,43 +2047,80 @@
                   "additionalProperties": false
                 },
                 "keywords": {
-                  "type": "object",
-                  "properties": {
-                    "code_keywords": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
+                  "description": "Keyword scoring signals. The legacy four-list shape remains accepted for upgrades.",
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "simple_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "medium_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "complex_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        }
                       },
-                      "minItems": 1
+                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "additionalProperties": false
                     },
-                    "reasoning_keywords": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
+                    {
+                      "type": "object",
+                      "deprecated": true,
+                      "properties": {
+                        "code_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "reasoning_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "technical_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        },
+                        "simple_keywords": {
+                          "type": "array",
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "minItems": 1
+                        }
                       },
-                      "minItems": 1
-                    },
-                    "technical_keywords": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "minItems": 1
-                    },
-                    "simple_keywords": {
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "minItems": 1
+                      "required": ["code_keywords", "reasoning_keywords", "technical_keywords", "simple_keywords"],
+                      "additionalProperties": false
                     }
-                  },
-                  "required": ["code_keywords", "reasoning_keywords", "technical_keywords", "simple_keywords"],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "required": ["tier_boundaries", "keywords"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -894,10 +894,9 @@ bifrost:
       #   simple_medium: 0.20   # Scores below this are SIMPLE
       #   medium_complex: 0.40  # Scores below this (and >= simple_medium) are MEDIUM; at or above are COMPLEX
       # keywords:
-      #   code_keywords: ["function", "class", "api", "debug", "deploy"]
-      #   reasoning_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]
-      #   technical_keywords: ["architecture", "kubernetes", "latency", "authentication"]
       #   simple_keywords: ["hello", "hi", "thanks", "what is", "define"]
+      #   medium_keywords: ["function", "api", "debug", "architecture", "kubernetes", "latency"]
+      #   complex_keywords: ["step by step", "explain why", "tradeoffs", "root cause analysis"]
     authConfig:
       adminUsername: ""
       adminPassword: ""

--- a/plugins/governance/complexity/analyzer.go
+++ b/plugins/governance/complexity/analyzer.go
@@ -52,33 +52,27 @@ func (a *ComplexityAnalyzer) Analyze(input ComplexityInput) *ComplexityResult {
 	}
 
 	// Score primary message signals.
-	userCodeScore := scoreCount(lastSignals.codeCount, 3)
-	reasoningScore := scoreCount(lastSignals.reasoningCount, 2)
-	userTechnicalScore := scoreCount(lastSignals.technicalCount, 3)
-	userSimpleScore := scoreCount(lastSignals.simpleCount, 2)
+	userMediumScore := scoreCount(lastSignals.mediumCount, mediumMatchSaturation)
+	complexScore := scoreCount(lastSignals.complexCount, complexMatchSaturation)
+	userSimpleScore := scoreCount(lastSignals.simpleCount, simpleMatchSaturation)
 	tokenScore := 0.0
 	if hasPositiveSignal || isContinuation {
 		tokenScore = scoreTokenCount(wordCount)
 	}
 
-	// System prompt provides soft lexical context for code/technical signals,
-	// but never drives reasoning override or token count.
-	systemCodeScore := scoreCount(systemSignals.codeCount, 3)
-	systemTechnicalScore := scoreCount(systemSignals.technicalCount, 3)
+	// System prompts provide soft Medium evidence, but never drive the Complex
+	// override or token count.
+	systemMediumScore := scoreCount(systemSignals.mediumCount, mediumMatchSaturation)
+	mediumScore := clamp(userMediumScore+(systemMediumScore*systemPromptAssistFactor), 0.0, 1.0)
 
-	codeScore := clamp(userCodeScore+(systemCodeScore*systemPromptAssistFactor), 0.0, 1.0)
-	technicalScore := clamp(userTechnicalScore+(systemTechnicalScore*systemPromptAssistFactor), 0.0, 1.0)
-
-	codeContribution := codeScore * codeWeight
-	reasoningContribution := reasoningScore * reasoningWeight
-	technicalContribution := technicalScore * technicalWeight
+	mediumContribution := mediumScore * mediumWeight
+	complexContribution := complexScore * complexWeight
 	simplePenalty := -(userSimpleScore * simpleWeight)
 	tokenContribution := tokenScore * tokenCountWeight
 
 	// Weighted sum for last message.
-	lastMsgScore := codeContribution +
-		reasoningContribution +
-		technicalContribution +
+	lastMsgScore := mediumContribution +
+		complexContribution +
 		simplePenalty +
 		tokenContribution
 	lastMsgScore = clamp(lastMsgScore, 0.0, 1.0)
@@ -108,15 +102,14 @@ func (a *ComplexityAnalyzer) Analyze(input ComplexityInput) *ComplexityResult {
 
 	finalScore := clamp(blended, 0.0, 1.0)
 
-	// Tier classification with reasoning override: strong reasoning signals
-	// promote the request to COMPLEX even when the blended score falls below
-	// the medium/complex boundary.
-	strongCount := lastSignals.strongReasoningCount
+	// Complex evidence has explicit product-level guarantees in addition to the
+	// numeric score: one match guarantees at least MEDIUM and two force COMPLEX.
+	complexCount := lastSignals.complexCount
 	tier := a.classifyTier(finalScore)
-	if strongCount >= 2 {
+	if complexCount >= complexOverrideMatchCount {
 		tier = TierComplex
-	} else if strongCount >= 1 && (userCodeScore > 0.5 || userTechnicalScore > 0.5) {
-		tier = TierComplex
+	} else if complexCount >= 1 && tier == TierSimple {
+		tier = TierMedium
 	}
 
 	return &ComplexityResult{
@@ -141,11 +134,10 @@ func (a *ComplexityAnalyzer) scoreConversationContext(priorUserTexts []string) f
 	lastIdx := len(texts) - 1
 	for idx, text := range texts {
 		signals := a.matcher.analyzeText(text, contextTextScanMask)
-		code := scoreCount(signals.codeCount, 3)
-		tech := scoreCount(signals.technicalCount, 3)
-		reasoning := scoreCount(signals.reasoningCount, 2)
-		msgScore := (code*codeWeight + tech*technicalWeight + reasoning*reasoningWeight) /
-			(codeWeight + technicalWeight + reasoningWeight)
+		medium := scoreCount(signals.mediumCount, mediumMatchSaturation)
+		complex := scoreCount(signals.complexCount, complexMatchSaturation)
+		msgScore := (medium*mediumWeight + complex*complexWeight) /
+			(mediumWeight + complexWeight)
 		weight := 1.0
 		if lastIdx > 0 {
 			weight = 1.0 + (2.0 * float64(idx) / float64(lastIdx))
@@ -162,12 +154,12 @@ func (a *ComplexityAnalyzer) scoreConversationContext(priorUserTexts []string) f
 }
 
 func hasPositiveSignal(signals textSignalCounts) bool {
-	return signals.codeCount > 0 || signals.reasoningCount > 0 || signals.technicalCount > 0
+	return signals.mediumCount > 0 || signals.complexCount > 0
 }
 
 // isContinuationFollowup reports whether the last message should lean on
 // conversation context. Two triggers, both gated on the conversation actually
-// carrying meaningful technical context (convScore): an explicit continuation
+// carrying meaningful complexity context (convScore): an explicit continuation
 // phrase, or a message short enough that brevity itself is the signal ("yes
 // but make it faster"). The short-message path defers to simple-keyword
 // matches so conversation closers like "thanks!" keep classifying as SIMPLE

--- a/plugins/governance/complexity/analyzer_test.go
+++ b/plugins/governance/complexity/analyzer_test.go
@@ -34,17 +34,68 @@ func TestAnalyze_CustomTierBoundaries(t *testing.T) {
 	}
 }
 
-func TestAnalyze_CustomReasoningKeywordsAffectOverride(t *testing.T) {
+func TestAnalyze_CustomComplexKeywordsAffectOverride(t *testing.T) {
 	cfg := DefaultAnalyzerConfig()
-	cfg.Keywords.ReasoningKeywords = []string{"deepmagic"}
+	cfg.Keywords.ComplexKeywords = []string{"deepmagic", "deepmagic-two"}
 	a := NewComplexityAnalyzerWithConfig(&cfg)
 
 	result := a.Analyze(ComplexityInput{
-		LastUserText: "deepmagic api function",
+		LastUserText: "deepmagic deepmagic-two",
 	})
 
 	if result.Tier != TierComplex {
-		t.Fatalf("expected custom reasoning keyword to promote tier to %s, got %s (score=%.3f)", TierComplex, result.Tier, result.Score)
+		t.Fatalf("expected custom Complex keywords to promote tier to %s, got %s (score=%.3f)", TierComplex, result.Tier, result.Score)
+	}
+}
+
+func TestAnalyze_DefaultKeywordCalibration(t *testing.T) {
+	cfg := DefaultAnalyzerConfig()
+	cfg.Keywords.MediumKeywords = []string{"mediumone", "mediumtwo", "mediumthree", "mediumfour"}
+	cfg.Keywords.ComplexKeywords = []string{"complexone", "complextwo", "complexthree"}
+	cfg.Keywords.SimpleKeywords = []string{"simpleone", "simpletwo", "simplethree", "simplefour"}
+	a := NewComplexityAnalyzerWithConfig(&cfg)
+
+	mediumCases := []struct {
+		text string
+		want string
+	}{
+		{text: "mediumone", want: TierSimple},
+		{text: "mediumone mediumtwo", want: TierMedium},
+		{text: "mediumone mediumtwo mediumthree", want: TierMedium},
+		{text: "mediumone mediumtwo mediumthree mediumfour", want: TierComplex},
+	}
+	for _, tc := range mediumCases {
+		result := a.Analyze(ComplexityInput{LastUserText: tc.text})
+		if result == nil || result.Tier != tc.want {
+			t.Fatalf("medium calibration for %q: got %+v, want tier %s", tc.text, result, tc.want)
+		}
+	}
+
+	complexCases := []struct {
+		text string
+		want string
+	}{
+		{text: "complexone", want: TierMedium},
+		{text: "complexone complextwo", want: TierComplex},
+		{text: "complexone complextwo complexthree", want: TierComplex},
+	}
+	for _, tc := range complexCases {
+		result := a.Analyze(ComplexityInput{LastUserText: tc.text})
+		if result == nil || result.Tier != tc.want {
+			t.Fatalf("complex calibration for %q: got %+v, want tier %s", tc.text, result, tc.want)
+		}
+	}
+
+	for _, text := range []string{
+		"simpleone",
+		"simpleone simpletwo",
+		"simpleone simpletwo simplethree",
+		"simpleone simpletwo simplethree simplefour",
+	} {
+		result := a.Analyze(ComplexityInput{LastUserText: text})
+		if result == nil || result.Tier != TierSimple || result.Score != 0 {
+			t.Fatalf("simple calibration for %q: got %+v, want SIMPLE with score 0", text, result)
+		}
 	}
 }
 
@@ -344,7 +395,7 @@ func TestAnalyze_EmptyInput(t *testing.T) {
 	}
 }
 
-func TestAnalyze_ReasoningOverrideNotTooEager(t *testing.T) {
+func TestAnalyze_ComplexOverrideNotTooEager(t *testing.T) {
 	a := NewComplexityAnalyzer()
 
 	result := a.Analyze(ComplexityInput{
@@ -352,7 +403,7 @@ func TestAnalyze_ReasoningOverrideNotTooEager(t *testing.T) {
 	})
 
 	if result != nil {
-		t.Errorf("expected removed broad reasoning markers to be unclassified, got %s (score=%.3f)", result.Tier, result.Score)
+		t.Errorf("expected removed broad Complex markers to be unclassified, got %s (score=%.3f)", result.Tier, result.Score)
 	}
 }
 
@@ -885,7 +936,7 @@ func TestAnalyze_PunctuatedKeywordStillMatches(t *testing.T) {
 	a := NewComplexityAnalyzer()
 
 	signals := a.matcher.analyzeText("Please review our CI/CD pipeline and retry middleware behavior.", lastTextBaseScanMask)
-	if signals.codeCount == 0 {
+	if signals.mediumCount == 0 {
 		t.Fatalf("expected punctuated keyword path to match code signals")
 	}
 }

--- a/plugins/governance/complexity/config.go
+++ b/plugins/governance/complexity/config.go
@@ -53,11 +53,10 @@ type AnalyzerConfig = configstore.ComplexityAnalyzerConfig
 
 // KeywordConfig is the full internal keyword set used by the compiled matcher.
 type KeywordConfig struct {
-	CodeKeywords            []string
-	StrongReasoningKeywords []string
-	TechnicalKeywords       []string
-	SimpleKeywords          []string
-	ContinuationPhrases     []string
+	MediumKeywords      []string
+	ComplexKeywords     []string
+	SimpleKeywords      []string
+	ContinuationPhrases []string
 }
 
 // DefaultTierBoundaries returns the built-in classification thresholds.
@@ -71,10 +70,9 @@ func DefaultTierBoundaries() TierBoundaries {
 // DefaultEditableKeywordConfig returns the user-visible default keyword lists.
 func DefaultEditableKeywordConfig() EditableKeywordConfig {
 	return EditableKeywordConfig{
-		CodeKeywords:      cloneStringSlice(codeKeywords),
-		ReasoningKeywords: cloneStringSlice(strongReasoningKeywords),
-		TechnicalKeywords: cloneStringSlice(technicalKeywords),
-		SimpleKeywords:    cloneStringSlice(simpleKeywords),
+		SimpleKeywords:  cloneStringSlice(simpleKeywords),
+		MediumKeywords:  cloneStringSlice(mediumKeywords),
+		ComplexKeywords: cloneStringSlice(complexKeywords),
 	}
 }
 
@@ -101,28 +99,24 @@ func ValidateAndNormalize(cfg *AnalyzerConfig) (*AnalyzerConfig, error) {
 
 func mergeEditableKeywordsOntoDefaults(editable EditableKeywordConfig) KeywordConfig {
 	keywords := defaultFullKeywordConfig()
-	if len(editable.CodeKeywords) > 0 {
-		keywords.CodeKeywords = cloneStringSlice(editable.CodeKeywords)
-	}
-	if len(editable.ReasoningKeywords) > 0 {
-		keywords.StrongReasoningKeywords = cloneStringSlice(editable.ReasoningKeywords)
-	}
-	if len(editable.TechnicalKeywords) > 0 {
-		keywords.TechnicalKeywords = cloneStringSlice(editable.TechnicalKeywords)
-	}
 	if len(editable.SimpleKeywords) > 0 {
 		keywords.SimpleKeywords = cloneStringSlice(editable.SimpleKeywords)
+	}
+	if len(editable.MediumKeywords) > 0 {
+		keywords.MediumKeywords = cloneStringSlice(editable.MediumKeywords)
+	}
+	if len(editable.ComplexKeywords) > 0 {
+		keywords.ComplexKeywords = cloneStringSlice(editable.ComplexKeywords)
 	}
 	return keywords
 }
 
 func defaultFullKeywordConfig() KeywordConfig {
 	return KeywordConfig{
-		CodeKeywords:            cloneStringSlice(codeKeywords),
-		StrongReasoningKeywords: cloneStringSlice(strongReasoningKeywords),
-		TechnicalKeywords:       cloneStringSlice(technicalKeywords),
-		SimpleKeywords:          cloneStringSlice(simpleKeywords),
-		ContinuationPhrases:     cloneStringSlice(continuationPhrases),
+		MediumKeywords:      cloneStringSlice(mediumKeywords),
+		ComplexKeywords:     cloneStringSlice(complexKeywords),
+		SimpleKeywords:      cloneStringSlice(simpleKeywords),
+		ContinuationPhrases: cloneStringSlice(continuationPhrases),
 	}
 }
 

--- a/plugins/governance/complexity/keywords.go
+++ b/plugins/governance/complexity/keywords.go
@@ -2,13 +2,12 @@ package complexity
 
 // --- Dimension weights ---
 
-// The positive weights (code + reasoning + technical + token count) sum to
+// The positive weights (medium + complex + token count) sum to
 // 1.00 so a prompt maxing every signal reaches the full score range. The
 // simple weight is a penalty and deliberately not part of that budget.
 const (
-	codeWeight                         = 0.34
-	reasoningWeight                    = 0.28
-	technicalWeight                    = 0.28
+	mediumWeight                       = 0.40
+	complexWeight                      = 0.50
 	simpleWeight                       = 0.05
 	tokenCountWeight                   = 0.10
 	systemPromptAssistFactor           = 0.25
@@ -21,9 +20,19 @@ const (
 	wordPresenceSetMinBytes            = 8 * 1024
 )
 
+// Match saturation points define when each normalized keyword score reaches 1.
+// Two Complex matches bypass the numeric boundary and force COMPLEX.
+const (
+	mediumMatchSaturation     = 4
+	complexMatchSaturation    = 3
+	simpleMatchSaturation     = 2
+	complexOverrideMatchCount = 2
+)
+
 // --- Keyword lists ---
-// CodePresence: implementation/code syntax/workflow signals
-var codeKeywords = []string{
+// Medium indicators combine implementation/code signals with technical,
+// architecture, infrastructure, security, and operational terminology.
+var mediumKeywords = []string{
 	"function", "class", "api", "database", "algorithm", "code", "implement",
 	"debug", "error", "syntax", "compile", "runtime", "library", "framework",
 	"variable", "loop", "array", "object", "method", "interface",
@@ -35,18 +44,6 @@ var codeKeywords = []string{
 	"retry", "fallback", "middleware", "patch", "diff", "pr", "pull request",
 	"commit", "commit message", "behavior change",
 	"cel", "auto-routing", "rwmutex", "goroutine",
-}
-
-var strongReasoningKeywords = []string{
-	"step by step", "think through", "tradeoffs", "pros and cons",
-	"justify", "critique", "implications", "explain why",
-	"root cause analysis", "reconstruct the sequence",
-	"reconstruct the most likely sequence", "what should have happened instead",
-	"explain your reasoning", "weigh the tradeoffs", "recommend a design",
-}
-
-// TechnicalTerms: architecture/distributed/security/infrastructure signals
-var technicalKeywords = []string{
 	"architecture", "distributed", "encryption", "authentication", "scalability",
 	"microservices", "kubernetes", "infrastructure", "protocol", "latency",
 	"throughput", "concurrency", "optimization", "load balancer", "caching",
@@ -68,6 +65,16 @@ var technicalKeywords = []string{
 	"deterministic replay", "tamper evidence", "hash chain",
 	"approval workflow", "vpc", "soc 2", "data residency",
 	"disaster recovery", "data race", "struct copy", "hybrid search",
+}
+
+// Complex indicators are intentionally narrow, high-confidence phrases that
+// signal deeper analysis or reasoning. Two matches force the COMPLEX tier.
+var complexKeywords = []string{
+	"step by step", "think through", "tradeoffs", "pros and cons",
+	"justify", "critique", "implications", "explain why",
+	"root cause analysis", "reconstruct the sequence",
+	"reconstruct the most likely sequence", "what should have happened instead",
+	"explain your reasoning", "weigh the tradeoffs", "recommend a design",
 }
 
 // SimpleIndicators: signals for trivial/greeting-type requests

--- a/plugins/governance/complexity/matcher.go
+++ b/plugins/governance/complexity/matcher.go
@@ -9,18 +9,16 @@ import (
 type compiledKeywordMask uint16
 
 const (
-	maskCode compiledKeywordMask = 1 << iota
-	maskReasoning
-	maskStrongReasoning
-	maskTechnical
+	maskMedium compiledKeywordMask = 1 << iota
+	maskComplex
 	maskSimple
 	maskContinuation
 )
 
 const (
-	lastTextBaseScanMask = maskCode | maskReasoning | maskStrongReasoning | maskTechnical | maskSimple | maskContinuation
-	systemTextScanMask   = maskCode | maskTechnical
-	contextTextScanMask  = maskCode | maskReasoning | maskTechnical
+	lastTextBaseScanMask = maskMedium | maskComplex | maskSimple | maskContinuation
+	systemTextScanMask   = maskMedium
+	contextTextScanMask  = maskMedium | maskComplex
 )
 
 const (
@@ -73,10 +71,8 @@ type compiledKeywordMatcher struct {
 
 type textSignalCounts struct {
 	wordCount               int
-	codeCount               int
-	reasoningCount          int
-	strongReasoningCount    int
-	technicalCount          int
+	mediumCount             int
+	complexCount            int
 	simpleCount             int
 	continuationPhraseCount int
 }
@@ -104,9 +100,8 @@ func newCompiledKeywordMatcher(keywords KeywordConfig) *compiledKeywordMatcher {
 		}
 	}
 
-	addKeywords(keywords.CodeKeywords, maskCode)
-	addKeywords(keywords.StrongReasoningKeywords, maskReasoning|maskStrongReasoning)
-	addKeywords(keywords.TechnicalKeywords, maskTechnical)
+	addKeywords(keywords.MediumKeywords, maskMedium)
+	addKeywords(keywords.ComplexKeywords, maskComplex)
 	addKeywords(keywords.SimpleKeywords, maskSimple)
 	addKeywords(keywords.ContinuationPhrases, maskContinuation)
 
@@ -270,17 +265,11 @@ func (m *compiledKeywordMatcher) addStemmedMatches(lowerText string, scanMask co
 
 // addMask increments every scoring bucket a matched keyword contributes to.
 func (s *textSignalCounts) addMask(mask compiledKeywordMask) {
-	if mask&maskCode != 0 {
-		s.codeCount++
+	if mask&maskMedium != 0 {
+		s.mediumCount++
 	}
-	if mask&maskReasoning != 0 {
-		s.reasoningCount++
-	}
-	if mask&maskStrongReasoning != 0 {
-		s.strongReasoningCount++
-	}
-	if mask&maskTechnical != 0 {
-		s.technicalCount++
+	if mask&maskComplex != 0 {
+		s.complexCount++
 	}
 	if mask&maskSimple != 0 {
 		s.simpleCount++

--- a/plugins/governance/complexity/matcher_test.go
+++ b/plugins/governance/complexity/matcher_test.go
@@ -4,97 +4,97 @@ import "testing"
 
 func TestCompiledKeywordMatcher_StemmedSingleWordMatchesInflection(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"debug"},
+		MediumKeywords: []string{"debug"},
 	})
 
 	signals := matcher.analyzeText("We are debugging the handler before release.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected stemmed debug keyword to match debugging once, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected stemmed debug keyword to match debugging once, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_CustomInflectedKeywordMatchesRootForm(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"debugging"},
+		MediumKeywords: []string{"debugging"},
 	})
 
 	signals := matcher.analyzeText("Please debug the handler before release.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected custom debugging keyword to match debug once, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected custom debugging keyword to match debug once, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_ExactAndStemmedMatchDoesNotDoubleCount(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"debug"},
+		MediumKeywords: []string{"debug"},
 	})
 
 	signals := matcher.analyzeText("Please debug the handler before release.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected exact debug match not to be double-counted by stemming, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected exact debug match not to be double-counted by stemming, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_RepeatedStemmedFormsDoNotDoubleCount(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"debug"},
+		MediumKeywords: []string{"debug"},
 	})
 
 	signals := matcher.analyzeText("Please debugged and debugging the handler before release.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected repeated stemmed forms of debug to count once, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected repeated stemmed forms of debug to count once, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_StemDedupePreservesDistinctSameStemKeywords(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords:      []string{"debug"},
-		TechnicalKeywords: []string{"debugging"},
+		MediumKeywords:  []string{"debug"},
+		ComplexKeywords: []string{"debugging"},
 	})
 
 	signals := matcher.analyzeText("Please debug the handler before release.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected exact debug keyword to contribute code once, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected exact debug keyword to contribute Medium once, got mediumCount=%d", signals.mediumCount)
 	}
-	if signals.technicalCount != 1 {
-		t.Fatalf("expected distinct same-stem debugging keyword to contribute technical once, got technicalCount=%d", signals.technicalCount)
+	if signals.complexCount != 1 {
+		t.Fatalf("expected distinct same-stem debugging keyword to contribute Complex once, got complexCount=%d", signals.complexCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_StemmedPhraseMatchesContiguousVariant(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"analyzing this function"},
+		MediumKeywords: []string{"analyzing this function"},
 	})
 
 	signals := matcher.analyzeText("Please analyze this function before merging.", lastTextBaseScanMask)
-	if signals.codeCount != 1 {
-		t.Fatalf("expected stemmed phrase to match contiguous variant once, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 1 {
+		t.Fatalf("expected stemmed phrase to match contiguous variant once, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_StemmedPhraseDoesNotMatchInsertedWords(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"analyzing this function"},
+		MediumKeywords: []string{"analyzing this function"},
 	})
 
 	signals := matcher.analyzeText("Please analyze this Python function before merging.", lastTextBaseScanMask)
-	if signals.codeCount != 0 {
-		t.Fatalf("expected stemmed phrase not to match with inserted words, got codeCount=%d", signals.codeCount)
+	if signals.mediumCount != 0 {
+		t.Fatalf("expected stemmed phrase not to match with inserted words, got mediumCount=%d", signals.mediumCount)
 	}
 }
 
 func TestCompiledKeywordMatcher_PunctuationKeywordRemainsLiteral(t *testing.T) {
 	matcher := newCompiledKeywordMatcher(KeywordConfig{
-		CodeKeywords: []string{"ci/cd"},
+		MediumKeywords: []string{"ci/cd"},
 	})
 
 	literalSignals := matcher.analyzeText("The ci/cd pipeline is failing.", lastTextBaseScanMask)
-	if literalSignals.codeCount != 1 {
-		t.Fatalf("expected literal ci/cd keyword to match, got codeCount=%d", literalSignals.codeCount)
+	if literalSignals.mediumCount != 1 {
+		t.Fatalf("expected literal ci/cd keyword to match, got mediumCount=%d", literalSignals.mediumCount)
 	}
 
 	tokenSignals := matcher.analyzeText("The ci cd pipeline is failing.", lastTextBaseScanMask)
-	if tokenSignals.codeCount != 0 {
-		t.Fatalf("expected ci cd not to match literal ci/cd keyword, got codeCount=%d", tokenSignals.codeCount)
+	if tokenSignals.mediumCount != 0 {
+		t.Fatalf("expected ci cd not to match literal ci/cd keyword, got mediumCount=%d", tokenSignals.mediumCount)
 	}
 }

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -325,8 +325,8 @@ func TestComplexityAnalyzerConfigGetReturnsDefaultsWhenUnset(t *testing.T) {
 	if resp.TierBoundaries != complexity.DefaultTierBoundaries() {
 		t.Fatalf("expected default boundaries, got %+v", resp.TierBoundaries)
 	}
-	if len(resp.Keywords.CodeKeywords) == 0 {
-		t.Fatalf("expected default code keywords")
+	if len(resp.Keywords.MediumKeywords) == 0 {
+		t.Fatalf("expected default Medium keywords")
 	}
 }
 
@@ -342,7 +342,7 @@ func TestComplexityAnalyzerConfigPutPersistsAndReloads(t *testing.T) {
 	cfg := complexity.DefaultAnalyzerConfig()
 	cfg.TierBoundaries.SimpleMedium = 0.12
 	cfg.TierBoundaries.MediumComplex = 0.34
-	cfg.Keywords.CodeKeywords = []string{" Function ", "api", "API"}
+	cfg.Keywords.MediumKeywords = []string{" Function ", "api", "API"}
 
 	ctx := newTestRequestCtx(testComplexityAnalyzerPayload(t, cfg))
 	handler.updateComplexityAnalyzerConfig(ctx)
@@ -361,8 +361,96 @@ func TestComplexityAnalyzerConfigPutPersistsAndReloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get stored config: %v", err)
 	}
-	if stored == nil || len(stored.Keywords.CodeKeywords) != 2 || stored.Keywords.CodeKeywords[0] != "api" {
+	if stored == nil || len(stored.Keywords.MediumKeywords) != 2 || stored.Keywords.MediumKeywords[0] != "api" {
 		t.Fatalf("expected normalized stored keywords, got %+v", stored)
+	}
+}
+
+func TestComplexityAnalyzerConfigPutAcceptsLegacyKeywordsAndWritesCanonicalShape(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := setupPricingOverrideHandlerStore(t)
+	manager := &mockComplexityGovernanceManager{}
+	handler := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: manager,
+	}
+
+	legacyPayload := `{"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4},` +
+		`"keywords":{"code_keywords":["api"],"reasoning_keywords":["tradeoffs"],` +
+		`"technical_keywords":["latency"],"simple_keywords":["hello"]}}`
+	ctx := newTestRequestCtx(legacyPayload)
+	handler.updateComplexityAnalyzerConfig(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	response := string(ctx.Response.Body())
+	for _, canonical := range []string{"simple_keywords", "medium_keywords", "complex_keywords"} {
+		if !strings.Contains(response, canonical) {
+			t.Fatalf("expected response to contain %q: %s", canonical, response)
+		}
+	}
+	for _, legacy := range []string{"code_keywords", "technical_keywords", "reasoning_keywords"} {
+		if strings.Contains(response, legacy) {
+			t.Fatalf("expected response to omit legacy field %q: %s", legacy, response)
+		}
+	}
+
+	entry, err := store.GetConfig(context.Background(), configstoreTables.ConfigComplexityAnalyzerConfigKey)
+	if err != nil {
+		t.Fatalf("get raw config row: %v", err)
+	}
+	if !strings.Contains(entry.Value, `"medium_keywords":["api","latency"]`) {
+		t.Fatalf("expected canonical merged Medium keywords in stored row: %s", entry.Value)
+	}
+	for _, legacy := range []string{"code_keywords", "technical_keywords", "reasoning_keywords"} {
+		if strings.Contains(entry.Value, legacy) {
+			t.Fatalf("expected stored row to omit legacy field %q: %s", legacy, entry.Value)
+		}
+	}
+}
+
+func TestComplexityAnalyzerConfigGetCanonicalizesLegacyRowWithoutRewritingIt(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := setupPricingOverrideHandlerStore(t)
+	handler := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: &mockComplexityGovernanceManager{},
+	}
+
+	legacyJSON := `{"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4},` +
+		`"keywords":{"code_keywords":["api"],"reasoning_keywords":["tradeoffs"],` +
+		`"technical_keywords":["latency"],"simple_keywords":["hello"]}}`
+	if err := store.UpdateConfig(context.Background(), &configstoreTables.TableGovernanceConfig{
+		Key:   configstoreTables.ConfigComplexityAnalyzerConfigKey,
+		Value: legacyJSON,
+	}); err != nil {
+		t.Fatalf("seed legacy config row: %v", err)
+	}
+
+	ctx := newTestRequestCtx("")
+	handler.getComplexityAnalyzerConfig(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	response := string(ctx.Response.Body())
+	if !strings.Contains(response, `"medium_keywords":["api","latency"]`) ||
+		!strings.Contains(response, `"complex_keywords":["tradeoffs"]`) {
+		t.Fatalf("expected canonical API response for legacy row: %s", response)
+	}
+	for _, legacy := range []string{"code_keywords", "technical_keywords", "reasoning_keywords"} {
+		if strings.Contains(response, legacy) {
+			t.Fatalf("expected response to omit legacy field %q: %s", legacy, response)
+		}
+	}
+
+	entry, err := store.GetConfig(context.Background(), configstoreTables.ConfigComplexityAnalyzerConfigKey)
+	if err != nil {
+		t.Fatalf("get raw config row: %v", err)
+	}
+	if entry.Value != legacyJSON {
+		t.Fatalf("GET should not rewrite legacy row: got %s", entry.Value)
 	}
 }
 
@@ -379,7 +467,7 @@ func TestComplexityAnalyzerConfigPutRejectsInvalidPayloads(t *testing.T) {
 	invalidBoundaries := valid
 	invalidBoundaries.TierBoundaries.MediumComplex = invalidBoundaries.TierBoundaries.SimpleMedium
 	emptyKeywords := valid
-	emptyKeywords.Keywords.CodeKeywords = nil
+	emptyKeywords.Keywords.MediumKeywords = nil
 
 	tests := []struct {
 		name string

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -199,7 +199,11 @@ type ConfigData struct {
 	// the removed "complex_reasoning" tier boundary (REASONING merged into
 	// COMPLEX), so config load can surface a deprecation notice.
 	hasLegacyComplexReasoningBoundary bool
-	SkillsRegistry                    *SkillsRegistryConfig `json:"skills_registry,omitempty"`
+	// legacyComplexityMediumKeywordsHash preserves the source identity of
+	// separate legacy Code/Technical lists after they are merged into Medium.
+	// An empty value means config.json uses the canonical keyword shape.
+	legacyComplexityMediumKeywordsHash string
+	SkillsRegistry                     *SkillsRegistryConfig `json:"skills_registry,omitempty"`
 }
 
 // SkillsRegistryConfig defines declarative skill definitions in config.json.
@@ -480,6 +484,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	cd.FeatureFlags = temp.FeatureFlags
 	cd.presentGovernanceSections = nil
 	cd.hasLegacyComplexReasoningBoundary = false
+	cd.legacyComplexityMediumKeywordsHash = ""
 	if rawGovernance, ok := raw["governance"]; ok && len(rawGovernance) > 0 {
 		var rawGovernanceFields map[string]json.RawMessage
 		if err := json.Unmarshal(rawGovernance, &rawGovernanceFields); err == nil {
@@ -488,11 +493,34 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 				cd.presentGovernanceSections[key] = true
 			}
 			if rawComplexity, ok := rawGovernanceFields["complexity_analyzer_config"]; ok {
-				var rawBoundaries struct {
+				var rawComplexityFields struct {
 					TierBoundaries map[string]json.RawMessage `json:"tier_boundaries"`
+					Keywords       map[string]json.RawMessage `json:"keywords"`
 				}
-				if err := json.Unmarshal(rawComplexity, &rawBoundaries); err == nil {
-					_, cd.hasLegacyComplexReasoningBoundary = rawBoundaries.TierBoundaries["complex_reasoning"]
+				if err := json.Unmarshal(rawComplexity, &rawComplexityFields); err == nil {
+					_, cd.hasLegacyComplexReasoningBoundary = rawComplexityFields.TierBoundaries["complex_reasoning"]
+					_, hasCode := rawComplexityFields.Keywords["code_keywords"]
+					_, hasReasoning := rawComplexityFields.Keywords["reasoning_keywords"]
+					_, hasTechnical := rawComplexityFields.Keywords["technical_keywords"]
+					if hasCode || hasReasoning || hasTechnical {
+						var legacyCodeKeywords []string
+						if rawCode, ok := rawComplexityFields.Keywords["code_keywords"]; ok {
+							if err := json.Unmarshal(rawCode, &legacyCodeKeywords); err != nil {
+								return fmt.Errorf("failed to unmarshal legacy complexity code keywords: %w", err)
+							}
+						}
+						var legacyTechnicalKeywords []string
+						if rawTechnical, ok := rawComplexityFields.Keywords["technical_keywords"]; ok {
+							if err := json.Unmarshal(rawTechnical, &legacyTechnicalKeywords); err != nil {
+								return fmt.Errorf("failed to unmarshal legacy complexity technical keywords: %w", err)
+							}
+						}
+						legacyMediumHash, err := configstore.GenerateLegacyComplexityMediumKeywordsHash(legacyCodeKeywords, legacyTechnicalKeywords)
+						if err != nil {
+							return fmt.Errorf("failed to hash legacy complexity keywords: %w", err)
+						}
+						cd.legacyComplexityMediumKeywordsHash = legacyMediumHash
+					}
 				}
 			}
 		}
@@ -3381,6 +3409,9 @@ func complexityAnalyzerConfigFromFile(configData *ConfigData) (*configstore.Comp
 	if configData.hasLegacyComplexReasoningBoundary {
 		logger.Warn("config.json sets governance.complexity_analyzer_config.tier_boundaries.complex_reasoning, which no longer exists: the REASONING tier was merged into COMPLEX. The value is ignored; remove it from config.json")
 	}
+	if configData.legacyComplexityMediumKeywordsHash != "" {
+		logger.Warn("config.json uses deprecated complexity keyword fields code_keywords, technical_keywords, and reasoning_keywords; use medium_keywords and complex_keywords. The legacy fields remain supported and are not rewritten")
+	}
 	fileConfig, err := complexity.ValidateAndNormalize(configData.Governance.ComplexityAnalyzerConfig)
 	if err != nil {
 		logger.Error("invalid complexity analyzer config in config file: %v", err)
@@ -3390,6 +3421,9 @@ func complexityAnalyzerConfigFromFile(configData *ConfigData) (*configstore.Comp
 	if err != nil {
 		logger.Warn("failed to generate complexity analyzer config hashes: %v", err)
 		return nil, configstore.ComplexityAnalyzerConfigHashes{}, false
+	}
+	if configData.legacyComplexityMediumKeywordsHash != "" {
+		fileHashes.MediumKeywords = configData.legacyComplexityMediumKeywordsHash
 	}
 	fileConfig.ConfigHashes = fileHashes
 	return fileConfig, fileHashes, true

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1933,10 +1933,9 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 			MediumComplex: 0.33,
 		},
 		Keywords: configstore.ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{" Function ", "api", "API", "file-code-seed"},
-			ReasoningKeywords: []string{"tradeoffs", "file-reason-seed"},
-			TechnicalKeywords: []string{"latency", "file-tech-seed"},
-			SimpleKeywords:    []string{"hello", "file-simple-seed"},
+			SimpleKeywords:  []string{"hello", "file-simple-seed"},
+			MediumKeywords:  []string{" Function ", "api", "API", "latency", "file-medium-seed"},
+			ComplexKeywords: []string{"tradeoffs", "file-complex-seed"},
 		},
 	}
 	configData := &ConfigData{
@@ -1953,9 +1952,8 @@ func TestMergeGovernanceConfig_SyncsComplexityAnalyzerConfig(t *testing.T) {
 	require.Equal(t, 0.11, stored.TierBoundaries.SimpleMedium)
 	require.Equal(t, 0.33, stored.TierBoundaries.MediumComplex)
 	defaults := complexity.DefaultAnalyzerConfig()
-	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.CodeKeywords, fileConfig.Keywords.CodeKeywords), stored.Keywords.CodeKeywords)
-	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.ReasoningKeywords, fileConfig.Keywords.ReasoningKeywords), stored.Keywords.ReasoningKeywords)
-	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.TechnicalKeywords, fileConfig.Keywords.TechnicalKeywords), stored.Keywords.TechnicalKeywords)
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.MediumKeywords, fileConfig.Keywords.MediumKeywords), stored.Keywords.MediumKeywords)
+	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.ComplexKeywords, fileConfig.Keywords.ComplexKeywords), stored.Keywords.ComplexKeywords)
 	require.Equal(t, expectedMergedComplexityKeywords(defaults.Keywords.SimpleKeywords, fileConfig.Keywords.SimpleKeywords), stored.Keywords.SimpleKeywords)
 	require.False(t, stored.ConfigHashes.Empty())
 	require.Equal(t, stored, config.GovernanceConfig.ComplexityAnalyzerConfig)
@@ -1967,7 +1965,7 @@ func TestMergeGovernanceConfig_AppliesComplexityAnalyzerConfigWhenHashesAreEmpty
 	store := NewMockConfigStore()
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.TierBoundaries.SimpleMedium = 0.12
-	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium"}
 	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
@@ -1990,7 +1988,7 @@ func TestMergeGovernanceConfig_AppliesComplexityAnalyzerConfigWhenHashesAreEmpty
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
-	require.ElementsMatch(t, []string{"file-code", "ui-code"}, stored.Keywords.CodeKeywords)
+	require.ElementsMatch(t, []string{"file-medium", "ui-medium"}, stored.Keywords.MediumKeywords)
 	require.Equal(t, fileHashes, stored.ConfigHashes)
 }
 
@@ -2023,7 +2021,7 @@ func TestMergeGovernanceConfig_PreservesComplexityAnalyzerConfigWhenSectionHashe
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.ConfigHashes = fileHashes
 	dbConfig.TierBoundaries.SimpleMedium = 0.21
-	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium"}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
 	config := &Config{
@@ -2042,8 +2040,89 @@ func TestMergeGovernanceConfig_PreservesComplexityAnalyzerConfigWhenSectionHashe
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.21, stored.TierBoundaries.SimpleMedium)
-	require.Equal(t, []string{"ui-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, []string{"ui-medium"}, stored.Keywords.MediumKeywords)
 	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func legacyComplexityConfigData(t *testing.T, codeKeywords, technicalKeywords []string) *ConfigData {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"governance": map[string]any{
+			"complexity_analyzer_config": map[string]any{
+				"tier_boundaries": map[string]any{
+					"simple_medium":  0.20,
+					"medium_complex": 0.40,
+				},
+				"keywords": map[string]any{
+					"code_keywords":      codeKeywords,
+					"reasoning_keywords": []string{"file-complex"},
+					"technical_keywords": technicalKeywords,
+					"simple_keywords":    []string{"file-simple"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var configData ConfigData
+	require.NoError(t, json.Unmarshal(raw, &configData))
+	return &configData
+}
+
+func TestMergeGovernanceConfig_UnchangedLegacyComplexityFilePreservesUIEdits(t *testing.T) {
+	initTestLogger()
+
+	fileData := legacyComplexityConfigData(t, []string{"file-code"}, []string{"file-technical"})
+	_, fileHashes, ok := complexityAnalyzerConfigFromFile(fileData)
+	require.True(t, ok)
+
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = fileHashes
+	// These values intentionally omit the file keywords, modeling UI deletions.
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium"}
+	dbConfig.Keywords.ComplexKeywords = []string{"ui-complex"}
+	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store := NewMockConfigStore()
+	store.governanceConfig = dbGovernance
+	config := &Config{ConfigStore: store, GovernanceConfig: dbGovernance}
+
+	mergeGovernanceConfig(context.Background(), config, fileData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"ui-medium"}, stored.Keywords.MediumKeywords)
+	require.Equal(t, []string{"ui-complex"}, stored.Keywords.ComplexKeywords)
+	require.Equal(t, []string{"ui-simple"}, stored.Keywords.SimpleKeywords)
+	require.Equal(t, fileHashes, stored.ConfigHashes)
+}
+
+func TestMergeGovernanceConfig_ChangedLegacyCodeKeywordsMergeIntoMedium(t *testing.T) {
+	initTestLogger()
+
+	oldFileData := legacyComplexityConfigData(t, []string{"file-code"}, []string{"file-technical"})
+	_, oldHashes, ok := complexityAnalyzerConfigFromFile(oldFileData)
+	require.True(t, ok)
+
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.ConfigHashes = oldHashes
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium"}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store := NewMockConfigStore()
+	store.governanceConfig = dbGovernance
+	config := &Config{ConfigStore: store, GovernanceConfig: dbGovernance}
+
+	newFileData := legacyComplexityConfigData(t, []string{"file-code", "file-code-new"}, []string{"file-technical"})
+	_, newHashes, ok := complexityAnalyzerConfigFromFile(newFileData)
+	require.True(t, ok)
+	require.NotEqual(t, oldHashes.MediumKeywords, newHashes.MediumKeywords)
+
+	mergeGovernanceConfig(context.Background(), config, newFileData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"file-code", "file-code-new", "file-technical", "ui-medium"}, stored.Keywords.MediumKeywords)
+	require.Equal(t, newHashes.MediumKeywords, stored.ConfigHashes.MediumKeywords)
 }
 
 func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenSectionHashesChange(t *testing.T) {
@@ -2052,15 +2131,13 @@ func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenSectionHashesChange(t
 	store := NewMockConfigStore()
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "old-tier-hash",
-		CodeKeywords:      "old-code-hash",
-		ReasoningKeywords: "old-reason-hash",
-		TechnicalKeywords: "old-tech-hash",
-		SimpleKeywords:    "old-simple-hash",
+		TierBoundaries:  "old-tier-hash",
+		SimpleKeywords:  "old-simple-hash",
+		MediumKeywords:  "old-medium-hash",
+		ComplexKeywords: "old-complex-hash",
 	}
-	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
-	dbConfig.Keywords.ReasoningKeywords = []string{"ui-reason"}
-	dbConfig.Keywords.TechnicalKeywords = []string{"ui-tech"}
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium", "ui-technical"}
+	dbConfig.Keywords.ComplexKeywords = []string{"ui-complex"}
 	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
@@ -2083,9 +2160,8 @@ func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenSectionHashesChange(t
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
-	require.ElementsMatch(t, []string{"file-code", "ui-code"}, stored.Keywords.CodeKeywords)
-	require.ElementsMatch(t, []string{"file-reason", "ui-reason"}, stored.Keywords.ReasoningKeywords)
-	require.ElementsMatch(t, []string{"file-tech", "ui-tech"}, stored.Keywords.TechnicalKeywords)
+	require.ElementsMatch(t, []string{"file-medium", "ui-medium", "ui-technical"}, stored.Keywords.MediumKeywords)
+	require.ElementsMatch(t, []string{"file-complex", "ui-complex"}, stored.Keywords.ComplexKeywords)
 	require.ElementsMatch(t, []string{"file-simple", "ui-simple"}, stored.Keywords.SimpleKeywords)
 	require.Equal(t, fileHashes, stored.ConfigHashes)
 }
@@ -2101,9 +2177,8 @@ func TestMergeGovernanceConfig_OnlyChangedComplexitySectionsApply(t *testing.T) 
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.ConfigHashes = oldFileHashes
 	dbConfig.TierBoundaries.SimpleMedium = 0.21
-	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
-	dbConfig.Keywords.ReasoningKeywords = []string{"ui-reason"}
-	dbConfig.Keywords.TechnicalKeywords = []string{"ui-tech"}
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium", "ui-technical"}
+	dbConfig.Keywords.ComplexKeywords = []string{"ui-complex"}
 	dbConfig.Keywords.SimpleKeywords = []string{"ui-simple"}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
@@ -2113,7 +2188,7 @@ func TestMergeGovernanceConfig_OnlyChangedComplexitySectionsApply(t *testing.T) 
 	}
 
 	newFileConfig := testFileComplexityAnalyzerConfig()
-	newFileConfig.Keywords.CodeKeywords = []string{"file-code", "file-code-new"}
+	newFileConfig.Keywords.MediumKeywords = []string{"file-medium", "file-medium-new"}
 	newFileHashes, err := configstore.GenerateComplexityAnalyzerConfigHashes(newFileConfig)
 	require.NoError(t, err)
 	configData := &ConfigData{
@@ -2128,14 +2203,12 @@ func TestMergeGovernanceConfig_OnlyChangedComplexitySectionsApply(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.21, stored.TierBoundaries.SimpleMedium)
-	require.ElementsMatch(t, []string{"file-code", "file-code-new", "ui-code"}, stored.Keywords.CodeKeywords)
-	require.Equal(t, []string{"ui-reason"}, stored.Keywords.ReasoningKeywords)
-	require.Equal(t, []string{"ui-tech"}, stored.Keywords.TechnicalKeywords)
+	require.ElementsMatch(t, []string{"file-medium", "file-medium-new", "ui-medium", "ui-technical"}, stored.Keywords.MediumKeywords)
+	require.Equal(t, []string{"ui-complex"}, stored.Keywords.ComplexKeywords)
 	require.Equal(t, []string{"ui-simple"}, stored.Keywords.SimpleKeywords)
 	require.Equal(t, oldFileHashes.TierBoundaries, stored.ConfigHashes.TierBoundaries)
-	require.Equal(t, newFileHashes.CodeKeywords, stored.ConfigHashes.CodeKeywords)
-	require.Equal(t, oldFileHashes.ReasoningKeywords, stored.ConfigHashes.ReasoningKeywords)
-	require.Equal(t, oldFileHashes.TechnicalKeywords, stored.ConfigHashes.TechnicalKeywords)
+	require.Equal(t, newFileHashes.MediumKeywords, stored.ConfigHashes.MediumKeywords)
+	require.Equal(t, oldFileHashes.ComplexKeywords, stored.ConfigHashes.ComplexKeywords)
 	require.Equal(t, oldFileHashes.SimpleKeywords, stored.ConfigHashes.SimpleKeywords)
 }
 
@@ -2145,13 +2218,12 @@ func TestMergeGovernanceConfig_SourceOfTruthConfigJSONUsesComplexityFileConfig(t
 	store := NewMockConfigStore()
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "old-tier-hash",
-		CodeKeywords:      "old-code-hash",
-		ReasoningKeywords: "old-reason-hash",
-		TechnicalKeywords: "old-tech-hash",
-		SimpleKeywords:    "old-simple-hash",
+		TierBoundaries:  "old-tier-hash",
+		SimpleKeywords:  "old-simple-hash",
+		MediumKeywords:  "old-medium-hash",
+		ComplexKeywords: "old-complex-hash",
 	}
-	dbConfig.Keywords.CodeKeywords = []string{"ui-code"}
+	dbConfig.Keywords.MediumKeywords = []string{"ui-medium"}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
 	config := &Config{
@@ -2174,7 +2246,7 @@ func TestMergeGovernanceConfig_SourceOfTruthConfigJSONUsesComplexityFileConfig(t
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, fileConfig.TierBoundaries, stored.TierBoundaries)
-	require.Equal(t, []string{"file-code"}, stored.Keywords.CodeKeywords)
+	require.Equal(t, []string{"file-medium"}, stored.Keywords.MediumKeywords)
 	require.Equal(t, fileHashes, stored.ConfigHashes)
 }
 
@@ -2184,11 +2256,10 @@ func TestMergeGovernanceConfig_SourceOfTruthConfigJSONMissingComplexityLeavesDBC
 	store := NewMockConfigStore()
 	dbConfig := testRuntimeComplexityAnalyzerConfig()
 	dbConfig.ConfigHashes = configstore.ComplexityAnalyzerConfigHashes{
-		TierBoundaries:    "old-tier-hash",
-		CodeKeywords:      "old-code-hash",
-		ReasoningKeywords: "old-reason-hash",
-		TechnicalKeywords: "old-tech-hash",
-		SimpleKeywords:    "old-simple-hash",
+		TierBoundaries:  "old-tier-hash",
+		SimpleKeywords:  "old-simple-hash",
+		MediumKeywords:  "old-medium-hash",
+		ComplexKeywords: "old-complex-hash",
 	}
 	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
 	store.governanceConfig = dbGovernance
@@ -2217,10 +2288,9 @@ func testRuntimeComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig
 			MediumComplex: 0.30,
 		},
 		Keywords: configstore.ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{"runtime-code"},
-			ReasoningKeywords: []string{"runtime-reason"},
-			TechnicalKeywords: []string{"runtime-tech"},
-			SimpleKeywords:    []string{"runtime-simple"},
+			SimpleKeywords:  []string{"runtime-simple"},
+			MediumKeywords:  []string{"runtime-medium", "runtime-technical"},
+			ComplexKeywords: []string{"runtime-complex"},
 		},
 	}
 }
@@ -2232,10 +2302,9 @@ func testFileComplexityAnalyzerConfig() *configstore.ComplexityAnalyzerConfig {
 			MediumComplex: 0.40,
 		},
 		Keywords: configstore.ComplexityEditableKeywordConfig{
-			CodeKeywords:      []string{"file-code"},
-			ReasoningKeywords: []string{"file-reason"},
-			TechnicalKeywords: []string{"file-tech"},
-			SimpleKeywords:    []string{"file-simple"},
+			SimpleKeywords:  []string{"file-simple"},
+			MediumKeywords:  []string{"file-medium"},
+			ComplexKeywords: []string{"file-complex"},
 		},
 	}
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3610,33 +3610,25 @@
     },
     "complexity_analyzer_keywords": {
       "type": "object",
-      "description": "User-editable keyword lists for complexity analysis",
+      "description": "User-editable keyword scoring signals. The legacy four-list shape remains accepted for config.json compatibility.",
       "properties": {
-        "code_keywords": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "reasoning_keywords": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "technical_keywords": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
         "simple_keywords": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "medium_keywords": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "complex_keywords": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -3645,13 +3637,42 @@
           }
         }
       },
-      "required": [
-        "code_keywords",
-        "reasoning_keywords",
-        "technical_keywords",
-        "simple_keywords"
+      "oneOf": [
+        {
+          "required": ["simple_keywords", "medium_keywords", "complex_keywords"]
+        },
+        {
+          "deprecated": true,
+          "properties": {
+            "code_keywords": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "reasoning_keywords": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "technical_keywords": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "required": ["code_keywords", "reasoning_keywords", "technical_keywords", "simple_keywords"]
+        }
       ],
-      "additionalProperties": false
+      "unevaluatedProperties": false
     },
     "complexity_analyzer_config": {
       "type": "object",

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -437,6 +437,49 @@ func TestSchemaComplexityTierBoundaryCompatibility(t *testing.T) {
 	}
 }
 
+func TestSchemaComplexityAnalyzerKeywordCompatibility(t *testing.T) {
+	compiled := compileSchema(t)
+	prefix := `{"governance":{"complexity_analyzer_config":{"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4},"keywords":`
+	suffix := `}}}`
+
+	tests := []struct {
+		name      string
+		keywords  string
+		wantError bool
+	}{
+		{
+			name:     "canonical three-list shape",
+			keywords: `{"simple_keywords":["hello"],"medium_keywords":["api"],"complex_keywords":["tradeoffs"]}`,
+		},
+		{
+			name:     "legacy four-list shape",
+			keywords: `{"simple_keywords":["hello"],"code_keywords":["api"],"technical_keywords":["latency"],"reasoning_keywords":["tradeoffs"]}`,
+		},
+		{
+			name:      "mixed canonical and legacy shape",
+			keywords:  `{"simple_keywords":["hello"],"medium_keywords":["api"],"complex_keywords":["tradeoffs"],"code_keywords":["debug"]}`,
+			wantError: true,
+		},
+		{
+			name:      "unknown keyword field",
+			keywords:  `{"simple_keywords":["hello"],"medium_keywords":["api"],"complex_keywords":["tradeoffs"],"other_keywords":["unknown"]}`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(t, compiled, prefix+tt.keywords+suffix)
+			if tt.wantError && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected config to validate, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestSchemaSCIMConfigValidation(t *testing.T) {
 	compiled := compileSchema(t)
 

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -96,19 +96,17 @@ const analyzerConfigSchema = z.object({
 		}),
 	keywords: z.object({
 		simple_keywords: z.array(z.string()).min(1, "Simple keywords cannot be empty"),
-		code_keywords: z.array(z.string()).min(1, "Code keywords cannot be empty"),
-		technical_keywords: z.array(z.string()).min(1, "Technical keywords cannot be empty"),
-		reasoning_keywords: z.array(z.string()).min(1, "Reasoning keywords cannot be empty"),
+		medium_keywords: z.array(z.string()).min(1, "Medium keywords cannot be empty"),
+		complex_keywords: z.array(z.string()).min(1, "Complex keywords cannot be empty"),
 	}),
 });
 
 const DEFAULT_FORM_VALUES: AnalyzerConfig = {
 	tier_boundaries: { ...DEFAULT_TIER_BOUNDARIES },
 	keywords: {
-		code_keywords: [],
-		reasoning_keywords: [],
-		technical_keywords: [],
 		simple_keywords: [],
+		medium_keywords: [],
+		complex_keywords: [],
 	},
 };
 
@@ -320,7 +318,7 @@ export default function ComplexityRouterPage() {
 					<div className="space-y-1.5">
 						<h1 className="text-2xl font-semibold tracking-tight">Complexity Router</h1>
 						<p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
-							Tune how incoming requests are classified into four tiers. Thresholds and keyword lists feed the{" "}
+							Tune how incoming requests are classified into three tiers. Thresholds and keyword lists feed the{" "}
 							<code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
 							target.
 						</p>
@@ -491,7 +489,7 @@ export default function ComplexityRouterPage() {
 				)}
 
 				{/* ── Action footer ── */}
-				<div className="bg-card sticky bottom-0 flex flex-wrap items-center justify-end gap-2.5 border-t py-4 z-10">
+				<div className="bg-card sticky bottom-0 z-10 flex flex-wrap items-center justify-end gap-2.5 border-t py-4">
 					<Button
 						data-testid="complexity-router-restore-defaults-button"
 						type="button"

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -9,10 +9,9 @@ export interface TierBoundaries {
 }
 
 export interface EditableKeywordConfig {
-	code_keywords: string[];
-	reasoning_keywords: string[];
-	technical_keywords: string[];
 	simple_keywords: string[];
+	medium_keywords: string[];
+	complex_keywords: string[];
 }
 
 export interface AnalyzerConfig {
@@ -47,22 +46,17 @@ export const KEYWORD_LIST_DEFINITIONS: Array<{
 	{
 		key: "simple_keywords",
 		label: "Simple keywords",
-		description: "Phrases that bias the request toward the SIMPLE tier (greetings, trivia, small talk).",
+		description: "Lightweight-language signals that slightly lower the lexical complexity score.",
 	},
 	{
-		key: "code_keywords",
-		label: "Code keywords",
-		description: "Signals that the request involves code, debugging, or programming artifacts.",
+		key: "medium_keywords",
+		label: "Medium keywords",
+		description: "Implementation and technical signals that raise the lexical complexity score gradually.",
 	},
 	{
-		key: "technical_keywords",
-		label: "Technical keywords",
-		description: "Architecture, infra, and operational terms that raise the complexity score.",
-	},
-	{
-		key: "reasoning_keywords",
-		label: "Reasoning keywords",
-		description: "Strong reasoning triggers. Matching these phrases can override tier selection toward the COMPLEX tier.",
+		key: "complex_keywords",
+		label: "Complex keywords",
+		description: "High-confidence reasoning signals. One guarantees at least MEDIUM; two route to COMPLEX.",
 	},
 ];
 


### PR DESCRIPTION
## Summary

Replaces the four-list keyword configuration (`code_keywords`, `technical_keywords`, `reasoning_keywords`, `simple_keywords`) with a canonical three-list shape (`simple_keywords`, `medium_keywords`, `complex_keywords`) across the complexity router. The old "Code" and "Technical" dimensions are merged into a single Medium signal, and the "Reasoning" dimension becomes Complex. The scoring model is updated to reflect the new weights and saturation points, and explicit tier guarantees replace the previous reasoning override logic.

## Changes

- `code_keywords` and `technical_keywords` are merged into `medium_keywords` (40% weight, saturates at 4 matches). `reasoning_keywords` becomes `complex_keywords` (50% weight, saturates at 3 matches). `simple_keywords` remains a -5% dampener (saturates at 2 matches).
- The previous "reasoning override" (2+ reasoning keywords or 1 reasoning + strong code/technical) is replaced with explicit Complex guarantees: one `complex_keywords` match guarantees at least Medium; two or more force Complex regardless of numeric score.
- System prompt contribution is narrowed to Medium signals only; it no longer influences Complex overrides.
- Conversation history scoring excludes token length and the Simple dampener, normalizing over the two positive weights only.
- `ComplexityEditableKeywordConfig` and `ComplexityAnalyzerConfigHashes` gain custom `UnmarshalJSON` implementations that transparently read the legacy four-list shape and translate it to the canonical three-list shape at decode time. Mixed canonical and legacy fields in one payload are rejected.
- `GenerateLegacyComplexityMediumKeywordsHash` preserves source identity for legacy `config.json` files by hashing the two legacy section hashes rather than the merged runtime list, keeping change detection independent of DB/UI edits.
- A deprecation warning is emitted at startup when `config.json` still uses the legacy keyword fields.
- The Helm values schema accepts both shapes via `oneOf`, with the legacy shape marked deprecated.
- OpenAPI schema, `config.schema.json`, UI types, and UI form validation are all updated to the canonical three-list shape.
- UI description copy updated to reflect three tiers instead of four.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/complexity/... ./transports/bifrost-http/... ./transports/schema_test/...

# UI
cd ui
pnpm i
pnpm build
```

**Legacy upgrade path:** Seed a database row or `config.json` with the old four-list shape and confirm that:
1. `GET /api/governance/complexity-analyzer-config` returns the canonical three-list shape.
2. The raw database row is not rewritten by a GET.
3. A subsequent `PUT` with the canonical shape writes canonical JSON to the database.
4. Helm values using the legacy shape pass schema validation and render correctly.

**Mixed-shape rejection:** Submit a payload containing both `medium_keywords` and `code_keywords` and confirm a 400 response with an error mentioning "cannot mix canonical and legacy fields".

## Breaking changes

- [x] Yes
- [ ] No

Existing `config.json` files and Helm values that use `code_keywords`, `technical_keywords`, and `reasoning_keywords` continue to work without modification — they are accepted and translated at read time. However, API clients and tooling that construct or parse the keyword payload must migrate to `simple_keywords`, `medium_keywords`, and `complex_keywords`. The UI and all API responses always return the canonical three-list shape. Do not mix legacy and canonical fields in a single configuration object.

## Related issues

## Security considerations

No authentication, secrets, or PII changes. Keyword lists are user-supplied strings normalized to lowercase and deduplicated on save; no change to that behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable