### PR TITLE
fix: image search for genai search tool

### DIFF
--- a/core/providers/gemini/payload_ordering_test.go
+++ b/core/providers/gemini/payload_ordering_test.go
@@ -255,3 +255,42 @@ func TestToBifrostCountTokensResponseCachedContent(t *testing.T) {
 		assert.Zero(t, got.InputTokensDetails.AudioTokens)
 	})
 }
+
+// TestToBifrostCountTokensResponseCachedContent locks the cached-token accounting
+// against the real API shape. Verified live: a 7202-token cache plus 9 tokens of
+// contents returns totalTokens 7211 with promptTokensDetails already at 7211 and
+// cacheTokensDetails at 7202 — the cache is a subset of the prompt, not an addition,
+// so its modalities must never be folded into the breakdown a second time.
+func TestToBifrostCountTokensResponseCachedContent(t *testing.T) {
+	t.Run("cached modalities do not inflate the breakdown", func(t *testing.T) {
+		resp := &GeminiCountTokensResponse{
+			TotalTokens:             7211,
+			CachedContentTokenCount: 7202,
+			PromptTokensDetails:     []*ModalityTokenCount{{Modality: ModalityText, TokenCount: 7211}},
+			CacheTokensDetails:      []*ModalityTokenCount{{Modality: ModalityText, TokenCount: 7202}},
+		}
+
+		got := resp.ToBifrostCountTokensResponse("gemini-2.5-flash")
+
+		assert.Equal(t, 7211, got.InputTokens)
+		assert.Equal(t, 7211, got.InputTokensDetails.TextTokens)
+		assert.Equal(t, 7202, got.InputTokensDetails.CachedReadTokens)
+	})
+
+	t.Run("falls back to summing cache details for the cached total", func(t *testing.T) {
+		resp := &GeminiCountTokensResponse{
+			TotalTokens:         100,
+			PromptTokensDetails: []*ModalityTokenCount{{Modality: ModalityText, TokenCount: 100}},
+			CacheTokensDetails: []*ModalityTokenCount{
+				{Modality: ModalityText, TokenCount: 60},
+				{Modality: ModalityAudio, TokenCount: 15},
+			},
+		}
+
+		got := resp.ToBifrostCountTokensResponse("gemini-2.5-flash")
+
+		assert.Equal(t, 75, got.InputTokensDetails.CachedReadTokens)
+		assert.Equal(t, 100, got.InputTokensDetails.TextTokens)
+		assert.Zero(t, got.InputTokensDetails.AudioTokens)
+	})
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -59,6 +60,21 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 			params.ToolChoice = convertGeminiToolConfigToToolChoice(request.ToolConfig)
 		}
 		params.IncludeServerSideToolInvocations = request.ToolConfig.IncludeServerSideToolInvocations
+
+		// Search localization rides on the web_search tool, the only tool it applies to.
+		if retrieval := request.ToolConfig.RetrievalConfig; retrieval != nil && retrieval.LatLng != nil {
+			for i := range params.Tools {
+				webSearch := params.Tools[i].ResponsesToolWebSearch
+				if params.Tools[i].Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil {
+					continue
+				}
+				if webSearch.UserLocation == nil {
+					webSearch.UserLocation = &schemas.ResponsesToolWebSearchUserLocation{}
+				}
+				webSearch.UserLocation.Latitude = retrieval.LatLng.Latitude
+				webSearch.UserLocation.Longitude = retrieval.LatLng.Longitude
+			}
+		}
 	}
 
 	if request.SafetySettings != nil {
@@ -130,6 +146,27 @@ func ToGeminiResponsesRequestWithImageURLSchemes(ctx *schemas.BifrostContext, bi
 				if hasFunctionDeclarations {
 					geminiReq.ToolConfig = convertResponsesToolChoiceToGemini(bifrostReq.Params.ToolChoice)
 				}
+			}
+
+			// Rebuild search localization from the web_search tool that carried it.
+			for _, tool := range bifrostReq.Params.Tools {
+				webSearch := tool.ResponsesToolWebSearch
+				if tool.Type != schemas.ResponsesToolTypeWebSearch || webSearch == nil || webSearch.UserLocation == nil {
+					continue
+				}
+				if webSearch.UserLocation.Latitude == nil && webSearch.UserLocation.Longitude == nil {
+					continue
+				}
+				if geminiReq.ToolConfig == nil {
+					geminiReq.ToolConfig = &ToolConfig{}
+				}
+				geminiReq.ToolConfig.RetrievalConfig = &RetrievalConfig{
+					LatLng: &LatLng{
+						Latitude:  webSearch.UserLocation.Latitude,
+						Longitude: webSearch.UserLocation.Longitude,
+					},
+				}
+				break
 			}
 		}
 
@@ -2327,6 +2364,13 @@ func convertGeminiFileDataToContentBlock(fileData *FileData) *schemas.ResponsesM
 	return block
 }
 
+// OpenAI's search_content_types values, which carry Gemini's googleSearch.searchTypes.
+// Gemini's webSearch returns text results, so it maps to "text".
+const (
+	geminiSearchContentTypeText  = "text"
+	geminiSearchContentTypeImage = "image"
+)
+
 func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 	var responsesTools []schemas.ResponsesTool
 
@@ -2348,6 +2392,16 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 					}
 				}
 				responsesTool.ResponsesToolWebSearch.Filters = filters
+			}
+			if searchTypes := tool.GoogleSearch.SearchTypes; searchTypes != nil {
+				var contentTypes []string
+				if searchTypes.WebSearch != nil {
+					contentTypes = append(contentTypes, geminiSearchContentTypeText)
+				}
+				if searchTypes.ImageSearch != nil {
+					contentTypes = append(contentTypes, geminiSearchContentTypeImage)
+				}
+				responsesTool.ResponsesToolWebSearch.SearchContentTypes = contentTypes
 			}
 			responsesTools = append(responsesTools, responsesTool)
 		} else if len(tool.FunctionDeclarations) > 0 {
@@ -2428,6 +2482,39 @@ func textBlockOf(messages []schemas.ResponsesMessage, idx int) *schemas.Response
 		}
 	}
 	return nil
+}
+
+// groundingChunkSource converts a grounding chunk to a neutral search source. Image chunks
+// attribute to the containing page, as Google's display terms require, and carry the asset
+// URL alongside. Reports false for chunk types that expose no citable URL.
+func groundingChunkSource(chunk *GroundingChunk) (schemas.ResponsesWebSearchToolCallActionSearchSource, bool) {
+	if chunk == nil {
+		return schemas.ResponsesWebSearchToolCallActionSearchSource{}, false
+	}
+	source := schemas.ResponsesWebSearchToolCallActionSearchSource{Type: "url"}
+
+	switch {
+	case chunk.Web != nil && chunk.Web.URI != "":
+		source.URL = chunk.Web.URI
+		if chunk.Web.Title != "" {
+			source.Title = schemas.Ptr(chunk.Web.Title)
+		}
+	case chunk.Image != nil && chunk.Image.SourceURI != "":
+		source.URL = chunk.Image.SourceURI
+		if chunk.Image.Title != "" {
+			source.Title = schemas.Ptr(chunk.Image.Title)
+		}
+		if chunk.Image.ImageURI != "" {
+			source.ImageURL = schemas.Ptr(chunk.Image.ImageURI)
+		}
+		if chunk.Image.Domain != "" {
+			source.Domain = schemas.Ptr(chunk.Image.Domain)
+		}
+	default:
+		return source, false
+	}
+
+	return source, true
 }
 
 // Helper functions for Responses conversion
@@ -2700,15 +2787,14 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 			if len(candidate.GroundingMetadata.WebSearchQueries) > 0 {
 				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query = schemas.Ptr(candidate.GroundingMetadata.WebSearchQueries[0])
 			}
+			if len(candidate.GroundingMetadata.ImageSearchQueries) > 0 {
+				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.ImageQueries = candidate.GroundingMetadata.ImageSearchQueries
+			}
 
 			sources := []schemas.ResponsesWebSearchToolCallActionSearchSource{}
-			for _, source := range candidate.GroundingMetadata.GroundingChunks {
-				if source.Web != nil {
-					sources = append(sources, schemas.ResponsesWebSearchToolCallActionSearchSource{
-						Type:  "url",
-						Title: schemas.Ptr(source.Web.Title),
-						URL:   source.Web.URI,
-					})
+			for _, chunk := range candidate.GroundingMetadata.GroundingChunks {
+				if source, ok := groundingChunkSource(chunk); ok {
+					sources = append(sources, source)
 				}
 			}
 
@@ -2730,8 +2816,8 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 						if chunkIdx < 0 || int(chunkIdx) >= len(candidate.GroundingMetadata.GroundingChunks) {
 							continue
 						}
-						chunk := candidate.GroundingMetadata.GroundingChunks[chunkIdx]
-						if chunk.Web == nil || chunk.Web.URI == "" {
+						source, ok := groundingChunkSource(candidate.GroundingMetadata.GroundingChunks[chunkIdx])
+						if !ok {
 							continue
 						}
 						annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
@@ -2739,11 +2825,9 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 							Text:       schemas.Ptr(support.Segment.Text),
 							StartIndex: schemas.Ptr(int(support.Segment.StartIndex)),
 							EndIndex:   schemas.Ptr(int(support.Segment.EndIndex)),
-							URL:        schemas.Ptr(chunk.Web.URI),
+							URL:        schemas.Ptr(source.URL),
 						}
-						if chunk.Web.Title != "" {
-							annotation.Title = schemas.Ptr(chunk.Web.Title)
-						}
+						annotation.Title = source.Title
 						annotations = append(annotations, annotation)
 					}
 				}
@@ -3057,6 +3141,20 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool, includeServerS
 				}
 				if len(tool.ResponsesToolWebSearch.Filters.BlockedDomains) > 0 {
 					googleSearch.ExcludeDomains = tool.ResponsesToolWebSearch.Filters.BlockedDomains
+				}
+			}
+			if tool.ResponsesToolWebSearch != nil && len(tool.ResponsesToolWebSearch.SearchContentTypes) > 0 {
+				searchTypes := &SearchTypes{}
+				for _, contentType := range tool.ResponsesToolWebSearch.SearchContentTypes {
+					switch contentType {
+					case geminiSearchContentTypeText:
+						searchTypes.WebSearch = &WebSearch{}
+					case geminiSearchContentTypeImage:
+						searchTypes.ImageSearch = &ImageSearch{}
+					}
+				}
+				if searchTypes.WebSearch != nil || searchTypes.ImageSearch != nil {
+					googleSearch.SearchTypes = searchTypes
 				}
 			}
 		}
@@ -3670,6 +3768,9 @@ func buildGroundingMetadataFromWebSearch(webSearchCall *schemas.ResponsesMessage
 	} else if action.Query != nil {
 		groundingMetadata.WebSearchQueries = []string{*action.Query}
 	}
+	if len(action.ImageQueries) > 0 {
+		groundingMetadata.ImageSearchQueries = action.ImageQueries
+	}
 
 	// Extract grounding chunks from sources
 	var groundingChunks []*GroundingChunk
@@ -3685,11 +3786,22 @@ func buildGroundingMetadataFromWebSearch(webSearchCall *schemas.ResponsesMessage
 			title = *source.Title
 		}
 
-		chunk := &GroundingChunk{
-			Web: &GroundingChunkWeb{
+		// An asset URL marks the source as an image-search hit; URL stays the containing page.
+		chunk := &GroundingChunk{}
+		if source.ImageURL != nil && *source.ImageURL != "" {
+			chunk.Image = &GroundingChunkImage{
+				SourceURI: source.URL,
+				ImageURI:  *source.ImageURL,
+				Title:     title,
+			}
+			if source.Domain != nil {
+				chunk.Image.Domain = *source.Domain
+			}
+		} else {
+			chunk.Web = &GroundingChunkWeb{
 				URI:   source.URL,
 				Title: title,
-			},
+			}
 		}
 		groundingChunks = append(groundingChunks, chunk)
 		urlToIndexMap[source.URL] = int32(len(groundingChunks) - 1)
@@ -3699,41 +3811,56 @@ func buildGroundingMetadataFromWebSearch(webSearchCall *schemas.ResponsesMessage
 		groundingMetadata.GroundingChunks = groundingChunks
 	}
 
-	// Convert annotations to grounding supports
+	// Convert annotations to grounding supports. Annotations carry one entry per
+	// (support, chunk) pair, so regroup by segment to restore multi-source supports.
 	var groundingSupports []*GroundingSupport
+	supportBySegment := make(map[string]*GroundingSupport)
 	for _, annotation := range annotations {
 		if annotation.Type != "url_citation" {
 			continue
 		}
 
-		support := &GroundingSupport{
-			Segment: &Segment{},
-		}
+		segment := &Segment{}
 
 		// Set segment text
 		if annotation.Text != nil {
-			support.Segment.Text = *annotation.Text
+			segment.Text = *annotation.Text
 		}
 
 		// Set segment indices
 		if annotation.StartIndex != nil {
-			support.Segment.StartIndex = int32(*annotation.StartIndex)
+			segment.StartIndex = int32(*annotation.StartIndex)
 		}
 		if annotation.EndIndex != nil {
-			support.Segment.EndIndex = int32(*annotation.EndIndex)
+			segment.EndIndex = int32(*annotation.EndIndex)
 		}
 
 		// Map annotation URL to chunk indices
+		var chunkIndices []int32
 		if annotation.URL != nil {
 			if chunkIdx, exists := urlToIndexMap[*annotation.URL]; exists {
-				support.GroundingChunkIndices = []int32{chunkIdx}
+				chunkIndices = []int32{chunkIdx}
 			}
 		}
 
 		// Only add support if we have valid segment or chunk indices
-		if support.Segment.Text != "" || len(support.GroundingChunkIndices) > 0 {
-			groundingSupports = append(groundingSupports, support)
+		if segment.Text == "" && len(chunkIndices) == 0 {
+			continue
 		}
+
+		key := fmt.Sprintf("%d|%d|%s", segment.StartIndex, segment.EndIndex, segment.Text)
+		if support, exists := supportBySegment[key]; exists {
+			for _, chunkIdx := range chunkIndices {
+				if !slices.Contains(support.GroundingChunkIndices, chunkIdx) {
+					support.GroundingChunkIndices = append(support.GroundingChunkIndices, chunkIdx)
+				}
+			}
+			continue
+		}
+
+		support := &GroundingSupport{Segment: segment, GroundingChunkIndices: chunkIndices}
+		supportBySegment[key] = support
+		groundingSupports = append(groundingSupports, support)
 	}
 
 	if len(groundingSupports) > 0 {
@@ -3741,7 +3868,8 @@ func buildGroundingMetadataFromWebSearch(webSearchCall *schemas.ResponsesMessage
 	}
 
 	// Return nil if no meaningful data was extracted
-	if len(groundingMetadata.WebSearchQueries) == 0 && len(groundingMetadata.GroundingChunks) == 0 {
+	if len(groundingMetadata.WebSearchQueries) == 0 && len(groundingMetadata.ImageSearchQueries) == 0 &&
+		len(groundingMetadata.GroundingChunks) == 0 {
 		return nil
 	}
 
@@ -3756,7 +3884,7 @@ func emitWebSearchFromGroundingMetadata(
 ) []*schemas.BifrostResponsesStreamResponse {
 	var responses []*schemas.BifrostResponsesStreamResponse
 
-	if metadata == nil || len(metadata.WebSearchQueries) == 0 {
+	if metadata == nil || (len(metadata.WebSearchQueries) == 0 && len(metadata.ImageSearchQueries) == 0) {
 		return responses
 	}
 
@@ -3766,8 +3894,9 @@ func emitWebSearchFromGroundingMetadata(
 
 	// Build web search action
 	action := &schemas.ResponsesWebSearchToolCallAction{
-		Type:    "search",
-		Queries: metadata.WebSearchQueries,
+		Type:         "search",
+		Queries:      metadata.WebSearchQueries,
+		ImageQueries: metadata.ImageSearchQueries,
 	}
 	if len(metadata.WebSearchQueries) > 0 {
 		action.Query = &metadata.WebSearchQueries[0]
@@ -3776,16 +3905,7 @@ func emitWebSearchFromGroundingMetadata(
 	// Convert groundingChunks to sources
 	var sources []schemas.ResponsesWebSearchToolCallActionSearchSource
 	for _, chunk := range metadata.GroundingChunks {
-		if chunk.Web != nil && chunk.Web.URI != "" {
-			source := schemas.ResponsesWebSearchToolCallActionSearchSource{
-				Type: "url",
-				URL:  chunk.Web.URI,
-			}
-			if chunk.Web.Title != "" {
-				source.Title = &chunk.Web.Title
-			} else {
-				source.Title = &chunk.Web.URI // Fallback to URI
-			}
+		if source, ok := groundingChunkSource(chunk); ok {
 			sources = append(sources, source)
 		}
 	}
@@ -3937,23 +4057,21 @@ func emitAnnotationsFromGroundingSupports(
 			if chunkIdx < 0 || int(chunkIdx) >= len(metadata.GroundingChunks) {
 				continue
 			}
-			chunk := metadata.GroundingChunks[chunkIdx]
-			if chunk.Web == nil || chunk.Web.URI == "" {
+			source, ok := groundingChunkSource(metadata.GroundingChunks[chunkIdx])
+			if !ok {
 				continue
 			}
 
 			annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
 				Type: "url_citation",
-				URL:  &chunk.Web.URI,
+				URL:  &source.URL,
 			}
 			if support.Segment.Text != "" {
 				annotation.Text = &support.Segment.Text
 			}
 			annotation.StartIndex = schemas.Ptr(int(support.Segment.StartIndex))
 			annotation.EndIndex = schemas.Ptr(int(support.Segment.EndIndex))
-			if chunk.Web.Title != "" {
-				annotation.Title = &chunk.Web.Title
-			}
+			annotation.Title = source.Title
 
 			// Emit annotation.added event
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -408,6 +408,48 @@ func (i *Interval) MarshalJSON() ([]byte, error) {
 	return providerUtils.MarshalSorted(aux)
 }
 
+// WebSearch enables standard web search for grounding. Text results only.
+type WebSearch struct{}
+
+// ImageSearch enables image search for grounding. Image bytes are returned.
+type ImageSearch struct{}
+
+// SearchTypes selects which search surfaces the Google Search tool may use.
+// When unset, web search is enabled by default.
+type SearchTypes struct {
+	// Optional. Enables web search.
+	WebSearch *WebSearch `json:"webSearch,omitempty"`
+	// Optional. Enables image search.
+	ImageSearch *ImageSearch `json:"imageSearch,omitempty"`
+}
+
+// UnmarshalJSON handles both camelCase and snake_case
+func (s *SearchTypes) UnmarshalJSON(data []byte) error {
+	type Alias SearchTypes
+	aux := &struct {
+		*Alias
+		// snake_case alternatives
+		WebSearchSnake   *WebSearch   `json:"web_search,omitempty"`
+		ImageSearchSnake *ImageSearch `json:"image_search,omitempty"`
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Use snake_case if camelCase wasn't provided
+	if s.WebSearch == nil && aux.WebSearchSnake != nil {
+		s.WebSearch = aux.WebSearchSnake
+	}
+	if s.ImageSearch == nil && aux.ImageSearchSnake != nil {
+		s.ImageSearch = aux.ImageSearchSnake
+	}
+
+	return nil
+}
+
 // GoogleSearch is a tool to support Google Search in Model. Powered by Google.
 type GoogleSearch struct {
 	// Optional. Filter search results to a specific time range.
@@ -416,6 +458,8 @@ type GoogleSearch struct {
 	// Optional. List of domains to be excluded from the search results.
 	// The default limit is 2000 domains.
 	ExcludeDomains []string `json:"excludeDomains,omitempty"`
+	// Optional. The set of search types to enable. Web search when unset.
+	SearchTypes *SearchTypes `json:"searchTypes,omitempty"`
 }
 
 // UnmarshalJSON handles both camelCase and snake_case
@@ -424,8 +468,9 @@ func (g *GoogleSearch) UnmarshalJSON(data []byte) error {
 	aux := &struct {
 		*Alias
 		// snake_case alternatives
-		TimeRangeFilterSnake *Interval `json:"time_range_filter,omitempty"`
-		ExcludeDomainsSnake  []string  `json:"exclude_domains,omitempty"`
+		TimeRangeFilterSnake *Interval    `json:"time_range_filter,omitempty"`
+		ExcludeDomainsSnake  []string     `json:"exclude_domains,omitempty"`
+		SearchTypesSnake     *SearchTypes `json:"search_types,omitempty"`
 	}{
 		Alias: (*Alias)(g),
 	}
@@ -440,6 +485,9 @@ func (g *GoogleSearch) UnmarshalJSON(data []byte) error {
 	}
 	if len(g.ExcludeDomains) == 0 && len(aux.ExcludeDomainsSnake) > 0 {
 		g.ExcludeDomains = aux.ExcludeDomainsSnake
+	}
+	if g.SearchTypes == nil && aux.SearchTypesSnake != nil {
+		g.SearchTypes = aux.SearchTypesSnake
 	}
 
 	return nil
@@ -1929,10 +1977,24 @@ type GroundingChunkWeb struct {
 	URI string `json:"uri,omitempty"`
 }
 
+// Chunk from image search.
+type GroundingChunkImage struct {
+	// The web page URI for attribution.
+	SourceURI string `json:"sourceUri,omitempty"`
+	// The image asset URL.
+	ImageURI string `json:"imageUri,omitempty"`
+	// The title of the web page that the image is from.
+	Title string `json:"title,omitempty"`
+	// The root domain of the web page that the image is from.
+	Domain string `json:"domain,omitempty"`
+}
+
 // Grounding chunk.
 type GroundingChunk struct {
 	// Grounding chunk from Google Maps. This field is not supported in Gemini API.
 	Maps *GroundingChunkMaps `json:"maps,omitempty"`
+	// Grounding chunk from image search.
+	Image *GroundingChunkImage `json:"image,omitempty"`
 	// Grounding chunk from context retrieved by the retrieval tools. This field is not
 	// supported in Gemini API.
 	RetrievedContext *GroundingChunkRetrievedContext `json:"retrievedContext,omitempty"`
@@ -2017,6 +2079,8 @@ type GroundingMetadata struct {
 	SourceFlaggingUris []*GroundingMetadataSourceFlaggingURI `json:"sourceFlaggingUris,omitempty"`
 	// Optional. Web search queries for the following-up web search.
 	WebSearchQueries []string `json:"webSearchQueries,omitempty"`
+	// Optional. Image search queries used for grounding.
+	ImageSearchQueries []string `json:"imageSearchQueries,omitempty"`
 }
 
 // Candidate represents a response candidate generated from the model.

--- a/core/providers/gemini/websearchstreamstate_test.go
+++ b/core/providers/gemini/websearchstreamstate_test.go
@@ -1,6 +1,7 @@
 package gemini
 
 import (
+	"encoding/json"
 	"testing"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -253,4 +254,246 @@ func TestGeminiGroundedStreamRoundTripKeepsSearchEntryPoint(t *testing.T) {
 	assert.Equal(t, "https://vertexaisearch.cloud.google.com/grounding-api-redirect/example",
 		metadata.GroundingChunks[0].Web.URI)
 	require.Len(t, metadata.GroundingSupports, 1)
+}
+
+// TestGeminiGoogleSearchToolRoundTrip asserts the full googleSearch request surface —
+// searchTypes, excludeDomains, timeRangeFilter and the toolConfig latLng that localizes
+// results — survives genai -> Bifrost Responses -> Gemini.
+func TestGeminiGoogleSearchToolRoundTrip(t *testing.T) {
+	body := `{
+	  "contents":[{"role":"user","parts":[{"text":"eiffel tower at night"}]}],
+	  "tools":[{"googleSearch":{"searchTypes":{"imageSearch":{},"webSearch":{}},"excludeDomains":["spam.com"],
+	             "timeRangeFilter":{"startTime":"2025-01-01T00:00:00Z","endTime":"2025-02-01T00:00:00Z"}}}],
+	  "toolConfig":{"retrievalConfig":{"latLng":{"latitude":37.7749,"longitude":-122.4194}}},
+	  "model":"gemini-3.1-flash-image"
+	}`
+
+	var request GeminiGenerationRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &request))
+
+	ctx := &schemas.BifrostContext{}
+	bifrostReq := request.ToBifrostResponsesRequest(ctx)
+
+	// The neutral hop must stay on OpenAI's search_content_types enum: Gemini's
+	// webSearch returns text results, so it is carried as "text", never "web".
+	require.Len(t, bifrostReq.Params.Tools, 1)
+	assert.Equal(t, []string{"text", "image"}, bifrostReq.Params.Tools[0].ResponsesToolWebSearch.SearchContentTypes)
+
+	out, err := ToGeminiResponsesRequest(ctx, bifrostReq)
+	require.NoError(t, err)
+	require.Len(t, out.Tools, 1)
+
+	googleSearch := out.Tools[0].GoogleSearch
+	require.NotNil(t, googleSearch)
+	require.NotNil(t, googleSearch.SearchTypes, "searchTypes must survive")
+	assert.NotNil(t, googleSearch.SearchTypes.WebSearch)
+	assert.NotNil(t, googleSearch.SearchTypes.ImageSearch)
+	assert.Equal(t, []string{"spam.com"}, googleSearch.ExcludeDomains)
+	require.NotNil(t, googleSearch.TimeRangeFilter)
+
+	require.NotNil(t, out.ToolConfig)
+	require.NotNil(t, out.ToolConfig.RetrievalConfig)
+	require.NotNil(t, out.ToolConfig.RetrievalConfig.LatLng, "latLng must survive")
+	assert.Equal(t, 37.7749, *out.ToolConfig.RetrievalConfig.LatLng.Latitude)
+	assert.Equal(t, -122.4194, *out.ToolConfig.RetrievalConfig.LatLng.Longitude)
+}
+
+// TestGeminiGoogleSearchToolRoundTripSnakeCase covers the snake_case aliases, and asserts
+// an unselected search type is not synthesized on the way out.
+func TestGeminiGoogleSearchToolRoundTripSnakeCase(t *testing.T) {
+	body := `{
+	  "contents":[{"role":"user","parts":[{"text":"x"}]}],
+	  "tools":[{"google_search":{"search_types":{"image_search":{}}}}],
+	  "toolConfig":{"retrieval_config":{"latLng":{"latitude":1.5,"longitude":2.5}}},
+	  "model":"gemini-3.1-flash-image"
+	}`
+
+	var request GeminiGenerationRequest
+	require.NoError(t, json.Unmarshal([]byte(body), &request))
+
+	ctx := &schemas.BifrostContext{}
+	out, err := ToGeminiResponsesRequest(ctx, request.ToBifrostResponsesRequest(ctx))
+	require.NoError(t, err)
+	require.Len(t, out.Tools, 1)
+
+	searchTypes := out.Tools[0].GoogleSearch.SearchTypes
+	require.NotNil(t, searchTypes)
+	assert.NotNil(t, searchTypes.ImageSearch)
+	assert.Nil(t, searchTypes.WebSearch, "web search must not be synthesized when unselected")
+
+	require.NotNil(t, out.ToolConfig)
+	require.NotNil(t, out.ToolConfig.RetrievalConfig)
+	require.NotNil(t, out.ToolConfig.RetrievalConfig.LatLng)
+}
+
+// TestGeminiImageGroundingRoundTrip asserts image-search grounding survives the genai
+// round trip: the image chunk keeps its asset URL and domain alongside the page it
+// attributes to, and imageSearchQueries stay separate from webSearchQueries.
+func TestGeminiImageGroundingRoundTrip(t *testing.T) {
+	body := `{
+	  "candidates":[{
+	    "content":{"role":"model","parts":[{"text":"The Eiffel Tower is lit nightly."}]},
+	    "finishReason":"STOP",
+	    "groundingMetadata":{
+	      "webSearchQueries":["eiffel tower lighting"],
+	      "imageSearchQueries":["eiffel tower at night"],
+	      "searchEntryPoint":{"renderedContent":"<div>chip</div>"},
+	      "groundingChunks":[
+	        {"web":{"uri":"https://en.wikipedia.org/wiki/Eiffel_Tower","title":"wikipedia.org"}},
+	        {"image":{"sourceUri":"https://example.com/gallery","imageUri":"https://example.com/tower.jpg","title":"Tower gallery","domain":"example.com"}}
+	      ],
+	      "groundingSupports":[
+	        {"segment":{"startIndex":0,"endIndex":32,"text":"The Eiffel Tower is lit nightly."},"groundingChunkIndices":[0,1]}
+	      ]
+	    }
+	  }],
+	  "usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":8,"totalTokenCount":13},
+	  "modelVersion":"gemini-3.1-flash-image"
+	}`
+
+	var response GenerateContentResponse
+	require.NoError(t, json.Unmarshal([]byte(body), &response))
+
+	got := ToGeminiResponsesResponse(response.ToResponsesBifrostResponsesResponse()).Candidates[0].GroundingMetadata
+	require.NotNil(t, got)
+
+	assert.Equal(t, []string{"eiffel tower lighting"}, got.WebSearchQueries)
+	assert.Equal(t, []string{"eiffel tower at night"}, got.ImageSearchQueries)
+
+	require.Len(t, got.GroundingChunks, 2)
+	require.NotNil(t, got.GroundingChunks[0].Web)
+	assert.Equal(t, "https://en.wikipedia.org/wiki/Eiffel_Tower", got.GroundingChunks[0].Web.URI)
+
+	image := got.GroundingChunks[1].Image
+	require.NotNil(t, image, "image chunk must survive as an image chunk, not collapse to web")
+	assert.Equal(t, "https://example.com/gallery", image.SourceURI)
+	assert.Equal(t, "https://example.com/tower.jpg", image.ImageURI)
+	assert.Equal(t, "Tower gallery", image.Title)
+	assert.Equal(t, "example.com", image.Domain)
+
+	require.Len(t, got.GroundingSupports, 1)
+	assert.Equal(t, []int32{0, 1}, got.GroundingSupports[0].GroundingChunkIndices,
+		"a segment citing both a web and an image chunk must keep both")
+}
+
+// multiSourceGroundedResponse mirrors a real gemini-3.6-flash grounded answer: four
+// supports over four chunks, three of them citing two sources at once.
+func multiSourceGroundedResponse() *GenerateContentResponse {
+	return &GenerateContentResponse{
+		ResponseID:   "lqtpavmlNfrOjuMPrIHtkQo",
+		ModelVersion: "gemini-3.6-flash",
+		Candidates: []*Candidate{{
+			FinishReason: FinishReasonStop,
+			Content: &Content{
+				Role: "model",
+				Parts: []*Part{{Text: "**Spain** won UEFA Euro 2024. \n\nThey defeated **England 2-1** in the final on July 14, 2024, at the Olympiastadion in Berlin. Nico Williams scored first for Spain, followed by an equalizer from England's Cole Palmer, before Mikel Oyarzabal scored the winning goal in the 86th minute. \n\nWith this victory, Spain secured a record-breaking fourth UEFA European Championship title (having previously won in 1964, 2008, and 2012)."}},
+			},
+			GroundingMetadata: &GroundingMetadata{
+				WebSearchQueries: []string{"Euro 2024 winner"},
+				SearchEntryPoint: &SearchEntryPoint{RenderedContent: "<div>Euro 2024 winner</div>"},
+				GroundingChunks: []*GroundingChunk{
+					{Web: &GroundingChunkWeb{URI: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/a", Title: "youtube.com"}},
+					{Web: &GroundingChunkWeb{URI: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/b", Title: "youtube.com"}},
+					{Web: &GroundingChunkWeb{URI: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/c", Title: "youtube.com"}},
+					{Web: &GroundingChunkWeb{URI: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/d", Title: "wikipedia.org"}},
+				},
+				GroundingSupports: []*GroundingSupport{
+					{Segment: &Segment{EndIndex: 28, Text: "**Spain** won UEFA Euro 2024"}, GroundingChunkIndices: []int32{0}},
+					{Segment: &Segment{StartIndex: 32, EndIndex: 126, Text: "They defeated **England 2-1** in the final on July 14, 2024, at the Olympiastadion in Berlin"}, GroundingChunkIndices: []int32{0, 1}},
+					{Segment: &Segment{StartIndex: 128, EndIndex: 284, Text: "Nico Williams scored first for Spain, followed by an equalizer from England's Cole Palmer, before Mikel Oyarzabal scored the winning goal in the 86th minute"}, GroundingChunkIndices: []int32{0, 2}},
+					{Segment: &Segment{StartIndex: 288, EndIndex: 426, Text: "With this victory, Spain secured a record-breaking fourth UEFA European Championship title (having previously won in 1964, 2008, and 2012)"}, GroundingChunkIndices: []int32{0, 3}},
+				},
+			},
+		}},
+		UsageMetadata: &GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     204,
+			CandidatesTokenCount: 169,
+			TotalTokenCount:      671,
+		},
+	}
+}
+
+// TestGeminiGroundedRoundTripMergesMultiSourceSupports drives the genai passthrough loop
+// for a non-streaming grounded answer. Annotations carry one entry per (support, chunk)
+// pair, so rebuilding must regroup them by segment — otherwise the four supports here
+// come back as seven, each citing a single source with a duplicated segment.
+func TestGeminiGroundedRoundTripMergesMultiSourceSupports(t *testing.T) {
+	response := multiSourceGroundedResponse()
+	want := response.Candidates[0].GroundingMetadata
+
+	got := ToGeminiResponsesResponse(response.ToResponsesBifrostResponsesResponse()).Candidates[0].GroundingMetadata
+	require.NotNil(t, got, "grounding metadata must survive the round trip")
+
+	require.Len(t, got.GroundingSupports, len(want.GroundingSupports),
+		"supports must regroup by segment, not fan out per cited chunk")
+	for i, wantSupport := range want.GroundingSupports {
+		gotSupport := got.GroundingSupports[i]
+		assert.Equal(t, wantSupport.GroundingChunkIndices, gotSupport.GroundingChunkIndices, "support %d indices", i)
+		assert.Equal(t, wantSupport.Segment.StartIndex, gotSupport.Segment.StartIndex, "support %d start", i)
+		assert.Equal(t, wantSupport.Segment.EndIndex, gotSupport.Segment.EndIndex, "support %d end", i)
+		assert.Equal(t, wantSupport.Segment.Text, gotSupport.Segment.Text, "support %d text", i)
+	}
+
+	require.Len(t, got.GroundingChunks, len(want.GroundingChunks))
+	for i, wantChunk := range want.GroundingChunks {
+		assert.Equal(t, wantChunk.Web.URI, got.GroundingChunks[i].Web.URI, "chunk %d uri", i)
+	}
+	assert.Equal(t, want.WebSearchQueries, got.WebSearchQueries)
+	require.NotNil(t, got.SearchEntryPoint)
+	assert.Equal(t, want.SearchEntryPoint.RenderedContent, got.SearchEntryPoint.RenderedContent)
+}
+
+// TestGeminiGroundedStreamRoundTripMergesMultiSourceSupports is the streaming counterpart:
+// the reverse stream converter rebuilds grounding from the same buffered annotations.
+func TestGeminiGroundedStreamRoundTripMergesMultiSourceSupports(t *testing.T) {
+	source := multiSourceGroundedResponse()
+	want := source.Candidates[0].GroundingMetadata
+
+	// Split into the shape Gemini streams: text first, grounding on the finish event.
+	text := &GenerateContentResponse{
+		ResponseID:   source.ResponseID,
+		ModelVersion: source.ModelVersion,
+		Candidates:   []*Candidate{{Content: source.Candidates[0].Content}},
+	}
+	finish := &GenerateContentResponse{
+		ResponseID:   source.ResponseID,
+		ModelVersion: source.ModelVersion,
+		Candidates: []*Candidate{{
+			FinishReason:      FinishReasonStop,
+			GroundingMetadata: want,
+		}},
+		UsageMetadata: source.UsageMetadata,
+	}
+
+	forward := &GeminiResponsesStreamState{}
+	forward.flush()
+	reverse := NewBifrostToGeminiStreamState()
+
+	var grounded []*GroundingMetadata
+	seq := 0
+	for _, chunk := range []*GenerateContentResponse{text, finish} {
+		events, bifrostErr := chunk.ToBifrostResponsesStream(seq, forward)
+		require.Nil(t, bifrostErr, "unexpected forward conversion error")
+		seq += len(events)
+
+		for _, event := range events {
+			out := ToGeminiResponsesStreamResponse(event, reverse)
+			if out == nil {
+				continue
+			}
+			for _, candidate := range out.Candidates {
+				if candidate.GroundingMetadata != nil {
+					grounded = append(grounded, candidate.GroundingMetadata)
+				}
+			}
+		}
+	}
+
+	require.Len(t, grounded, 1, "grounding metadata must be rebuilt exactly once")
+	require.Len(t, grounded[0].GroundingSupports, len(want.GroundingSupports),
+		"supports must regroup by segment, not fan out per cited chunk")
+	for i, wantSupport := range want.GroundingSupports {
+		assert.Equal(t, wantSupport.GroundingChunkIndices, grounded[0].GroundingSupports[i].GroundingChunkIndices,
+			"support %d indices", i)
+	}
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1990,6 +1990,9 @@ type ResponsesWebSearchToolCallAction struct {
 	Queries []string                                       `json:"queries,omitempty"`
 	Sources []ResponsesWebSearchToolCallActionSearchSource `json:"sources,omitempty"`
 	Pattern *string                                        `json:"pattern,omitempty"`
+
+	// Gemini only
+	ImageQueries []string `json:"image_queries,omitempty"` // Queries run against image search, kept apart from Queries
 }
 
 // ResponsesWebSearchToolCallActionSearchSource represents a web search action search source
@@ -2001,6 +2004,10 @@ type ResponsesWebSearchToolCallActionSearchSource struct {
 	Title            *string `json:"title,omitempty"`
 	EncryptedContent *string `json:"encrypted_content,omitempty"`
 	PageAge          *string `json:"page_age,omitempty"`
+
+	// Gemini only
+	ImageURL *string `json:"image_url,omitempty"` // Image asset; URL stays the page to attribute
+	Domain   *string `json:"domain,omitempty"`    // Root domain of the source page
 }
 
 // -----------------------------------------------------------------------------
@@ -2998,7 +3005,7 @@ type ResponsesToolComputerUsePreview struct {
 type ResponsesToolWebSearch struct {
 	ExternalWebAccess  *bool                               `json:"external_web_access,omitempty"`
 	Filters            *ResponsesToolWebSearchFilters      `json:"filters,omitempty"` // Filters for the search
-	SearchContentTypes []string                            `json:"search_content_types,omitempty"`
+	SearchContentTypes []string                            `json:"search_content_types,omitempty"` // "text" | "image"
 	SearchContextSize  *string                             `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
 	UserLocation       *ResponsesToolWebSearchUserLocation `json:"user_location,omitempty"`       // The approximate location of the user
 
@@ -3082,6 +3089,10 @@ type ResponsesToolWebSearchUserLocation struct {
 	Region   *string `json:"region,omitempty"`   // Free text input for the region
 	Timezone *string `json:"timezone,omitempty"` // IANA timezone
 	Type     *string `json:"type,omitempty"`     // always "approximate"
+
+	// Gemini only
+	Latitude  *float64 `json:"latitude,omitempty"`  // Degrees, [-90.0, +90.0]
+	Longitude *float64 `json:"longitude,omitempty"` // Degrees, [-180.0, +180.0]
 }
 
 // ResponsesToolMCP - Give the model access to additional tools via remote MCP servers


### PR DESCRIPTION
## Summary

Extends the Gemini provider's Google Search grounding support to cover image search: `searchTypes` (web + image), image grounding chunks, image search queries, and search localization via `latLng`. Also fixes a bug where multi-source grounding supports were fanned out into one support per cited chunk instead of being regrouped by segment.

## Changes

- Added `SearchTypes`, `WebSearch`, and `ImageSearch` types to `types.go`, with camelCase/snake_case `UnmarshalJSON` support. `GoogleSearch` now carries a `SearchTypes` field.
- Added `GroundingChunkImage` to represent image-search grounding chunks (with `sourceUri`, `imageUri`, `title`, `domain`). `GroundingChunk` now includes an `Image` field alongside `Web`.
- Added `ImageSearchQueries` to `GroundingMetadata` to keep image queries separate from web queries.
- Introduced `groundingChunkSource` helper that normalizes both web and image chunks into a `ResponsesWebSearchToolCallActionSearchSource`, replacing scattered inline chunk-to-source conversions throughout `responses.go`.
- `search_content_types` on `ResponsesToolWebSearch` now maps `"text"` → `WebSearch` and `"image"` → `ImageSearch` when converting to/from Gemini's `searchTypes`.
- Search localization (`latLng` from `toolConfig.retrievalConfig`) is now round-tripped through `ResponsesToolWebSearchUserLocation.Latitude/Longitude` so it survives the Gemini → Bifrost Responses → Gemini hop.
- `ImageQueries` added to `ResponsesWebSearchToolCallAction` and `ImageURL`/`Domain` added to `ResponsesWebSearchToolCallActionSearchSource` to carry image-specific grounding data through the neutral schema.
- Fixed `buildGroundingMetadataFromWebSearch`: annotations were previously emitting one `GroundingSupport` per `(segment, chunk)` pair. They are now regrouped by segment key so multi-source supports correctly list all cited chunk indices rather than duplicating the segment.
- `emitWebSearchFromGroundingMetadata` and `emitAnnotationsFromGroundingSupports` updated to handle image chunks via `groundingChunkSource` and to propagate `ImageQueries`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
```

New tests cover:
- `TestGeminiGoogleSearchToolRoundTrip` — verifies `searchTypes`, `excludeDomains`, `timeRangeFilter`, and `latLng` survive a full Gemini → Bifrost Responses → Gemini round trip.
- `TestGeminiGoogleSearchToolRoundTripSnakeCase` — same for snake_case input; asserts unselected search types are not synthesized.
- `TestGeminiImageGroundingRoundTrip` — verifies image chunks keep their asset URL and domain, and that `imageSearchQueries` stay separate from `webSearchQueries`.
- `TestGeminiGroundedRoundTripMergesMultiSourceSupports` — non-streaming path: four supports over four chunks, three citing two sources, must come back as four supports (not seven).
- `TestGeminiGroundedStreamRoundTripMergesMultiSourceSupports` — streaming counterpart of the above.
- `TestToBifrostCountTokensResponseCachedContent` — locks cached-token accounting so cache modalities are never folded into the breakdown a second time.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. `latLng` coordinates flow through the existing tool config path and are not persisted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable