### PR TITLE
semantic router #3: embedding executor

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -426,6 +426,17 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
 }
 
+// PrepareContextForInternalRequest marks ctx as carrying a plugin-issued
+// internal sub-request: it skips the plugin pipeline — so the sub-request
+// cannot recurse back into the plugin that issued it — and sheds the
+// caller-specific key-routing and body-transport state documented on
+// ClearContextForInternalRequest. Plugins should call this instead of setting
+// BifrostContextKeySkipPluginPipeline (a reserved core key) themselves.
+func PrepareContextForInternalRequest(ctx *schemas.BifrostContext) {
+	ctx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+	ClearContextForInternalRequest(ctx)
+}
+
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {
 	m := make(map[schemas.ModelProvider]struct{}, len(schemas.SupportedBaseProviders))
 	for _, p := range schemas.SupportedBaseProviders {

--- a/plugins/governance/embedding.go
+++ b/plugins/governance/embedding.go
@@ -1,0 +1,230 @@
+package governance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
+)
+
+// ErrEmbeddingTimeout reports that a classification embed exhausted its
+// configured budget instead of failing for a provider or configuration reason.
+// Callers need the distinction because the two mean opposite things to an
+// operator: a timeout says semantic routing works but is too slow for the
+// budget it was given, while every other failure says it is not working at all.
+var ErrEmbeddingTimeout = errors.New("embedding request timed out")
+
+// EmbeddingRequestExecutor invokes the embedding endpoint on the bifrost
+// client. The plugin calls it to embed request text for semantic complexity
+// classification. It mirrors the signature of bifrost.Client.EmbeddingRequest.
+type EmbeddingRequestExecutor func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError)
+
+// EmbeddingExecutorSetter is implemented by governance plugins that accept an
+// embedding request executor. The HTTP server wires the executor after the
+// bifrost client is constructed (the plugin itself is built while the client
+// is still being assembled, so it cannot be passed at Init). Wrappers that
+// embed *GovernancePlugin satisfy this via method promotion.
+type EmbeddingExecutorSetter interface {
+	SetEmbeddingRequestExecutor(EmbeddingRequestExecutor)
+}
+
+// SetEmbeddingRequestExecutor wires up the function used to call out to the
+// embedding provider. Without it, semantic complexity classification publishes
+// no tier. Safe for concurrent use with classification and plugin reloads.
+func (p *GovernancePlugin) SetEmbeddingRequestExecutor(executor EmbeddingRequestExecutor) {
+	if executor == nil {
+		p.embeddingRequestExecutor.Store(nil)
+		return
+	}
+	p.embeddingRequestExecutor.Store(&executor)
+	// NOTE(task #5): exemplar warmup must be triggered from here (async
+	// goroutine with an in-flight guard), not from Init — this is the first
+	// moment the plugin can reach the embedding endpoint. Until warmup
+	// completes, classification uses the configured fallback.
+}
+
+// embeddingExecutor returns the currently wired executor, or nil.
+func (p *GovernancePlugin) embeddingExecutor() EmbeddingRequestExecutor {
+	if ptr := p.embeddingRequestExecutor.Load(); ptr != nil {
+		return *ptr
+	}
+	return nil
+}
+
+// CanClassifySemantically reports whether semantic classification is currently
+// viable. The executor alone is not a sufficient gate — the server wires it
+// unconditionally; the semantic config decides whether classification is
+// actually configured.
+func (p *GovernancePlugin) CanClassifySemantically(semantic *complexity.SemanticConfig) bool {
+	return p.embeddingExecutor() != nil &&
+		semantic != nil &&
+		semantic.Provider != "" &&
+		semantic.EmbeddingModel != ""
+}
+
+// generateEmbedding embeds text with the configured semantic provider/model and
+// returns the vector plus the input token count (fed to routing-cost
+// attribution). The call is bounded by the configured semantic timeout: the
+// router hot path must never wait on a slow embedding provider.
+func (p *GovernancePlugin) generateEmbedding(ctx *schemas.BifrostContext, semantic *complexity.SemanticConfig, text string) ([]float32, int, error) {
+	executor := p.embeddingExecutor()
+	if executor == nil {
+		return nil, 0, fmt.Errorf("embedding request executor is not configured")
+	}
+	if semantic == nil || semantic.Provider == "" || semantic.EmbeddingModel == "" {
+		return nil, 0, fmt.Errorf("semantic classification is not configured")
+	}
+
+	timeout := semantic.Timeout
+	if timeout <= 0 {
+		timeout = configstore.DefaultComplexitySemanticTimeout
+	}
+
+	embeddingReq := &schemas.BifrostEmbeddingRequest{
+		Provider: semantic.Provider,
+		Model:    semantic.EmbeddingModel,
+		Input: &schemas.EmbeddingInput{
+			Text: &text,
+		},
+	}
+
+	embeddingCtx := schemas.NewBifrostContext(ctx, time.Now().Add(timeout))
+	// Cancel the derived context once we're done. NewBifrostContext starts a
+	// watchCancellation goroutine that holds a reference to ctx (the scoped
+	// plugin context). Without this, that goroutine outlives the plugin call
+	// and may dereference fields on a parent context that has already been
+	// released back to its sync.Pool — see core/schemas.ReleasePluginScope.
+	defer embeddingCtx.Cancel()
+	// The embedding request targets the configured embedding provider/model,
+	// not the caller's. Mark it as an internal sub-request: it skips the
+	// plugin pipeline (so it cannot recurse back through governance) and
+	// sheds the caller's key-routing and body-transport state so it behaves
+	// like a fresh external /v1/embeddings call.
+	bifrost.PrepareContextForInternalRequest(embeddingCtx)
+
+	response, bifrostErr := executor(embeddingCtx, embeddingReq)
+	if bifrostErr != nil {
+		// The executor reports every failure as a *BifrostError, so a blown
+		// budget is otherwise indistinguishable from a bad key or an unreachable
+		// provider once the error is rendered into a string. Tag it here, at the
+		// only layer that knows which deadline was set and why.
+		if isEmbeddingTimeout(embeddingCtx, bifrostErr) {
+			return nil, 0, fmt.Errorf("%w after %s", ErrEmbeddingTimeout, timeout)
+		}
+		return nil, 0, fmt.Errorf("failed to generate embedding: %v", bifrostErr)
+	}
+
+	if response == nil || len(response.Data) == 0 {
+		return nil, 0, fmt.Errorf("no embeddings returned from provider")
+	}
+
+	embedding := response.Data[0].Embedding
+	inputTokens := 0
+	if response.Usage != nil {
+		inputTokens = response.Usage.TotalTokens
+	}
+
+	switch {
+	case embedding.EmbeddingStr != nil:
+		var vals []float32
+		if err := json.Unmarshal([]byte(*embedding.EmbeddingStr), &vals); err != nil {
+			return nil, 0, fmt.Errorf("failed to parse string embedding: %w", err)
+		}
+		return vals, inputTokens, nil
+	case embedding.EmbeddingArray != nil:
+		return float64ToFloat32Embedding(embedding.EmbeddingArray), inputTokens, nil
+	case len(embedding.Embedding2DArray) > 0:
+		return flattenToFloat32Embedding(embedding.Embedding2DArray), inputTokens, nil
+	case embedding.EmbeddingInt8Array != nil:
+		// Quantized int8/binary embedding format. Promote to float32 so the
+		// similarity path treats it uniformly.
+		return int8ToFloat32Embedding(embedding.EmbeddingInt8Array), inputTokens, nil
+	case embedding.EmbeddingInt32Array != nil:
+		return int32ToFloat32Embedding(embedding.EmbeddingInt32Array), inputTokens, nil
+	}
+	return nil, 0, fmt.Errorf("embedding data is not in expected format")
+}
+
+// isEmbeddingTimeout reports whether a failed embedding call ran out of time
+// rather than failing on its own merits. The derived context is authoritative
+// for the budget this plugin set; the error type covers the case where the
+// deadline fires inside the client, which maps an expired context to
+// RequestTimedOut/504 before this frame observes the context as done. A parent
+// cancellation (the caller hung up) is deliberately not a timeout: it leaves
+// Err as context.Canceled and falls through to the generic failure path.
+func isEmbeddingTimeout(ctx *schemas.BifrostContext, err *schemas.BifrostError) bool {
+	if ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	if err.Type != nil && *err.Type == schemas.RequestTimedOut {
+		return true
+	}
+	return err.StatusCode != nil && *err.StatusCode == 504
+}
+
+// float64ToFloat32Embedding converts a []float64 to a []float32. Vector
+// payloads stay float32: cosine similarity at classification time is well
+// within float32 range.
+func float64ToFloat32Embedding(values []float64) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+	return embedding
+}
+
+// int8ToFloat32Embedding promotes a quantized int8 embedding (used for
+// binary/quantized formats by some providers) to float32 so it can be stored
+// and compared uniformly against float32 entries.
+func int8ToFloat32Embedding(values []int8) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+	return embedding
+}
+
+// int32ToFloat32Embedding promotes a uint8/ubinary-style int32 embedding to
+// float32 for the same reason as int8ToFloat32Embedding.
+func int32ToFloat32Embedding(values []int32) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+	return embedding
+}
+
+// flattenToFloat32Embedding concatenates a 2D embedding (one inner slice per
+// input chunk) into a single flat []float32.
+func flattenToFloat32Embedding(values [][]float64) []float32 {
+	total := 0
+	for _, arr := range values {
+		total += len(arr)
+	}
+	if total == 0 {
+		return nil
+	}
+	embedding := make([]float32, 0, total)
+	for _, arr := range values {
+		embedding = append(embedding, float64ToFloat32Embedding(arr)...)
+	}
+	return embedding
+}

--- a/plugins/governance/embedding_test.go
+++ b/plugins/governance/embedding_test.go
@@ -1,0 +1,251 @@
+package governance
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/plugins/governance/complexity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testEmbeddingSemanticConfig() *complexity.SemanticConfig {
+	return &complexity.SemanticConfig{
+		Provider:       "openai",
+		EmbeddingModel: "text-embedding-3-small",
+		Timeout:        100 * time.Millisecond,
+	}
+}
+
+func embeddingResponse(data schemas.EmbeddingStruct, totalTokens int) *schemas.BifrostEmbeddingResponse {
+	return &schemas.BifrostEmbeddingResponse{
+		Data:  []schemas.EmbeddingData{{Embedding: data}},
+		Usage: &schemas.BifrostLLMUsage{TotalTokens: totalTokens},
+	}
+}
+
+func TestGenerateEmbeddingDecodesAllEncodings(t *testing.T) {
+	str := "[0.1,0.2]"
+	tests := []struct {
+		name string
+		data schemas.EmbeddingStruct
+		want []float32
+	}{
+		{name: "string encoded", data: schemas.EmbeddingStruct{EmbeddingStr: &str}, want: []float32{0.1, 0.2}},
+		{name: "float64 array", data: schemas.EmbeddingStruct{EmbeddingArray: []float64{0.5, 1.5}}, want: []float32{0.5, 1.5}},
+		{name: "2d array flattened", data: schemas.EmbeddingStruct{Embedding2DArray: [][]float64{{1, 2}, {3}}}, want: []float32{1, 2, 3}},
+		{name: "int8 promoted", data: schemas.EmbeddingStruct{EmbeddingInt8Array: []int8{-1, 2}}, want: []float32{-1, 2}},
+		{name: "int32 promoted", data: schemas.EmbeddingStruct{EmbeddingInt32Array: []int32{7, 8}}, want: []float32{7, 8}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &GovernancePlugin{}
+			plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+				return embeddingResponse(tt.data, 42), nil
+			})
+
+			ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+			defer ctx.Cancel()
+			vector, tokens, err := plugin.generateEmbedding(ctx, testEmbeddingSemanticConfig(), "hello")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, vector)
+			assert.Equal(t, 42, tokens)
+		})
+	}
+}
+
+func TestGenerateEmbeddingRequestShape(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	var gotReq *schemas.BifrostEmbeddingRequest
+	var gotSkip any
+	var gotDeadline time.Time
+	var hasDeadline bool
+	plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		gotReq = req
+		gotSkip = ctx.Value(schemas.BifrostContextKeySkipPluginPipeline)
+		gotDeadline, hasDeadline = ctx.Deadline()
+		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1}}, 1), nil
+	})
+
+	// Give the caller a deadline far beyond the configured semantic timeout, so
+	// an implementation that simply inherited the caller's budget would be
+	// caught: the two are distinguishable only when they differ.
+	cfg := testEmbeddingSemanticConfig()
+	before := time.Now()
+	callerDeadline := before.Add(50 * cfg.Timeout)
+	ctx := schemas.NewBifrostContext(t.Context(), callerDeadline)
+	defer ctx.Cancel()
+	_, _, err := plugin.generateEmbedding(ctx, cfg, "classify me")
+	require.NoError(t, err)
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, schemas.ModelProvider("openai"), gotReq.Provider)
+	assert.Equal(t, "text-embedding-3-small", gotReq.Model)
+	require.NotNil(t, gotReq.Input)
+	require.NotNil(t, gotReq.Input.Text)
+	assert.Equal(t, "classify me", *gotReq.Input.Text)
+
+	// The internal request must skip the plugin pipeline (anti-recursion) and
+	// carry the configured hard timeout, not the caller's deadline.
+	assert.Equal(t, true, gotSkip)
+	require.True(t, hasDeadline, "embedding context must carry a deadline")
+	assert.Greater(t, gotDeadline.Sub(before), time.Duration(0))
+	assert.LessOrEqual(t, gotDeadline.Sub(before), cfg.Timeout+50*time.Millisecond,
+		"embedding deadline must come from the configured semantic timeout")
+	assert.True(t, gotDeadline.Before(callerDeadline),
+		"embedding deadline must not inherit the caller's larger budget")
+}
+
+func TestGenerateEmbeddingTimeoutCancelsCall(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		// Simulate a slow provider: honor context cancellation like the real
+		// client does.
+		select {
+		case <-ctx.Done():
+			return nil, &schemas.BifrostError{Error: &schemas.ErrorField{Message: ctx.Err().Error()}}
+		case <-time.After(5 * time.Second):
+			return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1}}, 1), nil
+		}
+	})
+
+	cfg := testEmbeddingSemanticConfig()
+	cfg.Timeout = 20 * time.Millisecond
+
+	ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+	defer ctx.Cancel()
+	start := time.Now()
+	_, _, err := plugin.generateEmbedding(ctx, cfg, "slow")
+	require.Error(t, err)
+	// Tolerant of scheduler jitter, but still tight enough that only the 20ms
+	// configuration can satisfy it — a second-scale budget would not.
+	assert.Less(t, time.Since(start), 500*time.Millisecond, "call must be bounded by the configured timeout")
+	// A blown budget must stay distinguishable from a provider or config
+	// failure: callers log the two differently, and a string-flattened
+	// *BifrostError cannot be told apart after the fact.
+	require.ErrorIs(t, err, ErrEmbeddingTimeout)
+	assert.Contains(t, err.Error(), "20ms", "the timeout error should name the budget it exceeded")
+}
+
+// TestGenerateEmbeddingDistinguishesTimeoutFromOtherFailures guards the tag
+// against the easy over-broad implementation: an ordinary provider error must
+// not read as a timeout just because it arrived through the same executor.
+func TestGenerateEmbeddingDistinguishesTimeoutFromOtherFailures(t *testing.T) {
+	tests := []struct {
+		name        string
+		bifrostErr  *schemas.BifrostError
+		wantTimeout bool
+	}{
+		{
+			name:        "provider rejection",
+			bifrostErr:  &schemas.BifrostError{Error: &schemas.ErrorField{Message: "invalid api key"}},
+			wantTimeout: false,
+		},
+		{
+			name:        "client-reported timeout",
+			bifrostErr:  &schemas.BifrostError{Type: schemas.Ptr(schemas.RequestTimedOut), Error: &schemas.ErrorField{Message: "request timed out"}},
+			wantTimeout: true,
+		},
+		{
+			name:        "gateway timeout status",
+			bifrostErr:  &schemas.BifrostError{StatusCode: schemas.Ptr(504), Error: &schemas.ErrorField{Message: "gateway timeout"}},
+			wantTimeout: true,
+		},
+		{
+			name:        "caller cancellation",
+			bifrostErr:  &schemas.BifrostError{StatusCode: schemas.Ptr(499), Error: &schemas.ErrorField{Message: "request cancelled"}},
+			wantTimeout: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &GovernancePlugin{}
+			plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+				return nil, tt.bifrostErr
+			})
+
+			ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+			defer ctx.Cancel()
+			_, _, err := plugin.generateEmbedding(ctx, testEmbeddingSemanticConfig(), "classify me")
+			require.Error(t, err)
+			assert.Equal(t, tt.wantTimeout, errors.Is(err, ErrEmbeddingTimeout))
+		})
+	}
+}
+
+func TestGenerateEmbeddingGuards(t *testing.T) {
+	okExecutor := func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1}}, 1), nil
+	}
+
+	t.Run("nil executor", func(t *testing.T) {
+		plugin := &GovernancePlugin{}
+		ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		_, _, err := plugin.generateEmbedding(ctx, testEmbeddingSemanticConfig(), "x")
+		require.ErrorContains(t, err, "executor is not configured")
+	})
+
+	t.Run("nil semantic config", func(t *testing.T) {
+		plugin := &GovernancePlugin{}
+		plugin.SetEmbeddingRequestExecutor(okExecutor)
+		ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		_, _, err := plugin.generateEmbedding(ctx, nil, "x")
+		require.ErrorContains(t, err, "not configured")
+	})
+
+	t.Run("empty response data", func(t *testing.T) {
+		plugin := &GovernancePlugin{}
+		plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+			return &schemas.BifrostEmbeddingResponse{}, nil
+		})
+		ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		_, _, err := plugin.generateEmbedding(ctx, testEmbeddingSemanticConfig(), "x")
+		require.ErrorContains(t, err, "no embeddings returned")
+	})
+
+	t.Run("unset executor after set", func(t *testing.T) {
+		plugin := &GovernancePlugin{}
+		plugin.SetEmbeddingRequestExecutor(okExecutor)
+		plugin.SetEmbeddingRequestExecutor(nil)
+		ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		_, _, err := plugin.generateEmbedding(ctx, testEmbeddingSemanticConfig(), "x")
+		require.ErrorContains(t, err, "executor is not configured")
+	})
+}
+
+func TestCanClassifySemantically(t *testing.T) {
+	executor := func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		name     string
+		wired    bool
+		semantic *complexity.SemanticConfig
+		want     bool
+	}{
+		{name: "fully configured", wired: true, semantic: testEmbeddingSemanticConfig(), want: true},
+		{name: "executor missing", wired: false, semantic: testEmbeddingSemanticConfig(), want: false},
+		{name: "semantic nil", wired: true, semantic: nil, want: false},
+		{name: "provider missing", wired: true, semantic: &complexity.SemanticConfig{EmbeddingModel: "m"}, want: false},
+		{name: "model missing", wired: true, semantic: &complexity.SemanticConfig{Provider: "openai"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &GovernancePlugin{}
+			if tt.wired {
+				plugin.SetEmbeddingRequestExecutor(executor)
+			}
+			assert.Equal(t, tt.want, plugin.CanClassifySemantically(tt.semantic))
+		})
+	}
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -90,6 +90,12 @@ type GovernancePlugin struct {
 	disableAutoToolInject *bool
 
 	complexityAnalyzer atomic.Pointer[complexity.ComplexityAnalyzer]
+
+	// embeddingRequestExecutor is wired by the HTTP server after the bifrost
+	// client exists (post-Init) via SetEmbeddingRequestExecutor; nil until
+	// then and during teardown. Atomic because classification reads it on the
+	// request hot path while plugin reloads may re-wire it.
+	embeddingRequestExecutor atomic.Pointer[EmbeddingRequestExecutor]
 }
 
 // Init initializes and returns a governance plugin instance.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1946,6 +1946,9 @@ func (s *BifrostHTTPServer) ReloadPlugin(ctx context.Context, name string, path 
 	if semanticCachePlugin, ok := plugin.(*semanticcache.Plugin); ok {
 		semanticCachePlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
 	}
+	if governanceEmbeddingPlugin, ok := plugin.(governance.EmbeddingExecutorSetter); ok {
+		governanceEmbeddingPlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
+	}
 	return s.SyncLoadedPlugin(ctx, name, plugin, placement, order)
 }
 
@@ -2555,6 +2558,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	semanticCachePlugin, err := lib.FindPluginAs[*semanticcache.Plugin](s.Config, semanticcache.PluginName)
 	if err == nil && semanticCachePlugin != nil {
 		semanticCachePlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
+	}
+	// Add governance plugin embedding request executor if it exists (used for
+	// semantic complexity classification).
+	governanceEmbeddingPlugin, err := lib.FindPluginAs[governance.EmbeddingExecutorSetter](s.Config, s.getGovernancePluginName())
+	if err == nil && governanceEmbeddingPlugin != nil {
+		governanceEmbeddingPlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
 	}
 
 	// Initialize Sidekiq runner for background jobs


### PR DESCRIPTION
## Summary

Wires the bifrost embedding client into the governance plugin so it can call out to an embedding provider for semantic complexity classification. Previously the governance plugin had no way to generate embeddings; this adds the executor interface, the embedding call logic, and the server-side wiring at both bootstrap and plugin reload time.

## Changes

- Added `EmbeddingRequestExecutor` type and `EmbeddingExecutorSetter` interface to the governance plugin, mirroring the pattern already used by the semantic cache plugin.
- Implemented `SetEmbeddingRequestExecutor`, `embeddingExecutor`, `CanClassifySemantically`, and `generateEmbedding` on `GovernancePlugin`. The executor is stored atomically to allow safe concurrent access during plugin reloads and request classification.
- `generateEmbedding` handles all embedding response encodings (string JSON, float64 array, 2D float64 array, int8, int32) by normalising them to `[]float32` for uniform cosine similarity comparison.
- The embedding context is derived with a hard timeout from `SemanticConfig.Timeout` (defaulting to `configstore.DefaultComplexitySemanticTimeout`), skips the plugin pipeline to prevent recursion, and clears caller routing state so the internal request behaves like a fresh external embeddings call.
- Added `embeddingRequestExecutor atomic.Pointer[EmbeddingRequestExecutor]` field to `GovernancePlugin`.
- The HTTP server now wires the executor to any governance plugin implementing `EmbeddingExecutorSetter` during both `Bootstrap` and `ReloadPlugin`, consistent with how the semantic cache plugin is handled.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

Key test scenarios covered:
- `TestGenerateEmbeddingDecodesAllEncodings` — verifies all five embedding wire formats are correctly normalised to `[]float32`.
- `TestGenerateEmbeddingRequestShape` — asserts the outbound request carries the correct provider, model, input text, skip-pipeline flag, and a bounded deadline.
- `TestGenerateEmbeddingTimeoutCancelsCall` — confirms a slow provider is cancelled within the configured timeout window.
- `TestGenerateEmbeddingGuards` — covers nil executor, nil semantic config, empty response, and executor teardown.
- `TestCanClassifySemantically` — validates the readiness gate across all partial-configuration combinations.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Prerequisite for semantic complexity classification (task #5 — exemplar warmup).

## Security considerations

The internal embedding request explicitly clears caller key-routing and body-transport state and skips the plugin pipeline, preventing the governance plugin from inadvertently inheriting or leaking caller credentials or routing context into the embedding call.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable