### PR TITLE
otel adds export timeouts

### DIFF
--- a/framework/tracing/obsisolation_test.go
+++ b/framework/tracing/obsisolation_test.go
@@ -1,0 +1,195 @@
+package tracing
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// blockingObsPlugin is an observability plugin whose Inject blocks until released.
+// It stands in for a connector pointed at an unreachable collector.
+type blockingObsPlugin struct {
+	name string
+	// release gates Inject; a nil channel means Inject returns immediately.
+	release chan struct{}
+	// delay, when non-zero, is slept in Inject instead of waiting on release.
+	delay time.Duration
+
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+	started     atomic.Int64
+	firstEntry  atomic.Int64 // UnixNano of the first Inject entry
+}
+
+func (p *blockingObsPlugin) GetName() string { return p.name }
+func (p *blockingObsPlugin) Cleanup() error  { return nil }
+func (p *blockingObsPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+func (p *blockingObsPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	return req, nil, nil
+}
+func (p *blockingObsPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	return resp, bifrostErr, nil
+}
+
+func (p *blockingObsPlugin) Inject(_ context.Context, _ *schemas.Trace) error {
+	p.started.Add(1)
+	p.firstEntry.CompareAndSwap(0, time.Now().UnixNano())
+
+	cur := p.inFlight.Add(1)
+	for {
+		observed := p.maxInFlight.Load()
+		if cur <= observed || p.maxInFlight.CompareAndSwap(observed, cur) {
+			break
+		}
+	}
+	defer p.inFlight.Add(-1)
+
+	if p.delay > 0 {
+		time.Sleep(p.delay)
+		return nil
+	}
+	if p.release != nil {
+		<-p.release
+	}
+	return nil
+}
+
+// TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers is the core regression: the
+// observability plugins used to be invoked sequentially on a single flush goroutine, so
+// a connector doing blocking network I/O sat in front of every plugin after it —
+// including the logging plugin, whose Inject is what enqueues the row for Postgres.
+func TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	const slowInject = 750 * time.Millisecond
+	slow := &blockingObsPlugin{name: "slow-connector", delay: slowInject}
+	fast := &blockingObsPlugin{name: "fast-connector"}
+
+	// Slow one registered first: the ordering that used to cause the stall.
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{slow, fast})
+
+	traceID := tracer.CreateTrace("")
+	start := time.Now()
+	tracer.CompleteAndFlushTrace(traceID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for fast.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if fast.started.Load() == 0 {
+		t.Fatal("fast plugin was never injected")
+	}
+
+	elapsed := time.Unix(0, fast.firstEntry.Load()).Sub(start)
+	if elapsed >= slowInject {
+		t.Fatalf("fast plugin was blocked behind the slow one: entered Inject after %v (slow plugin takes %v)", elapsed, slowInject)
+	}
+}
+
+// TestCompleteAndFlushTrace_BoundsInjectsPerPlugin verifies the concurrency cap. Without
+// it, one goroutine and one full trace snapshot accumulate per request for as long as the
+// collector hangs, and that heap/scheduler pressure is what starves the log batch writer.
+func TestCompleteAndFlushTrace_BoundsInjectsPerPlugin(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+
+	stuck := &blockingObsPlugin{name: "stuck-connector", release: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{stuck})
+
+	const overshoot = 250
+	total := maxConcurrentInjectsPerPlugin + overshoot
+	for range total {
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}
+
+	// Wait for the semaphore to saturate and the excess to be skipped.
+	deadline := time.Now().Add(10 * time.Second)
+	for tracer.ObservabilityDropCounts()["stuck-connector"] == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := stuck.maxInFlight.Load(); got > maxConcurrentInjectsPerPlugin {
+		t.Fatalf("concurrent injects exceeded the cap: got %d, cap %d", got, maxConcurrentInjectsPerPlugin)
+	}
+	if dropped := tracer.ObservabilityDropCounts()["stuck-connector"]; dropped == 0 {
+		t.Fatal("expected traces to be skipped once the plugin saturated, got 0")
+	}
+
+	close(stuck.release)
+	tracer.Stop()
+}
+
+// TestWaitForFlushes_TimesOutOnHungPlugin ensures a connector blocked on an unreachable
+// collector cannot hold up shutdown or a config reload.
+func TestWaitForFlushes_TimesOutOnHungPlugin(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+
+	hung := &blockingObsPlugin{name: "hung-connector", release: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{hung})
+	tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for hung.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if hung.started.Load() == 0 {
+		t.Fatal("hung plugin was never injected")
+	}
+
+	start := time.Now()
+	if completed := tracer.waitForFlushes(200 * time.Millisecond); completed {
+		t.Fatal("waitForFlushes reported completion while a plugin was still blocked")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("waitForFlushes did not honour its timeout: took %v", elapsed)
+	}
+
+	close(hung.release)
+	tracer.Stop()
+}
+
+// TestSetObservabilityPlugins_DedupesByName preserves the behaviour the old flush loop
+// implemented with a per-flush `seen` map.
+func TestSetObservabilityPlugins_DedupesByName(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	dup := &blockingObsPlugin{name: "dup-connector"}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{dup, dup, dup})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}()
+	wg.Wait()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for dup.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	tracer.waitForFlushes(5 * time.Second)
+
+	if got := dup.started.Load(); got != 1 {
+		t.Fatalf("expected a duplicate-named plugin to be injected once, got %d", got)
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -13,6 +13,31 @@ import (
 	"github.com/maximhq/bifrost/framework/streaming"
 )
 
+const (
+	// maxConcurrentInjectsPerPlugin bounds how many traces may sit inside a single
+	// observability connector's Inject at once. A connector pointed at a wrong or
+	// black-holed endpoint blocks on network I/O while pinning a full trace snapshot;
+	// uncapped that is one goroutine and one snapshot per request, whose heap and
+	// scheduler pressure starves the rest of the process — notably the logging
+	// plugin's single DB batch writer, whose queue then drops rows silently.
+	// Each connector gets its own budget so a stalled one cannot crowd out a healthy one.
+	maxConcurrentInjectsPerPlugin = 1024
+
+	// flushStopTimeout bounds how long Stop waits for in-flight trace exports, so a
+	// hung collector cannot block shutdown or a config reload.
+	flushStopTimeout = 10 * time.Second
+)
+
+// obsPluginSlot pairs an observability plugin with its own concurrency budget and
+// drop counter. Isolating the budget per connector is what keeps a misconfigured
+// exporter from consuming the capacity that healthy connectors need.
+type obsPluginSlot struct {
+	plugin  schemas.ObservabilityPlugin
+	name    string
+	sem     chan struct{}
+	dropped atomic.Int64
+}
+
 // Tracer implements schemas.Tracer using TraceStore.
 // It provides the bridge between the core Tracer interface and the
 // framework's TraceStore implementation.
@@ -22,7 +47,7 @@ type Tracer struct {
 	accumulator       *streaming.Accumulator
 	pricingManager    *modelcatalog.ModelCatalog
 	logger            schemas.Logger
-	obsPlugins        atomic.Pointer[[]schemas.ObservabilityPlugin]
+	obsPlugins        atomic.Pointer[[]*obsPluginSlot]
 	cachedHdrPatterns atomic.Pointer[[]string]
 	flushWG           sync.WaitGroup
 }
@@ -36,7 +61,7 @@ func NewTracer(store *TraceStore, pricingManager *modelcatalog.ModelCatalog, log
 		accumulator:    streaming.NewAccumulator(pricingManager, logger),
 		pricingManager: pricingManager,
 		logger:         logger,
-		obsPlugins:     atomic.Pointer[[]schemas.ObservabilityPlugin]{},
+		obsPlugins:     atomic.Pointer[[]*obsPluginSlot]{},
 	}
 }
 
