### PR TITLE
fix: show `FullPageLoader` on initial fetch to prevent empty-state flash in pricing overrides and model limits views

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -1,4 +1,5 @@
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
+import FullPageLoader from "@/components/fullPageLoader";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -23,7 +24,7 @@ import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { PricingOverride, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { useLocation } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import PricingOverrideSheet from "./pricingOverrideSheet";
 import { PricingOverridesEmptyState } from "./pricingOverridesEmptyState";
@@ -215,6 +216,8 @@ export default function ScopedPricingOverridesView() {
 	);
 
 	const { data, isLoading, error } = useGetPricingOverridesQuery(queryArgs);
+	const hasLoadedOnceRef = useRef(false);
+	if (data || error) hasLoadedOnceRef.current = true;
 
 	// Snap offset back when total shrinks past current page
 	const totalCount = data?.total_count ?? 0;
@@ -292,6 +295,13 @@ export default function ScopedPricingOverridesView() {
 	};
 
 	const hasActiveFilters = debouncedSearch || scopeKind !== "all" || userID || virtualKeyID || providerID || providerKeyID;
+
+	// Without this the table chrome paints first, then swaps to the full-page empty
+	// state once the first response resolves to zero rows. Hold a plain loader until
+	// then; later filter/page fetches keep the table so the chrome doesn't jump.
+	if (isLoading && !hasLoadedOnceRef.current) {
+		return <FullPageLoader />;
+	}
 
 	if (!isLoading && !error && totalCount === 0 && !hasActiveFilters) {
 		return (

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,7 +1,8 @@
+import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitsTable from "./modelLimitsTable";
 
@@ -43,6 +44,9 @@ export default function ModelLimitsView() {
 		},
 	);
 
+	const hasLoadedOnceRef = useRef(false);
+	if (modelConfigsData || modelConfigsError) hasLoadedOnceRef.current = true;
+
 	const totalCount = modelConfigsData?.total_count ?? 0;
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
@@ -57,6 +61,14 @@ export default function ModelLimitsView() {
 			toast.error(`Failed to load model configs: ${getErrorMessage(modelConfigsError)}`);
 		}
 	}, [modelConfigsError]);
+
+	// The table chrome renders "Loading limits..." while the first request is in
+	// flight, then collapses to the full-page empty state once it resolves to zero
+	// rows — a visible flash. Hold a plain loader until the first response lands.
+	// Subsequent filter/page fetches keep the table so the chrome doesn't jump.
+	if (isModelConfigsLoading && !hasLoadedOnceRef.current) {
+		return <FullPageLoader />;
+	}
 
 	return (
 		<ModelLimitsTable


### PR DESCRIPTION
## Summary

Fixes a visible UI flash in the Pricing Overrides and Model Limits views where the table chrome (including an inline "loading" state) would render first, then abruptly collapse into a full-page empty state once the initial data fetch resolved to zero rows.

## Changes

- Added a `hasLoadedOnceRef` ref in both `ScopedPricingOverridesView` and `ModelLimitsView` that flips to `true` on the first successful response or error.
- During the initial load (before any response has landed), a `FullPageLoader` is returned instead of the table chrome, preventing the flash.
- Subsequent fetches triggered by filter changes or pagination keep the existing table visible so the UI doesn't jump.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the **Custom Pricing → Overrides** page with no existing overrides configured.
2. Confirm that a full-page loader appears while the initial request is in flight, and that the empty state renders directly without a flash of the table chrome.
3. Repeat on the **Model Limits** page with no model configs configured.
4. Add filters or change pages on a view with data and confirm the table remains visible during subsequent fetches (no loader re-appears).

## Screenshots/Recordings

Before: Table chrome renders briefly with an inline loading indicator, then snaps to the full-page empty state.
After: `FullPageLoader` is shown until the first response lands, then transitions cleanly to the empty state or populated table.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable