### PR TITLE
`feat: expose streaming request types as distinct `_stream` suffixed values in routing CEL`

### DIFF
--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -42,7 +42,7 @@ type RoutingContext struct {
 	UserID                   string                              // Resolved calling user id; empty when the request carries no user identity
 	Provider                 schemas.ModelProvider               // Current provider
 	Model                    string                              // Current model
-	RequestType              string                              // Normalized request type (e.g., "chat_completion", "embedding") from HTTP context
+	RequestType              string                              // Request type (e.g., "chat_completion", "embedding"); streaming requests carry a distinct "_stream" suffix (e.g., "chat_completion_stream")
 	Fallbacks                []string                            // Fallback chain: ["provider/model", ...]
 	Headers                  map[string]string                   // Request headers for dynamic routing
 	QueryParams              map[string]string                   // Query parameters for dynamic routing
@@ -460,7 +460,7 @@ func extractRoutingVariables(ctx *RoutingContext) (map[string]interface{}, error
 	// Basic request context
 	variables["model"] = ctx.Model
 	variables["provider"] = string(ctx.Provider)
-	variables["request_type"] = ctx.RequestType // Normalized request type (e.g., "chat_completion", "embedding")
+	variables["request_type"] = ctx.RequestType // Request type as-is; streaming variants keep their "_stream" suffix (e.g., "chat_completion_stream")
 
 	// Headers and params - normalize headers to lowercase keys for case-insensitive CEL matching
 	// This allows CEL expressions like headers["content-type"] to work regardless of how the header was sent
@@ -658,7 +658,7 @@ func createCELEnvironment() (*cel.Env, error) {
 		// Basic request context
 		cel.Variable("model", cel.StringType),
 		cel.Variable("provider", cel.StringType),
-		cel.Variable("request_type", cel.StringType), // Normalized request type (e.g., "chat_completion", "embedding", "text_completion")
+		cel.Variable("request_type", cel.StringType), // Request type (e.g., "chat_completion", "embedding"); streaming variants are distinct values with a "_stream" suffix
 
 		// Headers and params (dynamic from request)
 		cel.Variable("headers", cel.MapType(cel.StringType, cel.StringType)),

--- a/ui/lib/config/celFieldsRouting.ts
+++ b/ui/lib/config/celFieldsRouting.ts
@@ -12,13 +12,13 @@ export interface CELFieldDefinition {
 	placeholder?: string;
 	inputType?: "text" | "select" | "keyValue" | "number";
 	valueEditorType?:
-		| "text"
-		| "select"
-		| "keyValue"
-		| "number"
-		| "textarea"
-		| "budgetNumber"
-		| ((operator: string) => "text" | "select" | "keyValue" | "number" | "textarea" | "budgetNumber");
+	| "text"
+	| "select"
+	| "keyValue"
+	| "number"
+	| "textarea"
+	| "budgetNumber"
+	| ((operator: string) => "text" | "select" | "keyValue" | "number" | "textarea" | "budgetNumber");
 	operators?: string[];
 	defaultOperator?: string;
 	defaultValue?: any;
@@ -59,19 +59,27 @@ export const baseRoutingFields: CELFieldDefinition[] = [
 		defaultOperator: "=",
 		values: [
 			{ name: "text_completion", label: "Text Completion" },
+			{ name: "text_completion_stream", label: "Text Completion (Streaming)" },
 			{ name: "chat_completion", label: "Chat Completion" },
+			{ name: "chat_completion_stream", label: "Chat Completion (Streaming)" },
 			{ name: "responses", label: "Responses" },
+			{ name: "responses_stream", label: "Responses (Streaming)" },
 			{ name: "embedding", label: "Embeddings" },
 			{ name: "image_generation", label: "Image Generation" },
+			{ name: "image_generation_stream", label: "Image Generation (Streaming)" },
 			{ name: "image_edit", label: "Image Edit" },
+			{ name: "image_edit_stream", label: "Image Edit (Streaming)" },
 			{ name: "image_variation", label: "Image Variation" },
 			{ name: "speech", label: "Speech" },
+			{ name: "speech_stream", label: "Speech (Streaming)" },
 			{ name: "transcription", label: "Transcription" },
+			{ name: "transcription_stream", label: "Transcription (Streaming)" },
 			{ name: "count_tokens", label: "Count Tokens" },
 			{ name: "rerank", label: "Rerank" },
 			{ name: "video_generation", label: "Video Generation" },
 		],
-		description: "Filter rules by the type of API request (chat, text, embeddings, images, audio, etc.)",
+		description:
+			"Filter rules by the type of API request (chat, text, embeddings, images, audio, etc.). Streaming and non-streaming requests are distinct types: select both to cover all requests of a kind.",
 	},
 	{
 		name: "headers",
@@ -143,18 +151,18 @@ export function getRoutingFields(providers: string[] = [], models: string[] = []
 	const providerValues =
 		providers.length > 0
 			? providers.map((provider) => ({
-					name: provider,
-					label: getProviderLabel(provider),
-				}))
+				name: provider,
+				label: getProviderLabel(provider),
+			}))
 			: [{ name: "_no_providers", label: "No providers configured", disabled: true }];
 
 	// Create model field values
 	const modelValues =
 		models.length > 0
 			? models.map((model) => ({
-					name: model,
-					label: model,
-				}))
+				name: model,
+				label: model,
+			}))
 			: [];
 
 	// Create metric options for scope input: providers + models


### PR DESCRIPTION
## Summary

Streaming requests now carry a distinct `_stream` suffix in the `request_type` routing variable (e.g., `chat_completion_stream` instead of `chat_completion`), allowing routing rules to differentiate between streaming and non-streaming variants of the same request type.

## Changes

- Updated `request_type` documentation in `RoutingContext` and `extractRoutingVariables` to clarify that streaming requests produce a distinct value with a `_stream` suffix rather than being normalized to the same value as their non-streaming counterparts.
- Added streaming variants (`text_completion_stream`, `chat_completion_stream`, `responses_stream`, `image_generation_stream`, `image_edit_stream`, `speech_stream`, `transcription_stream`) to the `request_type` field options in the UI routing rule builder.
- Updated the `request_type` field description to inform users that streaming and non-streaming requests are distinct types and that both must be selected to cover all requests of a given kind.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a routing rule using `request_type = "chat_completion_stream"`.
2. Send a streaming chat completion request and verify the rule is matched.
3. Send a non-streaming chat completion request and verify the rule is **not** matched.
4. Add a second rule for `request_type = "chat_completion"` and confirm non-streaming requests match it while streaming requests do not.

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [x] Yes
- [ ] No

Routing rules that previously matched `chat_completion` (or other request types) expecting to cover both streaming and non-streaming requests will no longer match streaming variants. Rules must be updated to explicitly include the `_stream` suffixed variant if streaming coverage is required.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable