### PR TITLE
[fix]: bound ClickHouse log list memory usage

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+[fix]: bound ClickHouse memory usage for paginated log lists [@kaaanata](https://github.com/kaaanata)

--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -493,6 +493,54 @@ func TestClickHouseSearchAndStats(t *testing.T) {
 	assert.ElementsMatch(t, []string{"gpt-4o", "claude-sonnet-4-5"}, models)
 }
 
+func TestClickHousePaginatedLogListsPreserveLatestVersions(t *testing.T) {
+	store := trySetupClickHouseStore(t)
+	ctx := context.Background()
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	sessionID := "ch-list-session"
+	largeHistory := fmt.Sprintf(`[{"role":"user","content":"%s"}]`, strings.Repeat("x", 64*1024))
+
+	for i := 0; i < 6; i++ {
+		entry := chTestLog(fmt.Sprintf("ch-list-%d", i), ts.Add(time.Duration(i)*time.Second))
+		entry.ParentRequestID = &sessionID
+		entry.InputHistory = largeHistory
+		entry.ResponsesInputHistory = largeHistory
+		entry.ContentSummary = strings.Repeat("s", 64*1024)
+		require.NoError(t, store.CreateIfNotExists(ctx, entry))
+	}
+
+	require.NoError(t, store.Update(ctx, "ch-list-4", map[string]interface{}{
+		"status":          "success",
+		"content_summary": "latest version",
+	}))
+
+	result, err := store.SearchLogs(ctx, SearchFilters{}, PaginationOptions{
+		Limit:  2,
+		Offset: 1,
+		SortBy: "timestamp",
+		Order:  "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Logs, 2)
+	assert.Equal(t, "ch-list-4", result.Logs[0].ID)
+	assert.Equal(t, "success", result.Logs[0].Status)
+	assert.Equal(t, "latest version", result.Logs[0].ContentSummary)
+	assert.Equal(t, "ch-list-3", result.Logs[1].ID)
+	assert.Equal(t, int64(6), result.Pagination.TotalCount)
+
+	sessionResult, err := store.GetSessionLogs(ctx, sessionID, PaginationOptions{
+		Limit:  2,
+		Offset: 1,
+		Order:  "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, sessionResult.Logs, 2)
+	assert.Equal(t, "ch-list-4", sessionResult.Logs[0].ID)
+	assert.Equal(t, "success", sessionResult.Logs[0].Status)
+	assert.Equal(t, "ch-list-3", sessionResult.Logs[1].ID)
+	assert.Equal(t, int64(6), sessionResult.Count)
+}
+
 func TestClickHouseDeleteLogs(t *testing.T) {
 	store := trySetupClickHouseStore(t)
 	ctx := context.Background()

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -755,10 +755,7 @@ func (s *RDBLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pag
 	g.Go(func() error {
 		dataQuery := s.ScopedDB(gCtx).Model(&Log{})
 		dataQuery = s.applyFilters(dataQuery, filters)
-		dataQuery = dataQuery.Order(orderClause).Select(s.listSelectColumns()).Limit(limit)
-		if pagination.Offset > 0 {
-			dataQuery = dataQuery.Offset(pagination.Offset)
-		}
+		dataQuery = s.paginatedLogListQuery(gCtx, dataQuery, orderClause, limit, pagination.Offset)
 		err := dataQuery.Find(&logs).Error
 		if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil
@@ -826,14 +823,13 @@ func (s *RDBLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagi
 	})
 
 	g.Go(func() error {
-		dataQuery := baseQuery.Session(&gorm.Session{}).
-			WithContext(gCtx).
-			Order(orderClause).
-			Select(s.listSelectColumns()).
-			Limit(limit)
-		if pagination.Offset > 0 {
-			dataQuery = dataQuery.Offset(pagination.Offset)
-		}
+		dataQuery := s.paginatedLogListQuery(
+			gCtx,
+			baseQuery.Session(&gorm.Session{}).WithContext(gCtx),
+			orderClause,
+			limit,
+			pagination.Offset,
+		)
 		err := dataQuery.Find(&logs).Error
 		if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil
@@ -1020,6 +1016,34 @@ func (s *RDBLogStore) listSelectColumns() string {
 	}
 
 	return baseCols + ", " + inputHistoryExpr + ", " + responsesInputExpr + ", " + outputMessageExpr
+}
+
+// paginatedLogListQuery applies list projection and pagination to a filtered
+// logs query. ClickHouse connections enable final=1 so ReplacingMergeTree
+// updates are immediately visible. Selecting wide payload columns in the same
+// query forces FINAL to materialize those columns for every candidate row
+// before LIMIT can be applied, which can exhaust memory on large tables.
+//
+// For ClickHouse, first select only the page's dedup keys, then fetch the wide
+// list projection for those keys. FINAL still applies to both stages, preserving
+// latest-version semantics while bounding wide-column reads to the requested
+// page. Other dialects keep the direct query shape.
+func (s *RDBLogStore) paginatedLogListQuery(ctx context.Context, filteredQuery *gorm.DB, orderClause string, limit, offset int) *gorm.DB {
+	pageQuery := filteredQuery.Order(orderClause).Limit(limit)
+	if offset > 0 {
+		pageQuery = pageQuery.Offset(offset)
+	}
+	if s.db.Dialector.Name() != "clickhouse" {
+		return pageQuery.Select(s.listSelectColumns())
+	}
+
+	keyQuery := pageQuery.Select("timestamp, id")
+	return s.ScopedDB(ctx).
+		Model(&Log{}).
+		Where("(timestamp, id) IN (?)", keyQuery).
+		Order(orderClause).
+		Limit(limit).
+		Select(s.listSelectColumns())
 }
 
 // GetStats calculates statistics for logs matching the given filters.


### PR DESCRIPTION
## Summary

This PR prevents ClickHouse-backed paginated log list queries from exhausting the server memory limit when the logs table contains large request or response histories.

The affected queries requested a small page but selected several wide payload columns from the full filtered data set. Because the ClickHouse connection enables `final=1` for `ReplacingMergeTree` correctness, ClickHouse had to resolve row versions while processing those selected columns before the page limit could reduce the result. Memory usage therefore scaled with the amount and width of matching data rather than with the requested page size, and sufficiently large data sets could fail with `MEMORY_LIMIT_EXCEEDED`.

## Changes

- Added a ClickHouse-specific two-stage list query:
  1. Apply the original filters, ordering, offset, and limit while selecting only the narrow `(timestamp, id)` row keys.
  2. Fetch the existing wide list projection only for those page keys.
- Applied the query shape to both general log search and session log listing.
- Kept `FINAL` active in both stages, so updated `ReplacingMergeTree` rows still return their latest version.
- Kept the existing direct query path unchanged for non-ClickHouse dialects.
- Added ClickHouse regression coverage using large history fields, offset pagination, session filtering, total counts, and an updated row version.
- Added the required framework changelog entry.

This approach intentionally does not raise the ClickHouse memory limit. The narrow stage may still scan the matching keys to preserve the existing sort and pagination contract, but wide payload reads are bounded by the requested page size.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Start the repository's ClickHouse test service, then run:

```sh
cd framework
go test ./logstore -count=1
```

Expected result: the package passes, including `TestClickHousePaginatedLogListsPreserveLatestVersions`. The regression test verifies that both list APIs return the requested page, preserve total counts, and expose the latest version of an updated row while wide history fields are present.

Validation completed for this PR:

```text
ok   github.com/maximhq/bifrost/framework/logstore  4.102s
```

No new configuration or environment variables are introduced.

## Screenshots/Recordings

Not applicable; there are no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No authentication, authorization, secret handling, or data-retention behavior changes. Existing query scoping and filters are retained in the narrow key subquery, and the outer query uses the same scoped database handle.

## Checklist

- [x] I read the contributing guidelines and followed them
- [x] I added/updated tests where appropriate
- [x] I updated the framework changelog
- [x] I verified the affected Go package succeeds
- [ ] I ran the complete repository test suite
