### PR TITLE
fixes skipped cases in semanticcache tests

### DIFF
--- a/plugins/semanticcache/plugin_no_store_test.go
+++ b/plugins/semanticcache/plugin_no_store_test.go
@@ -81,7 +81,6 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 // TestCacheNoStoreWithDifferentRequestTypes tests NoStore with various request types
 func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 	t.Parallel()
-	t.Skip("Skipping Embedding Tests")
 
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()

--- a/plugins/semanticcache/plugin_streaming_test.go
+++ b/plugins/semanticcache/plugin_streaming_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
 // TestStreamingCacheBasicFunctionality tests streaming response caching
@@ -184,10 +186,107 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 	t.Log("✅ Streaming vs non-streaming test completed!")
 }
 
+// chunkStreamPlugin is a test-only LLMPlugin that short-circuits
+// ChatCompletionStreamRequest with a genuine multi-chunk stream via
+// LLMPluginShortCircuit.Stream — the same mechanism real streaming providers
+// use (see e.g. core/providers/openai/openai.go). The shared mocker plugin
+// (getMockedBifrostClient) only ever short-circuits with a single complete
+// Response, so it can never exercise the semantic cache's multi-chunk
+// ordering/replay path; this plugin fills that gap for
+// TestStreamingChunkOrdering. Any request type other than
+// ChatCompletionStreamRequest passes through untouched to the next plugin
+// (mocker).
+type chunkStreamPlugin struct {
+	chunks []string
+}
+
+func (p *chunkStreamPlugin) GetName() string { return "chunk-stream-test-plugin" }
+func (p *chunkStreamPlugin) Cleanup() error  { return nil }
+
+func (p *chunkStreamPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+
+func (p *chunkStreamPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	if req.RequestType != schemas.ChatCompletionStreamRequest {
+		return req, nil, nil
+	}
+
+	_, model, _ := req.GetRequestFields()
+	// Root() unwraps past this call's plugin-scoped context, which is released
+	// (and unsafe to retain) the instant PreLLMHook returns — the goroutine
+	// below outlives that.
+	root := ctx.Root()
+	streamCh := make(chan *schemas.BifrostStreamChunk)
+
+	go func() {
+		defer close(streamCh)
+		for i, piece := range p.chunks {
+			if i > 0 {
+				// Real streaming providers are paced by network I/O between
+				// chunks, which in practice gives each chunk's async cache-write
+				// goroutine (main.go PostLLMHook) time to finish appending before
+				// the next chunk's PostLLMHook fires. Sending back-to-back with no
+				// delay at all removes that natural pacing and reliably wins a
+				// real race in the plugin: the final chunk's write goroutine can
+				// flush (and latch IsComplete) before an earlier chunk's goroutine
+				// has appended, silently dropping it from the cached entry. This
+				// sleep restores realistic pacing so the test exercises chunk
+				// ordering/replay rather than that unrelated, already-tracked race.
+				time.Sleep(20 * time.Millisecond)
+			}
+			delta := &schemas.ChatStreamResponseChoiceDelta{Content: bifrost.Ptr(piece)}
+			if i == 0 {
+				delta.Role = bifrost.Ptr("assistant")
+			}
+			choice := schemas.BifrostResponseChoice{
+				Index:                    0,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{Delta: delta},
+			}
+			resp := &schemas.BifrostChatResponse{
+				Model:       model,
+				Choices:     []schemas.BifrostResponseChoice{choice},
+				ExtraFields: schemas.BifrostResponseExtraFields{ChunkIndex: i},
+			}
+
+			isLast := i == len(p.chunks)-1
+			if isLast {
+				resp.Choices[0].FinishReason = bifrost.Ptr("stop")
+				resp.Usage = &schemas.BifrostLLMUsage{
+					PromptTokens:     10,
+					CompletionTokens: len(p.chunks),
+					TotalTokens:      10 + len(p.chunks),
+				}
+				// Must be set before the send below — this is the same
+				// set-before-send ordering real provider streaming code
+				// uses, so the consumer only observes it once it dequeues
+				// this last chunk (see semanticcache/main.go PostLLMHook).
+				root.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			}
+
+			streamCh <- &schemas.BifrostStreamChunk{BifrostChatResponse: resp}
+		}
+	}()
+
+	return req, &schemas.LLMPluginShortCircuit{Stream: streamCh}, nil
+}
+
+func (p *chunkStreamPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	return resp, bifrostErr, nil
+}
+
 // TestStreamingChunkOrdering tests that cached streaming responses maintain proper chunk ordering
 func TestStreamingChunkOrdering(t *testing.T) {
 	t.Parallel()
-	setup := NewTestSetup(t)
+	chunkPlugin := &chunkStreamPlugin{
+		chunks: []string{
+			"2, 3, 5, 7, ",
+			"and 11 are ",
+			"the first five ",
+			"prime numbers.",
+		},
+	}
+	setup := NewTestSetupWithVectorStore(t, getDefaultTestConfig(), vectorstore.VectorStoreTypeWeaviate, chunkPlugin)
 	defer setup.Cleanup()
 
 	ctx := CreateContextWithCacheKey(t, "chunk-order-test")
@@ -202,7 +301,7 @@ func TestStreamingChunkOrdering(t *testing.T) {
 	t.Log("Making first streaming request to establish cache...")
 	stream1, err1 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
 	if err1 != nil {
-		t.Skipf("upstream request error, skipping test: %v", err1)
+		t.Fatalf("First streaming request failed: %v", err1)
 	}
 
 	var originalChunks []schemas.BifrostChatResponse
@@ -215,11 +314,10 @@ func TestStreamingChunkOrdering(t *testing.T) {
 		}
 	}
 
-	if len(originalChunks) < 2 {
-		// Stream chunking is at the provider's discretion — under load OpenAI
-		// occasionally bundles a short reply into a single delivered chunk.
-		// Ordering is not testable in that case; skip rather than fail.
-		t.Skipf("Need at least 2 chunks to test ordering, got %d", len(originalChunks))
+	// chunkStreamPlugin deterministically emits len(chunkPlugin.chunks)
+	// chunks — this is no longer at any provider's discretion.
+	if len(originalChunks) != len(chunkPlugin.chunks) {
+		t.Fatalf("Expected %d chunks from the test plugin, got %d", len(chunkPlugin.chunks), len(originalChunks))
 	}
 
 	t.Logf("Original stream had %d chunks", len(originalChunks))

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -433,7 +433,12 @@ func getMockRules() []mocker.MockRule {
 }
 
 // getMockedBifrostClient creates a Bifrost client with a mocker plugin for testing
-func getMockedBifrostClient(t *testing.T, ctx *schemas.BifrostContext, logger schemas.Logger, semanticCachePlugin schemas.LLMPlugin) *bifrost.Bifrost {
+// extraPlugins, when given, are inserted between semanticCachePlugin and the
+// mocker plugin — e.g. a test-local plugin that short-circuits with a real
+// multi-chunk stream (see chunkStreamPlugin) where the mocker's single-shot
+// Response short-circuit can't exercise the case being tested. Any request
+// an extra plugin doesn't handle falls through to mocker as usual.
+func getMockedBifrostClient(t *testing.T, ctx *schemas.BifrostContext, logger schemas.Logger, semanticCachePlugin schemas.LLMPlugin, extraPlugins ...schemas.LLMPlugin) *bifrost.Bifrost {
 	mockerCfg := mocker.MockerConfig{
 		Enabled: true,
 		Rules:   getMockRules(),
@@ -444,10 +449,13 @@ func getMockedBifrostClient(t *testing.T, ctx *schemas.BifrostContext, logger sc
 		t.Fatalf("Failed to initialize mocker plugin: %v", err)
 	}
 
+	llmPlugins := append([]schemas.LLMPlugin{semanticCachePlugin}, extraPlugins...)
+	llmPlugins = append(llmPlugins, mockerPlugin)
+
 	account := &BaseAccount{}
 	client, err := bifrost.Init(ctx, schemas.BifrostConfig{
 		Account:    account,
-		LLMPlugins: []schemas.LLMPlugin{semanticCachePlugin, mockerPlugin},
+		LLMPlugins: llmPlugins,
 		Logger:     logger,
 	})
 	if err != nil {
@@ -506,8 +514,9 @@ func ensureSharedTestNamespace(ctx context.Context, store vectorstore.VectorStor
 	return sharedTestNamespaceErr
 }
 
-// NewTestSetupWithVectorStore creates a new test setup with custom configuration and vector store type
-func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectorstore.VectorStoreType) *TestSetup {
+// NewTestSetupWithVectorStore creates a new test setup with custom configuration and vector store type.
+// extraPlugins are forwarded to getMockedBifrostClient — see its doc comment.
+func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectorstore.VectorStoreType, extraPlugins ...schemas.LLMPlugin) *TestSetup {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 
@@ -550,7 +559,7 @@ func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectors
 	clearTestKeysWithStore(t, pluginImpl.store)
 
 	// Get a mocked Bifrost client
-	client := getMockedBifrostClient(t, ctx, logger, plugin)
+	client := getMockedBifrostClient(t, ctx, logger, plugin, extraPlugins...)
 
 	// Wire the global client as the embedding executor so semantic search works.
 	pluginImpl.SetEmbeddingRequestExecutor(throttledEmbeddingExecutor(client.EmbeddingRequest))


### PR DESCRIPTION
## Summary

The `TestStreamingChunkOrdering` test previously relied on a real upstream provider to emit multiple chunks, which made it non-deterministic and prone to skipping when the provider bundled the response into a single chunk. This PR introduces a deterministic, test-local `chunkStreamPlugin` that short-circuits streaming requests with a controlled multi-chunk sequence, making the test reliable and self-contained.

## Changes

- Added `chunkStreamPlugin`, a test-only `LLMPlugin` that intercepts `ChatCompletionStreamRequest` and emits a fixed sequence of chunks via `LLMPluginShortCircuit.Stream`, mirroring how real streaming providers work. A 20ms inter-chunk delay is included to replicate natural network pacing and avoid a known race in the cache's async write path.
- `TestStreamingChunkOrdering` now uses `NewTestSetupWithVectorStore` with `chunkStreamPlugin` injected, replacing the previous `NewTestSetup` call. The test now asserts an exact chunk count instead of skipping when fewer than 2 chunks arrive.
- `getMockedBifrostClient` and `NewTestSetupWithVectorStore` accept variadic `extraPlugins`, inserted between the semantic cache plugin and the mocker plugin, allowing test-local plugins to intercept specific request types while falling through to the mocker for everything else.
- Removed the `t.Skip("Skipping Embedding Tests")` call from `TestCacheNoStoreWithDifferentRequestTypes`, re-enabling that test.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/semanticcache/... -run TestStreamingChunkOrdering -v
go test ./plugins/semanticcache/... -run TestCacheNoStoreWithDifferentRequestTypes -v
go test ./plugins/semanticcache/... -v
```

`TestStreamingChunkOrdering` should now pass deterministically without skipping, emitting exactly 4 chunks on the first request and replaying them correctly from cache on the second.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable