### PR TITLE
fix: scope filterdata cache per caller and add item-budget admission control

### DIFF
--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -79,6 +79,65 @@ const filterDataFanOutLimit = 4
 
 const defaultFilterDataLimit = 1000
 
+// filterDataMatViewBackedDims lists the dimensions served by a per-dimension
+// materialized view (see framework/logstore filterMatViews). Those reads are
+// small indexed lookups, so caching them buys little — the cache exists for the
+// dimensions that still hit the raw logs table.
+//
+// metadata_keys is the notable absentee: it has no matview and scans up to
+// maxMetadataRows recent rows, JSON-parsing each, on every dialect. It is also
+// the one dimension the logs page requests unconditionally on mount.
+var filterDataMatViewBackedDims = map[string]struct{}{
+	filterDimModels:         {},
+	filterDimAliases:        {},
+	filterDimSelectedKeys:   {},
+	filterDimVirtualKeys:    {},
+	filterDimRoutingRules:   {},
+	filterDimRoutingEngines: {},
+	filterDimStopReasons:    {},
+	filterDimTeams:          {},
+	filterDimCustomers:      {},
+	filterDimUsers:          {},
+	filterDimBusinessUnits:  {},
+}
+
+// shouldCacheFilterDimensions reports whether the requested dimensions are
+// expensive enough to be worth a cache entry.
+//
+// Caching is not free here: entries are partitioned per caller (see
+// filterDataCacheIdentity) because dropdown values are row-visibility-scoped,
+// so a cached response serves exactly one user. Spending that memory on a
+// single indexed matview read is a poor trade; spending it on a raw-table scan
+// is a good one.
+//
+// Without matviews (SQLite, or any non-Postgres store) every dimension is a raw
+// scan, so everything stays cacheable. This deliberately does not track
+// matViewsReady: that flag lives inside the store and flips on shape errors, and
+// the decision has to be made before the single-flight lock is taken — deciding
+// after the fetch would serialize concurrent callers behind each other. The cost
+// of getting it wrong during a self-heal window is a few uncached matview reads.
+func (h *LoggingHandler) shouldCacheFilterDimensions(dims []string) bool {
+	if !h.logStoreServesMatViews() {
+		return true
+	}
+	for _, dim := range dims {
+		if _, backed := filterDataMatViewBackedDims[dim]; !backed {
+			return true
+		}
+	}
+	return false
+}
+
+// logStoreServesMatViews reports whether the configured logs store is one that
+// builds the filter matviews at all. Conservative: an unknown/absent config
+// reports false, so the cache stays on rather than silently dropping it.
+func (h *LoggingHandler) logStoreServesMatViews() bool {
+	if h == nil || h.config == nil || h.config.LogsStoreConfig == nil {
+		return false
+	}
+	return h.config.LogsStoreConfig.Type == logstore.LogStoreTypePostgres
+}
+
 // shouldUseFilterDataCache reports whether a filterdata response is cacheable
 // at all. Text-search responses are not (unbounded key space), nor are ones
 // already carrying an explicit query scope.
@@ -1482,11 +1541,11 @@ func (h *LoggingHandler) getAvailableFilterData(ctx *fasthttp.RequestCtx) {
 	dims := parseFilterDimensions(string(ctx.QueryArgs().Peek("dimensions")), allFilterDimensions)
 	want := dimSet(dims)
 	query := strings.TrimSpace(string(ctx.QueryArgs().Peek("q")))
-	useCache := shouldUseFilterDataCache(ctx, query)
+	useCache := shouldUseFilterDataCache(ctx, query) && h.shouldCacheFilterDimensions(dims)
 
 	var entry *filterDataCacheEntry
 	if useCache {
-		cacheKey := fmt.Sprintf("hide_deleted=%v|dims=%s", hideDeletedVirtualKeys, strings.Join(dims, ","))
+		cacheKey := fmt.Sprintf("who=%s|hide_deleted=%v|dims=%s", filterDataCacheIdentity(ctx), hideDeletedVirtualKeys, strings.Join(dims, ","))
 		var cached map[string]interface{}
 		var ok bool
 		entry, cached, ok = h.filterDataCache.load(cacheKey)
@@ -2404,11 +2463,14 @@ func (h *LoggingHandler) getMCPLogsFilterData(ctx *fasthttp.RequestCtx) {
 	dims := parseFilterDimensions(string(ctx.QueryArgs().Peek("dimensions")), allMCPFilterDimensions)
 	want := dimSet(dims)
 	query := strings.TrimSpace(string(ctx.QueryArgs().Peek("q")))
+	// Not narrowed by dimension like the LLM endpoint above: no mv_filter_* view
+	// covers mcp_tool_logs, so every MCP dimension is a raw DISTINCT over the
+	// 30-day window and all of them are worth caching.
 	useCache := shouldUseFilterDataCache(ctx, query)
 
 	var entry *filterDataCacheEntry
 	if useCache {
-		cacheKey := fmt.Sprintf("hide_deleted=%v|dims=%s", hideDeletedVirtualKeys, strings.Join(dims, ","))
+		cacheKey := fmt.Sprintf("who=%s|hide_deleted=%v|dims=%s", filterDataCacheIdentity(ctx), hideDeletedVirtualKeys, strings.Join(dims, ","))
 		var cached map[string]interface{}
 		var ok bool
 		entry, cached, ok = h.mcpFilterDataCache.load(cacheKey)

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -9,11 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/queryscope"
 	"github.com/maximhq/bifrost/framework/sidekiq"
 	loggingplugin "github.com/maximhq/bifrost/plugins/logging"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
 )
@@ -45,6 +47,82 @@ func TestShouldUseFilterDataCacheRejectsScopedContext(t *testing.T) {
 	})
 	if shouldUseFilterDataCache(ctx, "") {
 		t.Fatal("expected scoped request to bypass filterdata cache")
+	}
+}
+
+// TestShouldCacheFilterDimensions_NarrowsToRawScans verifies the cache is spent
+// only where it saves real work. Matview-backed dimensions are indexed lookups
+// and a cache entry serves exactly one caller, so they are not worth caching;
+// metadata_keys still hits the raw logs table and is.
+func TestShouldCacheFilterDimensions_NarrowsToRawScans(t *testing.T) {
+	pg := &LoggingHandler{config: &lib.Config{
+		LogsStoreConfig: &logstore.Config{Type: logstore.LogStoreTypePostgres},
+	}}
+
+	cases := []struct {
+		name string
+		dims []string
+		want bool
+	}{
+		{"single matview dimension", []string{filterDimUsers}, false},
+		{"several matview dimensions", []string{filterDimUsers, filterDimTeams, filterDimModels}, false},
+		{"metadata keys alone", []string{filterDimMetadataKeys}, true},
+		{"metadata keys mixed in", []string{filterDimUsers, filterDimMetadataKeys}, true},
+		{"default all dimensions", allFilterDimensions, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pg.shouldCacheFilterDimensions(tc.dims); got != tc.want {
+				t.Fatalf("shouldCacheFilterDimensions(%v) = %v, want %v", tc.dims, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldCacheFilterDimensions_NonPostgresCachesEverything verifies stores
+// without matviews keep the original behaviour: there every dimension is a raw
+// 30-day DISTINCT, so none of them should lose the cache.
+func TestShouldCacheFilterDimensions_NonPostgresCachesEverything(t *testing.T) {
+	for _, h := range []*LoggingHandler{
+		{config: &lib.Config{LogsStoreConfig: &logstore.Config{Type: logstore.LogStoreTypeSQLite}}},
+		{config: &lib.Config{}}, // no logs-store config: fail safe, keep caching
+		{},                      // no config at all
+	} {
+		if !h.shouldCacheFilterDimensions([]string{filterDimUsers}) {
+			t.Fatal("stores without matviews must keep caching every dimension")
+		}
+	}
+}
+
+// TestFilterDataCacheIdentity_PartitionsPerCaller is the regression for
+// cross-user leakage through the filterdata cache. Filter dropdowns are
+// row-visibility-scoped, but the scope is resolved below the handler, so the
+// cache cannot detect it — two callers must therefore never share a key.
+func TestFilterDataCacheIdentity_PartitionsPerCaller(t *testing.T) {
+	withUser := func(userID string, roleID uint) *fasthttp.RequestCtx {
+		ctx := &fasthttp.RequestCtx{}
+		if userID != "" {
+			ctx.SetUserValue(schemas.BifrostContextKeyUserID, userID)
+			ctx.SetUserValue(schemas.BifrostContextKeyUserRoleID, roleID)
+		}
+		return ctx
+	}
+
+	alice := filterDataCacheIdentity(withUser("alice", 2))
+	bob := filterDataCacheIdentity(withUser("bob", 2))
+	if alice == bob {
+		t.Fatalf("distinct users must not share a cache partition, both got %q", alice)
+	}
+
+	// A role change flips visibility, so it must miss the cache immediately
+	// rather than serve the old scope for the remainder of the TTL.
+	if promoted := filterDataCacheIdentity(withUser("alice", 1)); promoted == alice {
+		t.Fatalf("role change must repartition the cache, both got %q", alice)
+	}
+
+	// Unauthenticated / local-admin requests keep the single shared partition.
+	if anon := filterDataCacheIdentity(withUser("", 0)); anon != "anon" {
+		t.Fatalf("identity-less request should use the shared partition, got %q", anon)
 	}
 }
 


### PR DESCRIPTION
## Summary

The filter-data cache was shared across all callers using a key that did not include any user identity, meaning two users with different row-visibility scopes could receive each other's cached dropdown values. Additionally, the cache had no size bounds, so a large tenant's per-caller entries would accumulate for the process's lifetime. This PR fixes the cross-user leakage, adds admission control, and avoids spending cache budget on dimensions already served by fast indexed matviews.

## Changes

- **Cache key now includes caller identity**: `filterDataCacheIdentity` is incorporated into the cache key for both the LLM and MCP filter-data endpoints. Distinct users and role changes produce distinct partitions, preventing cross-user leakage. Unauthenticated/local-admin requests share a single `"anon"` partition as before.

- **Admission control added to `filterDataCache`**: Two limits are enforced — a maximum entry count (`256`) and a maximum leaf-item budget (`50,000`). Over budget, requests are served uncached rather than evicting live entries. The item budget is tracked atomically so `store()` never needs to hold both the cache lock and an entry lock simultaneously.

- **Expired entries are pruned on the miss path**: `pruneExpiredLocked` runs on every cache miss, keeping the resident set bounded to callers active within the last TTL rather than callers seen since boot. In-flight entries are skipped via `TryLock` so a result is never evicted from under its owner.

- **Matview-backed dimensions are excluded from caching on Postgres**: Dimensions served by `mv_filter_*` materialized views are small indexed lookups. Since cache entries are per-caller, spending that memory on a matview read is a poor trade. `shouldCacheFilterDimensions` skips caching when all requested dimensions are matview-backed. `metadata_keys` has no matview and scans raw logs, so it remains cacheable. Non-Postgres stores have no matviews and continue caching everything.

- **`filterDataPayloadItems` counts leaf rows for admission weight**: Uses reflection to count dropdown rows, including nested `metadata_keys` values, so the budget reflects actual payload footprint rather than entry count alone.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

New tests cover:
- `TestShouldCacheFilterDimensions_NarrowsToRawScans` — matview-backed dims are not cached on Postgres; `metadata_keys` and mixed requests are.
- `TestShouldCacheFilterDimensions_NonPostgresCachesEverything` — SQLite and unconfigured stores keep caching all dimensions.
- `TestFilterDataCacheIdentity_PartitionsPerCaller` — distinct users and role changes produce distinct cache partitions; unauthenticated requests share `"anon"`.
- `TestFilterDataCachePrunesExpiredEntries` — expired entries and their item budget are reclaimed on the miss path; live entries are not evicted.
- `TestFilterDataCacheRefusesAdmissionOverBudget` — over-budget requests receive a nil entry and are served uncached; admission resumes after expiry.
- `TestFilterDataPayloadItems_CountsLeafRows` — leaf-row counting includes nested metadata values.

## Breaking changes

- [x] No

## Security considerations

The previous cache key did not include user identity, meaning filter dropdown responses (models, users, teams, virtual keys, etc.) could be served to a user whose visibility scope differed from the cache's original requester. This is fixed by partitioning the cache per caller identity (user ID + role ID). The fix is conservative: any request without an identity falls into the shared `"anon"` partition, which matches the existing behaviour for local-admin and unauthenticated deployments.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)