### PR TITLE
fix: vertex count tokens unsupported fields

### DIFF
--- a/core/providers/vertex/payload_ordering_test.go
+++ b/core/providers/vertex/payload_ordering_test.go
@@ -13,3 +13,25 @@ func TestStripVertexGeminiUnsupportedFieldsRawPreservesOrdering(t *testing.T) {
 
 	assert.Equal(t, `{"contents":[{"role":"user","parts":[{"functionCall":{"name":"lookup","args":{"z":1,"a":2}}},{"functionResponse":{"name":"lookup","response":{"output":{"z":1,"a":2}}}}]}],"generationConfig":{"temperature":0.2}}`, string(got))
 }
+
+func TestStripVertexCountTokensUnsupportedFields(t *testing.T) {
+	t.Run("keeps fields that contribute to the count", func(t *testing.T) {
+		raw := []byte(`{"model":"gemini-3.6-flash","contents":[{"role":"user","parts":[{"text":"hi"}]}],"systemInstruction":{"parts":[{"text":"be terse"}]},"tools":[{"functionDeclarations":[{"name":"probe"}]}],"generationConfig":{"temperature":0.2}}`)
+
+		got := stripVertexCountTokensUnsupportedFields(raw)
+
+		assert.Equal(t, string(raw), string(got))
+	})
+
+	t.Run("drops fields countTokens rejects", func(t *testing.T) {
+		raw := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"systemInstruction":{"parts":[{"text":"be terse"}]},"toolConfig":{"functionCallingConfig":{"mode":"AUTO"}},"safetySettings":[{"category":"HARM_CATEGORY_HARASSMENT"}],"cachedContent":"cachedContents/abc","serviceTier":"SERVICE_TIER_STANDARD","labels":{"a":"b"}}`)
+
+		got := stripVertexCountTokensUnsupportedFields(raw)
+
+		assert.JSONEq(t, `{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"systemInstruction":{"parts":[{"text":"be terse"}]}}`, string(got))
+	})
+
+	t.Run("handles empty body", func(t *testing.T) {
+		assert.Empty(t, stripVertexCountTokensUnsupportedFields(nil))
+	})
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -4025,6 +4025,33 @@ func (provider *VertexProvider) fileContentByKey(ctx *schemas.BifrostContext, ke
 	}, nil
 }
 
+// vertexCountTokensUnsupportedFields lists generateContent fields that Vertex's
+// CountTokensRequest does not define, and which it rejects with a 400.
+var vertexCountTokensUnsupportedFields = []string{
+	"toolConfig",
+	"safetySettings",
+	"cachedContent",
+	"serviceTier",
+	"labels",
+}
+
+// stripVertexCountTokensUnsupportedFields drops fields the countTokens endpoint rejects.
+// systemInstruction, tools and generationConfig are supported there and must survive —
+// they contribute to the token count.
+func stripVertexCountTokensUnsupportedFields(jsonBody []byte) []byte {
+	if len(jsonBody) == 0 {
+		return jsonBody
+	}
+
+	out := jsonBody
+	for _, field := range vertexCountTokensUnsupportedFields {
+		if updated, err := providerUtils.DeleteJSONField(out, field); err == nil {
+			out = updated
+		}
+	}
+	return out
+}
+
 // CountTokens counts the number of tokens in the provided content using Vertex AI's countTokens endpoint.
 // Supports Gemini models with both text and image content.
 func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
@@ -4071,10 +4098,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		// Skip field-stripping when large payload mode is active — jsonBody is nil
 		// and the raw body will stream directly from the ingress reader.
 		if jsonBody != nil {
-			// Use sjson to delete fields directly from JSON bytes, preserving key ordering
-			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "toolConfig")
-			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "generationConfig")
-			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "systemInstruction")
+			jsonBody = stripVertexCountTokensUnsupportedFields(jsonBody)
 		}
 	}
 


### PR DESCRIPTION
## Summary

The Vertex `countTokens` endpoint rejects several fields that are valid in `generateContent` requests, causing 400 errors. Previously, the field-stripping logic incorrectly removed `generationConfig` and `systemInstruction`, which the `countTokens` endpoint actually supports and uses to produce accurate token counts. This PR fixes the set of fields being stripped and consolidates the logic into a dedicated helper.

## Changes

- Introduced `stripVertexCountTokensUnsupportedFields` to replace the inline ad-hoc field deletions in `CountTokens`. The new helper drops only the fields the `countTokens` endpoint actually rejects: `toolConfig`, `safetySettings`, `cachedContent`, `serviceTier`, and `labels`.
- Removed the incorrect stripping of `generationConfig` and `systemInstruction`, both of which are valid and meaningful to the `countTokens` endpoint.
- Added unit tests covering: fields that should be preserved, fields that should be dropped, and a nil/empty body edge case.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/vertex/...
```

Verify that `TestStripVertexCountTokensUnsupportedFields` passes, confirming that `systemInstruction`, `tools`, and `generationConfig` survive stripping while `toolConfig`, `safetySettings`, `cachedContent`, `serviceTier`, and `labels` are removed.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects which JSON fields are forwarded to the Vertex `countTokens` endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable