### PR TITLE
seleector ux fixes

### DIFF
--- a/ui/components/entitySelectors/entitySelector.tsx
+++ b/ui/components/entitySelectors/entitySelector.tsx
@@ -21,6 +21,7 @@
 
 import { CheckIcon, ChevronDownIcon, PlusIcon } from "lucide-react";
 import { type ComponentType, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { components } from "react-select";
 
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
@@ -308,6 +309,10 @@ export function EntitySelector(props: EntitySelectorProps) {
 						if (props.multiple !== true) return;
 						props.onChange(selected.map((option) => option.value));
 					}}
+					// Dialog's centering transform turns the menu's `position: fixed`
+					// into relative-to-dialog instead of relative-to-viewport, which
+					// clips it; portaling to body escapes that ancestor entirely.
+					menuPortalTarget={typeof document !== "undefined" ? document.body : undefined}
 					// Clearing the input never reaches `reload`, so mirror every
 					// keystroke into the search state instead.
 					onInputChange={(inputValue) => onSearchChange(inputValue)}
@@ -319,24 +324,26 @@ export function EntitySelector(props: EntitySelectorProps) {
 					noOptionsMessage={() => (isError ? errorMessage : emptyMessage)}
 					views={{
 						option: (optionProps) => {
+							const { Option } = components;
 							const data = optionProps.data as Option<EntityOptionMeta>;
+							const isLast = optionProps.options[optionProps.options.length - 1] === optionProps.data;
 							return (
-								<div
+								<Option
+									{...optionProps}
 									className={cn(
 										"flex w-full cursor-pointer flex-col gap-0.5 rounded-sm p-2 text-sm",
-										optionProps.isFocused && "bg-background-highlight-primary/60",
-										optionProps.isSelected && "bg-background-highlight-primary/40",
+										optionProps.isFocused && "bg-accent",
+										isLast && "mb-2",
 									)}
-									onClick={() => optionProps.selectOption(optionProps.data)}
 								>
 									<div className="flex items-center justify-between">
-										<span className="text-content-primary font-medium">{data.label}</span>
-										{optionProps.isSelected && <span className="text-primary text-xs">Selected</span>}
+										<span className="font-medium">{data.label}</span>
+										<CheckIcon className={cn("ml-auto size-3.5 shrink-0", optionProps.isSelected ? "opacity-100" : "opacity-0")} />
 									</div>
 									{data.meta?.description && data.meta.description !== data.label && (
-										<span className="text-content-tertiary line-clamp-1 text-xs">{data.meta.description}</span>
+										<span className="text-muted-foreground line-clamp-1 text-xs">{data.meta.description}</span>
 									)}
-								</div>
+								</Option>
 							);
 						},
 					}}

--- a/ui/components/ui/asyncMultiselect.tsx
+++ b/ui/components/ui/asyncMultiselect.tsx
@@ -421,7 +421,11 @@ export function AsyncMultiSelect<T>(props: AsyncMultiSelectProps<T>) {
 				}
 				inputValue={props.inputValue}
 				styles={{
-					menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+					// react-remove-scroll (used by Radix Dialog/Sheet while open) sets
+					// `pointer-events: none` on body; a menu portaled to body inherits
+					// that and never gets it back, so force it here (same fix as the
+					// Sonner toaster override in globals.css).
+					menuPortal: (base) => ({ ...base, zIndex: 9999, pointerEvents: "auto" }),
 					control: (base) => ({ ...base, boxShadow: "none", minHeight: "32px" }),
 					multiValue: () => ({}),
 					multiValueLabel: () => ({}),


### PR DESCRIPTION
## Summary

Fixes the `EntitySelector` dropdown menu being clipped when rendered inside a Radix Dialog, and restores pointer interaction on the portaled menu when a Dialog or Sheet is open.

## Changes

- Adds `menuPortalTarget={document.body}` to the `AsyncMultiSelect` inside `EntitySelector` so the dropdown escapes the Dialog's centering transform, which was causing `position: fixed` to be calculated relative to the dialog ancestor rather than the viewport.
- Adds `pointerEvents: "auto"` to the `menuPortal` style override in `AsyncMultiSelect` to counteract `react-remove-scroll` setting `pointer-events: none` on `body` while a Radix Dialog or Sheet is open, which was making the portaled menu unclickable.
- Replaces the custom `<div>` option renderer with react-select's `<Option>` component so that built-in accessibility and selection behaviour is preserved.
- Updates option highlight styling to use `bg-accent` and replaces the "Selected" text label with a `CheckIcon` that fades in/out based on selection state.
- Adds a bottom margin to the last option in the list for visual spacing.
- Replaces `text-content-primary` / `text-content-tertiary` tokens with `font-medium` and `text-muted-foreground` to align with the design system.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open any dialog that contains an `EntitySelector`.
2. Click the selector to open the dropdown — confirm it is not clipped and renders over the dialog.
3. Click an option — confirm it is selectable and the check icon appears.
4. Confirm the dropdown closes and the selected value is reflected correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: dropdown menu was clipped inside the dialog and/or unclickable due to `pointer-events: none` on body.

After: dropdown renders correctly over the dialog and all options are interactive.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable