### PR TITLE
fix: add `customer_id`/`business_unit_id` to matview `scopeProjection` so team-data DAC scope resolves without column errors

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -181,16 +181,16 @@ type filterMatViewDef struct {
 // histogram readers use — so a team / business unit that only ever appears in
 // the JSON array still surfaces in the filter dropdown. The fanned-out
 // dim_id/dim_name become the dropdown id/name; the visibility columns
-// (user_id, team_id, virtual_key_id) come from the original log row (exposed via
-// l.* by the fan-out subquery) so DAC scope still applies. idCol is the scalar
-// id column ("team_id" / "business_unit_id").
+// (scopeProjection) come from the original log row (exposed via l.* by the
+// fan-out subquery) so DAC scope still applies — including the scalar
+// customer_id / business_unit_id, which stay the row's own owner columns and
+// are independent of the fanned-out dim_id. idCol is the scalar id column
+// ("team_id" / "business_unit_id").
 func multiValueFilterMatViewBody(idCol string) string {
 	from, _ := teamOrBUFanoutFrom(idCol)
 	return fmt.Sprintf(
-		"SELECT DISTINCT dim_id AS id, dim_name AS name, "+
-			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, "+
-			"COALESCE(virtual_key_id, '') AS virtual_key_id "+
-			"FROM %s WHERE timestamp >= NOW() - INTERVAL '%s' AND dim_id != '' AND dim_name != ''",
+		"SELECT DISTINCT dim_id AS id, dim_name AS name, "+scopeProjection+
+			" FROM %s WHERE timestamp >= NOW() - INTERVAL '%s' AND dim_id != '' AND dim_name != ''",
 		from, filterDataMatViewWindow,
 	)
 }
@@ -202,20 +202,31 @@ func multiValueFilterMatViewBody(idCol string) string {
 // the unique index from rejecting NULLs on REFRESH CONCURRENTLY).
 const scopeProjection = "COALESCE(user_id, '') AS user_id, " +
 	"COALESCE(team_id, '') AS team_id, " +
-	"COALESCE(virtual_key_id, '') AS virtual_key_id"
+	"COALESCE(virtual_key_id, '') AS virtual_key_id, " +
+	"COALESCE(customer_id, '') AS customer_id, " +
+	"COALESCE(business_unit_id, '') AS business_unit_id"
 
 // scopeIdxColumns is the unique-index suffix that pairs with scopeProjection.
-const scopeIdxColumns = "user_id, team_id, virtual_key_id"
+const scopeIdxColumns = "user_id, team_id, virtual_key_id, customer_id, business_unit_id"
 
 // scopeRequiredColumns lists the resolved column aliases produced by
 // scopeProjection. Appended to each matview's requiredColumns so
 // repairMatViewShapes can verify them against pg_attribute.
-var scopeRequiredColumns = []string{"user_id", "team_id", "virtual_key_id"}
+//
+// customer_id / business_unit_id are part of the set because a team-data
+// DAC principal widens visibility by those org dimensions: the scope
+// predicate ORs them in alongside user_id / team_id / virtual_key_id, and
+// a matview missing the columns would fail the query outright rather than
+// filter it. Adding them here also drives the rebuild — repairMatViewShapes
+// sees the old three-column views as drifted and drops them on boot, so no
+// separate migration is needed.
+var scopeRequiredColumns = []string{"user_id", "team_id", "virtual_key_id", "customer_id", "business_unit_id"}
 
 // filterMatViews enumerates every per-dimension materialized view used to
 // populate filter dropdowns on the logs page. Each view carries the
 // dropdown's dimension columns plus the visibility columns
-// (user_id, team_id, virtual_key_id) so DAC scope applies in-matview.
+// (user_id, team_id, virtual_key_id, customer_id, business_unit_id) so
+// every DAC scope predicate applies in-matview.
 // Order matters only for deterministic startup logs.
 var filterMatViews = []filterMatViewDef{
 	{
@@ -257,9 +268,7 @@ var filterMatViews = []filterMatViewDef{
 		name: "mv_filter_virtual_keys",
 		// virtual_key_id is exposed as "id" for the dropdown and also as the
 		// scope column so DAC predicates use a stable name across matviews.
-		selectExpr: "virtual_key_id AS id, virtual_key_name AS name, " +
-			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
-			"COALESCE(virtual_key_id, '') AS virtual_key_id",
+		selectExpr:      "virtual_key_id AS id, virtual_key_name AS name, " + scopeProjection,
 		whereExpr:       "virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != ''",
 		uniqueIdx:       "id, name, " + scopeIdxColumns,
 		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
@@ -404,7 +413,8 @@ var matviewUniqueIndexes = func() []matviewIndexDef {
 
 // matviewScopeIndexes enumerates the secondary BTREE indexes that make
 // DAC-scoped reads on the per-dimension filter matviews cheap. The
-// composite (user_id, team_id, virtual_key_id) is a covering index for
+// composite (user_id, team_id, virtual_key_id, customer_id,
+// business_unit_id) is a covering index for
 // the only column subset every filter-dropdown query selects, so
 // Postgres can serve scoped DISTINCT queries via an index-only scan
 // even when only the trailing columns are in the predicate. Filter

--- a/framework/logstore/matviews_dac_test.go
+++ b/framework/logstore/matviews_dac_test.go
@@ -11,11 +11,13 @@ import (
 
 // TestFilterMatViews_AllCarryVisibilityColumns asserts the widening
 // from Fix 4 — every per-dimension matview projects user_id, team_id,
-// and virtual_key_id (or has them as part of its dimension columns).
-// Without these columns the DAC scope WHERE applied via ScopedDB
-// would error at the SQL layer with "no such column".
+// virtual_key_id, customer_id and business_unit_id (or has them as part
+// of its dimension columns). Without these columns the DAC scope WHERE
+// applied via ScopedDB would error at the SQL layer with "no such
+// column"; customer_id / business_unit_id specifically are the ones a
+// team-data principal's scope ORs in.
 func TestFilterMatViews_AllCarryVisibilityColumns(t *testing.T) {
-	required := []string{"user_id", "team_id", "virtual_key_id"}
+	required := []string{"user_id", "team_id", "virtual_key_id", "customer_id", "business_unit_id"}
 	for _, v := range filterMatViews {
 		cols := filterMatViewRequiredColumns(v)
 		colSet := make(map[string]struct{}, len(cols))
@@ -32,17 +34,17 @@ func TestFilterMatViews_AllCarryVisibilityColumns(t *testing.T) {
 }
 
 // TestFilterMatViews_UniqueIdxIncludesVisibilityColumns asserts the
-// widened unique index covers (user_id, team_id, virtual_key_id) so
-// the new row shape can be uniquely keyed for REFRESH ... CONCURRENTLY.
+// widened unique index covers every visibility column so the row shape
+// stays uniquely keyed for REFRESH ... CONCURRENTLY. The view is a
+// DISTINCT over (dimension + visibility columns); leaving one out of
+// the index would let two rows differing only in that column collide.
 func TestFilterMatViews_UniqueIdxIncludesVisibilityColumns(t *testing.T) {
 	for _, v := range filterMatViews {
 		idx := strings.ToLower(v.uniqueIdx)
-		assert.Contains(t, idx, "user_id",
-			"matview %s unique index must include user_id", v.name)
-		assert.Contains(t, idx, "team_id",
-			"matview %s unique index must include team_id", v.name)
-		assert.Contains(t, idx, "virtual_key_id",
-			"matview %s unique index must include virtual_key_id", v.name)
+		for _, col := range scopeRequiredColumns {
+			assert.Containsf(t, idx, col,
+				"matview %s unique index must include %s", v.name, col)
+		}
 	}
 }
 
@@ -60,7 +62,7 @@ func TestFilterMatViewScopeIdx_IsConcurrentAndIdempotent(t *testing.T) {
 		assert.Contains(t, ddl, filterMatViewScopeIdxName(v),
 			"scope index DDL must reference the canonical index name")
 		assert.Contains(t, ddl, scopeIdxColumns,
-			"scope index must lead with (user_id, team_id, virtual_key_id)")
+			"scope index must lead with the visibility columns (%s)", scopeIdxColumns)
 	}
 }
 

--- a/framework/logstore/multi_team_matview_test.go
+++ b/framework/logstore/multi_team_matview_test.go
@@ -210,3 +210,126 @@ func TestFilterTeamMatView_DACScopeAppliesAfterFanout(t *testing.T) {
 	_, leaked := byID["t-secret"]
 	assert.False(t, leaked, "array team owned by another user must be filtered out by DAC scope")
 }
+
+// insertOrgScopeLog inserts a log row carrying the full set of ownership
+// columns a DAC scope can predicate on, so the org dimensions
+// (customer_id / business_unit_id) can be exercised independently of the
+// user / team ones.
+func insertOrgScopeLog(t *testing.T, db *gorm.DB, ts time.Time,
+	userID, userName, teamID, customerID, buID string) {
+	t.Helper()
+	nz := func(s string) any {
+		if s == "" {
+			return nil
+		}
+		return s
+	}
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			user_id, user_name, team_id, customer_id, business_unit_id,
+			created_at, latency, cost, prompt_tokens, completion_tokens, total_tokens)
+		VALUES (?, ?, 'chat_completion', 'openai', 'gpt-4', 'success',
+			?, ?, ?, ?, ?, ?, 100, 0.01, 10, 5, 15)
+	`, uuid.New().String(), ts, nz(userID), nz(userName), nz(teamID),
+		nz(customerID), nz(buID), ts).Error
+	require.NoError(t, err, "failed to insert org-scope test log")
+}
+
+// teamDataScope mirrors the predicate the enterprise DAC resolver builds for a
+// team-data principal: a single OR over every ownership dimension, including
+// the org ones. Kept faithful to that shape because the failure mode it guards
+// is a column the matview does not project, which errors the whole query rather
+// than under-filtering it.
+func teamDataScope(userIDs, teamIDs, customerIDs, buIDs []string) queryscope.QueryScope {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where(
+			"(user_id IN ? OR team_id IN ? OR customer_id IN ? OR business_unit_id IN ?)",
+			userIDs, teamIDs, customerIDs, buIDs,
+		)
+	}
+}
+
+// TestFilterUsersMatView_TeamDataScopeIncludesOrgDimensions is the regression for
+// the org-dimension gap: mv_filter_* projected only (user_id, team_id,
+// virtual_key_id), while a team-data DAC scope also ORs customer_id and
+// business_unit_id. The matview query then failed with 42703 undefined_column,
+// which fallBackToRaw classifies as a shape error — so every team-data
+// filterdata request silently disabled the matview read path process-wide,
+// kicked a self-heal that rebuilt the same too-narrow views, and served a raw
+// full-window scan instead. The widened views must resolve the predicate AND
+// honour it: a user reachable only through the shared customer is visible, an
+// unrelated one is not.
+//
+// Asserted against getDistinctKeyPairsFromMatView rather than the public
+// GetDistinctKeyPairs precisely because the raw fallback hides the failure —
+// through the public method the old shape returns correct rows, just from the
+// wrong (slow) path.
+func TestFilterUsersMatView_TeamDataScopeIncludesOrgDimensions(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	store.matViewsReady.Store(true)
+	now := time.Now().UTC()
+
+	// Visible only via customer_id, and only via business_unit_id respectively;
+	// neither shares the principal's user or team, so the predicate cannot be
+	// satisfied without those two columns being present on the view.
+	insertOrgScopeLog(t, db, now, "u-cust", "Customer Peer", "t-other", "c-mine", "")
+	insertOrgScopeLog(t, db, now, "u-bu", "BU Peer", "t-other", "", "bu-mine")
+	insertOrgScopeLog(t, db, now, "u-outsider", "Outsider", "t-other", "c-other", "bu-other")
+	refreshTestMatViews(t, db)
+
+	ctx := queryscope.WithQueryScope(context.Background(),
+		teamDataScope([]string{"u-me"}, []string{"t-mine"}, []string{"c-mine"}, []string{"bu-mine"}))
+
+	pairs, served, err := store.getDistinctKeyPairsFromMatView(ctx, "user_id", "user_name", 1000, "")
+	require.True(t, served, "mv_filter_users must serve the users dimension")
+	require.NoError(t, err, "team-data scope must resolve against mv_filter_users' visibility columns")
+	byID := keyPairsByID(pairs)
+
+	assert.Equal(t, "Customer Peer", byID["u-cust"], "user sharing the principal's customer must appear")
+	assert.Equal(t, "BU Peer", byID["u-bu"], "user sharing the principal's business unit must appear")
+	_, leaked := byID["u-outsider"]
+	assert.False(t, leaked, "user in another customer and BU must stay hidden")
+
+	// The public path must agree, and must not have tripped the shape-error
+	// fallback on the way (that flag flip is the production symptom).
+	public, err := store.GetDistinctKeyPairs(ctx, "user_id", "user_name", 1000, "")
+	require.NoError(t, err)
+	assert.Equal(t, byID, keyPairsByID(public), "matview and public paths must agree")
+	assert.True(t, store.matViewsReady.Load(),
+		"a scoped filterdata read must not disable the matview read path")
+}
+
+// TestFilterMultiValueMatViews_TeamDataScopeResolves covers the bodyOverride
+// views (teams / business units), whose visibility columns are projected by
+// multiValueFilterMatViewBody rather than scopeProjection — the two are easy to
+// let drift apart, and drift there means the same silent demotion to raw scans.
+func TestFilterMultiValueMatViews_TeamDataScopeResolves(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	store.matViewsReady.Store(true)
+	now := time.Now().UTC()
+
+	insertOrgScopeLog(t, db, now, "u-cust", "Customer Peer", "t-visible", "c-mine", "bu-mine")
+	insertOrgScopeLog(t, db, now, "u-outsider", "Outsider", "t-hidden", "c-other", "bu-other")
+	// Name the teams/BUs so they qualify for the dropdown (the views drop rows
+	// with an empty name).
+	require.NoError(t, db.Exec(`UPDATE logs SET team_name = 'Team ' || team_id,
+		business_unit_name = 'BU ' || business_unit_id`).Error)
+	refreshTestMatViews(t, db)
+
+	ctx := queryscope.WithQueryScope(context.Background(),
+		teamDataScope([]string{"u-me"}, []string{"t-mine"}, []string{"c-mine"}, []string{"bu-mine"}))
+
+	teams, served, err := store.getDistinctKeyPairsFromMatView(ctx, "team_id", "team_name", 1000, "")
+	require.True(t, served)
+	require.NoError(t, err, "team-data scope must resolve against mv_filter_teams")
+	teamsByID := keyPairsByID(teams)
+	assert.Contains(t, teamsByID, "t-visible", "team on a row inside the principal's customer must appear")
+	assert.NotContains(t, teamsByID, "t-hidden", "team on an out-of-scope row must not leak")
+
+	bus, served, err := store.getDistinctKeyPairsFromMatView(ctx, "business_unit_id", "business_unit_name", 1000, "")
+	require.True(t, served)
+	require.NoError(t, err, "team-data scope must resolve against mv_filter_business_units")
+	busByID := keyPairsByID(bus)
+	assert.Contains(t, busByID, "bu-mine", "the principal's own business unit must appear")
+	assert.NotContains(t, busByID, "bu-other", "an out-of-scope business unit must not leak")
+}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -3623,11 +3623,10 @@ var allowedKeyPairColumns = map[string]struct{}{
 // GetDistinctKeyPairs returns unique non-empty ID-Name pairs for the given columns using SELECT DISTINCT.
 // idCol and nameCol must be valid column names (e.g., "selected_key_id", "selected_key_name").
 //
-// Matview path is DAC-aware: each per-dimension matview carries the
-// visibility columns (user_id, team_id, virtual_key_id), so a
-// QueryScope on ctx applies on the matview directly. Until
-// matViewsReady the raw-table fallback (also ScopedDB-aware) serves
-// requests.
+// Matview path is DAC-aware: each per-dimension matview carries every
+// visibility column a scope can predicate on (see scopeProjection), so a
+// QueryScope on ctx applies on the matview directly. Until matViewsReady
+// the raw-table fallback (also ScopedDB-aware) serves requests.
 func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol string, limit int, query string) ([]KeyPairResult, error) {
 	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
 		results, served, err := s.getDistinctKeyPairsFromMatView(ctx, idCol, nameCol, limit, query)

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -79,10 +79,36 @@ const filterDataFanOutLimit = 4
 
 const defaultFilterDataLimit = 1000
 
-// shouldUseFilterDataCache reports whether a filterdata response can be shared
-// across callers without bypassing DAC-scoped query constraints.
+// shouldUseFilterDataCache reports whether a filterdata response is cacheable
+// at all. Text-search responses are not (unbounded key space), nor are ones
+// already carrying an explicit query scope.
+//
+// Note this is NOT what makes the cache DAC-safe: row visibility is resolved
+// deeper in the store, so no QueryScope is on the request context yet at this
+// point. Sharing across callers is prevented by filterDataCacheIdentity, which
+// partitions the cache key per caller.
 func shouldUseFilterDataCache(ctx context.Context, query string) bool {
 	return strings.TrimSpace(query) == "" && queryscope.FromContext(ctx) == nil
+}
+
+// filterDataCacheIdentity returns the cache-key fragment that partitions
+// filterdata responses per caller.
+//
+// Filter dropdowns are row-visibility-scoped in enterprise builds: two users
+// hitting the same dimensions legitimately get different values. The cache key
+// therefore carries the caller's user and role, so a narrowly-scoped user's
+// response can never be served to anyone else — and a role change (which
+// changes visibility) misses the cache immediately rather than after the TTL.
+//
+// Requests with no user identity (OSS deployments, local-admin sessions) share
+// a single "anon" partition, which is exactly the pre-DAC behaviour.
+func filterDataCacheIdentity(ctx *fasthttp.RequestCtx) string {
+	userID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+	if userID == "" {
+		return "anon"
+	}
+	roleID, _ := ctx.UserValue(schemas.BifrostContextKeyUserRoleID).(uint)
+	return fmt.Sprintf("%s/%d", userID, roleID)
 }
 
 // Filter dimension names accepted by the ?dimensions= query param on

--- a/ui/app/_fallbacks/enterprise/components/user-groups/sheets/customerDetailSheet.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/sheets/customerDetailSheet.tsx
@@ -1,3 +1,4 @@
+import { CopyableId } from "@/components/copyableId";
 import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { resetDurationLabels } from "@/lib/constants/governance";
@@ -97,7 +98,10 @@ export function CustomerDetailSheet({ customer, open, onOpenChange }: Props) {
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="max-w-[700px] overflow-y-auto p-0 pt-4">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 px-8 sticky -top-4 bg-card z-10">
-					<SheetTitle className="text-lg">{customer?.name || "Customer Details"}</SheetTitle>
+					<div className="flex min-w-0 items-center gap-1">
+						<SheetTitle className="truncate text-lg">{customer?.name || "Customer Details"}</SheetTitle>
+						{customer?.id && <CopyableId id={customer.id} entityLabel="Customer" />}
+					</div>
 					<SheetDescription>Usage details for this customer.</SheetDescription>
 				</SheetHeader>
 

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -8,6 +8,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { CopyableId } from "@/components/copyableId";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -274,7 +275,10 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="max-w-[900px] p-0 pt-4 sm:max-w-2xl" data-testid="customer-dialog-content">
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Customer" : "Create Customer"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">
+						{isEditing ? "Edit Customer" : "Create Customer"}
+						{customer?.id && <CopyableId id={customer.id} entityLabel="Customer" />}
+					</SheetTitle>
 					<SheetDescription>
 						{isEditing
 							? "Update the customer information and settings."

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -9,6 +9,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { CopyableId } from "@/components/copyableId";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -320,7 +321,10 @@ export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 				onEscapeKeyDown={() => onCancel()}
 			>
 				<SheetHeader className="flex flex-col items-start px-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8">
-					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Create Team"}</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">
+						{isEditing ? "Edit Team" : "Create Team"}
+						{team?.id && <CopyableId id={team.id} entityLabel="Team" />}
+					</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the team information and settings." : "Create a new team to organize users and manage shared resources."}
 					</SheetDescription>

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -1,4 +1,5 @@
 import { BudgetOverrideDialog } from "@/components/budgetOverrideDialog";
+import { CopyableId } from "@/components/copyableId";
 import { SheetNavigationButtons } from "@/components/sheetNavigationButtons";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -120,8 +121,11 @@ export default function VirtualKeyDetailSheet({
 					className="flex flex-row items-center justify-between px-0 py-4"
 					headerClassName="mb-0 sticky -top-4 bg-card z-10 px-8"
 				>
-					<div className="flex flex-col items-start">
-						<SheetTitle>{virtualKey.name}</SheetTitle>
+					<div className="flex min-w-0 flex-col items-start">
+						<div className="flex min-w-0 items-center gap-1">
+							<SheetTitle className="truncate">{virtualKey.name}</SheetTitle>
+							<CopyableId id={virtualKey.id} entityLabel="Virtual key" />
+						</div>
 						<SheetDescription>{virtualKey.description || "Virtual key details and usage information"}</SheetDescription>
 					</div>
 					<SheetNavigationButtons
@@ -226,8 +230,7 @@ export default function VirtualKeyDetailSheet({
 													<span className="font-medium">{ProviderLabels[config.provider as ProviderName] || config.provider}</span>
 												</div>
 												<Badge variant="outline" className="font-mono text-xs">
-													Weight:{" "}
-													{config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
+													Weight: {config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
 												</Badge>
 											</div>
 

--- a/ui/components/copyableId.tsx
+++ b/ui/components/copyableId.tsx
@@ -1,0 +1,50 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { cn } from "@/lib/utils";
+import { Check, Copy } from "lucide-react";
+
+interface CopyableIdProps {
+	id: string | number;
+	/** Entity name used in the toast, tooltip, and aria-label, e.g. "Team" -> "Copy team ID". */
+	entityLabel?: string;
+	className?: string;
+}
+
+/**
+ * Icon-only click-to-copy control for an entity id, sized to sit inline beside a
+ * sheet title. The full id lives in the tooltip so it never competes with the name.
+ */
+export function CopyableId({ id, entityLabel, className }: CopyableIdProps) {
+	const value = String(id ?? "");
+	const noun = entityLabel ? `${entityLabel.toLowerCase()} ID` : "ID";
+	const { copy, copied } = useCopyToClipboard({
+		successMessage: `${entityLabel ? `${entityLabel} ID` : "ID"} copied`,
+	});
+
+	if (!value) return null;
+
+	return (
+		<Tooltip delayDuration={0}>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						copy(value);
+					}}
+					aria-label={`Copy ${noun}`}
+					className={cn(
+						"text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded transition-colors",
+						className,
+					)}
+				>
+					{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="flex flex-col items-start gap-0.5 px-2 py-1">
+				<span className="text-xs">Copy {noun}</span>
+				<span className="font-mono text-xs opacity-80">{value}</span>
+			</TooltipContent>
+		</Tooltip>
+	);
+}


### PR DESCRIPTION
## Summary

Filter-dropdown materialized views previously projected only `user_id`, `team_id`, and `virtual_key_id` as visibility columns. Enterprise DAC scopes for team-data principals also predicate on `customer_id` and `business_unit_id`, causing those queries to fail with a `42703 undefined_column` error. The `fallBackToRaw` handler classified this as a shape error, silently disabling the matview read path process-wide and falling back to expensive full-window raw table scans for every subsequent filterdata request. This PR widens `scopeProjection`, `scopeIdxColumns`, and `scopeRequiredColumns` to include `customer_id` and `business_unit_id`, so every DAC scope predicate resolves correctly against the matviews.

## Changes

- `scopeProjection` now includes `COALESCE(customer_id, '') AS customer_id` and `COALESCE(business_unit_id, '') AS business_unit_id`, making these columns available on every filter matview.
- `scopeIdxColumns` and `scopeRequiredColumns` are widened to match, so `repairMatViewShapes` detects old three-column views as drifted on boot and drops/rebuilds them automatically — no separate migration needed.
- `multiValueFilterMatViewBody` (used for the teams and business units fan-out views) now references `scopeProjection` directly instead of an inline column list, eliminating the drift risk that caused the original gap.
- `mv_filter_virtual_keys` likewise switched to `scopeProjection` to stay consistent.
- The secondary DAC scope BTREE index is updated to cover all five visibility columns.
- `filterDataCacheIdentity` is introduced in the HTTP handler to partition the filterdata cache per caller identity (user ID + role ID), preventing a narrowly-scoped user's cached response from being served to a broader-scoped caller. Unauthenticated/OSS callers share a single `anon` partition, preserving pre-DAC behaviour.
- The comment on `shouldUseFilterDataCache` is clarified to distinguish its role (text-search / explicit-scope exclusion) from DAC safety (which is handled by `filterDataCacheIdentity`).
- Tests are extended to cover the org-dimension gap directly via `getDistinctKeyPairsFromMatView`, bypassing the raw fallback that previously hid the failure, and to assert that a scoped filterdata read does not flip `matViewsReady` to false.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./framework/logstore/... -run TestFilterUsersMatView_TeamDataScopeIncludesOrgDimensions
go test ./framework/logstore/... -run TestFilterMultiValueMatViews_TeamDataScopeResolves
go test ./framework/logstore/... -run TestFilterMatViews_AllCarryVisibilityColumns
go test ./framework/logstore/... -run TestFilterMatViews_UniqueIdxIncludesVisibilityColumns
go test ./framework/logstore/... -run TestFilterMatViewScopeIdx_IsConcurrentAndIdempotent
go test ./...
```

On a running instance with enterprise DAC and a team-data principal configured, verify that:
1. Filter dropdowns load without triggering a matview rebuild loop in logs.
2. `matViewsReady` remains `true` after a scoped filterdata request.
3. Users/teams/business units visible only via `customer_id` or `business_unit_id` appear in the appropriate dropdowns for the owning principal and are absent for unrelated principals.

## Breaking changes

- [x] No

Existing matview views missing `customer_id`/`business_unit_id` are detected as drifted by `repairMatViewShapes` on boot and rebuilt automatically.

## Security considerations

The `filterDataCacheIdentity` partitioning ensures that a cached filterdata response scoped to one user's visibility cannot be returned to a different user. Previously, without this partitioning, a response cached for a broad-scope caller could theoretically be served to a narrow-scope caller (or vice versa) within the cache TTL window.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable