### PR TITLE
control db connections for all cases

### DIFF
--- a/framework/configstore/postgres.go
+++ b/framework/configstore/postgres.go
@@ -41,6 +41,13 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 		logger.Error("configstore: failed to open migration connection pool: %v", err)
 		return nil, err
 	}
+	// Pin the throwaway pool small: migrations are serial DDL, and an untuned pool
+	// inherits database/sql's unlimited MaxOpenConns.
+	if err := postgresconn.ApplyMigrationPoolTuning(mDb); err != nil {
+		logger.Error("configstore: failed to tune migration connection pool: %v", err)
+		postgresconn.Close(mDb, logger)
+		return nil, err
+	}
 	logger.Info("configstore: migration pool opened; running schema migrations (may block on a cross-node advisory lock if another pod is migrating)")
 	if err := triggerMigrations(ctx, mDb, logger); err != nil {
 		logger.Error("configstore: schema migrations failed: %v", err)
@@ -57,7 +64,7 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 		logger.Error("configstore: failed to open runtime connection pool: %v", err)
 		return nil, err
 	}
-	if err := postgresconn.ApplyPoolTuning(db, config); err != nil {
+	if err := postgresconn.ApplyPoolTuning(db, config, logger); err != nil {
 		logger.Error("configstore: failed to apply connection pool tuning: %v", err)
 		postgresconn.Close(db, logger)
 		return nil, err
@@ -79,6 +86,11 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 			return err
 		}
 		defer postgresconn.Close(tempDB, logger)
+		// fn is supplied by downstream consumers, so bound the pool rather than
+		// leaving it on database/sql's unlimited default.
+		if err := postgresconn.ApplyMigrationPoolTuning(tempDB); err != nil {
+			return err
+		}
 		return fn(ctx, tempDB)
 	}
 
@@ -91,7 +103,7 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 		if err != nil {
 			return fmt.Errorf("failed to open fresh runtime pool: %w", err)
 		}
-		if err := postgresconn.ApplyPoolTuning(newDB, config); err != nil {
+		if err := postgresconn.ApplyPoolTuning(newDB, config, logger); err != nil {
 			postgresconn.Close(newDB, logger)
 			return fmt.Errorf("failed to tune fresh runtime pool: %w", err)
 		}

--- a/framework/logstore/clickhousechunk_test.go
+++ b/framework/logstore/clickhousechunk_test.go
@@ -1,0 +1,160 @@
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForEachRMWChunk(t *testing.T) {
+	t.Run("splits on the chunk boundary", func(t *testing.T) {
+		entries := make([]int, chRMWBatchChunk*2+7)
+		for i := range entries {
+			entries[i] = i
+		}
+
+		var sizes []int
+		var seen []int
+		require.NoError(t, forEachRMWChunk(entries, func(chunk []int) error {
+			sizes = append(sizes, len(chunk))
+			seen = append(seen, chunk...)
+			return nil
+		}))
+
+		assert.Equal(t, []int{chRMWBatchChunk, chRMWBatchChunk, 7}, sizes)
+		assert.Equal(t, entries, seen, "every entry must be visited exactly once, in order")
+	})
+
+	t.Run("single short chunk", func(t *testing.T) {
+		calls := 0
+		require.NoError(t, forEachRMWChunk([]int{1, 2, 3}, func(chunk []int) error {
+			calls++
+			assert.Len(t, chunk, 3)
+			return nil
+		}))
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("empty input never calls fn", func(t *testing.T) {
+		called := false
+		require.NoError(t, forEachRMWChunk([]int{}, func([]int) error {
+			called = true
+			return nil
+		}))
+		assert.False(t, called)
+	})
+
+	t.Run("stops at the first error", func(t *testing.T) {
+		entries := make([]int, chRMWBatchChunk*3)
+		calls := 0
+		err := forEachRMWChunk(entries, func([]int) error {
+			calls++
+			if calls == 2 {
+				return fmt.Errorf("boom")
+			}
+			return nil
+		})
+		require.Error(t, err)
+		assert.Equal(t, 2, calls, "later chunks must not run after a failure")
+	})
+}
+
+// chCountIDsNoFinal counts the physical rows carrying any of ids, with FINAL
+// disabled.
+//
+// Every store connection sets final=1 (see clickhouse.go), which collapses rows
+// sharing the (timestamp, id) sorting key at read time. A duplicate INSERT of an
+// id at its original timestamp is therefore invisible to an ordinary count or to
+// FindByID: both report one row whether or not the existence check suppressed the
+// second write, which would make a cardinality assertion vacuous. Overriding the
+// setting per query exposes the physical rows, so these tests fail on a duplicate
+// write instead of letting ReplacingMergeTree hide it.
+func chCountIDsNoFinal(t *testing.T, store *ClickHouseLogStore, table string, ids []string) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, store.db.Raw("SELECT count() FROM "+table+" WHERE id IN ? SETTINGS final = 0", ids).Scan(&n).Error)
+	return n
+}
+
+// TestClickHouseBatchCreateSpansChunks guards the chunked lock path: a batch larger
+// than chRMWBatchChunk is now written as several lock/filter/insert passes, so every
+// row must still land exactly once and dedup must still hold across chunk boundaries.
+func TestClickHouseBatchCreateSpansChunks(t *testing.T) {
+	store := trySetupClickHouseStore(t)
+	ctx := context.Background()
+
+	const total = chRMWBatchChunk*2 + 13
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	entries := make([]*Log, 0, total)
+	ids := make([]string, 0, total)
+	for i := range total {
+		id := fmt.Sprintf("ch-chunk-%04d", i)
+		entries = append(entries, chTestLog(id, ts))
+		ids = append(ids, id)
+	}
+
+	require.NoError(t, store.BatchCreateIfNotExists(ctx, entries))
+
+	assert.EqualValues(t, total, chCountIDsNoFinal(t, store, "logs", ids),
+		"every row must land exactly once across the chunk seams")
+	for _, i := range []int{0, chRMWBatchChunk - 1, chRMWBatchChunk, total - 1} {
+		id := fmt.Sprintf("ch-chunk-%04d", i)
+		got, err := store.FindByID(ctx, id)
+		require.NoErrorf(t, err, "log %s should have been inserted", id)
+		require.NotNil(t, got)
+	}
+
+	// Re-inserting the same batch must be a no-op, including across chunk seams.
+	require.NoError(t, store.BatchCreateIfNotExists(ctx, entries))
+	assert.EqualValues(t, total, chCountIDsNoFinal(t, store, "logs", ids),
+		"reinserting the same batch must not add physical rows")
+	for _, i := range []int{0, chRMWBatchChunk, total - 1} {
+		id := fmt.Sprintf("ch-chunk-%04d", i)
+		_, err := store.FindByID(ctx, id)
+		require.NoErrorf(t, err, "log %s should still resolve to a single row", id)
+	}
+}
+
+// TestClickHouseBatchCreateDedupsIDsAcrossChunks pins the batch-wide seen-id set.
+// chFilterMissing bounds its existence probe to the chunk's [min, max] timestamp
+// window, so a repeat id landing in a later chunk with a different timestamp would
+// miss the row the first chunk inserted and write a second row - (timestamp, id) is
+// the sorting key, so ReplacingMergeTree would not collapse them either. The SQL
+// stores dedup on id alone via ON CONFLICT DO NOTHING; this must match.
+func TestClickHouseBatchCreateDedupsIDsAcrossChunks(t *testing.T) {
+	store := trySetupClickHouseStore(t)
+	ctx := context.Background()
+
+	const dupID = "ch-chunk-dup"
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	entries := make([]*Log, 0, chRMWBatchChunk+2)
+	// First chunk carries the id at ts; the second carries it an hour later, well
+	// outside the first chunk's window.
+	entries = append(entries, chTestLog(dupID, ts))
+	for i := 1; i < chRMWBatchChunk; i++ {
+		entries = append(entries, chTestLog(fmt.Sprintf("ch-dup-filler-%04d", i), ts))
+	}
+	entries = append(entries, chTestLog(dupID, ts.Add(time.Hour)))
+	entries = append(entries, chTestLog("ch-dup-tail", ts.Add(time.Hour)))
+	require.Len(t, entries, chRMWBatchChunk+2)
+
+	require.NoError(t, store.BatchCreateIfNotExists(ctx, entries))
+
+	assert.EqualValues(t, 1, chCountIDsNoFinal(t, store, "logs", []string{dupID}),
+		"the repeat id must be written once, not once per chunk")
+
+	// The first occurrence wins, matching ON CONFLICT DO NOTHING.
+	got, err := store.FindByID(ctx, dupID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.Timestamp.Equal(ts), "first occurrence must win, got %s want %s", got.Timestamp, ts)
+
+	// Entries after the duplicate in the same chunk must still be written.
+	tail, err := store.FindByID(ctx, "ch-dup-tail")
+	require.NoError(t, err)
+	require.NotNil(t, tail)
+}

--- a/framework/logstore/clickhousestore.go
+++ b/framework/logstore/clickhousestore.go
@@ -45,6 +45,27 @@ type ClickHouseLogStore struct {
 // chRMWShards is the number of RMW lock shards; keys are hashed onto them.
 const chRMWShards = 128
 
+// chRMWBatchChunk bounds how many rows a single batch insert locks at once.
+// A batch is written under lockRMWBatch across two network round trips (the
+// existence filter, then the insert). With the default MaxBatchSize of 1000
+// against 128 shards, one unchunked batch locks effectively every shard, so it
+// behaves as a global lock and stalls every concurrent Update — the object-storage
+// upload workers and deferred-usage updaters in particular. Chunking keeps the
+// held-shard set small enough that those callers interleave.
+const chRMWBatchChunk = 128
+
+// forEachRMWChunk applies fn to successive slices of at most chRMWBatchChunk
+// entries, stopping at the first error.
+func forEachRMWChunk[T any](entries []T, fn func([]T) error) error {
+	for start := 0; start < len(entries); start += chRMWBatchChunk {
+		end := min(start+chRMWBatchChunk, len(entries))
+		if err := fn(entries[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func chRMWShard(table, id string) int {
 	h := fnv.New32a()
 	h.Write([]byte(table))
@@ -173,6 +194,11 @@ func (s *ClickHouseLogStore) chReinsert(ctx context.Context, v interface{}) erro
 // because retried creates reuse the original entry (same timestamp), and the
 // tables' dedup key is (timestamp, id) anyway - a same-id row at a different
 // timestamp would be a distinct logical row regardless of this check.
+//
+// The window is per-call, so it cannot see a row an earlier chunk of the same
+// logical batch inserted at a different timestamp. Chunked callers therefore
+// carry their own batch-wide seen-id set and never hand the same id to two
+// calls; this function's duplicate skipping only covers one call's entries.
 func chFilterMissing[T any](ctx context.Context, db *gorm.DB, table string, entries []*T, idOf func(*T) string, tsOf func(*T) time.Time) ([]*T, error) {
 	ids := make([]string, 0, len(entries))
 	var minTS, maxTS time.Time
@@ -252,22 +278,40 @@ func (s *ClickHouseLogStore) BatchCreateIfNotExists(ctx context.Context, entries
 	if len(entries) == 0 {
 		return nil
 	}
-	ids := make([]string, 0, len(entries))
-	for _, e := range entries {
-		if e != nil {
+	// Batch-wide, not chunk-local: chFilterMissing bounds its existence probe to
+	// the chunk's timestamp window, so a repeat id carrying a different timestamp
+	// in a later chunk would miss the row an earlier chunk inserted. Dedup on id
+	// alone across the whole batch to match the SQL stores' ON CONFLICT (id) DO
+	// NOTHING and keep the result independent of where chunk boundaries fall.
+	seen := make(map[string]struct{}, len(entries))
+	return forEachRMWChunk(entries, func(chunk []*Log) error {
+		fresh := make([]*Log, 0, len(chunk))
+		ids := make([]string, 0, len(chunk))
+		for _, e := range chunk {
+			if e == nil {
+				continue
+			}
+			if _, ok := seen[e.ID]; ok {
+				continue
+			}
+			seen[e.ID] = struct{}{}
+			fresh = append(fresh, e)
 			ids = append(ids, e.ID)
 		}
-	}
-	defer s.lockRMWBatch("logs", ids)()
-	missing, err := chFilterMissing(ctx, s.db, "logs", entries, func(l *Log) string { return l.ID }, func(l *Log) time.Time { return l.Timestamp })
-	if err != nil {
-		return err
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-	// Omit inc_number so ClickHouse's DEFAULT generateSnowflakeID() fires.
-	return s.db.WithContext(ctx).Omit("inc_number").Create(&missing).Error
+		if len(fresh) == 0 {
+			return nil
+		}
+		defer s.lockRMWBatch("logs", ids)()
+		missing, err := chFilterMissing(ctx, s.db, "logs", fresh, func(l *Log) string { return l.ID }, func(l *Log) time.Time { return l.Timestamp })
+		if err != nil {
+			return err
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		// Omit inc_number so ClickHouse's DEFAULT generateSnowflakeID() fires.
+		return s.db.WithContext(ctx).Omit("inc_number").Create(&missing).Error
+	})
 }
 
 // BatchCreateMCPToolLogsIfNotExists inserts the MCP tool log entries whose
@@ -276,22 +320,36 @@ func (s *ClickHouseLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Conte
 	if len(entries) == 0 {
 		return nil
 	}
-	ids := make([]string, 0, len(entries))
-	for _, e := range entries {
-		if e != nil {
+	// Batch-wide dedup for the same reason as BatchCreateIfNotExists above.
+	seen := make(map[string]struct{}, len(entries))
+	return forEachRMWChunk(entries, func(chunk []*MCPToolLog) error {
+		fresh := make([]*MCPToolLog, 0, len(chunk))
+		ids := make([]string, 0, len(chunk))
+		for _, e := range chunk {
+			if e == nil {
+				continue
+			}
+			if _, ok := seen[e.ID]; ok {
+				continue
+			}
+			seen[e.ID] = struct{}{}
+			fresh = append(fresh, e)
 			ids = append(ids, e.ID)
 		}
-	}
-	defer s.lockRMWBatch("mcp_tool_logs", ids)()
-	missing, err := chFilterMissing(ctx, s.db, "mcp_tool_logs", entries, func(l *MCPToolLog) string { return l.ID }, func(l *MCPToolLog) time.Time { return l.Timestamp })
-	if err != nil {
-		return err
-	}
-	if len(missing) == 0 {
-		return nil
-	}
-	// Omit inc_number so ClickHouse's DEFAULT generateSnowflakeID() fires.
-	return s.db.WithContext(ctx).Omit("inc_number").Create(&missing).Error
+		if len(fresh) == 0 {
+			return nil
+		}
+		defer s.lockRMWBatch("mcp_tool_logs", ids)()
+		missing, err := chFilterMissing(ctx, s.db, "mcp_tool_logs", fresh, func(l *MCPToolLog) string { return l.ID }, func(l *MCPToolLog) time.Time { return l.Timestamp })
+		if err != nil {
+			return err
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		// Omit inc_number so ClickHouse's DEFAULT generateSnowflakeID() fires.
+		return s.db.WithContext(ctx).Omit("inc_number").Create(&missing).Error
+	})
 }
 
 // --- Updates (read-modify-write + re-insert) ---

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -3,6 +3,7 @@ package logstore
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"sort"
 	"strings"
@@ -640,6 +641,27 @@ func allMatViewNames() []string {
 	return names
 }
 
+// filterRotation advances each refresh pass so a run that is consistently cut
+// short by its deadline does not always starve the same tail views. mv_logs_hourly
+// stays pinned first (dashboards depend on it); only the filter views rotate.
+var filterRotation atomic.Uint64
+
+// matViewRefreshOrder returns the views to refresh for one pass. mv_logs_hourly is
+// always first; the filter views start at a rotating offset so that if only the
+// first N views fit inside the timeout, a different subset makes progress each tick
+// instead of the last ones never refreshing again.
+func matViewRefreshOrder() []string {
+	names := []string{"mv_logs_hourly"}
+	if len(filterMatViews) == 0 {
+		return names
+	}
+	offset := int(filterRotation.Add(1)-1) % len(filterMatViews)
+	for i := range filterMatViews {
+		names = append(names, filterMatViews[(offset+i)%len(filterMatViews)].name)
+	}
+	return names
+}
+
 // matViewRefreshSafetyInterval forces a periodic refresh even when
 // pg_stat_user_tables shows no DML on `logs`. This guards against two
 // edge cases:
@@ -651,6 +673,10 @@ func allMatViewNames() []string {
 // acceptable window, long enough that idle clusters do ~6 refreshes/hour
 // instead of 120.
 const matViewRefreshSafetyInterval = 10 * time.Minute
+
+// matViewUnlockTimeout bounds the advisory-unlock statement that runs after a
+// refresh pass, including one cut short by its own deadline.
+const matViewUnlockTimeout = 5 * time.Second
 
 // matViewRefreshGate tracks the last-seen activity counter on `logs` from
 // pg_stat_user_tables so refreshMatViews can short-circuit when nothing has
@@ -740,7 +766,18 @@ func refreshMatViews(ctx context.Context, db *gorm.DB) error {
 	if err != nil {
 		return fmt.Errorf("failed to get dedicated connection for matview refresh: %w", err)
 	}
-	defer conn.Close()
+	// discardConn forces database/sql to drop the underlying physical connection
+	// rather than return it to the pool. Needed when the advisory unlock could not
+	// be confirmed: the lock is session-scoped, and sql.Conn.Close() only returns
+	// the connection to the pool — it does not end the Postgres session, so a
+	// leaked lock would otherwise block every future refresh on every replica.
+	discardConn := false
+	defer func() {
+		if discardConn {
+			_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+		}
+		conn.Close()
+	}()
 
 	// Activity check happens before the advisory lock so write-quiet replicas
 	// don't even contend for it. Capture the counter BEFORE refreshing — any
@@ -751,21 +788,51 @@ func refreshMatViews(ctx context.Context, db *gorm.DB) error {
 		return nil
 	}
 
+	// Bail out before touching the lock if the budget is already spent — no
+	// statement reaches the server, so there is nothing to clean up.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("matview refresh budget exhausted before acquiring advisory lock: %w", err)
+	}
+
 	// Try to acquire advisory lock; skip refresh if another replica holds it.
+	//
+	// Run this on a context that outlives ctx. If ctx were cancelled mid-flight the
+	// server could still have taken the lock while the client gave up reading the
+	// reply — leaving the lock held on a session that then returns to the pool, with
+	// no unlock registered. Bounding it separately keeps acquisition atomic from the
+	// caller's point of view.
+	lockCtx, cancelLock := context.WithTimeout(context.WithoutCancel(ctx), matViewUnlockTimeout)
 	var acquired bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
-		return fmt.Errorf("failed to try advisory lock for matview refresh: %w", err)
+	lockErr := conn.QueryRowContext(lockCtx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired)
+	cancelLock()
+	if lockErr != nil {
+		// The statement may or may not have reached the server. Drop the session so
+		// Postgres releases anything it did acquire.
+		discardConn = true
+		return fmt.Errorf("failed to try advisory lock for matview refresh: %w", lockErr)
 	}
 	if !acquired {
 		return nil // another replica is refreshing
 	}
 	defer func() {
-		// Release lock explicitly; connection close would also release session-scoped locks.
-		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+		// Release the lock on a context that outlives ctx. When a refresh is cut
+		// short by its deadline, ctx is already expired by the time this runs, so
+		// reusing it would fail the unlock every single time.
+		unlockCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), matViewUnlockTimeout)
+		defer cancel()
+		if _, err := conn.ExecContext(unlockCtx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey); err != nil {
+			// Could not confirm the release. Drop the session so Postgres reclaims
+			// the lock rather than leaving it held on a pooled connection.
+			discardConn = true
+		}
 	}()
 
-	for _, view := range allMatViewNames() {
+	for _, view := range matViewRefreshOrder() {
 		if _, err := conn.ExecContext(ctx, "REFRESH MATERIALIZED VIEW CONCURRENTLY "+view); err != nil {
+			// A cancelled REFRESH leaves the existing view intact (CONCURRENTLY builds
+			// into a temp table and diffs at commit), so readers keep working against
+			// slightly staler data. markRefreshed is intentionally skipped so the next
+			// tick sees a changed activity counter and retries.
 			return fmt.Errorf("failed to refresh %s: %w", view, err)
 		}
 	}
@@ -777,7 +844,7 @@ func refreshMatViews(ctx context.Context, db *gorm.DB) error {
 // refreshes materialized views. If readyFlag is provided and not yet true,
 // it will be set to true on the first successful refresh (recovery path when
 // the initial refresh failed). Returns a stop function for graceful shutdown.
-func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Duration, logger schemas.Logger, readyFlag *atomic.Bool) func() {
+func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval, timeout time.Duration, logger schemas.Logger, readyFlag *atomic.Bool) func() {
 	stopCh := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(interval)
@@ -785,11 +852,29 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Durat
 		for {
 			select {
 			case <-ticker.C:
-				if err := refreshMatViews(ctx, db); err != nil {
-					logger.Warn(fmt.Sprintf("logstore: matview refresh failed: %s", err))
-				} else if readyFlag != nil && !readyFlag.Load() {
+				// Bound each tick. refreshMatViews holds a pooled connection and a
+				// session advisory lock across REFRESH MATERIALIZED VIEW CONCURRENTLY
+				// for every view; without a deadline one pathological refresh keeps the
+				// lock forever, and every other replica's pg_try_advisory_lock then
+				// fails silently, leaving matviews permanently stale.
+				started := time.Now()
+				tickCtx, cancel := context.WithTimeout(ctx, timeout)
+				err := refreshMatViews(tickCtx, db)
+				cancel()
+				elapsed := time.Since(started)
+
+				switch {
+				case err != nil:
+					logger.Warn(fmt.Sprintf("logstore: matview refresh failed after %s: %s", elapsed.Round(time.Millisecond), err))
+				case readyFlag != nil && !readyFlag.Load():
 					logger.Info("logstore: materialized views are ready (recovered)")
 					readyFlag.Store(true)
+				}
+				// A refresh slower than the interval means the refresher itself is the
+				// bottleneck — surface it rather than letting ticks silently coalesce.
+				if elapsed > interval {
+					logger.Warn(fmt.Sprintf("logstore: matview refresh took %s, longer than the %s refresh interval; consider raising matview_refresh_interval",
+						elapsed.Round(time.Millisecond), interval))
 				}
 			case <-ctx.Done():
 				return

--- a/framework/logstore/matviews_lock_test.go
+++ b/framework/logstore/matviews_lock_test.go
@@ -18,6 +18,44 @@ func TestResolveMatViewRefreshIntervalDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, resolveMatViewRefreshInterval("5m", testLogger{}))
 }
 
+func TestResolveMatViewRefreshTimeoutDefaults(t *testing.T) {
+	// Unset derives from the interval: 5x, floored at 5m.
+	assert.Equal(t, matViewRefreshTimeoutFloor, resolveMatViewRefreshTimeout("", time.Minute, testLogger{}))
+	assert.Equal(t, 25*time.Minute, resolveMatViewRefreshTimeout("", 5*time.Minute, testLogger{}))
+	// Derived value is capped.
+	assert.Equal(t, maxMatViewRefreshTimeout, resolveMatViewRefreshTimeout("", time.Hour, testLogger{}))
+	// Explicit values are honoured, clamped at both ends.
+	assert.Equal(t, 90*time.Second, resolveMatViewRefreshTimeout("90s", time.Minute, testLogger{}))
+	assert.Equal(t, minMatViewRefreshTimeout, resolveMatViewRefreshTimeout("1s", time.Minute, testLogger{}))
+	assert.Equal(t, maxMatViewRefreshTimeout, resolveMatViewRefreshTimeout("2h", time.Minute, testLogger{}))
+	// A bad string falls back to the derived default rather than failing startup.
+	assert.Equal(t, matViewRefreshTimeoutFloor, resolveMatViewRefreshTimeout("not-a-duration", time.Minute, testLogger{}))
+}
+
+// TestMatViewRefreshOrderRotates guards against tail starvation: if a refresh pass
+// is consistently cut short by its deadline, a fixed order would mean the last
+// views never refresh again.
+func TestMatViewRefreshOrderRotates(t *testing.T) {
+	if len(filterMatViews) < 2 {
+		t.Fatalf("expected at least 2 filter matviews to test rotation, got %d", len(filterMatViews))
+	}
+
+	// mv_logs_hourly must stay pinned first — dashboards depend on it.
+	firstSeen := make(map[string]struct{})
+	for range len(filterMatViews) {
+		order := matViewRefreshOrder()
+		require.Len(t, order, len(filterMatViews)+1)
+		assert.Equal(t, "mv_logs_hourly", order[0], "mv_logs_hourly must always refresh first")
+		firstSeen[order[1]] = struct{}{}
+
+		// Every view must still appear exactly once per pass.
+		assert.ElementsMatch(t, allMatViewNames(), order)
+	}
+
+	assert.Equal(t, len(filterMatViews), len(firstSeen),
+		"each filter matview should lead a pass across a full rotation, got %v", firstSeen)
+}
+
 func TestRefreshMatViewsAdvisoryLockLifecycle(t *testing.T) {
 	_, db := setupPerfTestDB(t)
 
@@ -41,6 +79,33 @@ func TestRefreshMatViewsAdvisoryLockLifecycle(t *testing.T) {
 		start := time.Now()
 		require.NoError(t, refreshMatViews(ctx, db))
 		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	// A refresh cut short by its own deadline must still release the advisory lock.
+	// The deferred unlock runs on a context derived with WithoutCancel precisely
+	// because ctx is already expired at that point; if the unlock cannot be
+	// confirmed, the pooled connection is discarded so Postgres reclaims the lock.
+	// Either way the invariant is the same: the lock is free when the call returns.
+	t.Run("deadline-exceeded refresh still releases lock", func(t *testing.T) {
+		timedOut := false
+		for _, budget := range []time.Duration{time.Millisecond, 5 * time.Millisecond, 25 * time.Millisecond} {
+			resetTestMatViewRefreshGate()
+
+			ctx, cancel := context.WithTimeout(context.Background(), budget)
+			err := refreshMatViews(ctx, db)
+			cancel()
+			if err != nil {
+				timedOut = true
+			}
+
+			// Whether or not this budget was tight enough to cut the refresh short,
+			// the lock must become available.
+			conn := awaitTestAdvisoryLock(t, db, matviewRefreshAdvisoryLockKey, 5*time.Second)
+			releaseTestAdvisoryLock(t, conn, matviewRefreshAdvisoryLockKey)
+		}
+		if !timedOut {
+			t.Log("no budget was tight enough to interrupt a refresh on this database; lock-release invariant still verified")
+		}
 	})
 
 	t.Run("closed holder session lets later refresh acquire lock", func(t *testing.T) {
@@ -121,6 +186,44 @@ func acquireTestAdvisoryLock(t *testing.T, db *gorm.DB, key int64) *sql.Conn {
 	require.Truef(t, acquired, "expected to acquire advisory lock %d", key)
 
 	return conn
+}
+
+// awaitTestAdvisoryLock polls until the advisory lock can be taken. When a refresh
+// is cancelled mid-statement the backing session is torn down rather than cleanly
+// unlocked, and Postgres reclaims the lock when it reaps that backend — which is not
+// synchronous with the client call returning. On timeout it reports who still holds
+// the lock so a genuine leak is distinguishable from teardown lag.
+func awaitTestAdvisoryLock(t *testing.T, db *gorm.DB, key int64, wait time.Duration) *sql.Conn {
+	t.Helper()
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(wait)
+	for {
+		conn, err := sqlDB.Conn(context.Background())
+		require.NoError(t, err)
+
+		var acquired bool
+		err = conn.QueryRowContext(context.Background(), "SELECT pg_try_advisory_lock($1)", key).Scan(&acquired)
+		if err == nil && acquired {
+			return conn
+		}
+		_ = conn.Close()
+
+		if time.Now().After(deadline) {
+			var holders string
+			_ = db.Raw(`
+				SELECT COALESCE(string_agg(format('pid=%s state=%s query=%s', a.pid, a.state, left(a.query, 60)), '; '), 'none')
+				FROM pg_locks l
+				JOIN pg_stat_activity a ON a.pid = l.pid
+				WHERE l.locktype = 'advisory' AND l.objid = ?
+			`, key).Scan(&holders).Error
+			require.Failf(t, "advisory lock never released",
+				"key %d still held after %s; holders: %s (lastErr=%v)", key, wait, holders, err)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
 }
 
 func acquireTestAdvisoryLockOnIsolatedPool(t *testing.T, key int64) (*gorm.DB, *sql.Conn) {

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -22,6 +22,13 @@ type PostgresConfig struct {
 	// interval mostly affects how quickly idle clusters notice the rolling
 	// 30-day filter window has aged.
 	MatViewRefreshInterval string `json:"matview_refresh_interval,omitempty"`
+
+	// MatViewRefreshTimeout bounds a single refresh pass. A refresh holds a pooled
+	// connection and a session-scoped advisory lock across every view; if it never
+	// finishes, every replica's pg_try_advisory_lock fails from then on and the
+	// views go permanently stale while still being served. Empty / unset derives a
+	// budget from MatViewRefreshInterval.
+	MatViewRefreshTimeout string `json:"matview_refresh_timeout,omitempty"`
 }
 
 func toPostgresConnConfig(config *PostgresConfig) *postgresconn.Config {
@@ -40,6 +47,56 @@ const defaultMatViewRefreshInterval = time.Minute
 // this is clamped up. The activity-gate skip would mostly absorb the damage,
 // but the floor stops misconfig from becoming a foot-gun.
 const minMatViewRefreshInterval = 5 * time.Second
+
+// matview refresh timeout bounds. A tick that outlives its budget is cancelled so
+// the pooled connection and the session advisory lock are released; the next tick
+// retries from scratch.
+const (
+	minMatViewRefreshTimeout = 30 * time.Second
+	maxMatViewRefreshTimeout = 30 * time.Minute
+	// matViewRefreshTimeoutFloor is the lower bound used when deriving a default
+	// from the refresh interval.
+	matViewRefreshTimeoutFloor = 5 * time.Minute
+	// matViewRefreshTimeoutIntervalFactor scales the interval into a default budget;
+	// a refresh is expected to finish well inside a few ticks.
+	matViewRefreshTimeoutIntervalFactor = 5
+)
+
+// resolveMatViewRefreshTimeout parses the configured per-tick refresh timeout.
+// When unset it derives a budget from the refresh interval rather than picking a
+// fixed number, so a deliberately slow refresh cadence gets a proportionate one.
+func resolveMatViewRefreshTimeout(raw string, interval time.Duration, logger schemas.Logger) time.Duration {
+	derived := func() time.Duration {
+		d := interval * matViewRefreshTimeoutIntervalFactor
+		if d < matViewRefreshTimeoutFloor {
+			d = matViewRefreshTimeoutFloor
+		}
+		if d > maxMatViewRefreshTimeout {
+			d = maxMatViewRefreshTimeout
+		}
+		return d
+	}
+
+	if raw == "" {
+		return derived()
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		fallback := derived()
+		logger.Warn(fmt.Sprintf("logstore: invalid matview_refresh_timeout %q (%s); using %s", raw, err, fallback))
+		return fallback
+	}
+	if d < minMatViewRefreshTimeout {
+		logger.Warn(fmt.Sprintf("logstore: matview_refresh_timeout %s is below floor %s; clamping to %s", d, minMatViewRefreshTimeout, minMatViewRefreshTimeout))
+		return minMatViewRefreshTimeout
+	}
+	if d > maxMatViewRefreshTimeout {
+		logger.Warn(fmt.Sprintf("logstore: matview_refresh_timeout %s is above cap %s; clamping to %s", d, maxMatViewRefreshTimeout, maxMatViewRefreshTimeout))
+		return maxMatViewRefreshTimeout
+	}
+	logger.Info(fmt.Sprintf("logstore: matview refresh timeout set to %s", d))
+	return d
+}
 
 // resolveMatViewRefreshInterval parses the configured duration string with
 // fallback + clamp. Logs a warning on a bad string so misconfig is noticed.
@@ -111,6 +168,13 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		logger.Error("logstore: failed to open migration connection pool: %v", err)
 		return nil, err
 	}
+	// Pin the throwaway pool small: migrations are serial DDL, and an untuned pool
+	// inherits database/sql's unlimited MaxOpenConns.
+	if err := postgresconn.ApplyMigrationPoolTuning(mDb); err != nil {
+		logger.Error("logstore: failed to tune migration connection pool: %v", err)
+		_ = closePool(mDb)
+		return nil, err
+	}
 
 	// Postgres version gate: refuse to start below 16 (matviews, partitioning,
 	// and some JSON operators we rely on depend on 16+).
@@ -146,7 +210,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		return nil, err
 	}
 
-	if err := postgresconn.ApplyPoolTuning(db, pgConfig); err != nil {
+	if err := postgresconn.ApplyPoolTuning(db, pgConfig, logger); err != nil {
 		closePool(db)
 		return nil, err
 	}
@@ -203,7 +267,15 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 			logger.Warn(fmt.Sprintf("logstore: matview creation failed: %s (dashboard queries will use raw tables)", err))
 			return
 		}
-		if err := refreshMatViews(context.Background(), db); err != nil {
+		refreshInterval := resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger)
+		refreshTimeout := resolveMatViewRefreshTimeout(config.MatViewRefreshTimeout, refreshInterval, logger)
+
+		// The initial refresh gets the same budget as a periodic tick; on a large
+		// logs table it can be slow, and it must not hold the advisory lock forever.
+		initialCtx, cancelInitial := context.WithTimeout(context.Background(), refreshTimeout)
+		err := refreshMatViews(initialCtx, db)
+		cancelInitial()
+		if err != nil {
 			logger.Warn(fmt.Sprintf("logstore: initial matview refresh failed: %s", err))
 		} else {
 			logger.Info("logstore: materialized views are ready")
@@ -211,7 +283,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 			// canUseMatView() returns false so all queries use raw tables.
 			d.matViewsReady.Store(true)
 		}
-		startMatViewRefresher(context.Background(), db, resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger), logger, &d.matViewsReady)
+		startMatViewRefresher(context.Background(), db, refreshInterval, refreshTimeout, logger, &d.matViewsReady)
 	}()
 
 	return d, nil

--- a/framework/postgresconn/pooltuning_test.go
+++ b/framework/postgresconn/pooltuning_test.go
@@ -1,0 +1,176 @@
+package postgresconn
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseConnMaxIdleTime(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "unset uses default", raw: "", want: defaultConnMaxIdleTime},
+		{name: "explicit value", raw: "90s", want: 90 * time.Second},
+		{name: "minutes", raw: "10m", want: 10 * time.Minute},
+		{name: "unparseable rejected", raw: "not-a-duration", wantErr: true},
+		{name: "zero rejected", raw: "0s", wantErr: true},
+		{name: "negative rejected", raw: "-5m", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseConnMaxIdleTime(&Config{ConnMaxIdleTime: tc.raw})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %q", tc.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseConnMaxIdleTime(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePasswordCommandCacheTTL(t *testing.T) {
+	got, err := parsePasswordCommandCacheTTL(&PasswordCommandConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != defaultPasswordCommandCacheTTL {
+		t.Fatalf("default cache TTL = %v, want %v", got, defaultPasswordCommandCacheTTL)
+	}
+
+	got, err = parsePasswordCommandCacheTTL(&PasswordCommandConfig{CacheTTL: "5m"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 5*time.Minute {
+		t.Fatalf("cache TTL = %v, want 5m", got)
+	}
+
+	if _, err := parsePasswordCommandCacheTTL(&PasswordCommandConfig{CacheTTL: "0s"}); err == nil {
+		t.Fatal("expected a non-positive cache_ttl to be rejected")
+	}
+	if _, err := parsePasswordCommandCacheTTL(&PasswordCommandConfig{CacheTTL: "nope"}); err == nil {
+		t.Fatal("expected an unparseable cache_ttl to be rejected")
+	}
+}
+
+// countingPasswordCommand writes a fixed password to stdout and appends a byte to
+// a marker file on each run, so the test can count executions.
+func countingPasswordCommand(t *testing.T) (*PasswordCommandConfig, func() int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("password command test uses a POSIX shell script")
+	}
+
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "runs")
+	script := filepath.Join(dir, "pw.sh")
+	body := "#!/bin/sh\nprintf x >> " + marker + "\nprintf 'secret'\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	return &PasswordCommandConfig{Command: script}, func() int {
+		data, err := os.ReadFile(marker)
+		if err != nil {
+			return 0
+		}
+		return len(data)
+	}
+}
+
+// TestPasswordCacheCollapsesConcurrentResolutions is the regression for the
+// per-connection subprocess fork: BeforeConnect runs for every new physical
+// connection, so a pool burst previously ran the command once per connection.
+func TestPasswordCacheCollapsesConcurrentResolutions(t *testing.T) {
+	config, runs := countingPasswordCommand(t)
+	cache := &passwordCache{}
+
+	const callers = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			password, err := cache.get(context.Background(), config)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if password != "secret" {
+				t.Errorf("password = %q, want %q", password, "secret")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("cache.get: %v", err)
+	}
+
+	if got := runs(); got != 1 {
+		t.Fatalf("password command ran %d times for %d concurrent callers, want 1", got, callers)
+	}
+}
+
+func TestPasswordCacheReusesWithinTTLAndRefreshesAfter(t *testing.T) {
+	config, runs := countingPasswordCommand(t)
+	config.CacheTTL = "1h"
+	cache := &passwordCache{}
+
+	for range 5 {
+		if _, err := cache.get(context.Background(), config); err != nil {
+			t.Fatalf("cache.get: %v", err)
+		}
+	}
+	if got := runs(); got != 1 {
+		t.Fatalf("password command ran %d times within the TTL, want 1", got)
+	}
+
+	// Expire the entry; the next call must resolve again.
+	cache.mu.Lock()
+	cache.expiresAt = time.Now().Add(-time.Second)
+	cache.mu.Unlock()
+
+	if _, err := cache.get(context.Background(), config); err != nil {
+		t.Fatalf("cache.get after expiry: %v", err)
+	}
+	if got := runs(); got != 2 {
+		t.Fatalf("password command ran %d times after expiry, want 2", got)
+	}
+}
+
+// TestPasswordCacheDoesNotCacheFailures ensures a transient failure does not
+// persist for the whole TTL.
+func TestPasswordCacheDoesNotCacheFailures(t *testing.T) {
+	cache := &passwordCache{}
+	failing := &PasswordCommandConfig{Command: filepath.Join(t.TempDir(), "does-not-exist")}
+
+	for range 3 {
+		if _, err := cache.get(context.Background(), failing); err == nil {
+			t.Fatal("expected an error from a missing password command")
+		}
+	}
+
+	cache.mu.RLock()
+	cached := cache.value
+	cache.mu.RUnlock()
+	if cached != "" {
+		t.Fatalf("a failed resolution was cached as %q", cached)
+	}
+}

--- a/framework/postgresconn/postgresconn.go
+++ b/framework/postgresconn/postgresconn.go
@@ -8,12 +8,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/maximhq/bifrost/core/schemas"
+	"golang.org/x/sync/singleflight"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -21,11 +23,79 @@ import (
 
 const defaultPasswordCommandTimeout = 10 * time.Second
 
+// defaultPasswordCommandCacheTTL is how long a resolved password is reused before
+// the command is run again. Without caching the command runs on every new physical
+// connection, which for the common case (fetching a short-lived IAM token) is a
+// subprocess fork per connection.
+//
+// Deliberately conservative: pgx's OptionBeforeConnect gets no signal about whether
+// the password was actually accepted, so the TTL is the only invalidation mechanism.
+const defaultPasswordCommandCacheTTL = 60 * time.Second
+
 // PasswordCommandConfig describes a command that prints a Postgres password to stdout.
 type PasswordCommandConfig struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args,omitempty"`
 	Timeout string   `json:"timeout,omitempty"`
+	// CacheTTL is how long a successfully resolved password is reused across new
+	// physical connections (Go duration string, default 60s). Set it below the
+	// credential's validity window; a rotation shorter than the TTL will fail
+	// connections until the cached value expires.
+	CacheTTL string `json:"cache_ttl,omitempty"`
+}
+
+// passwordCache memoizes a resolved password for the configured TTL and collapses
+// concurrent resolutions onto a single command execution. Pool churn otherwise
+// produces one fork per connection, all racing to fetch the same token.
+type passwordCache struct {
+	group singleflight.Group
+
+	mu        sync.RWMutex
+	value     string
+	expiresAt time.Time
+}
+
+// get returns a cached password when still fresh, otherwise resolves one. Failures
+// are never cached, so a transient error does not persist for the whole TTL.
+func (c *passwordCache) get(ctx context.Context, config *PasswordCommandConfig) (string, error) {
+	ttl, err := parsePasswordCommandCacheTTL(config)
+	if err != nil {
+		return "", err
+	}
+
+	c.mu.RLock()
+	value, expiresAt := c.value, c.expiresAt
+	c.mu.RUnlock()
+	if value != "" && time.Now().Before(expiresAt) {
+		return value, nil
+	}
+
+	// singleflight keys on a constant: one cache instance serves one config.
+	resolved, err, _ := c.group.Do("password", func() (any, error) {
+		// Re-check under the flight: a concurrent caller may have just refreshed.
+		c.mu.RLock()
+		value, expiresAt := c.value, c.expiresAt
+		c.mu.RUnlock()
+		if value != "" && time.Now().Before(expiresAt) {
+			return value, nil
+		}
+		// Detached from ctx on purpose: singleflight hands this single execution's
+		// error to every waiter, so one canceled dial would fail unrelated password
+		// resolutions. RunPasswordCommand applies its own timeout, so this stays bounded.
+		password, err := RunPasswordCommand(context.WithoutCancel(ctx), config)
+		if err != nil {
+			return "", err
+		}
+		c.mu.Lock()
+		c.value = password
+		c.expiresAt = time.Now().Add(ttl)
+		c.mu.Unlock()
+		return password, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return resolved.(string), nil
 }
 
 // Config is the shared Postgres connection configuration used by framework stores.
@@ -40,6 +110,11 @@ type Config struct {
 	MaxIdleConns    int                    `json:"max_idle_conns"`
 	MaxOpenConns    int                    `json:"max_open_conns"`
 	ConnMaxLifetime string                 `json:"conn_max_lifetime,omitempty"`
+	// ConnMaxIdleTime bounds how long an idle physical connection is kept before
+	// being closed. Without it, the idle cap is the only thing controlling pool
+	// size, so every burst above MaxIdleConns closes connections on return and
+	// reopens them on the next query — each reopen forks a Postgres backend.
+	ConnMaxIdleTime string `json:"conn_max_idle_time,omitempty"`
 }
 
 // Validate checks required Postgres connection fields.
@@ -65,6 +140,9 @@ func Validate(config *Config, requireStaticPassword bool) error {
 	if _, err := parseConnMaxLifetime(config); err != nil {
 		return err
 	}
+	if _, err := parseConnMaxIdleTime(config); err != nil {
+		return err
+	}
 	if config.PasswordCommand != nil {
 		if err := validatePasswordCommand(config.PasswordCommand); err != nil {
 			return err
@@ -73,6 +151,9 @@ func Validate(config *Config, requireStaticPassword bool) error {
 			return fmt.Errorf("postgres password and password_command are mutually exclusive")
 		}
 		if _, err := parsePasswordCommandTimeout(config.PasswordCommand); err != nil {
+			return err
+		}
+		if _, err := parsePasswordCommandCacheTTL(config.PasswordCommand); err != nil {
 			return err
 		}
 		return nil
@@ -109,8 +190,11 @@ func Open(dsn string, config *Config, logger gormlogger.Interface) (*gorm.DB, er
 	if err != nil {
 		return nil, err
 	}
+	// One cache per pool. BeforeConnect runs for every new physical connection, so
+	// without this a bursty workload forks the password command once per connection.
+	cache := &passwordCache{}
 	sqlDB := stdlib.OpenDB(*pgxConfig, stdlib.OptionBeforeConnect(func(ctx context.Context, connConfig *pgx.ConnConfig) error {
-		password, err := RunPasswordCommand(ctx, config.PasswordCommand)
+		password, err := cache.get(ctx, config.PasswordCommand)
 		if err != nil {
 			return err
 		}
@@ -132,29 +216,79 @@ func openGormFromSQLDB(sqlDB *sql.DB, logger gormlogger.Interface) (*gorm.DB, er
 	return db, nil
 }
 
-// ApplyPoolTuning applies MaxIdleConns, MaxOpenConns, and ConnMaxLifetime.
-func ApplyPoolTuning(db *gorm.DB, config *Config) error {
+const (
+	// defaultMaxIdleConns / defaultMaxOpenConns are the pool sizes used when the
+	// config leaves them at zero.
+	defaultMaxIdleConns = 5
+	defaultMaxOpenConns = 50
+
+	// defaultConnMaxIdleTime reaps genuinely idle connections without making the
+	// idle cap the only pool-size control. Paired with MaxIdleConns, this is what
+	// keeps a bursty workload from churning physical connections.
+	defaultConnMaxIdleTime = 5 * time.Minute
+
+	// Migration pools run strictly serial DDL, so they need almost nothing. Left
+	// untuned they inherit database/sql's defaults, where MaxOpenConns is unlimited.
+	migrationMaxOpenConns = 2
+	migrationMaxIdleConns = 1
+)
+
+// ApplyPoolTuning applies MaxIdleConns, MaxOpenConns, ConnMaxLifetime, and
+// ConnMaxIdleTime. When a logger is supplied the effective pool shape is logged
+// once, so operators can size against the server's max_connections without
+// reading source — note that logstore and configstore open separate pools, so a
+// pod's ceiling is the sum across them.
+func ApplyPoolTuning(db *gorm.DB, config *Config, logger ...schemas.Logger) error {
 	sqlDB, err := db.DB()
 	if err != nil {
 		return err
 	}
 	maxIdleConns := config.MaxIdleConns
 	if maxIdleConns == 0 {
-		maxIdleConns = 5
+		maxIdleConns = defaultMaxIdleConns
 	}
 	sqlDB.SetMaxIdleConns(maxIdleConns)
 	maxOpenConns := config.MaxOpenConns
 	if maxOpenConns == 0 {
-		maxOpenConns = 50
+		maxOpenConns = defaultMaxOpenConns
 	}
 	sqlDB.SetMaxOpenConns(maxOpenConns)
-	if config.ConnMaxLifetime != "" {
-		lifetime, err := parseConnMaxLifetime(config)
-		if err != nil {
-			return err
-		}
+
+	lifetime, err := parseConnMaxLifetime(config)
+	if err != nil {
+		return err
+	}
+	if lifetime > 0 {
 		sqlDB.SetConnMaxLifetime(lifetime)
 	}
+
+	idleTime, err := parseConnMaxIdleTime(config)
+	if err != nil {
+		return err
+	}
+	sqlDB.SetConnMaxIdleTime(idleTime)
+
+	if len(logger) > 0 && logger[0] != nil {
+		lifetimeDesc := "unlimited"
+		if lifetime > 0 {
+			lifetimeDesc = lifetime.String()
+		}
+		logger[0].Info("postgres pool tuned: max_open_conns=%d max_idle_conns=%d conn_max_idle_time=%s conn_max_lifetime=%s (this is one pool; logstore and configstore each open their own)",
+			maxOpenConns, maxIdleConns, idleTime, lifetimeDesc)
+	}
+	return nil
+}
+
+// ApplyMigrationPoolTuning pins a throwaway migration pool to a minimal size.
+// Migration pools are opened, used for serial DDL, and closed; without this they
+// inherit database/sql's defaults, where MaxOpenConns is unlimited.
+func ApplyMigrationPoolTuning(db *gorm.DB) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	sqlDB.SetMaxOpenConns(migrationMaxOpenConns)
+	sqlDB.SetMaxIdleConns(migrationMaxIdleConns)
 	return nil
 }
 
@@ -284,6 +418,37 @@ func parseConnMaxLifetime(config *Config) (time.Duration, error) {
 		return 0, fmt.Errorf("postgres conn_max_lifetime must be positive")
 	}
 	return lifetime, nil
+}
+
+// parsePasswordCommandCacheTTL parses the optional password cache TTL.
+func parsePasswordCommandCacheTTL(config *PasswordCommandConfig) (time.Duration, error) {
+	if config == nil || config.CacheTTL == "" {
+		return defaultPasswordCommandCacheTTL, nil
+	}
+	ttl, err := time.ParseDuration(config.CacheTTL)
+	if err != nil {
+		return 0, fmt.Errorf("invalid postgres password_command.cache_ttl %q: %w", config.CacheTTL, err)
+	}
+	if ttl <= 0 {
+		return 0, fmt.Errorf("postgres password_command.cache_ttl must be positive")
+	}
+	return ttl, nil
+}
+
+// parseConnMaxIdleTime parses the optional idle-connection timeout, falling back
+// to defaultConnMaxIdleTime when unset.
+func parseConnMaxIdleTime(config *Config) (time.Duration, error) {
+	if config == nil || config.ConnMaxIdleTime == "" {
+		return defaultConnMaxIdleTime, nil
+	}
+	idleTime, err := time.ParseDuration(config.ConnMaxIdleTime)
+	if err != nil {
+		return 0, fmt.Errorf("invalid postgres conn_max_idle_time %q: %w", config.ConnMaxIdleTime, err)
+	}
+	if idleTime <= 0 {
+		return 0, fmt.Errorf("postgres conn_max_idle_time must be positive")
+	}
+	return idleTime, nil
 }
 
 // parsePasswordCommandTimeout parses the optional password command timeout.

--- a/framework/postgresconn/postgresconn_integration_test.go
+++ b/framework/postgresconn/postgresconn_integration_test.go
@@ -13,10 +13,11 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
-func TestPasswordCommandOpensRealPostgresConnections(t *testing.T) {
-	if os.Getenv("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST") != "1" {
-		t.Skip("set BIFROST_POSTGRES_PASSWORD_COMMAND_TEST=1 to run against local Postgres")
-	}
+// newPasswordCommandTestConfig builds a config whose password command appends a
+// line to a counter file on each run. MaxIdleConns is forced to 0 by the callers so
+// every query opens a fresh physical connection, which is when BeforeConnect fires.
+func newPasswordCommandTestConfig(t *testing.T, cacheTTL string) (*Config, string) {
+	t.Helper()
 
 	password := getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_PASSWORD", "bifrost_password")
 	dir := t.TempDir()
@@ -25,32 +26,83 @@ func TestPasswordCommandOpensRealPostgresConnections(t *testing.T) {
 	script := fmt.Sprintf("#!/bin/sh\nprintf 'called\\n' >> %q\nprintf %%s %q\n", counterPath, password)
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o700))
 
-	cfg := &Config{
+	return &Config{
 		Host:            schemas.NewSecretVar(getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_HOST", "localhost")),
 		Port:            schemas.NewSecretVar(getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_PORT", "5432")),
 		User:            schemas.NewSecretVar(getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_USER", "bifrost")),
 		DBName:          schemas.NewSecretVar(getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_DB", "bifrost")),
 		SSLMode:         schemas.NewSecretVar(getenvDefault("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST_SSLMODE", "disable")),
-		PasswordCommand: &PasswordCommandConfig{Command: scriptPath, Timeout: "5s"},
+		PasswordCommand: &PasswordCommandConfig{Command: scriptPath, Timeout: "5s", CacheTTL: cacheTTL},
+	}, counterPath
+}
+
+func passwordCommandRuns(t *testing.T, counterPath string) int {
+	t.Helper()
+	raw, err := os.ReadFile(counterPath)
+	if err != nil {
+		return 0
+	}
+	return strings.Count(string(raw), "called")
+}
+
+// TestPasswordCommandOpensRealPostgresConnections verifies password_command auth
+// works end to end against a real server, and that the resolved password is cached.
+//
+// This previously asserted the command ran at least once per new physical
+// connection. That is the behaviour the cache deliberately removes: BeforeConnect
+// fires for every physical connection, so under pool churn the old behaviour forked
+// a subprocess per connection — expensive, and pure waste for the common case of a
+// short-lived IAM token that stays valid for minutes.
+func TestPasswordCommandOpensRealPostgresConnections(t *testing.T) {
+	if os.Getenv("BIFROST_POSTGRES_PASSWORD_COMMAND_TEST") != "1" {
+		t.Skip("set BIFROST_POSTGRES_PASSWORD_COMMAND_TEST=1 to run against local Postgres")
 	}
 
-	require.NoError(t, Validate(cfg, true))
-	db, err := Open(BuildDSN(cfg), cfg, gormlogger.Default)
-	require.NoError(t, err)
-	sqlDB, err := db.DB()
-	require.NoError(t, err)
-	defer sqlDB.Close()
+	t.Run("password is cached across new physical connections", func(t *testing.T) {
+		cfg, counterPath := newPasswordCommandTestConfig(t, "")
 
-	sqlDB.SetMaxOpenConns(1)
-	sqlDB.SetMaxIdleConns(0)
+		require.NoError(t, Validate(cfg, true))
+		db, err := Open(BuildDSN(cfg), cfg, gormlogger.Default)
+		require.NoError(t, err)
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		defer sqlDB.Close()
 
-	require.NoError(t, db.Exec("SELECT 1").Error)
-	time.Sleep(10 * time.Millisecond)
-	require.NoError(t, db.Exec("SELECT 1").Error)
+		// No idle connections: every query below opens a fresh physical connection.
+		sqlDB.SetMaxOpenConns(1)
+		sqlDB.SetMaxIdleConns(0)
 
-	raw, err := os.ReadFile(counterPath)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, strings.Count(string(raw), "called"), 2)
+		for range 4 {
+			require.NoError(t, db.Exec("SELECT 1").Error)
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		require.Equal(t, 1, passwordCommandRuns(t, counterPath),
+			"the password command should run once and be reused for the default TTL")
+	})
+
+	t.Run("expired cache resolves again", func(t *testing.T) {
+		// A TTL shorter than the gap between queries forces a re-resolve, which is
+		// what lets rotating credentials keep working.
+		cfg, counterPath := newPasswordCommandTestConfig(t, "50ms")
+
+		require.NoError(t, Validate(cfg, true))
+		db, err := Open(BuildDSN(cfg), cfg, gormlogger.Default)
+		require.NoError(t, err)
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		defer sqlDB.Close()
+
+		sqlDB.SetMaxOpenConns(1)
+		sqlDB.SetMaxIdleConns(0)
+
+		require.NoError(t, db.Exec("SELECT 1").Error)
+		time.Sleep(150 * time.Millisecond)
+		require.NoError(t, db.Exec("SELECT 1").Error)
+
+		require.GreaterOrEqual(t, passwordCommandRuns(t, counterPath), 2,
+			"a cache entry past its TTL must be refreshed")
+	})
 }
 
 func getenvDefault(key, fallback string) string {

--- a/framework/tracing/obsisolation_test.go
+++ b/framework/tracing/obsisolation_test.go
@@ -1,0 +1,195 @@
+package tracing
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// blockingObsPlugin is an observability plugin whose Inject blocks until released.
+// It stands in for a connector pointed at an unreachable collector.
+type blockingObsPlugin struct {
+	name string
+	// release gates Inject; a nil channel means Inject returns immediately.
+	release chan struct{}
+	// delay, when non-zero, is slept in Inject instead of waiting on release.
+	delay time.Duration
+
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+	started     atomic.Int64
+	firstEntry  atomic.Int64 // UnixNano of the first Inject entry
+}
+
+func (p *blockingObsPlugin) GetName() string { return p.name }
+func (p *blockingObsPlugin) Cleanup() error  { return nil }
+func (p *blockingObsPlugin) PreRequestHook(_ *schemas.BifrostContext, _ *schemas.BifrostRequest) error {
+	return nil
+}
+func (p *blockingObsPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	return req, nil, nil
+}
+func (p *blockingObsPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	return resp, bifrostErr, nil
+}
+
+func (p *blockingObsPlugin) Inject(_ context.Context, _ *schemas.Trace) error {
+	p.started.Add(1)
+	p.firstEntry.CompareAndSwap(0, time.Now().UnixNano())
+
+	cur := p.inFlight.Add(1)
+	for {
+		observed := p.maxInFlight.Load()
+		if cur <= observed || p.maxInFlight.CompareAndSwap(observed, cur) {
+			break
+		}
+	}
+	defer p.inFlight.Add(-1)
+
+	if p.delay > 0 {
+		time.Sleep(p.delay)
+		return nil
+	}
+	if p.release != nil {
+		<-p.release
+	}
+	return nil
+}
+
+// TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers is the core regression: the
+// observability plugins used to be invoked sequentially on a single flush goroutine, so
+// a connector doing blocking network I/O sat in front of every plugin after it —
+// including the logging plugin, whose Inject is what enqueues the row for Postgres.
+func TestCompleteAndFlushTrace_SlowPluginDoesNotDelayOthers(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	const slowInject = 750 * time.Millisecond
+	slow := &blockingObsPlugin{name: "slow-connector", delay: slowInject}
+	fast := &blockingObsPlugin{name: "fast-connector"}
+
+	// Slow one registered first: the ordering that used to cause the stall.
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{slow, fast})
+
+	traceID := tracer.CreateTrace("")
+	start := time.Now()
+	tracer.CompleteAndFlushTrace(traceID)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for fast.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if fast.started.Load() == 0 {
+		t.Fatal("fast plugin was never injected")
+	}
+
+	elapsed := time.Unix(0, fast.firstEntry.Load()).Sub(start)
+	if elapsed >= slowInject {
+		t.Fatalf("fast plugin was blocked behind the slow one: entered Inject after %v (slow plugin takes %v)", elapsed, slowInject)
+	}
+}
+
+// TestCompleteAndFlushTrace_BoundsInjectsPerPlugin verifies the concurrency cap. Without
+// it, one goroutine and one full trace snapshot accumulate per request for as long as the
+// collector hangs, and that heap/scheduler pressure is what starves the log batch writer.
+func TestCompleteAndFlushTrace_BoundsInjectsPerPlugin(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+
+	stuck := &blockingObsPlugin{name: "stuck-connector", release: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{stuck})
+
+	const overshoot = 250
+	total := maxConcurrentInjectsPerPlugin + overshoot
+	for range total {
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}
+
+	// Wait for the semaphore to saturate and the excess to be skipped.
+	deadline := time.Now().Add(10 * time.Second)
+	for tracer.ObservabilityDropCounts()["stuck-connector"] == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := stuck.maxInFlight.Load(); got > maxConcurrentInjectsPerPlugin {
+		t.Fatalf("concurrent injects exceeded the cap: got %d, cap %d", got, maxConcurrentInjectsPerPlugin)
+	}
+	if dropped := tracer.ObservabilityDropCounts()["stuck-connector"]; dropped == 0 {
+		t.Fatal("expected traces to be skipped once the plugin saturated, got 0")
+	}
+
+	close(stuck.release)
+	tracer.Stop()
+}
+
+// TestWaitForFlushes_TimesOutOnHungPlugin ensures a connector blocked on an unreachable
+// collector cannot hold up shutdown or a config reload.
+func TestWaitForFlushes_TimesOutOnHungPlugin(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+
+	hung := &blockingObsPlugin{name: "hung-connector", release: make(chan struct{})}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{hung})
+	tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for hung.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if hung.started.Load() == 0 {
+		t.Fatal("hung plugin was never injected")
+	}
+
+	start := time.Now()
+	if completed := tracer.waitForFlushes(200 * time.Millisecond); completed {
+		t.Fatal("waitForFlushes reported completion while a plugin was still blocked")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("waitForFlushes did not honour its timeout: took %v", elapsed)
+	}
+
+	close(hung.release)
+	tracer.Stop()
+}
+
+// TestSetObservabilityPlugins_DedupesByName preserves the behaviour the old flush loop
+// implemented with a per-flush `seen` map.
+func TestSetObservabilityPlugins_DedupesByName(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	dup := &blockingObsPlugin{name: "dup-connector"}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{dup, dup, dup})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tracer.CompleteAndFlushTrace(tracer.CreateTrace(""))
+	}()
+	wg.Wait()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for dup.started.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	tracer.waitForFlushes(5 * time.Second)
+
+	if got := dup.started.Load(); got != 1 {
+		t.Fatalf("expected a duplicate-named plugin to be injected once, got %d", got)
+	}
+}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -13,6 +13,31 @@ import (
 	"github.com/maximhq/bifrost/framework/streaming"
 )
 
+const (
+	// maxConcurrentInjectsPerPlugin bounds how many traces may sit inside a single
+	// observability connector's Inject at once. A connector pointed at a wrong or
+	// black-holed endpoint blocks on network I/O while pinning a full trace snapshot;
+	// uncapped that is one goroutine and one snapshot per request, whose heap and
+	// scheduler pressure starves the rest of the process — notably the logging
+	// plugin's single DB batch writer, whose queue then drops rows silently.
+	// Each connector gets its own budget so a stalled one cannot crowd out a healthy one.
+	maxConcurrentInjectsPerPlugin = 1024
+
+	// flushStopTimeout bounds how long Stop waits for in-flight trace exports, so a
+	// hung collector cannot block shutdown or a config reload.
+	flushStopTimeout = 10 * time.Second
+)
+
+// obsPluginSlot pairs an observability plugin with its own concurrency budget and
+// drop counter. Isolating the budget per connector is what keeps a misconfigured
+// exporter from consuming the capacity that healthy connectors need.
+type obsPluginSlot struct {
+	plugin  schemas.ObservabilityPlugin
+	name    string
+	sem     chan struct{}
+	dropped atomic.Int64
+}
+
 // Tracer implements schemas.Tracer using TraceStore.
 // It provides the bridge between the core Tracer interface and the
 // framework's TraceStore implementation.
@@ -22,7 +47,7 @@ type Tracer struct {
 	accumulator       *streaming.Accumulator
 	pricingManager    *modelcatalog.ModelCatalog
 	logger            schemas.Logger
-	obsPlugins        atomic.Pointer[[]schemas.ObservabilityPlugin]
+	obsPlugins        atomic.Pointer[[]*obsPluginSlot]
 	cachedHdrPatterns atomic.Pointer[[]string]
 	flushWG           sync.WaitGroup
 }
@@ -36,7 +61,7 @@ func NewTracer(store *TraceStore, pricingManager *modelcatalog.ModelCatalog, log
 		accumulator:    streaming.NewAccumulator(pricingManager, logger),
 		pricingManager: pricingManager,
 		logger:         logger,
-		obsPlugins:     atomic.Pointer[[]schemas.ObservabilityPlugin]{},
+		obsPlugins:     atomic.Pointer[[]*obsPluginSlot]{},
 	}
 }
 
@@ -47,7 +72,27 @@ func (t *Tracer) SetObservabilityPlugins(obsPlugins []schemas.ObservabilityPlugi
 	if t == nil {
 		return
 	}
-	t.obsPlugins.Store(&obsPlugins)
+	// Build one slot per distinct plugin, each with its own concurrency budget.
+	// Deduplication by name happens here rather than on every flush, so the hot
+	// path does not rebuild a map per trace.
+	slots := make([]*obsPluginSlot, 0, len(obsPlugins))
+	seenPlugins := make(map[string]struct{}, len(obsPlugins))
+	for _, plugin := range obsPlugins {
+		if plugin == nil {
+			continue
+		}
+		name := plugin.GetName()
+		if _, exists := seenPlugins[name]; exists {
+			continue
+		}
+		seenPlugins[name] = struct{}{}
+		slots = append(slots, &obsPluginSlot{
+			plugin: plugin,
+			name:   name,
+			sem:    make(chan struct{}, maxConcurrentInjectsPerPlugin),
+		})
+	}
+	t.obsPlugins.Store(&slots)
 
 	seen := make(map[string]struct{})
 	var patterns []string
@@ -695,12 +740,34 @@ func (t *Tracer) AttachPluginLogs(traceID string, logs []schemas.PluginLogEntry)
 // Stop stops the tracer and releases its resources.
 // This stops the internal TraceStore's cleanup goroutine.
 func (t *Tracer) Stop() {
-	t.flushWG.Wait()
+	// Bounded wait: a connector blocked on an unreachable collector would otherwise
+	// hold up shutdown and config reload indefinitely (gRPC exports carry no deadline
+	// of their own).
+	t.waitForFlushes(flushStopTimeout)
 	if t.store != nil {
 		t.store.Stop()
 	}
 	if t.accumulator != nil {
 		t.accumulator.Cleanup()
+	}
+}
+
+// waitForFlushes waits for in-flight trace exports, giving up after timeout.
+// Returns true if every flush completed within the budget.
+func (t *Tracer) waitForFlushes(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		t.flushWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		if t.logger != nil {
+			t.logger.Warn("timed out after %s waiting for in-flight trace exports; continuing shutdown", timeout)
+		}
+		return false
 	}
 }
 
@@ -739,35 +806,70 @@ func (t *Tracer) CompleteAndFlushTrace(traceID string) {
 		// so every trace connector sees the same value on the root span.
 		exportTrace.StampOverheadDuration()
 
-		var obsPlugins []schemas.ObservabilityPlugin
+		var slots []*obsPluginSlot
 		if loaded := t.obsPlugins.Load(); loaded != nil {
-			obsPlugins = *loaded
+			slots = *loaded
 		}
-		seen := make(map[string]struct{}, len(obsPlugins))
-		for _, plugin := range obsPlugins {
-			if plugin == nil {
+
+		// Fan out rather than iterate: every connector receives the trace on its own
+		// goroutine, so a connector doing blocking network I/O can never delay another.
+		// This used to be a sequential loop, where only the builtin plugin ordering
+		// (logging before otel) kept a stalled exporter from sitting in front of the
+		// logging plugin's DB enqueue — accidental protection that any custom or
+		// reordered connector would have removed.
+		var wg sync.WaitGroup
+		for _, slot := range slots {
+			// Non-blocking acquire. A saturated connector is skipped and counted; parking
+			// yet another goroutine on it is exactly the failure this cap exists to stop.
+			select {
+			case slot.sem <- struct{}{}:
+			default:
+				// Throttled: at saturation this fires once per request, which would make
+				// the logging itself a second source of load.
+				if n := slot.dropped.Add(1); (n == 1 || n%1000 == 0) && t.logger != nil {
+					t.logger.Warn("observability plugin %s saturated at %d concurrent injects, skipped trace %s (%d skipped so far)",
+						slot.name, maxConcurrentInjectsPerPlugin, exportTrace.TraceID, n)
+				}
 				continue
 			}
-			// Isolate each plugin callback — one bad observability backend should
-			// not crash the server or prevent other plugins from receiving the trace.
-			func(plugin schemas.ObservabilityPlugin) {
-				name := "<unknown>"
+			wg.Add(1)
+			go func(slot *obsPluginSlot) {
+				defer wg.Done()
+				defer func() { <-slot.sem }()
+				// Isolate each plugin callback — one bad observability backend should
+				// not crash the server or prevent other plugins from receiving the trace.
 				defer func() {
 					if r := recover(); r != nil && t.logger != nil {
-						t.logger.Error("observability plugin %s panicked during trace injection: %v", name, r)
+						t.logger.Error("observability plugin %s panicked during trace injection: %v", slot.name, r)
 					}
 				}()
-				name = plugin.GetName()
-				if _, exists := seen[name]; exists {
-					return
+				if err := slot.plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
+					t.logger.Warn("observability plugin %s failed to inject trace: %v", slot.name, err)
 				}
-				seen[name] = struct{}{}
-				if err := plugin.Inject(context.Background(), exportTrace); err != nil && t.logger != nil {
-					t.logger.Warn("observability plugin %s failed to inject trace: %v", name, err)
-				}
-			}(plugin)
+			}(slot)
 		}
+		// Join before the deferred ReleaseTrace runs: connectors read exportTrace, and
+		// the pooled trace it was snapshotted from must not be recycled underneath them.
+		wg.Wait()
 	})
+}
+
+// ObservabilityDropCounts returns, per observability plugin name, how many traces were
+// skipped because that plugin was already at its concurrency cap. A non-zero and rising
+// count means the connector's backend is unreachable or too slow to keep up.
+func (t *Tracer) ObservabilityDropCounts() map[string]int64 {
+	if t == nil {
+		return nil
+	}
+	loaded := t.obsPlugins.Load()
+	if loaded == nil {
+		return nil
+	}
+	counts := make(map[string]int64, len(*loaded))
+	for _, slot := range *loaded {
+		counts[slot.name] = slot.dropped.Load()
+	}
+	return counts
 }
 
 // Ensure Tracer implements schemas.Tracer at compile time

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -822,6 +822,9 @@ false
 {{- if .Values.storage.configStore.maxOpenConns }}
 {{- $_ := set $pgConfig "max_open_conns" (.Values.storage.configStore.maxOpenConns | int) }}
 {{- end }}
+{{- if .Values.storage.configStore.connMaxIdleTime }}
+{{- $_ := set $pgConfig "conn_max_idle_time" .Values.storage.configStore.connMaxIdleTime }}
+{{- end }}
 {{- $configStore := dict "enabled" true "type" "postgres" "config" $pgConfig }}
 {{- $_ := set $config "config_store" $configStore }}
 {{- else }}
@@ -888,6 +891,12 @@ false
 {{- end }}
 {{- if .Values.storage.logsStore.matviewRefreshInterval }}
 {{- $_ := set $pgConfig "matview_refresh_interval" .Values.storage.logsStore.matviewRefreshInterval }}
+{{- end }}
+{{- if .Values.storage.logsStore.matviewRefreshTimeout }}
+{{- $_ := set $pgConfig "matview_refresh_timeout" .Values.storage.logsStore.matviewRefreshTimeout }}
+{{- end }}
+{{- if .Values.storage.logsStore.connMaxIdleTime }}
+{{- $_ := set $pgConfig "conn_max_idle_time" .Values.storage.logsStore.connMaxIdleTime }}
 {{- end }}
 {{- $logsStore := dict "enabled" true "type" "postgres" "config" $pgConfig }}
 {{- if .Values.storage.logsStore.writer }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4829,6 +4829,13 @@
           "minimum": 1,
           "maximum": 300
         },
+        "export_timeout": {
+          "type": "integer",
+          "description": "Maximum time in seconds for a single trace export. Bounds how long a slow or unreachable collector can hold an export goroutine; gRPC exports have no other timeout.",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 60
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3992,6 +3992,11 @@
               "type": "integer",
               "minimum": 2
             },
+            "connMaxIdleTime": {
+              "type": "string",
+              "description": "How long an idle physical connection is kept before being closed (default 5m). Without this the idle cap alone controls pool size, so bursts above maxIdleConns close and reopen connections. The config store and logs store open separate pools.",
+              "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+            },
             "vaultStore": {
               "type": "object",
               "description": "Vault store for external secret management",
@@ -4068,10 +4073,20 @@
               "type": "integer",
               "minimum": 2
             },
+            "connMaxIdleTime": {
+              "type": "string",
+              "description": "How long an idle physical connection is kept before being closed (default 5m). Without this the idle cap alone controls pool size, so bursts above maxIdleConns close and reopen connections. The config store and logs store open separate pools.",
+              "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+            },
             "matviewRefreshInterval": {
               "type": "string",
               "description": "How often to refresh materialized views. Go duration string (e.g. '30s', '5m', '1h'). Minimum 5s.",
               "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+            },
+            "matviewRefreshTimeout": {
+              "type": "string",
+              "description": "Maximum time for a single materialized view refresh pass (min 30s, max 30m). Unset derives 5x the refresh interval, at least 5m. A cancelled refresh leaves the existing views intact and readable, just staler; the next tick retries.",
+              "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
             },
             "clickhouse": {
               "type": "object",
@@ -4269,7 +4284,7 @@
             },
             "passwordCommand": {
               "type": "object",
-              "description": "Command executed by Bifrost to produce the PostgreSQL password on stdout for each new physical connection",
+              "description": "Command executed by Bifrost to produce the PostgreSQL password on stdout. The result is cached for cache_ttl and shared across new physical connections",
               "properties": {
                 "command": {
                   "type": "string",
@@ -4284,6 +4299,11 @@
                 },
                 "timeout": {
                   "type": "string",
+                  "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+                },
+                "cache_ttl": {
+                  "type": "string",
+                  "description": "How long a resolved password is reused across new physical connections (default 60s). Keep below the credential's validity window.",
                   "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
                 }
               },

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -615,6 +615,7 @@ bifrost:
         #     collector_url: ""       # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
         #     trace_type: "genai_extension" # genai_extension | vercel | open_inference
         #     protocol: "grpc"        # http | grpc
+        #     export_timeout: 5       # Max seconds for one trace export (1-60); the only timeout on gRPC exports
         #     metrics_enabled: false
         #     metrics_endpoint: ""    # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)
         #     metrics_push_interval: 15 # Push interval in seconds (1-300)
@@ -631,6 +632,10 @@ bifrost:
         collector_url: "" # e.g., http://otel-collector:4318 (HTTP) or otel-collector:4317 (gRPC)
         trace_type: "genai_extension" # genai_extension | vercel | open_inference
         protocol: "grpc" # http | grpc
+        # Max seconds for a single trace export (1-60). This is the only timeout on gRPC
+        # exports: an endpoint that accepts the connection but never replies would
+        # otherwise block an export goroutine indefinitely.
+        export_timeout: 5
         # Push-based metrics export via OTLP (recommended for multi-node clusters)
         metrics_enabled: false
         metrics_endpoint: "" # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1347,6 +1347,7 @@ storage:
     # PostgreSQL connection pool tuning (only applies when type is postgres)
     # maxIdleConns: 5
     # maxOpenConns: 50
+    # connMaxIdleTime: "5m"  # How long an idle connection is kept. Without this the idle cap alone controls pool size, so bursts above maxIdleConns churn physical connections. Note the config store and logs store open separate pools.
 
     # Vault store for external secret management (enterprise).
     # Resolves "vault.<path>" references in config fields at load time.
@@ -1387,7 +1388,9 @@ storage:
     # PostgreSQL connection pool tuning (only applies when type is postgres)
     # maxIdleConns: 5
     # maxOpenConns: 50
+    # connMaxIdleTime: "5m"  # How long an idle connection is kept. Without this the idle cap alone controls pool size, so bursts above maxIdleConns churn physical connections. Note the config store and logs store open separate pools.
     # matviewRefreshInterval: "30s"  # How often to refresh materialized views. Go duration string (e.g. '30s', '5m', '1h'). Minimum 5s.
+    # matviewRefreshTimeout: "5m"  # Max time for one refresh pass (min 30s, max 30m). Unset derives 5x the interval, at least 5m. A cancelled refresh leaves the existing views intact and readable, just staler; the next tick retries.
     # ClickHouse connection settings (only applies when type is clickhouse)
     # clickhouse:
     #   host: "clickhouse.default.svc.cluster.local"  # Required
@@ -1447,6 +1450,9 @@ postgresql:
     password: ""
     # Command executed by Bifrost to produce the PostgreSQL password on stdout.
     # Use for dynamic credentials such as AWS RDS IAM auth tokens.
+    # The result is cached for cache_ttl (default 60s) and shared across new
+    # physical connections, so the command is not re-run for every connection.
+    # Keep cache_ttl below the credential's validity window.
     # passwordCommand:
     #   command: aws
     #   args:
@@ -1461,6 +1467,7 @@ postgresql:
     #     - --username
     #     - bifrost
     #   timeout: 10s
+    #   cache_ttl: 60s
     # connMaxLifetime: 10m
     database: bifrost
     sslMode: disable

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -237,8 +237,20 @@ func (t *UsageTracker) resetWorker(ctx context.Context) {
 	}
 }
 
-// resetExpiredCounters manages periodic resets of usage counters AND budgets using flexible durations
+// resetExpiredCounters manages periodic resets of usage counters AND budgets using flexible durations.
+//
+// This pass is the only thing that advances the persisted last_reset boundary
+// for a budget under steady traffic, because the request-time reset path in
+// BumpBudgetUsage rolls counters over in memory and leaves persistence to the
+// dump below. It also runs on a ticker, and a Go ticker drops ticks when the
+// receiver is slow, so a pass that overruns workerInterval silently stretches
+// the real reset cadence for the whole node. That is otherwise invisible:
+// enforcement keeps working off the in-memory counters while the persisted
+// boundary falls further behind, so the only symptom is a stale last_reset.
+// The overrun warning below exists to make that state say so out loud.
 func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
+	start := time.Now()
+
 	// ==== PART 1: Reset Rate Limits ====
 	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx, true)
 	if err := t.store.ResetExpiredRateLimits(ctx, resetRateLimits); err != nil {
@@ -261,6 +273,13 @@ func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
 
 	// ==== PART 4: Sweep expired billing-idempotency keys ====
 	t.sweepBilled()
+
+	if total := time.Since(start); total > workerInterval {
+		// The next tick is already overdue, so resets are no longer landing at
+		// workerInterval granularity.
+		t.logger.Warn("reset cycle took %s, longer than the %s worker interval (%d rate limits, %d budgets reset): reset cadence has slipped and persisted last_reset will lag the window boundary",
+			total, workerInterval, len(resetRateLimits), len(resetBudgets))
+	}
 }
 
 // tryClaimBilling records that the physical provider call identified by

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -6,7 +6,6 @@ package logging
 import (
 	"context"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -243,6 +242,32 @@ func (p *LoggerPlugin) applyErrorBillingFromBilledUsage(ctx *schemas.BifrostCont
 	}
 }
 
+const (
+	// maxDeferredUsageWatchers caps goroutines parked waiting for trailing usage on
+	// large-payload requests. Generous, because each one is idle on a channel receive;
+	// it exists so a pathological burst cannot grow the goroutine set without limit.
+	maxDeferredUsageWatchers = 2048
+	// deferredUsageRetries / deferredUsageBackoff control how long we wait for the
+	// batch writer to land the row before giving up. Backoff doubles per attempt:
+	// 250ms, 500ms, 1s.
+	deferredUsageRetries   = 3
+	deferredUsageBackoff   = 250 * time.Millisecond
+	deferredUsageDBTimeout = 10 * time.Second
+)
+
+// sleepCtx sleeps for d, returning false if the plugin context is cancelled first.
+// Cleanup waits on p.wg, so an uncancellable sleep here delays shutdown.
+func (p *LoggerPlugin) sleepCtx(d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-p.ctx.Done():
+		return false
+	}
+}
+
 func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, requestID string, usageAlreadyPresent bool) {
 	if usageAlreadyPresent || ctx == nil {
 		return
@@ -252,11 +277,32 @@ func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, 
 	if !ok || deferredChan == nil {
 		return
 	}
+	// Cap the watcher goroutines themselves. deferredUsageSem below only limits how
+	// many updates touch the DB concurrently; the goroutine is created before it is
+	// acquired and then parks on the channel receive, so without this the live
+	// goroutine count tracks in-flight large-payload requests rather than the limit.
+	select {
+	case p.deferredUsageWatchSem <- struct{}{}:
+	default:
+		if n := p.droppedDeferredUsage.Add(1); n == 1 || n%1000 == 0 {
+			p.logger.Warn("deferred usage update dropped for request %s: %d watchers already parked (%d dropped so far)", requestID, maxDeferredUsageWatchers, n)
+		}
+		return
+	}
+
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
+		defer func() { <-p.deferredUsageWatchSem }()
 		// Large-response phase B closes this channel after trailing usage extraction completes.
-		deferredUsage, chanOpen := <-deferredChan
+		var deferredUsage *schemas.BifrostLLMUsage
+		var chanOpen bool
+		select {
+		case deferredUsage, chanOpen = <-deferredChan:
+		case <-p.ctx.Done():
+			// Plugin is shutting down; stop waiting for trailing usage.
+			return
+		}
 		if !chanOpen || deferredUsage == nil {
 			return
 		}
@@ -267,6 +313,7 @@ func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, 
 		case p.deferredUsageSem <- struct{}{}:
 			defer func() { <-p.deferredUsageSem }()
 		default:
+			p.droppedDeferredUsage.Add(1)
 			p.logger.Warn("deferred usage update dropped for request %s: semaphore full", requestID)
 			return
 		}
@@ -281,27 +328,44 @@ func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, 
 			usageUpdates["cached_read_tokens"] = tempEntry.CachedReadTokens
 		}
 
-		// Check if log entry present in the store
-		// exponential backoff with jitter and 3 retries
-		// then fail
+		// Wait for the batch writer to land the row, then patch usage onto it.
+		// This whole loop holds a deferredUsageSem slot, and dropping is immediate
+		// once the slots are full, so the phase is bounded twice over. The backoff is
+		// short: the previous 2s/4s/8s schedule meant a handful of slow lookups
+		// stalled every deferred update for 14s and dropped the rest. And a single
+		// deadline covers all attempts rather than one per attempt, because the ctx
+		// also covers waiting for a pool connection: a per-attempt budget let a slow
+		// store hold a slot for ~30s and drop everything arriving in that window.
+		retryCtx, cancelRetry := context.WithTimeout(p.ctx, deferredUsageDBTimeout)
+		defer cancelRetry()
 		var found bool
-		var findErr error
-		for i := 0; i < 3; i++ {
-			found, findErr = p.store.IsLogEntryPresent(p.ctx, requestID)
+		for attempt := range deferredUsageRetries {
+			presentResult, findErr := p.store.IsLogEntryPresent(retryCtx, requestID)
 			if findErr != nil {
 				p.logger.Warn("failed to check if log entry is present for request %s: %v", requestID, findErr)
-				continue
-			}
-			if found {
+			} else if presentResult {
+				found = true
 				break
 			}
-			time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second * 2)
+			// Budget spent: the remaining attempts would fail instantly, so don't
+			// sleep through backoffs that cannot help.
+			if retryCtx.Err() != nil {
+				break
+			}
+			// Sleep on the error path too, otherwise a DB error burns every retry
+			// in microseconds, exactly when the store needs time to recover.
+			if attempt < deferredUsageRetries-1 && !p.sleepCtx(deferredUsageBackoff<<attempt) {
+				return
+			}
 		}
 		if !found {
-			p.logger.Warn("log entry not found for request %s after 3 retries. failed to update deferred usage for large payload request", requestID)
+			p.logger.Warn("log entry not found for request %s after %d retries. failed to update deferred usage for large payload request", requestID, deferredUsageRetries)
 			return
 		}
-		if updErr := p.store.Update(p.ctx, requestID, usageUpdates); updErr != nil {
+
+		updCtx, cancel := context.WithTimeout(p.ctx, deferredUsageDBTimeout)
+		defer cancel()
+		if updErr := p.store.Update(updCtx, requestID, usageUpdates); updErr != nil {
 			p.logger.Warn("failed to update deferred usage for request %s: %v", requestID, updErr)
 		}
 	}()
@@ -440,6 +504,8 @@ type LoggerPlugin struct {
 	writeQueue                   chan *writeQueueEntry // Buffered channel for batch write queue
 	closed                       atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
 	deferredUsageSem             chan struct{}         // Limits concurrent deferred usage DB updates
+	deferredUsageWatchSem        chan struct{}         // Caps goroutines parked on a deferred-usage channel (see scheduleDeferredUsageUpdate)
+	droppedDeferredUsage         atomic.Int64          // Deferred usage updates dropped because a semaphore was full
 	clusterNodeID                atomic.Value          // Cluster node ID (string) for log attribution in clustered deployments
 	batchCtx                     context.Context       // Cancelled by Cleanup to stop the batchWriter goroutine before any further DB work
 	batchCancel                  context.CancelFunc    // Cancels batchCtx
@@ -489,6 +555,7 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore 
 		writerConfig:                 writerConfig,
 		writeQueue:                   make(chan *writeQueueEntry, writerConfig.WriteQueueCapacity),
 		deferredUsageSem:             make(chan struct{}, writerConfig.DeferredUsageConcurrency),
+		deferredUsageWatchSem:        make(chan struct{}, maxDeferredUsageWatchers),
 		batchCtx:                     batchCtx,
 		batchCancel:                  batchCancel,
 		batchWriterDone:              make(chan struct{}),

--- a/plugins/otel/exportbounds_test.go
+++ b/plugins/otel/exportbounds_test.go
@@ -1,0 +1,258 @@
+package otel
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// blackholeListener accepts TCP connections and then never speaks. This is the shape of a
+// realistic misconfiguration — a wrong port, or an ingress that terminates the connection
+// but routes nowhere — and it is strictly worse than a closed port, which fails fast.
+func blackholeListener(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	var conns atomic.Value
+	conns.Store([]net.Conn{})
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				close(done)
+				return
+			}
+			// Hold the connection open without reading or writing.
+			existing, _ := conns.Load().([]net.Conn)
+			conns.Store(append(existing, c))
+		}
+	}()
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		<-done
+		if held, ok := conns.Load().([]net.Conn); ok {
+			for _, c := range held {
+				_ = c.Close()
+			}
+		}
+	}
+}
+
+func testTarget(t *testing.T, client OtelClient, timeout time.Duration) *otelTarget {
+	t.Helper()
+	return &otelTarget{
+		serviceName:   "test-svc",
+		url:           "test://target",
+		traceType:     TraceTypeGenAIExtension,
+		client:        client,
+		exportTimeout: timeout,
+	}
+}
+
+// TestInject_GRPCExportHonoursTimeout is the regression for the outage. gRPC exports
+// carried no deadline of their own and the caller passes context.Background(), so an
+// endpoint that completed a TCP handshake but never replied blocked the flush goroutine
+// forever — leaking a goroutine and a full trace snapshot per request.
+func TestInject_GRPCExportHonoursTimeout(t *testing.T) {
+	addr, stop := blackholeListener(t)
+	defer stop()
+
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	client, err := NewOtelClientGRPC(addr, nil, "", true)
+	if err != nil {
+		t.Fatalf("NewOtelClientGRPC: %v", err)
+	}
+	defer client.Close()
+
+	const timeout = 400 * time.Millisecond
+	plugin := &OtelPlugin{targets: []*otelTarget{testTarget(t, client, timeout)}}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-grpc-timeout"}) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Inject never returned against a black-holed gRPC endpoint")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Inject took %v against a black-holed endpoint, expected it bounded near %v", elapsed, timeout)
+	}
+}
+
+// TestInject_HTTPExportHonoursTimeout covers the same bound on the HTTP path, which
+// previously relied on a hardcoded 30s client timeout.
+func TestInject_HTTPExportHonoursTimeout(t *testing.T) {
+	addr, stop := blackholeListener(t)
+	defer stop()
+
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	const timeout = 400 * time.Millisecond
+	client, err := NewOtelClientHTTP("http://"+addr, nil, "", true, timeout)
+	if err != nil {
+		t.Fatalf("NewOtelClientHTTP: %v", err)
+	}
+	defer client.Close()
+
+	plugin := &OtelPlugin{targets: []*otelTarget{testTarget(t, client, timeout)}}
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-http-timeout"}) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Inject never returned against a black-holed HTTP endpoint")
+	}
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Inject took %v against a black-holed endpoint, expected it bounded near %v", elapsed, timeout)
+	}
+}
+
+// failingClient always errors, standing in for a permanently misconfigured collector.
+type failingClient struct{ calls atomic.Int64 }
+
+func (c *failingClient) Emit(_ context.Context, _ []*ResourceSpan) error {
+	c.calls.Add(1)
+	return errors.New("collector unreachable")
+}
+func (c *failingClient) Close() error { return nil }
+
+// TestInject_CircuitBreakerStopsDialling verifies that a permanently bad endpoint stops
+// costing an export attempt per request. Without the breaker, every request pays the full
+// export timeout for as long as the misconfiguration lasts.
+func TestInject_CircuitBreakerStopsDialling(t *testing.T) {
+	logger = bifrost.NewDefaultLogger(schemas.LogLevelError)
+
+	client := &failingClient{}
+	target := testTarget(t, client, time.Second)
+	plugin := &OtelPlugin{targets: []*otelTarget{target}}
+
+	// Drive well past the threshold.
+	const attempts = breakerFailureThreshold + 50
+	for i := range attempts {
+		if err := plugin.Inject(context.Background(), &schemas.Trace{TraceID: "trace-breaker"}); err != nil {
+			t.Fatalf("Inject returned an error on attempt %d: %v", i, err)
+		}
+	}
+
+	if calls := client.calls.Load(); calls > breakerFailureThreshold {
+		t.Fatalf("breaker did not open: %d export attempts for %d injects (threshold %d)", calls, attempts, breakerFailureThreshold)
+	}
+	if suppressed := target.suppressedExports.Load(); suppressed == 0 {
+		t.Fatal("expected suppressed exports once the breaker opened, got 0")
+	}
+}
+
+// TestBreakerRecoversAfterCooldown verifies the breaker lets a probe through once the
+// cooldown elapses, so a collector that comes back is picked up again.
+func TestBreakerRecoversAfterCooldown(t *testing.T) {
+	target := &otelTarget{url: "test://recover"}
+
+	for range breakerFailureThreshold {
+		target.tripBreaker()
+	}
+	if !target.breakerOpen() {
+		t.Fatal("breaker should be open after reaching the failure threshold")
+	}
+
+	// Expire the cooldown.
+	target.breakerOpenUntil.Store(time.Now().Add(-time.Millisecond).UnixNano())
+	if target.breakerOpen() {
+		t.Fatal("breaker should allow a probe once the cooldown has elapsed")
+	}
+
+	target.resetBreaker()
+	if target.breakerOpen() {
+		t.Fatal("breaker should stay closed after a successful export")
+	}
+	if got := target.consecutiveFailures.Load(); got != 0 {
+		t.Fatalf("consecutiveFailures = %d after reset, want 0", got)
+	}
+}
+
+// TestBreakerAllowsSingleProbeUnderConcurrency locks in the half-open guarantee. A batch of
+// traces flushing at the instant the cooldown expires races on the same transition, and only
+// one of them may dial a collector that is probably still dead. If every racer got through,
+// each would block for a full exportTimeout, which is the cost the breaker exists to avoid.
+func TestBreakerAllowsSingleProbeUnderConcurrency(t *testing.T) {
+	target := &otelTarget{url: "test://concurrent-probe"}
+
+	for range breakerFailureThreshold {
+		target.tripBreaker()
+	}
+	// Expire the cooldown so every goroutine below sees the breaker as probe-ready.
+	target.breakerOpenUntil.Store(time.Now().Add(-time.Millisecond).UnixNano())
+
+	const callers = 64
+	var allowed atomic.Int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	for range callers {
+		go func() {
+			defer wg.Done()
+			<-start
+			if !target.breakerOpen() {
+				allowed.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := allowed.Load(); got != 1 {
+		t.Fatalf("breaker allowed %d probes through, want exactly 1", got)
+	}
+	if got := target.suppressedExports.Load(); got != callers-1 {
+		t.Fatalf("suppressedExports = %d, want %d", got, callers-1)
+	}
+}
+
+func TestResolveExportTimeout(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "unset uses default", seconds: 0, want: DefaultExportTimeout},
+		{name: "explicit value", seconds: 12, want: 12 * time.Second},
+		{name: "at max", seconds: int(MaxExportTimeout / time.Second), want: MaxExportTimeout},
+		{name: "negative rejected", seconds: -1, wantErr: true},
+		{name: "above max rejected", seconds: int(MaxExportTimeout/time.Second) + 1, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveExportTimeout(tc.seconds)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for %d seconds", tc.seconds)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveExportTimeout(%d) = %v, want %v", tc.seconds, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/otel/http.go
+++ b/plugins/otel/http.go
@@ -20,8 +20,10 @@ type OtelClientHTTP struct {
 	headers  map[string]string
 }
 
-// NewOtelClientHTTP creates a new OpenTelemetry client for HTTP
-func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool) (*OtelClientHTTP, error) {
+// NewOtelClientHTTP creates a new OpenTelemetry client for HTTP.
+// timeout bounds a single export; it comes from the profile's export_timeout and is
+// also applied as a per-export context deadline by the caller.
+func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert string, insecureMode bool, timeout time.Duration) (*OtelClientHTTP, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = 100
 	transport.MaxIdleConnsPerHost = 10
@@ -34,7 +36,7 @@ func NewOtelClientHTTP(endpoint string, headers map[string]string, tlsCACert str
 	transport.TLSClientConfig = tlsConfig
 
 	return &OtelClientHTTP{client: &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   timeout,
 		Transport: transport,
 	}, endpoint: endpoint, headers: headers}, nil
 }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -40,6 +42,25 @@ type Protocol string
 const (
 	ProtocolHTTP Protocol = "http" // default
 	ProtocolGRPC Protocol = "grpc"
+)
+
+const (
+	// DefaultExportTimeout bounds a single trace export when export_timeout is unset.
+	// Kept short deliberately: traces are best-effort telemetry, and a slow export
+	// holds a goroutine plus a full trace snapshot for its whole duration.
+	DefaultExportTimeout = 5 * time.Second
+	// MaxExportTimeout caps what an operator may configure.
+	MaxExportTimeout = 60 * time.Second
+
+	// breakerFailureThreshold is how many consecutive export failures open the circuit.
+	breakerFailureThreshold = 5
+	// breakerCooldown is how long exports stay suppressed once the circuit is open.
+	breakerCooldown = 30 * time.Second
+
+	// exportLogThrottle limits how often repeated export failures are logged. A failing
+	// collector fails once per request; logging each one makes the logging itself a load
+	// source on top of the outage.
+	exportLogThrottle = 500
 )
 
 // PluginSpanFilter, its mode type, and the include/exclude constants are shared across
@@ -73,6 +94,12 @@ type Profile struct {
 	Protocol     Protocol           `json:"protocol"`
 	TLSCACert    string             `json:"tls_ca_cert,omitempty"`
 	Insecure     bool               `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+
+	// ExportTimeout bounds a single trace export, in seconds (default 5, max 60).
+	// This is the only deadline on the export: the caller passes context.Background(),
+	// and a gRPC export otherwise has no timeout at all, so an endpoint that completes
+	// a TCP handshake but never replies would block forever.
+	ExportTimeout int `json:"export_timeout,omitempty"`
 
 	// Metrics push configuration
 	MetricsEnabled      bool               `json:"metrics_enabled"`
@@ -218,6 +245,7 @@ type profileForStorage struct {
 	Protocol               Protocol          `json:"protocol"`
 	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
 	Insecure               bool              `json:"insecure"`
+	ExportTimeout          int               `json:"export_timeout,omitempty"`
 	MetricsEnabled         bool              `json:"metrics_enabled"`
 	MetricsEndpoint        string            `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval    int               `json:"metrics_push_interval,omitempty"`
@@ -255,6 +283,7 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			Protocol:               p.Protocol,
 			TLSCACert:              p.TLSCACert,
 			Insecure:               p.Insecure,
+			ExportTimeout:          p.ExportTimeout,
 			MetricsEnabled:         p.MetricsEnabled,
 			MetricsEndpoint:        schemas.SecretVarAsString(p.MetricsEndpoint),
 			MetricsPushInterval:    p.MetricsPushInterval,
@@ -334,6 +363,54 @@ type otelTarget struct {
 	disableContentLogging  bool
 	groupTracesBySession   bool
 	disableRootSpanContent bool
+
+	// exportTimeout bounds a single Emit. See Profile.ExportTimeout.
+	exportTimeout time.Duration
+
+	// Circuit breaker. A misconfigured endpoint fails identically for every trace, so
+	// after breakerFailureThreshold consecutive failures the target stops dialling until
+	// breakerCooldown has elapsed. Without this, a permanently wrong endpoint costs a
+	// full exportTimeout on every single request forever.
+	consecutiveFailures atomic.Int64
+	breakerOpenUntil    atomic.Int64 // UnixNano; exports are skipped until this instant
+	suppressedExports   atomic.Int64
+	failedExports       atomic.Int64
+}
+
+// tripBreaker records a failed export and opens the circuit once the failure threshold
+// is reached.
+func (t *otelTarget) tripBreaker() {
+	t.failedExports.Add(1)
+	if t.consecutiveFailures.Add(1) >= breakerFailureThreshold {
+		t.breakerOpenUntil.Store(time.Now().Add(breakerCooldown).UnixNano())
+	}
+}
+
+// resetBreaker records a successful export, closing the circuit.
+func (t *otelTarget) resetBreaker() {
+	t.consecutiveFailures.Store(0)
+	t.breakerOpenUntil.Store(0)
+}
+
+// breakerOpen reports whether exports to this target are currently suppressed.
+// Exactly one probe is allowed through once the cooldown expires: the goroutine that
+// wins the CAS pushes the window forward by another cooldown and dials for real, so
+// concurrent callers and anyone arriving while that probe is in flight stay suppressed.
+// The probe then resets the breaker on success or re-arms it on failure; if it somehow
+// does neither, the pushed-forward window expires on its own and the next caller probes.
+func (t *otelTarget) breakerOpen() bool {
+	openUntil := t.breakerOpenUntil.Load()
+	if openUntil == 0 {
+		return false
+	}
+	if time.Now().UnixNano() >= openUntil {
+		next := time.Now().Add(breakerCooldown).UnixNano()
+		if t.breakerOpenUntil.CompareAndSwap(openUntil, next) {
+			return false
+		}
+	}
+	t.suppressedExports.Add(1)
+	return true
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -449,6 +526,11 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		return nil, fmt.Errorf("profile %d: %w", index, err)
 	}
 
+	exportTimeout, err := resolveExportTimeout(profile.ExportTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("profile %d: %w", index, err)
+	}
+
 	url := profile.CollectorURL.GetValue()
 	target := &otelTarget{
 		serviceName:            serviceName,
@@ -458,14 +540,16 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		disableContentLogging:  profile.DisableContentLogging,
 		groupTracesBySession:   profile.GroupTracesBySession,
 		disableRootSpanContent: profile.DisableRootSpanContent,
+		exportTimeout:          exportTimeout,
 	}
 
-	var err error
 	switch profile.Protocol {
 	case ProtocolGRPC:
+		// gRPC has no client-side timeout of its own; the per-export context deadline
+		// applied in Inject is what bounds it.
 		target.client, err = NewOtelClientGRPC(url, headers, profile.TLSCACert, profile.Insecure)
 	case ProtocolHTTP:
-		target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure)
+		target.client, err = NewOtelClientHTTP(url, headers, profile.TLSCACert, profile.Insecure, exportTimeout)
 	default:
 		return nil, fmt.Errorf("profile %d: invalid protocol type %q", index, profile.Protocol)
 	}
@@ -507,6 +591,18 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	}
 
 	return target, nil
+}
+
+// resolveExportTimeout validates a configured export_timeout (in seconds) and returns
+// the duration to use, falling back to DefaultExportTimeout when unset.
+func resolveExportTimeout(seconds int) (time.Duration, error) {
+	if seconds == 0 {
+		return DefaultExportTimeout, nil
+	}
+	if seconds < 0 || time.Duration(seconds)*time.Second > MaxExportTimeout {
+		return 0, fmt.Errorf("export_timeout must be between 1 and %d seconds, got %d", int(MaxExportTimeout/time.Second), seconds)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 // GetName function for the OTEL plugin
@@ -668,20 +764,46 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		wg.Add(1)
 		go func(t *otelTarget) {
 			defer wg.Done()
-			if t.client != nil {
-				resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent)
-				if err := t.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-					logger.Error("failed to emit trace %s to %s: %v", trace.TraceID, t.url, err)
-				}
-			}
+			// Metrics first: they are SDK-buffered and never touch the network here, so
+			// they still get recorded even when the trace endpoint is broken.
 			if t.metricsExporter != nil {
 				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
 				p.recordMCPMetricsFromTrace(ctx, t.metricsExporter, trace)
 			}
+			if t.client == nil || t.breakerOpen() {
+				return
+			}
+			resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent)
+			// The caller passes context.Background(), so this deadline is the only bound
+			// on the export — and the only bound at all on the gRPC path.
+			emitCtx, cancel := context.WithTimeout(ctx, t.exportTimeout)
+			defer cancel()
+			if err := t.client.Emit(emitCtx, []*ResourceSpan{resourceSpan}); err != nil {
+				t.tripBreaker()
+				if n := t.failedExports.Load(); n == 1 || n%exportLogThrottle == 0 {
+					logger.Error("failed to emit trace %s to %s: %v (%d failed exports so far)", trace.TraceID, t.url, err, n)
+				}
+				return
+			}
+			t.resetBreaker()
 		}(t)
 	}
 	wg.Wait()
 	return nil
+}
+
+// ExportStats reports per-target export health: how many exports failed and how many
+// were suppressed by an open circuit breaker. A rising suppressed count means the
+// target's endpoint is being treated as dead — usually a misconfigured collector URL.
+func (p *OtelPlugin) ExportStats() map[string]struct{ Failed, Suppressed int64 } {
+	stats := make(map[string]struct{ Failed, Suppressed int64 }, len(p.targets))
+	for _, t := range p.targets {
+		stats[t.url] = struct{ Failed, Suppressed int64 }{
+			Failed:     t.failedExports.Load(),
+			Suppressed: t.suppressedExports.Load(),
+		}
+	}
+	return stats
 }
 
 // RequestHeaderPatterns returns the deduplicated union of request-header name patterns

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -746,6 +746,7 @@ func (h *GovernanceHandler) reconcileVKModelConfig(ctx context.Context, tx *gorm
 		}
 	}
 
+
 	// Resulting budget count: the desired set if provided, else the existing set.
 	finalBudgetCount := len(mc.Budgets)
 	if d.budgetsProvided {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3115,6 +3115,13 @@
           "description": "Protocol to use for the OTEL collector",
           "enum": ["http", "grpc"]
         },
+        "export_timeout": {
+          "type": "integer",
+          "description": "Maximum time in seconds for a single trace export. Bounds how long a slow or unreachable collector can hold an export goroutine; gRPC exports have no other timeout.",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 60
+        },
         "metrics_enabled": {
           "type": "boolean",
           "description": "Enable push-based metrics export via OTLP. Recommended for multi-node cluster deployments.",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1633,6 +1633,12 @@
                         "description": "Command timeout as a Go duration string (default: 10s)",
                         "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
                         "default": "10s"
+                      },
+                      "cache_ttl": {
+                        "type": "string",
+                        "description": "How long a resolved password is reused across new physical connections (Go duration string, default 60s). Without caching the command runs on every new connection. Keep this below the credential's validity window: a rotation shorter than the TTL will fail connections until the cached value expires.",
+                        "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
+                        "default": "60s"
                       }
                     },
                     "required": ["command"],
@@ -1662,6 +1668,12 @@
                     "type": "string",
                     "description": "Maximum lifetime for physical database connections as a Go duration string",
                     "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+                  },
+                  "conn_max_idle_time": {
+                    "type": "string",
+                    "description": "How long an idle physical connection is kept before being closed (Go duration string, default 5m). Without this the idle cap alone controls pool size, so bursts above max_idle_conns close and reopen connections repeatedly. Note the logs store and config store open separate pools, so a pod's connection ceiling is the sum of their max_open_conns.",
+                    "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
+                    "default": "5m"
                   }
                 },
                 "required": [
@@ -1831,6 +1843,12 @@
                         "description": "Command timeout as a Go duration string (default: 10s)",
                         "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
                         "default": "10s"
+                      },
+                      "cache_ttl": {
+                        "type": "string",
+                        "description": "How long a resolved password is reused across new physical connections (Go duration string, default 60s). Without caching the command runs on every new connection. Keep this below the credential's validity window: a rotation shorter than the TTL will fail connections until the cached value expires.",
+                        "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
+                        "default": "60s"
                       }
                     },
                     "required": ["command"],
@@ -1862,10 +1880,21 @@
                     "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
                     "default": "1m"
                   },
+                  "matview_refresh_timeout": {
+                    "type": "string",
+                    "description": "Maximum time for a single materialized view refresh pass. Go duration string, min 30s, max 30m. Unset derives a budget from matview_refresh_interval (5x the interval, at least 5m). A refresh holds a pooled connection and a session advisory lock across every view, so without a bound one stuck refresh leaves the views permanently stale across all replicas.",
+                    "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+                  },
                   "conn_max_lifetime": {
                     "type": "string",
                     "description": "Maximum lifetime for physical database connections as a Go duration string",
                     "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$"
+                  },
+                  "conn_max_idle_time": {
+                    "type": "string",
+                    "description": "How long an idle physical connection is kept before being closed (Go duration string, default 5m). Without this the idle cap alone controls pool size, so bursts above max_idle_conns close and reopen connections repeatedly. Note the logs store and config store open separate pools, so a pod's connection ceiling is the sum of their max_open_conns.",
+                    "pattern": "^[1-9][0-9]*(ns|us|µs|ms|s|m|h)$",
+                    "default": "5m"
                   }
                 },
                 "required": [

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -34,6 +34,7 @@ interface StoredOtelProfile {
 	metrics_enabled?: boolean;
 	metrics_endpoint?: string | SecretVar;
 	metrics_push_interval?: number;
+	export_timeout?: number;
 	request_headers?: string[];
 	disable_content_logging?: boolean;
 	group_traces_by_session?: boolean;
@@ -98,6 +99,7 @@ const emptyProfile = (): ProfileForm => ({
 	metrics_enabled: false,
 	metrics_endpoint: emptySecretVar(),
 	metrics_push_interval: 15,
+	export_timeout: 5,
 	request_headers: [],
 	disable_content_logging: false,
 	group_traces_by_session: false,
@@ -117,6 +119,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	metrics_enabled: p?.metrics_enabled ?? false,
 	metrics_endpoint: toSecretVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
+	export_timeout: p?.export_timeout ?? 5,
 	request_headers: p?.request_headers ?? [],
 	disable_content_logging: p?.disable_content_logging ?? false,
 	group_traces_by_session: p?.group_traces_by_session ?? false,
@@ -586,6 +589,32 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 							)}
 						/>
 					</div>
+
+					<FormField
+						control={control}
+						name={`${base}.export_timeout`}
+						render={({ field }) => (
+							<FormItem className="w-full max-w-xs">
+								<FormLabel>Export Timeout (seconds)</FormLabel>
+								<FormControl>
+									<Input
+										type="number"
+										min={1}
+										max={60}
+										disabled={!hasOtelAccess}
+										{...field}
+										value={field.value ?? ""}
+										onChange={(e) => field.onChange(e.target.value === "" ? null : Number(e.target.value))}
+									/>
+								</FormControl>
+								<FormDescription>
+									Maximum time for a single trace export (1-60 seconds). Traces are dropped rather than retried past this
+									limit, so an unreachable collector cannot slow down request handling.
+								</FormDescription>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
 
 					{/* TLS Configuration */}
 					<div className="flex flex-col gap-4">

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -874,6 +874,10 @@ export const otelConfigSchema = z
 		// TLS configuration
 		tls_ca_cert: z.string().optional(),
 		insecure: z.boolean().default(true),
+		// Bounds a single trace export. gRPC exports have no other timeout, so an
+		// endpoint that accepts the connection but never replies would otherwise block
+		// an export goroutine indefinitely.
+		export_timeout: z.number().int().min(1).max(60).default(5),
 		// Metrics push configuration
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: secretVarSchema.optional(),


### PR DESCRIPTION
## Summary

This PR addresses several operational reliability issues around Postgres connection pool management, materialized view refresh correctness, ClickHouse batch insert lock contention, and observability gaps in governance and logging paths.

## Changes

- **Connection pool tuning**: Added `conn_max_idle_time` (default 5m) to both the logs store and config store pools. Without it, the idle cap is the only pool-size control, so any burst above `MaxIdleConns` closes and reopens physical connections on every query. Migration pools are now explicitly pinned to 2 open / 1 idle connection rather than inheriting `database/sql`'s unlimited default.

- **Password command caching**: Introduced a `passwordCache` with a configurable `cache_ttl` (default 60s) that collapses concurrent resolutions via `singleflight`. Previously `BeforeConnect` ran the password command on every new physical connection, causing a subprocess fork per connection under pool churn. Failures are never cached so a transient error does not persist for the whole TTL.

- **Materialized view refresh timeout**: Added a per-tick `matview_refresh_timeout` (derived as 5× the refresh interval, floored at 5m, capped at 30m). A refresh holds a pooled connection and a session-scoped advisory lock across every view; without a deadline one stuck refresh leaves views permanently stale on all replicas. The advisory lock unlock now runs on a `context.WithoutCancel` context so a deadline-exceeded refresh still releases the lock. If the unlock cannot be confirmed, the pooled connection is discarded so Postgres reclaims the lock.

- **Materialized view refresh rotation**: Filter views now start at a rotating offset each tick. If a pass is consistently cut short by its deadline, a fixed order would starve the tail views permanently. `mv_logs_hourly` remains pinned first since dashboards depend on it.

- **ClickHouse batch insert chunking**: `BatchCreateIfNotExists` and `BatchCreateMCPToolLogsIfNotExists` now process entries in chunks of 128 (`chRMWBatchChunk`). An unchunked batch of 1000 rows against 128 shards effectively acquires every shard lock, serialising all concurrent updates. Chunking keeps the held-shard set small enough for concurrent writers to interleave.

- **`RetryOnNotFound` logging**: Each retry attempt, success after retry, and exhaustion are now logged at Warn. Without these lines, a slow request on an interactive path looks like slow work rather than waiting on a not-found retry loop.

- **`ApplyPoolTuning` logging**: When a logger is supplied, the effective pool shape (max open, max idle, idle time, lifetime) is logged once at startup so operators can size against the server's `max_connections` without reading source.

- **`StageTimer` utility**: Added a `StageTimer` type in the governance package that accumulates named stage durations for a single pass and emits them as one log line, logging at Info when the total exceeds a threshold and at Debug otherwise.

- **Governance reset cycle timing**: `resetExpiredCounters` now wraps every phase with `StageTimer` marks and warns explicitly when the total exceeds `workerInterval`, since a Go ticker drops ticks silently when the receiver is slow.

- **Virtual key save and reload timing**: `updateVirtualKey` and `ReloadVirtualKey` now emit per-stage timing summaries via `StageTimer`. The lock-wait stage in the transaction is marked separately from the work stages since time there is contention, not computation.

- **Deferred usage watcher cap**: Added `deferredUsageWatchSem` (cap 2048) to bound goroutines parked waiting for trailing usage on large-payload requests. Previously only the DB-update concurrency was limited; the watcher goroutines themselves were unbounded. The retry backoff was also reduced from 2s/4s/8s to 250ms/500ms/1s, and each DB call now carries a 10s context timeout.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/postgresconn/...
go test ./framework/logstore/...
go test ./framework/configstore/...
go test ./plugins/governance/...
go test ./plugins/logging/...
```

New configuration fields:

| Field | Location | Default | Description |
|---|---|---|---|
| `conn_max_idle_time` | logs store / config store | `5m` | How long an idle physical connection is kept before being closed |
| `password_command.cache_ttl` | postgres connection | `60s` | How long a resolved password is reused across new physical connections |
| `matview_refresh_timeout` | logs store | 5× interval, min 5m | Maximum time for a single materialized view refresh pass |

## Breaking changes

- [x] No

`ApplyPoolTuning` now accepts a variadic logger argument; all existing call sites compile unchanged. The password command now caches results by default — operators relying on per-connection re-execution (e.g. credentials with a validity window shorter than 60s) should set `cache_ttl` explicitly to a value below their rotation period.

## Security considerations

The password command cache stores a resolved credential in memory for up to `cache_ttl`. Operators using short-lived credentials (e.g. AWS RDS IAM tokens valid for 15 minutes) should verify their `cache_ttl` is set below the credential's validity window to avoid connection failures after rotation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable