### PR TITLE
refactor: replace preloaded teams/customers with `TeamSelector`/`CustomerSelector` in virtual keys table and sheet

### DIFF
--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -2,7 +2,7 @@ import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTabl
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { parseAsSafeString } from "@/lib/queryParamsParser";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import { getErrorMessage, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -13,8 +13,6 @@ const PAGE_SIZE = 25;
 
 export default function GovernanceVirtualKeysPage() {
 	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
 
 	const [urlState, setUrlState] = useQueryStates(
@@ -52,24 +50,6 @@ export default function GovernanceVirtualKeysPage() {
 		},
 	);
 
-	const {
-		data: teamsData,
-		error: teamsError,
-		isLoading: teamsLoading,
-	} = useGetTeamsQuery(undefined, {
-		skip: !hasTeamsAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
-
-	const {
-		data: customersData,
-		error: customersError,
-		isLoading: customersLoading,
-	} = useGetCustomersQuery(undefined, {
-		skip: !hasCustomersAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
-
 	const vkTotal = virtualKeysData?.total_count ?? 0;
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
@@ -80,24 +60,18 @@ export default function GovernanceVirtualKeysPage() {
 		});
 	}, [vkTotal, urlState.offset]);
 
-	const isLoading = vkLoading || teamsLoading || customersLoading;
+	const isLoading = vkLoading;
 
 	useEffect(() => {
-		if (!vkError && !teamsError && !customersError) {
+		if (!vkError) {
 			shownErrorsRef.current.clear();
 			return;
 		}
-		const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
+		const errorKey = `${!!vkError}`;
 		if (shownErrorsRef.current.has(errorKey)) return;
 		shownErrorsRef.current.add(errorKey);
-		if (vkError && teamsError && customersError) {
-			toast.error("Failed to load governance data.");
-		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
-			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
-			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
-		}
-	}, [vkError, teamsError, customersError]);
+		toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
+	}, [vkError]);
 
 	if (isLoading) {
 		return <FullPageLoader />;
@@ -142,8 +116,6 @@ export default function GovernanceVirtualKeysPage() {
 			<VirtualKeysTable
 				virtualKeys={virtualKeysData?.virtual_keys || []}
 				totalCount={virtualKeysData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				customers={customersData?.customers || []}
 				search={urlState.search}
 				debouncedSearch={debouncedSearch}
 				onSearchChange={handleSearchChange}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -41,20 +41,14 @@ import {
 	useGetAllKeysQuery,
 	useGetMCPClientsQuery,
 	useGetProvidersQuery,
+	useGetTeamQuery,
 	useRotateVirtualKeyMutation,
 	useRemoveVirtualKeyBudgetOverrideMutation,
 	useSetVirtualKeyBudgetOverrideMutation,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import {
-	BudgetOverrideRequest,
-	CreateVirtualKeyRequest,
-	Customer,
-	Team,
-	UpdateVirtualKeyRequest,
-	VirtualKey,
-} from "@/lib/types/governance";
+import { BudgetOverrideRequest, CreateVirtualKeyRequest, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import { formatCurrency, getEffectiveBudgetLimit, hasActiveBudgetOverride, parseResetPeriod } from "@/lib/utils/governance";
 import ManagedVirtualKeyActions from "@enterprise/components/access-profiles/managedVirtualKeyActions";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -69,8 +63,6 @@ import { z } from "zod";
 
 interface VirtualKeySheetProps {
 	virtualKey?: VirtualKey | null;
-	teams: Team[];
-	customers: Customer[];
 	// When set, the new VK is created under this team. The entity assignment is pre-set
 	// and cannot be changed (but all other fields remain editable).
 	defaultTeamId?: string;
@@ -241,7 +233,7 @@ function ExpiryPickerField({ value, onChange }: ExpiryFieldProps) {
 	);
 }
 
-export default function VirtualKeySheet({ virtualKey, teams, customers, defaultTeamId, onSave, onCancel }: VirtualKeySheetProps) {
+export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onCancel }: VirtualKeySheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
 	const navigate = useNavigate();
 	const isEditing = !!virtualKey;
@@ -257,8 +249,13 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	// Team attachment: when creating from a team context (defaultTeamId provided), the entity
 	// assignment is pre-set and locked. When editing an existing VK the assignment can be changed.
 	const attachedTeamId = isEditing ? virtualKey?.team_id || "" : defaultTeamId || "";
-	const attachedTeam = attachedTeamId ? teams.find((t) => t.id === attachedTeamId) : undefined;
 	const isTeamLocked = !isEditing && !!defaultTeamId;
+	// Only the locked banner needs this name, and only when creating under a team,
+	// so resolve that one team by id rather than holding the whole list.
+	const { data: attachedTeamData } = useGetTeamQuery(attachedTeamId, {
+		skip: !isTeamLocked || !attachedTeamId,
+	});
+	const attachedTeam = attachedTeamData?.team;
 
 	const handleClose = () => {
 		setIsOpen(false);
@@ -279,9 +276,15 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	const mcpClientsData = mcpClientsResponse?.clients || [];
 	const isLoading = isCreating || isUpdating || isRotating;
 	const persistedOverrideBudgets = [
-		...(virtualKey?.budgets ?? []).map((budget) => ({ budget, label: "Virtual key" })),
+		...(virtualKey?.budgets ?? []).map((budget) => ({
+			budget,
+			label: "Virtual key",
+		})),
 		...(virtualKey?.provider_configs ?? []).flatMap((config) =>
-			(config.budgets ?? []).map((budget) => ({ budget, label: ProviderLabels[config.provider as ProviderName] ?? config.provider })),
+			(config.budgets ?? []).map((budget) => ({
+				budget,
+				label: ProviderLabels[config.provider as ProviderName] ?? config.provider,
+			})),
 		),
 	];
 	const saveBudgetOverride = async (budgetId: string, data: BudgetOverrideRequest) => {
@@ -1119,10 +1122,16 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																blacklisted_models: next.blacklistedModels,
 																weight: next.weight ?? undefined,
 																key_ids: next.keyIds,
-																budgets: next.budgets.map((l) => ({ id: l.id, max_limit: l.max_limit, reset_duration: l.reset_duration })),
+																budgets: next.budgets.map((l) => ({
+																	id: l.id,
+																	max_limit: l.max_limit,
+																	reset_duration: l.reset_duration,
+																})),
 																rate_limit: next.rateLimit ?? undefined,
 															};
-															form.setValue("providerConfigs", updated, { shouldDirty: true });
+															form.setValue("providerConfigs", updated, {
+																shouldDirty: true,
+															});
 														}}
 													/>
 												);
@@ -1535,156 +1544,147 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 										</AlertDialogFooter>
 									</AlertDialogContent>
 								</AlertDialog>
-								{(teams?.length > 0 || customers?.length > 0) && (
-									<>
-										<DottedSeparator className="my-6" />
+								<DottedSeparator className="my-6" />
 
-										{/* Entity Assignment */}
-										<div className="space-y-4">
-											<Label className="text-sm font-medium">Entity Assignment</Label>
+								{/* Entity Assignment */}
+								<div className="space-y-4">
+									<Label className="text-sm font-medium">Entity Assignment</Label>
 
-											<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
-												<FormField
-													control={form.control}
-													name="entityType"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel className="font-normal">Assignment Type</FormLabel>
-															<ComboboxSelect
-																options={[
-																	{ value: "none", label: "No Assignment" },
-																	...(teams?.length > 0
-																		? [
-																				{
-																					value: "team",
-																					label: "Assign to Team",
-																				},
-																			]
-																		: []),
-																	...(customers?.length > 0
-																		? [
-																				{
-																					value: "customer",
-																					label: "Assign to Customer",
-																				},
-																			]
-																		: []),
-																]}
-																value={field.value}
-																onValueChange={async (value) => {
-																	const val = value ?? "none";
-																	field.onChange(val);
-																	if (val === "team" && teams?.length > 0) {
-																		form.setValue("teamId", teams[0].id, {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		form.setValue("customerId", "", {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		await form.trigger(["teamId", "customerId", "entityType"]);
-																	} else if (val === "customer" && customers?.length > 0) {
-																		form.setValue("customerId", customers[0].id, {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		form.setValue("teamId", "", {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		await form.trigger(["teamId", "customerId", "entityType"]);
-																	} else {
-																		form.setValue("teamId", "", {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		form.setValue("customerId", "", {
-																			shouldDirty: true,
-																			shouldValidate: true,
-																		});
-																		await form.trigger(["teamId", "customerId", "entityType"]);
-																	}
-																}}
-																disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
-																disableSearch
-																hideClear
-																className="h-9"
-															/>
-															{isEditing && assignedUsers.length > 0 ? (
-																<p className="text-muted-foreground text-xs">
-																	This key is assigned to a user. Detach the user first to change the assignment type.
-																</p>
-															) : (
-																<FormMessage />
-															)}
-														</FormItem>
+									<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
+										<FormField
+											control={form.control}
+											name="entityType"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel className="font-normal">Assignment Type</FormLabel>
+													<ComboboxSelect
+														options={[
+															{ value: "none", label: "No Assignment" },
+															{ value: "team", label: "Assign to Team" },
+															{
+																value: "customer",
+																label: "Assign to Customer",
+															},
+														]}
+														value={field.value}
+														onValueChange={async (value) => {
+															const val = value ?? "none";
+															field.onChange(val);
+															// Switching type clears both ids and lets the user pick;
+															// there is no entity list loaded to default from.
+															if (val === "team") {
+																form.setValue("teamId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																form.setValue("customerId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																await form.trigger(["teamId", "customerId", "entityType"]);
+															} else if (val === "customer") {
+																form.setValue("customerId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																form.setValue("teamId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																await form.trigger(["teamId", "customerId", "entityType"]);
+															} else {
+																form.setValue("teamId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																form.setValue("customerId", "", {
+																	shouldDirty: true,
+																	shouldValidate: true,
+																});
+																await form.trigger(["teamId", "customerId", "entityType"]);
+															}
+														}}
+														disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
+														disableSearch
+														hideClear
+														className="h-9"
+													/>
+													{isEditing && assignedUsers.length > 0 ? (
+														<p className="text-muted-foreground text-xs">
+															This key is assigned to a user. Detach the user first to change the assignment type.
+														</p>
+													) : (
+														<FormMessage />
 													)}
-												/>
-												{form.watch("entityType") === "team" && teams?.length > 0 && (
-													<FormField
-														control={form.control}
-														name="teamId"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel className="font-normal">Select Team</FormLabel>
-																<TeamSelector
-																	value={field.value || ""}
-																	onChange={(newVal) => {
-																		if (isEditing && virtualKey?.team_id && newVal && newVal !== virtualKey.team_id) {
-																			setPendingTeamId(newVal);
-																			setShowReassignTeamWarning(true);
-																		} else {
-																			field.onChange(newVal);
+												</FormItem>
+											)}
+										/>
+										{form.watch("entityType") === "team" && (
+											<FormField
+												control={form.control}
+												name="teamId"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel className="font-normal">Select Team</FormLabel>
+														<TeamSelector
+															value={field.value || ""}
+															onChange={(newVal) => {
+																if (isEditing && virtualKey?.team_id && newVal && newVal !== virtualKey.team_id) {
+																	setPendingTeamId(newVal);
+																	setShowReassignTeamWarning(true);
+																} else {
+																	field.onChange(newVal);
+																}
+															}}
+															// The already-assigned team may fall outside the
+															// selector's first page, so seed its label from the
+															// team embedded on the virtual key itself.
+															fallbackOption={
+																field.value
+																	? {
+																			value: field.value,
+																			label: field.value === virtualKey?.team_id ? (virtualKey?.team?.name ?? field.value) : field.value,
 																		}
-																	}}
-																	// The already-assigned team may fall outside the
-																	// selector's first page, so seed its label from the
-																	// list the page already fetched.
-																	fallbackOption={
-																		field.value
-																			? { value: field.value, label: teams.find((t) => t.id === field.value)?.name ?? field.value }
-																			: null
-																	}
-																	disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
-																	triggerClassName="h-9"
-																/>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
+																	: null
+															}
+															disabled={isTeamLocked || (isEditing && assignedUsers.length > 0)}
+															triggerClassName="h-9"
+														/>
+														<FormMessage />
+													</FormItem>
 												)}
+											/>
+										)}
 
-												{form.watch("entityType") === "customer" && customers?.length > 0 && (
-													<FormField
-														control={form.control}
-														name="customerId"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel className="font-normal">Select Customer</FormLabel>
-																<CustomerSelector
-																	value={field.value || ""}
-																	onChange={(val) => field.onChange(val)}
-																	fallbackOption={
-																		field.value
-																			? {
-																					value: field.value,
-																					label: customers.find((c) => c.id === field.value)?.name ?? field.value,
-																				}
-																			: null
-																	}
-																	disabled={isEditing && assignedUsers.length > 0}
-																	triggerClassName="h-9"
-																/>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
+										{form.watch("entityType") === "customer" && (
+											<FormField
+												control={form.control}
+												name="customerId"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel className="font-normal">Select Customer</FormLabel>
+														<CustomerSelector
+															value={field.value || ""}
+															onChange={(val) => field.onChange(val)}
+															fallbackOption={
+																field.value
+																	? {
+																			value: field.value,
+																			label:
+																				field.value === virtualKey?.customer_id ? (virtualKey?.customer?.name ?? field.value) : field.value,
+																		}
+																	: null
+															}
+															disabled={isEditing && assignedUsers.length > 0}
+															triggerClassName="h-9"
+														/>
+														<FormMessage />
+													</FormItem>
 												)}
-											</div>
-										</div>
-									</>
-								)}
+											/>
+										)}
+									</div>
+								</div>
 							</fieldset>
 						</div>
 						<AlertDialog open={showRotateWarning} onOpenChange={setShowRotateWarning}>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -1,4 +1,6 @@
 import { BudgetDisplay } from "@/components/budgetDisplay";
+import { CustomerSelector } from "@/components/entitySelectors/customerSelector";
+import { TeamSelector } from "@/components/entitySelectors/teamSelector";
 import { RateLimitDisplay } from "@/components/rateLimitDisplay";
 import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
@@ -14,7 +16,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ComboboxSelect } from "@/components/ui/combobox";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
@@ -32,7 +33,7 @@ import {
 	useLazyGetVirtualKeysQuery,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
-import { Customer, Team, VirtualKey } from "@/lib/types/governance";
+import { VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency, getEffectiveBudgetLimit } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -52,10 +53,11 @@ import {
 	MoreHorizontal,
 	Plus,
 	RotateCcw,
+	ScrollText,
 	Search,
 	ShieldCheck,
-	ScrollText,
 	Trash2,
+	X,
 } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
@@ -104,6 +106,35 @@ function downloadCSV(content: string) {
 function VKBudgetCell({ vk }: { vk: VirtualKey }) {
 	const { displayBudgets } = useVirtualKeyUsage(vk);
 	return <BudgetDisplay budgets={displayBudgets} calendarAligned={vk.calendar_aligned} />;
+}
+
+// Entity selectors only ever set a value, so a filter built on one needs its own
+// reset back to "all" — this restores the affordance ComboboxSelect gave for free.
+function FilterClearButton({
+	show,
+	label,
+	onClear,
+	"data-testid": dataTestId,
+}: {
+	show: boolean;
+	label: string;
+	onClear: () => void;
+	"data-testid"?: string;
+}) {
+	if (!show) return null;
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="icon"
+			className="h-9 w-7 shrink-0"
+			aria-label={label}
+			onClick={onClear}
+			data-testid={dataTestId}
+		>
+			<X className="h-3.5 w-3.5" />
+		</Button>
+	);
 }
 
 function VKAssignedToCell({ vk }: { vk: VirtualKey }) {
@@ -263,8 +294,6 @@ function VKActionsMenu({
 interface VirtualKeysTableProps {
 	virtualKeys: VirtualKey[];
 	totalCount: number;
-	teams: Team[];
-	customers: Customer[];
 	search: string;
 	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
@@ -285,8 +314,6 @@ interface VirtualKeysTableProps {
 export default function VirtualKeysTable({
 	virtualKeys,
 	totalCount,
-	teams,
-	customers,
 	search,
 	debouncedSearch,
 	onSearchChange,
@@ -326,7 +353,9 @@ export default function VirtualKeysTable({
 	// The target may not be on the current page/filter, so fetch it by id as a fallback.
 	const [vkParam, setVkParam] = useQueryState("vk");
 	const needsVkFetch = !!selectedVkId && !selectedVkInList;
-	const { data: fetchedVkData } = useGetVirtualKeyQuery(selectedVkId ?? "", { skip: !needsVkFetch });
+	const { data: fetchedVkData } = useGetVirtualKeyQuery(selectedVkId ?? "", {
+		skip: !needsVkFetch,
+	});
 	const selectedVirtualKey = selectedVkInList ?? (needsVkFetch ? (fetchedVkData?.virtual_key ?? null) : null);
 
 	useEffect(() => {
@@ -596,13 +625,7 @@ export default function VirtualKeysTable({
 		return (
 			<>
 				{showVirtualKeySheet && (
-					<VirtualKeySheet
-						virtualKey={editingVirtualKey}
-						teams={teams}
-						customers={customers}
-						onSave={handleVirtualKeySaved}
-						onCancel={() => setShowVirtualKeySheet(false)}
-					/>
+					<VirtualKeySheet virtualKey={editingVirtualKey} onSave={handleVirtualKeySaved} onCancel={() => setShowVirtualKeySheet(false)} />
 				)}
 				<VirtualKeysEmptyState onAddClick={handleAddVirtualKey} canCreate={hasCreateAccess} />
 			</>
@@ -612,13 +635,7 @@ export default function VirtualKeysTable({
 	return (
 		<>
 			{showVirtualKeySheet && (
-				<VirtualKeySheet
-					virtualKey={editingVirtualKey}
-					teams={teams}
-					customers={customers}
-					onSave={handleVirtualKeySaved}
-					onCancel={() => setShowVirtualKeySheet(false)}
-				/>
+				<VirtualKeySheet virtualKey={editingVirtualKey} onSave={handleVirtualKeySaved} onCancel={() => setShowVirtualKeySheet(false)} />
 			)}
 
 			{!!selectedVkId && selectedVirtualKey && (
@@ -788,23 +805,39 @@ export default function VirtualKeysTable({
 							data-testid="vk-search-input"
 						/>
 					</div>
-					<ComboboxSelect
-						data-testid="vk-customer-filter"
-						options={customers.map((c) => ({ label: c.name, value: c.id }))}
-						value={customerFilter || null}
-						onValueChange={(val) => onCustomerFilterChange(val ?? "")}
-						placeholder="All Customers"
-						className="h-9 w-[180px]"
-					/>
+					{/* Both filters search server-side and resolve their own label for a
+					    value restored from the URL, so the page fetches no entity lists. */}
+					<div className="flex items-center gap-1" data-testid="vk-customer-filter">
+						<CustomerSelector
+							value={customerFilter}
+							onChange={onCustomerFilterChange}
+							placeholder="All Customers"
+							triggerClassName="h-9"
+							className="w-[250px]"
+						/>
+						<FilterClearButton
+							show={!!customerFilter}
+							label="Clear customer filter"
+							onClear={() => onCustomerFilterChange("")}
+							data-testid="vk-customer-filter-clear-btn"
+						/>
+					</div>
 					{customerFilter && teamFilter && <span className="text-muted-foreground text-xs font-medium">or</span>}
-					<ComboboxSelect
-						data-testid="vk-team-filter"
-						options={teams.map((t) => ({ label: t.name, value: t.id }))}
-						value={teamFilter || null}
-						onValueChange={(val) => onTeamFilterChange(val ?? "")}
-						placeholder="All Teams"
-						className="h-9 w-[180px]"
-					/>
+					<div className="flex items-center gap-1" data-testid="vk-team-filter">
+						<TeamSelector
+							value={teamFilter}
+							onChange={onTeamFilterChange}
+							placeholder="All Teams"
+							triggerClassName="h-9"
+							className="w-[250px]"
+						/>
+						<FilterClearButton
+							show={!!teamFilter}
+							label="Clear team filter"
+							onClear={() => onTeamFilterChange("")}
+							data-testid="vk-team-filter-clear-btn"
+						/>
+					</div>
 				</div>
 
 				<div className="mb-2 min-h-0 grow overflow-hidden rounded-sm border">


### PR DESCRIPTION
## Summary

The virtual keys page and sheet previously fetched the full teams and customers lists upfront and passed them down as props for filtering and entity assignment. This PR removes those bulk fetches in favour of server-side search selectors (`TeamSelector` / `CustomerSelector`) that resolve their own labels on demand, eliminating unnecessary data loading and prop drilling.

## Changes

- Removed `useGetTeamsQuery` and `useGetCustomersQuery` calls from the governance virtual keys page; the page no longer fetches or holds teams/customers lists.
- Dropped `teams` and `customers` props from `VirtualKeysTable` and `VirtualKeySheet`.
- Replaced the static `ComboboxSelect` team/customer filters in the table toolbar with `TeamSelector` and `CustomerSelector` components, which search server-side. Added a `FilterClearButton` helper component to restore the "clear to all" affordance that `ComboboxSelect` previously provided for free.
- In `VirtualKeySheet`, the entity assignment section is now always rendered (previously hidden when no teams/customers were loaded). The assignment type dropdown always shows both "Assign to Team" and "Assign to Customer" options. Switching type clears the id fields rather than defaulting to the first item in a list.
- The locked-team banner in `VirtualKeySheet` now resolves the team name via a single `useGetTeamQuery(attachedTeamId)` call instead of searching through the full teams list.
- The team/customer fallback labels in the selectors are now sourced from the `team` and `customer` objects embedded on the `VirtualKey` itself rather than from the previously fetched lists.
- RBAC checks for `Teams` and `Customers` view permissions were removed from the governance page since no bulk fetches are gated on them anymore.
- Error handling in the governance page was simplified to only track virtual key fetch errors.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Governance → Virtual Keys page and confirm it loads without fetching `/teams` or `/customers` on mount.
2. Use the Team and Customer filter dropdowns — verify they search server-side and display results correctly.
3. Select a filter value and confirm the clear (`×`) button resets the filter back to "All".
4. Open the virtual key sheet for an existing key assigned to a team; confirm the team name resolves correctly in the locked banner and in the team selector fallback label.
5. Create a new virtual key, switch the assignment type between Team and Customer, and confirm the id fields are cleared on each switch.
6. Confirm error toasts still appear when the virtual keys fetch fails.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the filter toolbar and entity assignment section if available._

## Breaking changes

- [x] No

## Related issues

## Security considerations

No new auth surfaces introduced. Removed RBAC checks for teams/customers on this page are safe because the underlying selectors enforce their own access controls server-side.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable