### PR TITLE
docs: clarify that logs_store.retention_days is ClickHouse-only

### DIFF
--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -240,18 +240,21 @@ For high log volumes, increase `max_open_conns`:
 
 ### Log Retention
 
-Set `retention_days` to automatically purge old log entries. `0` disables retention-based cleanup.
+<Note>
+`retention_days` on `logs_store` applies to the **ClickHouse** log store only, where it becomes a table TTL. On **SQLite and PostgreSQL it has no effect** - set `log_retention_days` on the client config instead.
+</Note>
+
+For SQLite and PostgreSQL, retention is configured on the client config. A background cleaner deletes log rows older than `now - log_retention_days`, once on startup and every 24 hours thereafter:
 
 ```json
 {
-  "logs_store": {
-    "enabled": true,
-    "type": "postgres",
-    "config": { "...": "..." },
-    "retention_days": 90
+  "client": {
+    "log_retention_days": 90
   }
 }
 ```
+
+See [Client Configuration](/deployment-guides/config-json/client) for the rest of the client surface.
 
 ### Materialized View Refresh Interval (PostgreSQL only)
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2189,7 +2189,7 @@
         "retention_days": {
           "type": "integer",
           "minimum": 0,
-          "description": "Days to retain log entries. 0 disables retention-based cleanup."
+          "description": "Days to retain log entries. Applies to the ClickHouse log store only, where it becomes a table TTL. SQLite and PostgreSQL use client.log_retention_days instead."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

The "Log Retention" section of the config.json storage guide documented `logs_store.retention_days` as a general purge control, directly below the PostgreSQL config example. On SQLite and PostgreSQL that key has no effect, so a reader following the page sets a value that does nothing while cleanup silently runs at the 365-day default.

Closes #5630 (the first item; the two smaller follow-ups noted there are left for maintainers to decide).

## Changes

- `docs/deployment-guides/config-json/storage.mdx` — rewrote the Log Retention section: a `<Note>` stating `retention_days` is ClickHouse-only, and a `client.log_retention_days` example for SQLite/PostgreSQL with a link to the Client Configuration page.
- `transports/config.schema.json` — qualified the `logs_store.retention_days` description the same way.

Docs-only + one schema description string. No behaviour change.

`docs/enterprise/log-exports.mdx` already describes this correctly, so it is left as is.

## Type of change

- [x] Documentation

## Affected areas

- [x] Docs
- [x] Transports (HTTP) — `config.schema.json` description text only

## How to test

Reproduced on `maximhq/bifrost:latest` + `postgres:16-alpine`.

**1. Only `logs_store.retention_days` set:**

```json
{
  "logs_store": {
    "enabled": true,
    "type": "postgres",
    "retention_days": 1,
    "config": { "host": "...", "port": "5432", "user": "...", "password": "...", "db_name": "bifrost", "ssl_mode": "disable" }
  }
}
```

```
{"level":"info","message":"log retention days: 365"}
{"level":"info","message":"log retention cleaner initialized with 365 days retention"}
{"level":"info","message":"starting log cleanup: deleting logs older than 2025-07-28T17:36:01Z (retention: 365 days)"}
```

Rows seeded at 30 days old survive the startup cleanup pass.

**2. Adding `client.log_retention_days: 1`:**

```
{"level":"info","message":"log retention days: 1"}
{"level":"info","message":"starting log cleanup: deleting logs older than 2026-07-27T17:36:32Z (retention: 1 days)"}
{"level":"info","message":"log cleanup completed: deleted 10 logs in 1 batches"}
```

**Schema sync:**

```sh
.github/workflows/scripts/validate-schema-sync.sh
# schemasync: 1 errors, 15 warnings   (identical with and without this change;
# the error is a pre-existing governance.pricing_overrides.user_id gap)
```

## Breaking changes

- [x] No

## Related issues

- Closes #5630
- Context: #1665

## Security considerations

None. Documentation and one schema description string.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate — n/a, docs-only
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI) — n/a, no code changed; schema-sync validation run and unchanged
- [x] I verified the CI pipeline passes locally if applicable