@@ -47,7 +72,27 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 	if t == nil {
 		return
 	}
-	t.obsPlugins.Store(&obsPlugins)
+	// Build one slot per distinct plugin, each with its own concurrency budget.
+	// Deduplication by name happens here rather than on every flush, so the hot
+	// path does not rebuild a map per trace.
+	slots := make([]*obsPluginSlot, 0, len(obsPlugins))
+	seenPlugins := make(map[string]struct{}, len(obsPlugins))
+	for _, plugin := range obsPlugins {
+		if plugin == nil {
+			continue
+		}
+		name := plugin.GetName()
+		if _, exists := seenPlugins[name]; exists {
+			continue
+		}
+		seenPlugins[name] = struct{}{}
+		slots = append(slots, &obsPluginSlot{
+			plugin: plugin,
+			name:   name,
+			sem:    make(chan struct{}, maxConcurrentInjectsPerPlugin),
+		})
+	}
+	t.obsPlugins.Store(&slots)
 
 	seen := make(map[string]struct{})
 	var patterns []string
@@ -695,12 +740,34 @@ func (t *Tracer) AttachPluginLogs(traceID string, logs []schemas.PluginLogEntry)
 // Stop stops the tracer and releases its resources.
 // This stops the internal TraceStore's cleanup goroutine.
 func (t *Tracer) Stop() {
-	t.flushWG.Wait()
+	// Bounded wait: a connector blocked on an unreachable collector would otherwise
+	// hold up shutdown and config reload indefinitely (gRPC exports carry no deadline
+	// of their own).
+	t.waitForFlushes(flushStopTimeout)
 	if t.store != nil {
 		t.store.Stop()
 	}
 	if t.accumulator != nil {
 		t.accumulator.Cleanup()
+	}
+}
+
+// waitForFlushes waits for in-flight trace exports, giving up after timeout.
+// Returns true if every flush completed within the budget.
+func (t *Tracer) waitForFlushes(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		t.flushWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		if t.logger != nil {
+			t.logger.Warn("timed out after %s waiting for in-flight trace exports; continuing shutdown", timeout)
+		}
+		return false
 	}
 }
 
@@ -739,35 +806,70 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// so every trace connector sees the same value on the root span.
 		exportTrace.StampOverheadDuration()
 
-		var obsPlugins []schemas.ObservabilityPlugin
+		var slots []*obsPluginSlot
 		if loaded := t.obsPlugins.Load(); loaded != nil {
-			obsPlugins = *loaded
+			slots = *loaded
 		}
-		seen := make(map[string]struct{}, len(obsPlugins))
-		for _, plugin := range obsPlugins {
-			if plugin == nil {
+
+		// Fan out rather than iterate: every connector receives the trace on its own
+		// goroutine, so a connector doing blocking network I/O can never delay another.
+		// This used to be a sequential loop, where only the builtin plugin ordering
+		// (logging before otel) kept a stalled exporter from sitting in front of the
+		// logging plugin's DB enqueue — accidental protection that any custom or
+		// reordered connector would have removed.
+		var wg sync.WaitGroup
+		for _, slot := range slots {
+			// Non-blocking acquire. A saturated connector is skipped and counted; parking
+			// yet another goroutine on it is exactly the failure this cap exists to stop.
+			select {
+			case slot.sem <- struct{}{}:
+			default:
+				// Throttled: at saturation this fires once per request, which would make
+				// the logging itself a second source of load.
+				if n := slot.dropped.Add(1); (n == 1 || n%1000 == 0) && t.logger != nil {
+					t.logger.Warn("observability plugin %s saturated at %d concurrent injects, skipped trace %s (%d skipped so far)",
+						slot.name, maxConcurrentInjectsPerPlugin, exportTrace.TraceID, n)
+				}
 				continue
 			}
-			// Isolate each plugin callback — one bad observability backend should
-			// not crash the server or prevent other plugins from receiving the trace.
-			func(plugin schemas.ObservabilityPlugin) {
-				name := "<unknown>"
+			wg.Add(1)
+			go func(slot *obsPluginSlot) {
+				defer wg.Done()
+				defer func() { <-slot.sem }()
+				// Isolate each plugin callback — one bad observability backend should
+				// not crash the server or prevent other plugins from receiving the trace.
 				defer func() {
 					if r := recover(); r != nil && t.logger != nil {
-						t.logger.Error("observability plugin %s panicked during trace injection: %v", name, r)
+						t.logger.Error("observability plugin %s panicked during trace injection: %v", slot.name, r)
 					}
 				}()
-				name = plugin.GetName()
-				if _, exists := seen[name]; exists {
-					return
+				if err := slot.plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
+					t.logger.Warn("observability plugin %s failed to inject trace: %v", slot.name, err)
 				}
-				seen[name] = struct{}{}
-				if err := plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
-					t.logger.Warn("observability plugin %s failed to inject trace: %v", name, err)
-				}
-			}(plugin)
+			}(slot)
 		}
+		// Join before the deferred ReleaseTrace runs: connectors read exportTrace, and
+		// the pooled trace it was snapshotted from must not be recycled underneath them.
+		wg.Wait()
 	})
+}
+
+// ObservabilityDropCounts returns, per observability plugin name, how many traces were
+// skipped because that plugin was already at its concurrency cap. A non-zero and rising
+// count means the connector's backend is unreachable or too slow to keep up.
+func (t *Tracer) ObservabilityDropCounts() map[string]int64 {
+	if t == nil {
+		return nil
+	}
+	loaded := t.obsPlugins.Load()
+	if loaded == nil {
+		return nil
+	}
+	counts := make(map[string]int64, len(*loaded))
+	for _, slot := range *loaded {
+		counts[slot.name] = slot.dropped.Load()
+	}
+	return counts
 }
 
 // Ensure Tracer implements schemas.Tracer at compile time

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4829,6 +4829,13 @@
           "minimum": 1,
           "maximum": 300
         },
+        "export_timeout": {
+          "type": "integer",
+          "description": "Maximum time in seconds for a single trace export. Bounds how long a slow or unreachable collector can hold an export goroutine; gRPC exports have no other timeout.",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 60
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -615,6 +615,7 @@ bifrost:
         #     collector_url: ""       # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
         #     trace_type: "genai_extension" # genai_extension | vercel | open_inference
         #     protocol: "grpc"        # http | grpc
+        #     export_timeout: 5       # Max seconds for one trace export (1-60); the only timeout on gRPC exports
         #     metrics_enabled: false
         #     metrics_endpoint: ""    # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
         #     metrics_push_interval: 15 # Push interval in seconds (1-300)
@@ -631,6 +632,10 @@ bifrost:
         collector_url: "" # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
         trace_type: "genai_extension" # genai_extension | vercel | open_inference
         protocol: "grpc" # http | grpc
+        # Max seconds for a single trace export (1-60). This is the only timeout on gRPC
+        # exports: an endpoint that accepts the connection but never replies would
+        # otherwise block an export goroutine indefinitely.
+        export_timeout: 5
         # Push-based metrics export via OTLP (recommended for multi-node clusters)
         metrics_enabled: false
         metrics_endpoint: "" # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)

--- a/plugins/otel/exportbounds_test.go
+++ b/plugins/otel/exportbounds_test.go
@@ -1,0 +1,258 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// blackholeListener accepts TCP connections and then never speaks. This is the shape of a
+// realistic misconfiguration — a wrong port, or an ingress that terminates the connection
+// but routes nowhere — and it is strictly worse than a closed port, which fails fast.
+func blackholeListener(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	var conns atomic.Value
+	conns.Store([]net.Conn{})
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				close(done)
+				return
+			}
+			// Hold the connection open without reading or writing.
+			existing, _ := conns.Load().([]net.Conn)
+			conns.Store(append(existing, c))
+		}
+	}()
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		<-done
+		if held, ok := conns.Load().([]net.Conn); ok {
+			for _, c := range held {
+				_ = c.Close()
+			}
+		}
+	}
+}
+
+func testTarget(t *testing.T, client OtelClient, timeout time.Duration) *otelTarget {
+	t.Helper()
+	return &otelTarget{
+		serviceName:   "test-svc",
+		url:           "test://target",
+		traceType:     TraceTypeGenAIExtension,
+		client:        client,
+		exportTimeout: timeout,
+	}
+}
+
+// TestInject_GRPCExportHonoursTimeout is the regression for the outage. gRPC exports
+// carried no deadline of their own and the caller passes context.Background(), so an
+// endpoint that completed a TCP handshake but never replied blocked the flush goroutine
+// forever — leaking a goroutine and a full trace snapshot per request.
+func TestInject_GRPCExportHonoursTimeout(t *testing.T) {
+	addr, stop := blackholeListener(t)
+	defer stop()
+
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	client, err := NewOtelClientGRPC(addr, nil, "", true)
+	if err != nil {
+		t.Fatalf("NewOtelClientGRPC: %v", err)
+	}
+	defer client.Close()
+
+	const timeout = 400 * time.Millisecond
+	plugin := &OtelPlugin{targets: []*otelTarget{testTarget(t, client, timeout)}}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-grpc-timeout"}) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Inject never returned against a black-holed gRPC endpoint")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Inject took %v against a black-holed endpoint, expected it bounded near %v", elapsed, timeout)
+	}
+}
+
+// TestInject_HTTPExportHonoursTimeout covers the same bound on the HTTP path, which
+// previously relied on a hardcoded 30s client timeout.
+func TestInject_HTTPExportHonoursTimeout(t *testing.T) {
+	addr, stop := blackholeListener(t)
+	defer stop()
+
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	const timeout = 400 * time.Millisecond
+	client, err := NewOtelClientHTTP("http://"+addr, nil, "", true, timeout)
+	if err != nil {
+		t.Fatalf("NewOtelClientHTTP: %v", err)
+	}
+	defer client.Close()
+
+	plugin := &OtelPlugin{targets: []*otelTarget{testTarget(t, client, timeout)}}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-http-timeout"}) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Inject never returned against a black-holed HTTP endpoint")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Inject took %v against a black-holed endpoint, expected it bounded near %v", elapsed, timeout)
+	}
+}
+
+// failingClient always errors, standing in for a permanently misconfigured collector.
+type failingClient struct{ calls atomic.Int64 }
+
+func (c *failingClient) Emit(_ context.Context, _ []*ResourceSpan) error {
+	c.calls.Add(1)
+	return errors.New("collector unreachable")
+}
+func (c *failingClient) Close() error { return nil }
+
+// TestInject_CircuitBreakerStopsDialling verifies that a permanently bad endpoint stops
+// costing an export attempt per request. Without the breaker, every request pays the full
+// export timeout for as long as the misconfiguration lasts.
+func TestInject_CircuitBreakerStopsDialling(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	client := &failingClient{}
+	target := testTarget(t, client, time.Second)
+	plugin := &OtelPlugin{targets: []*otelTarget{target}}
+
+	// Drive well past the threshold.
+	const attempts = breakerFailureThreshold + 50
+	for i := range attempts {
+		if err := plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-breaker"}); err != nil {
+			t.Fatalf("Inject returned an error on attempt %d: %v", i, err)
+		}
+	}
+
+	if calls := client.calls.Load(); calls > breakerFailureThreshold {
+		t.Fatalf("breaker did not open: %d export attempts for %d injects (threshold %d)", calls, attempts, breakerFailureThreshold)
+	}
+	if suppressed := target.suppressedExports.Load(); suppressed == 0 {
+		t.Fatal("expected suppressed exports once the breaker opened, got 0")
+	}
+}
+
+// TestBreakerRecoversAfterCooldown verifies the breaker lets a probe through once the
+// cooldown elapses, so a collector that comes back is picked up again.
+func TestBreakerRecoversAfterCooldown(t *testing.T) {
+	target := &otelTarget{url: "test://recover"}
+
+	for range breakerFailureThreshold {
+		target.tripBreaker()
+	}
+	if !target.breakerOpen() {
+		t.Fatal("breaker should be open after reaching the failure threshold")
+	}
+
+	// Expire the cooldown.
+	target.breakerOpenUntil.Store(time.Now().Add(-time.Millisecond).UnixNano())
+	if target.breakerOpen() {
+		t.Fatal("breaker should allow a probe once the cooldown has elapsed")
+	}
+
+	target.resetBreaker()
+	if target.breakerOpen() {
+		t.Fatal("breaker should stay closed after a successful export")
+	}
+	if got := target.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("consecutiveFailures = %d after reset, want 0", got)
+	}
+}
+
+// TestBreakerAllowsSingleProbeUnderConcurrency locks in the half-open guarantee. A batch of
+// traces flushing at the instant the cooldown expires races on the same transition, and only
+// one of them may dial a collector that is probably still dead. If every racer got through,
+// each would block for a full exportTimeout, which is the cost the breaker exists to avoid.
+func TestBreakerAllowsSingleProbeUnderConcurrency(t *testing.T) {
+	target := &otelTarget{url: "test://concurrent-probe"}
+
+	for range breakerFailureThreshold {
+		target.tripBreaker()
+	}
+	// Expire the cooldown so every goroutine below sees the breaker as probe-ready.
+	target.breakerOpenUntil.Store(time.Now().Add(-time.Millisecond).UnixNano())
+
+	const callers = 64
+	var allowed atomic.Int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			if !target.breakerOpen() {
+				allowed.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := allowed.Load(); got != 1 {
+		t.Fatalf("breaker allowed %d probes through, want exactly 1", got)
+	}
+	if got := target.suppressedExports.Load(); got != callers-1 {
+		t.Fatalf("suppressedExports = %d, want %d", got, callers-1)
+	}
+}
+
+func TestResolveExportTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "unset uses default", seconds: 0, want: DefaultExportTimeout},
+		{name: "explicit value", seconds: 12, want: 12 * time.Second},
+		{name: "at max", seconds: int(MaxExportTimeout / time.Second), want: MaxExportTimeout},
+		{name: "negative rejected", seconds: -1, wantErr: true},
+		{name: "above max rejected", seconds: int(MaxExportTimeout/time.Second) + 1, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveExportTimeout(tc.seconds)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %d seconds", tc.seconds)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveExportTimeout(%d) = %v, want %v", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/otel/http.go
+++ b/plugins/otel/http.go
@@ -20,8 +20,10 @@ type OtelClientHTTP struct {
 	headers  map[string]string
 }
 
-// NewOtelClientHTTP creates a new OpenTelemetry client for HTTP
-func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool) (*OtelClientHTTP, error) {
+// NewOtelClientHTTP creates a new OpenTelemetry client for HTTP.
+// timeout bounds a single export; it comes from the profile's export_timeout and is
+// also applied as a per-export context deadline by the caller.
+func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool, timeout time.Duration) (*OtelClientHTTP, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = 100
 	transport.MaxIdleConnsPerHost = 10
@@ -34,7 +36,7 @@ func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert str
 	transport.TLSClientConfig = tlsConfig
 
 	return &OtelClientHTTP{client: &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   timeout,
 		Transport: transport,
 	}, endpoint: endpoint, headers: headers}, nil
 }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -40,6 +42,25 @@ type Protocol string
 const (
 	ProtocolHTTP Protocol = "http" // default
 	ProtocolGRPC Protocol = "grpc"
+)
+
+const (
+	// DefaultExportTimeout bounds a single trace export when export_timeout is unset.
+	// Kept short deliberately: traces are best-effort telemetry, and a slow export
+	// holds a goroutine plus a full trace snapshot for its whole duration.
+	DefaultExportTimeout = 5 * time.Second
+	// MaxExportTimeout caps what an operator may configure.
+	MaxExportTimeout = 60 * time.Second
+
+	// breakerFailureThreshold is how many consecutive export failures open the circuit.
+	breakerFailureThreshold = 5
+	// breakerCooldown is how long exports stay suppressed once the circuit is open.
+	breakerCooldown = 30 * time.Second
+
+	// exportLogThrottle limits how often repeated export failures are logged. A failing
+	// collector fails once per request; logging each one makes the logging itself a load
+	// source on top of the outage.
+	exportLogThrottle = 500
 )
 
 // PluginSpanFilter, its mode type, and the include/exclude constants are shared across
