### PR TITLE
semantic router #1: add chromem backend

### DIFF
--- a/framework/go.mod
+++ b/framework/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/maximhq/bifrost/core v1.7.9
+	github.com/philippgille/chromem-go v0.7.0
 	github.com/pinecone-io/go-pinecone/v5 v5.3.0
 	github.com/qdrant/go-client v1.16.2
 	github.com/redis/go-redis/v9 v9.17.2

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -272,6 +272,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=
 github.com/paulmach/orb v0.11.1/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
+github.com/philippgille/chromem-go v0.7.0 h1:4jfvfyKymjKNfGxBUhHUcj1kp7B17NL/I1P+vGh1RvY=
+github.com/philippgille/chromem-go v0.7.0/go.mod h1:hTd+wGEm/fFPQl7ilfCwQXkgEUxceYh86iIdoKMolPo=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pinecone-io/go-pinecone/v5 v5.3.0 h1:0YQlEtmXGWK/I8ztkOVM6PuBYgFJZhjSdb0ddU+bHPE=

--- a/framework/vectorstore/chromem.go
+++ b/framework/vectorstore/chromem.go
@@ -1,0 +1,663 @@
+package vectorstore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	chromem "github.com/philippgille/chromem-go"
+)
+
+// ChromemConfig represents the configuration for the embedded chromem vector store.
+// Chromem runs in-process (pure Go, no external service). With an empty Path the
+// store is memory-only; with a Path set, documents are persisted to disk and
+// reloaded on startup.
+type ChromemConfig struct {
+	Path     string `json:"path,omitempty"`
+	Compress bool   `json:"compress,omitempty"`
+}
+
+// ChromemStore is an embedded VectorStore backed by chromem-go.
+//
+// Chromem has no document-enumeration API and no typed metadata, so this
+// backend bridges both gaps itself:
+//   - metadata values are JSON-encoded into chromem's map[string]string and
+//     decoded back to typed values on read;
+//   - GetAll/DeleteAll/GetNearest enumerate via an exhaustive QueryEmbedding
+//     with a probe vector, which requires the namespace dimension. Like the
+//     Pinecone backend, the dimension is recorded in memory by CreateNamespace,
+//     so callers must CreateNamespace after every process start (all current
+//     callers already do).
+type ChromemStore struct {
+	db     *chromem.DB
+	config *ChromemConfig
+	logger schemas.Logger
+
+	mu                  sync.RWMutex
+	namespaceDimensions map[string]int
+}
+
+// chromemStubEmbeddingFunc is passed to chromem collection constructors.
+// All entries carry precomputed vectors (RequiresVectors is true), so chromem
+// should never need to embed on our behalf.
+func chromemStubEmbeddingFunc(ctx context.Context, text string) ([]float32, error) {
+	return nil, fmt.Errorf("chromem backend requires precomputed embeddings")
+}
+
+func newChromemStore(_ context.Context, config *ChromemConfig, logger schemas.Logger) (*ChromemStore, error) {
+	if config == nil {
+		return nil, fmt.Errorf("chromem config is required")
+	}
+
+	var db *chromem.DB
+	var err error
+	if strings.TrimSpace(config.Path) != "" {
+		db, err = chromem.NewPersistentDB(config.Path, config.Compress)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open chromem persistent db at %s: %w", config.Path, err)
+		}
+	} else {
+		db = chromem.NewDB()
+	}
+
+	return &ChromemStore{
+		db:                  db,
+		config:              config,
+		logger:              logger,
+		namespaceDimensions: make(map[string]int),
+	}, nil
+}
+
+// Ping checks the health of the store. Chromem is in-process, so this only
+// verifies the store was initialized.
+func (s *ChromemStore) Ping(ctx context.Context) error {
+	if s.db == nil {
+		return fmt.Errorf("chromem db is not initialized")
+	}
+	return nil
+}
+
+// CreateNamespace creates a collection if it does not exist and records its
+// dimension. Idempotent: callers invoke it on every startup.
+func (s *ChromemStore) CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]VectorStoreProperties) error {
+	if strings.TrimSpace(namespace) == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if dimension <= 0 {
+		return fmt.Errorf("dimension must be positive, got %d", dimension)
+	}
+
+	if _, err := s.db.GetOrCreateCollection(namespace, nil, chromemStubEmbeddingFunc); err != nil {
+		return fmt.Errorf("failed to create chromem collection %s: %w", namespace, err)
+	}
+
+	s.mu.Lock()
+	s.namespaceDimensions[namespace] = dimension
+	s.mu.Unlock()
+	return nil
+}
+
+// DeleteNamespace removes a collection. Idempotent: deleting a missing
+// namespace is not an error.
+func (s *ChromemStore) DeleteNamespace(ctx context.Context, namespace string) error {
+	if s.db.GetCollection(namespace, chromemStubEmbeddingFunc) == nil {
+		return nil
+	}
+	if err := s.db.DeleteCollection(namespace); err != nil {
+		return fmt.Errorf("failed to delete chromem collection %s: %w", namespace, err)
+	}
+	s.mu.Lock()
+	delete(s.namespaceDimensions, namespace)
+	s.mu.Unlock()
+	return nil
+}
+
+// GetChunk retrieves a single document by ID.
+func (s *ChromemStore) GetChunk(ctx context.Context, namespace string, id string) (SearchResult, error) {
+	if strings.TrimSpace(id) == "" {
+		return SearchResult{}, fmt.Errorf("id is required")
+	}
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return SearchResult{}, fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
+	}
+	doc, err := col.GetByID(ctx, id)
+	if err != nil {
+		return SearchResult{}, fmt.Errorf("%w: %s", ErrNotFound, id)
+	}
+	return SearchResult{
+		ID:         doc.ID,
+		Properties: decodeChromemMetadata(doc.Metadata),
+	}, nil
+}
+
+// GetChunks retrieves multiple documents by ID. Missing IDs are skipped,
+// matching the behavior of the other backends.
+func (s *ChromemStore) GetChunks(ctx context.Context, namespace string, ids []string) ([]SearchResult, error) {
+	if len(ids) == 0 {
+		return []SearchResult{}, nil
+	}
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return nil, fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
+	}
+	results := make([]SearchResult, 0, len(ids))
+	for _, id := range ids {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		doc, err := col.GetByID(ctx, id)
+		if err != nil {
+			s.logger.Debug(fmt.Sprintf("chromem: skipping missing id %s", id))
+			continue
+		}
+		results = append(results, SearchResult{
+			ID:         doc.ID,
+			Properties: decodeChromemMetadata(doc.Metadata),
+		})
+	}
+	return results, nil
+}
+
+// GetAll retrieves documents with optional filtering, using an offset cursor
+// for pagination. Results are ordered by ID for deterministic paging.
+func (s *ChromemStore) GetAll(ctx context.Context, namespace string, queries []Query, selectFields []string, cursor *string, limit int64) ([]SearchResult, *string, error) {
+	docs, err := s.enumerateAll(ctx, namespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filtered := make([]SearchResult, 0, len(docs))
+	for _, doc := range docs {
+		props := decodeChromemMetadata(doc.Metadata)
+		if !matchesChromemQueries(props, queries) {
+			continue
+		}
+		filtered = append(filtered, SearchResult{
+			ID:         doc.ID,
+			Properties: applyChromemSelectFields(props, selectFields),
+		})
+	}
+	sort.Slice(filtered, func(i, j int) bool { return filtered[i].ID < filtered[j].ID })
+
+	offset := int64(0)
+	if cursor != nil && *cursor != "" {
+		offset, err = strconv.ParseInt(*cursor, 10, 64)
+		if err != nil || offset < 0 {
+			return nil, nil, fmt.Errorf("%w: invalid cursor %q", ErrQuerySyntax, *cursor)
+		}
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+
+	total := int64(len(filtered))
+	if offset >= total {
+		return []SearchResult{}, nil, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	page := filtered[offset:end]
+
+	var nextCursor *string
+	if end < total {
+		next := strconv.FormatInt(end, 10)
+		nextCursor = &next
+	}
+	return page, nextCursor, nil
+}
+
+// GetNearest performs an exhaustive cosine-similarity search.
+func (s *ChromemStore) GetNearest(ctx context.Context, namespace string, vector []float32, queries []Query, selectFields []string, threshold float64, limit int64) ([]SearchResult, error) {
+	if len(vector) == 0 {
+		return nil, fmt.Errorf("vector is required")
+	}
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return nil, fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
+	}
+	// Query everything, then filter/threshold/limit here: chromem's own where
+	// filter is equality-only over encoded strings, so pushing filters down
+	// would change semantics.
+	results, err := chromemQueryAll(ctx, col, vector)
+	if err != nil {
+		return nil, fmt.Errorf("chromem query failed: %w", err)
+	}
+	if len(results) == 0 {
+		return []SearchResult{}, nil
+	}
+
+	if limit <= 0 {
+		limit = 10
+	}
+	out := make([]SearchResult, 0, limit)
+	for _, res := range results {
+		if float64(res.Similarity) < threshold {
+			// Results are ranked by similarity; everything after is below threshold too.
+			break
+		}
+		props := decodeChromemMetadata(res.Metadata)
+		if !matchesChromemQueries(props, queries) {
+			continue
+		}
+		score := float64(res.Similarity)
+		out = append(out, SearchResult{
+			ID:         res.ID,
+			Score:      &score,
+			Properties: applyChromemSelectFields(props, selectFields),
+		})
+		if int64(len(out)) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// RequiresVectors returns true: chromem entries always carry vectors.
+func (s *ChromemStore) RequiresVectors() bool {
+	return true
+}
+
+// Add upserts a document with a precomputed embedding.
+func (s *ChromemStore) Add(ctx context.Context, namespace string, id string, embedding []float32, metadata map[string]interface{}) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if len(embedding) == 0 {
+		return fmt.Errorf("embedding is required")
+	}
+	s.mu.RLock()
+	dimension, hasDimension := s.namespaceDimensions[namespace]
+	s.mu.RUnlock()
+	if hasDimension && len(embedding) != dimension {
+		return fmt.Errorf("embedding dimension %d does not match namespace dimension %d", len(embedding), dimension)
+	}
+
+	col, err := s.db.GetOrCreateCollection(namespace, nil, chromemStubEmbeddingFunc)
+	if err != nil {
+		return fmt.Errorf("failed to get chromem collection %s: %w", namespace, err)
+	}
+	encoded, err := encodeChromemMetadata(metadata)
+	if err != nil {
+		return err
+	}
+	if err := col.AddDocument(ctx, chromem.Document{
+		ID:        id,
+		Metadata:  encoded,
+		Embedding: embedding,
+	}); err != nil {
+		return fmt.Errorf("failed to add document %s: %w", id, err)
+	}
+	return nil
+}
+
+// Delete removes a single document. Deleting a missing document is not an error.
+func (s *ChromemStore) Delete(ctx context.Context, namespace string, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("id is required")
+	}
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return nil
+	}
+	if err := col.Delete(ctx, nil, nil, id); err != nil {
+		return fmt.Errorf("failed to delete document %s: %w", id, err)
+	}
+	return nil
+}
+
+// DeleteAll removes all documents matching the queries (all documents when no
+// queries are given) and reports per-document status.
+func (s *ChromemStore) DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error) {
+	docs, err := s.enumerateAll(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return []DeleteResult{}, nil
+	}
+
+	matched := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		if matchesChromemQueries(decodeChromemMetadata(doc.Metadata), queries) {
+			matched = append(matched, doc.ID)
+		}
+	}
+	// Never call chromem Delete with zero ids: chromem treats that as
+	// "delete everything in the collection".
+	if len(matched) == 0 {
+		return []DeleteResult{}, nil
+	}
+
+	results := make([]DeleteResult, 0, len(matched))
+	for _, id := range matched {
+		if err := col.Delete(ctx, nil, nil, id); err != nil {
+			results = append(results, DeleteResult{ID: id, Status: DeleteStatusError, Error: err.Error()})
+			continue
+		}
+		results = append(results, DeleteResult{ID: id, Status: DeleteStatusSuccess})
+	}
+	return results, nil
+}
+
+// Close is a no-op: chromem persists synchronously on each write.
+func (s *ChromemStore) Close(ctx context.Context, namespace string) error {
+	return nil
+}
+
+// enumerateAll returns every document in the namespace. Chromem has no listing
+// API, so this runs an exhaustive query with a probe vector and
+// nResults == Count(). Requires the namespace dimension recorded by
+// CreateNamespace.
+func (s *ChromemStore) enumerateAll(ctx context.Context, namespace string) ([]chromem.Result, error) {
+	col := s.db.GetCollection(namespace, chromemStubEmbeddingFunc)
+	if col == nil {
+		return nil, nil
+	}
+	if col.Count() == 0 {
+		return nil, nil
+	}
+
+	s.mu.RLock()
+	dimension, ok := s.namespaceDimensions[namespace]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("dimension not set for namespace %s: call CreateNamespace first", namespace)
+	}
+
+	probe := make([]float32, dimension)
+	probe[0] = 1
+	results, err := chromemQueryAll(ctx, col, probe)
+	if err != nil {
+		return nil, fmt.Errorf("chromem enumeration failed: %w", err)
+	}
+	return results, nil
+}
+
+// chromemQueryAll runs an exhaustive QueryEmbedding with nResults == Count().
+// Chromem rejects nResults larger than the collection, so if a concurrent
+// delete shrinks the collection between the count and the query, the query is
+// retried with the refreshed count. Returns nil results for an empty collection.
+func chromemQueryAll(ctx context.Context, col *chromem.Collection, vector []float32) ([]chromem.Result, error) {
+	count := col.Count()
+	for {
+		if count == 0 {
+			return nil, nil
+		}
+		results, err := col.QueryEmbedding(ctx, vector, count, nil, nil)
+		if err == nil {
+			return results, nil
+		}
+		if refreshed := col.Count(); refreshed < count {
+			count = refreshed
+			continue
+		}
+		return nil, err
+	}
+}
+
+// encodeChromemMetadata JSON-encodes each typed value into chromem's
+// map[string]string metadata.
+func encodeChromemMetadata(metadata map[string]interface{}) (map[string]string, error) {
+	if len(metadata) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(metadata))
+	for key, value := range metadata {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode metadata field %s: %w", key, err)
+		}
+		out[key] = string(encoded)
+	}
+	return out, nil
+}
+
+// decodeChromemMetadata reverses encodeChromemMetadata. Values that fail to
+// decode are returned as raw strings.
+func decodeChromemMetadata(metadata map[string]string) map[string]interface{} {
+	if len(metadata) == 0 {
+		return map[string]interface{}{}
+	}
+	props := make(map[string]interface{}, len(metadata))
+	for key, raw := range metadata {
+		props[key] = decodeChromemValue(raw)
+	}
+	return props
+}
+
+func decodeChromemValue(raw string) interface{} {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return raw
+	}
+	return normalizeChromemDecoded(value)
+}
+
+// normalizeChromemDecoded maps decoded JSON onto the property types the
+// interface declares: integral numbers become int64, other numbers float64,
+// and all-string arrays become []string.
+func normalizeChromemDecoded(value interface{}) interface{} {
+	switch v := value.(type) {
+	case json.Number:
+		if i, err := strconv.ParseInt(string(v), 10, 64); err == nil {
+			return i
+		}
+		f, err := v.Float64()
+		if err != nil {
+			return string(v)
+		}
+		return f
+	case []interface{}:
+		allStrings := true
+		for i, elem := range v {
+			v[i] = normalizeChromemDecoded(elem)
+			if _, ok := v[i].(string); !ok {
+				allStrings = false
+			}
+		}
+		if allStrings {
+			out := make([]string, len(v))
+			for i, elem := range v {
+				out[i] = elem.(string)
+			}
+			return out
+		}
+		return v
+	default:
+		return value
+	}
+}
+
+func applyChromemSelectFields(props map[string]interface{}, selectFields []string) map[string]interface{} {
+	if len(selectFields) == 0 {
+		return props
+	}
+	out := make(map[string]interface{}, len(selectFields))
+	for _, field := range selectFields {
+		if value, ok := props[field]; ok {
+			out[field] = value
+		}
+	}
+	return out
+}
+
+func matchesChromemQueries(props map[string]interface{}, queries []Query) bool {
+	for _, query := range queries {
+		if !matchesChromemQuery(props, query) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesChromemQuery(props map[string]interface{}, query Query) bool {
+	value, exists := props[query.Field]
+
+	switch query.Operator {
+	case QueryOperatorIsNull:
+		return !exists || value == nil
+	case QueryOperatorIsNotNull:
+		return exists && value != nil
+	}
+	if !exists || value == nil {
+		return false
+	}
+
+	switch query.Operator {
+	case QueryOperatorEqual:
+		cmp, ok := compareChromemValues(value, query.Value)
+		return ok && cmp == 0
+	case QueryOperatorNotEqual:
+		cmp, ok := compareChromemValues(value, query.Value)
+		// Incomparable values (mismatched types, nil query value) are not equal.
+		return !ok || cmp != 0
+	case QueryOperatorGreaterThan:
+		cmp, ok := compareChromemValues(value, query.Value)
+		return ok && cmp > 0
+	case QueryOperatorLessThan:
+		cmp, ok := compareChromemValues(value, query.Value)
+		return ok && cmp < 0
+	case QueryOperatorGreaterThanOrEqual:
+		cmp, ok := compareChromemValues(value, query.Value)
+		return ok && cmp >= 0
+	case QueryOperatorLessThanOrEqual:
+		cmp, ok := compareChromemValues(value, query.Value)
+		return ok && cmp <= 0
+	case QueryOperatorLike:
+		text, textOK := value.(string)
+		pattern, patternOK := query.Value.(string)
+		return textOK && patternOK && matchesChromemLike(text, pattern)
+	case QueryOperatorContainsAny:
+		return chromemContains(value, query.Value, false)
+	case QueryOperatorContainsAll:
+		return chromemContains(value, query.Value, true)
+	default:
+		return false
+	}
+}
+
+// compareChromemValues compares a stored value against a query value,
+// tolerating numeric type mismatches (int64 vs float64 vs int).
+func compareChromemValues(stored, queried interface{}) (int, bool) {
+	if storedNum, ok := chromemToFloat(stored); ok {
+		if queriedNum, ok := chromemToFloat(queried); ok {
+			switch {
+			case storedNum < queriedNum:
+				return -1, true
+			case storedNum > queriedNum:
+				return 1, true
+			default:
+				return 0, true
+			}
+		}
+		return 0, false
+	}
+	if storedStr, ok := stored.(string); ok {
+		if queriedStr, ok := queried.(string); ok {
+			return strings.Compare(storedStr, queriedStr), true
+		}
+		return 0, false
+	}
+	if storedBool, ok := stored.(bool); ok {
+		if queriedBool, ok := queried.(bool); ok {
+			if storedBool == queriedBool {
+				return 0, true
+			}
+			return 1, true
+		}
+	}
+	return 0, false
+}
+
+func chromemToFloat(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+// matchesChromemLike supports SQL-style % and glob-style * wildcards; a
+// pattern without wildcards matches as a substring.
+func matchesChromemLike(text, pattern string) bool {
+	if !strings.ContainsAny(pattern, "%*") {
+		return strings.Contains(text, pattern)
+	}
+	var builder strings.Builder
+	builder.WriteString("^")
+	for _, part := range strings.FieldsFunc(pattern, func(r rune) bool { return r == '%' || r == '*' }) {
+		builder.WriteString(regexp.QuoteMeta(part))
+		builder.WriteString(".*")
+	}
+	expr := builder.String()
+	if !strings.HasSuffix(pattern, "%") && !strings.HasSuffix(pattern, "*") {
+		expr = strings.TrimSuffix(expr, ".*") + "$"
+	}
+	if strings.HasPrefix(pattern, "%") || strings.HasPrefix(pattern, "*") {
+		expr = "^.*" + strings.TrimPrefix(expr, "^")
+	}
+	matched, err := regexp.MatchString(expr, text)
+	return err == nil && matched
+}
+
+// chromemContains implements ContainsAny/ContainsAll. The stored value may be
+// an array or a scalar; the query value may be a slice or a single value.
+func chromemContains(stored, queried interface{}, requireAll bool) bool {
+	queryValues := chromemToSlice(queried)
+	if len(queryValues) == 0 {
+		return false
+	}
+	storedValues := chromemToSlice(stored)
+	for _, queryValue := range queryValues {
+		found := false
+		for _, storedValue := range storedValues {
+			if cmp, ok := compareChromemValues(storedValue, queryValue); ok && cmp == 0 {
+				found = true
+				break
+			}
+		}
+		if requireAll && !found {
+			return false
+		}
+		if !requireAll && found {
+			return true
+		}
+	}
+	return requireAll
+}
+
+func chromemToSlice(value interface{}) []interface{} {
+	switch v := value.(type) {
+	case []interface{}:
+		return v
+	case []string:
+		out := make([]interface{}, len(v))
+		for i, s := range v {
+			out[i] = s
+		}
+		return out
+	default:
+		return []interface{}{value}
+	}
+}

--- a/framework/vectorstore/chromem_test.go
+++ b/framework/vectorstore/chromem_test.go
@@ -1,0 +1,479 @@
+package vectorstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ChromemTestTimeout   = 30 * time.Second
+	ChromemTestNamespace = "chromem_test_collection"
+	ChromemTestDimension = 384
+)
+
+// ChromemTestSetup provides utilities for chromem store testing.
+// Chromem is embedded, so unlike the other backends these tests need no
+// external server and no testing.Short() gating.
+type ChromemTestSetup struct {
+	Store  *ChromemStore
+	Logger schemas.Logger
+	Config ChromemConfig
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewChromemTestSetup creates a new memory-only test setup for chromem tests.
+func NewChromemTestSetup(t *testing.T) *ChromemTestSetup {
+	return newChromemTestSetupWithConfig(t, ChromemConfig{})
+}
+
+func newChromemTestSetupWithConfig(t *testing.T, config ChromemConfig) *ChromemTestSetup {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+	ctx, cancel := context.WithTimeout(context.Background(), ChromemTestTimeout)
+
+	store, err := newChromemStore(ctx, &config, logger)
+	require.NoError(t, err, "Failed to create chromem store")
+
+	setup := &ChromemTestSetup{
+		Store:  store,
+		Logger: logger,
+		Config: config,
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	setup.ensureNamespaceExists(t)
+	return setup
+}
+
+// Cleanup releases test resources.
+func (ts *ChromemTestSetup) Cleanup(t *testing.T) {
+	defer ts.cancel()
+	err := ts.Store.DeleteNamespace(ts.ctx, ChromemTestNamespace)
+	assert.NoError(t, err, "Failed to delete test namespace")
+	err = ts.Store.Close(ts.ctx, "")
+	assert.NoError(t, err, "Failed to close store")
+}
+
+func (ts *ChromemTestSetup) ensureNamespaceExists(t *testing.T) {
+	err := ts.Store.CreateNamespace(ts.ctx, ChromemTestNamespace, ChromemTestDimension, map[string]VectorStoreProperties{
+		"key":      {DataType: VectorStorePropertyTypeString, Description: "Cache key"},
+		"type":     {DataType: VectorStorePropertyTypeString, Description: "Entry type"},
+		"size":     {DataType: VectorStorePropertyTypeInteger, Description: "Entry size"},
+		"public":   {DataType: VectorStorePropertyTypeBoolean, Description: "Is public"},
+		"tags":     {DataType: VectorStorePropertyTypeStringArray, Description: "Tags"},
+		"content":  {DataType: VectorStorePropertyTypeString, Description: "Content"},
+		"category": {DataType: VectorStorePropertyTypeString, Description: "Category"},
+	})
+	require.NoError(t, err, "Failed to create test namespace")
+}
+
+func TestChromemConfig_Validation(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		config      *ChromemConfig
+		expectError bool
+	}{
+		{name: "nil config", config: nil, expectError: true},
+		{name: "empty config (memory-only)", config: &ChromemConfig{}, expectError: false},
+		{name: "persistent path", config: &ChromemConfig{Path: filepath.Join(t.TempDir(), "chromem")}, expectError: false},
+		{name: "compressed persistent path", config: &ChromemConfig{Path: filepath.Join(t.TempDir(), "chromem"), Compress: true}, expectError: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := newChromemStore(ctx, tt.config, logger)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NoError(t, store.Ping(ctx))
+		})
+	}
+
+	t.Run("path is an existing file", func(t *testing.T) {
+		filePath := filepath.Join(t.TempDir(), "not-a-dir")
+		require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+		_, err := newChromemStore(ctx, &ChromemConfig{Path: filePath}, logger)
+		assert.Error(t, err)
+	})
+}
+
+func TestChromemStore_Integration(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	id1 := generateUUID()
+	id2 := generateUUID()
+	embedding1 := generateTestEmbedding(ChromemTestDimension)
+	embedding2 := generateSimilarEmbedding(embedding1, 0.9)
+
+	err := ts.Store.Add(ts.ctx, ChromemTestNamespace, id1, embedding1, map[string]interface{}{
+		"key":     "entry-1",
+		"type":    "chat",
+		"size":    int64(128),
+		"public":  true,
+		"tags":    []string{"alpha", "beta"},
+		"content": "hello world",
+	})
+	require.NoError(t, err)
+
+	err = ts.Store.Add(ts.ctx, ChromemTestNamespace, id2, embedding2, map[string]interface{}{
+		"key":    "entry-2",
+		"type":   "completion",
+		"size":   int64(256),
+		"public": false,
+	})
+	require.NoError(t, err)
+
+	// GetChunk round-trips typed metadata.
+	result, err := ts.Store.GetChunk(ts.ctx, ChromemTestNamespace, id1)
+	require.NoError(t, err)
+	assert.Equal(t, id1, result.ID)
+	assert.Equal(t, "entry-1", result.Properties["key"])
+	assert.Equal(t, int64(128), result.Properties["size"])
+	assert.Equal(t, true, result.Properties["public"])
+	assert.Equal(t, []string{"alpha", "beta"}, result.Properties["tags"])
+
+	// GetChunks skips missing IDs.
+	results, err := ts.Store.GetChunks(ts.ctx, ChromemTestNamespace, []string{id1, "missing-id", id2})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// GetAll returns both entries.
+	all, cursor, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, nil, 100)
+	require.NoError(t, err)
+	assert.Nil(t, cursor)
+	assert.Len(t, all, 2)
+
+	// GetAll with select fields projects properties.
+	all, _, err = ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, []string{"key"}, nil, 100)
+	require.NoError(t, err)
+	for _, res := range all {
+		assert.Contains(t, res.Properties, "key")
+		assert.NotContains(t, res.Properties, "type")
+	}
+
+	// Upsert overwrites in place.
+	err = ts.Store.Add(ts.ctx, ChromemTestNamespace, id1, embedding1, map[string]interface{}{"key": "entry-1-updated"})
+	require.NoError(t, err)
+	result, err = ts.Store.GetChunk(ts.ctx, ChromemTestNamespace, id1)
+	require.NoError(t, err)
+	assert.Equal(t, "entry-1-updated", result.Properties["key"])
+}
+
+func TestChromemStore_Filtering(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	base := generateTestEmbedding(ChromemTestDimension)
+	for i, meta := range []map[string]interface{}{
+		{"key": "a", "type": "chat", "size": int64(10), "public": true, "tags": []string{"x", "y"}, "content": "the quick brown fox"},
+		{"key": "b", "type": "chat", "size": int64(20), "public": false, "tags": []string{"y", "z"}, "content": "lazy dog"},
+		{"key": "c", "type": "completion", "size": int64(30), "public": true, "content": "quick start guide"},
+	} {
+		require.NoError(t, ts.Store.Add(ts.ctx, ChromemTestNamespace, fmt.Sprintf("doc-%d", i), generateSimilarEmbedding(base, 0.95), meta))
+	}
+
+	tests := []struct {
+		name     string
+		queries  []Query
+		expected int
+	}{
+		{"equal", []Query{{Field: "type", Operator: QueryOperatorEqual, Value: "chat"}}, 2},
+		{"not equal", []Query{{Field: "type", Operator: QueryOperatorNotEqual, Value: "chat"}}, 1},
+		{"greater than", []Query{{Field: "size", Operator: QueryOperatorGreaterThan, Value: 10}}, 2},
+		{"less than or equal", []Query{{Field: "size", Operator: QueryOperatorLessThanOrEqual, Value: 20}}, 2},
+		{"boolean equal", []Query{{Field: "public", Operator: QueryOperatorEqual, Value: true}}, 2},
+		{"like substring", []Query{{Field: "content", Operator: QueryOperatorLike, Value: "quick"}}, 2},
+		{"like wildcard", []Query{{Field: "content", Operator: QueryOperatorLike, Value: "the%fox"}}, 1},
+		{"contains any", []Query{{Field: "tags", Operator: QueryOperatorContainsAny, Value: []string{"z", "nope"}}}, 1},
+		{"contains all", []Query{{Field: "tags", Operator: QueryOperatorContainsAll, Value: []string{"x", "y"}}}, 1},
+		{"is null", []Query{{Field: "tags", Operator: QueryOperatorIsNull}}, 1},
+		{"is not null", []Query{{Field: "tags", Operator: QueryOperatorIsNotNull}}, 2},
+		{"combined", []Query{
+			{Field: "type", Operator: QueryOperatorEqual, Value: "chat"},
+			{Field: "public", Operator: QueryOperatorEqual, Value: true},
+		}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, _, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, tt.queries, nil, nil, 100)
+			require.NoError(t, err)
+			assert.Len(t, results, tt.expected)
+		})
+	}
+}
+
+func TestChromemStore_VectorSearch(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	// Deterministic vectors: cosine similarity is exactly 0.9 for "near"
+	// (0.9*e0 + sqrt(1-0.81)*e1) and exactly 0 for the orthogonal "far" (e1).
+	queryVector := make([]float32, ChromemTestDimension)
+	queryVector[0] = 1
+	near := make([]float32, ChromemTestDimension)
+	near[0] = 0.9
+	near[1] = 0.43589
+	far := make([]float32, ChromemTestDimension)
+	far[1] = 1
+
+	require.NoError(t, ts.Store.Add(ts.ctx, ChromemTestNamespace, "near", near, map[string]interface{}{"key": "near", "type": "chat"}))
+	require.NoError(t, ts.Store.Add(ts.ctx, ChromemTestNamespace, "far", far, map[string]interface{}{"key": "far", "type": "chat"}))
+
+	results, err := ts.Store.GetNearest(ts.ctx, ChromemTestNamespace, queryVector, nil, nil, -1.0, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "near", results[0].ID, "nearest result should rank first")
+	require.NotNil(t, results[0].Score)
+
+	// A threshold between the two similarities excludes the orthogonal vector.
+	results, err = ts.Store.GetNearest(ts.ctx, ChromemTestNamespace, queryVector, nil, nil, 0.5, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "near", results[0].ID)
+	require.NotNil(t, results[0].Score)
+	assert.InDelta(t, 0.9, *results[0].Score, 0.01)
+
+	// Filters apply on top of similarity.
+	results, err = ts.Store.GetNearest(ts.ctx, ChromemTestNamespace, queryVector,
+		[]Query{{Field: "key", Operator: QueryOperatorEqual, Value: "far"}}, nil, -1.0, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "far", results[0].ID)
+
+	// Empty namespace returns no results, not an error.
+	require.NoError(t, ts.Store.CreateNamespace(ts.ctx, "chromem_empty_ns", ChromemTestDimension, nil))
+	defer func() { _ = ts.Store.DeleteNamespace(ts.ctx, "chromem_empty_ns") }()
+	results, err = ts.Store.GetNearest(ts.ctx, "chromem_empty_ns", queryVector, nil, nil, -1.0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestChromemStore_Pagination(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	base := generateTestEmbedding(ChromemTestDimension)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, ts.Store.Add(ts.ctx, ChromemTestNamespace, fmt.Sprintf("page-doc-%d", i),
+			generateSimilarEmbedding(base, 0.9), map[string]interface{}{"key": fmt.Sprintf("k-%d", i)}))
+	}
+
+	seen := make(map[string]bool)
+	var cursor *string
+	pages := 0
+	for {
+		results, next, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, cursor, 2)
+		require.NoError(t, err)
+		for _, res := range results {
+			assert.False(t, seen[res.ID], "duplicate result across pages: %s", res.ID)
+			seen[res.ID] = true
+		}
+		pages++
+		if next == nil {
+			break
+		}
+		cursor = next
+	}
+	assert.Len(t, seen, 5)
+	assert.Equal(t, 3, pages)
+
+	// Invalid cursor errors instead of silently rescanning.
+	badCursor := "not-a-number"
+	_, _, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, &badCursor, 2)
+	assert.Error(t, err)
+}
+
+func TestChromemStore_DimensionHandling(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	namespace := "chromem_dimension_test"
+	require.NoError(t, ts.Store.CreateNamespace(ts.ctx, namespace, 512, nil))
+
+	// Mismatched embedding dimension is rejected.
+	err := ts.Store.Add(ts.ctx, namespace, "doc-1", generateTestEmbedding(384), nil)
+	assert.Error(t, err)
+
+	// Recreate at a different dimension.
+	require.NoError(t, ts.Store.DeleteNamespace(ts.ctx, namespace))
+	require.NoError(t, ts.Store.CreateNamespace(ts.ctx, namespace, 384, nil))
+	defer func() { _ = ts.Store.DeleteNamespace(ts.ctx, namespace) }()
+
+	embedding := generateTestEmbedding(384)
+	require.NoError(t, ts.Store.Add(ts.ctx, namespace, "doc-1", embedding, map[string]interface{}{"key": "v"}))
+	results, err := ts.Store.GetNearest(ts.ctx, namespace, embedding, nil, nil, 0.0, 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	// Invalid dimensions are rejected at namespace creation.
+	assert.Error(t, ts.Store.CreateNamespace(ts.ctx, "chromem_bad_dim", 0, nil))
+	assert.Error(t, ts.Store.CreateNamespace(ts.ctx, "chromem_bad_dim", -1, nil))
+}
+
+func TestChromemStore_ErrorHandling(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	// Empty IDs are rejected.
+	err := ts.Store.Add(ts.ctx, ChromemTestNamespace, "", generateTestEmbedding(ChromemTestDimension), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "id is required")
+
+	_, err = ts.Store.GetChunk(ts.ctx, ChromemTestNamespace, "")
+	assert.Error(t, err)
+
+	err = ts.Store.Delete(ts.ctx, ChromemTestNamespace, "")
+	assert.Error(t, err)
+
+	// Missing embedding is rejected (RequiresVectors is true).
+	err = ts.Store.Add(ts.ctx, ChromemTestNamespace, "doc-x", nil, nil)
+	assert.Error(t, err)
+
+	// Missing chunk surfaces ErrNotFound.
+	_, err = ts.Store.GetChunk(ts.ctx, ChromemTestNamespace, "missing-id")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Deleting a missing document is idempotent.
+	assert.NoError(t, ts.Store.Delete(ts.ctx, ChromemTestNamespace, "missing-id"))
+
+	// Deleting a missing namespace is idempotent.
+	assert.NoError(t, ts.Store.DeleteNamespace(ts.ctx, "chromem_never_created"))
+}
+
+func TestChromemStore_DeleteOperations(t *testing.T) {
+	ts := NewChromemTestSetup(t)
+	defer ts.Cleanup(t)
+
+	base := generateTestEmbedding(ChromemTestDimension)
+	for i := 0; i < 4; i++ {
+		entryType := "chat"
+		if i%2 == 1 {
+			entryType = "completion"
+		}
+		require.NoError(t, ts.Store.Add(ts.ctx, ChromemTestNamespace, fmt.Sprintf("del-doc-%d", i),
+			generateSimilarEmbedding(base, 0.9), map[string]interface{}{"type": entryType}))
+	}
+
+	// Single delete.
+	require.NoError(t, ts.Store.Delete(ts.ctx, ChromemTestNamespace, "del-doc-0"))
+	_, err := ts.Store.GetChunk(ts.ctx, ChromemTestNamespace, "del-doc-0")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// Filtered DeleteAll only removes matches.
+	results, err := ts.Store.DeleteAll(ts.ctx, ChromemTestNamespace, []Query{{Field: "type", Operator: QueryOperatorEqual, Value: "completion"}})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+	for _, res := range results {
+		assert.Equal(t, DeleteStatusSuccess, res.Status)
+	}
+
+	// A non-matching filter must not delete anything.
+	results, err = ts.Store.DeleteAll(ts.ctx, ChromemTestNamespace, []Query{{Field: "type", Operator: QueryOperatorEqual, Value: "no-such-type"}})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	remaining, _, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, nil, 100)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 1)
+
+	// Unfiltered DeleteAll clears the namespace.
+	_, err = ts.Store.DeleteAll(ts.ctx, ChromemTestNamespace, nil)
+	require.NoError(t, err)
+	remaining, _, err = ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, nil, 100)
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+}
+
+func TestChromemStore_Persistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "chromem-data")
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+	ctx := context.Background()
+
+	embedding := generateTestEmbedding(ChromemTestDimension)
+
+	store1, err := newChromemStore(ctx, &ChromemConfig{Path: path}, logger)
+	require.NoError(t, err)
+	require.NoError(t, store1.CreateNamespace(ctx, ChromemTestNamespace, ChromemTestDimension, nil))
+	require.NoError(t, store1.Add(ctx, ChromemTestNamespace, "persistent-doc", embedding, map[string]interface{}{
+		"key":  "persisted",
+		"size": int64(42),
+	}))
+	require.NoError(t, store1.Close(ctx, ""))
+
+	// Reopen from disk with a fresh store.
+	store2, err := newChromemStore(ctx, &ChromemConfig{Path: path}, logger)
+	require.NoError(t, err)
+
+	// GetChunk works before CreateNamespace (no enumeration needed).
+	result, err := store2.GetChunk(ctx, ChromemTestNamespace, "persistent-doc")
+	require.NoError(t, err)
+	assert.Equal(t, "persisted", result.Properties["key"])
+	assert.Equal(t, int64(42), result.Properties["size"])
+
+	// Enumeration requires the dimension, which is only known after
+	// CreateNamespace — the documented startup contract.
+	_, _, err = store2.GetAll(ctx, ChromemTestNamespace, nil, nil, nil, 100)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dimension not set")
+
+	require.NoError(t, store2.CreateNamespace(ctx, ChromemTestNamespace, ChromemTestDimension, nil))
+	all, _, err := store2.GetAll(ctx, ChromemTestNamespace, nil, nil, nil, 100)
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	results, err := store2.GetNearest(ctx, ChromemTestNamespace, embedding, nil, nil, 0.9, 10)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestChromemStore_InterfaceCompliance(t *testing.T) {
+	var _ VectorStore = (*ChromemStore)(nil)
+}
+
+func TestVectorStoreFactory_Chromem(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+	ctx := context.Background()
+
+	config := &Config{
+		Enabled: true,
+		Type:    VectorStoreTypeChromem,
+		Config:  ChromemConfig{},
+	}
+	store, err := NewVectorStore(ctx, config, logger)
+	require.NoError(t, err)
+	_, ok := store.(*ChromemStore)
+	assert.True(t, ok, "expected *ChromemStore from factory")
+	assert.True(t, store.RequiresVectors())
+
+	// JSON round-trip through Config.UnmarshalJSON, including a missing
+	// config block (valid for chromem).
+	var parsed Config
+	require.NoError(t, parsed.UnmarshalJSON([]byte(`{"enabled": true, "type": "chromem", "config": {"path": "", "compress": false}}`)))
+	assert.Equal(t, VectorStoreTypeChromem, parsed.Type)
+	_, ok = parsed.Config.(ChromemConfig)
+	assert.True(t, ok)
+
+	var parsedNoConfig Config
+	require.NoError(t, parsedNoConfig.UnmarshalJSON([]byte(`{"enabled": true, "type": "chromem"}`)))
+	store, err = NewVectorStore(ctx, &parsedNoConfig, logger)
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -16,6 +16,7 @@ const (
 	VectorStoreTypeRedis    VectorStoreType = "redis"
 	VectorStoreTypeQdrant   VectorStoreType = "qdrant"
 	VectorStoreTypePinecone VectorStoreType = "pinecone"
+	VectorStoreTypeChromem  VectorStoreType = "chromem"
 )
 
 // Query represents a query to the vector store.
@@ -179,6 +180,15 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("failed to unmarshal pinecone config: %w", err)
 		}
 		c.Config = pineconeConfig
+	case VectorStoreTypeChromem:
+		var chromemConfig ChromemConfig
+		// Chromem has no required fields, so a missing config block is valid.
+		if len(temp.Config) > 0 {
+			if err := json.Unmarshal(temp.Config, &chromemConfig); err != nil {
+				return fmt.Errorf("failed to unmarshal chromem config: %w", err)
+			}
+		}
+		c.Config = chromemConfig
 	default:
 		return fmt.Errorf("unknown vector store type: %s", temp.Type)
 	}
@@ -233,6 +243,13 @@ func NewVectorStore(ctx context.Context, config *Config, logger schemas.Logger) 
 			return nil, fmt.Errorf("invalid pinecone config")
 		}
 		return newPineconeStore(ctx, &pineconeConfig, logger)
+	case VectorStoreTypeChromem:
+		// A nil config block is valid: chromem defaults to memory-only mode.
+		chromemConfig, ok := config.Config.(ChromemConfig)
+		if !ok && config.Config != nil {
+			return nil, fmt.Errorf("invalid chromem config")
+		}
+		return newChromemStore(ctx, &chromemConfig, logger)
 	}
 	return nil, fmt.Errorf("invalid vector store type: %s", config.Type)
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -7179,6 +7179,11 @@ func (c *Config) GetVectorStoreConfigRedacted(ctx context.Context) (*vectorstore
 		redactedVectorStoreConfig.Config = &redactedWeaviateConfig
 		return &redactedVectorStoreConfig, nil
 	}
+	if vectorStoreConfig.Type == vectorstore.VectorStoreTypeChromem {
+		// Chromem is embedded and its config carries no secrets.
+		redactedVectorStoreConfig := *vectorStoreConfig
+		return &redactedVectorStoreConfig, nil
+	}
 	return nil, nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1533,8 +1533,8 @@
         },
         "type": {
           "type": "string",
-          "enum": ["weaviate", "redis", "qdrant", "pinecone"],
-          "description": "Vector store type (use \"redis\" for Redis or Valkey-compatible endpoints)"
+          "enum": ["weaviate", "redis", "qdrant", "pinecone", "chromem"],
+          "description": "Vector store type (use \"redis\" for Redis or Valkey-compatible endpoints; \"chromem\" runs embedded in-process with optional file persistence)"
         },
         "config": {
           "anyOf": [
@@ -1584,6 +1584,18 @@
               },
               "then": {
                 "$ref": "#/$defs/pinecone_config"
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "type": {
+                    "const": "chromem"
+                  }
+                }
+              },
+              "then": {
+                "$ref": "#/$defs/chromem_config"
               }
             }
           ]
@@ -5608,6 +5620,21 @@
         }
       },
       "required": ["api_key", "index_host"],
+      "additionalProperties": false
+    },
+    "chromem_config": {
+      "type": "object",
+      "description": "Chromem configuration for the embedded in-process vector store",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Directory for file persistence; omit for a memory-only store that re-populates on restart"
+        },
+        "compress": {
+          "type": "boolean",
+          "description": "Gzip-compress persisted documents (only used when path is set)"
+        }
+      },
       "additionalProperties": false
     },
     "proxy_config": {


### PR DESCRIPTION
## Summary

Adds `chromem` as a new embedded vector store backend powered by [`chromem-go`](https://github.com/philippgille/chromem-go). Unlike the existing backends (Weaviate, Redis, Qdrant, Pinecone), chromem runs entirely in-process with no external service dependency. It supports optional file persistence with optional gzip compression, or operates as a pure in-memory store when no path is configured.

## Changes

- **New `ChromemStore` implementation** (`framework/vectorstore/chromem.go`): implements the full `VectorStore` interface including `Add`, `GetChunk`, `GetChunks`, `GetAll`, `GetNearest`, `Delete`, `DeleteAll`, `CreateNamespace`, `DeleteNamespace`, `Ping`, and `Close`.
  - Metadata is JSON-encoded into chromem's `map[string]string` and decoded back to typed values (`int64`, `float64`, `bool`, `[]string`) on read.
  - Since chromem has no document-enumeration API, `GetAll`/`DeleteAll` use an exhaustive `QueryEmbedding` probe, which requires the namespace dimension to be registered via `CreateNamespace` (consistent with the existing Pinecone backend contract).
  - All query operators (`Equal`, `NotEqual`, `GreaterThan`, `LessThan`, `Like`, `ContainsAny`, `ContainsAll`, `IsNull`, `IsNotNull`) are implemented in-process since chromem's native filter is equality-only over strings.
  - Offset-based cursor pagination is applied after in-process filtering.
  - `DeleteAll` with zero matched IDs is explicitly guarded to avoid chromem's "delete everything" behavior when called with no IDs.
- **Factory and config wiring** (`framework/vectorstore/store.go`): registers `VectorStoreTypeChromem = "chromem"`, adds JSON unmarshalling for `ChromemConfig`, and wires the factory. A missing config block is valid and defaults to memory-only mode.
- **HTTP transport redaction** (`transports/bifrost-http/lib/config.go`): chromem carries no secrets, so the config is returned as-is from `GetVectorStoreConfigRedacted`.
- **JSON schema** (`transports/config.schema.json`): adds `"chromem"` to the `type` enum, adds a `chromem_config` definition with `path` and `compress` fields, and wires the conditional `$ref`.
- **Dependency** (`framework/go.mod`, `go.sum`): adds `github.com/philippgille/chromem-go v0.7.0`.
- **Tests** (`framework/vectorstore/chromem_test.go`): covers config validation, CRUD round-trips, metadata type fidelity, all filter operators, vector similarity search with threshold, offset pagination, dimension enforcement, error handling, persistence across store restarts, interface compliance, and factory JSON unmarshalling.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd framework
go test ./vectorstore/... -run TestChromem -v
go test ./vectorstore/... -v
go build ./...

cd ../transports/bifrost-http
go build ./...
```

**Memory-only config example:**
```json
{
  "enabled": true,
  "type": "chromem",
  "config": {}
}
```

**Persistent config example:**
```json
{
  "enabled": true,
  "type": "chromem",
  "config": {
    "path": "/var/data/chromem",
    "compress": true
  }
}
```

No external service is required. The tests are self-contained and run without any environment variables or network access.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Chromem is embedded and its configuration carries no API keys or credentials. The `GetVectorStoreConfigRedacted` path returns the config unchanged. When `path` is set, vector data is written to disk in the configured directory; operators should apply appropriate filesystem permissions to that path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable