### PR TITLE
fix: prune mcp_tool_logs on the retention schedule

### DIFF
--- a/docs/enterprise/log-exports.mdx
+++ b/docs/enterprise/log-exports.mdx
@@ -227,7 +227,7 @@ If you have object storage enabled, configure a lifecycle / object-lifecycle-man
     {
       "ID": "bifrost-logs-expire-30d",
       "Status": "Enabled",
-      "Filter": { "Prefix": "bifrost/logs/" },
+      "Filter": { "Prefix": "bifrost/" },
       "Expiration": { "Days": 30 }
     }
   ]
@@ -246,7 +246,7 @@ Apply with `aws s3api put-bucket-lifecycle-configuration --bucket <bucket> --lif
         "action": { "type": "Delete" },
         "condition": {
           "age": 30,
-          "matchesPrefix": ["bifrost/logs/"]
+          "matchesPrefix": ["bifrost/"]
         }
       }
     ]

--- a/docs/enterprise/log-exports.mdx
+++ b/docs/enterprise/log-exports.mdx
@@ -217,7 +217,7 @@ The cleaner deletes **database rows** older than `now - retention_days` (UTC). I
 
 > **Important**: the retention cleaner does **not** delete the corresponding payloads in S3 or GCS. The hybrid log store explicitly delegates object cleanup to the bucket's own lifecycle policy.
 
-If you have object storage enabled, configure a lifecycle / object-lifecycle-management rule on the bucket to expire objects under your `prefix/`. Pick a duration that matches (or exceeds) `log_retention_days`.
+If you have object storage enabled, configure a lifecycle / object-lifecycle-management rule on the bucket to expire objects under your `prefix/`. Pick a duration that matches (or exceeds) `log_retention_days`. Scope the rule to the whole `prefix/`, not just `prefix/logs/` — MCP tool call payloads live under `prefix/mcp-logs/` and would otherwise be orphaned once their rows are pruned.
 
 **Amazon S3 lifecycle rule (example)**
 

--- a/framework/logstore/cleaner.go
+++ b/framework/logstore/cleaner.go
@@ -22,12 +22,27 @@ type LogRetentionManager interface {
 	DeleteLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (deletedCount int64, err error)
 }
 
+// MCPToolLogRetentionManager is implemented by log stores that can prune MCP
+// tool logs by age. It is intentionally separate from LogRetentionManager so
+// that a store which does not implement it keeps working (it simply skips MCP
+// pruning) instead of failing the LogRetentionManager type assertion that
+// gates the cleaner being started at all.
+//
+// Note for decorators: a type that embeds LogStore satisfies
+// LogRetentionManager for free (DeleteLogsBatch is part of LogStore) but does
+// NOT satisfy this interface, so it keeps pruning logs while silently skipping
+// mcp_tool_logs. Forward DeleteMCPToolLogsBatch explicitly, as HybridLogStore
+// does.
+type MCPToolLogRetentionManager interface {
+	DeleteMCPToolLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (deletedCount int64, err error)
+}
+
 // CleanerConfig holds configuration for the log cleaner
 type CleanerConfig struct {
 	RetentionDays int
 }
 
-// LogsCleaner manages the cleanup of old logs
+// LogsCleaner manages the cleanup of old logs and MCP tool logs
 type LogsCleaner struct {
 	manager     LogRetentionManager
 	config      CleanerConfig
@@ -46,6 +61,7 @@ func NewLogsCleaner(manager LogRetentionManager, config CleanerConfig, logger sc
 }
 
 // StartCleanupRoutine starts a goroutine that periodically cleans up old logs
+// and MCP tool logs
 func (c *LogsCleaner) StartCleanupRoutine() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -102,7 +118,8 @@ func (c *LogsCleaner) StopCleanupRoutine() {
 	c.stopCleanup = nil
 }
 
-// cleanupOldLogs deletes logs older than the retention period in batches
+// cleanupOldLogs deletes logs older than the retention period in batches, and
+// prunes MCP tool logs against the same cutoff when the store supports it
 func (c *LogsCleaner) cleanupOldLogs(ctx context.Context) {
 	retentionDays := c.config.RetentionDays
 	if retentionDays < 1 {
@@ -112,6 +129,13 @@ func (c *LogsCleaner) cleanupOldLogs(ctx context.Context) {
 	// Calculate cutoff time
 	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays)
 	c.logger.Info("starting log cleanup: deleting logs older than %s (retention: %d days)", cutoff.Format(time.RFC3339), retentionDays)
+
+	// Deferred so the MCP sweep runs on every exit path below. The two tables
+	// are independent, and the logs loop bails out on the first delete error:
+	// letting that starve MCP pruning would leave mcp_tool_logs growing without
+	// bound, which is the bug this sweep exists to fix. A cancelled ctx still
+	// short-circuits inside cleanupOldMCPToolLogs.
+	defer c.cleanupOldMCPToolLogs(ctx, cutoff)
 
 	totalDeleted := int64(0)
 	batchCount := 0
@@ -151,6 +175,61 @@ func (c *LogsCleaner) cleanupOldLogs(ctx context.Context) {
 		c.logger.Info("log cleanup completed: deleted %d logs in %d batches", totalDeleted, batchCount)
 	} else {
 		c.logger.Debug("log cleanup completed: no old logs to delete")
+	}
+}
+
+// cleanupOldMCPToolLogs deletes MCP tool logs older than cutoff in batches.
+// mcp_tool_logs carries the same retention as logs - ClickHouse applies the
+// same TTL to both tables - so the backends without a table TTL need the same
+// age-based sweep or mcp_tool_logs grows without bound. Counts are reported
+// separately from the logs sweep so operators can tell the two apart. A store
+// that does not implement MCPToolLogRetentionManager is skipped rather than
+// treated as a failure: MCP pruning is best-effort, log pruning is not.
+func (c *LogsCleaner) cleanupOldMCPToolLogs(ctx context.Context, cutoff time.Time) {
+	manager, ok := c.manager.(MCPToolLogRetentionManager)
+	if !ok {
+		c.logger.Debug("mcp tool log cleanup skipped: log store does not support pruning mcp tool logs by age")
+		return
+	}
+
+	totalDeleted := int64(0)
+	batchCount := 0
+
+	for {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			c.logger.Warn("mcp tool log cleanup cancelled: %v", ctx.Err())
+			return
+		default:
+		}
+
+		// Delete MCP tool logs in batches using the manager
+		deleted, err := manager.DeleteMCPToolLogsBatch(ctx, cutoff, batchSize)
+		if err != nil {
+			c.logger.Error("failed to delete old mcp tool logs: %v", err)
+			return
+		}
+
+		if deleted == 0 {
+			// No more MCP tool logs to delete
+			break
+		}
+
+		totalDeleted += deleted
+		batchCount++
+		c.logger.Debug("deleted batch %d: %d mcp tool logs", batchCount, deleted)
+
+		// If we deleted fewer than the batch size, we're done
+		if deleted < int64(batchSize) {
+			break
+		}
+	}
+
+	if totalDeleted > 0 {
+		c.logger.Info("mcp tool log cleanup completed: deleted %d mcp tool logs in %d batches", totalDeleted, batchCount)
+	} else {
+		c.logger.Debug("mcp tool log cleanup completed: no old mcp tool logs to delete")
 	}
 }
 

--- a/framework/logstore/cleaner_test.go
+++ b/framework/logstore/cleaner_test.go
@@ -456,20 +456,19 @@ func TestHybrid_DeleteMCPToolLogsBatchUnsupportedInnerReturnsZero(t *testing.T) 
 }
 
 // An inner failure must reach the cleaner unchanged, otherwise a broken store
-// reads as a drained table and retention silently stops.
+// reads as a drained table and retention silently stops. Asserted with a
+// sentinel rather than require.Error so a wrapper-generated error cannot pass.
 func TestHybrid_DeleteMCPToolLogsBatchPropagatesInnerError(t *testing.T) {
 	inner, err := newSqliteLogStore(context.Background(), &SQLiteConfig{
-		Path: filepath.Join(t.TempDir(), "hybrid-closed.db"),
+		Path: filepath.Join(t.TempDir(), "hybrid-inner-error.db"),
 	}, hybridTestLogger{})
 	require.NoError(t, err)
-	hybrid := newHybridLogStore(inner, objectstore.NewInMemoryObjectStore(), "test", hybridTestLogger{}, nil)
+	hybrid := newHybridLogStore(mcpRetentionFailingStore{LogStore: inner}, objectstore.NewInMemoryObjectStore(), "test", hybridTestLogger{}, nil)
+	defer hybrid.Close(context.Background())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	_, err = hybrid.DeleteMCPToolLogsBatch(context.Background(), time.Now().UTC(), 100)
 
-	_, err = hybrid.DeleteMCPToolLogsBatch(ctx, time.Now().UTC(), 100)
-
-	require.Error(t, err)
+	require.ErrorIs(t, err, errInnerMCPPruneFailed)
 }
 
 // mcpRetentionUnawareStore is a complete LogStore that does not satisfy
@@ -483,3 +482,19 @@ type mcpRetentionUnawareStore struct {
 }
 
 func (mcpRetentionUnawareStore) DeleteMCPToolLogsBatch() {}
+
+// errInnerMCPPruneFailed is the sentinel the failing fixture below returns, so
+// the delegation test can assert the inner store's own error survives the hop
+// through HybridLogStore rather than being replaced or swallowed.
+var errInnerMCPPruneFailed = errors.New("inner store failed to prune mcp tool logs")
+
+// mcpRetentionFailingStore is an MCP-capable inner store whose age-based prune
+// always fails, standing in for an inner backend that is unreachable or has
+// lost the grant on mcp_tool_logs.
+type mcpRetentionFailingStore struct {
+	LogStore
+}
+
+func (mcpRetentionFailingStore) DeleteMCPToolLogsBatch(context.Context, time.Time, int) (int64, error) {
+	return 0, errInnerMCPPruneFailed
+}

--- a/framework/logstore/cleaner_test.go
+++ b/framework/logstore/cleaner_test.go
@@ -1,0 +1,485 @@
+package logstore
+
+// Retention coverage for the LogsCleaner. The MCP tool log sweep is driven
+// through the optional MCPToolLogRetentionManager interface, so most of these
+// tests script a fake manager to pin down the loop's termination, cancellation
+// and error behaviour without needing a database. The tail of the file uses a
+// real SQLite store to prove the RDB implementation prunes the right table.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/objectstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every backend the cleaner can be handed must prune MCP tool logs by age, or
+// mcp_tool_logs silently grows without bound on that backend. Compile-time
+// assertions keep a new store (or a dropped override) from regressing that.
+var (
+	_ MCPToolLogRetentionManager = (*RDBLogStore)(nil)
+	_ MCPToolLogRetentionManager = (*ClickHouseLogStore)(nil)
+	_ MCPToolLogRetentionManager = (*HybridLogStore)(nil)
+)
+
+// --- Fakes ---
+
+// retentionCall records the arguments one batch delete was invoked with.
+type retentionCall struct {
+	cutoff    time.Time
+	batchSize int
+}
+
+// retentionResult is one scripted reply. Calls past the end of a script get
+// (0, nil), i.e. "nothing left to delete".
+type retentionResult struct {
+	deleted int64
+	err     error
+}
+
+func scriptedResult(results []retentionResult, callIndex int) (int64, error) {
+	if callIndex < len(results) {
+		return results[callIndex].deleted, results[callIndex].err
+	}
+	return 0, nil
+}
+
+// logsOnlyManager implements LogRetentionManager and deliberately nothing
+// else, standing in for a store that cannot prune MCP tool logs by age.
+// onLogCall runs before the scripted reply is returned so a test can cancel
+// the context from inside the logs loop.
+type logsOnlyManager struct {
+	logCalls   []retentionCall
+	logResults []retentionResult
+	onLogCall  func(callIndex int)
+}
+
+func (m *logsOnlyManager) DeleteLogsBatch(_ context.Context, cutoff time.Time, batchSize int) (int64, error) {
+	m.logCalls = append(m.logCalls, retentionCall{cutoff: cutoff, batchSize: batchSize})
+	if m.onLogCall != nil {
+		m.onLogCall(len(m.logCalls) - 1)
+	}
+	return scriptedResult(m.logResults, len(m.logCalls)-1)
+}
+
+// logsAndMCPManager additionally implements MCPToolLogRetentionManager.
+// onMCPCall runs before the scripted reply is returned so a test can cancel
+// the context from inside the loop.
+type logsAndMCPManager struct {
+	logsOnlyManager
+	mcpCalls   []retentionCall
+	mcpResults []retentionResult
+	onMCPCall  func(callIndex int)
+}
+
+func (m *logsAndMCPManager) DeleteMCPToolLogsBatch(_ context.Context, cutoff time.Time, batchSize int) (int64, error) {
+	m.mcpCalls = append(m.mcpCalls, retentionCall{cutoff: cutoff, batchSize: batchSize})
+	if m.onMCPCall != nil {
+		m.onMCPCall(len(m.mcpCalls) - 1)
+	}
+	return scriptedResult(m.mcpResults, len(m.mcpCalls)-1)
+}
+
+// recordingLogger captures formatted Error and Warn lines so tests can assert
+// the cleaner reported a failure instead of swallowing it, and can tell the
+// logs sweep's messages apart from the MCP sweep's.
+type recordingLogger struct {
+	mu     sync.Mutex
+	errors []string
+	warns  []string
+}
+
+func (l *recordingLogger) Debug(string, ...any) {}
+func (l *recordingLogger) Info(string, ...any)  {}
+func (l *recordingLogger) Warn(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warns = append(l.warns, fmt.Sprintf(format, args...))
+}
+func (l *recordingLogger) Error(format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, fmt.Sprintf(format, args...))
+}
+func (l *recordingLogger) Fatal(string, ...any)                   {}
+func (l *recordingLogger) SetLevel(schemas.LogLevel)              {}
+func (l *recordingLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (l *recordingLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func newTestCleaner(manager LogRetentionManager, logger schemas.Logger) *LogsCleaner {
+	return NewLogsCleaner(manager, CleanerConfig{RetentionDays: 30}, logger)
+}
+
+// --- Failure and edge cases ---
+
+// A store without the optional interface must keep working: the logs sweep
+// still runs and nothing is reported as an error. This is the regression the
+// separate interface exists to prevent.
+func TestLogsCleaner_StoreWithoutMCPSupportStillPrunesLogs(t *testing.T) {
+	_, implements := any(&logsOnlyManager{}).(MCPToolLogRetentionManager)
+	require.False(t, implements, "fixture must not implement the optional MCP interface")
+
+	manager := &logsOnlyManager{logResults: []retentionResult{{deleted: 7}}}
+	logger := &recordingLogger{}
+
+	newTestCleaner(manager, logger).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.logCalls, 1, "a short batch drains the logs table in one pass")
+	assert.Empty(t, logger.errors, "an MCP-incapable store is not an error")
+	assert.Empty(t, logger.warns)
+}
+
+// An MCP batch failure must be logged and must stop only the MCP loop - the
+// logs sweep already completed and its work must not be re-attempted or lost.
+func TestLogsCleaner_MCPBatchErrorStopsOnlyMCPLoop(t *testing.T) {
+	manager := &logsAndMCPManager{
+		logsOnlyManager: logsOnlyManager{logResults: []retentionResult{{deleted: 5}}},
+		mcpResults:      []retentionResult{{err: errors.New("mcp delete exploded")}},
+	}
+	logger := &recordingLogger{}
+
+	newTestCleaner(manager, logger).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.logCalls, 1, "logs sweep must have run to completion")
+	assert.Len(t, manager.mcpCalls, 1, "MCP loop must stop on the failing batch")
+	require.Len(t, logger.errors, 1, "the MCP failure must be logged, not swallowed")
+	assert.Contains(t, logger.errors[0], "mcp tool logs", "the MCP sweep must be the reported failure")
+}
+
+// A failing logs sweep must NOT starve MCP pruning. The two tables are
+// independent, so a persistently broken logs delete would otherwise leave
+// mcp_tool_logs growing without bound - the very bug this sweep fixes.
+func TestLogsCleaner_LogsBatchErrorStillPrunesMCPToolLogs(t *testing.T) {
+	manager := &logsAndMCPManager{
+		logsOnlyManager: logsOnlyManager{logResults: []retentionResult{{err: errors.New("logs delete exploded")}}},
+		mcpResults:      []retentionResult{{deleted: 4}},
+	}
+	logger := &recordingLogger{}
+
+	newTestCleaner(manager, logger).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.logCalls, 1)
+	assert.Len(t, manager.mcpCalls, 1, "MCP sweep must run even though the logs sweep failed")
+	require.Len(t, logger.errors, 1)
+	assert.Contains(t, logger.errors[0], "logs delete exploded")
+}
+
+// A logs sweep cancelled mid-run leaves a dead context, so the MCP sweep must
+// bail immediately rather than issuing deletes that cannot succeed.
+func TestLogsCleaner_LogsSweepCancelledSkipsMCPDeletes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	manager := &logsAndMCPManager{
+		logsOnlyManager: logsOnlyManager{logResults: []retentionResult{{deleted: int64(batchSize)}}},
+	}
+	manager.onLogCall = func(int) { cancel() }
+	logger := &recordingLogger{}
+
+	newTestCleaner(manager, logger).cleanupOldLogs(ctx)
+
+	assert.Len(t, manager.logCalls, 1)
+	assert.Empty(t, manager.mcpCalls, "a dead context must not drive MCP deletes")
+	assert.Len(t, logger.warns, 2, "both sweeps report the cancellation")
+}
+
+// Zero matching rows must terminate after a single probe - no second call and
+// no delete issued behind it.
+func TestLogsCleaner_MCPZeroRowsIssuesSingleCall(t *testing.T) {
+	manager := &logsAndMCPManager{}
+
+	newTestCleaner(manager, testLogger{}).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.mcpCalls, 1)
+}
+
+// A short batch means the table is drained, so the loop must not probe again.
+func TestLogsCleaner_MCPFewerRowsThanBatchSizeStopsAfterOnePass(t *testing.T) {
+	manager := &logsAndMCPManager{mcpResults: []retentionResult{{deleted: int64(batchSize) - 1}}}
+
+	newTestCleaner(manager, testLogger{}).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.mcpCalls, 1)
+	assert.Equal(t, batchSize, manager.mcpCalls[0].batchSize)
+}
+
+// Full batches must keep the loop going until a short batch drains the table.
+func TestLogsCleaner_MCPMoreRowsThanBatchSizeIteratesUntilDrained(t *testing.T) {
+	manager := &logsAndMCPManager{mcpResults: []retentionResult{
+		{deleted: int64(batchSize)},
+		{deleted: int64(batchSize)},
+		{deleted: 3},
+	}}
+
+	newTestCleaner(manager, testLogger{}).cleanupOldLogs(context.Background())
+
+	assert.Len(t, manager.mcpCalls, 3)
+}
+
+// An already-cancelled context must be noticed before any delete is issued.
+func TestLogsCleaner_MCPAlreadyCancelledContextIssuesNoCalls(t *testing.T) {
+	manager := &logsAndMCPManager{mcpResults: []retentionResult{{deleted: int64(batchSize)}}}
+	logger := &recordingLogger{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	newTestCleaner(manager, logger).cleanupOldMCPToolLogs(ctx, time.Now().UTC())
+
+	assert.Empty(t, manager.mcpCalls)
+	assert.Len(t, logger.warns, 1, "cancellation must be reported")
+}
+
+// Cancelling mid-loop must break out at the next iteration rather than
+// draining the whole table on a dead context.
+func TestLogsCleaner_MCPContextCancelledMidLoopReturnsPromptly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	full := retentionResult{deleted: int64(batchSize)}
+	manager := &logsAndMCPManager{mcpResults: []retentionResult{full, full, full, full}}
+	manager.onMCPCall = func(callIndex int) {
+		if callIndex == 1 {
+			cancel()
+		}
+	}
+	logger := &recordingLogger{}
+
+	newTestCleaner(manager, logger).cleanupOldMCPToolLogs(ctx, time.Now().UTC())
+
+	assert.Len(t, manager.mcpCalls, 2, "loop must stop at the iteration after cancellation")
+	assert.Len(t, logger.warns, 1)
+}
+
+// --- Happy paths ---
+
+// Both tables are pruned against one cutoff derived from RetentionDays, so an
+// operator cannot end up with logs and mcp_tool_logs on different horizons.
+func TestLogsCleaner_MCPSweepUsesSameCutoffAsLogsSweep(t *testing.T) {
+	manager := &logsAndMCPManager{
+		logsOnlyManager: logsOnlyManager{logResults: []retentionResult{{deleted: 1}}},
+		mcpResults:      []retentionResult{{deleted: 1}},
+	}
+	before := time.Now().UTC()
+
+	NewLogsCleaner(manager, CleanerConfig{RetentionDays: 30}, testLogger{}).cleanupOldLogs(context.Background())
+
+	require.NotEmpty(t, manager.logCalls)
+	require.NotEmpty(t, manager.mcpCalls)
+	cutoff := manager.logCalls[0].cutoff
+	assert.Equal(t, cutoff, manager.mcpCalls[0].cutoff)
+	assert.WithinDuration(t, before.AddDate(0, 0, -30), cutoff, time.Minute)
+}
+
+// A non-positive retention falls back to the default for both tables alike.
+func TestLogsCleaner_MCPSweepUsesDefaultRetentionWhenUnset(t *testing.T) {
+	manager := &logsAndMCPManager{}
+	before := time.Now().UTC()
+
+	NewLogsCleaner(manager, CleanerConfig{RetentionDays: 0}, testLogger{}).cleanupOldLogs(context.Background())
+
+	require.NotEmpty(t, manager.mcpCalls)
+	assert.WithinDuration(t, before.AddDate(0, 0, -defaultRetentionDays), manager.mcpCalls[0].cutoff, time.Minute)
+}
+
+// --- RDB implementation against a real SQLite store ---
+
+func seedMCPToolLog(t *testing.T, store *RDBLogStore, id string, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, store.CreateMCPToolLog(context.Background(), &MCPToolLog{
+		ID: id, Timestamp: createdAt, CreatedAt: createdAt,
+		ToolName: "search_web", Status: "success",
+	}))
+}
+
+func mcpToolLogIDs(t *testing.T, store *RDBLogStore) []string {
+	t.Helper()
+	var ids []string
+	require.NoError(t, store.db.Model(&MCPToolLog{}).Order("id ASC").Pluck("id", &ids).Error)
+	return ids
+}
+
+// Rows at or after the cutoff must survive; only strictly older rows go. The
+// row seeded exactly at the cutoff pins the comparison as `<`, not `<=`.
+func TestRDBDeleteMCPToolLogsBatch_KeepsRowsNewerThanCutoff(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	cutoff := now.Add(-24 * time.Hour)
+	seedMCPToolLog(t, store, "old", now.Add(-48*time.Hour))
+	seedMCPToolLog(t, store, "at-cutoff", cutoff)
+	seedMCPToolLog(t, store, "new", now.Add(-1*time.Hour))
+
+	deleted, err := store.DeleteMCPToolLogsBatch(context.Background(), cutoff, 100)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+	assert.Equal(t, []string{"at-cutoff", "new"}, mcpToolLogIDs(t, store))
+}
+
+// No matching rows must report zero without erroring, so the cleaner's loop
+// terminates on the first pass.
+func TestRDBDeleteMCPToolLogsBatch_NoMatchingRowsReturnsZero(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	seedMCPToolLog(t, store, "new", now.Add(-1*time.Hour))
+
+	deleted, err := store.DeleteMCPToolLogsBatch(context.Background(), now.Add(-24*time.Hour), 100)
+
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
+	assert.Equal(t, []string{"new"}, mcpToolLogIDs(t, store))
+}
+
+// An empty table is the degenerate case of the above and must not error.
+func TestRDBDeleteMCPToolLogsBatch_EmptyTableReturnsZero(t *testing.T) {
+	store := newTestSQLiteStore(t)
+
+	deleted, err := store.DeleteMCPToolLogsBatch(context.Background(), time.Now().UTC(), 100)
+
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
+}
+
+// The limit must be honoured so a large backlog is drained in bounded chunks
+// rather than one table-locking DELETE.
+func TestRDBDeleteMCPToolLogsBatch_RespectsBatchSize(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, id := range []string{"a", "b", "c", "d", "e"} {
+		seedMCPToolLog(t, store, id, now.Add(-48*time.Hour))
+	}
+
+	deleted, err := store.DeleteMCPToolLogsBatch(context.Background(), now.Add(-24*time.Hour), 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), deleted)
+	assert.Len(t, mcpToolLogIDs(t, store), 3)
+}
+
+// A cancelled context must surface as an error rather than a silent no-op that
+// the cleaner would read as "table drained".
+func TestRDBDeleteMCPToolLogsBatch_CancelledContextErrors(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	seedMCPToolLog(t, store, "old", time.Now().UTC().Add(-48*time.Hour))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := store.DeleteMCPToolLogsBatch(ctx, time.Now().UTC(), 100)
+
+	require.Error(t, err)
+	assert.Len(t, mcpToolLogIDs(t, store), 1)
+}
+
+// The two sweeps must stay on their own tables: pruning MCP tool logs must not
+// touch logs, and vice versa.
+func TestRDBDeleteMCPToolLogsBatch_LeavesLogsTableAlone(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().Truncate(time.Second).Add(-48 * time.Hour)
+	seedMCPToolLog(t, store, "mcp-old", old)
+	require.NoError(t, store.Create(ctx, &Log{ID: "log-old", Timestamp: old, CreatedAt: old, Status: "success"}))
+
+	deleted, err := store.DeleteMCPToolLogsBatch(ctx, time.Now().UTC(), 100)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+	assert.Empty(t, mcpToolLogIDs(t, store))
+	_, err = store.FindByID(ctx, "log-old")
+	assert.NoError(t, err, "the logs table must be untouched by the MCP sweep")
+}
+
+// End to end: the cleaner drains both tables of a real store in one run.
+func TestLogsCleaner_PrunesBothTablesOnSQLiteStore(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().Truncate(time.Second).AddDate(0, 0, -60)
+	seedMCPToolLog(t, store, "mcp-old", old)
+	require.NoError(t, store.Create(ctx, &Log{ID: "log-old", Timestamp: old, CreatedAt: old, Status: "success"}))
+
+	newTestCleaner(store, testLogger{}).cleanupOldLogs(ctx)
+
+	assert.Empty(t, mcpToolLogIDs(t, store))
+	_, err := store.FindByID(ctx, "log-old")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// --- Hybrid delegation ---
+
+// The hybrid store must forward age-based MCP pruning to its inner store,
+// otherwise object-storage deployments lose MCP retention entirely.
+func TestHybrid_DeleteMCPToolLogsBatchDelegatesToInner(t *testing.T) {
+	hybrid, inner, _ := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+
+	ctx := context.Background()
+	old := time.Now().UTC().Truncate(time.Second).Add(-48 * time.Hour)
+	require.NoError(t, inner.CreateMCPToolLog(ctx, &MCPToolLog{
+		ID: "mcp-old", Timestamp: old, CreatedAt: old, ToolName: "search_web", Status: "success",
+	}))
+
+	deleted, err := hybrid.DeleteMCPToolLogsBatch(ctx, time.Now().UTC(), 100)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), deleted)
+	_, err = inner.FindMCPToolLog(ctx, "mcp-old")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// An inner store that cannot prune MCP tool logs by age must degrade to a
+// no-op rather than failing the type assertion.
+func TestHybrid_DeleteMCPToolLogsBatchUnsupportedInnerReturnsZero(t *testing.T) {
+	inner, err := newSqliteLogStore(context.Background(), &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "hybrid-unsupported.db"),
+	}, hybridTestLogger{})
+	require.NoError(t, err)
+
+	wrapped := mcpRetentionUnawareStore{LogStore: inner}
+	_, implements := any(wrapped).(MCPToolLogRetentionManager)
+	require.False(t, implements, "fixture must not implement the optional MCP interface")
+
+	hybrid := newHybridLogStore(wrapped, objectstore.NewInMemoryObjectStore(), "test", hybridTestLogger{}, nil)
+	defer hybrid.Close(context.Background())
+
+	deleted, err := hybrid.DeleteMCPToolLogsBatch(context.Background(), time.Now().UTC(), 100)
+
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
+}
+
+// An inner failure must reach the cleaner unchanged, otherwise a broken store
+// reads as a drained table and retention silently stops.
+func TestHybrid_DeleteMCPToolLogsBatchPropagatesInnerError(t *testing.T) {
+	inner, err := newSqliteLogStore(context.Background(), &SQLiteConfig{
+		Path: filepath.Join(t.TempDir(), "hybrid-closed.db"),
+	}, hybridTestLogger{})
+	require.NoError(t, err)
+	hybrid := newHybridLogStore(inner, objectstore.NewInMemoryObjectStore(), "test", hybridTestLogger{}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = hybrid.DeleteMCPToolLogsBatch(ctx, time.Now().UTC(), 100)
+
+	require.Error(t, err)
+}
+
+// mcpRetentionUnawareStore is a complete LogStore that does not satisfy
+// MCPToolLogRetentionManager, standing in for a decorator that predates
+// age-based MCP pruning. Embedding the LogStore interface promotes only the
+// LogStore method set, which excludes DeleteMCPToolLogsBatch; the wrong-shaped
+// method below keeps the fixture unsupported even if DeleteMCPToolLogsBatch is
+// later promoted into LogStore.
+type mcpRetentionUnawareStore struct {
+	LogStore
+}
+
+func (mcpRetentionUnawareStore) DeleteMCPToolLogsBatch() {}

--- a/framework/logstore/clickhouse.go
+++ b/framework/logstore/clickhouse.go
@@ -146,7 +146,7 @@ func buildClickHouseDSN(config *ClickHouseConfig) (string, error) {
 
 // newClickHouseLogStore creates a new ClickHouse log store. retentionDays drives
 // the table TTL; values < 1 leave TTL unset (the LogsCleaner still prunes via
-// DeleteLogsBatch).
+// DeleteLogsBatch and DeleteMCPToolLogsBatch).
 func newClickHouseLogStore(ctx context.Context, config *ClickHouseConfig, retentionDays int, logger schemas.Logger) (LogStore, error) {
 	dsn, err := buildClickHouseDSN(config)
 	if err != nil {

--- a/framework/logstore/clickhousemigrate.go
+++ b/framework/logstore/clickhousemigrate.go
@@ -224,7 +224,7 @@ func clickhouseReconcileColumns(ctx context.Context, db *gorm.DB, model any, tab
 
 // chLogsTTL derives the logs/mcp_tool_logs TTL clause from the configured
 // retention. Values < 1 leave TTL unset (the LogsCleaner still prunes via
-// DeleteLogsBatch).
+// DeleteLogsBatch and DeleteMCPToolLogsBatch).
 func chLogsTTL(retentionDays int) string {
 	if retentionDays < 1 {
 		return ""

--- a/framework/logstore/clickhousestore.go
+++ b/framework/logstore/clickhousestore.go
@@ -505,6 +505,33 @@ func (s *ClickHouseLogStore) DeleteLogsBatch(ctx context.Context, cutoff time.Ti
 	return int64(len(ids)), nil
 }
 
+// DeleteMCPToolLogsBatch deletes MCP tool logs older than cutoff in batches.
+// Overridden for the same reason as DeleteLogsBatch: the GORM ClickHouse driver
+// rewrites DELETE into an ALTER TABLE mutation whose driver result reports 0
+// rows affected, so the inherited implementation would always return 0 and the
+// LogsCleaner would treat every batch as empty and stop early. The ids are
+// selected first, so their count is the deleted count once the
+// (mutations_sync=1) delete returns.
+func (s *ClickHouseLogStore) DeleteMCPToolLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (int64, error) {
+	var ids []string
+	if err := s.db.WithContext(ctx).
+		Model(&MCPToolLog{}).
+		Select("id").
+		Where("created_at < ?", cutoff).
+		Order("created_at ASC").
+		Limit(batchSize).
+		Pluck("id", &ids).Error; err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if err := s.db.WithContext(ctx).Where("id IN ?", ids).Delete(&MCPToolLog{}).Error; err != nil {
+		return 0, err
+	}
+	return int64(len(ids)), nil
+}
+
 // DeleteExpiredAsyncJobs deletes async jobs whose expiry has passed.
 // Overridden for the same reason as DeleteLogsBatch: mutation deletes report
 // 0 rows affected, so ids are selected first and their count returned.

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -39,7 +39,8 @@ type uploadWork struct {
 //   - Delegated directly (40+ methods): all analytics, search, histogram, ranking,
 //     distinct, MCP, async job methods
 //   - Intercepted: Create, CreateIfNotExists, BatchCreateIfNotExists, FindByID,
-//     Update, DeleteLog, DeleteLogs, DeleteLogsBatch, Close
+//     Update, DeleteLog, DeleteLogs, DeleteLogsBatch, DeleteMCPToolLogsBatch,
+//     Close
 type HybridLogStore struct {
 	inner          LogStore
 	objects        objectstore.ObjectStore
@@ -544,6 +545,28 @@ func (h *HybridLogStore) DeleteLogs(ctx context.Context, ids []string) error {
 func (h *HybridLogStore) DeleteLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (int64, error) {
 	// Delegate to inner — S3 objects will be cleaned up by lifecycle policies.
 	return h.inner.DeleteLogsBatch(ctx, cutoff, batchSize)
+}
+
+// DeleteMCPToolLogsBatch deletes old MCP tool log rows older than cutoff in
+// batches of batchSize. As with DeleteLogsBatch, object-store entries are
+// intentionally NOT deleted here: the expectation is that the bucket has a
+// lifecycle policy configured to expire objects on the same schedule, which is
+// far cheaper than per-row DELETEs. Note that MCP payloads live under a
+// separate <prefix>/mcp-logs/ key space, so a lifecycle rule scoped only to
+// <prefix>/logs/ will orphan them once the rows are pruned. Age-based MCP
+// pruning is optional on the inner store, so an inner store without it reports
+// nothing deleted and the cleaner stops after a single pass instead of
+// erroring.
+func (h *HybridLogStore) DeleteMCPToolLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (int64, error) {
+	inner, ok := h.inner.(MCPToolLogRetentionManager)
+	if !ok {
+		// Logged because the hybrid itself satisfies the interface, so the
+		// cleaner cannot tell this apart from an already-drained table.
+		h.logger.Warn("objectstore: inner log store does not support pruning mcp tool logs by age; mcp_tool_logs will not be pruned")
+		return 0, nil
+	}
+	// Delegate to inner — S3 objects will be cleaned up by lifecycle policies.
+	return inner.DeleteMCPToolLogsBatch(ctx, cutoff, batchSize)
 }
 
 // Close shuts the store down cleanly: marks the store closed (so further

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -1229,6 +1229,24 @@ func TestLogStoreParity(t *testing.T) {
 			}
 			assertParity(t, stores, 1e-6, remainingMCPIDs)
 		})
+		t.Run("delete_mcp_logs_batch", func(t *testing.T) {
+			// Retention pruning of mcp_tool_logs rides the optional
+			// MCPToolLogRetentionManager interface, so every backend must both
+			// implement it and agree on the count (ClickHouse mutations report
+			// 0 rows affected natively). Deletes m2 (base-85s) and leaves m3.
+			for name, s := range stores {
+				_, ok := s.(MCPToolLogRetentionManager)
+				require.True(t, ok, "%s must support age-based mcp tool log pruning", name)
+			}
+			assertParity(t, stores, 1e-6, func(ctx context.Context, s LogStore) (any, error) {
+				manager, ok := s.(MCPToolLogRetentionManager)
+				if !ok {
+					return nil, fmt.Errorf("store does not support age-based mcp tool log pruning")
+				}
+				return manager.DeleteMCPToolLogsBatch(ctx, base.Add(-80*time.Second), 100)
+			})
+			assertParity(t, stores, 1e-6, remainingMCPIDs)
+		})
 	})
 
 	// --- Phase: shutdown ---

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -4416,6 +4416,34 @@ func (s *RDBLogStore) DeleteLogsBatch(ctx context.Context, cutoff time.Time, bat
 	return result.RowsAffected, nil
 }
 
+// DeleteMCPToolLogsBatch deletes MCP tool logs older than the cutoff time in
+// batches. mcp_tool_logs is pruned on the same retention schedule as logs, so
+// this mirrors DeleteLogsBatch exactly - only the model differs.
+func (s *RDBLogStore) DeleteMCPToolLogsBatch(ctx context.Context, cutoff time.Time, batchSize int) (deletedCount int64, err error) {
+	// First, select the IDs of MCP tool logs to delete with proper LIMIT
+	var ids []string
+	if err := s.db.WithContext(ctx).
+		Model(&MCPToolLog{}).
+		Select("id").
+		Where("created_at < ?", cutoff).
+		Limit(batchSize).
+		Pluck("id", &ids).Error; err != nil {
+		return 0, err
+	}
+
+	// If no IDs found, return early
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	// Delete the selected IDs
+	result := s.db.WithContext(ctx).Where("id IN ?", ids).Delete(&MCPToolLog{})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}
+
 // Close closes the log store.
 func (s *RDBLogStore) Close(ctx context.Context) error {
 	sqlDB, err := s.db.WithContext(ctx).DB()


### PR DESCRIPTION
## Summary

The retention cleaner only pruned the `logs` table. `mcp_tool_logs` was never deleted by age on the RDB path, so it grew without bound on postgres and sqlite regardless of the configured retention.

Closes #5631.

## Why this is a parity gap, not a deliberate exclusion

- ClickHouse already applies the same TTL to both tables (`migrationClickHouseMCPToolLogsTable`).
- `chLogsTTL`, which builds that TTL clause for **both** `logs` and `mcp_tool_logs`, documents itself as:
  > derives the logs/mcp_tool_logs TTL clause from the configured retention. Values < 1 leave TTL unset (the LogsCleaner still prunes via DeleteLogsBatch).

  i.e. the cleaner was expected to cover `mcp_tool_logs` on backends without a table TTL.
- `docs/enterprise/log-exports.mdx` already documents the cleaner as deleting "the main `Log` table as well as the MCP tool logs table".

So the documented and ClickHouse behaviour was already the intended one; only the RDB path was missing it.

## Changes

- `framework/logstore/cleaner.go` — new `MCPToolLogRetentionManager` optional interface, plus `cleanupOldMCPToolLogs` which runs the same batched loop against the same cutoff and reports its counts separately.
- `framework/logstore/rdb.go`, `clickhousestore.go`, `hybrid.go` — `DeleteMCPToolLogsBatch` on each store.
- `framework/logstore/clickhouse.go`, `clickhousemigrate.go` — doc comments updated to name both methods (1 line each).
- `docs/enterprise/log-exports.mdx` — bucket lifecycle rules must cover `<prefix>/mcp-logs/`, which only becomes reachable now that MCP rows are pruned (`MCPToolObjectKey` writes there).

### Two design decisions worth reviewing

**1. A separate optional interface rather than widening `LogRetentionManager`.**

`transports/bifrost-http/server/server.go` gates the entire cleaner on `s.Config.LogsStore.(logstore.LogRetentionManager)` and silently skips starting it when the assertion fails. Adding a method to that interface would therefore silently disable *all* retention for any store that does not implement it. With a separate interface, such a store skips MCP pruning only.

Trade-off, documented on the interface: a downstream type embedding `logstore.LogStore` satisfies `LogRetentionManager` for free but not `MCPToolLogRetentionManager`, so it keeps pruning `logs` while skipping `mcp_tool_logs`. Partial skip seemed clearly better than silently disabling retention entirely, but happy to change this if you prefer the interface widened.

**2. The MCP sweep is `defer`red inside `cleanupOldLogs`.**

The logs loop returns early on its first delete error. Running the MCP sweep after it sequentially would mean any persistent condition on `logs` (lock contention, statement timeout, restricted grants) aborts every daily run before MCP is reached — reintroducing the same unbounded growth through another path, on exactly the deployments most likely to hit it. The `defer` sits immediately after the cutoff is computed so no existing line moved. A cancelled context still short-circuits inside `cleanupOldMCPToolLogs`.

## How to test

### Reproduction: same test file, same database, only the branch differs

A temporary in-package test (not included in this PR) seeded the rows from #5631 into real Postgres from `framework/docker-compose.yml`, ran one `cleanupOldLogs` pass with `RetentionDays: 1`, then counted both tables.

**On `dev`:**

```
SEEDED       logs=10  mcp_tool_logs=10
AFTER SWEEP  logs=0   mcp_tool_logs=10
--- FAIL: TestZZReproMCPToolLogsRetention
    Should be zero, but was 10
    Messages: mcp_tool_logs should be pruned on the same schedule
```

**On this branch:**

```
SEEDED       logs=10  mcp_tool_logs=10
{"level":"info","message":"starting log cleanup: deleting logs older than 2026-07-27T18:37:36Z (retention: 1 days)"}
{"level":"info","message":"log cleanup completed: deleted 10 logs in 1 batches"}
{"level":"info","message":"mcp tool log cleanup completed: deleted 10 mcp tool logs in 1 batches"}
AFTER SWEEP  logs=0   mcp_tool_logs=0
--- PASS: TestZZReproMCPToolLogsRetention
```

### Suite

Run against live Postgres + ClickHouse (`framework/docker-compose.yml`), since the parity suite skips silently otherwise:

```sh
cd framework
gofmt -l logstore/     # no output
go vet ./logstore/...  # clean
go test ./logstore/... -count=1
# ok  github.com/maximhq/bifrost/framework/logstore  103.686s
```

The new parity case is confirmed not skipped:

```
--- PASS: TestLogStoreParity/Deletes/delete_logs_batch (0.04s)
--- PASS: TestLogStoreParity/Deletes/delete_mcp_logs_batch (0.03s)
```

### Tests added — 21, of which 16 are failure/edge cases

`cleaner_test.go` (new): store without MCP support still prunes logs; MCP batch error stops only the MCP loop; logs batch error still prunes MCP; cancelled sweep skips MCP deletes; zero rows issues a single call; fewer-than-batchSize stops after one pass; more-than-batchSize iterates until drained; already-cancelled context issues no calls; cancellation mid-loop returns promptly; MCP sweep uses the same cutoff as the logs sweep; default retention when unset; both tables pruned on a real SQLite store.

`rdb.go` (real SQLite): keeps rows newer than cutoff; no matching rows returns zero; empty table returns zero; respects batchSize; cancelled context errors; leaves the logs table alone.

`hybrid.go`: delegates to inner; unsupported inner returns zero; propagates inner error.

`logstoreparity_test.go`: `delete_mcp_logs_batch` across backends, plus compile-time `var _ MCPToolLogRetentionManager` assertions for all three stores.

Two mutation checks confirm the tests bite rather than merely pass:
- removing the ClickHouse override → `FAIL … delete_mcp_logs_batch: postgres vs clickhouse mismatch`
- flipping `created_at <` to `<=` in `rdb.go` → `FAIL … KeepsRowsNewerThanCutoff`

## Breaking changes

- [x] No

`LogRetentionManager` is unchanged, so existing implementations keep working. Stores that do not implement the new optional interface simply skip MCP pruning, which is the current behaviour.

Behaviour change worth calling out: on an existing deployment with a backlog of `mcp_tool_logs`, the first cleanup pass after upgrading will delete every row older than the retention window, in batches of 100.

## Known limitations (deliberate, flagged for follow-up)

1. **Shared 30-minute budget.** Both sweeps share one `context.WithTimeout(30*time.Minute)` and `logs` always spends it first, so a very large first-run backlog can leave nothing for MCP. It self-corrects on subsequent runs. Splitting the budget felt out of scope here.
2. **`DeleteMCPToolLogsBatch` duplicates `DeleteLogsBatch`** in each store. Deliberate — structural de-duplication (generics or a shared helper) would mix a refactor into a behavioural fix. Happy to follow up separately if you want it.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go) — `framework/logstore`
- [x] Docs

## Related issues

- Closes #5631
- Context: #1665, #5630

## Security considerations

None. No new data is exposed; a table that was previously retained indefinitely is now subject to the retention already configured for logs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go) — `go vet` and the full `framework/logstore` suite; the UI was untouched
- [x] I verified the CI pipeline passes locally if applicable
