### PR TITLE
refactor: replace preloaded customers/virtual-keys with `CustomerSelector` and server-computed `virtual_key_count` in teams view

### DIFF
--- a/tests/e2e/features/governance/pages/governance.page.ts
+++ b/tests/e2e/features/governance/pages/governance.page.ts
@@ -5,9 +5,13 @@ import { fillSelect, waitForNetworkIdle } from '../../../core/utils/test-helpers
 
 export interface TeamConfig {
   name: string
-  /** Assign by customer id (from API). Prefer customerName for UI-only flow. */
+  /**
+   * Only `''` is honoured, meaning "clear the assignment". The picker is an
+   * async CustomerSelector that searches server-side and renders names, not
+   * ids, so assigning must go through `customerName`.
+   */
   customerId?: string
-  /** Assign by customer name in the create-team dropdown (UI-only, no API). */
+  /** Assign by customer name in the create-team customer picker (UI-only, no API). */
   customerName?: string
   budget?: { maxLimit: number; resetDuration?: string }
   rateLimit?: {
@@ -80,6 +84,30 @@ export class GovernancePage extends BasePage {
     return (await row.count()) > 0
   }
 
+  /**
+   * Drives the team sheet's CustomerSelector. Search is server-side, so the
+   * name is typed rather than picked from a preloaded option list.
+   */
+  private async selectTeamCustomer(customerName: string): Promise<void> {
+    const selector = this.page.getByTestId('team-customer-selector')
+    await selector.getByRole('combobox').click()
+
+    const search = this.page.getByPlaceholder('Search customers...')
+    await search.waitFor({ state: 'visible', timeout: 5000 })
+    await search.fill(customerName)
+
+    const option = this.page.getByRole('option').filter({ hasText: customerName }).first()
+    await option.waitFor({ state: 'visible', timeout: 5000 })
+    await option.click()
+  }
+
+  private async clearTeamCustomer(): Promise<void> {
+    const clearBtn = this.page.getByTestId('team-customer-clear-btn')
+    if (await clearBtn.isVisible().catch(() => false)) {
+      await clearBtn.click()
+    }
+  }
+
   async createTeam(config: TeamConfig): Promise<void> {
     await this.teamsCreateBtn.click()
     await expect(this.teamDialog).toBeVisible({ timeout: 5000 })
@@ -87,22 +115,10 @@ export class GovernancePage extends BasePage {
 
     await this.teamNameInput.fill(config.name)
 
-    if (config.customerId !== undefined || config.customerName !== undefined) {
-      const trigger = this.page.getByTestId('team-customer-select-trigger')
-      await trigger.click()
-      if (config.customerId === '') {
-        await this.page.getByTestId('team-customer-option-none').click()
-      } else if (config.customerName !== undefined) {
-        const customerOption = this.page
-          .locator('[data-testid^="team-customer-option-"]')
-          .filter({ hasText: config.customerName })
-        await customerOption.waitFor({ state: 'visible', timeout: 5000 })
-        await customerOption.click()
-      } else if (config.customerId !== undefined && config.customerId !== '') {
-        const customerOption = this.page.getByTestId(`team-customer-option-${config.customerId}`)
-        await customerOption.waitFor({ state: 'visible', timeout: 5000 })
-        await customerOption.click()
-      }
+    if (config.customerId === '') {
+      await this.clearTeamCustomer()
+    } else if (config.customerName !== undefined) {
+      await this.selectTeamCustomer(config.customerName)
     }
 
     if (config.budget?.maxLimit !== undefined) {
@@ -185,14 +201,10 @@ export class GovernancePage extends BasePage {
       await this.teamNameInput.fill(updates.name)
     }
 
-    if (updates.customerId !== undefined) {
-      const trigger = this.page.getByTestId('team-customer-select-trigger')
-      await trigger.click()
-      if (updates.customerId === '') {
-        await this.page.getByTestId('team-customer-option-none').click()
-      } else {
-        await this.page.getByTestId(`team-customer-option-${updates.customerId}`).click()
-      }
+    if (updates.customerId === '') {
+      await this.clearTeamCustomer()
+    } else if (updates.customerName !== undefined) {
+      await this.selectTeamCustomer(updates.customerName)
     }
 
     if (updates.budget?.maxLimit !== undefined) {

--- a/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
@@ -2,7 +2,7 @@ import TeamsTable from "@/app/workspace/governance/views/teamsTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { parseAsSafeString } from "@/lib/queryParamsParser";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import { getErrorMessage, useGetTeamsQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -11,9 +11,11 @@ import { toast } from "sonner";
 const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
+// The teams list is the only thing fetched here. Customer names ride along on
+// each team row (`customer`) and the virtual-key tally is server-computed
+// (`virtual_key_count`), so neither needs its own unpaginated list request; the
+// customer picker in the sheet fetches its own page on open.
 export function TeamsView() {
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
 
@@ -28,22 +30,6 @@ export function TeamsView() {
 
 	const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
-	const {
-		data: virtualKeysData,
-		error: vkError,
-		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(undefined, {
-		skip: !hasVirtualKeysAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
-	const {
-		data: customersData,
-		error: customersError,
-		isLoading: customersLoading,
-	} = useGetCustomersQuery(undefined, {
-		skip: !hasCustomersAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
 	const {
 		data: teamsData,
 		error: teamsError,
@@ -69,26 +55,18 @@ export function TeamsView() {
 		setUrlState({ offset: teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
 	}, [teamsTotal, urlState.offset]);
 
-	const isLoading = vkLoading || customersLoading || teamsLoading;
-
 	useEffect(() => {
-		if (!vkError && !customersError && !teamsError) {
+		if (!teamsError) {
 			shownErrorsRef.current.clear();
 			return;
 		}
-		const errorKey = `${!!vkError}-${!!customersError}-${!!teamsError}`;
+		const errorKey = `${!!teamsError}`;
 		if (shownErrorsRef.current.has(errorKey)) return;
 		shownErrorsRef.current.add(errorKey);
-		if (vkError && customersError && teamsError) {
-			toast.error("Failed to load governance data.");
-		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
-			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
-			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
-		}
-	}, [vkError, customersError, teamsError]);
+		toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
+	}, [teamsError]);
 
-	if (isLoading) {
+	if (teamsLoading) {
 		return <FullPageLoader />;
 	}
 
@@ -96,8 +74,6 @@ export function TeamsView() {
 		<TeamsTable
 			teams={teamsData?.teams || []}
 			totalCount={teamsData?.total_count || 0}
-			customers={customersData?.customers || []}
-			virtualKeys={virtualKeysData?.virtual_keys || []}
 			search={urlState.search}
 			debouncedSearch={debouncedSearch}
 			onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 }, { history: "replace" })}

--- a/ui/app/workspace/dashboard/components/exportPopover.tsx
+++ b/ui/app/workspace/dashboard/components/exportPopover.tsx
@@ -1,72 +1,86 @@
 import { Button } from "@/components/ui/button";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuPortal,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { buildCSV, downloadCSV } from "@/lib/utils/csv";
 import { Download, FileSpreadsheet, FileText, Loader2 } from "lucide-react";
 import { useCallback, useState } from "react";
-import { type DashboardData, getCSVSections } from "../utils/exportUtils";
-
-const PDF_TAB_LABELS = ["Overview", "Provider Usage", "Model Rankings", "MCP Usage"];
+import { type DashboardData, type DashboardTab, type ExportTab, getCSVSections, getExportTabLabel } from "../utils/exportUtils";
 
 interface ExportPopoverProps {
 	getData: () => DashboardData;
-	/** Enters export mode, loads every tab's uncapped data and waits for it to render. */
-	onPreloadData: () => Promise<void>;
-	onPdfExport: () => Promise<HTMLElement[]>;
+	/** The tab currently open, offered as the "this tab only" export scope. */
+	activeTab: DashboardTab;
+	/** Enters export mode, loads the scoped tabs' uncapped data and waits for it to render. */
+	onPreloadData: (scope: ExportTab) => Promise<void>;
+	onPdfExport: (scope: ExportTab) => Promise<{ element: HTMLElement; label: string }[]>;
 	/** Leaves export mode; both flows must call this, since both enter it via onPreloadData. */
 	onExportDone: () => void;
 }
 
-export function ExportPopover({ getData, onPreloadData, onPdfExport, onExportDone }: ExportPopoverProps) {
+export function ExportPopover({ getData, activeTab, onPreloadData, onPdfExport, onExportDone }: ExportPopoverProps) {
 	const [exporting, setExporting] = useState(false);
 
-	const handleCsvExport = useCallback(async () => {
-		setExporting(true);
-		try {
-			await onPreloadData();
-			const sections = getCSVSections(getData(), "all");
-			const parts: string[] = [];
-			for (const section of sections) {
-				if (section.csv.rows.length === 0) continue;
-				parts.push(`# ${section.name}`);
-				parts.push(buildCSV(section.csv.headers, section.csv.rows));
-				parts.push("");
+	const fileName = useCallback((scope: ExportTab) => (scope === "all" ? "dashboard-export" : `dashboard-${scope}`), []);
+
+	const handleCsvExport = useCallback(
+		async (scope: ExportTab) => {
+			setExporting(true);
+			try {
+				await onPreloadData(scope);
+				const sections = getCSVSections(getData(), scope);
+				const parts: string[] = [];
+				for (const section of sections) {
+					if (section.csv.rows.length === 0) continue;
+					parts.push(`# ${section.name}`);
+					parts.push(buildCSV(section.csv.headers, section.csv.rows));
+					parts.push("");
+				}
+				if (parts.length > 0) {
+					downloadCSV(parts.join("\n"), fileName(scope));
+				}
+			} finally {
+				onExportDone();
+				setExporting(false);
 			}
-			if (parts.length > 0) {
-				downloadCSV(parts.join("\n"), "dashboard-export");
+		},
+		[getData, onPreloadData, onExportDone, fileName],
+	);
+
+	const handlePdfExport = useCallback(
+		async (scope: ExportTab) => {
+			setExporting(true);
+
+			// Yield a frame so the spinner renders before heavy work starts
+			await new Promise((r) => requestAnimationFrame(r));
+
+			try {
+				const { generatePdf } = await import("@/lib/utils/pdf");
+
+				const sections = await onPdfExport(scope);
+
+				await generatePdf(sections, fileName(scope), {
+					branding: {
+						logoSrc: "/bifrost-logo.webp",
+						text: "Powered by",
+					},
+				});
+			} finally {
+				onExportDone();
+				setExporting(false);
 			}
-		} finally {
-			onExportDone();
-			setExporting(false);
-		}
-	}, [getData, onPreloadData, onExportDone]);
+		},
+		[onPdfExport, onExportDone, fileName],
+	);
 
-	const handlePdfExport = useCallback(async () => {
-		setExporting(true);
-
-		// Yield a frame so the spinner renders before heavy work starts
-		await new Promise((r) => requestAnimationFrame(r));
-
-		try {
-			const { generatePdf } = await import("@/lib/utils/pdf");
-
-			const elements = await onPdfExport();
-
-			const sections = elements.map((element, i) => ({
-				element,
-				label: PDF_TAB_LABELS[i],
-			}));
-
-			await generatePdf(sections, "dashboard-export", {
-				branding: {
-					logoSrc: "/bifrost-logo.webp",
-					text: "Powered by",
-				},
-			});
-		} finally {
-			onExportDone();
-			setExporting(false);
-		}
-	}, [onPdfExport, onExportDone]);
+	const activeTabLabel = getExportTabLabel(activeTab);
 
 	return (
 		<DropdownMenu>
@@ -77,14 +91,38 @@ export function ExportPopover({ getData, onPreloadData, onPdfExport, onExportDon
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="end">
-				<DropdownMenuItem onClick={handleCsvExport} data-testid="export-csv-item">
-					<FileSpreadsheet className="h-4 w-4" />
-					CSV
-				</DropdownMenuItem>
-				<DropdownMenuItem onClick={handlePdfExport} data-testid="export-pdf-item">
-					<FileText className="h-4 w-4" />
-					PDF
-				</DropdownMenuItem>
+				<DropdownMenuSub>
+					<DropdownMenuSubTrigger data-testid="export-csv-item">
+						<FileSpreadsheet className="h-4 w-4" />
+						CSV
+					</DropdownMenuSubTrigger>
+					<DropdownMenuPortal>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem onClick={() => handleCsvExport(activeTab)} data-testid="export-csv-current-tab">
+								This tab ({activeTabLabel})
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => handleCsvExport("all")} data-testid="export-csv-all-tabs">
+								All tabs
+							</DropdownMenuItem>
+						</DropdownMenuSubContent>
+					</DropdownMenuPortal>
+				</DropdownMenuSub>
+				<DropdownMenuSub>
+					<DropdownMenuSubTrigger data-testid="export-pdf-item">
+						<FileText className="h-4 w-4" />
+						PDF
+					</DropdownMenuSubTrigger>
+					<DropdownMenuPortal>
+						<DropdownMenuSubContent>
+							<DropdownMenuItem onClick={() => handlePdfExport(activeTab)} data-testid="export-pdf-current-tab">
+								This tab ({activeTabLabel})
+							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => handlePdfExport("all")} data-testid="export-pdf-all-tabs">
+								All tabs
+							</DropdownMenuItem>
+						</DropdownMenuSubContent>
+					</DropdownMenuPortal>
+				</DropdownMenuSub>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { dateUtils } from "@/lib/types/logs";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import { useLocation } from "@tanstack/react-router";
 import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
 import { type ChartType } from "./components/charts/chartTypeToggle";
 import { ModelFilterSelect } from "./components/charts/modelFilterSelect";
 import { ExportPopover } from "./components/exportPopover";
@@ -19,7 +19,7 @@ import { type MCPTabViewHandle, MCPTabView } from "./components/tabViews/mcpTabV
 import { type ModelRankingsTabViewHandle, ModelRankingsTabView } from "./components/tabViews/modelRankingsTabView";
 import { type OverviewTabViewHandle, OverviewTabView } from "./components/tabViews/overviewTabView";
 import { type ProviderUsageTabViewHandle, ProviderUsageTabView } from "./components/tabViews/providerUsageTabView";
-import type { DashboardData } from "./utils/exportUtils";
+import { type DashboardData, type DashboardTab, type ExportTab, DASHBOARD_EXPORT_TABS } from "./utils/exportUtils";
 
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
 
@@ -250,18 +250,36 @@ export default function DashboardPage() {
 		};
 	}, []);
 
-	// Export mode force-mounts every tab; see handlePreloadData.
-	const [pdfMode, setPdfMode] = useState(false);
+	// Which scope the in-flight export covers; null when not exporting.
+	// "all" force-mounts every tab, a single tab exports only what is open.
+	const [exportScope, setExportScope] = useState<ExportTab | null>(null);
+	const exportingAll = exportScope === "all";
+	/** True while this tab is part of the running export, so rankings render their uncapped snapshot. */
+	const isExportingTab = (tab: DashboardTab) => exportingAll || exportScope === tab;
 
-	const handlePreloadData = useCallback(async () => {
-		// Force-mount every tab before loading: Radix unmounts inactive
-		// TabsContent, so an inactive tab view has no ref yet and would never
-		// load its export snapshot - the report would only cover the tab that
-		// happened to be open.
-		setPdfMode(true);
+	const handlePreloadData = useCallback(async (scope: ExportTab) => {
+		// For an all-tabs export, force-mount every tab before loading: Radix
+		// unmounts inactive TabsContent, so an inactive tab view has no ref yet
+		// and would never load its export snapshot - the report would only cover
+		// the tab that happened to be open. A single-tab export deliberately
+		// skips this, so only the open tab's data reaches the export.
+		setExportScope(scope);
 		await nextFrames();
 
-		await Promise.all(allRefs.map((r) => r.current?.loadData()));
+		const refsByTab: Record<DashboardTab, RefObject<{ loadData: () => Promise<void> } | null>> = {
+			overview: overviewRef,
+			"provider-usage": providerRef,
+			mcp: mcpRef,
+			rankings: modelRankingsRef,
+			"team-rankings": teamRankingsRef,
+			"customer-rankings": customerRankingsRef,
+			"bu-rankings": buRankingsRef,
+			"user-rankings": userRankingsRef,
+			"virtual-key-rankings": virtualKeyRankingsRef,
+		};
+
+		const refs = scope === "all" ? allRefs : [refsByTab[scope]];
+		await Promise.all(refs.map((r) => r.current?.loadData()));
 
 		// Let the loaded snapshots commit before the caller reads getData() or
 		// captures the DOM.
@@ -386,40 +404,39 @@ export default function DashboardPage() {
 	const dashboardMinHeightRef = useRef<string>("");
 	const hiddenTabsRef = useRef<HTMLElement[]>([]);
 
-	const handlePdfExport = useCallback(async (): Promise<HTMLElement[]> => {
-		// Enters export mode, force-mounts every tab and waits for the loaded
-		// snapshots to render.
-		await handlePreloadData();
+	const handlePdfExport = useCallback(
+		async (scope: ExportTab): Promise<{ element: HTMLElement; label: string }[]> => {
+			// Enters export mode, force-mounts the scoped tabs and waits for the
+			// loaded snapshots to render.
+			await handlePreloadData(scope);
 
-		const hiddenTabs = document.querySelectorAll<HTMLElement>('[data-slot="tabs-content"][hidden]');
-		hiddenTabsRef.current = Array.from(hiddenTabs);
-		for (const tab of hiddenTabs) {
-			tab.removeAttribute("hidden");
-			tab.style.display = "block";
-		}
+			// Only an all-tabs export has hidden sections to reveal; a single-tab
+			// export captures the section already on screen.
+			if (scope === "all") {
+				const hiddenTabs = document.querySelectorAll<HTMLElement>('[data-slot="tabs-content"][hidden]');
+				hiddenTabsRef.current = Array.from(hiddenTabs);
+				for (const tab of hiddenTabs) {
+					tab.removeAttribute("hidden");
+					tab.style.display = "block";
+				}
+			}
 
-		const dashboardEl = document.getElementById("dashboard-root");
-		if (dashboardEl) {
-			dashboardMinHeightRef.current = dashboardEl.style.minHeight;
-			dashboardEl.style.minHeight = "0";
-		}
+			const dashboardEl = document.getElementById("dashboard-root");
+			if (dashboardEl) {
+				dashboardMinHeightRef.current = dashboardEl.style.minHeight;
+				dashboardEl.style.minHeight = "0";
+			}
 
-		window.dispatchEvent(new Event("resize"));
-		await nextFrames();
+			window.dispatchEvent(new Event("resize"));
+			await nextFrames();
 
-		const ids = [
-			"dashboard-section-overview",
-			"dashboard-section-provider-usage",
-			"dashboard-section-rankings",
-			"dashboard-section-mcp",
-			"dashboard-section-team-rankings",
-			"dashboard-section-customer-rankings",
-			"dashboard-section-bu-rankings",
-			"dashboard-section-user-rankings",
-			"dashboard-section-virtual-key-rankings",
-		];
-		return ids.map((id) => document.getElementById(id)).filter(Boolean) as HTMLElement[];
-	}, [handlePreloadData]);
+			const tabs = scope === "all" ? DASHBOARD_EXPORT_TABS : DASHBOARD_EXPORT_TABS.filter((t) => t.value === scope);
+			return tabs
+				.map(({ sectionId, label }) => ({ element: document.getElementById(sectionId), label }))
+				.filter((s): s is { element: HTMLElement; label: string } => s.element !== null);
+		},
+		[handlePreloadData],
+	);
 
 	const handleExportDone = useCallback(() => {
 		const dashboardEl = document.getElementById("dashboard-root");
@@ -433,10 +450,10 @@ export default function DashboardPage() {
 		}
 		hiddenTabsRef.current = [];
 
-		setPdfMode(false);
+		setExportScope(null);
 	}, []);
 
-	const activeTab = urlState.tab || "overview";
+	const activeTab = (urlState.tab || "overview") as DashboardTab;
 
 	return (
 		<div id="dashboard-root" className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
@@ -453,6 +470,7 @@ export default function DashboardPage() {
 					<div className="flex items-center gap-2">
 						<ExportPopover
 							getData={getDashboardData}
+							activeTab={activeTab}
 							onPreloadData={handlePreloadData}
 							onPdfExport={handlePdfExport}
 							onExportDone={handleExportDone}
@@ -542,12 +560,12 @@ export default function DashboardPage() {
 						</div>
 
 						{/* Overview Tab */}
-						<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="overview" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-overview">
 								<OverviewTabView
 									ref={overviewRef}
 									filters={filters}
-									active={activeTab === "overview" || pdfMode}
+									active={activeTab === "overview" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									volumeChartType={toChartType(urlState.volume_chart)}
@@ -571,12 +589,12 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Provider Usage Tab */}
-						<TabsContent value="provider-usage" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="provider-usage" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-provider-usage">
 								<ProviderUsageTabView
 									ref={providerRef}
 									filters={filters}
-									active={activeTab === "provider-usage" || pdfMode}
+									active={activeTab === "provider-usage" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									providerCostChartType={toChartType(urlState.provider_cost_chart)}
@@ -600,26 +618,26 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Model Rankings Tab */}
-						<TabsContent value="rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-rankings">
 								<ModelRankingsTabView
 									ref={modelRankingsRef}
 									filters={filters}
-									active={activeTab === "rankings" || pdfMode}
+									active={activeTab === "rankings" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* MCP Tab */}
-						<TabsContent value="mcp" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="mcp" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-mcp">
 								<MCPTabView
 									ref={mcpRef}
 									filters={mcpFilters}
-									active={activeTab === "mcp" || pdfMode}
+									active={activeTab === "mcp" || exportingAll}
 									startTime={urlState.start_time}
 									endTime={urlState.end_time}
 									mcpVolumeChartType={toChartType(urlState.mcp_volume_chart)}
@@ -631,81 +649,81 @@ export default function DashboardPage() {
 						</TabsContent>
 
 						{/* Team Rankings Tab */}
-						<TabsContent value="team-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="team-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-team-rankings">
 								<DimensionRankingsTabView
 									ref={teamRankingsRef}
 									filters={filters}
-									active={activeTab === "team-rankings" || pdfMode}
+									active={activeTab === "team-rankings" || exportingAll}
 									dimension="team"
 									dimensionLabel="Team"
 									testIdPrefix="dashboard-team-rankings"
 									dataKey="teamRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("team-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Customer Rankings Tab */}
-						<TabsContent value="customer-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="customer-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-customer-rankings">
 								<DimensionRankingsTabView
 									ref={customerRankingsRef}
 									filters={filters}
-									active={activeTab === "customer-rankings" || pdfMode}
+									active={activeTab === "customer-rankings" || exportingAll}
 									dimension="customer"
 									dimensionLabel="Customer"
 									testIdPrefix="dashboard-customer-rankings"
 									dataKey="customerRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("customer-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Business Unit Rankings Tab */}
-						<TabsContent value="bu-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="bu-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-bu-rankings">
 								<DimensionRankingsTabView
 									ref={buRankingsRef}
 									filters={filters}
-									active={activeTab === "bu-rankings" || pdfMode}
+									active={activeTab === "bu-rankings" || exportingAll}
 									dimension="business_unit"
 									dimensionLabel="Business Unit"
 									testIdPrefix="dashboard-bu-rankings"
 									dataKey="buRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("bu-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* User Rankings Tab */}
-						<TabsContent value="user-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="user-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-user-rankings">
 								<DimensionRankingsTabView
 									ref={userRankingsRef}
 									filters={filters}
-									active={activeTab === "user-rankings" || pdfMode}
+									active={activeTab === "user-rankings" || exportingAll}
 									dimension="user"
 									dimensionLabel="User"
 									testIdPrefix="dashboard-user-rankings"
 									dataKey="userRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("user-rankings")}
 								/>
 							</div>
 						</TabsContent>
 
 						{/* Virtual Key Rankings Tab */}
-						<TabsContent value="virtual-key-rankings" {...(pdfMode && { forceMount: true })}>
+						<TabsContent value="virtual-key-rankings" {...(exportingAll && { forceMount: true })}>
 							<div id="dashboard-section-virtual-key-rankings">
 								<DimensionRankingsTabView
 									ref={virtualKeyRankingsRef}
 									filters={filters}
-									active={activeTab === "virtual-key-rankings" || pdfMode}
+									active={activeTab === "virtual-key-rankings" || exportingAll}
 									dimension="virtual_key"
 									dimensionLabel="Virtual Key"
 									testIdPrefix="dashboard-virtual-key-rankings"
 									dataKey="virtualKeyRankingsData"
-									pdfMode={pdfMode}
+									pdfMode={isExportingTab("virtual-key-rankings")}
 								/>
 							</div>
 						</TabsContent>

--- a/ui/app/workspace/dashboard/utils/exportUtils.ts
+++ b/ui/app/workspace/dashboard/utils/exportUtils.ts
@@ -208,8 +208,7 @@ export interface DashboardData {
 	mcpTopToolsData: MCPTopToolsResponse | null;
 }
 
-export type ExportTab =
-	| "all"
+export type DashboardTab =
 	| "overview"
 	| "provider-usage"
 	| "rankings"
@@ -219,6 +218,27 @@ export type ExportTab =
 	| "user-rankings"
 	| "virtual-key-rankings"
 	| "mcp";
+
+export type ExportTab = DashboardTab | "all";
+
+/**
+ * Every exportable tab, in the order sections appear in a full export.
+ * Single source of truth for the tab labels shown in the export menu and as
+ * PDF section headings, and for the DOM ids the PDF capture reads.
+ */
+export const DASHBOARD_EXPORT_TABS: { value: DashboardTab; label: string; sectionId: string }[] = [
+	{ value: "overview", label: "Overview", sectionId: "dashboard-section-overview" },
+	{ value: "provider-usage", label: "Provider Usage", sectionId: "dashboard-section-provider-usage" },
+	{ value: "rankings", label: "Model Rankings", sectionId: "dashboard-section-rankings" },
+	{ value: "mcp", label: "MCP Usage", sectionId: "dashboard-section-mcp" },
+	{ value: "team-rankings", label: "Team Rankings", sectionId: "dashboard-section-team-rankings" },
+	{ value: "customer-rankings", label: "Customer Rankings", sectionId: "dashboard-section-customer-rankings" },
+	{ value: "bu-rankings", label: "BU Rankings", sectionId: "dashboard-section-bu-rankings" },
+	{ value: "user-rankings", label: "User Rankings", sectionId: "dashboard-section-user-rankings" },
+	{ value: "virtual-key-rankings", label: "Virtual Key Rankings", sectionId: "dashboard-section-virtual-key-rankings" },
+];
+
+export const getExportTabLabel = (tab: DashboardTab): string => DASHBOARD_EXPORT_TABS.find((t) => t.value === tab)?.label ?? "Current Tab";
 
 /** Return all CSV sections for the selected scope. Each entry becomes its own sheet / file section. */
 export function getCSVSections(data: DashboardData, tab: ExportTab): { name: string; csv: CSVData }[] {

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -1,3 +1,4 @@
+import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -13,13 +14,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { getErrorMessage, useCreateTeamMutation, useUpdateTeamMutation } from "@/lib/store";
-import { CreateTeamRequest, Customer, Team, UpdateTeamRequest } from "@/lib/types/governance";
+import { CreateTeamRequest, Team, UpdateTeamRequest } from "@/lib/types/governance";
 import { formatCurrency } from "@/lib/utils/governance";
 import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -31,7 +31,6 @@ import { v4 as uuid } from "uuid";
 
 interface TeamSheetProps {
 	team?: Team | null;
-	customers: Customer[];
 	onSave: () => void;
 	onCancel: () => void;
 }
@@ -82,7 +81,7 @@ const createInitialState = (team?: Team | null): Omit<TeamFormData, "isDirty"> =
 	};
 };
 
-export default function TeamSheet({ team, customers, onSave, onCancel }: TeamSheetProps) {
+export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 	const isEditing = !!team;
 	const [initialState, setInitialState] = useState<Omit<TeamFormData, "isDirty">>(createInitialState(team));
 	const [formData, setFormData] = useState<TeamFormData>({
@@ -204,17 +203,17 @@ export default function TeamSheet({ team, customers, onSave, onCancel }: TeamShe
 			// Rate limit validation - token limits
 			...(formData.tokenMaxLimit !== undefined && formData.tokenMaxLimit !== null
 				? [
-						Validator.minValue(tokenMaxLimitNum || 0, 1, "Token max limit must be at least 1"),
-						Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
-					]
+					Validator.minValue(tokenMaxLimitNum || 0, 1, "Token max limit must be at least 1"),
+					Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
+				]
 				: []),
 
 			// Rate limit validation - request limits
 			...(formData.requestMaxLimit !== undefined && formData.requestMaxLimit !== null
 				? [
-						Validator.minValue(requestMaxLimitNum || 0, 1, "Request max limit must be at least 1"),
-						Validator.required(formData.requestResetDuration, "Request reset duration is required"),
-					]
+					Validator.minValue(requestMaxLimitNum || 0, 1, "Request max limit must be at least 1"),
+					Validator.required(formData.requestResetDuration, "Request reset duration is required"),
+				]
 				: []),
 		]);
 	}, [formData, tokenMaxLimitNum, requestMaxLimitNum]);
@@ -344,31 +343,40 @@ export default function TeamSheet({ team, customers, onSave, onCancel }: TeamShe
 								{nameError && <p className="text-destructive text-sm">{nameError}</p>}
 							</div>
 
-							{/* Customer Assignment */}
-							{customers?.length > 0 && (
-								<div className="space-y-2">
-									<Label htmlFor="customer">Customer (optional)</Label>
-									<Select
-										value={formData.customerId || "__none__"}
-										onValueChange={(value) => updateField("customerId", value === "__none__" ? "" : value)}
-									>
-										<SelectTrigger id="customer" className="w-full" data-testid="team-customer-select-trigger">
-											<SelectValue placeholder="Select a customer" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="__none__" data-testid="team-customer-option-none">
-												None
-											</SelectItem>
-											{customers.map((customer) => (
-												<SelectItem key={customer.id} value={customer.id} data-testid={`team-customer-option-${customer.id}`}>
-													{customer.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<p className="text-muted-foreground text-sm">Assign to a customer or leave independent.</p>
+							{/* Customer Assignment — searchable/paginated, so the sheet never
+							    depends on the caller having fetched every customer up front. */}
+							<div className="space-y-2">
+								<Label htmlFor="customer">Customer (optional)</Label>
+								<div className="flex items-center gap-2" data-testid="team-customer-selector">
+									<CustomerSelector
+										value={formData.customerId}
+										onChange={(value) => updateField("customerId", value)}
+										// The team row embeds its customer, so an existing assignment
+										// renders a name instead of a raw UUID before any fetch.
+										fallbackOption={
+											team?.customer_id
+												? {
+													value: team.customer_id,
+													label: team.customer?.name ?? team.customer_id,
+												}
+												: null
+										}
+										className="min-w-0 flex-1"
+									/>
+									{formData.customerId && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onClick={() => updateField("customerId", "")}
+											data-testid="team-customer-clear-btn"
+										>
+											Clear
+										</Button>
+									)}
 								</div>
-							)}
+								<p className="text-muted-foreground text-sm">Assign to a customer or leave independent.</p>
+							</div>
 						</div>
 
 						{/* Multi-budget configuration: one row per budget, each keyed by reset_duration */}
@@ -558,7 +566,7 @@ export default function TeamSheet({ team, customers, onSave, onCancel }: TeamShe
 												<Badge
 													variant={
 														team.rate_limit.request_max_limit > 0 &&
-														team.rate_limit.request_current_usage >= team.rate_limit.request_max_limit
+															team.rate_limit.request_current_usage >= team.rate_limit.request_max_limit
 															? "destructive"
 															: "default"
 													}

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -18,7 +18,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationLabels } from "@/lib/constants/governance";
 import { getErrorMessage, useDeleteTeamMutation } from "@/lib/store";
-import { Customer, Team, VirtualKey } from "@/lib/types/governance";
+import { Team } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -126,8 +126,6 @@ function TeamActionsMenu({
 interface TeamsTableProps {
 	teams: Team[];
 	totalCount: number;
-	customers: Customer[];
-	virtualKeys: VirtualKey[];
 	search: string;
 	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
@@ -144,8 +142,6 @@ interface TeamsTableProps {
 export default function TeamsTable({
 	teams,
 	totalCount,
-	customers,
-	virtualKeys,
 	search,
 	debouncedSearch,
 	onSearchChange,
@@ -196,14 +192,12 @@ export default function TeamsTable({
 		onDialogClose();
 	};
 
-	const getVirtualKeysForTeam = (teamId: string) => {
-		return virtualKeys.filter((vk) => vk.team_id === teamId);
-	};
-
-	const getCustomerName = (customerId?: string) => {
-		if (!customerId) return "-";
-		const customer = customers.find((c) => c.id === customerId);
-		return customer ? customer.name : "Unknown Customer";
+	// Both the customer name and the virtual-key count come straight off the team
+	// row — the list endpoint preloads `customer` and computes `virtual_key_count`
+	// via a correlated subquery, so neither needs a client-side join.
+	const getCustomerName = (team: Team) => {
+		if (!team.customer_id) return "-";
+		return team.customer?.name ?? "Unknown Customer";
 	};
 
 	const hasActiveFilters = debouncedSearch;
@@ -213,7 +207,7 @@ export default function TeamsTable({
 		return (
 			<>
 				<TooltipProvider>
-					{showTeamSheet && <TeamSheet team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={onDialogClose} />}
+					{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
 					<TeamsEmptyState onAddClick={handleAddTeam} canCreate={hasCreateAccess} />
 				</TooltipProvider>
 			</>
@@ -223,7 +217,7 @@ export default function TeamsTable({
 	return (
 		<>
 			<TooltipProvider>
-				{showTeamSheet && <TeamSheet team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={onDialogClose} />}
+				{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
 
 				<div className="flex grow flex-col overflow-y-auto">
 					<div className="mb-4 flex items-center justify-between">
@@ -272,8 +266,8 @@ export default function TeamsTable({
 									</TableRow>
 								) : (
 									teams.map((team) => {
-										const vks = getVirtualKeysForTeam(team.id);
-										const customerName = getCustomerName(team.customer_id);
+										const vkCount = team.virtual_key_count ?? 0;
+										const customerName = getCustomerName(team);
 
 										// Budget calculations — any of the team's budgets exhausted
 										const teamBudgets = team.budgets ?? [];
@@ -439,16 +433,11 @@ export default function TeamsTable({
 													)}
 												</TableCell>
 												<TableCell>
-													{vks.length > 0 ? (
+													{vkCount > 0 ? (
 														<div className="flex items-center gap-2">
-															<Tooltip>
-																<TooltipTrigger>
-																	<Badge variant="outline" className="text-xs">
-																		{vks.length} {vks.length === 1 ? "key" : "keys"}
-																	</Badge>
-																</TooltipTrigger>
-																<TooltipContent>{vks.map((vk) => vk.name).join(", ")}</TooltipContent>
-															</Tooltip>
+															<Badge variant="outline" className="text-xs">
+																{vkCount} {vkCount === 1 ? "key" : "keys"}
+															</Badge>
 														</div>
 													) : (
 														<span className="text-muted-foreground text-sm">-</span>

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -47,6 +47,10 @@ export interface Team {
 	rate_limit_id?: string;
 	// Team-wide: applies to all team budgets and the team rate limit
 	calendar_aligned?: boolean;
+	// Number of virtual keys assigned to this team (server-computed via a
+	// correlated subquery; the list endpoints report this instead of embedding
+	// the virtual keys themselves)
+	virtual_key_count?: number;
 	// Populated relationships
 	customer?: Customer;
 	budgets?: Budget[]; // Multi-budget: each with a distinct reset_duration


### PR DESCRIPTION
## Summary

Replaces the static, pre-fetched customer dropdown in the team sheet with a searchable `CustomerSelector` component that fetches customers on demand. This removes the need to load all customers and virtual keys upfront when the Teams view mounts, reducing unnecessary API calls and eliminating client-side joins.

## Changes

- The team sheet's customer field now uses `CustomerSelector`, which performs server-side search as the user types, rather than a `<Select>` populated from a pre-fetched list passed down as props.
- A "Clear" button with `data-testid="team-customer-clear-btn"` replaces the "None" option for removing a customer assignment.
- A `fallbackOption` prop on `CustomerSelector` allows an existing team's customer name (embedded in the team row) to render immediately without waiting for a fetch.
- `TeamsView` no longer fetches `useGetCustomersQuery` or `useGetVirtualKeysQuery` on mount. Customer names are read from `team.customer.name` (preloaded by the list endpoint) and virtual key counts from a new `virtual_key_count` field (server-computed via a correlated subquery).
- `TeamsTable` and `TeamSheet` no longer accept `customers` or `virtualKeys` props. The virtual key tooltip showing individual key names is removed since only the count is now available from the server.
- The `Team` type gains a `virtual_key_count?: number` field.
- E2E page helpers are updated to drive the new `CustomerSelector` (type-to-search, pick from results) and the clear button, replacing the old test-id-based option selectors.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to the Governance → Teams view and confirm the page loads without triggering customer or virtual key list requests.
2. Open the create-team sheet and verify the customer field shows a search input. Type a partial customer name and confirm results appear and can be selected.
3. With an existing team that has a customer assigned, open the edit sheet and confirm the customer name renders immediately (before any search). Use the "Clear" button to remove the assignment and save.
4. Confirm the Teams table displays customer names and virtual key counts correctly from the team row data.

## Screenshots/Recordings

_Add before/after screenshots of the team sheet customer field if available._

## Breaking changes

- [x] Yes
- [ ] No

`TeamSheet` and `TeamsTable` no longer accept `customers` or `virtualKeys` props. Any callers outside this diff that pass those props will need to remove them. The `customerId` field on `TeamConfig` in E2E tests now only honours `''` (clear); customer assignment must use `customerName`.

## Related issues

## Security considerations

None. The customer search goes through the existing authenticated API; no new endpoints or permissions are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable