### PR TITLE
fix: add `no-padding-parent` and consistent padding across workspace pages

### DIFF
--- a/ui/app/workspace/adaptive-routing/page.tsx
+++ b/ui/app/workspace/adaptive-routing/page.tsx
@@ -2,7 +2,7 @@ import AdaptiveRoutingView from "@enterprise/components/adaptive-routing/adaptiv
 
 export default function AdaptiveRoutingPage() {
 	return (
-		<div className="mx-auto w-full">
+		<div className="mx-auto w-full no-padding-parent p-4">
 			<AdaptiveRoutingView />
 		</div>
 	);

--- a/ui/app/workspace/config/caching/page.tsx
+++ b/ui/app/workspace/config/caching/page.tsx
@@ -2,7 +2,7 @@ import CachingView from "../views/cachingView";
 
 export default function CachingPage() {
 	return (
-		<div className="mx-auto flex w-full max-w-7xl">
+		<div className="mx-auto flex w-full max-w-7xl no-padding-parent p-4">
 			<CachingView />
 		</div>
 	);

--- a/ui/app/workspace/config/client-settings/page.tsx
+++ b/ui/app/workspace/config/client-settings/page.tsx
@@ -2,7 +2,7 @@ import ClientSettingsView from "../views/clientSettingsView";
 
 export default function ClientSettingsPage() {
 	return (
-		<div className="mx-auto flex w-full max-w-7xl">
+		<div className="mx-auto flex w-full max-w-7xl no-padding-parent p-4">
 			<ClientSettingsView />
 		</div>
 	);

--- a/ui/app/workspace/config/logging/page.tsx
+++ b/ui/app/workspace/config/logging/page.tsx
@@ -2,7 +2,7 @@ import LoggingView from "../views/loggingView";
 
 export default function LoggingPage() {
 	return (
-		<div className="mx-auto flex w-full max-w-7xl">
+		<div className="mx-auto flex w-full no-padding-parent">
 			<LoggingView />
 		</div>
 	);

--- a/ui/app/workspace/config/proxy/page.tsx
+++ b/ui/app/workspace/config/proxy/page.tsx
@@ -17,7 +17,7 @@ export default function ProxyPage() {
 	}
 
 	return (
-		<div className="mx-auto flex w-full max-w-7xl">
+		<div className="mx-auto flex w-full max-w-7xl no-padding-parent p-4">
 			<ProxyView />
 		</div>
 	);

--- a/ui/app/workspace/config/security/page.tsx
+++ b/ui/app/workspace/config/security/page.tsx
@@ -2,7 +2,7 @@ import SecurityView from "../views/securityView";
 
 export default function SecurityPage() {
 	return (
-		<div className="mx-auto flex w-full max-w-7xl">
+		<div className="mx-auto flex w-full max-w-7xl no-padding-parent p-4">
 			<SecurityView />
 		</div>
 	);

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -75,7 +75,7 @@ export default function LoggingView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4 py-6">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Logs Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure logging settings for requests and responses.</p>

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -1,8 +1,8 @@
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Label } from "@/components/ui/label";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
@@ -204,8 +204,8 @@ export default function SecurityView() {
 				client_config: localConfig,
 				...(showPasswordSection
 					? {
-							auth_config: authConfig.is_enabled && hasUsername && hasPassword ? authConfig : { ...authConfig, is_enabled: false },
-						}
+						auth_config: authConfig.is_enabled && hasUsername && hasPassword ? authConfig : { ...authConfig, is_enabled: false },
+					}
 					: {}),
 			}).unwrap();
 			toast.success("Security settings updated successfully.");
@@ -215,7 +215,7 @@ export default function SecurityView() {
 	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto h-[calc(100vh-50px)] w-full max-w-4xl space-y-4 overflow-y-auto">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">Security Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
@@ -457,7 +457,7 @@ export default function SecurityView() {
 					</div>
 				</div>
 			</div>
-			<div className="bg-card sticky bottom-0 flex justify-end pt-2">
+			<div className="bg-card sticky bottom-0 flex justify-end py-2">
 				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>

--- a/ui/app/workspace/guardrails/providers/page.tsx
+++ b/ui/app/workspace/guardrails/providers/page.tsx
@@ -2,7 +2,7 @@ import GuardrailsProviderView from "@enterprise/components/guardrails/guardrails
 
 export default function GuardrailsProvidersPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl no-padding-parent p-4">
 			<GuardrailsProviderView />
 		</div>
 	);

--- a/ui/app/workspace/mcp-settings/page.tsx
+++ b/ui/app/workspace/mcp-settings/page.tsx
@@ -1,5 +1,5 @@
 import MCPView from "../config/views/mcpView";
 
 export default function MCPSettingsPage() {
-	return <MCPView />;
+	return <div className="mx-auto w-full max-w-7xl no-padding-parent p-4"><MCPView /></div>;
 }

--- a/ui/app/workspace/observability/page.tsx
+++ b/ui/app/workspace/observability/page.tsx
@@ -2,7 +2,7 @@ import ObservabilityView from "./views/observabilityView";
 
 export default function ObservabilityPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl no-padding-parent">
 			<ObservabilityView />
 		</div>
 	);

--- a/ui/app/workspace/observability/views/observabilityView.tsx
+++ b/ui/app/workspace/observability/views/observabilityView.tsx
@@ -133,7 +133,7 @@ export default function ObservabilityView() {
 	}
 
 	return (
-		<div className="flex h-full flex-row gap-4">
+		<div className="flex h-full flex-row gap-4 p-4">
 			<div className="flex flex-col">
 				<div className="flex w-[270px] flex-col gap-2 pb-10">
 					<div className="rounded-md bg-zinc-100/10 p-4 dark:bg-zinc-800/20">


### PR DESCRIPTION
## Summary

Workspace pages were missing consistent padding and were relying on parent-level padding that wasn't always applied correctly. This PR standardizes layout spacing across workspace pages by adding `no-padding-parent` and `p-4` classes where needed, and fixes a few overflow/height issues in specific views.

## Changes

- Added `no-padding-parent p-4` to the wrapper divs in Adaptive Routing, Caching, Client Settings, Proxy, Security, Guardrails Providers, MCP Settings, and Config pages so each page manages its own padding independently.
- Added `no-padding-parent` (without `p-4`) to Logging and Observability pages, which handle their own internal spacing.
- Moved padding into `ObservabilityView` directly via `p-4` on its root flex container.
- Added `py-6` to `LoggingView`'s root container to restore vertical spacing.
- Removed the fixed `h-[calc(100vh-50px)]` and `overflow-y-auto` from `SecurityView`, allowing the layout to flow naturally within the parent scroll context.
- Changed the sticky save button padding in `SecurityView` from `pt-2` to `py-2` for balanced spacing.
- Wrapped `MCPView` in a properly padded container div and added a trailing newline.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Navigate to each affected workspace page (Adaptive Routing, Caching, Client Settings, Logging, Proxy, Security, Guardrails Providers, MCP Settings, Observability) and verify that content is consistently padded and no pages appear flush against the edges or have unexpected scroll behavior.

## Screenshots/Recordings

Before/after screenshots recommended for Security, Observability, and Logging pages where layout behavior changed most significantly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable