### PR TITLE
fix(vertex): merge deployments into Model Garden catalog for list-models instead of replacing it

### DIFF
--- a/core/providers/vertex/models_test.go
+++ b/core/providers/vertex/models_test.go
@@ -1,6 +1,9 @@
 package vertex
 
 import (
+	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -115,5 +118,133 @@ func TestBuildResponseFromConfigWildcardAllowlistDeploymentsOnly(t *testing.T) {
 	ids := modelIDs(result)
 	if len(ids) != 1 || ids[0] != "vertex/my-pro" {
 		t.Errorf("expected only deployment vertex/my-pro, got %v", ids)
+	}
+}
+
+// garbageServiceAccountJSON parses as a valid service_account credential (so
+// getAuthTokenSource succeeds) but carries an unparseable private key, so the
+// token source fails at Token() without any network access.
+const garbageServiceAccountJSON = `{"type":"service_account","project_id":"p","private_key_id":"x","private_key":"-----BEGIN PRIVATE KEY-----\ngarbage\n-----END PRIVATE KEY-----\n","client_email":"a@b.iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}`
+
+// TestListModelsByKeyAuthFallback exercises listModelsByKey end to end for the
+// paths that never reach the Model Garden API: the restricted-allowlist fast
+// path (auth is irrelevant) and the deployments fallback when Model Garden
+// credentials are unavailable (token source creation or token acquisition
+// fails). Unfiltered requests must keep surfacing the auth error rather than
+// silently degrading to config-only output.
+func TestListModelsByKeyAuthFallback(t *testing.T) {
+	t.Parallel()
+
+	deployments := schemas.KeyAliases{
+		"my-pro": {ModelID: "gemini-2.5-pro"},
+	}
+
+	tests := []struct {
+		name        string
+		key         schemas.Key
+		request     *schemas.BifrostListModelsRequest
+		wantModels  []string
+		wantErrPart string
+	}{
+		{
+			name: "restricted allowlist skips auth entirely",
+			key: schemas.Key{
+				Models:  schemas.WhiteList{"my-pro", "gemini-2.0-flash"},
+				Aliases: deployments,
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					Region: *schemas.NewSecretVar("us-central1"),
+					// Invalid credentials must not matter: the fast path
+					// returns before any token source is created.
+					AuthCredentials: *schemas.NewSecretVar("restricted-not-json"),
+				},
+			},
+			request:    &schemas.BifrostListModelsRequest{Provider: schemas.Vertex},
+			wantModels: []string{"vertex/gemini-2.0-flash", "vertex/my-pro"},
+		},
+		{
+			name: "wildcard deployments fall back when token source creation fails",
+			key: schemas.Key{
+				Models:  schemas.WhiteList{"*"},
+				Aliases: deployments,
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					Region:          *schemas.NewSecretVar("us-central1"),
+					AuthCredentials: *schemas.NewSecretVar("wildcard-source-not-json"),
+				},
+			},
+			request:    &schemas.BifrostListModelsRequest{Provider: schemas.Vertex},
+			wantModels: []string{"vertex/my-pro"},
+		},
+		{
+			name: "wildcard deployments fall back when token acquisition fails",
+			key: schemas.Key{
+				Models:  schemas.WhiteList{"*"},
+				Aliases: deployments,
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					Region:          *schemas.NewSecretVar("us-central1"),
+					AuthCredentials: *schemas.NewSecretVar(garbageServiceAccountJSON),
+				},
+			},
+			request:    &schemas.BifrostListModelsRequest{Provider: schemas.Vertex},
+			wantModels: []string{"vertex/my-pro"},
+		},
+		{
+			name: "unfiltered preserves the auth error instead of falling back",
+			key: schemas.Key{
+				Models:  schemas.WhiteList{"*"},
+				Aliases: deployments,
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					Region:          *schemas.NewSecretVar("us-central1"),
+					AuthCredentials: *schemas.NewSecretVar("unfiltered-not-json"),
+				},
+			},
+			request:     &schemas.BifrostListModelsRequest{Provider: schemas.Vertex, Unfiltered: true},
+			wantErrPart: "error creating auth token source",
+		},
+		{
+			name: "wildcard without deployments preserves the auth error",
+			key: schemas.Key{
+				Models: schemas.WhiteList{"*"},
+				VertexKeyConfig: &schemas.VertexKeyConfig{
+					Region:          *schemas.NewSecretVar("us-central1"),
+					AuthCredentials: *schemas.NewSecretVar("no-deployments-not-json"),
+				},
+			},
+			request:     &schemas.BifrostListModelsRequest{Provider: schemas.Vertex},
+			wantErrPart: "error creating auth token source",
+		},
+	}
+
+	// A zero-value provider suffices: every case returns (or fails) before the
+	// Model Garden fetch, so the HTTP client and logger are never touched.
+	provider := &VertexProvider{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			defer ctx.Cancel()
+
+			response, bifrostErr := provider.listModelsByKey(ctx, tt.key, tt.request)
+
+			if tt.wantErrPart != "" {
+				if bifrostErr == nil {
+					t.Fatalf("expected error containing %q, got response %v", tt.wantErrPart, modelIDs(response))
+				}
+				if !strings.Contains(bifrostErr.Error.Message, tt.wantErrPart) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErrPart, bifrostErr.Error.Message)
+				}
+				return
+			}
+
+			if bifrostErr != nil {
+				t.Fatalf("unexpected error: %v", bifrostErr.Error.Message)
+			}
+			got := modelIDs(response)
+			slices.Sort(got)
+			if !slices.Equal(got, tt.wantModels) {
+				t.Errorf("expected models %v, got %v", tt.wantModels, got)
+			}
+		})
 	}
 }

--- a/core/providers/vertex/models_test.go
+++ b/core/providers/vertex/models_test.go
@@ -1,0 +1,119 @@
+package vertex
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func publisherModelsResponse(names ...string) *VertexListPublisherModelsResponse {
+	response := &VertexListPublisherModelsResponse{}
+	for _, name := range names {
+		response.PublisherModels = append(response.PublisherModels, VertexPublisherModel{
+			Name: "publishers/google/models/" + name,
+		})
+	}
+	return response
+}
+
+func modelIDs(response *schemas.BifrostListModelsResponse) []string {
+	ids := make([]string, 0, len(response.Data))
+	for _, model := range response.Data {
+		ids = append(ids, model.ID)
+	}
+	return ids
+}
+
+// TestPublisherModelsWildcardWithAliasesMergesCatalog verifies that a wildcard
+// allowlist combined with configured deployments (aliases) produces the full
+// catalog PLUS the alias entries, instead of the aliases replacing the catalog.
+// This is the conversion listModelsByKey relies on when it falls through to the
+// Model Garden fetch for wildcard-allowlist keys with deployments configured.
+func TestPublisherModelsWildcardWithAliasesMergesCatalog(t *testing.T) {
+	t.Parallel()
+
+	response := publisherModelsResponse("gemini-2.5-pro", "gemini-2.5-flash")
+	aliases := schemas.KeyAliases{
+		"my-pro":       {ModelID: "gemini-2.5-pro"},
+		"custom-model": {ModelID: "gemini-9.9-unreleased"},
+	}
+
+	result := response.ToBifrostListModelsResponse(schemas.WhiteList{"*"}, nil, aliases, false)
+
+	got := make(map[string]bool)
+	for _, id := range modelIDs(result) {
+		got[id] = true
+	}
+
+	// Catalog models must survive.
+	for _, want := range []string{"vertex/gemini-2.5-pro", "vertex/gemini-2.5-flash"} {
+		if !got[want] {
+			t.Errorf("expected catalog model %q in response, got %v", want, modelIDs(result))
+		}
+	}
+	// Alias matching a catalog model is surfaced alongside it.
+	if !got["vertex/my-pro"] {
+		t.Errorf("expected alias %q in response, got %v", "vertex/my-pro", modelIDs(result))
+	}
+	// Alias not present in the catalog is backfilled.
+	if !got["vertex/custom-model"] {
+		t.Errorf("expected backfilled alias %q in response, got %v", "vertex/custom-model", modelIDs(result))
+	}
+
+	// Alias entries must carry the provider-specific model ID.
+	for _, model := range result.Data {
+		if model.ID == "vertex/my-pro" {
+			if model.Alias == nil || *model.Alias != "gemini-2.5-pro" {
+				t.Errorf("expected alias value %q for vertex/my-pro, got %v", "gemini-2.5-pro", model.Alias)
+			}
+		}
+	}
+}
+
+// TestBuildResponseFromConfigRestrictedAllowlist verifies the config fast path
+// used when an explicit allowlist is configured: deployments filtered by the
+// allowlist plus remaining allowlist entries, no catalog access.
+func TestBuildResponseFromConfigRestrictedAllowlist(t *testing.T) {
+	t.Parallel()
+
+	deployments := schemas.KeyAliases{
+		"my-pro":   {ModelID: "gemini-2.5-pro"},
+		"excluded": {ModelID: "gemini-2.5-flash"},
+	}
+	allowed := schemas.WhiteList{"my-pro", "gemini-2.0-flash"}
+
+	result := buildResponseFromConfig(deployments, allowed, nil)
+
+	got := make(map[string]bool)
+	for _, id := range modelIDs(result) {
+		got[id] = true
+	}
+
+	if !got["vertex/my-pro"] {
+		t.Errorf("expected allowed deployment vertex/my-pro, got %v", modelIDs(result))
+	}
+	if !got["vertex/gemini-2.0-flash"] {
+		t.Errorf("expected allowlist entry vertex/gemini-2.0-flash, got %v", modelIDs(result))
+	}
+	if got["vertex/excluded"] {
+		t.Errorf("deployment not in allowlist must be filtered out, got %v", modelIDs(result))
+	}
+}
+
+// TestBuildResponseFromConfigWildcardAllowlistDeploymentsOnly documents the
+// auth-fallback shape: with a wildcard allowlist, only deployments are listed
+// (used when Model Garden credentials are unavailable).
+func TestBuildResponseFromConfigWildcardAllowlistDeploymentsOnly(t *testing.T) {
+	t.Parallel()
+
+	deployments := schemas.KeyAliases{
+		"my-pro": {ModelID: "gemini-2.5-pro"},
+	}
+
+	result := buildResponseFromConfig(deployments, schemas.WhiteList{"*"}, nil)
+
+	ids := modelIDs(result)
+	if len(ids) != 1 || ids[0] != "vertex/my-pro" {
+		t.Errorf("expected only deployment vertex/my-pro, got %v", ids)
+	}
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -206,8 +206,16 @@ func (provider *VertexProvider) GetProviderKey() schemas.ModelProvider {
 // Returns the response and latency, or an error if the request fails.
 //
 // The logic is:
-// 1. If deployments or allowedModels are configured, return those (no API call needed)
-// 2. Otherwise, fetch from the publishers.models.list API endpoint (Model Garden)
+//  1. If an explicit (restricted) allowedModels list is configured, return the
+//     configured models/deployments directly (no API call needed) — the user has
+//     enumerated exactly which models this key serves.
+//  2. Otherwise (wildcard allowlist), fetch the full catalog from the
+//     publishers.models.list API endpoint (Model Garden). Configured deployments
+//     are merged into the catalog by the list-models pipeline (matching aliases
+//     are surfaced and unmatched ones are backfilled), mirroring how providers
+//     like OpenAI combine aliases with the live model list. If Model Garden
+//     auth is unavailable (e.g. API-key-only keys), fall back to the configured
+//     deployments so the key still lists something useful.
 func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	region := resolveVertexRegion(ctx, key)
 	if region == "" {
@@ -221,13 +229,16 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 		return &schemas.BifrostListModelsResponse{Data: make([]schemas.Model, 0)}, nil
 	}
 
-	// If deployments or allowedModels are configured, return those directly without API call
+	// If an explicit allowlist is configured, it fully determines the model set —
+	// return it directly without an API call.
+	// A wildcard allowlist with deployments falls through to the Model Garden
+	// fetch so deployments ADD to the catalog instead of replacing it.
 	// Skip this fast path when Unfiltered is set so the full Vertex catalog can be retrieved
-	if !request.Unfiltered && (len(deployments) > 0 || allowedModels.IsRestricted()) {
+	if !request.Unfiltered && allowedModels.IsRestricted() {
 		return buildResponseFromConfig(deployments, allowedModels, key.BlacklistedModels), nil
 	}
 
-	// No deployments configured - fetch from Model Garden API
+	// Wildcard allowlist - fetch the full catalog from the Model Garden API
 	host := getVertexModelListingAPIHost(region)
 
 	// Accumulate all publisher models from paginated requests
@@ -239,10 +250,18 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	// Getting oauth2 token
 	tokenSource, err := getAuthTokenSource(key)
 	if err != nil {
+		// Keys without Model Garden credentials (e.g. api-key auth) can still
+		// surface their configured deployments instead of failing outright.
+		if !request.Unfiltered && len(deployments) > 0 {
+			return buildResponseFromConfig(deployments, allowedModels, key.BlacklistedModels), nil
+		}
 		return nil, providerUtils.NewBifrostOperationError("error creating auth token source (api key auth not supported for list models)", err)
 	}
 	token, err := tokenSource.Token()
 	if err != nil {
+		if !request.Unfiltered && len(deployments) > 0 {
+			return buildResponseFromConfig(deployments, allowedModels, key.BlacklistedModels), nil
+		}
 		return nil, providerUtils.NewBifrostOperationError("error getting token (api key auth not supported for list models)", err)
 	}
 


### PR DESCRIPTION
## Summary

On a Vertex key with a **wildcard allowlist** (`"*"`), configuring any deployment (alias) makes `listModelsByKey` skip the Model Garden fetch entirely and return only the configured aliases. Other providers (e.g. OpenAI) always fetch the upstream catalog and merge aliases into it via the shared `ListModelsPipeline` — Vertex is the outlier.

The impact goes beyond `/v1/models` output. The live model pool feeds the model catalog that governance consults for virtual keys with `allowed_models=["*"]` (`ModelCatalog.IsModelAllowedForProvider` → `GetProvidersForModel`). As soon as one deployment is added to a Vertex key, requests to real Vertex models that are absent from the static datasheet (e.g. newly released image/preview variants) start failing with:

```
Model 'gemini-3.1-flash-lite-image' is not allowed for this virtual key
```

even though the same model worked before the deployment was added and still works on keys without deployments.

## Changes

- `listModelsByKey` now only takes the no-API-call fast path when the allowlist is **explicitly restricted** (the user enumerated the exact model set). A wildcard allowlist falls through to the Model Garden fetch even when deployments are configured; the existing pipeline in `ToBifrostListModelsResponse` already surfaces matching aliases and backfills unmatched ones (same behavior as the OpenAI provider), so no pipeline changes were needed.
- If Model Garden auth is unavailable (api-key-only keys — token source creation or token fetch fails), fall back to `buildResponseFromConfig` instead of erroring, preserving the previous output for keys that cannot list the catalog.
- Restricted-allowlist keys keep the exact same behavior as before.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/vertex/ -run 'TestPublisherModelsWildcardWithAliasesMergesCatalog|TestBuildResponseFromConfig' -v
go build ./...
```

Manual: configure a Vertex key with Allowed Models = All Models and at least one deployment (e.g. `claude-fable → claude-fable-5`), then:

- `GET /v1/models?provider=vertex` — before: only deployment names; after: full Model Garden catalog + deployment aliases (with `alias` field set).
- Chat completion via a wildcard VK against a catalog model not in the pricing datasheet — before: `Model 'X' is not allowed for this virtual key`; after: allowed.

## Breaking changes

- [ ] Yes
- [x] No

Restricted-allowlist keys are unchanged. Wildcard-allowlist keys with deployments now return the full catalog from list-models — this restores the pre-deployments behavior and matches other providers, but is technically a larger response than before for such keys.

## Security considerations

None — list-models only. The Model Garden fetch uses the key's existing OAuth credentials; no new endpoints or auth paths.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
