### PR TITLE
refactor: extract provider config accordion into reusable `ProviderConfigCard` component

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1,6 +1,5 @@
 import { useVirtualKeyUsage } from "@/app/workspace/virtual-keys/hooks/useVirtualKeyUsage";
 import { BudgetOverrideDialog } from "@/components/budgetOverrideDialog";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
 	AlertDialog,
@@ -14,7 +13,6 @@ import {
 } from "@/components/ui/alertDialog";
 import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
 import { TeamSelector } from "@/components/entitySelectors/teamSelector";
-import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
 import { DateTimePicker } from "@/components/ui/datePickerWithRange";
 import { ComboboxSelect } from "@/components/ui/combobox";
@@ -22,10 +20,10 @@ import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import MultiBudgetLines from "@/components/ui/multibudgets";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
+import { ProviderConfigCard } from "@/components/ui/providerConfigCard";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -34,8 +32,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn } from "@/components/ui/utils";
-import { ModelPlaceholders } from "@/lib/constants/config";
 import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
@@ -65,10 +61,9 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
-import { Info, Lock, RotateCcw, Trash2, Users, X } from "lucide-react";
+import { Info, Lock, RotateCcw, Trash2, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { components, MultiValueProps, OptionProps } from "react-select";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -172,13 +167,6 @@ type BudgetComparisonEntry = {
 	max_limit?: number;
 	reset_duration?: string;
 	current_usage?: number;
-};
-
-type VirtualKeyType = {
-	label: string;
-	value: string;
-	description: string;
-	provider: string;
 };
 
 const pad2 = (n: number) => n.toString().padStart(2, "0");
@@ -459,13 +447,6 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	// Handle removing a provider configuration
 	const handleRemoveProvider = (index: number) => {
 		const updatedConfigs = providerConfigs.filter((_, i) => i !== index);
-		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle updating provider configuration
-	const handleUpdateProviderConfig = (index: number, field: string, value: any) => {
-		const updatedConfigs = [...providerConfigs];
-		updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
 		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
 	};
 
@@ -1103,386 +1084,49 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 
 									{/* Provider Configurations Table */}
 									{providerConfigs.length > 0 && (
-										<div className="rounded-md border px-2">
-											<Accordion type="multiple" className="w-full">
-												{providerConfigs.map((config, index) => {
-													const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
-													return (
-														<AccordionItem key={index} className="w-full" value={`${config.provider}-${index}`}>
-															<AccordionTrigger className="flex h-12 items-center gap-0 px-1">
-																<div className="flex w-full items-center justify-between">
-																	<div className="flex w-fit items-center gap-2">
-																		<RenderProviderIcon
-																			provider={
-																				providerConfig?.custom_provider_config?.base_provider_type || (config.provider as ProviderIconType)
-																			}
-																			size="sm"
-																			className="h-4 w-4"
-																		/>
-																		{providerConfig?.custom_provider_config
-																			? providerConfig.name
-																			: ProviderLabels[config.provider as ProviderName]}
-																	</div>
-																	<Button
-																		type="button"
-																		variant="ghost"
-																		size="icon"
-																		aria-label={`Remove ${config.provider} provider`}
-																		className="hover:bg-accent/50 h-8 w-8 rounded-sm p-2"
-																		data-testid={`vk-delete-provider-${index}`}
-																		onClick={(e) => {
-																			e.stopPropagation();
-																			handleRemoveProvider(index);
-																		}}
-																	>
-																		<Trash2 className="h-4 w-4 opacity-75" />
-																	</Button>
-																</div>
-															</AccordionTrigger>
-															<AccordionContent className="flex flex-col gap-4 px-1 text-balance">
-																<div className="flex w-full items-start gap-2">
-																	<div className="w-1/4">
-																		<NumberAndSelect
-																			id={`vk-weight-${index}`}
-																			label="Weight"
-																			labelClassName="text-sm font-medium"
-																			placeholder="Exclude from routing"
-																			inputClassName="h-[38px] w-full"
-																			dataTestId={`vk-weight-input-${index}`}
-																			value={config.weight}
-																			onChangeNumber={(value) => handleUpdateProviderConfig(index, "weight", value)}
-																		/>
-																	</div>
-																	<div className="w-3/4 space-y-2">
-																		<Label className="text-sm font-medium">
-																			Allowed Models <span className="text-muted-foreground ml-auto text-xs italic">type to search</span>
-																		</Label>
-																		{(() => {
-																			const hasWildcardModels = (config.allowed_models || []).includes("*");
-																			return (
-																				<ModelMultiselect
-																					data-testid={`vk-models-multiselect-${index}`}
-																					provider={config.provider}
-																					keys={(() => {
-																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																						const configKeyIds = config.key_ids || [];
-																						return configKeyIds.includes("*")
-																							? providerKeys.map((key) => key.key_id)
-																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
-																					})()}
-																					allowAllOption={true}
-																					value={hasWildcardModels ? ["*"] : config.allowed_models || []}
-																					onChange={(models: string[]) => {
-																						const hadStar = (config.allowed_models || []).includes("*");
-																						const hasStar = models.includes("*");
-																						if (!hadStar && hasStar) {
-																							handleUpdateProviderConfig(index, "allowed_models", ["*"]);
-																						} else if (hadStar && hasStar && models.length > 1) {
-																							handleUpdateProviderConfig(
-																								index,
-																								"allowed_models",
-																								models.filter((m) => m !== "*"),
-																							);
-																						} else {
-																							handleUpdateProviderConfig(index, "allowed_models", models);
-																						}
-																					}}
-																					placeholder={
-																						hasWildcardModels
-																							? "All models allowed"
-																							: (config.allowed_models || []).length === 0
-																								? "No models (deny all)"
-																								: config.provider
-																									? ModelPlaceholders[config.provider as keyof typeof ModelPlaceholders] ||
-																										ModelPlaceholders.default
-																									: ModelPlaceholders.default
-																					}
-																					className="min-h-10 max-w-[500px] min-w-[200px]"
-																				/>
-																			);
-																		})()}
-																		<p className="text-muted-foreground text-xs">
-																			Select specific models or choose “Allow All Models” to allow all. Leave empty to deny all.
-																		</p>
-																	</div>
-																</div>
-
-																{/* Blocked Models for this provider */}
-																<div className="flex w-full items-start gap-2">
-																	<div className="w-1/4" />
-																	<div className="w-3/4 space-y-2">
-																		<div className="flex items-center gap-2">
-																			<Label className="text-sm font-medium">Blocked Models</Label>
-																			<TooltipProvider>
-																				<Tooltip>
-																					<TooltipTrigger asChild>
-																						<span>
-																							<Info className="text-muted-foreground h-3 w-3" />
-																						</span>
-																					</TooltipTrigger>
-																					<TooltipContent>
-																						<p>
-																							Models this VK must never serve. The denylist wins if a model appears in both Allowed Models
-																							and Blocked Models.
-																						</p>
-																					</TooltipContent>
-																				</Tooltip>
-																			</TooltipProvider>
-																		</div>
-																		{(() => {
-																			const hasWildcardBlocked = (config.blacklisted_models || []).includes("*");
-																			return (
-																				<ModelMultiselect
-																					data-testid={`vk-models-blocked-multiselect-${index}`}
-																					provider={config.provider}
-																					keys={(() => {
-																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																						const configKeyIds = config.key_ids || [];
-																						return configKeyIds.includes("*")
-																							? providerKeys.map((key) => key.key_id)
-																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
-																					})()}
-																					allowAllOption={true}
-																					value={hasWildcardBlocked ? ["*"] : config.blacklisted_models || []}
-																					onChange={(models: string[]) => {
-																						const hadStar = (config.blacklisted_models || []).includes("*");
-																						const hasStar = models.includes("*");
-																						if (!hadStar && hasStar) {
-																							handleUpdateProviderConfig(index, "blacklisted_models", ["*"]);
-																						} else if (hadStar && hasStar && models.length > 1) {
-																							handleUpdateProviderConfig(
-																								index,
-																								"blacklisted_models",
-																								models.filter((m) => m !== "*"),
-																							);
-																						} else {
-																							handleUpdateProviderConfig(index, "blacklisted_models", models);
-																						}
-																					}}
-																					placeholder={
-																						hasWildcardBlocked
-																							? "All models blocked"
-																							: (config.blacklisted_models || []).length === 0
-																								? "No models blocked"
-																								: "Search models..."
-																					}
-																					className="min-h-10 max-w-[500px] min-w-[200px]"
-																				/>
-																			);
-																		})()}
-																	</div>
-																</div>
-
-																{/* Allowed Keys for this provider */}
-																{(() => {
-																	const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																	const configKeyIds = config.key_ids || [];
-																	const hasWildcard = configKeyIds.includes("*");
-																	const allKeyOptions = [
-																		{
-																			label: "Allow All Keys",
-																			value: "*",
-																			description: "Allow all current and future keys for this provider",
-																			provider: "",
-																		},
-																		...providerKeys.map((key) => ({
-																			label: key.name,
-																			value: key.key_id,
-																			description:
-																				key.models == null || key.models.includes("*")
-																					? "All models"
-																					: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																			provider: key.provider,
-																		})),
-																	];
-																	const selectedProviderKeys = hasWildcard
-																		? [allKeyOptions[0]]
-																		: providerKeys
-																				.filter((key) => configKeyIds.includes(key.key_id))
-																				.map((key) => ({
-																					label: key.name,
-																					value: key.key_id,
-																					description:
-																						key.models == null || key.models.includes("*")
-																							? "All models"
-																							: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																					provider: key.provider,
-																				}));
-
-																	return (
-																		<div className="mx-0.5 space-y-2">
-																			<Label className="text-sm font-medium">Allowed Keys</Label>
-																			<p className="text-muted-foreground text-xs">
-																				Select specific keys or allow all. Leave empty to block all keys for this provider.
-																			</p>
-																			<AsyncMultiSelect
-																				hideSelectedOptions
-																				isNonAsync
-																				closeMenuOnSelect={false}
-																				menuPlacement="auto"
-																				defaultOptions={allKeyOptions}
-																				views={{
-																					multiValue: (multiValueProps: MultiValueProps<VirtualKeyType>) => {
-																						return (
-																							<div
-																								{...multiValueProps.innerProps}
-																								className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
-																							>
-																								{multiValueProps.data.label}{" "}
-																								<X
-																									className="hover:text-foreground text-muted-foreground h-4 w-4 cursor-pointer"
-																									onClick={(e) => {
-																										e.stopPropagation();
-																										multiValueProps.removeProps.onClick?.(e as any);
-																									}}
-																								/>
-																							</div>
-																						);
-																					},
-																					option: (optionProps: OptionProps<VirtualKeyType>) => {
-																						const { Option } = components;
-																						return (
-																							<Option
-																								{...optionProps}
-																								className={cn(
-																									"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
-																									optionProps.isFocused && "bg-accent dark:!bg-card",
-																									"hover:bg-accent",
-																									optionProps.isSelected && "bg-accent dark:!bg-card",
-																								)}
-																							>
-																								<span className="text-content-primary grow truncate text-sm">{optionProps.data.label}</span>
-																								{optionProps.data.description && (
-																									<span className="text-content-tertiary max-w-[70%] text-sm">
-																										{optionProps.data.description}
-																									</span>
-																								)}
-																							</Option>
-																						);
-																					},
-																				}}
-																				value={selectedProviderKeys}
-																				onChange={(keys) => {
-																					const hadStar = hasWildcard;
-																					const hasStar = keys.some((k) => k.value === "*");
-																					if (!hadStar && hasStar) {
-																						// Just selected "Allow All Keys" — set to ["*"] only
-																						handleUpdateProviderConfig(index, "key_ids", ["*"]);
-																					} else if (hadStar && hasStar && keys.length > 1) {
-																						// Had "*", still has "*", but user also selected a specific key — drop "*"
-																						handleUpdateProviderConfig(
-																							index,
-																							"key_ids",
-																							keys.filter((k) => k.value !== "*").map((k) => k.value as string),
-																						);
-																					} else {
-																						handleUpdateProviderConfig(
-																							index,
-																							"key_ids",
-																							keys.map((k) => k.value as string),
-																						);
-																					}
-																				}}
-																				placeholder={
-																					hasWildcard
-																						? "All keys allowed"
-																						: configKeyIds.length === 0
-																							? "No keys selected"
-																							: "Select keys..."
-																				}
-																				className="hover:bg-accent w-full"
-																				menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
-																			/>
-																		</div>
-																	);
-																})()}
-
-																<DottedSeparator />
-
-																{/* Provider Budget Configuration */}
-																<MultiBudgetLines
-																	data-testid={`vk-provider-budget-${index}`}
-																	label="Provider Budget"
-																	lines={
-																		config.budgets && config.budgets.length > 0
-																			? config.budgets.map((b) => ({
-																					id: b.id,
-																					max_limit: b.max_limit,
-																					reset_duration: b.reset_duration || "1M",
-																				}))
-																			: []
-																	}
-																	onChange={(lines) => {
-																		const updatedConfigs = [...providerConfigs];
-																		updatedConfigs[index] = {
-																			...updatedConfigs[index],
-																			budgets: lines.map((l) => ({
-																				id: l.id,
-																				max_limit: l.max_limit,
-																				reset_duration: l.reset_duration,
-																			})),
-																		};
-																		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-																	}}
-																/>
-
-																<DottedSeparator />
-
-																{/* Provider Rate Limit Configuration */}
-																<div className="space-y-4">
-																	<Label className="text-sm font-medium">Provider Rate Limits</Label>
-
-																	<NumberAndSelect
-																		id={`providerTokenLimit-${index}`}
-																		labelClassName="font-normal"
-																		label="Maximum Tokens"
-																		value={config.rate_limit?.token_max_limit}
-																		selectValue={config.rate_limit?.token_reset_duration || "1h"}
-																		onChangeNumber={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				token_max_limit: value,
-																			});
-																		}}
-																		onChangeSelect={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				token_reset_duration: value,
-																			});
-																		}}
-																		options={resetDurationOptions}
-																	/>
-
-																	<NumberAndSelect
-																		id={`providerRequestLimit-${index}`}
-																		labelClassName="font-normal"
-																		label="Maximum Requests"
-																		value={config.rate_limit?.request_max_limit}
-																		selectValue={config.rate_limit?.request_reset_duration || "1h"}
-																		onChangeNumber={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				request_max_limit: value,
-																			});
-																		}}
-																		onChangeSelect={(value) => {
-																			const currentRateLimit = config.rate_limit || {};
-																			handleUpdateProviderConfig(index, "rate_limit", {
-																				...currentRateLimit,
-																				request_reset_duration: value,
-																			});
-																		}}
-																		options={resetDurationOptions}
-																	/>
-																</div>
-															</AccordionContent>
-														</AccordionItem>
-													);
-												})}
-											</Accordion>
+										<div className="space-y-2.5">
+											{providerConfigs.map((config, index) => {
+												const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
+												const providerLabel = providerConfig?.custom_provider_config
+													? providerConfig.name
+													: ProviderLabels[config.provider as ProviderName] || config.provider;
+												const iconProvider = (providerConfig?.custom_provider_config?.base_provider_type ||
+													config.provider) as ProviderIconType;
+												const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
+												return (
+													<ProviderConfigCard
+														key={config.provider}
+														index={index}
+														testIdPrefix="vk"
+														providerLabel={providerLabel}
+														iconProvider={iconProvider}
+														providerKeys={providerKeys}
+														onRemove={() => handleRemoveProvider(index)}
+														value={{
+															providerName: config.provider,
+															allowedModels: config.allowed_models || [],
+															blacklistedModels: config.blacklisted_models || [],
+															weight: config.weight,
+															keyIds: config.key_ids || [],
+															budgets: config.budgets || [],
+															rateLimit: config.rate_limit ?? null,
+														}}
+														onChange={(next) => {
+															const updated = [...providerConfigs];
+															updated[index] = {
+																...config,
+																allowed_models: next.allowedModels,
+																blacklisted_models: next.blacklistedModels,
+																weight: next.weight ?? undefined,
+																key_ids: next.keyIds,
+																budgets: next.budgets.map((l) => ({ id: l.id, max_limit: l.max_limit, reset_duration: l.reset_duration })),
+																rate_limit: next.rateLimit ?? undefined,
+															};
+															form.setValue("providerConfigs", updated, { shouldDirty: true });
+														}}
+													/>
+												);
+											})}
 										</div>
 									)}
 									{/* Display validation errors for provider configurations */}

--- a/ui/components/ui/providerConfigCard.tsx
+++ b/ui/components/ui/providerConfigCard.tsx
@@ -1,0 +1,723 @@
+import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
+import { Label } from "@/components/ui/label";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
+import NumberAndSelect from "@/components/ui/numberAndSelect";
+import { budgetLinesLabel, money, shortPeriod, swatchClass } from "@/lib/budgetOutline";
+import { resetDurationOptions } from "@/lib/constants/governance";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { cn } from "@/lib/utils";
+import { cleanNumericInput } from "@/lib/utils/strings";
+import { ChevronDown, Trash2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { components, MultiValueProps, OptionProps } from "react-select";
+
+// Generic, core-owned shapes so both the Access Profile (enterprise) and Virtual
+// Key (core) forms can drive this card. `"*"` in allowedModels/keyIds means "all".
+export interface ProviderConfigBudgetLine {
+	id?: string;
+	max_limit?: number;
+	reset_duration?: string;
+}
+
+export interface ProviderConfigRateLimit {
+	token_max_limit?: number;
+	token_reset_duration?: string;
+	request_max_limit?: number;
+	request_reset_duration?: string;
+}
+
+export interface ProviderConfigModelBudget {
+	model_name: string;
+	budgets: ProviderConfigBudgetLine[];
+	rate_limit?: ProviderConfigRateLimit;
+}
+
+export interface ProviderConfigCardValue {
+	providerName: string;
+	allowedModels: string[];
+	blacklistedModels: string[];
+	weight?: number | null;
+	keyIds: string[];
+	budgets: ProviderConfigBudgetLine[];
+	rateLimit?: ProviderConfigRateLimit | null;
+	/** Only rendered when `showModelBudgets` is set (Access Profile only). */
+	modelBudgets?: ProviderConfigModelBudget[];
+}
+
+export interface ProviderKeyInfo {
+	key_id: string;
+	name: string;
+	models?: string[] | null;
+}
+
+interface ProviderConfigCardBaseProps {
+	value: ProviderConfigCardValue;
+	onChange: (next: ProviderConfigCardValue) => void;
+	onRemove: () => void;
+	providerLabel: string;
+	iconProvider: ProviderIconType;
+	/** Keys available for this provider. `null` = still loading (keep section visible). */
+	providerKeys: ProviderKeyInfo[] | null;
+	/** Renders the per-model budgets tree (Access Profile). Off for Virtual Keys. */
+	showModelBudgets?: boolean;
+	/** Read-only global provider cap shown on the Provider budget row (Access Profile). */
+	globalProviderCap?: { max_limit: number; reset_duration?: string };
+	/** Prefix for data-testids, e.g. "ap" or "vk". */
+	testIdPrefix?: string;
+	index: number;
+}
+
+// Controlled and uncontrolled expand state are mutually exclusive: a controlled
+// `open` must ship its change handler, so a controlled header click can never
+// silently no-op. Uncontrolled consumers get `defaultOpen` and internal state.
+type ProviderConfigCardOpenProps =
+	| { open: boolean; onToggleOpen: () => void; defaultOpen?: never }
+	| { open?: never; onToggleOpen?: never; defaultOpen?: boolean };
+
+type ProviderConfigCardProps = ProviderConfigCardBaseProps & ProviderConfigCardOpenProps;
+
+// Clamp the load-balancer weight to the [0, 1] fraction both backends expect.
+function clampWeight(n: number | undefined): number | undefined {
+	if (n === undefined || Number.isNaN(n)) return undefined;
+	return Math.max(0, Math.min(1, n));
+}
+
+// Shared wildcard-selection logic for the keys / allowed-models / blocked-models
+// pickers: selecting "*" collapses to just ["*"]; adding anything else while "*"
+// is present drops the "*"; any other selection passes through unchanged.
+function resolveWildcardSelection(current: string[], next: string[]): string[] {
+	const hadStar = current.includes("*");
+	const hasStar = next.includes("*");
+	if (!hadStar && hasStar) return ["*"];
+	if (hadStar && hasStar && next.length > 1) return next.filter((v) => v !== "*");
+	return next;
+}
+
+// Weight input with an internal string buffer so intermediate values like "0."
+// survive keystrokes (a bare controlled number input collapses them). Mirrors
+// the display-value pattern in NumberAndSelect; clamps to [0, 1] on commit.
+function WeightInput({
+	id,
+	testId,
+	value,
+	onChange,
+}: {
+	id: string;
+	testId: string;
+	value?: number | null;
+	onChange: (n: number | undefined) => void;
+}) {
+	const [display, setDisplay] = useState(value != null ? String(value) : "");
+	useEffect(() => {
+		const displayNum = display === "" ? undefined : parseFloat(display);
+		if ((value ?? undefined) !== displayNum) setDisplay(value != null ? String(value) : "");
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [value]);
+	return (
+		<input
+			id={id}
+			type="text"
+			inputMode="decimal"
+			data-testid={testId}
+			value={display}
+			placeholder="Exclude from routing"
+			onChange={(e) => {
+				const cleaned = cleanNumericInput(e.target.value);
+				setDisplay(cleaned);
+				if (cleaned === "" || cleaned === ".") {
+					onChange(undefined);
+				} else {
+					const n = Number(cleaned);
+					if (!Number.isNaN(n)) onChange(clampWeight(n));
+				}
+			}}
+			onBlur={() => {
+				const clamped = clampWeight(display === "" || display === "." ? undefined : Number(display));
+				setDisplay(clamped != null ? String(clamped) : "");
+				onChange(clamped);
+			}}
+			className="border-input bg-background focus:border-ring placeholder:text-muted-foreground/60 h-9 w-full rounded-sm border px-2 text-sm outline-none"
+		/>
+	);
+}
+
+export function ProviderConfigCard({
+	value,
+	onChange,
+	onRemove,
+	providerLabel,
+	iconProvider,
+	providerKeys,
+	showModelBudgets = false,
+	globalProviderCap,
+	testIdPrefix = "provider",
+	index,
+	open: controlledOpen,
+	onToggleOpen,
+	defaultOpen = false,
+}: ProviderConfigCardProps) {
+	const [internalOpen, setInternalOpen] = useState(defaultOpen);
+	const open = controlledOpen ?? internalOpen;
+	const toggleOpen = () => (onToggleOpen ? onToggleOpen() : setInternalOpen((o) => !o));
+
+	// Inner collapsibles are always card-local UI state.
+	const [budgetOpen, setBudgetOpen] = useState(false);
+	const [modelsOpen, setModelsOpen] = useState(false);
+	// Keyed by model_name (stable; duplicate names are prevented when adding) so
+	// deleting an earlier row can't leave the editor pointing at the wrong model.
+	const [openModelEditor, setOpenModelEditor] = useState<string | null>(null);
+	const [accessOpen, setAccessOpen] = useState(false);
+
+	const tid = testIdPrefix;
+	const update = (patch: Partial<ProviderConfigCardValue>) => onChange({ ...value, ...patch });
+
+	const modelBudgets = value.modelBudgets || [];
+	const capLabel = budgetLinesLabel(value.budgets);
+	const ws = globalProviderCap;
+
+	// Key scope handed to ModelMultiselect so model suggestions match the keys
+	// actually granted on this provider config.
+	const keys = providerKeys ?? [];
+	const modelKeyScope = value.keyIds.includes("*")
+		? keys.map((k) => k.key_id)
+		: keys.filter((k) => value.keyIds.includes(k.key_id)).map((k) => k.key_id);
+
+	// Collapsed access summary.
+	const keysSummary = value.keyIds.includes("*")
+		? "All keys"
+		: value.keyIds.length > 0
+			? `${value.keyIds.length} key${value.keyIds.length > 1 ? "s" : ""}`
+			: "No keys";
+	const modelsSummary = value.allowedModels.includes("*")
+		? "All models"
+		: value.allowedModels.length > 0
+			? `${value.allowedModels.length} models`
+			: "Deny all";
+	const hasRl = value.rateLimit?.token_max_limit != null || value.rateLimit?.request_max_limit != null;
+	const rlSummary = hasRl ? "Rate limits set" : "No rate limits";
+
+	return (
+		<div className="bg-card overflow-hidden rounded-md border">
+			{/* Provider header — summary (name, cap); click expands the card */}
+			<div
+				role="button"
+				tabIndex={0}
+				onClick={toggleOpen}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						e.preventDefault();
+						toggleOpen();
+					}
+				}}
+				className="hover:bg-accent/30 flex min-w-0 cursor-pointer items-center gap-3 px-4 py-3"
+			>
+				<RenderProviderIcon provider={iconProvider} size="sm" className="h-4 w-4 shrink-0" />
+				<span className="shrink-0 text-sm font-medium whitespace-nowrap">{providerLabel}</span>
+				<span className="min-w-0 flex-1" />
+				<span className="text-muted-foreground shrink-0 text-sm whitespace-nowrap">{capLabel}</span>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						onRemove();
+					}}
+					aria-label={`Remove provider ${providerLabel}`}
+					data-testid={`${tid}-delete-provider-${index}`}
+					className="text-muted-foreground shrink-0 cursor-pointer rounded-sm p-1 hover:text-red-400"
+				>
+					<Trash2 className="h-3 w-3" />
+				</button>
+				<ChevronDown
+					className={cn("text-muted-foreground/60 h-3.5 w-3.5 shrink-0 transition-transform duration-150", open && "rotate-180")}
+				/>
+			</div>
+
+			{open && (
+				<>
+					{/* PROVIDER BUDGET — collapsible row */}
+					<div
+						role="button"
+						tabIndex={0}
+						onClick={() => setBudgetOpen((o) => !o)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								setBudgetOpen((o) => !o);
+							}
+						}}
+						className={cn(
+							"hover:bg-accent/30 flex cursor-pointer items-center gap-2.5 border-t py-2.5 pr-3.5 pl-10",
+							budgetOpen && "bg-accent/20",
+						)}
+					>
+						<span className="text-muted-foreground/50 text-sm">└</span>
+						<span className="text-muted-foreground text-sm font-medium whitespace-nowrap">Provider budget</span>
+						<span className="text-muted-foreground min-w-0 flex-1 truncate text-sm">{capLabel}</span>
+						{ws != null && (
+							<span className="text-muted-foreground/70 shrink-0 text-sm whitespace-nowrap">
+								Global provider cap {money(ws.max_limit)}
+								{ws.reset_duration ? `/${shortPeriod(ws.reset_duration)}` : ""}
+							</span>
+						)}
+						<ChevronDown
+							className={cn("text-muted-foreground/60 h-3.5 w-3.5 shrink-0 transition-transform duration-150", budgetOpen && "rotate-180")}
+						/>
+					</div>
+					{budgetOpen && (
+						<div className="bg-muted/30 border-t py-3 pr-3.5 pl-16">
+							<MultiBudgetLines
+								data-testid={`${tid}-provider-budget-${index}`}
+								label="Provider Budget"
+								lines={(value.budgets || []).map((b) => ({
+									id: b.id,
+									max_limit: b.max_limit,
+									reset_duration: b.reset_duration || "1M",
+								}))}
+								onChange={(lines: BudgetLineEntry[]) => {
+									update({
+										budgets: lines.map((l) => ({ id: l.id, max_limit: l.max_limit, reset_duration: l.reset_duration })),
+									});
+								}}
+							/>
+						</div>
+					)}
+
+					{/* MODEL BUDGETS tree section — Access Profile only */}
+					{showModelBudgets && (
+						<>
+							<div
+								role="button"
+								tabIndex={0}
+								onClick={() => setModelsOpen((o) => !o)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" || e.key === " ") {
+										e.preventDefault();
+										setModelsOpen((o) => !o);
+									}
+								}}
+								className="hover:bg-accent/30 flex cursor-pointer items-center gap-2.5 border-t py-2.5 pr-3.5 pl-10"
+							>
+								<span className="text-muted-foreground/50 text-sm">└</span>
+								<span className="text-muted-foreground text-sm font-medium whitespace-nowrap">Model budgets</span>
+								<span className="text-muted-foreground/60 min-w-0 flex-1 truncate text-sm">
+									{modelsOpen
+										? "If you skip this, models share the provider budget freely"
+										: `${modelBudgets.length} model budget${modelBudgets.length === 1 ? "" : "s"}`}
+								</span>
+								<ChevronDown
+									className={cn(
+										"text-muted-foreground/60 h-3.5 w-3.5 shrink-0 transition-transform duration-150",
+										modelsOpen && "rotate-180",
+									)}
+								/>
+							</div>
+
+							{modelsOpen &&
+								modelBudgets.map((mb, mbIndex) => {
+									const mbEditorOpen = openModelEditor === mb.model_name;
+									return (
+										<div key={mb.model_name}>
+											<div
+												role="button"
+												tabIndex={0}
+												onClick={() => setOpenModelEditor((prev) => (prev === mb.model_name ? null : mb.model_name))}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" || e.key === " ") {
+														e.preventDefault();
+														setOpenModelEditor((prev) => (prev === mb.model_name ? null : mb.model_name));
+													}
+												}}
+												className={cn(
+													"hover:bg-accent/30 flex cursor-pointer items-center gap-2.5 py-2 pr-3.5 pl-16",
+													mbEditorOpen && "bg-accent/20",
+												)}
+											>
+												<span className="text-muted-foreground/50 shrink-0 text-sm">└</span>
+												<span className={cn("h-[7px] w-[7px] shrink-0 rounded-[2px]", swatchClass(mbIndex))} />
+												<span className="text-foreground/90 min-w-0 flex-1 truncate text-sm font-medium">
+													{mb.model_name || "Select a model…"}
+												</span>
+												<span className="text-muted-foreground shrink-0 text-sm whitespace-nowrap">
+													{budgetLinesLabel(mb.budgets, "No cap")}
+												</span>
+												<button
+													type="button"
+													onClick={(e) => {
+														e.stopPropagation();
+														update({ modelBudgets: modelBudgets.filter((_, i) => i !== mbIndex) });
+														setOpenModelEditor((prev) => (prev === mb.model_name ? null : prev));
+													}}
+													aria-label={`Remove model budget ${mb.model_name || ""}`}
+													className="text-muted-foreground shrink-0 cursor-pointer rounded-sm p-1 hover:text-red-400"
+												>
+													<Trash2 className="h-3 w-3" />
+												</button>
+												<ChevronDown
+													className={cn(
+														"text-muted-foreground/60 h-3.5 w-3.5 shrink-0 transition-transform duration-150",
+														mbEditorOpen && "rotate-180",
+													)}
+												/>
+											</div>
+											{mbEditorOpen && (
+												<div className="bg-muted/30 space-y-4 border-t py-3 pr-3.5 pl-16">
+													<MultiBudgetLines
+														data-testid={`${tid}-model-budget-lines-${index}-${mbIndex}`}
+														label="Model Budget"
+														lines={(mb.budgets || []).map((b) => ({
+															max_limit: b.max_limit,
+															reset_duration: b.reset_duration || "1d",
+														}))}
+														onChange={(lines: BudgetLineEntry[]) => {
+															update({
+																modelBudgets: modelBudgets.map((m, i) =>
+																	i === mbIndex
+																		? { ...m, budgets: lines.map((l) => ({ max_limit: l.max_limit, reset_duration: l.reset_duration })) }
+																		: m,
+																),
+															});
+														}}
+													/>
+													<NumberAndSelect
+														id={`${tid}-modelTokenLimit-${index}-${mbIndex}`}
+														dataTestId={`${tid}-modelTokenLimit-${index}-${mbIndex}`}
+														labelClassName="font-medium"
+														label="Maximum tokens"
+														placeholder="No limit"
+														value={mb.rate_limit?.token_max_limit}
+														selectValue={mb.rate_limit?.token_reset_duration || "1h"}
+														onChangeNumber={(v) => {
+															update({
+																modelBudgets: modelBudgets.map((m, i) =>
+																	i === mbIndex
+																		? {
+																				...m,
+																				rate_limit: {
+																					...(m.rate_limit || {}),
+																					token_max_limit: v,
+																					token_reset_duration: m.rate_limit?.token_reset_duration || "1h",
+																				},
+																			}
+																		: m,
+																),
+															});
+														}}
+														onChangeSelect={(v) => {
+															update({
+																modelBudgets: modelBudgets.map((m, i) =>
+																	i === mbIndex ? { ...m, rate_limit: { ...(m.rate_limit || {}), token_reset_duration: v } } : m,
+																),
+															});
+														}}
+														options={resetDurationOptions}
+													/>
+													<NumberAndSelect
+														id={`${tid}-modelRequestLimit-${index}-${mbIndex}`}
+														dataTestId={`${tid}-modelRequestLimit-${index}-${mbIndex}`}
+														labelClassName="font-medium"
+														label="Maximum requests"
+														placeholder="No limit"
+														value={mb.rate_limit?.request_max_limit}
+														selectValue={mb.rate_limit?.request_reset_duration || "1h"}
+														onChangeNumber={(v) => {
+															update({
+																modelBudgets: modelBudgets.map((m, i) =>
+																	i === mbIndex
+																		? {
+																				...m,
+																				rate_limit: {
+																					...(m.rate_limit || {}),
+																					request_max_limit: v,
+																					request_reset_duration: m.rate_limit?.request_reset_duration || "1h",
+																				},
+																			}
+																		: m,
+																),
+															});
+														}}
+														onChangeSelect={(v) => {
+															update({
+																modelBudgets: modelBudgets.map((m, i) =>
+																	i === mbIndex ? { ...m, rate_limit: { ...(m.rate_limit || {}), request_reset_duration: v } } : m,
+																),
+															});
+														}}
+														options={resetDurationOptions}
+													/>
+												</div>
+											)}
+										</div>
+									);
+								})}
+
+							{modelsOpen && (
+								<div className="pt-1 pr-3.5 pb-2.5 pl-16">
+									<div className="w-[200px]">
+										<ModelMultiselect
+											isSingleSelect
+											clearable
+											hideSearchIcon
+											data-testid={`${tid}-add-model-budget-${index}`}
+											provider={value.providerName}
+											value=""
+											onChange={(model: string) => {
+												if (!model) return;
+												if (modelBudgets.some((m) => m.model_name === model)) return;
+												update({
+													modelBudgets: [...modelBudgets, { model_name: model, budgets: [{ max_limit: undefined, reset_duration: "1d" }] }],
+												});
+												setOpenModelEditor(model);
+											}}
+											placeholder="Add model…"
+										/>
+									</div>
+								</div>
+							)}
+						</>
+					)}
+
+					{/* ACCESS & RATE LIMITS — collapsed to one row */}
+					<div
+						role="button"
+						tabIndex={0}
+						onClick={() => setAccessOpen((o) => !o)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								setAccessOpen((o) => !o);
+							}
+						}}
+						className="hover:bg-accent/30 flex cursor-pointer items-center gap-2.5 border-t py-2.5 pr-3.5 pl-10"
+					>
+						<span className="text-muted-foreground/50 text-sm">└</span>
+						<span className="text-muted-foreground text-sm font-medium whitespace-nowrap">Access & rate limits</span>
+						<span className="text-muted-foreground/60 min-w-0 flex-1 truncate text-sm">
+							{keysSummary} · {modelsSummary} · {rlSummary}
+						</span>
+						<ChevronDown className={cn("text-muted-foreground/60 h-3.5 w-3.5 shrink-0 transition-transform", accessOpen && "rotate-180")} />
+					</div>
+
+					{accessOpen && (
+						<div className="bg-muted/20 flex flex-col gap-3 border-t py-3 pr-3.5 pl-10">
+							<div className="flex items-start gap-3.5">
+								{/* Provider key restriction */}
+								{(() => {
+									type KeyOption = { label: string; value: string; description: string };
+									// providerKeys === null while loading/errored — keep the section
+									// visible. Only hide when keys have loaded and there are none.
+									if (providerKeys !== null && keys.length === 0) return null;
+									const configKeyIds = value.keyIds;
+									const hasWildcard = configKeyIds.includes("*");
+									const allKeyOptions: KeyOption[] = [
+										{ label: "Allow All Keys", value: "*", description: "Allow all current and future keys for this provider" },
+										...keys.map((key) => ({
+											label: key.name,
+											value: key.key_id,
+											description:
+												key.models == null || key.models.includes("*")
+													? "All models"
+													: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
+										})),
+									];
+									const selectedProviderKeys = hasWildcard
+										? [allKeyOptions[0]]
+										: keys
+												.filter((key) => configKeyIds.includes(key.key_id))
+												.map((key) => ({
+													label: key.name,
+													value: key.key_id,
+													description:
+														key.models == null || key.models.includes("*")
+															? "All models"
+															: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
+												}));
+									return (
+										<div className="w-[260px] shrink-0 space-y-1.5">
+											<div className="flex h-5 items-center">
+												<Label>Provider keys</Label>
+											</div>
+											<AsyncMultiSelect
+												hideSelectedOptions
+												hideSearchIcon
+												isNonAsync
+												closeMenuOnSelect={false}
+												menuPlacement="auto"
+												defaultOptions={allKeyOptions}
+												value={selectedProviderKeys}
+												onChange={(picked) => {
+													update({
+														keyIds: resolveWildcardSelection(
+															value.keyIds,
+															picked.map((k) => k.value as string),
+														),
+													});
+												}}
+												views={{
+													multiValue: (multiValueProps: MultiValueProps<KeyOption>) => (
+														<div
+															{...multiValueProps.innerProps}
+															className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-[3px] border px-1.5 py-0.5 text-sm"
+														>
+															{multiValueProps.data.label}
+															<button
+																type="button"
+																aria-label={`Remove ${multiValueProps.data.label}`}
+																className="hover:text-foreground text-muted-foreground flex cursor-pointer items-center"
+																onClick={(e) => {
+																	e.stopPropagation();
+																	multiValueProps.removeProps.onClick?.(e as any);
+																}}
+															>
+																<X className="h-3 w-3" />
+															</button>
+														</div>
+													),
+													option: (optionProps: OptionProps<KeyOption>) => {
+														const { Option } = components;
+														return (
+															<Option
+																{...optionProps}
+																className={cn(
+																	"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
+																	optionProps.isFocused && "bg-accent dark:!bg-card",
+																	"hover:bg-accent",
+																	optionProps.isSelected && "bg-accent dark:!bg-card",
+																)}
+															>
+																<span className="text-content-primary grow truncate text-sm">{optionProps.data.label}</span>
+																{optionProps.data.description && (
+																	<span className="text-content-tertiary max-w-[70%] text-sm">{optionProps.data.description}</span>
+																)}
+															</Option>
+														);
+													},
+												}}
+												placeholder={hasWildcard ? "All keys allowed" : configKeyIds.length === 0 ? "No keys selected" : "Select keys..."}
+												className="hover:bg-accent w-full"
+												menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
+											/>
+										</div>
+									);
+								})()}
+
+								{/* ALLOWED MODELS — single textbox with an in-dropdown "All Models" option */}
+								{(() => {
+									const hasWildcardModels = value.allowedModels.includes("*");
+									return (
+										<div className="min-w-0 flex-1 space-y-1.5">
+											<div className="flex h-5 items-center">
+												<Label>Allowed models</Label>
+											</div>
+											<ModelMultiselect
+												allowAllOption
+												hideSearchIcon
+												data-testid={`${tid}-models-multiselect-${index}`}
+												provider={value.providerName}
+												keys={modelKeyScope}
+												value={hasWildcardModels ? ["*"] : value.allowedModels}
+												onChange={(models: string[]) => {
+													update({ allowedModels: resolveWildcardSelection(value.allowedModels, models) });
+												}}
+												placeholder={
+													hasWildcardModels
+														? "All models allowed"
+														: value.allowedModels.length === 0
+															? "No models (deny all)"
+															: "Add model…"
+												}
+											/>
+										</div>
+									);
+								})()}
+							</div>
+
+							{/* Weight + blocked models */}
+							<div className="flex items-start gap-3.5">
+								<div className="w-[260px] shrink-0 space-y-1.5">
+									<div className="flex h-5 items-center">
+										<Label htmlFor={`${tid}-weight-${index}`}>Weight</Label>
+									</div>
+									<WeightInput
+										id={`${tid}-weight-${index}`}
+										testId={`${tid}-weight-input-${index}`}
+										value={value.weight}
+										onChange={(n) => update({ weight: n })}
+									/>
+								</div>
+								<div className="min-w-0 flex-1 space-y-1.5">
+									<div className="flex h-5 items-center">
+										<Label>Blocked models</Label>
+									</div>
+									{(() => {
+										const hasWildcardBlocked = value.blacklistedModels.includes("*");
+										return (
+											<ModelMultiselect
+												allowAllOption
+												hideSearchIcon
+												data-testid={`${tid}-blocked-models-multiselect-${index}`}
+												provider={value.providerName}
+												keys={modelKeyScope}
+												value={hasWildcardBlocked ? ["*"] : value.blacklistedModels}
+												onChange={(models: string[]) => {
+													update({ blacklistedModels: resolveWildcardSelection(value.blacklistedModels, models) });
+												}}
+												placeholder={
+													hasWildcardBlocked
+														? "All models blocked"
+														: value.blacklistedModels.length === 0
+															? "No blocked models"
+															: "Search models..."
+												}
+											/>
+										);
+									})()}
+								</div>
+							</div>
+
+							{/* Per-provider rate limits */}
+							<NumberAndSelect
+								id={`${tid}-providerTokenLimit-${index}`}
+								dataTestId={`${tid}-providerTokenLimit-${index}`}
+								labelClassName="font-medium"
+								label="Maximum tokens"
+								placeholder="No limit"
+								value={value.rateLimit?.token_max_limit}
+								selectValue={value.rateLimit?.token_reset_duration || "1h"}
+								onChangeNumber={(v) => {
+									const current = value.rateLimit || {};
+									update({ rateLimit: { ...current, token_max_limit: v, token_reset_duration: current.token_reset_duration || "1h" } });
+								}}
+								onChangeSelect={(v) => {
+									const current = value.rateLimit || {};
+									update({ rateLimit: { ...current, token_reset_duration: v } });
+								}}
+								options={resetDurationOptions}
+							/>
+							<NumberAndSelect
+								id={`${tid}-providerRequestLimit-${index}`}
+								dataTestId={`${tid}-providerRequestLimit-${index}`}
+								labelClassName="font-medium"
+								label="Maximum requests"
+								placeholder="No limit"
+								value={value.rateLimit?.request_max_limit}
+								selectValue={value.rateLimit?.request_reset_duration || "1h"}
+								onChangeNumber={(v) => {
+									const current = value.rateLimit || {};
+									update({
+										rateLimit: { ...current, request_max_limit: v, request_reset_duration: current.request_reset_duration || "1h" },
+									});
+								}}
+								onChangeSelect={(v) => {
+									const current = value.rateLimit || {};
+									update({ rateLimit: { ...current, request_reset_duration: v } });
+								}}
+								options={resetDurationOptions}
+							/>
+						</div>
+					)}
+				</>
+			)}
+		</div>
+	);
+}

--- a/ui/lib/budgetOutline.ts
+++ b/ui/lib/budgetOutline.ts
@@ -1,0 +1,95 @@
+// Shared helpers for the provider-config outline/tree UI (Access Profile edit
+// fragment + saved detail view, and the Virtual Key provider card). Keeps the
+// compact mono budget labels, allocation-bar math, and the neutral swatch ramp
+// consistent across every screen that renders a provider config.
+
+export interface BudgetLineLike {
+	max_limit?: number | null;
+	reset_duration?: string;
+}
+
+// Short, mono-friendly period suffixes (e.g. "$20/wk"). Falls back to the raw
+// duration string for anything not in the map.
+const SHORT_PERIOD: Record<string, string> = {
+	"1m": "min",
+	"5m": "5min",
+	"15m": "15min",
+	"30m": "30min",
+	"1h": "hr",
+	"6h": "6hr",
+	"1d": "day",
+	"1w": "wk",
+	"1M": "mo",
+	"1Y": "yr",
+};
+
+export function shortPeriod(duration?: string | null): string {
+	if (!duration) return "";
+	return SHORT_PERIOD[duration] ?? duration;
+}
+
+// Ascending period order (minute → year) for displaying budget lines. Uses the
+// SHORT_PERIOD key order; unknown durations sort last.
+const PERIOD_ORDER = Object.keys(SHORT_PERIOD);
+
+export function periodRank(duration?: string | null): number {
+	const i = duration ? PERIOD_ORDER.indexOf(duration) : -1;
+	return i === -1 ? PERIOD_ORDER.length : i;
+}
+
+// Compact currency: whole numbers render without decimals ("$20"), fractional
+// values keep two places ("$23.48"). Matches the prototype's `money()`.
+export function money(value: number | null | undefined): string {
+	const v = Number(value) || 0;
+	return "$" + (v % 1 ? v.toFixed(2) : String(v));
+}
+
+// "$50/wk · $150/mo" — every budget line joined, in ascending period order.
+// Returns `fallback` when empty.
+export function budgetLinesLabel(budgets: BudgetLineLike[] | undefined, fallback = "No budget"): string {
+	if (!budgets || budgets.length === 0) return fallback;
+	return [...budgets]
+		.sort((a, b) => periodRank(a.reset_duration) - periodRank(b.reset_duration))
+		.map((b) => `${money(b.max_limit)}/${shortPeriod(b.reset_duration)}`)
+		.join(" · ");
+}
+
+// True when two or more budget lines share the same reset period. A budget
+// group can only have one cap per reset window — the sheet blocks saving while
+// any group violates this.
+export function hasDuplicateBudgetPeriods(lines: { reset_duration?: string }[] | undefined): boolean {
+	if (!lines || lines.length < 2) return false;
+	const seen = new Set<string>();
+	for (const l of lines) {
+		const key = l.reset_duration ?? "";
+		if (seen.has(key)) return true;
+		seen.add(key);
+	}
+	return false;
+}
+
+// The provider cap is the first (primary) budget line's amount.
+export function providerCap(budgets: BudgetLineLike[] | undefined): number {
+	return budgets && budgets.length ? Number(budgets[0].max_limit) || 0 : 0;
+}
+
+// A budget group's face value = the largest single line amount (matches the
+// prototype's `mAmt`, which takes the max across lines rather than summing).
+export function maxLine(budgets: BudgetLineLike[] | undefined): number {
+	return (budgets || []).reduce((acc, b) => Math.max(acc, Number(b.max_limit) || 0), 0);
+}
+
+// Total allocated to model budgets = Σ per-model face value. Model budgets are
+// slices of the provider cap; when this exceeds the cap the UI goes amber.
+export function sumModelAllocations(modelBudgets: { budgets?: BudgetLineLike[] }[] | undefined): number {
+	return (modelBudgets || []).reduce((acc, mb) => acc + maxLine(mb.budgets), 0);
+}
+
+// Neutral zinc ramp for allocation-bar segments and model swatches, matching
+// the design's hue order (#e4e4e7 #9f9fa8 #fafafa #71717a #c9c9cf #52525b).
+// Index maps 1:1 between a provider's bar segments and its model-budget rows.
+export const SWATCH_RAMP = ["bg-zinc-200", "bg-zinc-400", "bg-zinc-50", "bg-zinc-500", "bg-zinc-300", "bg-zinc-600"] as const;
+
+export function swatchClass(index: number): string {
+	return SWATCH_RAMP[index % SWATCH_RAMP.length];
+}


### PR DESCRIPTION
## Summary

Extracts the inline provider configuration UI from `virtualKeySheet.tsx` into a reusable `ProviderConfigCard` component. The previous implementation embedded ~340 lines of accordion-based provider config rendering directly in the sheet, making it difficult to maintain and reuse. This refactor delegates that responsibility to a dedicated component with a clean value/onChange interface.

## Changes

- Replaced the inline `Accordion`-based provider config rendering with a `ProviderConfigCard` component that accepts a structured `value` prop and an `onChange` callback
- Removed the `handleUpdateProviderConfig` helper function, as field-level updates are now handled inside `ProviderConfigCard` via the unified `onChange` interface
- Removed the local `VirtualKeyType` type definition and associated `react-select` component imports (`components`, `MultiValueProps`, `OptionProps`) that were only used in the inline key selector
- Removed imports for `Accordion`, `AsyncMultiSelect`, `ModelMultiselect`, `cn`, and `ModelPlaceholders` that are no longer needed in this file

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to the Virtual Keys section in the workspace.
2. Open an existing virtual key that has one or more provider configurations.
3. Verify that each provider config renders correctly with its icon, label, allowed/blocked models, allowed keys, budget, and rate limit fields.
4. Add a new provider config and confirm all fields are editable and saved correctly.
5. Remove a provider config and confirm it is removed from the list.

## Screenshots/Recordings

Before: Provider configs rendered as accordion items inline within `virtualKeySheet.tsx`.

After: Provider configs rendered via `ProviderConfigCard` with identical visual behavior and a cleaner component boundary.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. This is a pure UI refactor with no changes to data handling, authentication, or secrets management.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable