### PR TITLE
chore(ui): bump axios to 1.18.1 to clear audit advisories

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -40,7 +40,7 @@
 				"@tanstack/react-router": "1.168.10",
 				"@tanstack/react-table": "8.21.3",
 				"@xyflow/react": "12.10.1",
-				"axios": "1.16.1",
+				"axios": "1.18.1",
 				"canvas-confetti": "1.9.3",
 				"class-variance-authority": "0.7.1",
 				"clsx": "2.1.1",
@@ -5177,9 +5177,9 @@
 			"license": "MIT"
 		},
 		"node_modules/axios": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.16.0",
@@ -8123,9 +8123,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -8476,9 +8476,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+			"integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
 			"dev": true,
 			"funding": [
 				{
@@ -8496,7 +8496,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/ui/package.json
+++ b/ui/package.json
@@ -47,7 +47,7 @@
 		"@tanstack/react-router": "1.168.10",
 		"@tanstack/react-table": "8.21.3",
 		"@xyflow/react": "12.10.1",
-		"axios": "1.16.1",
+		"axios": "1.18.1",
 		"canvas-confetti": "1.9.3",
 		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",


### PR DESCRIPTION
## What

Bumps `axios` in `ui/` from `1.16.1` to `1.18.1`.

## Why

`npm audit` flagged one high-severity finding covering ten advisories, all affecting `axios 1.0.0 – 1.17.0`:

**Prototype pollution** — polluted `Object.prototype` keys leak into axios' request-config merge, allowing an injected `Basic` auth header, a rewritten URL/proxy, or a bypassed form-serializer `maxDepth` guard.
- [GHSA-xj6q-8x83-jv6g](https://github.com/advisories/GHSA-xj6q-8x83-jv6g), [GHSA-mmx7-hfxf-jppx](https://github.com/advisories/GHSA-mmx7-hfxf-jppx), [GHSA-7q8q-rj6j-mhjq](https://github.com/advisories/GHSA-7q8q-rj6j-mhjq), [GHSA-hcpx-6fm6-wx23](https://github.com/advisories/GHSA-hcpx-6fm6-wx23)

**Denial of service** — deeply nested keys recurse without bound in `formDataToJSON`, exhausting the stack.
- [GHSA-42h9-826w-cgv3](https://github.com/advisories/GHSA-42h9-826w-cgv3), [GHSA-pmv8-rq9r-6j72](https://github.com/advisories/GHSA-pmv8-rq9r-6j72)

**Limit / proxy bypass** — fetch `ReadableStream` and HTTP/2 uploads skip `maxBodyLength`; `NO_PROXY` misses `0.0.0.0`; the Node adapter reuses an inherited proxy after interceptor config cloning.
- [GHSA-jqh4-m9w3-8hp9](https://github.com/advisories/GHSA-jqh4-m9w3-8hp9), [GHSA-mwf2-3pr3-8698](https://github.com/advisories/GHSA-mwf2-3pr3-8698), [GHSA-f4gw-2p7v-4548](https://github.com/advisories/GHSA-f4gw-2p7v-4548), [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9)

Practical exposure was low — this is browser-side UI code, so the Node-adapter proxy and HTTP/2 items don't apply and the DoS paths need attacker-controlled form data. The prototype-pollution set is the real reason to patch.

`1.18.1` is the first patched version for all ten. `axios` was a direct, exact-pinned dependency, so bumping the pin was sufficient — no `npm audit fix --force` and no transitive overrides needed.

## Testing

- `npm audit` → `{critical: 0, high: 0, moderate: 0, low: 0, total: 0}`
- `tsc --noEmit` passes clean

## Note

The lockfile diff also carries pre-existing `nanoid` 3.3.12 → 3.3.16 and `postcss` 8.5.15 → 8.5.24 bumps that were already present in the working tree before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)