### PR TITLE
[fix]: Preserve document blocks in Bedrock tool results

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: preserve documents in Bedrock tool results [@michaeldunn9](https://github.com/michaeldunn9)

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -3029,6 +3029,7 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 		name           string
 		input          *schemas.BifrostResponsesResponse
 		expectedBlocks int // Expected number of ContentBlocks in the output
+		expectError    bool
 		description    string
 	}{
 		{
@@ -3100,7 +3101,7 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 			description:    "Reasoning block with nil Text should not create an empty ContentBlock",
 		},
 		{
-			name: "FileBlockWithNilFileData_ShouldNotCreateEmptyBlock",
+			name: "FileBlockWithNilFileData_ShouldReturnError",
 			input: &schemas.BifrostResponsesResponse{
 				CreatedAt: 1234567890,
 				Output: []schemas.ResponsesMessage{
@@ -3122,8 +3123,8 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 					},
 				},
 			},
-			expectedBlocks: 0,
-			description:    "File block with nil FileData should not create an empty ContentBlock",
+			expectError: true,
+			description: "File block with neither FileData nor FileURL should return an error instead of silently dropping the document",
 		},
 		{
 			name: "FileBlockWithNilFileBlock_ShouldNotCreateEmptyBlock",
@@ -3224,7 +3225,7 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 			description:    "Valid file block should create a document ContentBlock plus the required placeholder text block",
 		},
 		{
-			name: "MixedValidAndInvalidBlocks_ShouldOnlyCreateValidBlocks",
+			name: "MixedValidAndSourceLessFileBlocks_ShouldReturnError",
 			input: &schemas.BifrostResponsesResponse{
 				CreatedAt: 1234567890,
 				Output: []schemas.ResponsesMessage{
@@ -3256,8 +3257,8 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 					},
 				},
 			},
-			expectedBlocks: 2, // Only valid text and reasoning blocks
-			description:    "Mixed valid and invalid blocks should only create valid ContentBlocks",
+			expectError: true,
+			description: "A source-less document should fail the message conversion instead of being removed from otherwise valid content",
 		},
 		{
 			name: "CacheControlBlock_ShouldCreateCachePointBlock",
@@ -3289,6 +3290,10 @@ func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_Empty
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := bedrock.ToBedrockConverseResponse(tt.input)
+			if tt.expectError {
+				require.Error(t, err, tt.description)
+				return
+			}
 			require.NoError(t, err, "Conversion should not error")
 			require.NotNil(t, actual, "Response should not be nil")
 			require.NotNil(t, actual.Output, "Output should not be nil")

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4655,8 +4655,17 @@ func TestDocumentFormatFromDataURL(t *testing.T) {
 
 			assert.Equal(t, tt.expectedFormat, doc.Format,
 				"data URL media type %q should map to format %q", tt.mediaType, tt.expectedFormat)
-			require.NotNil(t, doc.Source.Bytes)
-			assert.Equal(t, payload, *doc.Source.Bytes, "data URL prefix must be stripped from source.bytes")
+			if strings.HasPrefix(strings.ToLower(tt.mediaType), "text/") {
+				decoded, err := base64.StdEncoding.DecodeString(payload)
+				require.NoError(t, err)
+				require.NotNil(t, doc.Source.Text)
+				assert.Equal(t, string(decoded), *doc.Source.Text)
+				assert.Nil(t, doc.Source.Bytes, "document source is a union")
+			} else {
+				require.NotNil(t, doc.Source.Bytes)
+				assert.Equal(t, payload, *doc.Source.Bytes, "data URL prefix must be stripped from source.bytes")
+				assert.Nil(t, doc.Source.Text, "document source is a union")
+			}
 		})
 	}
 }
@@ -4705,8 +4714,7 @@ func TestDocumentInlineTextDataURL(t *testing.T) {
 	assert.Equal(t, "txt", doc.Format)
 	require.NotNil(t, doc.Source.Text)
 	assert.Equal(t, "Hello World", *doc.Source.Text)
-	require.NotNil(t, doc.Source.Bytes)
-	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("Hello World")), *doc.Source.Bytes)
+	assert.Nil(t, doc.Source.Bytes, "document source is a union and text documents must not also carry bytes")
 
 	// A binary format never gets source.text, matching the raw file_data path.
 	doc = chatFileBlockDocument(t, &schemas.ChatInputFile{

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3,10 +3,8 @@ package bedrock
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -3785,6 +3783,24 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, 
 									// outside the caller's control, so the tool result still goes out
 									// without it. This is the only case the original drop was written for.
 								}
+							} else if block.Type == schemas.ResponsesInputMessageContentBlockTypeFile &&
+								block.ResponsesInputMessageContentBlockFile != nil {
+								file := block.ResponsesInputMessageContentBlockFile
+								document, err := materializeBedrockDocument(
+									ctx,
+									model,
+									file.FileData,
+									file.FileURL,
+									file.Filename,
+									file.FileType,
+									bedrockDocumentSourceRequired,
+								)
+								if err != nil {
+									return nil, nil, fmt.Errorf("bedrock: converting tool result document: %w", err)
+								}
+								if document != nil {
+									resultContent = append(resultContent, BedrockContentBlock{Document: document})
+								}
 							}
 						}
 					}
@@ -5157,154 +5173,19 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 				continue
 			case schemas.ResponsesInputMessageContentBlockTypeFile:
 				if file := block.ResponsesInputMessageContentBlockFile; file != nil {
-					doc := &BedrockDocumentSource{
-						Name:   "document", // Default
-						Format: "pdf",      // Default
-						Source: &BedrockDocumentSourceData{},
+					document, err := materializeBedrockDocument(
+						ctx,
+						model,
+						file.FileData,
+						file.FileURL,
+						file.Filename,
+						file.FileType,
+						bedrockDocumentSourceRequired,
+					)
+					if err != nil {
+						return nil, fmt.Errorf("failed to convert document in responses content block: %w", err)
 					}
-
-					// Set filename (normalized for Bedrock)
-					if file.Filename != nil {
-						doc.Name = normalizeBedrockFilename(*file.Filename)
-					}
-
-					// Parse the data URL once; it carries both the payload and (for
-					// standard OpenAI clients, which have no file_type field) the
-					// document's MIME type.
-					dataURLMediaType, dataURLPayload := "", ""
-					dataURLIsBase64, isDataURL := false, false
-					if file.FileData != nil && strings.HasPrefix(*file.FileData, "data:") {
-						dataURLMediaType, dataURLIsBase64, dataURLPayload, isDataURL = schemas.ParseDataURL(*file.FileData)
-					}
-
-					// Resolve the document format, most authoritative hint first. Falls
-					// back to the "pdf" default only when nothing identifies the document.
-					format, isTextFile := "", false
-					if file.FileType != nil {
-						format, isTextFile, _ = bedrockDocumentFormat(*file.FileType)
-					}
-					if format == "" && isDataURL {
-						format, isTextFile, _ = bedrockDocumentFormat(dataURLMediaType)
-					}
-					if format == "" && file.Filename != nil {
-						if dot := strings.LastIndex(*file.Filename, "."); dot >= 0 {
-							format, isTextFile, _ = bedrockDocumentFormat((*file.Filename)[dot+1:])
-						}
-					}
-					if format != "" {
-						doc.Format = format
-					}
-
-					// s3:// document: hand Converse the object reference instead of its
-					// bytes. See bedrockS3LocationFromURL; format must already be
-					// resolved above, since nothing is fetched here.
-					if file.FileURL != nil {
-						if s3Loc, ok := bedrockS3LocationFromURL(*file.FileURL); ok {
-							// Same gate as the chat path, ahead of format resolution for the
-							// same reason: see schemas.BedrockModelSupportsS3Location.
-							if !schemas.BedrockModelSupportsS3Location(model) {
-								return nil, bedrockS3LocationUnsupportedError(model, "document", *file.FileURL, "as base64 file_data")
-							}
-							// Last resort: the object key's own extension, which the
-							// refusal below already instructs the caller to supply. See
-							// bedrockDocumentFormatFromPath; the chat path does the same.
-							if format == "" {
-								if resolved, ok := bedrockDocumentFormatFromPath(*file.FileURL); ok {
-									format = resolved
-									doc.Format = format
-								}
-							}
-							if format == "" {
-								return nil, providerUtils.InvalidRequestErrorf("cannot determine document format for %q: set file_type or give the object a file extension", *file.FileURL)
-							}
-							doc.Source.S3Location = s3Loc
-							bedrockBlock.Document = doc
-							break
-						} else if strings.HasPrefix(*file.FileURL, "s3://") {
-							// Same refusal as the chat path: the scheme is supported, this
-							// particular reference is malformed (a bucket with no object
-							// key), and the http(s) fetch path's "unsupported URL scheme"
-							// error would say the opposite.
-							return nil, providerUtils.InvalidRequestErrorf("invalid s3:// document reference %q: expected s3://bucket/key", *file.FileURL)
-						}
-					}
-					if format != "" {
-						doc.Format = format
-					}
-
-					// URL-sourced document: fetch and inline the bytes (Bedrock Converse
-					// only accepts inline source bytes, not remote URLs).
-					if file.FileURL != nil && *file.FileURL != "" {
-						fetchedMediaType, fetchedB64, fetchErr := providerUtils.FetchAndEncodeURL(ctx, *file.FileURL)
-						if fetchErr != nil {
-							return nil, fetchErr
-						}
-						// Refine format from response Content-Type when present (more
-						// reliable than file extension or upstream-declared media type).
-						if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
-							doc.Format = fetchedFormat
-						}
-						doc.Source.Bytes = &fetchedB64
-						bedrockBlock.Document = doc
-						break
-					}
-
-					// URL-sourced document: fetch and inline the bytes. Converse has no
-					// url member on DocumentSource.
-					if file.FileURL != nil && *file.FileURL != "" {
-						fetchedMediaType, fetchedB64, fetchErr := providerUtils.FetchAndEncodeURL(ctx, *file.FileURL)
-						if fetchErr != nil {
-							return nil, fetchErr
-						}
-						// Refine format from response Content-Type when present (more
-						// reliable than file extension or upstream-declared media type).
-						if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
-							doc.Format = fetchedFormat
-						}
-						doc.Source.Bytes = &fetchedB64
-						bedrockBlock.Document = doc
-						break
-					}
-
-					// Handle file data
-					if file.FileData != nil {
-						fileData := *file.FileData
-
-						// Check if it's a data URL (e.g., "data:application/pdf;base64,...")
-						if isDataURL {
-							if dataURLIsBase64 {
-								doc.Source.Bytes = &dataURLPayload
-							} else {
-								// Inline percent-encoded payload (data:text/plain,Hello%20World)
-								decoded, err := url.PathUnescape(dataURLPayload)
-								if err != nil {
-									return nil, fmt.Errorf("invalid percent-encoded data URL payload: %w", err)
-								}
-								dataURLPayload = decoded
-								if isTextFile {
-									doc.Source.Text = &dataURLPayload
-								}
-								encoded := base64.StdEncoding.EncodeToString([]byte(dataURLPayload))
-								doc.Source.Bytes = &encoded
-							}
-							bedrockBlock.Document = doc
-							break
-						}
-
-						// Not a data URL - use as-is
-						if isTextFile {
-							// bytes is necessary for bedrock
-							// base64 string of the text
-							doc.Source.Text = &fileData
-							encoded := base64.StdEncoding.EncodeToString([]byte(fileData))
-							doc.Source.Bytes = &encoded
-						} else {
-							doc.Source.Bytes = &fileData
-						}
-
-						bedrockBlock.Document = doc
-
-					}
+					bedrockBlock.Document = document
 				}
 			default:
 				// Don't add anything for unknown types

--- a/core/providers/bedrock/toolresultdocument_test.go
+++ b/core/providers/bedrock/toolresultdocument_test.go
@@ -1,0 +1,220 @@
+package bedrock
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const toolResultDocumentTestModel = "amazon.nova-lite-v1:0"
+
+func toolResultDocumentMessage(blocks []schemas.ResponsesMessageContentBlock) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: schemas.Ptr("toolu_document"),
+			Output: &schemas.ResponsesToolMessageOutputStruct{
+				ResponsesFunctionToolCallOutputBlocks: blocks,
+			},
+		},
+	}
+}
+
+func requireBedrockToolResult(t *testing.T, messages []BedrockMessage) *BedrockToolResult {
+	t.Helper()
+	if len(messages) != 1 || len(messages[0].Content) != 1 || messages[0].Content[0].ToolResult == nil {
+		t.Fatalf("expected one Bedrock tool result, got %#v", messages)
+	}
+	return messages[0].Content[0].ToolResult
+}
+
+func convertToolResultDocument(t *testing.T, file *schemas.ResponsesInputMessageContentBlockFile) *BedrockDocumentSource {
+	t.Helper()
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, []schemas.ResponsesMessage{
+		toolResultDocumentMessage([]schemas.ResponsesMessageContentBlock{{
+			Type:                                  schemas.ResponsesInputMessageContentBlockTypeFile,
+			ResponsesInputMessageContentBlockFile: file,
+		}}),
+	}, false)
+	if err != nil {
+		t.Fatalf("unexpected conversion error: %v", err)
+	}
+	toolResult := requireBedrockToolResult(t, messages)
+	if len(toolResult.Content) != 1 || toolResult.Content[0].Document == nil {
+		t.Fatalf("expected one document block, got %#v", toolResult.Content)
+	}
+	return toolResult.Content[0].Document
+}
+
+func TestToolResultDocumentInlinePreserved(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		toolResultDocumentMessage([]schemas.ResponsesMessageContentBlock{
+			{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("Document generated")},
+			{
+				Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+				ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+					FileData: schemas.Ptr("data:application/pdf;base64,JVBERi0xLjQ="),
+					Filename: schemas.Ptr("quarterly/report.pdf"),
+					FileType: schemas.Ptr("application/pdf"),
+				},
+			},
+		}),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, input, false)
+	if err != nil {
+		t.Fatalf("unexpected conversion error: %v", err)
+	}
+	toolResult := requireBedrockToolResult(t, messages)
+	if len(toolResult.Content) != 2 || toolResult.Content[0].Text == nil || toolResult.Content[1].Document == nil {
+		t.Fatalf("expected text then document, got %#v", toolResult.Content)
+	}
+	if *toolResult.Content[0].Text != "Document generated" {
+		t.Fatalf("expected original text first, got %q", *toolResult.Content[0].Text)
+	}
+	document := toolResult.Content[1].Document
+	if document.Name != "quarterly_report_pdf" || document.Format != "pdf" {
+		t.Fatalf("expected normalized PDF metadata, got %#v", document)
+	}
+	if document.Source == nil || document.Source.Bytes == nil || *document.Source.Bytes != "JVBERi0xLjQ=" {
+		t.Fatalf("expected original inline bytes, got %#v", document.Source)
+	}
+}
+
+func TestToolResultDocumentKeepsDeclaredFormatForOpaqueDataURL(t *testing.T) {
+	document := convertToolResultDocument(t, &schemas.ResponsesInputMessageContentBlockFile{
+		FileData: schemas.Ptr("data:application/octet-stream;base64,QQ=="),
+		Filename: schemas.Ptr("report.csv"),
+		FileType: schemas.Ptr("text/csv"),
+	})
+	if document.Format != "csv" || document.Source == nil || document.Source.Bytes == nil || *document.Source.Bytes != "QQ==" {
+		t.Fatalf("expected declared CSV format with original bytes, got %#v", document)
+	}
+}
+
+func TestToolResultTextDocumentUsesSingleSourceMember(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileData string
+	}{
+		{name: "literal text", fileData: "Hello from the tool"},
+		{name: "base64 data URL", fileData: "data:text/plain;base64,SGVsbG8gZnJvbSB0aGUgdG9vbA=="},
+		{name: "mixed-case data URL", fileData: "DaTa:text/plain;base64,SGVsbG8gZnJvbSB0aGUgdG9vbA=="},
+		{name: "percent-encoded data URL", fileData: "data:text/plain,Hello%20from%20the%20tool"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			document := convertToolResultDocument(t, &schemas.ResponsesInputMessageContentBlockFile{
+				FileData: &tt.fileData,
+				Filename: schemas.Ptr("result.txt"),
+				FileType: schemas.Ptr("text/plain"),
+			})
+			if document.Format != "txt" || document.Source == nil || document.Source.Text == nil || *document.Source.Text != "Hello from the tool" {
+				t.Fatalf("expected plain text document source, got %#v", document)
+			}
+			if document.Source.Bytes != nil {
+				t.Fatalf("expected DocumentSource union to contain only text, got bytes %#v", document.Source.Bytes)
+			}
+		})
+	}
+}
+
+func TestToolResultDocumentURLFetchErrorReturned(t *testing.T) {
+	input := []schemas.ResponsesMessage{
+		toolResultDocumentMessage([]schemas.ResponsesMessageContentBlock{{
+			Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+			ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+				FileURL:  schemas.Ptr("file:///tmp/report.pdf"),
+				Filename: schemas.Ptr("report.pdf"),
+				FileType: schemas.Ptr("application/pdf"),
+			},
+		}}),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, input, false)
+	if err == nil {
+		t.Fatalf("expected bounded URL fetch error, got messages=%#v err=%v", messages, err)
+	}
+}
+
+func TestToolResultDocumentURLUsesSSRFSafeFetcher(t *testing.T) {
+	var reached atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		reached.Store(true)
+	}))
+	defer server.Close()
+
+	input := []schemas.ResponsesMessage{
+		toolResultDocumentMessage([]schemas.ResponsesMessageContentBlock{{
+			Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+			ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+				FileURL:  schemas.Ptr(server.URL + "/report.pdf"),
+				Filename: schemas.Ptr("report.pdf"),
+				FileType: schemas.Ptr("application/pdf"),
+			},
+		}}),
+	}
+
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, input, false)
+	if err == nil {
+		t.Fatalf("expected SSRF-safe fetch rejection, got messages=%#v err=%v", messages, err)
+	}
+	if reached.Load() {
+		t.Fatal("SSRF-safe fetcher reached the loopback server")
+	}
+}
+
+func TestToolResultDocumentAnthropicToBedrockRoundTrip(t *testing.T) {
+	request := &anthropic.AnthropicMessageRequest{
+		Model:     "bedrock/anthropic.claude-3-5-sonnet-v2",
+		MaxTokens: 1024,
+		Messages: []anthropic.AnthropicMessage{
+			{
+				Role: anthropic.AnthropicMessageRoleAssistant,
+				Content: anthropic.AnthropicContent{ContentBlocks: []anthropic.AnthropicContentBlock{{
+					Type: anthropic.AnthropicContentBlockTypeToolUse,
+					ID:   schemas.Ptr("toolu_document"), Name: schemas.Ptr("create_report"),
+					Input: []byte(`{"topic":"quarterly results"}`),
+				}}},
+			},
+			{
+				Role: anthropic.AnthropicMessageRoleUser,
+				Content: anthropic.AnthropicContent{ContentBlocks: []anthropic.AnthropicContentBlock{{
+					Type: anthropic.AnthropicContentBlockTypeToolResult, ToolUseID: schemas.Ptr("toolu_document"),
+					Content: &anthropic.AnthropicContent{ContentBlocks: []anthropic.AnthropicContentBlock{
+						{Type: anthropic.AnthropicContentBlockTypeText, Text: schemas.Ptr("Document generated")},
+						{
+							Type: anthropic.AnthropicContentBlockTypeDocument, Title: schemas.Ptr("report.pdf"),
+							Source: &anthropic.AnthropicBlockSource{SourceObj: &anthropic.AnthropicSource{
+								Type: "base64", MediaType: schemas.Ptr("application/pdf"), Data: schemas.Ptr("JVBERi0xLjQ="),
+							}},
+						},
+					}},
+				}}},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bedrockRequest, err := ToBedrockResponsesRequest(ctx, request.ToBifrostResponsesRequest(ctx))
+	if err != nil {
+		t.Fatalf("unexpected cross-provider conversion error: %v", err)
+	}
+	if len(bedrockRequest.Messages) != 2 {
+		t.Fatalf("expected assistant tool use and user tool result, got %d messages", len(bedrockRequest.Messages))
+	}
+	toolResult := bedrockRequest.Messages[1].Content[0].ToolResult
+	if toolResult == nil || len(toolResult.Content) != 2 || toolResult.Content[0].Text == nil || toolResult.Content[1].Document == nil {
+		t.Fatalf("expected text then document in final tool result, got %#v", toolResult)
+	}
+	document := toolResult.Content[1].Document
+	if document.Name != "report_pdf" || document.Format != "pdf" || document.Source == nil || document.Source.Bytes == nil || *document.Source.Bytes != "JVBERi0xLjQ=" {
+		t.Fatalf("expected normalized PDF with original inline bytes, got %#v", document)
+	}
+}

--- a/core/providers/bedrock/toolresultdocument_test.go
+++ b/core/providers/bedrock/toolresultdocument_test.go
@@ -33,14 +33,18 @@ func requireBedrockToolResult(t *testing.T, messages []BedrockMessage) *BedrockT
 	return messages[0].Content[0].ToolResult
 }
 
-func convertToolResultDocument(t *testing.T, file *schemas.ResponsesInputMessageContentBlockFile) *BedrockDocumentSource {
-	t.Helper()
-	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, []schemas.ResponsesMessage{
+func toolResultDocumentInput(file *schemas.ResponsesInputMessageContentBlockFile) []schemas.ResponsesMessage {
+	return []schemas.ResponsesMessage{
 		toolResultDocumentMessage([]schemas.ResponsesMessageContentBlock{{
 			Type:                                  schemas.ResponsesInputMessageContentBlockTypeFile,
 			ResponsesInputMessageContentBlockFile: file,
 		}}),
-	}, false)
+	}
+}
+
+func convertToolResultDocument(t *testing.T, file *schemas.ResponsesInputMessageContentBlockFile) *BedrockDocumentSource {
+	t.Helper()
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, toolResultDocumentInput(file), false)
 	if err != nil {
 		t.Fatalf("unexpected conversion error: %v", err)
 	}
@@ -94,6 +98,75 @@ func TestToolResultDocumentKeepsDeclaredFormatForOpaqueDataURL(t *testing.T) {
 	})
 	if document.Format != "csv" || document.Source == nil || document.Source.Bytes == nil || *document.Source.Bytes != "QQ==" {
 		t.Fatalf("expected declared CSV format with original bytes, got %#v", document)
+	}
+}
+
+func TestToolResultDocumentS3URIUsesS3Location(t *testing.T) {
+	s3URI := "s3://reports/quarterly/q4.pdf"
+	document := convertToolResultDocument(t, &schemas.ResponsesInputMessageContentBlockFile{
+		FileURL: &s3URI,
+	})
+
+	if document.Format != "pdf" || document.Source == nil || document.Source.S3Location == nil {
+		t.Fatalf("expected PDF backed by an S3 location, got %#v", document)
+	}
+	if document.Source.S3Location.URI != s3URI {
+		t.Fatalf("expected S3 URI %q, got %q", s3URI, document.Source.S3Location.URI)
+	}
+	if document.Source.Bytes != nil || document.Source.Text != nil {
+		t.Fatalf("expected DocumentSource union to contain only s3Location, got %#v", document.Source)
+	}
+}
+
+func TestToolResultDocumentRejectsUnsupportedExplicitTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		file *schemas.ResponsesInputMessageContentBlockFile
+	}{
+		{
+			name: "declared JSON",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("e30="), FileType: schemas.Ptr("application/json")},
+		},
+		{
+			name: "declared ZIP",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("UEsDBA=="), FileType: schemas.Ptr("application/zip")},
+		},
+		{
+			name: "declared PNG",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("iVBORw=="), FileType: schemas.Ptr("image/png")},
+		},
+		{
+			name: "data URL JSON",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("data:application/json;base64,e30=")},
+		},
+		{
+			name: "data URL ZIP",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("data:application/zip;base64,UEsDBA==")},
+		},
+		{
+			name: "data URL PNG",
+			file: &schemas.ResponsesInputMessageContentBlockFile{FileData: schemas.Ptr("data:image/png;base64,iVBORw==")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, toolResultDocumentInput(tt.file), false)
+			if err == nil {
+				t.Fatalf("expected unsupported document format error, got %#v", messages)
+			}
+		})
+	}
+}
+
+func TestToolResultDocumentRejectsMissingSource(t *testing.T) {
+	file := &schemas.ResponsesInputMessageContentBlockFile{
+		Filename: schemas.Ptr("report.pdf"),
+		FileType: schemas.Ptr("application/pdf"),
+	}
+	messages, _, err := ConvertBifrostMessagesToBedrockMessages(context.Background(), toolResultDocumentTestModel, toolResultDocumentInput(file), false)
+	if err == nil {
+		t.Fatalf("expected missing document source error, got %#v", messages)
 	}
 }
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -301,6 +301,145 @@ func bedrockDocumentFormat(fileType string) (format string, isText bool, ok bool
 	return "", false, false
 }
 
+type bedrockDocumentSourceRequirement uint8
+
+const (
+	bedrockDocumentSourceRequired bedrockDocumentSourceRequirement = iota
+	// Chat file blocks can carry a provider-native file ID without inline data.
+	// Preserve the historical document placeholder for that path until Bedrock
+	// has a native representation for the ID.
+	bedrockDocumentSourceOptional
+)
+
+// materializeBedrockDocument converts Bifrost's canonical file fields into the
+// document shape required by Bedrock Converse. All callers use this
+// boundary so chat files, Responses files, and tool-result files share format
+// inference, data-URL parsing, and bounded URL fetching behavior.
+func materializeBedrockDocument(
+	ctx context.Context,
+	model string,
+	fileData *string,
+	fileURL *string,
+	filename *string,
+	fileType *string,
+	sourceRequirement bedrockDocumentSourceRequirement,
+) (*BedrockDocumentSource, error) {
+	document := &BedrockDocumentSource{
+		Name:   "document",
+		Format: "pdf",
+		Source: &BedrockDocumentSourceData{},
+	}
+	if filename != nil {
+		document.Name = normalizeBedrockFilename(*filename)
+	}
+
+	dataURLMediaType, dataURLPayload := "", ""
+	dataURLIsBase64, isDataURL := false, false
+	if fileData != nil && len(*fileData) >= len("data:") && strings.EqualFold((*fileData)[:len("data:")], "data:") {
+		normalizedDataURL := "data:" + (*fileData)[len("data:"):]
+		dataURLMediaType, dataURLIsBase64, dataURLPayload, isDataURL = schemas.ParseDataURL(normalizedDataURL)
+		if !isDataURL {
+			return nil, fmt.Errorf("invalid document data URL")
+		}
+	}
+
+	// Resolve the document format from the most authoritative available hint.
+	// An unidentifiable document retains Bedrock's historical PDF default.
+	format, isText := "", false
+	if fileType != nil {
+		format, isText, _ = bedrockDocumentFormat(*fileType)
+	}
+	if format == "" && isDataURL {
+		format, isText, _ = bedrockDocumentFormat(dataURLMediaType)
+	}
+	if format == "" && filename != nil {
+		if dot := strings.LastIndex(*filename, "."); dot >= 0 {
+			format, isText, _ = bedrockDocumentFormat((*filename)[dot+1:])
+		}
+	}
+	if format != "" {
+		document.Format = format
+	}
+
+	if fileURL != nil && *fileURL != "" {
+		if s3Location, ok := bedrockS3LocationFromURL(*fileURL); ok {
+			if !schemas.BedrockModelSupportsS3Location(model) {
+				return nil, bedrockS3LocationUnsupportedError(model, "document", *fileURL, "as base64 file_data")
+			}
+			if format == "" {
+				if resolvedFormat, resolved := bedrockDocumentFormatFromPath(*fileURL); resolved {
+					format = resolvedFormat
+					document.Format = resolvedFormat
+				}
+			}
+			if format == "" {
+				return nil, providerUtils.InvalidRequestErrorf("cannot determine document format for %q: set file_type or give the object a file extension", *fileURL)
+			}
+			document.Source.S3Location = s3Location
+			return document, nil
+		}
+		if strings.HasPrefix(*fileURL, "s3://") {
+			return nil, providerUtils.InvalidRequestErrorf("invalid s3:// document reference %q: expected s3://bucket/key", *fileURL)
+		}
+
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		fetchedMediaType, fetchedBase64, err := providerUtils.FetchAndEncodeURL(ctx, *fileURL)
+		if err != nil {
+			return nil, err
+		}
+		if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
+			document.Format = fetchedFormat
+		}
+		document.Source.Bytes = &fetchedBase64
+		return document, nil
+	}
+
+	if fileData == nil {
+		if sourceRequirement == bedrockDocumentSourceOptional {
+			return document, nil
+		}
+		return nil, nil
+	}
+
+	if isDataURL {
+		_, dataURLIsText, _ := bedrockDocumentFormat(dataURLMediaType)
+		if dataURLIsBase64 {
+			if dataURLIsText {
+				decoded, err := base64.StdEncoding.DecodeString(dataURLPayload)
+				if err != nil {
+					return nil, fmt.Errorf("invalid base64 document data URL: %w", err)
+				}
+				text := string(decoded)
+				document.Source.Text = &text
+			} else {
+				document.Source.Bytes = &dataURLPayload
+			}
+			return document, nil
+		}
+
+		decoded, err := url.PathUnescape(dataURLPayload)
+		if err != nil {
+			return nil, fmt.Errorf("invalid document data URL payload: %w", err)
+		}
+		if dataURLIsText {
+			document.Source.Text = &decoded
+		} else {
+			encoded := base64.StdEncoding.EncodeToString([]byte(decoded))
+			document.Source.Bytes = &encoded
+		}
+		return document, nil
+	}
+
+	if isText {
+		document.Source.Text = fileData
+	} else {
+		document.Source.Bytes = fileData
+	}
+	return document, nil
+}
+
 // bedrockAliasToolName returns a Bedrock-safe tool name and records a reverse mapping.
 func bedrockAliasToolName(ctx context.Context, name string) string {
 	if len(name) <= 64 && !bedrockUnsafeToolNameCharRegex.MatchString(name) {
@@ -1377,149 +1516,19 @@ func convertContentBlock(ctx context.Context, model string, block schemas.ChatCo
 			return nil, fmt.Errorf("file block missing file field")
 		}
 
-		documentSource := &BedrockDocumentSource{
-			Name:   "document",
-			Format: "pdf",
-			Source: &BedrockDocumentSourceData{},
+		document, err := materializeBedrockDocument(
+			ctx,
+			model,
+			block.File.FileData,
+			block.File.FileURL,
+			block.File.Filename,
+			block.File.FileType,
+			bedrockDocumentSourceOptional,
+		)
+		if err != nil {
+			return nil, err
 		}
-
-		// Set filename (normalized for Bedrock)
-		if block.File.Filename != nil {
-			documentSource.Name = normalizeBedrockFilename(*block.File.Filename)
-		}
-
-		// Parse the data URL once; it carries both the payload and (for standard
-		// OpenAI clients, which have no file_type field) the document's MIME type.
-		dataURLMediaType, dataURLPayload := "", ""
-		dataURLIsBase64, isDataURL := false, false
-		if block.File.FileData != nil && strings.HasPrefix(*block.File.FileData, "data:") {
-			dataURLMediaType, dataURLIsBase64, dataURLPayload, isDataURL = schemas.ParseDataURL(*block.File.FileData)
-		}
-		// Resolve the document format, most authoritative hint first. Falls back to
-		// the "pdf" default only when nothing identifies the document.
-		format, isText := "", false
-		if block.File.FileType != nil {
-			format, isText, _ = bedrockDocumentFormat(*block.File.FileType)
-		}
-		if format == "" && isDataURL {
-			format, isText, _ = bedrockDocumentFormat(dataURLMediaType)
-		}
-		if format == "" && block.File.Filename != nil {
-			if dot := strings.LastIndex(*block.File.Filename, "."); dot >= 0 {
-				format, isText, _ = bedrockDocumentFormat((*block.File.Filename)[dot+1:])
-			}
-		}
-		if format != "" {
-			documentSource.Format = format
-		}
-
-		// s3:// document: hand Converse the object reference. Bytes and s3Location are
-		// alternative members of the same DocumentSource union, and Converse reads the
-		// object itself, so there is nothing to download here. Format has to come from
-		// the declared type / filename resolved above -- there is no Content-Type to
-		// refine it from.
-		if block.File.FileURL != nil {
-			if s3Loc, ok := bedrockS3LocationFromURL(*block.File.FileURL); ok {
-				// Ahead of format resolution: a model that cannot read the reference at all
-				// has no use for its format, and "cannot determine document format" would
-				// send the caller off renaming their object for no gain.
-				if !schemas.BedrockModelSupportsS3Location(model) {
-					return nil, bedrockS3LocationUnsupportedError(model, "document", *block.File.FileURL, "as base64 file_data")
-				}
-				// Last resort: the object key's own extension. Nothing is downloaded for
-				// an s3:// reference, so there is no Content-Type to read and no bytes to
-				// sniff -- the key is the only signal left, and the refusal below already
-				// tells the caller to use it. bedrockImageFormatFromPath does the same for
-				// the image twin.
-				if format == "" {
-					if resolved, ok := bedrockDocumentFormatFromPath(*block.File.FileURL); ok {
-						format = resolved
-						documentSource.Format = format
-					}
-				}
-				if format == "" {
-					return nil, providerUtils.InvalidRequestErrorf("cannot determine document format for %q: set file_type or give the object a file extension", *block.File.FileURL)
-				}
-				documentSource.Source.S3Location = s3Loc
-				return []BedrockContentBlock{
-					{
-						Document: documentSource,
-					},
-				}, nil
-			} else if strings.HasPrefix(*block.File.FileURL, "s3://") {
-				// The scheme is right but the reference is not: bedrockS3LocationFromURL
-				// rejects a bucket with no object key. Falling through would hand it to
-				// the http(s) fetch path, whose "unsupported URL scheme" refusal is
-				// actively misleading -- s3:// is supported, this one is just malformed.
-				return nil, providerUtils.InvalidRequestErrorf("invalid s3:// document reference %q: expected s3://bucket/key", *block.File.FileURL)
-			}
-		}
-		if format != "" {
-			documentSource.Format = format
-		}
-
-		// URL-sourced document: fetch and inline the bytes. Converse has no url member
-		// on DocumentSource, so an http(s) reference must travel as bytes.
-		if block.File.FileURL != nil && *block.File.FileURL != "" {
-			fetchedMediaType, fetchedB64, fetchErr := providerUtils.FetchAndEncodeURL(ctx, *block.File.FileURL)
-			if fetchErr != nil {
-				return nil, fetchErr
-			}
-			// Refine format from response Content-Type when present (more reliable
-			// than file extension or upstream-declared media type).
-			if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
-				documentSource.Format = fetchedFormat
-			}
-			documentSource.Source.Bytes = &fetchedB64
-			return []BedrockContentBlock{
-				{
-					Document: documentSource,
-				},
-			}, nil
-		}
-
-		// Handle file data - strip data URL prefix if present
-		if block.File.FileData != nil {
-			fileData := *block.File.FileData
-
-			if isDataURL {
-				if dataURLIsBase64 {
-					documentSource.Source.Bytes = &dataURLPayload
-				} else {
-					// Inline percent-encoded payload (data:text/plain,Hello%20World)
-					decoded, err := url.PathUnescape(dataURLPayload)
-					if err != nil {
-						return nil, fmt.Errorf("invalid percent-encoded data URL payload: %w", err)
-					}
-					dataURLPayload = decoded
-					if isText {
-						documentSource.Source.Text = &dataURLPayload
-					}
-					encoded := base64.StdEncoding.EncodeToString([]byte(dataURLPayload))
-					documentSource.Source.Bytes = &encoded
-				}
-				return []BedrockContentBlock{
-					{
-						Document: documentSource,
-					},
-				}, nil
-			}
-
-			// Set text or bytes based on file type
-			if isText {
-				documentSource.Source.Text = &fileData // Plain text
-				encoded := base64.StdEncoding.EncodeToString([]byte(fileData))
-				documentSource.Source.Bytes = &encoded // Also sets Bytes
-			} else {
-				documentSource.Source.Bytes = &fileData
-			}
-		}
-
-		return []BedrockContentBlock{
-			{
-				Document: documentSource,
-			},
-		}, nil
+		return []BedrockContentBlock{{Document: document}}, nil
 	case schemas.ChatContentBlockTypeInputAudio:
 		// Bedrock doesn't support audio input in Converse API
 		return nil, fmt.Errorf("audio input not supported in Bedrock Converse API")

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -259,18 +259,22 @@ func normalizeBedrockFilename(filename string) string {
 	return normalized
 }
 
-// bedrockDocumentFormat maps a MIME type or bare file extension to a Bedrock Converse
-// document format. Media type parameters (e.g. "; charset=utf-8") are ignored. ok is
-// false when the input maps to no format Bedrock supports, so callers can fall through
-// to the next available hint.
-func bedrockDocumentFormat(fileType string) (format string, isText bool, ok bool) {
+func normalizeBedrockDocumentType(fileType string) string {
 	fileType = strings.ToLower(strings.TrimSpace(fileType))
 	if mediaType, _, err := mime.ParseMediaType(fileType); err == nil {
 		fileType = mediaType
 	} else if idx := strings.Index(fileType, ";"); idx >= 0 {
 		fileType = strings.TrimSpace(fileType[:idx])
 	}
-	fileType = strings.TrimPrefix(fileType, ".")
+	return strings.TrimPrefix(fileType, ".")
+}
+
+// bedrockDocumentFormat maps a MIME type or bare file extension to a Bedrock Converse
+// document format. Media type parameters (e.g. "; charset=utf-8") are ignored. ok is
+// false when the input maps to no format Bedrock supports, so callers can fall through
+// to the next available hint.
+func bedrockDocumentFormat(fileType string) (format string, isText bool, ok bool) {
+	fileType = normalizeBedrockDocumentType(fileType)
 
 	switch fileType {
 	case "text/plain", "txt":
@@ -299,6 +303,15 @@ func bedrockDocumentFormat(fileType string) (format string, isText bool, ok bool
 	}
 
 	return "", false, false
+}
+
+func isOpaqueBedrockDocumentType(fileType string) bool {
+	switch normalizeBedrockDocumentType(fileType) {
+	case "", "application/octet-stream", "binary/octet-stream", "octet-stream":
+		return true
+	default:
+		return false
+	}
 }
 
 type bedrockDocumentSourceRequirement uint8
@@ -346,11 +359,23 @@ func materializeBedrockDocument(
 	// Resolve the document format from the most authoritative available hint.
 	// An unidentifiable document retains Bedrock's historical PDF default.
 	format, isText := "", false
-	if fileType != nil {
-		format, isText, _ = bedrockDocumentFormat(*fileType)
+	if fileType != nil && strings.TrimSpace(*fileType) != "" {
+		var matched bool
+		format, isText, matched = bedrockDocumentFormat(*fileType)
+		if !matched && !isOpaqueBedrockDocumentType(*fileType) {
+			return nil, fmt.Errorf("unsupported Bedrock document format %q", *fileType)
+		}
 	}
-	if format == "" && isDataURL {
-		format, isText, _ = bedrockDocumentFormat(dataURLMediaType)
+	dataURLIsText := false
+	if isDataURL {
+		dataURLFormat, sourceIsText, matched := bedrockDocumentFormat(dataURLMediaType)
+		if !matched && !isOpaqueBedrockDocumentType(dataURLMediaType) {
+			return nil, fmt.Errorf("unsupported Bedrock document format %q", dataURLMediaType)
+		}
+		dataURLIsText = sourceIsText
+		if format == "" && matched {
+			format, isText = dataURLFormat, sourceIsText
+		}
 	}
 	if format == "" && filename != nil {
 		if dot := strings.LastIndex(*filename, "."); dot >= 0 {
@@ -391,6 +416,8 @@ func materializeBedrockDocument(
 		}
 		if fetchedFormat, _, ok := bedrockDocumentFormat(fetchedMediaType); ok {
 			document.Format = fetchedFormat
+		} else if !isOpaqueBedrockDocumentType(fetchedMediaType) {
+			return nil, fmt.Errorf("unsupported Bedrock document format %q", fetchedMediaType)
 		}
 		document.Source.Bytes = &fetchedBase64
 		return document, nil
@@ -400,11 +427,10 @@ func materializeBedrockDocument(
 		if sourceRequirement == bedrockDocumentSourceOptional {
 			return document, nil
 		}
-		return nil, nil
+		return nil, fmt.Errorf("bedrock document requires file_data or file_url")
 	}
 
 	if isDataURL {
-		_, dataURLIsText, _ := bedrockDocumentFormat(dataURLMediaType)
 		if dataURLIsBase64 {
 			if dataURLIsText {
 				decoded, err := base64.StdEncoding.DecodeString(dataURLPayload)
@@ -421,7 +447,7 @@ func materializeBedrockDocument(
 
 		decoded, err := url.PathUnescape(dataURLPayload)
 		if err != nil {
-			return nil, fmt.Errorf("invalid document data URL payload: %w", err)
+			return nil, fmt.Errorf("invalid percent-encoded document data URL payload: %w", err)
 		}
 		if dataURLIsText {
 			document.Source.Text = &decoded


### PR DESCRIPTION
## Summary

Bifrost converts tool-returned text and images into Bedrock `toolResult` blocks, but ignored returned documents. The document therefore never reached Claude.

This PR adds the missing `input_file` conversion and reuses the same validated Bedrock document handling already used for ordinary user messages.

No Anthropic or Bedrock API behavior or public schema is changed. This adds no new ordinary-message document capability; those paths already existed and are refactored to share the same conversion logic.

## Changes

- Convert files in structured `function_call_output` content into Bedrock document blocks.
- Share document validation, decoding, URL fetching, naming, and format resolution across existing Bedrock paths.
- Return conversion errors instead of silently omitting an invalid document.
- Add regression coverage and the required changelog entry.

This follows the image tool-result precedent in [PR #2658](https://github.com/maximhq/bifrost/pull/2658). [PR #5884](https://github.com/maximhq/bifrost/pull/5884) supplies the Anthropic `tool_result.document` to canonical `input_file` conversion.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor only
- [ ] Documentation

## How to test

```sh
cd core
go test ./providers/anthropic ./providers/bedrock -count=1
go test -race ./providers/anthropic ./providers/bedrock -run 'ToolResultDocument|DocumentFormat' -count=1
go vet ./providers/anthropic ./providers/bedrock
go test ./... -run '^$' -count=1
golangci-lint run --new-from-rev=upstream/dev ./...
```

All commands pass locally; diff-only lint reports zero issues. Live provider tests require credentials.

## Breaking changes

None.

## Screenshots/recordings

N/A — provider conversion only.

## Related work

Closes #5661

## Checklist

- [x] Targets `dev` from a fork using a `feat/` branch
- [x] Tests and changelog included
- [x] No public API, config, UI, or documentation change
- [x] CLA signed