@@ -73,6 +94,12 @@ type Profile struct {
 	Protocol     Protocol           `json:"protocol"`
 	TLSCACert    string             `json:"tls_ca_cert,omitempty"`
 	Insecure     bool               `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+
+	// ExportTimeout bounds a single trace export, in seconds (default 5, max 60).
+	// This is the only deadline on the export: the caller passes context.Background(),
+	// and a gRPC export otherwise has no timeout at all, so an endpoint that completes
+	// a TCP handshake but never replies would block forever.
+	ExportTimeout int `json:"export_timeout,omitempty"`
 
 	// Metrics push configuration
 	MetricsEnabled      bool               `json:"metrics_enabled"`
@@ -218,6 +245,7 @@ type profileForStorage struct {
 	Protocol               Protocol          `json:"protocol"`
 	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
 	Insecure               bool              `json:"insecure"`
+	ExportTimeout          int               `json:"export_timeout,omitempty"`
 	MetricsEnabled         bool              `json:"metrics_enabled"`
 	MetricsEndpoint        string            `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval    int               `json:"metrics_push_interval,omitempty"`
@@ -255,6 +283,7 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			Protocol:               p.Protocol,
 			TLSCACert:              p.TLSCACert,
 			Insecure:               p.Insecure,
+			ExportTimeout:          p.ExportTimeout,
 			MetricsEnabled:         p.MetricsEnabled,
 			MetricsEndpoint:        schemas.SecretVarAsString(p.MetricsEndpoint),
 			MetricsPushInterval:    p.MetricsPushInterval,
@@ -334,6 +363,54 @@ type otelTarget struct {
 	disableContentLogging  bool
 	groupTracesBySession   bool
 	disableRootSpanContent bool
+
+	// exportTimeout bounds a single Emit. See Profile.ExportTimeout.
+	exportTimeout time.Duration
+
+	// Circuit breaker. A misconfigured endpoint fails identically for every trace, so
+	// after breakerFailureThreshold consecutive failures the target stops dialling until
+	// breakerCooldown has elapsed. Without this, a permanently wrong endpoint costs a
+	// full exportTimeout on every single request forever.
+	consecutiveFailures atomic.Int64
+	breakerOpenUntil    atomic.Int64 // UnixNano; exports are skipped until this instant
+	suppressedExports   atomic.Int64
+	failedExports       atomic.Int64
+}
+
+// tripBreaker records a failed export and opens the circuit once the failure threshold
+// is reached.
+func (t *otelTarget) tripBreaker() {
+	t.failedExports.Add(1)
+	if t.consecutiveFailures.Add(1) >= breakerFailureThreshold {
+		t.breakerOpenUntil.Store(time.Now().Add(breakerCooldown).UnixNano())
+	}
+}
+
+// resetBreaker records a successful export, closing the circuit.
+func (t *otelTarget) resetBreaker() {
+	t.consecutiveFailures.Store(0)
+	t.breakerOpenUntil.Store(0)
+}
+
+// breakerOpen reports whether exports to this target are currently suppressed.
+// Exactly one probe is allowed through once the cooldown expires: the goroutine that
+// wins the CAS pushes the window forward by another cooldown and dials for real, so
+// concurrent callers and anyone arriving while that probe is in flight stay suppressed.
+// The probe then resets the breaker on success or re-arms it on failure; if it somehow
+// does neither, the pushed-forward window expires on its own and the next caller probes.
+func (t *otelTarget) breakerOpen() bool {
+	openUntil := t.breakerOpenUntil.Load()
+	if openUntil == 0 {
+		return false
+	}
+	if time.Now().UnixNano() >= openUntil {
+		next := time.Now().Add(breakerCooldown).UnixNano()
+		if t.breakerOpenUntil.CompareAndSwap(openUntil, next) {
+			return false
+		}
+	}
+	t.suppressedExports.Add(1)
+	return true
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -449,6 +526,11 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		return nil, fmt.Errorf("profile %d: %w", index, err)
 	}
 
+	exportTimeout, err := resolveExportTimeout(profile.ExportTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("profile %d: %w", index, err)
+	}
+
 	url := profile.CollectorURL.GetValue()
 	target := &otelTarget{
 		serviceName:            serviceName,
@@ -458,14 +540,16 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		disableContentLogging:  profile.DisableContentLogging,
 		groupTracesBySession:   profile.GroupTracesBySession,
 		disableRootSpanContent: profile.DisableRootSpanContent,
+		exportTimeout:          exportTimeout,
 	}
 
-	var err error
 	switch profile.Protocol {
 	case ProtocolGRPC:
+		// gRPC has no client-side timeout of its own; the per-export context deadline
+		// applied in Inject is what bounds it.
 		target.client, err = NewOtelClientGRPC(url, headers, profile.TLSCACert, profile.Insecure)
 	case ProtocolHTTP:
-		target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure)
+		target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure, exportTimeout)
 	default:
 		return nil, fmt.Errorf("profile %d: invalid protocol type %q", index, profile.Protocol)
 	}
@@ -507,6 +591,18 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	}
 
 	return target, nil
+}
+
+// resolveExportTimeout validates a configured export_timeout (in seconds) and returns
+// the duration to use, falling back to DefaultExportTimeout when unset.
+func resolveExportTimeout(seconds int) (time.Duration, error) {
+	if seconds == 0 {
+		return DefaultExportTimeout, nil
+	}
+	if seconds < 0 || time.Duration(seconds)*time.Second > MaxExportTimeout {
+		return 0, fmt.Errorf("export_timeout must be between 1 and %d seconds, got %d", int(MaxExportTimeout/time.Second), seconds)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 // GetName function for the OTEL plugin
@@ -668,20 +764,46 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		wg.Add(1)
 		go func(t *otelTarget) {
 			defer wg.Done()
-			if t.client != nil {
-				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent)
-				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
-				}
-			}
+			// Metrics first: they are SDK-buffered and never touch the network here, so
+			// they still get recorded even when the trace endpoint is broken.
 			if t.metricsExporter != nil {
 				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
 				p.recordMCPMetricsFromTrace(ctx, t.metricsExporter, trace)
 			}
+			if t.client == nil || t.breakerOpen() {
+				return
+			}
+			resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent)
+			// The caller passes context.Background(), so this deadline is the only bound
+			// on the export — and the only bound at all on the gRPC path.
+			emitCtx, cancel := context.WithTimeout(ctx, t.exportTimeout)
+			defer cancel()
+			if err := t.client.Emit(emitCtx, []*ResourceSpan{resourceSpan}); err != nil {
+				t.tripBreaker()
+				if n := t.failedExports.Load(); n == 1 || n%exportLogThrottle == 0 {
+					logger.Error("failed to emit trace %s to %s: %v (%d failed exports so far)", trace.TraceID, t.url, err, n)
+				}
+				return
+			}
+			t.resetBreaker()
 		}(t)
 	}
 	wg.Wait()
 	return nil
+}
+
+// ExportStats reports per-target export health: how many exports failed and how many
+// were suppressed by an open circuit breaker. A rising suppressed count means the
+// target's endpoint is being treated as dead — usually a misconfigured collector URL.
+func (p *OtelPlugin) ExportStats() map[string]struct{ Failed, Suppressed int64 } {
+	stats := make(map[string]struct{ Failed, Suppressed int64 }, len(p.targets))
+	for _, t := range p.targets {
+		stats[t.url] = struct{ Failed, Suppressed int64 }{
+			Failed:     t.failedExports.Load(),
+			Suppressed: t.suppressedExports.Load(),
+		}
+	}
+	return stats
 }
 
 // RequestHeaderPatterns returns the deduplicated union of request-header name patterns

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3115,6 +3115,13 @@
           "description": "Protocol to use for the OTEL collector",
           "enum": ["http", "grpc"]
         },
+        "export_timeout": {
+          "type": "integer",
+          "description": "Maximum time in seconds for a single trace export. Bounds how long a slow or unreachable collector can hold an export goroutine; gRPC exports have no other timeout.",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 60
+        },
         "metrics_enabled": {
           "type": "boolean",
           "description": "Enable push-based metrics export via OTLP. Recommended for multi-node cluster deployments.",

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -34,6 +34,7 @@ interface StoredOtelProfile {
 	metrics_enabled?: boolean;
 	metrics_endpoint?: string | SecretVar;
 	metrics_push_interval?: number;
+	export_timeout?: number;
 	request_headers?: string[];
 	disable_content_logging?: boolean;
 	group_traces_by_session?: boolean;
@@ -98,6 +99,7 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_enabled: false,
 	metrics_endpoint: emptySecretVar(),
 	metrics_push_interval: 15,
+	export_timeout: 5,
 	request_headers: [],
 	disable_content_logging: false,
 	group_traces_by_session: false,
@@ -117,6 +119,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_enabled: p?.metrics_enabled ?? false,
 	metrics_endpoint: toSecretVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
+	export_timeout: p?.export_timeout ?? 5,
 	request_headers: p?.request_headers ?? [],
 	disable_content_logging: p?.disable_content_logging ?? false,
 	group_traces_by_session: p?.group_traces_by_session ?? false,
@@ -586,6 +589,32 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 							)}
 						/>
 					</div>
+
+					<FormField
+						control={control}
+						name={`${base}.export_timeout`}
+						render={({ field }) => (
+							<FormItem className="w-full max-w-xs">
+								<FormLabel>Export Timeout (seconds)</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										min={1}
+										max={60}
+										disabled={!hasOtelAccess}
+										{...field}
+										value={field.value ?? ""}
+										onChange={(e) => field.onChange(e.target.value === "" ? null : Number(e.target.value))}
+									/>
+								</FormControl>
+								<FormDescription>
+									Maximum time for a single trace export (1-60 seconds). Traces are dropped rather than retried past this
+									limit, so an unreachable collector cannot slow down request handling.
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
 
 					{/* TLS Configuration */}
 					<div className="flex flex-col gap-4">

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -874,6 +874,10 @@ export const otelConfigSchema = z
 		// TLS configuration
 		tls_ca_cert: z.string().optional(),
 		insecure: z.boolean().default(true),
+		// Bounds a single trace export. gRPC exports have no other timeout, so an
+		// endpoint that accepts the connection but never replies would otherwise block
+		// an export goroutine indefinitely.
+		export_timeout: z.number().int().min(1).max(60).default(5),
 		// Metrics push configuration
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: secretVarSchema.optional(),


### PR DESCRIPTION
## Summary

A misconfigured or unreachable OTEL collector (one that completes a TCP handshake but never replies) previously blocked export goroutines indefinitely — one goroutine and one full trace snapshot per request. On the gRPC path there was no client-side deadline at all, so the leak was permanent. This PR adds layered defences: a per-export timeout, a per-plugin concurrency cap in the tracer, and a per-target circuit breaker in the OTEL plugin.

## Changes

- **Per-export deadline (`export_timeout`)**: A new `export_timeout` field (default 5 s, max 60 s) is added to the OTEL profile. A `context.WithTimeout` wrapping every `Emit` call is now the only deadline on the gRPC path. The HTTP client timeout is wired to the same value instead of the previous hardcoded 30 s.

- **Per-plugin concurrency cap in the tracer**: `obsPluginSlot` wraps each observability plugin with a buffered semaphore (`maxConcurrentInjectsPerPlugin = 1024`). A non-blocking acquire is attempted before spawning a flush goroutine; if the plugin is already saturated the trace is skipped and counted. Plugins are now fanned out in parallel rather than called sequentially, so a stalled connector can no longer delay plugins registered after it.

- **Circuit breaker in the OTEL plugin**: After `breakerFailureThreshold` (5) consecutive export failures, a target suppresses further export attempts for `breakerCooldown` (30 s). A single probe is allowed through once the cooldown expires. Export failures and suppressed exports are tracked per target and exposed via `ExportStats()`.

- **Bounded shutdown wait**: `Tracer.Stop()` previously called `flushWG.Wait()` with no timeout. It now calls `waitForFlushes(10 s)`, which logs a warning and continues if in-flight exports have not drained in time.

- **Deduplication moved to `SetObservabilityPlugins`**: The per-flush `seen` map is replaced by deduplication at slot-build time, removing a map allocation from the hot path.

- **`ObservabilityDropCounts()`**: New method on `Tracer` exposes per-plugin skip counts for observability and testing.

- **Schema and UI**: `export_timeout` is added to `config.schema.json`, `values.schema.json`, `values.yaml`, the Zod schema, and the OTEL profile form with a numeric input (1–60 s) and description.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins
- [x] UI (React)

## How to test

```sh
# Core/Transports
go test ./framework/tracing/... -v -run TestCompleteAndFlushTrace
go test ./framework/tracing/... -v -run TestWaitForFlushes
go test ./framework/tracing/... -v -run TestSetObservabilityPlugins
go test ./plugins/otel/... -v -run TestInject_GRPCExportHonoursTimeout
go test ./plugins/otel/... -v -run TestInject_HTTPExportHonoursTimeout
go test ./plugins/otel/... -v -run TestInject_CircuitBreakerStopsDialling
go test ./plugins/otel/... -v -run TestBreakerRecoversAfterCooldown
go test ./plugins/otel/... -v -run TestResolveExportTimeout

# UI
cd ui
pnpm i
pnpm build
```

**New config field:**

| Field | Location | Default | Range | Description |
|---|---|---|---|---|
| `export_timeout` | OTEL profile | `5` | 1–60 s | Maximum duration for a single trace export. The only deadline on gRPC exports. |

To validate end-to-end: point an OTEL profile at a black-hole TCP listener (e.g. `nc -l 4317` without reading), send requests, and confirm that request latency is unaffected and that `ObservabilityDropCounts` / `ExportStats` report skipped/failed exports rather than the process stalling.

## Breaking changes

- [x] No

`NewOtelClientHTTP` gains a `timeout time.Duration` parameter. Any code calling it directly outside this repository will need to pass the timeout explicitly.

## Related issues

Closes the goroutine-leak / log-row-drop regression caused by a misconfigured OTEL collector blocking the logging plugin's DB batch writer.

## Security considerations

No auth, secrets, or PII changes. The circuit breaker and concurrency cap reduce the blast radius of a misconfigured or malicious collector endpoint by bounding how many goroutines and how much heap it can consume.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable