### PR TITLE
feat: add per-tab export scope to dashboard CSV and PDF export

### DIFF
--- a/ui/app/workspace/dashboard/components/exportPopover.tsx
+++ b/ui/app/workspace/dashboard/components/exportPopover.tsx
@@ -1,72 +1,86 @@
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuPortal,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { buildCSV, downloadCSV } from "@/lib/utils/csv";
 import { Download, FileSpreadsheet, FileText, Loader2 } from "lucide-react";
 import { useCallback, useState } from "react";
-import { type DashboardData, getCSVSections } from "../utils/exportUtils";
-
-const PDF_TAB_LABELS = ["Overview", "Provider Usage", "Model Rankings", "MCP Usage"];
+import { type DashboardData, type DashboardTab, type ExportTab, getCSVSections, getExportTabLabel } from "../utils/exportUtils";
 
 interface ExportPopoverProps {
 	getData: () => DashboardData;
-	/** Enters export mode, loads every tab's uncapped data and waits for it to render. */
-	onPreloadData: () => Promise<void>;
-	onPdfExport: () => Promise<HTMLElement[]>;
+	/** The tab currently open, offered as the "this tab only" export scope. */
+	activeTab: DashboardTab;
+	/** Enters export mode, loads the scoped tabs' uncapped data and waits for it to render. */
+	onPreloadData: (scope: ExportTab) => Promise<void>;
+	onPdfExport: (scope: ExportTab) => Promise<{ element: HTMLElement; label: string }[]>;
 	/** Leaves export mode; both flows must call this, since both enter it via onPreloadData. */
 	onExportDone: () => void;
 }
 
-export function ExportPopover({ getData, onPreloadData, onPdfExport, onExportDone }: ExportPopoverProps) {
+export function ExportPopover({ getData, activeTab, onPreloadData, onPdfExport, onExportDone }: ExportPopoverProps) {
 	const [exporting, setExporting] = useState(false);
 
-	const handleCsvExport = useCallback(async () => {
-		setExporting(true);
-		try {
-			await onPreloadData();
-			const sections = getCSVSections(getData(), "all");
-			const parts: string[] = [];
-			for (const section of sections) {
-				if (section.csv.rows.length === 0) continue;
-				parts.push(`# ${section.name}`);
-				parts.push(buildCSV(section.csv.headers, section.csv.rows));
-				parts.push("");
+	const fileName = useCallback((scope: ExportTab) => (scope === "all" ? "dashboard-export" : `dashboard-${scope}`), []);
+
+	const handleCsvExport = useCallback(
+		async (scope: ExportTab) => {
+			setExporting(true);
+			try {
+				await onPreloadData(scope);
+				const sections = getCSVSections(getData(), scope);
+				const parts: string[] = [];
+				for (const section of sections) {
+					if (section.csv.rows.length === 0) continue;
+					parts.push(`# ${section.name}`);
+					parts.push(buildCSV(section.csv.headers, section.csv.rows));
+					parts.push("");
+				}
+				if (parts.length > 0) {
+					downloadCSV(parts.join("\n"), fileName(scope));
+				}
+			} finally {
+				onExportDone();
+				setExporting(false);
 			}
-			if (parts.length > 0) {
-				downloadCSV(parts.join("\n"), "dashboard-export");
+		},
+		[getData, onPreloadData, onExportDone, fileName],
+	);
+
+	const handlePdfExport = useCallback(
+		async (scope: ExportTab) => {
+			setExporting(true);
+
+			// Yield a frame so the spinner renders before heavy work starts
+			await new Promise((r) => requestAnimationFrame(r));
+
+			try {
+				const { generatePdf } = await import("@/lib/utils/pdf");
+
+				const sections = await onPdfExport(scope);
+
+				await generatePdf(sections, fileName(scope), {
+					branding: {
+						logoSrc: "/bifrost-logo.webp",
+						text: "Powered by",
+					},
+				});
+			} finally {
+				onExportDone();
+				setExporting(false);
 			}
-		} finally {
-			onExportDone();
-			setExporting(false);
-		}
-	}, [getData, onPreloadData, onExportDone]);
+		},
+		[onPdfExport, onExportDone, fileName],
+	);
 
-	const handlePdfExport = useCallback(async () => {
-		setExporting(true);
-
-		// Yield a frame so the spinner renders before heavy work starts
-		await new Promise((r) => requestAnimationFrame(r));
-
-		try {
-			const { generatePdf } = await import("@/lib/utils/pdf");
-
-			const elements = await onPdfExport();
-
-			const sections = elements.map((element, i) => ({
-				element,
-				label: PDF_TAB_LABELS[i],
-			}));
-
-			await generatePdf(sections, "dashboard-export", {
-				branding: {
-					logoSrc: "/bifrost-logo.webp",
-					text: "Powered by",
-				},
-			});
-		} finally {
-			onExportDone();
-			setExporting(false);
-		}
-	}, [onPdfExport, onExportDone]);
+	const activeTabLabel = getExportTabLabel(activeTab);
 
 	return (
 		<DropdownMenu>
@@ -77,14 +91,38 @@ export function ExportPopover({ getData, onPreloadData, onPdfExport, onExportDon
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
-				<DropdownMenuItem onClick={handleCsvExport} data-testid="export-csv-item">
-					<FileSpreadsheet className="h-4 w-4" />
-					CSV
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={handlePdfExport} data-testid="export-pdf-item">
-					<FileText className="h-4 w-4" />
-					PDF
-				</DropdownMenuItem>
+				<DropdownMenuSub>
+					<DropdownMenuSubTrigger data-testid="export-csv-item">
+						<FileSpreadsheet className="h-4 w-4" />
+						CSV
+					</DropdownMenuSubTrigger>
+					<DropdownMenuPortal>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem onClick={() => handleCsvExport(activeTab)} data-testid="export-csv-current-tab">
+								This tab ({activeTabLabel})
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => handleCsvExport("all")} data-testid="export-csv-all-tabs">
+								All tabs
+							</DropdownMenuItem>
+						</DropdownMenuSubContent>
+					</DropdownMenuPortal>
+				</DropdownMenuSub>
+				<DropdownMenuSub>
+					<DropdownMenuSubTrigger data-testid="export-pdf-item">
+						<FileText className="h-4 w-4" />
+						PDF
+					</DropdownMenuSubTrigger>
+					<DropdownMenuPortal>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem onClick={() => handlePdfExport(activeTab)} data-testid="export-pdf-current-tab">
+								This tab ({activeTabLabel})
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => handlePdfExport("all")} data-testid="export-pdf-all-tabs">
+								All tabs
+							</DropdownMenuItem>
+						</DropdownMenuSubContent>
+					</DropdownMenuPortal>
+				</DropdownMenuSub>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { dateUtils } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { useLocation } from "@tanstack/react-router";
 import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
 import { type ChartType } from "./components/charts/chartTypeToggle";
 import { ModelFilterSelect } from "./components/charts/modelFilterSelect";
 import { ExportPopover } from "./components/exportPopover";
@@ -19,7 +19,7 @@ import { type MCPTabViewHandle, MCPTabView } from "./components/tabViews/mcpTabV
 import { type ModelRankingsTabViewHandle, ModelRankingsTabView } from "./components/tabViews/modelRankingsTabView";
 import { type OverviewTabViewHandle, OverviewTabView } from "./components/tabViews/overviewTabView";
 import { type ProviderUsageTabViewHandle, ProviderUsageTabView } from "./components/tabViews/providerUsageTabView";
-import type { DashboardData } from "./utils/exportUtils";
+import { type DashboardData, type DashboardTab, type ExportTab, DASHBOARD_EXPORT_TABS } from "./utils/exportUtils";
 
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
 
@@ -250,18 +250,36 @@ export default function DashboardPage() {
 		};
 	}, []);
 
-	// Export mode force-mounts every tab; see handlePreloadData.
-	const [pdfMode, setPdfMode] = useState(false);
+	// Which scope the in-flight export covers; null when not exporting.
+	// "all" force-mounts every tab, a single tab exports only what is open.
+	const [exportScope, setExportScope] = useState<ExportTab | null>(null);
+	const exportingAll = exportScope === "all";
+	/** True while this tab is part of the running export, so rankings render their uncapped snapshot. */
+	const isExportingTab = (tab: DashboardTab) => exportingAll || exportScope === tab;
 
-	const handlePreloadData = useCallback(async () => {
-		// Force-mount every tab before loading: Radix unmounts inactive
-		// TabsContent, so an inactive tab view has no ref yet and would never
-		// load its export snapshot - the report would only cover the tab that
-		// happened to be open.
-		setPdfMode(true);
+	const handlePreloadData = useCallback(async (scope: ExportTab) => {
+		// For an all-tabs export, force-mount every tab before loading: Radix
+		// unmounts inactive TabsContent, so an inactive tab view has no ref yet
+		// and would never load its export snapshot - the report would only cover
+		// the tab that happened to be open. A single-tab export deliberately
+		// skips this, so only the open tab's data reaches the export.
+		setExportScope(scope);
 		await nextFrames();
 
-		await Promise.all(allRefs.map((r) => r.current?.loadData()));
+		const refsByTab: Record<DashboardTab, RefObject<{ loadData: () => Promise<void> } | null>> = {
+			overview: overviewRef,
+			"provider-usage": providerRef,
+			mcp: mcpRef,
+			rankings: modelRankingsRef,
+			"team-rankings": teamRankingsRef,
+			"customer-rankings": customerRankingsRef,
+			"bu-rankings": buRankingsRef,
+			"user-rankings": userRankingsRef,
+			"virtual-key-rankings": virtualKeyRankingsRef,
+		};
+
+		const refs = scope === "all" ? allRefs : [refsByTab[scope]];
+		await Promise.all(refs.map((r) => r.current?.loadData()));
 
 		// Let the loaded snapshots commit before the caller reads getData() or
 		// captures the DOM.
@@ -386,40 +404,39 @@ export default function DashboardPage() {
 	const dashboardMinHeightRef = useRef<string>("");
 	const hiddenTabsRef = useRef<HTMLElement[]>([]);
 
-	const handlePdfExport = useCallback(async (): Promise<HTMLElement[]> => {
-		// Enters export mode, force-mounts every tab and waits for the loaded
-		// snapshots to render.
-		await handlePreloadData();
+	const handlePdfExport = useCallback(
+		async (scope: ExportTab): Promise<{ element: HTMLElement; label: string }[]> => {
+			// Enters export mode, force-mounts the scoped tabs and waits for the
+			// loaded snapshots to render.
+			await handlePreloadData(scope);
 
-		const hiddenTabs = document.querySelectorAll<HTMLElement>('[data-slot="tabs-content"][hidden]');
-		hiddenTabsRef.current = Array.from(hiddenTabs);
-		for (const tab of hiddenTabs) {
-			tab.removeAttribute("hidden");
-			tab.style.display = "block";
-		}
+			// Only an all-tabs export has hidden sections to reveal; a single-tab
+			// export captures the section already on screen.
+			if (scope === "all") {
+				const hiddenTabs = document.querySelectorAll<HTMLElement>('[data-slot="tabs-content"][hidden]');
+				hiddenTabsRef.current = Array.from(hiddenTabs);
+				for (const tab of hiddenTabs) {
+					tab.removeAttribute("hidden");
+					tab.style.display = "block";
+				}
+			}
 
-		const dashboardEl = document.getElementById("dashboard-root");
-		if (dashboardEl) {
-			dashboardMinHeightRef.current = dashboardEl.style.minHeight;
-			dashboardEl.style.minHeight = "0";
-		}
+			const dashboardEl = document.getElementById("dashboard-root");
+			if (dashboardEl) {
+				dashboardMinHeightRef.current = dashboardEl.style.minHeight;
+				dashboardEl.style.minHeight = "0";
+			}
 
-		window.dispatchEvent(new Event("resize"));
-		await nextFrames();
+			window.dispatchEvent(new Event("resize"));
+			await nextFrames();
 
-		const ids = [
-			"dashboard-section-overview",
-			"dashboard-section-provider-usage",
-			"dashboard-section-rankings",
-			"dashboard-section-mcp",
-			"dashboard-section-team-rankings",
-			"dashboard-section-customer-rankings",
-			"dashboard-section-bu-rankings",
-			"dashboard-section-user-rankings",
-			"dashboard-section-virtual-key-rankings",
-		];
-		return ids.map((id) => document.getElementById(id)).filter(Boolean) as HTMLElement[];
-	}, [handlePreloadData]);
+			const tabs = scope === "all" ? DASHBOARD_EXPORT_TABS : DASHBOARD_EXPORT_TABS.filter((t) => t.value === scope);
+			return tabs
+				.map(({ sectionId, label }) => ({ element: document.getElementById(sectionId), label }))
+				.filter((s): s is { element: HTMLElement; label: string } => s.element !== null);
+		},
+		[handlePreloadData],
+	);
 
 	const handleExportDone = useCallback(() => {
 		const dashboardEl = document.getElementById("dashboard-root");
@@ -433,10 +450,10 @@ export default function DashboardPage() {
 		}
 		hiddenTabsRef.current = [];
 
-		setPdfMode(false);
+		setExportScope(null);
 	}, []);
 
-	const activeTab = urlState.tab || "overview";
+	const activeTab = (urlState.tab || "overview") as DashboardTab;
 
 	return (
 		<div id="dashboard-root" className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
@@ -453,6 +470,7 @@ export default function DashboardPage() {
 					<div className="flex items-center gap-2">
 						<ExportPopover
 							getData={getDashboardData}
+							activeTab={activeTab}
 							onPreloadData={handlePreloadData}
 							onPdfExport={handlePdfExport}
 							onExportDone={handleExportDone}
@@ -542,12 +560,12 @@ export default function DashboardPage() {
 						</div>
 
 						{/* Overview Tab */}
-						<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="overview" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-overview">
 								<OverviewTabView
 									ref={overviewRef}
 									filters={filters}
-									active={activeTab === "overview" || pdfMode}
+									active={activeTab === "overview" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									volumeChartType={toChartType(urlState.volume_chart)}
@@ -571,12 +589,12 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Provider Usage Tab */}
-						<TabsContent value="provider-usage" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="provider-usage" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-provider-usage">
 								<ProviderUsageTabView
 									ref={providerRef}
 									filters={filters}
-									active={activeTab === "provider-usage" || pdfMode}
+									active={activeTab === "provider-usage" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									providerCostChartType={toChartType(urlState.provider_cost_chart)}
@@ -600,26 +618,26 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Model Rankings Tab */}
-						<TabsContent value="rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-rankings">
 								<ModelRankingsTabView
 									ref={modelRankingsRef}
 									filters={filters}
-									active={activeTab === "rankings" || pdfMode}
+									active={activeTab === "rankings" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* MCP Tab */}
-						<TabsContent value="mcp" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="mcp" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-mcp">
 								<MCPTabView
 									ref={mcpRef}
 									filters={mcpFilters}
-									active={activeTab === "mcp" || pdfMode}
+									active={activeTab === "mcp" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									mcpVolumeChartType={toChartType(urlState.mcp_volume_chart)}
@@ -631,81 +649,81 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Team Rankings Tab */}
-						<TabsContent value="team-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="team-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-team-rankings">
 								<DimensionRankingsTabView
 									ref={teamRankingsRef}
 									filters={filters}
-									active={activeTab === "team-rankings" || pdfMode}
+									active={activeTab === "team-rankings" || exportingAll}
 									dimension="team"
 									dimensionLabel="Team"
 									testIdPrefix="dashboard-team-rankings"
 									dataKey="teamRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("team-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Customer Rankings Tab */}
-						<TabsContent value="customer-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="customer-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-customer-rankings">
 								<DimensionRankingsTabView
 									ref={customerRankingsRef}
 									filters={filters}
-									active={activeTab === "customer-rankings" || pdfMode}
+									active={activeTab === "customer-rankings" || exportingAll}
 									dimension="customer"
 									dimensionLabel="Customer"
 									testIdPrefix="dashboard-customer-rankings"
 									dataKey="customerRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("customer-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Business Unit Rankings Tab */}
-						<TabsContent value="bu-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="bu-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-bu-rankings">
 								<DimensionRankingsTabView
 									ref={buRankingsRef}
 									filters={filters}
-									active={activeTab === "bu-rankings" || pdfMode}
+									active={activeTab === "bu-rankings" || exportingAll}
 									dimension="business_unit"
 									dimensionLabel="Business Unit"
 									testIdPrefix="dashboard-bu-rankings"
 									dataKey="buRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("bu-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* User Rankings Tab */}
-						<TabsContent value="user-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="user-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-user-rankings">
 								<DimensionRankingsTabView
 									ref={userRankingsRef}
 									filters={filters}
-									active={activeTab === "user-rankings" || pdfMode}
+									active={activeTab === "user-rankings" || exportingAll}
 									dimension="user"
 									dimensionLabel="User"
 									testIdPrefix="dashboard-user-rankings"
 									dataKey="userRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("user-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Virtual Key Rankings Tab */}
-						<TabsContent value="virtual-key-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="virtual-key-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-virtual-key-rankings">
 								<DimensionRankingsTabView
 									ref={virtualKeyRankingsRef}
 									filters={filters}
-									active={activeTab === "virtual-key-rankings" || pdfMode}
+									active={activeTab === "virtual-key-rankings" || exportingAll}
 									dimension="virtual_key"
 									dimensionLabel="Virtual Key"
 									testIdPrefix="dashboard-virtual-key-rankings"
 									dataKey="virtualKeyRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("virtual-key-rankings")}
 								/>
 							</div>
 						</TabsContent>

--- a/ui/app/workspace/dashboard/utils/exportUtils.ts
+++ b/ui/app/workspace/dashboard/utils/exportUtils.ts
@@ -208,8 +208,7 @@ export interface DashboardData {
 	mcpTopToolsData: MCPTopToolsResponse | null;
 }
 
-export type ExportTab =
-	| "all"
+export type DashboardTab =
 	| "overview"
 	| "provider-usage"
 	| "rankings"
@@ -219,6 +218,27 @@ export type ExportTab =
 	| "user-rankings"
 	| "virtual-key-rankings"
 	| "mcp";
+
+export type ExportTab = DashboardTab | "all";
+
+/**
+ * Every exportable tab, in the order sections appear in a full export.
+ * Single source of truth for the tab labels shown in the export menu and as
+ * PDF section headings, and for the DOM ids the PDF capture reads.
+ */
+export const DASHBOARD_EXPORT_TABS: { value: DashboardTab; label: string; sectionId: string }[] = [
+	{ value: "overview", label: "Overview", sectionId: "dashboard-section-overview" },
+	{ value: "provider-usage", label: "Provider Usage", sectionId: "dashboard-section-provider-usage" },
+	{ value: "rankings", label: "Model Rankings", sectionId: "dashboard-section-rankings" },
+	{ value: "mcp", label: "MCP Usage", sectionId: "dashboard-section-mcp" },
+	{ value: "team-rankings", label: "Team Rankings", sectionId: "dashboard-section-team-rankings" },
+	{ value: "customer-rankings", label: "Customer Rankings", sectionId: "dashboard-section-customer-rankings" },
+	{ value: "bu-rankings", label: "BU Rankings", sectionId: "dashboard-section-bu-rankings" },
+	{ value: "user-rankings", label: "User Rankings", sectionId: "dashboard-section-user-rankings" },
+	{ value: "virtual-key-rankings", label: "Virtual Key Rankings", sectionId: "dashboard-section-virtual-key-rankings" },
+];
+
+export const getExportTabLabel = (tab: DashboardTab): string => DASHBOARD_EXPORT_TABS.find((t) => t.value === tab)?.label ?? "Current Tab";
 
 /** Return all CSV sections for the selected scope. Each entry becomes its own sheet / file section. */
 export function getCSVSections(data: DashboardData, tab: ExportTab): { name: string; csv: CSVData }[] {


### PR DESCRIPTION
## Summary

The dashboard export menu previously only supported exporting all tabs at once. This PR adds a "this tab only" export scope for both CSV and PDF exports, letting users export just the currently active tab without triggering a full preload of every tab's data.

## Changes

- The CSV and PDF export menu items are now submenus with two options: "This tab (label)" and "All tabs"
- `ExportTab` is split into `DashboardTab` (the individual tab values) and `ExportTab` (`DashboardTab | "all"`)
- `DASHBOARD_EXPORT_TABS` is introduced as a single source of truth for tab values, labels, and DOM section IDs, replacing the previously hardcoded `PDF_TAB_LABELS` array and scattered `ids` list in the PDF capture path
- `exportScope` replaces the boolean `pdfMode` flag, tracking which tab (or "all") is currently being exported. Force-mounting inactive Radix tabs and activating uncapped snapshot rendering are now scoped to only the tabs involved in the export
- `handlePreloadData` and `handlePdfExport` accept a `scope` argument and limit data loading and DOM capture to the relevant tab(s)
- `onPdfExport` now returns `{ element, label }[]` directly instead of raw `HTMLElement[]`, so labels come from `DASHBOARD_EXPORT_TABS` rather than a parallel index-matched array
- The active tab is passed to `ExportPopover` as `activeTab` so the submenu can display the current tab's label

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the dashboard and navigate to any tab (e.g., Provider Usage).
2. Click the Export button and hover over CSV or PDF.
3. Verify the submenu shows "This tab (Provider Usage)" and "All tabs".
4. Export "This tab" as CSV and confirm only Provider Usage data is in the file.
5. Export "This tab" as PDF and confirm only the Provider Usage section appears.
6. Export "All tabs" as CSV and PDF and confirm all sections are present, matching previous behavior.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Export menu had a single CSV and PDF item that always exported all tabs.

After: Each format opens a submenu with "This tab (label)" and "All tabs" options.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable