### PR TITLE
feat: replace full `VirtualKeys` preload with `virtual_key_count` on paginated customer list

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -81961,10 +81961,18 @@
             }
           },
           "virtual_keys": {
-            "type": "array",
+            "type": [
+              "array",
+              "null"
+            ],
+            "description": "Virtual keys owned by this customer. Omitted or returned as null by the paginated list endpoint (`GET /api/governance/customers` with `limit`/`offset`/`search`), which reports `virtual_key_count` instead; use the single-customer endpoint to retrieve the keys themselves.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
             }
+          },
+          "virtual_key_count": {
+            "type": "integer",
+            "description": "Number of virtual keys owned by this customer. Always populated."
           },
           "config_hash": {
             "type": "string"

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -706,9 +706,17 @@ Customer:
       items:
         $ref: '#/Team'
     virtual_keys:
-      type: array
+      type: [array, 'null']
+      description: >
+        Virtual keys owned by this customer. Omitted or returned as null by the paginated
+        list endpoint (`GET /api/governance/customers` with `limit`/`offset`/`search`),
+        which reports `virtual_key_count` instead; use the single-customer endpoint to
+        retrieve the keys themselves.
       items:
         $ref: '#/VirtualKey'
+    virtual_key_count:
+      type: integer
+      description: Number of virtual keys owned by this customer. Always populated.
     config_hash:
       type: string
     created_at:

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3069,12 +3069,60 @@ func preloadCustomerRelations(db *gorm.DB, prefix string) *gorm.DB {
 		}
 		return prefix + name
 	}
+	return preloadCustomerRelationsWithoutVirtualKeys(db, prefix).
+		Preload(relation("VirtualKeys"))
+}
+
+// preloadCustomerRelationsWithoutVirtualKeys preloads every customer relation
+// except VirtualKeys. The paginated list path uses this and reports
+// VirtualKeyCount instead, so a customer with thousands of keys doesn't drag
+// them all into a page of 25 rows.
+func preloadCustomerRelationsWithoutVirtualKeys(db *gorm.DB, prefix string) *gorm.DB {
+	relation := func(name string) string {
+		if prefix == "" {
+			return name
+		}
+		return prefix + name
+	}
 	return db.
 		Preload(relation("Teams")).
 		Preload(relation("Teams.Budgets")).
 		Preload(relation("Budgets")).
-		Preload(relation("RateLimit")).
-		Preload(relation("VirtualKeys"))
+		Preload(relation("RateLimit"))
+}
+
+// attachCustomerVirtualKeyCounts populates VirtualKeyCount on each customer
+// using a single grouped count, avoiding an N+1 over the customers in a page.
+// The customers passed in have already been narrowed by any QueryScope on ctx,
+// so counting their keys unscoped exposes nothing the caller can't already see.
+func (s *RDBConfigStore) attachCustomerVirtualKeyCounts(ctx context.Context, customers []tables.TableCustomer) error {
+	if len(customers) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(customers))
+	for i := range customers {
+		ids = append(ids, customers[i].ID)
+	}
+	var rows []struct {
+		CustomerID string
+		Count      int
+	}
+	if err := s.DB().WithContext(ctx).
+		Model(&tables.TableVirtualKey{}).
+		Select("customer_id, COUNT(*) AS count").
+		Where("customer_id IN ?", ids).
+		Group("customer_id").
+		Scan(&rows).Error; err != nil {
+		return err
+	}
+	countByCustomer := make(map[string]int, len(rows))
+	for _, row := range rows {
+		countByCustomer[row.CustomerID] = row.Count
+	}
+	for i := range customers {
+		customers[i].VirtualKeyCount = countByCustomer[customers[i].ID]
+	}
+	return nil
 }
 
 // preloadVirtualKeyBaseRelations preloads the base relationships for a virtual key.
@@ -4134,6 +4182,9 @@ func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustom
 		Find(&customers).Error; err != nil {
 		return nil, err
 	}
+	for i := range customers {
+		customers[i].VirtualKeyCount = len(customers[i].VirtualKeys)
+	}
 	return customers, nil
 }
 
@@ -4163,10 +4214,13 @@ func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params Custo
 		offset = 0
 	}
 	var customers []tables.TableCustomer
-	if err := preloadCustomerRelations(baseQuery, "").
+	if err := preloadCustomerRelationsWithoutVirtualKeys(baseQuery, "").
 		Order("created_at ASC, id ASC").
 		Offset(offset).Limit(limit).
 		Find(&customers).Error; err != nil {
+		return nil, 0, err
+	}
+	if err := s.attachCustomerVirtualKeyCounts(ctx, customers); err != nil {
 		return nil, 0, err
 	}
 	return customers, totalCount, nil
@@ -4187,6 +4241,7 @@ func (s *RDBConfigStore) GetCustomer(ctx context.Context, id string) (*tables.Ta
 		}
 		return nil, err
 	}
+	customer.VirtualKeyCount = len(customer.VirtualKeys)
 	return &customer, nil
 }
 

--- a/framework/configstore/tables/customer.go
+++ b/framework/configstore/tables/customer.go
@@ -21,6 +21,11 @@ type TableCustomer struct {
 	Teams       []TableTeam       `gorm:"foreignKey:CustomerID" json:"teams"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:CustomerID" json:"virtual_keys"`
 
+	// VirtualKeyCount is the number of virtual keys owned by this customer. Not
+	// persisted; populated by the read paths so list responses can report the
+	// count without carrying (or even loading) the full VirtualKeys relation.
+	VirtualKeyCount int `gorm:"-" json:"virtual_key_count"`
+
 	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
 
 	// Config hash is used to detect the changes synced from config.json file

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -1,3 +1,4 @@
+import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CodeEditor } from "@/components/ui/codeEditor";
@@ -14,7 +15,6 @@ import {
 	getErrorMessage,
 	useCreatePricingOverrideMutation,
 	useGetProvidersQuery,
-	useGetVirtualKeysQuery,
 	useUpdatePricingOverrideMutation,
 } from "@/lib/store";
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
@@ -538,7 +538,6 @@ function isCompleteScopeLock(scopeLock?: PricingOverrideDrawerProps["scopeLock"]
 
 export default function PricingOverrideSheet({ open, onOpenChange, editingOverride, scopeLock, onSaved }: PricingOverrideDrawerProps) {
 	const { data: providersData, isLoading: isProvidersLoading, error: providersError } = useGetProvidersQuery();
-	const { data: virtualKeysData, isLoading: isVirtualKeysLoading, error: virtualKeysError } = useGetVirtualKeysQuery();
 	const { data: allKeysData = [] } = useGetAllKeysQuery();
 	const [createOverride, { isLoading: isCreating }] = useCreatePricingOverrideMutation();
 	const [updateOverride, { isLoading: isPatching }] = useUpdatePricingOverrideMutation();
@@ -554,7 +553,6 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 
 	const isSaving = isCreating || isPatching;
 	const providers = useMemo<ModelProvider[]>(() => (providersError ? [] : (providersData ?? [])), [providersData, providersError]);
-	const virtualKeys = useMemo(() => (virtualKeysError ? [] : (virtualKeysData?.virtual_keys ?? [])), [virtualKeysData, virtualKeysError]);
 
 	const scopeRoot = watch("scopeRoot");
 	const providerID = watch("providerID");
@@ -969,29 +967,23 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 															Virtual key <span className="text-red-500">*</span>
 														</FormLabel>
 														<FormControl>
-															<ComboboxSelect
-																data-testid="pricing-override-virtual-key-select"
-																options={virtualKeys.map((vk) => ({ label: vk.name, value: vk.id }))}
-																value={field.value || null}
-																onValueChange={(value) => {
-																	field.onChange(value ?? "");
+															<VirtualKeySelector
+																value={field.value}
+																onChange={(value) => {
+																	field.onChange(value);
 																	setValue("providerID", "");
 																	setValue("providerKeyID", "");
 																	clearErrors("virtualKeyID");
 																}}
-																placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"}
-																disabled={isVirtualKeysLoading || !!virtualKeysError}
-																noPortal
-																className="h-9"
+																fallbackOption={
+																	editingOverride?.virtual_key_id
+																		? { value: editingOverride.virtual_key_id, label: editingOverride.virtual_key_id }
+																		: null
+																}
+																placeholder="Select virtual key"
 															/>
 														</FormControl>
-														{virtualKeysError ? (
-															<p className="text-destructive mt-1 text-xs">
-																Failed to load virtual keys: {getErrorMessage(virtualKeysError)}
-															</p>
-														) : (
-															<FormMessage />
-														)}
+														<FormMessage />
 													</FormItem>
 												)}
 											/>

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -1,3 +1,4 @@
+import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -17,13 +18,7 @@ import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
-import {
-	getErrorMessage,
-	useDeletePricingOverrideMutation,
-	useGetPricingOverridesQuery,
-	useGetProvidersQuery,
-	useGetVirtualKeysQuery,
-} from "@/lib/store";
+import { getErrorMessage, useDeletePricingOverrideMutation, useGetPricingOverridesQuery, useGetProvidersQuery } from "@/lib/store";
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { PricingOverride, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { useLocation } from "@tanstack/react-router";
@@ -108,7 +103,7 @@ function parseScopeKind(value: string | null): ScopeFilter {
 }
 
 // Returns the top-level scope label: "Global", "Virtual Key", or "User".
-function scopeLabel(override: PricingOverride, _virtualKeyMap: Map<string, string>): string {
+function scopeLabel(override: PricingOverride): string {
 	const scopeKind = resolveScopeKind(override);
 	if (override.virtual_key_id && scopeKind.startsWith("virtual_key")) {
 		return "Virtual Key";
@@ -228,7 +223,6 @@ export default function ScopedPricingOverridesView() {
 		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
 	}, [totalCount, offset]);
 	const { data: providersData } = useGetProvidersQuery();
-	const { data: virtualKeysData } = useGetVirtualKeysQuery();
 	const { data: allKeysData = [] } = useGetAllKeysQuery();
 	const [deleteOverride, { isLoading: isDeleting }] = useDeletePricingOverrideMutation();
 
@@ -244,7 +238,6 @@ export default function ScopedPricingOverridesView() {
 
 	const rows = data?.pricing_overrides ?? [];
 	const providers = useMemo(() => providersData ?? [], [providersData]);
-	const virtualKeys = useMemo(() => virtualKeysData?.virtual_keys ?? [], [virtualKeysData]);
 
 	const providerMap = useMemo(() => new Map<string, string>(providers.map((provider) => [provider.name, provider.name])), [providers]);
 	const providerKeyOptions = useMemo(
@@ -264,7 +257,6 @@ export default function ScopedPricingOverridesView() {
 		() => new Map<string, string>(providerKeyOptions.map((key) => [key.id, key.label])),
 		[providerKeyOptions],
 	);
-	const virtualKeyMap = useMemo(() => new Map<string, string>(virtualKeys.map((vk) => [vk.id, vk.name])), [virtualKeys]);
 
 	const createScopeLock = useMemo(() => {
 		if (scopeKind === "all") return undefined;
@@ -330,17 +322,42 @@ export default function ScopedPricingOverridesView() {
 				</Button>
 			</div>
 
-			{/* Search */}
-			<div className="relative mb-4 max-w-sm">
-				<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-				<Input
-					aria-label="Search pricing overrides by name"
-					placeholder="Search by name..."
-					value={search}
-					onChange={(e) => setSearch(e.target.value)}
-					className="pl-9"
-					data-testid="pricing-overrides-search-input"
-				/>
+			{/* Search and filters */}
+			<div className="mb-4 flex flex-wrap items-center gap-2">
+				<div className="relative w-full max-w-sm">
+					<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+					<Input
+						aria-label="Search pricing overrides by name"
+						placeholder="Search by name..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="pl-9"
+						data-testid="pricing-overrides-search-input"
+					/>
+				</div>
+
+				<div className="w-56" data-testid="pricing-overrides-virtual-key-filter">
+					<VirtualKeySelector
+						value={virtualKeyID}
+						onChange={setVirtualKeyID}
+						placeholder="All virtual keys"
+						triggerClassName="h-9"
+						// A page, not a sheet — portalling keeps the popover out of the
+						// scrolling table container.
+						noPortal={false}
+					/>
+				</div>
+
+				{virtualKeyID && (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => setVirtualKeyID("")}
+						data-testid="pricing-overrides-virtual-key-filter-clear-btn"
+					>
+						Clear
+					</Button>
+				)}
 			</div>
 
 			<div className="mb-2 overflow-hidden rounded-sm border">
@@ -374,7 +391,7 @@ export default function ScopedPricingOverridesView() {
 									<TableRow key={row.id} className="group hover:bg-muted/50 cursor-pointer transition-colors">
 										<TableCell>{row.name || "-"}</TableCell>
 										<TableCell>
-											<Badge variant="secondary">{scopeLabel(row, virtualKeyMap)}</Badge>
+											<Badge variant="secondary">{scopeLabel(row)}</Badge>
 										</TableCell>
 										<TableCell>
 											{(() => {

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -2,7 +2,7 @@ import CustomersTable from "@/app/workspace/governance/views/customerTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { parseAsSafeString } from "@/lib/queryParamsParser";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -12,7 +12,6 @@ const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function GovernanceCustomersPage() {
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
 	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
 	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
@@ -27,14 +26,6 @@ export default function GovernanceCustomersPage() {
 
 	const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
-	const {
-		data: virtualKeysData,
-		error: vkError,
-		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(undefined, {
-		skip: !hasVirtualKeysAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
 	const {
 		data: teamsData,
 		error: teamsError,
@@ -65,24 +56,23 @@ export default function GovernanceCustomersPage() {
 		setUrlState({ offset: customersTotal === 0 ? 0 : Math.floor((customersTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
 	}, [customersTotal, urlState.offset]);
 
-	const isLoading = vkLoading || teamsLoading || customersLoading;
+	const isLoading = teamsLoading || customersLoading;
 
 	useEffect(() => {
-		if (!vkError && !teamsError && !customersError) {
+		if (!teamsError && !customersError) {
 			shownErrorsRef.current.clear();
 			return;
 		}
-		const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
+		const errorKey = `${!!teamsError}-${!!customersError}`;
 		if (shownErrorsRef.current.has(errorKey)) return;
 		shownErrorsRef.current.add(errorKey);
-		if (vkError && teamsError && customersError) {
+		if (teamsError && customersError) {
 			toast.error("Failed to load governance data.");
 		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
 			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
 			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
 		}
-	}, [vkError, teamsError, customersError]);
+	}, [teamsError, customersError]);
 
 	if (isLoading) {
 		return <FullPageLoader />;
@@ -94,7 +84,6 @@ export default function GovernanceCustomersPage() {
 				customers={customersData?.customers || []}
 				totalCount={customersData?.total_count || 0}
 				teams={teamsData?.teams || []}
-				virtualKeys={virtualKeysData?.virtual_keys || []}
 				search={urlState.search}
 				debouncedSearch={debouncedSearch}
 				onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 })}

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -18,7 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationLabels } from "@/lib/constants/governance";
 import { getErrorMessage, useDeleteCustomerMutation } from "@/lib/store";
-import { Customer, Team, VirtualKey } from "@/lib/types/governance";
+import { Customer, Team } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { CustomerDetailSheet } from "@enterprise/components/user-groups/sheets/customerDetailSheet";
@@ -117,7 +117,6 @@ interface CustomersTableProps {
 	customers: Customer[];
 	totalCount: number;
 	teams: Team[];
-	virtualKeys: VirtualKey[];
 	search: string;
 	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
@@ -131,7 +130,6 @@ export default function CustomersTable({
 	customers,
 	totalCount,
 	teams,
-	virtualKeys,
 	search,
 	debouncedSearch,
 	onSearchChange,
@@ -179,10 +177,6 @@ export default function CustomersTable({
 
 	const getTeamsForCustomer = (customerId: string) => {
 		return teams.filter((team) => team.customer_id === customerId);
-	};
-
-	const getVirtualKeysForCustomer = (customerId: string) => {
-		return virtualKeys.filter((vk) => vk.customer_id === customerId);
 	};
 
 	const hasActiveFilters = debouncedSearch;
@@ -276,7 +270,7 @@ export default function CustomersTable({
 								) : (
 									customers.map((customer) => {
 										const customerTeams = getTeamsForCustomer(customer.id);
-										const vks = getVirtualKeysForCustomer(customer.id);
+										const vkCount = customer.virtual_key_count ?? 0;
 
 										// Budget calculations (most-exhausted budget drives the row highlight)
 										const budgets = customer.budgets ?? [];
@@ -470,17 +464,10 @@ export default function CustomersTable({
 													)}
 												</TableCell>
 												<TableCell>
-													{vks?.length > 0 ? (
-														<div className="flex items-center gap-2">
-															<Tooltip>
-																<TooltipTrigger>
-																	<Badge variant="outline" className="text-xs">
-																		{vks.length} {vks.length === 1 ? "key" : "keys"}
-																	</Badge>
-																</TooltipTrigger>
-																<TooltipContent>{vks.map((vk) => vk.name).join(", ")}</TooltipContent>
-															</Tooltip>
-														</div>
+													{vkCount > 0 ? (
+														<Badge variant="outline" className="text-xs">
+															{vkCount} {vkCount === 1 ? "key" : "keys"}
+														</Badge>
 													) : (
 														<span className="text-muted-foreground text-sm">-</span>
 													)}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -20,7 +20,6 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { MultiSelect } from "@/components/ui/multiSelect";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -28,10 +27,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { TriStateCheckbox } from "@/components/ui/tristateCheckbox";
 import { useToast } from "@/hooks/use-toast";
-import { useDebouncedValue } from "@/hooks/useDebounce";
 import { useSheetNavigation } from "@/hooks/useSheetNavigation";
 import { MCP_STATUS_COLORS } from "@/lib/constants/config";
-import { getErrorMessage, useGetCoreConfigQuery, useGetVirtualKeysQuery, useUpdateMCPClientMutation } from "@/lib/store";
+import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
+import { getErrorMessage, useGetCoreConfigQuery, useUpdateMCPClientMutation } from "@/lib/store";
 import { MCPClient, MCPVKConfig } from "@/lib/types/mcp";
 import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
@@ -101,11 +100,6 @@ export default function MCPClientSheet({
 	const { toast } = useToast();
 	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
-	// VK access management — search-based dropdown (limit 20), no pagination issue
-	const [vkSearch, setVKSearch] = useState("");
-	const [vkPopoverOpen, setVKPopoverOpen] = useState(false);
-	const debouncedVkSearch = useDebouncedValue(vkSearch, 300);
-	const { data: vksData } = useGetVirtualKeysQuery({ limit: 20, search: debouncedVkSearch || undefined });
 	const allToolNames = useMemo(() => mcpClient.tools?.map((t) => t.name) ?? [], [mcpClient.tools]);
 
 	// Initial VK configs come directly from the MCP client response — always complete, no pagination issue.
@@ -143,22 +137,16 @@ export default function MCPClientSheet({
 		setPerUserHeaderKeysRaw((mcpClient.config.per_user_header_keys || []).join(", "));
 	}, [mcpClient.config.per_user_header_keys]);
 
-	// Name lookup: server response names → search results → locally cached names (highest priority)
+	// Name lookup: server response names → names captured when a key was picked.
+	// Every row is one or the other, so the selector's results aren't needed here.
 	const vkNameByID = useMemo<Record<string, string>>(() => {
 		const m: Record<string, string> = {};
 		for (const vc of mcpClient.vk_configs ?? []) m[vc.virtual_key_id] = vc.virtual_key_name;
-		for (const vk of vksData?.virtual_keys ?? []) m[vk.id] = vk.name;
 		Object.assign(m, localVKNames);
 		return m;
-	}, [mcpClient.vk_configs, vksData, localVKNames]);
+	}, [mcpClient.vk_configs, localVKNames]);
 
-	const vkOptions = useMemo(
-		() =>
-			(vksData?.virtual_keys ?? [])
-				.filter((vk) => !vkConfigs.some((vc) => vc.virtual_key_id === vk.id))
-				.map((vk) => ({ value: vk.id, label: vk.name })),
-		[vksData, vkConfigs],
-	);
+	const configuredVKIDs = useMemo(() => vkConfigs.map((vc) => vc.virtual_key_id), [vkConfigs]);
 
 	const toolOptions = useMemo(
 		() => [
@@ -170,9 +158,8 @@ export default function MCPClientSheet({
 	const supportsOAuthCredentialUpdate = false;
 	// mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
 
-	const addVKConfig = (vkId: string) => {
-		const name = vksData?.virtual_keys?.find((vk) => vk.id === vkId)?.name;
-		if (name) setLocalVKNames((prev) => ({ ...prev, [vkId]: name }));
+	const addVKConfig = ({ value: vkId, label }: { value: string; label: string }) => {
+		setLocalVKNames((prev) => ({ ...prev, [vkId]: label }));
 		setVKConfigs((prev) => [...prev, { virtual_key_id: vkId, tools_to_execute: ["*"] }]);
 		setVKConfigsDirty(true);
 	};
@@ -1318,14 +1305,11 @@ export default function MCPClientSheet({
 															</Tooltip>
 														</TooltipProvider>
 													</div>
-													<Popover
-														open={vkPopoverOpen}
-														onOpenChange={(open) => {
-															setVKPopoverOpen(open);
-															if (!open) setVKSearch("");
-														}}
-													>
-														<PopoverTrigger asChild>
+													<VirtualKeySelector
+														mode="add"
+														onSelect={addVKConfig}
+														excludeIds={configuredVKIDs}
+														trigger={
 															<Button
 																type="button"
 																variant="outline"
@@ -1336,45 +1320,8 @@ export default function MCPClientSheet({
 																<Plus className="h-4 w-4" />
 																Add Virtual Key
 															</Button>
-														</PopoverTrigger>
-														<PopoverContent side="top" align="end" className="w-56 p-0" noPortal>
-															<div className="pb-1">
-																<Input
-																	data-testid="mcpclient-virtualkey-search-input"
-																	placeholder="Start typing to search…"
-																	value={vkSearch}
-																	onChange={(e) => setVKSearch(e.target.value)}
-																	onKeyDown={(e) => {
-																		e.stopPropagation();
-																		if (e.key === "Enter") e.preventDefault();
-																	}}
-																	className="h-7 rounded-b-none border-0 border-b text-sm focus-visible:ring-0"
-																	autoFocus
-																/>
-															</div>
-															<div className="max-h-48 overflow-y-auto p-1">
-																{vkOptions.length > 0 ? (
-																	vkOptions.map((opt) => (
-																		<button
-																			data-testid={`mcpclient-virtualkey-option-${opt.value}`}
-																			key={opt.value}
-																			type="button"
-																			className="hover:bg-accent hover:text-accent-foreground w-full cursor-pointer rounded-sm px-2 py-1.5 text-left text-sm"
-																			onClick={() => {
-																				addVKConfig(opt.value);
-																				setVKSearch("");
-																				setVKPopoverOpen(false);
-																			}}
-																		>
-																			{opt.label}
-																		</button>
-																	))
-																) : (
-																	<div className="text-muted-foreground px-2 py-1.5 text-sm">No virtual keys found</div>
-																)}
-															</div>
-														</PopoverContent>
-													</Popover>
+														}
+													/>
 												</div>
 												{form.watch("allow_on_all_virtual_keys") && (
 													<p className="text-muted-foreground flex items-center gap-1 text-xs">

--- a/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
@@ -9,7 +9,7 @@ import { baseRoutingFields } from "@/lib/config/celFieldsRouting";
 import { getOperatorLabel } from "@/lib/config/celOperatorsRouting";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
-import { useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store/apis/governanceApi";
+import { useGetCustomerQuery, useGetTeamQuery, useGetVirtualKeyQuery } from "@/lib/store/apis/governanceApi";
 import { RoutingRule } from "@/lib/types/routingRules";
 import { getScopeLabel } from "@/lib/utils/labels";
 import { formatDistanceToNow } from "date-fns";
@@ -40,24 +40,27 @@ function formatRuleValue(value: any): string {
 	return String(value ?? "");
 }
 
+// Resolves a rule's scope_id to a display name. Each scope fetches only the one
+// entity it needs — the rule points at a single id, so pulling the full list to
+// find one name is wasted payload.
 function useScopeName(scope: string, scopeId?: string): string | undefined {
-	const { data: teamsData } = useGetTeamsQuery(undefined, {
+	const { data: teamData } = useGetTeamQuery(scopeId as string, {
 		skip: scope !== "team" || !scopeId,
 	});
-	const { data: customersData } = useGetCustomersQuery(undefined, {
+	const { data: customerData } = useGetCustomerQuery(scopeId as string, {
 		skip: scope !== "customer" || !scopeId,
 	});
-	const { data: vksData } = useGetVirtualKeysQuery(undefined, {
+	const { data: vkData } = useGetVirtualKeyQuery(scopeId as string, {
 		skip: scope !== "virtual_key" || !scopeId,
 	});
 
 	return useMemo(() => {
 		if (!scopeId) return undefined;
-		if (scope === "team") return teamsData?.teams?.find((t) => t.id === scopeId)?.name;
-		if (scope === "customer") return customersData?.customers?.find((c) => c.id === scopeId)?.name;
-		if (scope === "virtual_key") return vksData?.virtual_keys?.find((v) => v.id === scopeId)?.name;
+		if (scope === "team") return teamData?.team?.name;
+		if (scope === "customer") return customerData?.customer?.name;
+		if (scope === "virtual_key") return vkData?.virtual_key?.name;
 		return undefined;
-	}, [scope, scopeId, teamsData, customersData, vksData]);
+	}, [scope, scopeId, teamData, customerData, vkData]);
 }
 
 // ─── copy button ─────────────────────────────────────────────────────────────

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -3,6 +3,7 @@
  * Create/Edit form for routing rules
  */
 
+import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
@@ -17,7 +18,7 @@ import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import { getErrorMessage } from "@/lib/store";
-import { useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store/apis/governanceApi";
+import { useGetCustomersQuery, useGetTeamsQuery } from "@/lib/store/apis/governanceApi";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { useCreateRoutingRuleMutation, useGetRoutingRulesQuery, useUpdateRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
 import {
@@ -86,7 +87,6 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	const rules = rulesData?.rules || [];
 	const { data: providersData = [] } = useGetProvidersQuery();
 	const { data: allKeysData = [] } = useGetAllKeysQuery();
-	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
 	const { data: teamsData = { teams: [], count: 0, total_count: 0, limit: 0, offset: 0 } } = useGetTeamsQuery();
 	const { data: customersData = { customers: [] } } = useGetCustomersQuery();
 	const [createRoutingRule, { isLoading: isCreating }] = useCreateRoutingRuleMutation();
@@ -454,13 +454,15 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 										noPortal
 									/>
 								)}
-								{scope === "virtual_key" && vksData.virtual_keys.length > 0 && (
-									<ComboboxSelect
-										options={vksData.virtual_keys.map((vk) => ({ label: vk.name, value: vk.id }))}
-										value={scopeId || null}
-										onValueChange={(value) => setValue("scope_id", value ?? "")}
-										placeholder="Select a virtual key..."
-										noPortal
+								{scope === "virtual_key" && (
+									<VirtualKeySelector
+										value={scopeId || ""}
+										onChange={(value) => setValue("scope_id", value)}
+										fallbackOption={
+											editingRule?.scope === "virtual_key" && editingRule.scope_id
+												? { value: editingRule.scope_id, label: editingRule.scope_id }
+												: null
+										}
 									/>
 								)}
 								{scope === "user" &&
@@ -485,13 +487,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 											onChange={(e) => setValue("scope_id", e.target.value)}
 										/>
 									))}
-								{((scope === "team" && teamsData.teams.length === 0) ||
-									(scope === "customer" && customersData.customers.length === 0) ||
-									(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
-										<p className="text-muted-foreground text-sm">
-											No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
-										</p>
-									)}
+								{/* Virtual keys are searched lazily inside VirtualKeySelector, which
+								    surfaces its own empty state, so it is not covered here. */}
+								{((scope === "team" && teamsData.teams.length === 0) || (scope === "customer" && customersData.customers.length === 0)) && (
+									<p className="text-muted-foreground text-sm">No {scope === "team" ? "teams" : "customers"} available</p>
+								)}
 								{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
 							</div>
 						)}

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -3,6 +3,8 @@
  * Create/Edit form for routing rules
  */
 
+import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
+import { TeamSelector } from "@/components/entitySelectors/teamSelector";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
@@ -18,7 +20,6 @@ import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import { getErrorMessage } from "@/lib/store";
-import { useGetCustomersQuery, useGetTeamsQuery } from "@/lib/store/apis/governanceApi";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { useCreateRoutingRuleMutation, useGetRoutingRulesQuery, useUpdateRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
 import {
@@ -87,8 +88,6 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	const rules = rulesData?.rules || [];
 	const { data: providersData = [] } = useGetProvidersQuery();
 	const { data: allKeysData = [] } = useGetAllKeysQuery();
-	const { data: teamsData = { teams: [], count: 0, total_count: 0, limit: 0, offset: 0 } } = useGetTeamsQuery();
-	const { data: customersData = { customers: [] } } = useGetCustomersQuery();
 	const [createRoutingRule, { isLoading: isCreating }] = useCreateRoutingRuleMutation();
 	const [updateRoutingRule, { isLoading: isUpdating }] = useUpdateRoutingRuleMutation();
 
@@ -436,46 +435,14 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 									{scope === "team" ? "Team" : scope === "customer" ? "Customer" : scope === "user" ? "User" : "Virtual Key"}{" "}
 									<span className="text-red-500">*</span>
 								</Label>
-								{scope === "team" && teamsData.teams.length > 0 && (
-									<ComboboxSelect
-										options={teamsData.teams.map((team) => ({ label: team.name, value: team.id }))}
-										value={scopeId || null}
-										onValueChange={(value) => setValue("scope_id", value ?? "")}
-										placeholder="Select a team..."
-										noPortal
-									/>
-								)}
-								{scope === "customer" && customersData.customers.length > 0 && (
-									<ComboboxSelect
-										options={customersData.customers.map((customer) => ({ label: customer.name, value: customer.id }))}
-										value={scopeId || null}
-										onValueChange={(value) => setValue("scope_id", value ?? "")}
-										placeholder="Select a customer..."
-										noPortal
-									/>
-								)}
-								{scope === "virtual_key" && (
-									<VirtualKeySelector
-										value={scopeId || ""}
-										onChange={(value) => setValue("scope_id", value)}
-										fallbackOption={
-											editingRule?.scope === "virtual_key" && editingRule.scope_id
-												? { value: editingRule.scope_id, label: editingRule.scope_id }
-												: null
-										}
-									/>
-								)}
+								{/* A rule stores only its scope_id, so there is no name to seed
+								    these with — each selector resolves its own selection. */}
+								{scope === "team" && <TeamSelector value={scopeId || ""} onChange={(value) => setValue("scope_id", value)} />}
+								{scope === "customer" && <CustomerSelector value={scopeId || ""} onChange={(value) => setValue("scope_id", value)} />}
+								{scope === "virtual_key" && <VirtualKeySelector value={scopeId || ""} onChange={(value) => setValue("scope_id", value)} />}
 								{scope === "user" &&
 									(UserPicker ? (
-										<UserPicker
-											value={scopeId || ""}
-											onChange={(value) => setValue("scope_id", value)}
-											fallbackOption={
-												editingRule?.scope === "user" && editingRule.scope_id
-													? { value: editingRule.scope_id, label: editingRule.scope_id }
-													: null
-											}
-										/>
+										<UserPicker value={scopeId || ""} onChange={(value) => setValue("scope_id", value)} />
 									) : (
 										// No user directory in this build: keep a plain input so
 										// existing user-scoped rules remain editable.
@@ -487,12 +454,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 											onChange={(e) => setValue("scope_id", e.target.value)}
 										/>
 									))}
-								{/* Virtual keys are searched lazily inside VirtualKeySelector, which
-								    surfaces its own empty state, so it is not covered here. */}
-								{((scope === "team" && teamsData.teams.length === 0) || (scope === "customer" && customersData.customers.length === 0)) && (
-									<p className="text-muted-foreground text-sm">No {scope === "team" ? "teams" : "customers"} available</p>
-								)}
-								{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
+								{/* Teams, customers and virtual keys are all searched lazily inside their
+								    selectors, each of which surfaces its own empty state. */}
+								{errors.scope_id &&<p className="text-destructive text-sm">{errors.scope_id.message}</p>}
 							</div>
 						)}
 

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -12,6 +12,8 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
+import { TeamSelector } from "@/components/entitySelectors/teamSelector";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
 import { DateTimePicker } from "@/components/ui/datePickerWithRange";
@@ -1982,14 +1984,9 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 														render={({ field }) => (
 															<FormItem>
 																<FormLabel className="font-normal">Select Team</FormLabel>
-																<ComboboxSelect
-																	options={teams.map((team) => ({
-																		value: team.id,
-																		label: team.customer ? `${team.name} - ${team.customer.name}` : team.name,
-																	}))}
-																	value={field.value || null}
-																	onValueChange={(val) => {
-																		const newVal = val ?? "";
+																<TeamSelector
+																	value={field.value || ""}
+																	onChange={(newVal) => {
 																		if (isEditing && virtualKey?.team_id && newVal && newVal !== virtualKey.team_id) {
 																			setPendingTeamId(newVal);
 																			setShowReassignTeamWarning(true);
@@ -1997,10 +1994,16 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																			field.onChange(newVal);
 																		}
 																	}}
-																	placeholder="Select a team"
+																	// The already-assigned team may fall outside the
+																	// selector's first page, so seed its label from the
+																	// list the page already fetched.
+																	fallbackOption={
+																		field.value
+																			? { value: field.value, label: teams.find((t) => t.id === field.value)?.name ?? field.value }
+																			: null
+																	}
 																	disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
-																	emptyMessage="No teams found."
-																	className="h-9"
+																	triggerClassName="h-9"
 																/>
 																<FormMessage />
 															</FormItem>
@@ -2015,17 +2018,19 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 														render={({ field }) => (
 															<FormItem>
 																<FormLabel className="font-normal">Select Customer</FormLabel>
-																<ComboboxSelect
-																	options={customers.map((customer) => ({
-																		value: customer.id,
-																		label: customer.name,
-																	}))}
-																	value={field.value || null}
-																	onValueChange={(val) => field.onChange(val ?? "")}
-																	placeholder="Select a customer"
+																<CustomerSelector
+																	value={field.value || ""}
+																	onChange={(val) => field.onChange(val)}
+																	fallbackOption={
+																		field.value
+																			? {
+																					value: field.value,
+																					label: customers.find((c) => c.id === field.value)?.name ?? field.value,
+																				}
+																			: null
+																	}
 																	disabled={isEditing && assignedUsers.length > 0}
-																	emptyMessage="No customers found."
-																	className="h-9"
+																	triggerClassName="h-9"
 																/>
 																<FormMessage />
 															</FormItem>

--- a/ui/components/entitySelectors/customerSelector.tsx
+++ b/ui/components/entitySelectors/customerSelector.tsx
@@ -1,0 +1,69 @@
+// Unified async customer selector — the single way to pick a governance
+// customer (routing rules, model limits, pricing overrides).
+//
+// Lives in OSS because /governance/customers is an OSS endpoint; there is no
+// enterprise customers API.
+//
+// Single mode is prop-compatible with the model limit scope picker contract
+// ({ value, onChange, disabled, fallbackOption }).
+
+import {
+	EntitySelector,
+	ENTITY_SELECTOR_PAGE_SIZE,
+	type EntitySelectorCommonProps,
+	type EntityLabelResolverProps,
+	type EntitySelectorModeProps,
+	useEntitySelectorSearch,
+} from "@/components/entitySelectors/entitySelector";
+import { useGetCustomerQuery, useGetCustomersQuery } from "@/lib/store";
+import { useEffect, useMemo } from "react";
+
+function CustomerLabelResolver({ id, onResolved }: EntityLabelResolverProps) {
+	const { data } = useGetCustomerQuery(id);
+	const customer = data?.customer;
+	useEffect(() => {
+		if (customer) onResolved({ value: id, label: customer.name || id });
+	}, [customer, id, onResolved]);
+	return null;
+}
+
+interface CustomerSelectorOwnProps extends EntitySelectorCommonProps {
+	/** Page size for each search request. */
+	limit?: number;
+}
+
+export type CustomerSelectorProps = CustomerSelectorOwnProps & EntitySelectorModeProps;
+
+export function CustomerSelector({ limit = ENTITY_SELECTOR_PAGE_SIZE, ...props }: CustomerSelectorProps) {
+	const { open, setOpen, setSearch, debouncedSearch, skip, isDebouncing } = useEntitySelectorSearch();
+
+	const { data: customersData, isFetching, isError } = useGetCustomersQuery({ limit, search: debouncedSearch || undefined }, { skip });
+
+	// Memoized because multi mode hands this to react-select as defaultOptions,
+	// which re-syncs on identity change.
+	const options = useMemo(
+		() =>
+			(customersData?.customers ?? []).map((customer) => ({
+				value: customer.id,
+				label: customer.name || customer.id,
+			})),
+		[customersData],
+	);
+
+	return (
+		<EntitySelector
+			{...props}
+			LabelResolver={CustomerLabelResolver}
+			entityLabel="customer"
+			entityLabelPlural="customers"
+			options={options}
+			isFetching={isFetching}
+			isError={isError}
+			open={open}
+			onOpenChange={setOpen}
+			onSearchChange={setSearch}
+			isSearching={isDebouncing || (isFetching && !!debouncedSearch)}
+			debouncedSearch={debouncedSearch}
+		/>
+	);
+}

--- a/ui/components/entitySelectors/entitySelector.tsx
+++ b/ui/components/entitySelectors/entitySelector.tsx
@@ -1,0 +1,449 @@
+// Shared shell behind every async entity selector (virtual keys, users,
+// teams, customers, business units).
+//
+// Owns everything that is identical across entities: the three selection
+// modes, the label cache that keeps an already-selected id from rendering as
+// a raw UUID, and the search wiring.
+//
+// Two presentations, picked by mode:
+//   - single / add -> SearchSelect (a popover behind a button trigger)
+//   - multi        -> AsyncMultiSelect, the react-select control already used
+//                     for association fields, so chips render inline in the
+//                     control rather than in a separate row below it.
+// Fetching, debouncing and label resolution are identical either way.
+//
+// Each entity still ships a thin wrapper, because the parts that genuinely
+// differ — which endpoint to call, whether it pages by offset or page number,
+// and which field is the label — aren't worth abstracting over. A wrapper
+// owns its query and its debounce and hands the results down here.
+//
+// Lives in OSS so the enterprise-only selectors can build on it too.
+
+import { CheckIcon, ChevronDownIcon, PlusIcon } from "lucide-react";
+import { type ComponentType, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
+import { Button } from "@/components/ui/button";
+import type { Option } from "@/components/ui/multiselectUtils";
+import { SearchSelect } from "@/components/ui/searchSelect";
+import { cn } from "@/lib/utils";
+
+export const ENTITY_SEARCH_DEBOUNCE_MS = 300;
+export const ENTITY_SELECTOR_PAGE_SIZE = 20;
+
+export interface EntitySelectorOption {
+	value: string;
+	label: string;
+}
+
+/** One row in the dropdown. `description` renders as a dimmed sub-label. */
+export interface EntitySelectorEntry extends EntitySelectorOption {
+	description?: string;
+}
+
+/**
+ * Fetches one entity by id and reports its label, then renders nothing.
+ *
+ * A selector loads its first page only when the popover opens, so ids handed
+ * in by the caller — the row being edited, ids read off a URL — have no label
+ * until then and would otherwise render as raw UUIDs. There is no batch
+ * by-ids filter on any of these endpoints, so resolution is one request per
+ * id; a component per id is what lets each one own a hook.
+ */
+export interface EntityLabelResolverProps {
+	id: string;
+	onResolved: (option: EntitySelectorOption) => void;
+}
+
+/** Carried on each react-select option so the custom option view can read it. */
+interface EntityOptionMeta {
+	description?: string;
+}
+
+/**
+ * Props every wrapper re-exposes verbatim, so callers see the same surface
+ * whichever entity they are picking.
+ */
+export interface EntitySelectorCommonProps {
+	disabled?: boolean;
+	placeholder?: string;
+	className?: string;
+	/**
+	 * Guarantees an already-selected entity renders a real label even when it
+	 * falls outside the fetched search results — callers pass the edited row's
+	 * own id/name. Accepts one option (single mode) or several (multi).
+	 */
+	fallbackOption?: EntitySelectorOption | null;
+	fallbackOptions?: EntitySelectorOption[] | null;
+	/** Rendered inside a Sheet/Dialog by default, so portalling is off. Single/add only. */
+	noPortal?: boolean;
+	/**
+	 * Extra classes for the default combobox trigger — e.g. `h-9` to line up
+	 * with a taller control beside it. Ignored when `trigger` is supplied.
+	 * Single mode only.
+	 */
+	triggerClassName?: string;
+	/** Ids to omit from the results — e.g. entities already added to a list. */
+	excludeIds?: string[];
+	/**
+	 * Replaces the default full-width combobox trigger. Surfaces that already
+	 * show the selection elsewhere (a table, a chip row) pass a compact button
+	 * instead; the trigger then renders no selected label of its own.
+	 * Single/add only — multi mode renders its chips inside the control.
+	 */
+	trigger?: ReactNode;
+}
+
+interface EntitySelectorSingleProps {
+	mode?: undefined;
+	multiple?: false;
+	value: string;
+	onChange: (value: string) => void;
+}
+
+interface EntitySelectorMultiProps {
+	mode?: undefined;
+	multiple: true;
+	value: string[];
+	onChange: (value: string[]) => void;
+}
+
+/**
+ * Fire-and-forget "add" mode: the selector holds no value, and each pick is
+ * reported once. For surfaces that own their own collection — e.g. the MCP
+ * client sheet, where picking a key appends a row with its own tool config
+ * and removal happens in the table, not here.
+ */
+interface EntitySelectorAddProps {
+	mode: "add";
+	onSelect: (option: EntitySelectorOption) => void;
+	multiple?: never;
+	value?: never;
+	onChange?: never;
+}
+
+/**
+ * The selection contract, shared so wrappers can intersect it with their own
+ * options rather than restating all three variants.
+ */
+export type EntitySelectorModeProps = EntitySelectorSingleProps | EntitySelectorMultiProps | EntitySelectorAddProps;
+
+interface EntitySelectorChromeProps {
+	/** Lowercase noun used to build placeholders and empty/error copy. */
+	entityLabel: string;
+	entityLabelPlural: string;
+	/**
+	 * Must be referentially stable while the underlying data is unchanged —
+	 * memoize it in the wrapper. Multi mode feeds it to react-select as
+	 * `defaultOptions`, which re-syncs on identity change and would otherwise
+	 * loop.
+	 */
+	options: EntitySelectorEntry[];
+	isFetching: boolean;
+	isError: boolean;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onSearchChange: (search: string) => void;
+	/** The settled search the current `options` correspond to. */
+	debouncedSearch: string;
+	/** True while the wrapper's debounce is still settling, or a fetch is in flight for a search. */
+	isSearching: boolean;
+	searchPlaceholder?: string;
+	/**
+	 * Supplied by the wrapper that knows the by-id endpoint. Rendered once per
+	 * selected id whose label is still unknown — in every mode, so multi-select
+	 * chips resolve the same way a single trigger does.
+	 */
+	LabelResolver?: ComponentType<EntityLabelResolverProps>;
+}
+
+export type EntitySelectorProps = EntitySelectorChromeProps & EntitySelectorCommonProps & EntitySelectorModeProps;
+
+export function EntitySelector(props: EntitySelectorProps) {
+	const {
+		entityLabel,
+		entityLabelPlural,
+		options,
+		isFetching,
+		isError,
+		open,
+		onOpenChange,
+		onSearchChange,
+		debouncedSearch,
+		isSearching,
+		searchPlaceholder,
+		LabelResolver,
+		disabled = false,
+		placeholder,
+		className,
+		fallbackOption,
+		fallbackOptions,
+		noPortal = true,
+		triggerClassName,
+		excludeIds,
+		trigger,
+	} = props;
+
+	const isAdd = props.mode === "add";
+	const isMulti = props.multiple === true;
+	const selectedIds = useMemo(() => {
+		if (isAdd) return [];
+		return props.multiple === true ? props.value : props.value ? [props.value] : [];
+	}, [isAdd, props.multiple, props.value]);
+
+	// Labels of entities seen so far. Results change as the user types and are
+	// dropped entirely once the popover closes, so selected ids can't rely on
+	// being present in `options` — the cache is what keeps their labels stable.
+	const [labelCache, setLabelCache] = useState<Record<string, string>>({});
+
+	useEffect(() => {
+		if (options.length === 0) return;
+		setLabelCache((prev) => {
+			let changed = false;
+			const next = { ...prev };
+			for (const option of options) {
+				if (next[option.value] !== option.label) {
+					next[option.value] = option.label;
+					changed = true;
+				}
+			}
+			return changed ? next : prev;
+		});
+	}, [options]);
+
+	const fallbackLabels = useMemo(() => {
+		const entries = [...(fallbackOption ? [fallbackOption] : []), ...(fallbackOptions ?? [])];
+		// A fallback whose label is just the id names nothing — the common shape
+		// when a surface holds only ids. Drop it so the resolver still runs.
+		return Object.fromEntries(entries.filter((o) => o.label && o.label !== o.value).map((o) => [o.value, o.label]));
+	}, [fallbackOption, fallbackOptions]);
+
+	// Falls back to the raw id only when no label is known from any source.
+	const labelFor = (id: string) => labelCache[id] ?? fallbackLabels[id] ?? id;
+
+	const cacheLabel = useCallback((option: EntitySelectorOption) => {
+		setLabelCache((prev) => (prev[option.value] === option.label ? prev : { ...prev, [option.value]: option.label }));
+	}, []);
+
+	// Each resolver unmounts as soon as it reports, since its id leaves this
+	// list; the label it cached is what keeps it from being fetched again.
+	const unresolvedIds = useMemo(
+		() => (LabelResolver ? selectedIds.filter((id) => !labelCache[id] && !fallbackLabels[id]) : []),
+		[LabelResolver, selectedIds, labelCache, fallbackLabels],
+	);
+
+	const labelResolvers = LabelResolver ? unresolvedIds.map((id) => <LabelResolver key={id} id={id} onResolved={cacheLabel} />) : null;
+
+	// Array identity has to survive renders, so key off the contents.
+	const excludeKey = excludeIds?.join(" ") ?? "";
+	const visibleOptions = useMemo(
+		() => (excludeKey ? options.filter((option) => !excludeKey.split(" ").includes(option.value)) : options),
+		[options, excludeKey],
+	);
+
+	// Only reached by the single/add presentation; multi selection is handled
+	// by react-select's own onChange below.
+	const handleSelect = (option: EntitySelectorEntry) => {
+		cacheLabel(option);
+
+		if (props.mode === "add") {
+			props.onSelect({ value: option.value, label: option.label });
+		} else if (props.multiple !== true) {
+			props.onChange(option.value);
+		}
+		onOpenChange(false);
+	};
+
+	const resolvedPlaceholder = placeholder ?? (isMulti ? `Select ${entityLabelPlural}...` : `Select a ${entityLabel}...`);
+	const resolvedSearchPlaceholder = searchPlaceholder ?? `Search ${entityLabelPlural}...`;
+	const emptyMessage = debouncedSearch ? `No matching ${entityLabelPlural}` : `No ${entityLabelPlural} found`;
+	const errorMessage = `Failed to load ${entityLabelPlural}`;
+
+	// ---------------------------------------------------------------------
+	// Multi mode — react-select, so chips live inside the control.
+	// ---------------------------------------------------------------------
+
+	const multiOptions = useMemo<Option<EntityOptionMeta>[]>(
+		() => visibleOptions.map((option) => ({ label: option.label, value: option.value, meta: { description: option.description } })),
+		[visibleOptions],
+	);
+
+	const selectedValues = useMemo<Option<EntityOptionMeta>[]>(
+		() => selectedIds.map((id) => ({ label: labelCache[id] ?? fallbackLabels[id] ?? id, value: id })),
+		[selectedIds, labelCache, fallbackLabels],
+	);
+
+	// react-select asks for options through a callback, but the results arrive
+	// through RTK Query on a later render. Park the callback and settle it once
+	// the debounce has caught up and the request is done.
+	const pendingLoad = useRef<{ query: string; callback: (options: Option<EntityOptionMeta>[]) => void } | null>(null);
+
+	const handleReload = useCallback((query: string, callback: (loaded: Option<EntityOptionMeta>[]) => void) => {
+		pendingLoad.current = { query, callback };
+	}, []);
+
+	useEffect(() => {
+		const pending = pendingLoad.current;
+		if (!pending) return;
+		// `options` only answers the pending query once the debounce has settled
+		// on it and nothing is in flight.
+		if (pending.query !== debouncedSearch || isFetching) return;
+		pendingLoad.current = null;
+		pending.callback(multiOptions);
+	}, [multiOptions, isFetching, debouncedSearch]);
+
+	if (isMulti) {
+		return (
+			<>
+				{labelResolvers}
+				<AsyncMultiSelect<EntityOptionMeta>
+					className={className}
+					disabled={disabled}
+					placeholder={resolvedPlaceholder}
+					defaultOptions={multiOptions}
+					reload={handleReload}
+					isLoading={isSearching || (isFetching && multiOptions.length === 0)}
+					value={selectedValues}
+					onChange={(selected) => {
+						if (props.multiple !== true) return;
+						props.onChange(selected.map((option) => option.value));
+					}}
+					// Clearing the input never reaches `reload`, so mirror every
+					// keystroke into the search state instead.
+					onInputChange={(inputValue) => onSearchChange(inputValue)}
+					onMenuOpen={() => onOpenChange(true)}
+					onMenuClose={() => onOpenChange(false)}
+					isClearable
+					closeMenuOnSelect={false}
+					hideSelectedOptions={false}
+					noOptionsMessage={() => (isError ? errorMessage : emptyMessage)}
+					views={{
+						option: (optionProps) => {
+							const data = optionProps.data as Option<EntityOptionMeta>;
+							return (
+								<div
+									className={cn(
+										"flex w-full cursor-pointer flex-col gap-0.5 rounded-sm p-2 text-sm",
+										optionProps.isFocused && "bg-background-highlight-primary/60",
+										optionProps.isSelected && "bg-background-highlight-primary/40",
+									)}
+									onClick={() => optionProps.selectOption(optionProps.data)}
+								>
+									<div className="flex items-center justify-between">
+										<span className="text-content-primary font-medium">{data.label}</span>
+										{optionProps.isSelected && <span className="text-primary text-xs">Selected</span>}
+									</div>
+									{data.meta?.description && data.meta.description !== data.label && (
+										<span className="text-content-tertiary line-clamp-1 text-xs">{data.meta.description}</span>
+									)}
+								</div>
+							);
+						},
+					}}
+				/>
+			</>
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// Single / add mode — popover behind a button trigger.
+	// ---------------------------------------------------------------------
+
+	const triggerLabel = selectedIds.length > 0 ? labelFor(selectedIds[0]) : "";
+
+	// Add mode has no value to display, so it defaults to a compact action
+	// button rather than the full-width combobox.
+	const defaultTrigger = isAdd ? (
+		<Button type="button" variant="outline" size="sm" disabled={disabled} className="h-7.5 gap-1.5 px-2 py-1 text-sm font-medium">
+			<PlusIcon className="size-4" />
+			{placeholder ?? `Add ${entityLabel}`}
+		</Button>
+	) : (
+		<Button
+			type="button"
+			variant="outline"
+			role="combobox"
+			disabled={disabled}
+			className={cn(
+				"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
+				!triggerLabel && "text-muted-foreground",
+				triggerClassName,
+			)}
+		>
+			<span className="truncate">{triggerLabel || resolvedPlaceholder}</span>
+			<ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+		</Button>
+	);
+
+	return (
+		// Single wrapping element, so no vertical spacing utility here — it only
+		// ever holds the trigger and the (invisible) label resolvers.
+		<div className={cn(isAdd ? "inline-flex" : "w-full", className)}>
+			{labelResolvers}
+			<SearchSelect
+				async
+				options={visibleOptions.map((option) => ({ ...option, selected: selectedIds.includes(option.value) }))}
+				onValueSelect={handleSelect}
+				entryView={(option) => (
+					<>
+						<div className="flex min-w-0 flex-col">
+							<span className="truncate font-medium">{option.label}</span>
+							{option.description && option.description !== option.label && (
+								<span className="text-muted-foreground truncate text-xs">{option.description}</span>
+							)}
+						</div>
+						{/* Add mode never marks rows as selected — picked entities leave the list. */}
+						{!isAdd && <CheckIcon className={cn("ml-auto size-3.5 shrink-0", option.selected ? "opacity-100" : "opacity-0")} />}
+					</>
+				)}
+				label={trigger ?? defaultTrigger}
+				open={open}
+				onOpenChange={onOpenChange}
+				onSearchChange={onSearchChange}
+				isSearching={isSearching}
+				// Skeletons only when there's nothing to show yet; refetching on
+				// each keystroke shouldn't blank out the current results.
+				isLoading={isFetching && visibleOptions.length === 0}
+				isError={isError}
+				errorMessage={errorMessage}
+				searchPlaceholder={resolvedSearchPlaceholder}
+				emptyMessage={emptyMessage}
+				disabled={disabled}
+				// A compact trigger shouldn't dictate the popover width, so add
+				// mode keeps SearchSelect's own fixed width.
+				align={isAdd ? "end" : "start"}
+				className={isAdd ? undefined : "w-full"}
+				contentClassName={isAdd ? undefined : "w-(--radix-popover-trigger-width)"}
+				noPortal={noPortal}
+			/>
+		</div>
+	);
+}
+
+/**
+ * The open/search/debounce state every wrapper needs, so none of them
+ * hand-roll it. `skip` feeds RTK Query — nothing is fetched until the picker
+ * opens.
+ */
+export function useEntitySelectorSearch() {
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+
+	// Deployments can hold far more rows than one page, so pickers search
+	// server-side instead of filtering a capped pre-fetched list.
+	useEffect(() => {
+		const timer = setTimeout(() => setDebouncedSearch(search), ENTITY_SEARCH_DEBOUNCE_MS);
+		return () => clearTimeout(timer);
+	}, [search]);
+
+	return {
+		open,
+		setOpen,
+		setSearch,
+		debouncedSearch,
+		skip: !open,
+		// Debounce is part of the wait, so the spinner covers it too.
+		isDebouncing: search !== debouncedSearch,
+	};
+}

--- a/ui/components/entitySelectors/teamSelector.tsx
+++ b/ui/components/entitySelectors/teamSelector.tsx
@@ -1,0 +1,80 @@
+// Unified async team selector — the single way to pick a governance team
+// (routing rules, model limits, pricing overrides).
+//
+// Lives in OSS because the governance teams endpoint (/governance/teams) is
+// OSS. Note this is a different entity from the enterprise user-groups team
+// list (/teams), which carries membership and business-unit fields and is
+// only used by the admin surfaces under Users & Groups.
+//
+// Single mode is prop-compatible with the model limit scope picker contract
+// ({ value, onChange, disabled, fallbackOption }).
+
+import {
+	EntitySelector,
+	ENTITY_SELECTOR_PAGE_SIZE,
+	type EntitySelectorCommonProps,
+	type EntityLabelResolverProps,
+	type EntitySelectorModeProps,
+	useEntitySelectorSearch,
+} from "@/components/entitySelectors/entitySelector";
+import { useGetTeamQuery, useGetTeamsQuery } from "@/lib/store";
+import type { GetTeamsParams } from "@/lib/types/governance";
+import { useEffect, useMemo } from "react";
+
+function TeamLabelResolver({ id, onResolved }: EntityLabelResolverProps) {
+	const { data } = useGetTeamQuery(id);
+	const team = data?.team;
+	useEffect(() => {
+		if (team) onResolved({ value: id, label: team.name || id });
+	}, [team, id, onResolved]);
+	return null;
+}
+
+/** Server-side filters beyond search/limit, e.g. scoping to one customer. */
+export type TeamSelectorFilters = Omit<GetTeamsParams, "limit" | "offset" | "search">;
+
+interface TeamSelectorOwnProps extends EntitySelectorCommonProps {
+	/** Page size for each search request. */
+	limit?: number;
+	/** Extra server-side filters merged into every request. */
+	filters?: TeamSelectorFilters;
+}
+
+export type TeamSelectorProps = TeamSelectorOwnProps & EntitySelectorModeProps;
+
+export function TeamSelector({ limit = ENTITY_SELECTOR_PAGE_SIZE, filters, ...props }: TeamSelectorProps) {
+	const { open, setOpen, setSearch, debouncedSearch, skip, isDebouncing } = useEntitySelectorSearch();
+
+	const { data: teamsData, isFetching, isError } = useGetTeamsQuery({ ...filters, limit, search: debouncedSearch || undefined }, { skip });
+
+	// Memoized because multi mode hands this to react-select as defaultOptions,
+	// which re-syncs on identity change.
+	const options = useMemo(
+		() =>
+			(teamsData?.teams ?? []).map((team) => ({
+				value: team.id,
+				label: team.name || team.id,
+				// The customer a team rolls up to is the only thing that
+				// disambiguates two teams sharing a name.
+				description: team.customer?.name,
+			})),
+		[teamsData],
+	);
+
+	return (
+		<EntitySelector
+			{...props}
+			LabelResolver={TeamLabelResolver}
+			entityLabel="team"
+			entityLabelPlural="teams"
+			options={options}
+			isFetching={isFetching}
+			isError={isError}
+			open={open}
+			onOpenChange={setOpen}
+			onSearchChange={setSearch}
+			isSearching={isDebouncing || (isFetching && !!debouncedSearch)}
+			debouncedSearch={debouncedSearch}
+		/>
+	);
+}

--- a/ui/components/entitySelectors/virtualKeySelector.tsx
+++ b/ui/components/entitySelectors/virtualKeySelector.tsx
@@ -1,0 +1,83 @@
+// Unified async virtual key selector — the single way to pick virtual keys
+// across governance surfaces (model limits, pricing overrides, routing rules,
+// MCP clients).
+//
+// Single mode is prop-compatible with the model limit scope picker contract
+// ({ value, onChange, disabled, fallbackOption }), so it can be registered
+// as-is in lib/registries/modelLimitScopes.tsx.
+
+import {
+	EntitySelector,
+	ENTITY_SELECTOR_PAGE_SIZE,
+	type EntitySelectorCommonProps,
+	type EntityLabelResolverProps,
+	type EntitySelectorModeProps,
+	type EntitySelectorOption,
+	useEntitySelectorSearch,
+} from "@/components/entitySelectors/entitySelector";
+import { useGetVirtualKeyQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import type { GetVirtualKeysParams } from "@/lib/types/governance";
+import { useEffect, useMemo } from "react";
+
+function VirtualKeyLabelResolver({ id, onResolved }: EntityLabelResolverProps) {
+	const { data } = useGetVirtualKeyQuery(id);
+	const virtualKey = data?.virtual_key;
+	useEffect(() => {
+		if (virtualKey) onResolved({ value: id, label: virtualKey.name || id });
+	}, [virtualKey, id, onResolved]);
+	return null;
+}
+
+export type VirtualKeySelectorOption = EntitySelectorOption;
+
+/** Server-side filters beyond search/limit, e.g. scoping to a team or customer. */
+export type VirtualKeySelectorFilters = Omit<GetVirtualKeysParams, "limit" | "offset" | "search" | "export">;
+
+interface VirtualKeySelectorOwnProps extends EntitySelectorCommonProps {
+	/** Page size for each search request. */
+	limit?: number;
+	/** Extra server-side filters merged into every request. */
+	filters?: VirtualKeySelectorFilters;
+}
+
+export type VirtualKeySelectorProps = VirtualKeySelectorOwnProps & EntitySelectorModeProps;
+
+export function VirtualKeySelector({ limit = ENTITY_SELECTOR_PAGE_SIZE, filters, ...props }: VirtualKeySelectorProps) {
+	const { open, setOpen, setSearch, debouncedSearch, skip, isDebouncing } = useEntitySelectorSearch();
+
+	const {
+		data: vksData,
+		isFetching,
+		isError,
+	} = useGetVirtualKeysQuery({ ...filters, limit, search: debouncedSearch || undefined }, { skip });
+
+	// Memoized because multi mode hands this to react-select as defaultOptions,
+	// which re-syncs on identity change. vk.value is the secret itself and is
+	// deliberately never rendered.
+	const options = useMemo(
+		() =>
+			(vksData?.virtual_keys ?? []).map((vk) => ({
+				value: vk.id,
+				label: vk.name || vk.id,
+				description: vk.description,
+			})),
+		[vksData],
+	);
+
+	return (
+		<EntitySelector
+			{...props}
+			LabelResolver={VirtualKeyLabelResolver}
+			entityLabel="virtual key"
+			entityLabelPlural="virtual keys"
+			options={options}
+			isFetching={isFetching}
+			isError={isError}
+			open={open}
+			onOpenChange={setOpen}
+			onSearchChange={setSearch}
+			isSearching={isDebouncing || (isFetching && !!debouncedSearch)}
+			debouncedSearch={debouncedSearch}
+		/>
+	);
+}

--- a/ui/components/prompts/components/apiKeySelectorView.tsx
+++ b/ui/components/prompts/components/apiKeySelectorView.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import type { DBKey, VirtualKey } from "@/lib/types/governance";
-import { useCallback, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export function ApiKeySelectorView({
 	providerKeys,
@@ -20,6 +21,8 @@ export function ApiKeySelectorView({
 	disabled,
 	placeholder,
 	requireVirtualKey,
+	onSearchChange,
+	isSearching,
 }: {
 	providerKeys: DBKey[];
 	virtualKeys: VirtualKey[];
@@ -28,32 +31,55 @@ export function ApiKeySelectorView({
 	disabled?: boolean;
 	placeholder?: string;
 	requireVirtualKey?: boolean;
+	/** Mirrors typing to the caller so virtual keys can be searched server-side. */
+	onSearchChange?: (search: string) => void;
+	isSearching?: boolean;
 }) {
 	const [query, setQuery] = useState("");
 
-	const allOptions = useMemo(() => {
-		const apiKeyOpts = providerKeys.map((k) => ({ label: k.name, value: k.key_id, group: "api" as const }));
-		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.value, group: "virtual" as const }));
-		if (requireVirtualKey) return vkOpts;
-		return [{ label: "Auto (default)", value: "__auto__", group: "api" as const }, ...apiKeyOpts, ...vkOpts];
-	}, [providerKeys, virtualKeys, requireVirtualKey]);
-
-	const filtered = useMemo(() => {
-		if (!query) return allOptions;
+	// Provider keys are already in memory, so they filter here. Virtual keys
+	// arrive from the server pre-narrowed by the same query.
+	const apiKeyOptions = useMemo(() => {
+		if (requireVirtualKey) return [];
+		const opts = [{ label: "Auto (default)", value: "__auto__" }, ...providerKeys.map((k) => ({ label: k.name, value: k.key_id }))];
+		if (!query) return opts;
 		const q = query.toLowerCase();
-		return allOptions.filter((o) => o.label.toLowerCase().includes(q));
-	}, [allOptions, query]);
+		return opts.filter((o) => o.label.toLowerCase().includes(q));
+	}, [providerKeys, requireVirtualKey, query]);
 
-	const filteredApiKeys = useMemo(() => filtered.filter((o) => o.group === "api"), [filtered]);
-	const filteredVirtualKeys = useMemo(() => filtered.filter((o) => o.group === "virtual"), [filtered]);
+	const virtualKeyOptions = useMemo(() => virtualKeys.map((vk) => ({ label: vk.name, value: vk.value })), [virtualKeys]);
+
+	// Only one page of virtual keys is loaded at a time, so the selected key can
+	// drop out of the list as the search narrows. Names seen once are kept so the
+	// trigger doesn't lose its label.
+	const labelCacheRef = useRef<Map<string, string>>(new Map());
+	useEffect(() => {
+		for (const o of virtualKeyOptions) labelCacheRef.current.set(o.value, o.label);
+	}, [virtualKeyOptions]);
+
+	const handleSearchChange = useCallback(
+		(v: string) => {
+			setQuery(v);
+			onSearchChange?.(v);
+		},
+		[onSearchChange],
+	);
 
 	const getLabel = useCallback(
 		(val: string | null) => {
-			if (requireVirtualKey && val === "__auto__") return "";
-			return allOptions.find((o) => o.value === val)?.label ?? val ?? "";
+			if (!val) return "";
+			if (val === "__auto__") return requireVirtualKey ? "" : "Auto (default)";
+			const providerKey = providerKeys.find((k) => k.key_id === val);
+			if (providerKey) return providerKey.name;
+			const virtualKey = virtualKeys.find((vk) => vk.value === val);
+			if (virtualKey) return virtualKey.name;
+			// Never fall back to `val` — for a virtual key that is the secret itself.
+			return labelCacheRef.current.get(val) ?? "";
 		},
-		[allOptions, requireVirtualKey],
+		[providerKeys, virtualKeys, requireVirtualKey],
 	);
+
+	const hasResults = apiKeyOptions.length > 0 || virtualKeyOptions.length > 0;
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -64,9 +90,9 @@ export function ApiKeySelectorView({
 				value={value}
 				onValueChange={(v) => onValueChange(v)}
 				onOpenChange={(open) => {
-					if (open) setQuery("");
+					if (open) handleSearchChange("");
 				}}
-				onInputValueChange={(v) => setQuery(v)}
+				onInputValueChange={handleSearchChange}
 				filter={null}
 				itemToStringLabel={getLabel}
 			>
@@ -78,28 +104,34 @@ export function ApiKeySelectorView({
 				/>
 				<ComboboxContent>
 					<ComboboxList>
-						{filteredApiKeys.length > 0 && (
+						{apiKeyOptions.length > 0 && (
 							<ComboboxGroup>
 								<ComboboxLabel>API Keys</ComboboxLabel>
-								{filteredApiKeys.map((o) => (
+								{apiKeyOptions.map((o) => (
 									<ComboboxItem key={o.value} value={o.value}>
 										{o.label}
 									</ComboboxItem>
 								))}
 							</ComboboxGroup>
 						)}
-						{filteredApiKeys.length > 0 && filteredVirtualKeys.length > 0 && <ComboboxSeparator />}
-						{filteredVirtualKeys.length > 0 && (
+						{apiKeyOptions.length > 0 && virtualKeyOptions.length > 0 && <ComboboxSeparator />}
+						{virtualKeyOptions.length > 0 && (
 							<ComboboxGroup>
 								<ComboboxLabel>Virtual Keys</ComboboxLabel>
-								{filteredVirtualKeys.map((o) => (
+								{virtualKeyOptions.map((o) => (
 									<ComboboxItem key={o.value} value={o.value}>
 										{o.label}
 									</ComboboxItem>
 								))}
 							</ComboboxGroup>
 						)}
-						{filtered.length === 0 && <div className="text-muted-foreground py-6 text-center text-sm">No results found.</div>}
+						{isSearching && !hasResults && (
+							<div className="text-muted-foreground flex items-center justify-center gap-2 py-6 text-sm">
+								<Loader2 className="size-4 animate-spin" />
+								Searching...
+							</div>
+						)}
+						{!isSearching && !hasResults && <div className="text-muted-foreground py-6 text-center text-sm">No results found.</div>}
 					</ComboboxList>
 				</ComboboxContent>
 			</Combobox>

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -11,13 +11,17 @@ import { useGetVirtualKeysQuery } from "@/lib/store";
 import { useGetCoreConfigQuery } from "@/lib/store/apis/configApi";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { ModelProviderName } from "@/lib/types/config";
+import type { VirtualKey } from "@/lib/types/governance";
 import { ModelParams } from "@/lib/types/prompts";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { cn } from "@/lib/utils";
 import { PromptDeploymentsAccordionItem } from "@enterprise/components/prompt-deployments/promptDeploymentsAccordionItem";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ApiKeySelectorView } from "../components/apiKeySelectorView";
 import { VariablesTableView } from "../components/variablesTableView";
 import { usePromptContext } from "../context";
+
+const VIRTUAL_KEY_PAGE_SIZE = 20;
 
 export function SettingsPanel() {
 	const {
@@ -55,7 +59,15 @@ export function SettingsPanel() {
 	);
 	// Dynamic providers
 	const { data: providers, isLoading: isLoadingProviders } = useGetProvidersQuery();
-	const { data: virtualKeysData } = useGetVirtualKeysQuery();
+
+	// Virtual keys are searched server-side and capped at one page — calling this
+	// with no params at all makes the handler return every key, fully hydrated.
+	const [vkSearch, setVkSearch] = useState("");
+	const debouncedVkSearch = useDebouncedValue(vkSearch, 300);
+	const { data: virtualKeysData, isFetching: isFetchingVirtualKeys } = useGetVirtualKeysQuery({
+		limit: VIRTUAL_KEY_PAGE_SIZE,
+		search: debouncedVkSearch || undefined,
+	});
 	const { data: coreConfig } = useGetCoreConfigQuery({});
 	const enforceVirtualKeys = coreConfig?.client_config?.enforce_auth_on_inference ?? false;
 	// Keys for the API Key selector (from /api/keys endpoint, provider-filtered)
@@ -108,22 +120,33 @@ export function SettingsPanel() {
 		}
 	}, [apiKeyId, enforceVirtualKeys, providerKeys, setApiKeyId]);
 
+	// Only one page of virtual keys is loaded, so the selected key can fall out of
+	// the list as the search narrows. Pin it once resolved — model filtering below
+	// reads its id, and losing it would silently widen the model list.
+	const [selectedVirtualKey, setSelectedVirtualKey] = useState<VirtualKey | null>(null);
+	useEffect(() => {
+		setSelectedVirtualKey((prev) => {
+			const match = providerVirtualKeys.find((vk) => vk.value === apiKeyId);
+			if (match) return match;
+			return prev?.value === apiKeyId ? prev : null;
+		});
+	}, [apiKeyId, providerVirtualKeys]);
+
 	// Separate keys/vks to pass to model fetch for filtering.
 	const filterKeys = useMemo(() => {
 		if (enforceVirtualKeys) return undefined;
 		const isProviderKey = providerKeys.some((k) => k.key_id === apiKeyId);
 		if (isProviderKey) return [apiKeyId];
-		const isVirtualKey = providerVirtualKeys.some((vk) => vk.value === apiKeyId);
-		if (isVirtualKey) return undefined;
+		if (selectedVirtualKey) return undefined;
 		// Auto: pass all provider key IDs
 		return providerKeys.map((k) => k.key_id);
-	}, [apiKeyId, enforceVirtualKeys, providerKeys, providerVirtualKeys]);
+	}, [apiKeyId, enforceVirtualKeys, providerKeys, selectedVirtualKey]);
 
-	const filterVks = useMemo(() => {
-		const virtualKey = providerVirtualKeys.find((vk) => vk.value === apiKeyId);
-		if (virtualKey) return [virtualKey.id];
-		return undefined;
-	}, [apiKeyId, providerVirtualKeys]);
+	const filterVks = useMemo(() => (selectedVirtualKey ? [selectedVirtualKey.id] : undefined), [selectedVirtualKey]);
+
+	// A search that matches nothing must not unmount the picker in enforce mode —
+	// that would take the search box away with it.
+	const hasVirtualKeysForProvider = providerVirtualKeys.length > 0 || !!selectedVirtualKey || !!vkSearch;
 
 	const handleModelParamsChange = useCallback(
 		(params: Record<string, unknown>) => {
@@ -211,7 +234,7 @@ export function SettingsPanel() {
 									/>
 								</div>
 
-								{!!provider && (enforceVirtualKeys ? providerVirtualKeys.length > 0 : true) && (
+								{!!provider && (enforceVirtualKeys ? hasVirtualKeysForProvider : true) && (
 									<ApiKeySelectorView
 										providerKeys={providerKeys}
 										virtualKeys={providerVirtualKeys}
@@ -219,6 +242,8 @@ export function SettingsPanel() {
 										onValueChange={(v) => onApiKeyIdChange(v ?? "__auto__")}
 										disabled={!provider}
 										requireVirtualKey={enforceVirtualKeys}
+										onSearchChange={setVkSearch}
+										isSearching={isFetchingVirtualKeys || vkSearch !== debouncedVkSearch}
 									/>
 								)}
 

--- a/ui/components/ui/asyncMultiselect.tsx
+++ b/ui/components/ui/asyncMultiselect.tsx
@@ -186,6 +186,10 @@ interface AsyncMultiSelectProps<T> {
 
 	/** callback function to be called when input value changes */
 	onInputChange?: (inputValue: string, actionMeta: { action: string }) => void;
+	/** called when the menu opens — e.g. to start fetching options lazily */
+	onMenuOpen?: () => void;
+	/** called when the menu closes */
+	onMenuClose?: () => void;
 	onKeyDown?: KeyboardEventHandler;
 
 	/** custom no options message */
@@ -403,9 +407,11 @@ export function AsyncMultiSelect<T>(props: AsyncMultiSelectProps<T>) {
 				}}
 				onMenuOpen={() => {
 					menuOpenRef.current = true;
+					props.onMenuOpen?.();
 				}}
 				onMenuClose={() => {
 					menuOpenRef.current = false;
+					props.onMenuClose?.();
 				}}
 				menuIsOpen={props.menuIsOpen}
 				noOptionsMessage={

--- a/ui/components/ui/searchSelect.tsx
+++ b/ui/components/ui/searchSelect.tsx
@@ -30,6 +30,10 @@ interface SearchSelectBaseProps<T extends SearchSelectOption = SearchSelectOptio
 	triggerClassName?: string;
 	contentClassName?: string;
 	noPortal?: boolean;
+	/** Called when the list is scrolled near the bottom — load the next page. */
+	onLoadMore?: () => void;
+	/** Shows a spinner row under the options while the next page is in flight. */
+	isLoadingMore?: boolean;
 }
 
 interface SearchSelectSyncProps<T extends SearchSelectOption = SearchSelectOption> extends SearchSelectBaseProps<T> {
@@ -81,6 +85,8 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 		triggerClassName,
 		contentClassName,
 		noPortal,
+		onLoadMore,
+		isLoadingMore = false,
 	} = props;
 
 	const isAsync = props.async === true;
@@ -97,6 +103,10 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 
 	const setOpen = React.useCallback(
 		(v: boolean) => {
+			// The trigger is a span, so `disabled` on it is inert, and a disabled
+			// button trigger has `pointer-events-none` — which lets the click fall
+			// through to the span behind it. Refuse to open here instead.
+			if (v && disabled) return;
 			setInternalOpen(v);
 			onOpenChange?.(v);
 			if (!v) {
@@ -104,7 +114,7 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 				onSearchChange?.("");
 			}
 		},
-		[onOpenChange, onSearchChange],
+		[onOpenChange, onSearchChange, disabled],
 	);
 
 	const handleSearchChange = React.useCallback(
@@ -116,6 +126,17 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 	);
 
 	const inputRef = React.useRef<HTMLInputElement>(null);
+
+	const handleListScroll = React.useCallback(
+		(e: React.UIEvent<HTMLDivElement>) => {
+			if (!onLoadMore || isLoadingMore) return;
+			const el = e.currentTarget;
+			// Fire a little before the true bottom so the next page is already
+			// arriving by the time the user reaches it.
+			if (el.scrollHeight - el.scrollTop - el.clientHeight < 48) onLoadMore();
+		},
+		[onLoadMore, isLoadingMore],
+	);
 
 	React.useEffect(() => {
 		if (open) {
@@ -129,7 +150,11 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild disabled={disabled}>
-				<span data-slot="search-select" className={cn("inline-flex", className)}>
+				<span
+					data-slot="search-select"
+					aria-disabled={disabled || undefined}
+					className={cn("inline-flex", disabled && "pointer-events-none", className)}
+				>
 					{typeof label === "string" ? (
 						<button
 							type="button"
@@ -169,7 +194,11 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 							onValueChange={handleSearchChange}
 						/>
 					</div>
-					<CommandPrimitive.List data-slot="search-select-list" className="max-h-[300px] overflow-x-hidden overflow-y-auto p-1">
+					<CommandPrimitive.List
+						data-slot="search-select-list"
+						className="max-h-[300px] overflow-x-hidden overflow-y-auto p-1"
+						onScroll={onLoadMore ? handleListScroll : undefined}
+					>
 						{isLoading ? (
 							<div className="space-y-1 p-1">
 								{Array.from({ length: 3 }).map((_, i) => (
@@ -198,6 +227,11 @@ function SearchSelect<T extends SearchSelectOption = SearchSelectOption>(props: 
 										{entryView ? entryView(option) : <DefaultEntryView option={option} />}
 									</CommandPrimitive.Item>
 								))}
+								{isLoadingMore && (
+									<div className="flex justify-center py-2">
+										<Loader2 className="size-4 animate-spin opacity-50" />
+									</div>
+								)}
 							</>
 						)}
 					</CommandPrimitive.List>

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -14,8 +14,7 @@
 //     user clicks the Scope Target badge on the Model Limits table.
 
 import type { ComponentType } from "react";
-import { ComboboxSelect } from "@/components/ui/combobox";
-import { useGetVirtualKeysQuery } from "@/lib/store";
+import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
 
 export interface ScopePickerProps {
 	value: string;
@@ -68,25 +67,6 @@ export function getModelLimitScope(value: string): ModelLimitScopeEntry | undefi
 // OSS default registrations.
 // ---------------------------------------------------------------------------
 
-function VirtualKeyPicker({ value, onChange, disabled, fallbackOption }: ScopePickerProps) {
-	const { data: vksData } = useGetVirtualKeysQuery();
-	const virtualKeys = vksData?.virtual_keys ?? [];
-	const options = [
-		...(fallbackOption && !virtualKeys.some((vk) => vk.id === fallbackOption.value) ? [fallbackOption] : []),
-		...virtualKeys.map((vk) => ({ label: vk.name, value: vk.id })),
-	];
-	return (
-		<ComboboxSelect
-			options={options}
-			value={value || null}
-			onValueChange={(v: string | null) => onChange(v ?? "")}
-			placeholder="Select a virtual key..."
-			disabled={disabled}
-			noPortal
-		/>
-	);
-}
-
 registerModelLimitScope({
 	value: "global",
 	label: "Global",
@@ -95,7 +75,7 @@ registerModelLimitScope({
 registerModelLimitScope({
 	value: "virtual_key",
 	label: "Virtual Key",
-	PickerComponent: VirtualKeyPicker,
+	PickerComponent: VirtualKeySelector,
 	buildDeepLink: (scopeId) => ({
 		to: "/workspace/governance/virtual-keys",
 		search: { vk: scopeId },

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -58,6 +58,9 @@ export interface Customer {
 	name: string;
 	rate_limit_id?: string;
 	calendar_aligned?: boolean;
+	// Number of virtual keys owned by this customer (server-computed; the list
+	// endpoint reports this instead of embedding the virtual keys themselves)
+	virtual_key_count?: number;
 	// Populated relationships
 	teams?: Team[];
 	budgets?: Budget[];


### PR DESCRIPTION
## Summary

The paginated customer list endpoint was loading the full `VirtualKeys` relation for every customer on a page, which becomes expensive when customers have thousands of keys. This PR replaces that eager-load with a single grouped `COUNT` query and exposes the result as a new `virtual_key_count` field on the `Customer` schema, while the full `virtual_keys` array is still returned by the single-customer endpoint.

## Changes

- Added `preloadCustomerRelationsWithoutVirtualKeys` to separate the preload path used by `GetCustomersPaginated` from the one used by `GetCustomers` and `GetCustomer`.
- Added `attachCustomerVirtualKeyCounts` which issues one `SELECT customer_id, COUNT(*) … GROUP BY customer_id` query to populate counts for an entire page of customers, avoiding an N+1.
- `GetCustomers` and `GetCustomer` continue to load the full `VirtualKeys` slice and derive `VirtualKeyCount` from `len(VirtualKeys)` so existing callers are unaffected.
- Added `VirtualKeyCount int` to `TableCustomer` with `gorm:"-"` so it is never persisted and is always computed at read time.
- Updated the OpenAPI schema and YAML to mark `virtual_keys` as nullable (omitted or null on the list endpoint) and document the new `virtual_key_count` integer field.
- Removed the separate `useGetVirtualKeysQuery` call from the customers page; the UI now reads `customer.virtual_key_count` directly from the paginated response instead of filtering a full virtual-keys list client-side.
- Simplified the virtual-keys badge in `CustomersTable` to show the count without a tooltip listing key names (names are not available from the list endpoint).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/...

# Verify paginated list returns virtual_key_count and null/omitted virtual_keys
curl -s "http://localhost:<port>/api/governance/customers?limit=25&offset=0" | jq '.customers[0] | {virtual_key_count, virtual_keys}'

# Verify single-customer endpoint still returns the full virtual_keys array
curl -s "http://localhost:<port>/api/governance/customers/<id>" | jq '{virtual_key_count, virtual_keys}'

# UI
cd ui
pnpm i
pnpm build
```

Navigate to the Governance → Customers page and confirm:
- The virtual key badge shows the correct count per customer row.
- No separate virtual-keys network request is made from the customers page.
- Opening a customer detail sheet still shows the full list of keys.

## Breaking changes

- [ ] Yes
- [x] No

The `virtual_keys` field on the list endpoint now returns `null` instead of an array. Consumers that relied on `virtual_keys` being populated in paginated list responses should switch to `virtual_key_count` for the count and use the single-customer endpoint to retrieve the keys themselves.

## Related issues

## Security considerations

The grouped count query is scoped to the customer IDs already returned by the page query (which itself respects any `QueryScope` on the context), so no additional customer or key data is exposed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable