### PR TITLE
docs: clarify SDK virtual key placeholders

### DIFF
--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -112,7 +112,9 @@ To make non-OpenAI models show up in `/models` and carry correct metadata, creat
 
 ### 1. Create a model catalog file
 
-Create `~/.codex/bifrost_catalog.json` with one entry per model you want listed. At minimum, set the `slug` (the `provider/model` string you pass to Codex), a `display_name`, and the `context_window`:
+You don't need to create a model entry from scratch. First choose a complete, compatible entry from `~/.codex/models_cache.json`, then copy it into `~/.codex/bifrost_catalog.json` while overriding only `slug`, `display_name`, and `context_window`.
+
+The following example shows the complete entry shape. The two `<COPY-...>` values represent long, version-specific strings; copy their full values from the same source entry without modifying them.
 
 ```json
 {
@@ -120,23 +122,72 @@ Create `~/.codex/bifrost_catalog.json` with one entry per model you want listed.
     {
       "slug": "bedrock/anthropic.claude-haiku-4-5",
       "display_name": "Claude Haiku 4.5 (Bifrost)",
-      "description": "Served via Bifrost gateway",
-      "context_window": 200000,
-      "max_context_window": 200000,
+      "description": "Small, fast, and cost-efficient model for simpler coding tasks.",
       "default_reasoning_level": "medium",
       "supported_reasoning_levels": [
-        { "effort": "low", "description": "Fast responses with lighter reasoning" },
-        { "effort": "medium", "description": "Balances speed and reasoning depth" },
-        { "effort": "high", "description": "Greater reasoning depth for complex problems" }
+        {
+          "effort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "effort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "effort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        }
       ],
-      "visibility": "list"
+      "shell_type": "shell_command",
+      "visibility": "list",
+      "supported_in_api": true,
+      "priority": 23,
+      "additional_speed_tiers": [],
+      "service_tiers": [],
+      "availability_nux": null,
+      "upgrade": null,
+      "base_instructions": "<COPY-FULL-BASE-INSTRUCTIONS-FROM-SOURCE-ENTRY>",
+      "model_messages": {
+        "instructions_template": "<COPY-FULL-INSTRUCTIONS-TEMPLATE-FROM-SOURCE-ENTRY>",
+        "instructions_variables": {},
+        "approvals": null,
+        "auto_review": null,
+        "permissions": null
+      },
+      "include_skills_usage_instructions": true,
+      "default_reasoning_summary": "none",
+      "support_verbosity": true,
+      "default_verbosity": "medium",
+      "apply_patch_tool_type": "freeform",
+      "web_search_tool_type": "text_and_image",
+      "truncation_policy": {
+        "mode": "tokens",
+        "limit": 10000
+      },
+      "supports_parallel_tool_calls": true,
+      "supports_image_detail_original": true,
+      "context_window": 200000,
+      "max_context_window": 272000,
+      "comp_hash": "2911",
+      "effective_context_window_percent": 95,
+      "experimental_supported_tools": [],
+      "input_modalities": [
+        "text",
+        "image"
+      ],
+      "supports_search_tool": true,
+      "use_responses_lite": false
     }
   ]
 }
 ```
 
 <Note>
-The catalog JSON schema is internal to Codex and its full entry shape (35+ fields) can change between Codex versions. The most reliable way to build valid entries is to copy an existing entry from `~/.codex/models_cache.json` (Codex's own cached catalog) and override `slug`, `display_name`, and `context_window`. Drop reasoning levels that the target model doesn't support — non-OpenAI models generally accept only `low`/`medium`/`high`.
+The catalog JSON schema is internal to Codex and can change between versions. Select a source entry whose API behavior and capabilities are closest to the target model. Preserve every other field from that entry, including compatibility, response parsing, priority, visibility, truncation, reasoning, and tooling metadata. Do not trim the copied object into a minimal entry or remove fields that appear optional.
 </Note>
 
 ### 2. Reference it from config.toml

--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -96,3 +96,59 @@ Bifrost supports the following providers with the `provider/model-name` format:
 <Warning>
 Non-OpenAI models **must support tool use** for Codex CLI to work properly. Codex CLI relies on tool calling for file operations, terminal commands, and code editing. Models without tool use support will fail on most operations.
 </Warning>
+
+## Listing Non-OpenAI Models in the Model Picker
+
+You can always start or switch to a non-OpenAI model by passing it explicitly (`codex --model bedrock/...` or `/model bedrock/...`). However, these models do not appear in the `/models` picker by default, and selecting them logs a warning like:
+
+```
+⚠ Model metadata for `bedrock/anthropic.claude-haiku-4-5` not found.
+  Defaulting to fallback metadata; this can degrade performance and cause issues.
+```
+
+This happens because Codex CLI builds its model picker from its own catalogue i.e. a list bundled into the Codex binary plus a refresh tied to your OpenAI account. Bifrost sits on the inference path, not Codex's model-discovery path, so Codex never learns about your non-OpenAI models. The fallback metadata also assigns a conservative context window, which can trigger premature history compaction.
+
+To make non-OpenAI models show up in `/models` and carry correct metadata, create a local model catalog file and reference it from `config.toml`.
+
+### 1. Create a model catalog file
+
+Create `~/.codex/bifrost_catalog.json` with one entry per model you want listed. At minimum, set the `slug` (the `provider/model` string you pass to Codex), a `display_name`, and the `context_window`:
+
+```json
+{
+  "models": [
+    {
+      "slug": "bedrock/anthropic.claude-haiku-4-5",
+      "display_name": "Claude Haiku 4.5 (Bifrost)",
+      "description": "Served via Bifrost gateway",
+      "context_window": 200000,
+      "max_context_window": 200000,
+      "default_reasoning_level": "medium",
+      "supported_reasoning_levels": [
+        { "effort": "low", "description": "Fast responses with lighter reasoning" },
+        { "effort": "medium", "description": "Balances speed and reasoning depth" },
+        { "effort": "high", "description": "Greater reasoning depth for complex problems" }
+      ],
+      "visibility": "list"
+    }
+  ]
+}
+```
+
+<Note>
+The catalog JSON schema is internal to Codex and its full entry shape (35+ fields) can change between Codex versions. The most reliable way to build valid entries is to copy an existing entry from `~/.codex/models_cache.json` (Codex's own cached catalog) and override `slug`, `display_name`, and `context_window`. Drop reasoning levels that the target model doesn't support — non-OpenAI models generally accept only `low`/`medium`/`high`.
+</Note>
+
+### 2. Reference it from config.toml
+
+Add the `model_catalog_json` key to your `~/.codex/config.toml`, pointing at the file:
+
+```toml
+model_catalog_json = "/Users/<you>/.codex/bifrost_catalog.json"
+```
+
+Restart Codex and run `/models` — your Bifrost models now appear in the picker, and the metadata warning is gone.
+
+<Warning>
+This makes non-OpenAI models appear in the **Codex CLI** picker only. The Codex desktop app's model dropdown is populated from your OpenAI account's catalogue and does **not** merge the local `model_catalog_json` file. Non-OpenAI models won't appear there. In the app, select them with the in-session `/model bedrock/...` command instead.
+</Warning>

--- a/docs/cli-agents/librechat.mdx
+++ b/docs/cli-agents/librechat.mdx
@@ -23,7 +23,7 @@ Add the following to your `librechat.yaml` file:
 ```yaml
 custom:
   - name: "Bifrost"
-    apiKey: "dummy"
+    apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>" # Replace with your actual Bifrost virtual key.
     baseURL: "http://localhost:8080/v1"
     models:
       default: ["openai/gpt-4o"]
@@ -39,7 +39,7 @@ custom:
 
 | Field | Description |
 |-------|-------------|
-| `apiKey` | Bifrost virtual key if authentication is enabled; use `dummy` otherwise |
+| `apiKey` | Replace the example value with your actual Bifrost virtual key. Omit it only when your deployment does not require authentication. |
 | `baseURL` | Bifrost gateway URL + `/v1` (LibreChat uses OpenAI format) |
 | `models.default` | Default models to show. Use Bifrost model IDs (`provider/model`) |
 | `models.fetch` | Set `true` to fetch available models from Bifrost |
@@ -76,7 +76,7 @@ Start LibreChat. Bifrost will appear as a provider with all configured models av
 When Bifrost has [virtual key authentication](/features/governance/virtual-keys) enabled, set `apiKey` to your virtual key:
 
 ```yaml
-apiKey: "bf-your-virtual-key-here"
+apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>"
 ```
 
 This lets you enforce usage limits, budgets, and access control per user or team. For team deployments, create a separate virtual key for each team or environment - each key can have its own rate limits, budgets, and provider access rules configured in the Bifrost dashboard.

--- a/docs/cli-agents/open-webui.mdx
+++ b/docs/cli-agents/open-webui.mdx
@@ -30,7 +30,7 @@ If running Open WebUI in Docker and Bifrost is on the host machine, use `http://
 | Field | Value |
 |-------|-------|
 | **URL** | `http://localhost:8080/v1` (or your Bifrost host, e.g. `https://bifrost.yourcompany.com/v1`) |
-| **API Key** | Your Bifrost virtual key if authentication is enabled; otherwise leave empty or use `dummy` |
+| **API Key** | Replace the example value with your actual Bifrost virtual key. Leave it empty only when your deployment does not require authentication. |
 
 5. Click **Save**
 
@@ -144,7 +144,7 @@ You can also configure Bifrost via environment variables when running Open WebUI
 ```bash
 # Single connection
 OPENAI_API_BASE_URLS="http://localhost:8080/v1"
-OPENAI_API_KEYS="your-bifrost-virtual-key"
+OPENAI_API_KEYS="<YOUR-BIFROST-VIRTUAL-KEY>"
 
 # Multiple connections (semicolon-separated)
 OPENAI_API_BASE_URLS="http://localhost:8080/v1;https://other-gateway.com/v1"

--- a/docs/cli-agents/roo-code.mdx
+++ b/docs/cli-agents/roo-code.mdx
@@ -26,7 +26,7 @@ Install the [Roo Code extension](https://marketplace.visualstudio.com/items?item
 | Field | Value |
 |-------|-------|
 | **Base URL** | `http://localhost:8080/openai` (or your Bifrost host, e.g. `https://bifrost.yourcompany.com/openai`) |
-| **API Key** | Your Bifrost virtual key if authentication is enabled; otherwise use `dummy` or leave empty |
+| **API Key** | Replace the example value with your actual Bifrost virtual key. Leave it empty only when your deployment does not require authentication. |
 | **Model** | Bifrost model ID in `provider/model` format (e.g. `anthropic/claude-sonnet-4-5-20250929`, `openai/gpt-5`) |
 
 ![Roo Code Bifrost configuration](/media/roo-code-config.png)

--- a/docs/features/drop-in-replacement.mdx
+++ b/docs/features/drop-in-replacement.mdx
@@ -21,13 +21,13 @@ Bifrost provides **100% compatible endpoints** for popular AI SDKs by acting as 
 ```python
 # Before: Direct to OpenAI
 client = openai.OpenAI(
-    api_key="your-openai-key"
+    api_key="<YOUR-OPENAI-API-KEY>"
 )
 
 # After: Through Bifrost
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",  # Only change needed
-    api_key="dummy-key"  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 ```
 
@@ -38,13 +38,13 @@ client = openai.OpenAI(
 ```python
 # Before: Direct to Anthropic
 client = anthropic.Anthropic(
-    api_key="your-anthropic-key"
+    api_key="<YOUR-ANTHROPIC-API-KEY>"
 )
 
 # After: Through Bifrost
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",  # Only change needed
-    api_key="dummy-key"  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 ```
 

--- a/docs/integrations/anthropic-sdk/files-and-batch.mdx
+++ b/docs/integrations/anthropic-sdk/files-and-batch.mdx
@@ -20,7 +20,7 @@ The provider is specified using the `x-model-provider` header in `default_header
 ## Client Setup
 
 <Note>
-In API Key section, you can either send virtual key or a dummy key to escape client side validation.
+Replace `<YOUR-BIFROST-VIRTUAL-KEY>` with your actual Bifrost virtual key. The Anthropic SDK sends this value in `x-api-key`, which Bifrost parses as a virtual key.
 </Note>
 
 ### Anthropic Provider (Default)
@@ -30,7 +30,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 ```
 
@@ -46,7 +46,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 ```
@@ -59,7 +59,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "bedrock"}
 )
 ```
@@ -76,7 +76,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "gemini"}
 )
 ```
@@ -102,7 +102,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Upload a text file
@@ -127,7 +127,7 @@ import anthropic
 # Client configured for OpenAI provider
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 
@@ -155,7 +155,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # List all files
@@ -177,7 +177,7 @@ import anthropic
 # Client configured for OpenAI provider
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 
@@ -198,7 +198,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}  # or omit for anthropic
 )
 
@@ -218,7 +218,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 
@@ -246,7 +246,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Create batch with inline requests
@@ -290,7 +290,7 @@ import anthropic
 # Client configured for OpenAI provider
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 
@@ -335,7 +335,7 @@ import anthropic
 # Client configured for Gemini provider
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "gemini"}
 )
 
@@ -383,7 +383,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "anthropic"}  # or "openai", "gemini"
 )
 
@@ -407,7 +407,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "anthropic"}  # or "openai", "gemini"
 )
 
@@ -431,7 +431,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "anthropic"}  # or "openai", "gemini"
 )
 
@@ -450,7 +450,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Get batch results (only available after batch is completed)
@@ -480,7 +480,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Step 1: Create batch with inline requests
@@ -556,7 +556,7 @@ import anthropic
 # Create client with OpenAI provider header
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="virtual-key-or-dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={"x-model-provider": "openai"}
 )
 

--- a/docs/integrations/anthropic-sdk/overview.mdx
+++ b/docs/integrations/anthropic-sdk/overview.mdx
@@ -31,7 +31,7 @@ import anthropic
 # Configure client to use Bifrost
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="dummy-key"  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Make requests as usual
@@ -53,7 +53,7 @@ import Anthropic from "@anthropic-ai/sdk";
 // Configure client to use Bifrost
 const anthropic = new Anthropic({
   baseURL: "http://localhost:8080/anthropic",
-  apiKey: "dummy-key", // Keys handled by Bifrost
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Make requests as usual
@@ -83,7 +83,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Anthropic models (default)
@@ -130,7 +130,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 const anthropic = new Anthropic({
   baseURL: "http://localhost:8080/anthropic",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Anthropic models (default)
@@ -186,9 +186,9 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={
-        "x-bf-vk": "vk_12345",  # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     }
 )
 
@@ -207,9 +207,9 @@ import Anthropic from "@anthropic-ai/sdk";
 
 const anthropic = new Anthropic({
   baseURL: "http://localhost:8080/anthropic",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   defaultHeaders: {
-    "x-bf-vk": "vk_12345", // Virtual key for governance
+    "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   },
 });
 
@@ -244,7 +244,7 @@ import time
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Submit async request
@@ -281,7 +281,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 const anthropic = new Anthropic({
   baseURL: "http://localhost:8080/anthropic",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Submit async request

--- a/docs/integrations/anthropic-sdk/overview.mdx
+++ b/docs/integrations/anthropic-sdk/overview.mdx
@@ -184,6 +184,7 @@ Pass custom headers required by Bifrost plugins (like governance, telemetry, etc
 ```python
 import anthropic
 
+# Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic",
     api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
@@ -205,6 +206,7 @@ response = client.messages.create(
 ```javascript
 import Anthropic from "@anthropic-ai/sdk";
 
+// Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 const anthropic = new Anthropic({
   baseURL: "http://localhost:8080/anthropic",
   apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.

--- a/docs/integrations/bedrock-sdk/overview.mdx
+++ b/docs/integrations/bedrock-sdk/overview.mdx
@@ -103,7 +103,7 @@ import boto3
 
 def add_bifrost_headers(request, **kwargs):
     """Add custom Bifrost headers to the request before signing."""
-    request.headers.add_header("x-bf-vk", "vk_12345")  # Virtual key for governance
+    request.headers.add_header("x-bf-vk", "<YOUR-BIFROST-VIRTUAL-KEY>")  # Replace with your actual Bifrost virtual key.
     request.headers.add_header("x-bf-env", "production")  # Environment tag
 
 client = boto3.client(
@@ -230,4 +230,3 @@ The Bedrock integration currently supports:
 - **[What is an integration?](../what-is-an-integration)** - Core integration concepts  
 - **[Configuration](../../quickstart/gateway/provider-configuration)** - Bedrock provider setup and API key management  
 - **[Core Features](../../features/)** - Governance, semantic caching, and more
-

--- a/docs/integrations/genai-sdk/files-and-batch.mdx
+++ b/docs/integrations/genai-sdk/files-and-batch.mdx
@@ -25,7 +25,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>", # replace with gemini api key here
     http_options=HttpOptions(base_url="http://localhost:8080/genai")
 )
 ```
@@ -42,7 +42,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>", # replace with your gemini api key here.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "gemini"}
@@ -58,7 +58,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>", # replace with your OpenAI API key here.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "openai"}
@@ -74,7 +74,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-anthropic-api-key",
+    api_key="<YOUR-ANTHROPIC-API-KEY>", # replace with your Anthropic api key here.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "anthropic"}
@@ -94,7 +94,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-api-key",
+    api_key="<YOUR-BEDROCK-API-KEY>",  # Replace with your actual Bedrock API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "bedrock"}
@@ -115,10 +115,10 @@ Bedrock requires S3-based file storage for batch operations. Use the [Bedrock SD
 from google import genai
 from google.genai.types import HttpOptions
 
-def get_provider_client(provider: str, api_key: str):
+def get_provider_client(provider: str, bifrost_virtual_key: str):
     """Create GenAI client with x-model-provider header"""
     return genai.Client(
-        api_key=api_key,
+        api_key=bifrost_virtual_key,
         http_options=HttpOptions(
             base_url="http://localhost:8080/genai",
             headers={"x-model-provider": provider}
@@ -126,8 +126,8 @@ def get_provider_client(provider: str, api_key: str):
     )
 
 # Usage
-gemini_client = get_provider_client("gemini", "your-gemini-key")
-openai_client = get_provider_client("openai", "your-openai-key")
+gemini_client = get_provider_client("gemini", "<YOUR-BIFROST-VIRTUAL-KEY>")
+openai_client = get_provider_client("openai", "<YOUR-BIFROST-VIRTUAL-KEY>")
 ```
 
 ---
@@ -151,7 +151,7 @@ def add_gemini_header():
     return {"x-model-provider": "gemini"}
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>",  # Replace with your gemini api key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers=add_gemini_header()
@@ -202,7 +202,7 @@ import json
 import tempfile
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>",  # Replace with your OpenAI API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "openai"}
@@ -270,7 +270,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-VIRTUAL-KEY>",  # Replace with your Gemini API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "gemini"}
@@ -294,7 +294,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>",  # Replace with your OpenAI API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "openai"}
@@ -388,7 +388,7 @@ import json
 import tempfile
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>",  # Replace with your Gemini API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "gemini"}
@@ -435,7 +435,7 @@ import json
 import tempfile
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>",  # Replace with your OpenAI API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "openai"}
@@ -501,7 +501,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>",  # Replace with your Gemini API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "gemini"}
@@ -548,7 +548,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>",  # Replace with your OpenAI API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "openai"}
@@ -594,7 +594,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="your-anthropic-api-key",
+    api_key="<YOUR-ANTHROPIC-API-KEY>",  # Replace with your Anthropic API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "anthropic"}
@@ -747,7 +747,7 @@ provider = "gemini"
 model = "gemini-1.5-flash"
 
 client = genai.Client(
-    api_key="your-gemini-api-key",
+    api_key="<YOUR-GEMINI-API-KEY>",  # Replace with your Gemini API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": provider}
@@ -844,7 +844,7 @@ provider = "openai"
 model = "gpt-4o-mini"
 
 client = genai.Client(
-    api_key="your-openai-api-key",
+    api_key="<YOUR-OPENAI-API-KEY>",  # Replace with your OpenAI API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": provider}
@@ -911,7 +911,7 @@ provider = "anthropic"
 model = "claude-3-sonnet-20240229"
 
 client = genai.Client(
-    api_key="your-anthropic-api-key",
+    api_key="<YOUR-ANTHROPIC-API-KEY>",  # Replace with your Anthropic API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": provider}
@@ -1019,4 +1019,3 @@ print(f"\nSuccess! Anthropic batch {batch_job.name} completed via GenAI SDK.")
 - **[Overview](./overview)** - GenAI SDK integration basics
 - **[Configuration](../../quickstart/gateway/provider-configuration)** - Bifrost setup and configuration
 - **[Core Features](../../features/)** - Governance, semantic caching, and more
-

--- a/docs/integrations/genai-sdk/files-and-batch.mdx
+++ b/docs/integrations/genai-sdk/files-and-batch.mdx
@@ -270,7 +270,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="<YOUR-GEMINI-VIRTUAL-KEY>",  # Replace with your Gemini API key.
+    api_key="<YOUR-GEMINI-API-KEY>",  # Replace with your Gemini API key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={"x-model-provider": "gemini"}

--- a/docs/integrations/genai-sdk/overview.mdx
+++ b/docs/integrations/genai-sdk/overview.mdx
@@ -25,7 +25,7 @@ from google.genai.types import HttpOptions
 
 # Configure client to use Bifrost
 client = genai.Client(
-    api_key="dummy-key",  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     http_options=HttpOptions(base_url="http://localhost:8080/genai")
 )
 
@@ -45,7 +45,8 @@ print(response.text)
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 // Configure client to use Bifrost
-const genAI = new GoogleGenerativeAI("dummy-key", {
+// Replace with your actual Bifrost virtual key.
+const genAI = new GoogleGenerativeAI("<YOUR-BIFROST-VIRTUAL-KEY>", {
   baseUrl: "http://localhost:8080/genai", // Keys handled by Bifrost
 });
 
@@ -73,7 +74,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     http_options=HttpOptions(base_url="http://localhost:8080/genai")
 )
 
@@ -114,7 +115,8 @@ ollama_response = client.models.generate_content(
 ```javascript
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
-const genAI = new GoogleGenerativeAI("dummy-key", {
+// Replace with your actual Bifrost virtual key.
+const genAI = new GoogleGenerativeAI("<YOUR-BIFROST-VIRTUAL-KEY>", {
   baseUrl: "http://localhost:8080/genai",
 });
 
@@ -157,11 +159,11 @@ from google.genai.types import HttpOptions
 
 # Configure client with custom headers
 client = genai.Client(
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     http_options=HttpOptions(
         base_url="http://localhost:8080/genai",
         headers={
-            "x-bf-vk": "vk_12345",  # Virtual key for governance
+            "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key for governance.
         }
     )
 )
@@ -179,10 +181,11 @@ response = client.models.generate_content(
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 // Configure client with custom headers
-const genAI = new GoogleGenerativeAI("dummy-key", {
+// Replace with your actual Bifrost virtual key.
+const genAI = new GoogleGenerativeAI("<YOUR-BIFROST-VIRTUAL-KEY>", {
   baseUrl: "http://localhost:8080/genai",
   customHeaders: {
-    "x-bf-vk": "vk_12345", // Virtual key for governance
+    "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key for governance.
   },
 });
 
@@ -229,4 +232,3 @@ The Google GenAI integration supports all features that are available in both th
 - **[OpenAI SDK](../openai-sdk/overview)** - GPT integration patterns
 - **[Configuration](../../quickstart/gateway/provider-configuration)** - Bifrost setup and configuration
 - **[Core Features](../../features/)** - Advanced Bifrost capabilities
-

--- a/docs/integrations/genai-sdk/overview.mdx
+++ b/docs/integrations/genai-sdk/overview.mdx
@@ -157,6 +157,7 @@ Pass custom headers required by Bifrost plugins (like governance, telemetry, etc
 from google import genai
 from google.genai.types import HttpOptions
 
+# Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 # Configure client with custom headers
 client = genai.Client(
     api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
@@ -180,6 +181,7 @@ response = client.models.generate_content(
 ```javascript
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
+// Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 // Configure client with custom headers
 // Replace with your actual Bifrost virtual key.
 const genAI = new GoogleGenerativeAI("<YOUR-BIFROST-VIRTUAL-KEY>", {

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -26,7 +26,7 @@ from langchain_core.messages import HumanMessage
 llm = ChatOpenAI(
     model="gpt-4o-mini",
     openai_api_base="http://localhost:8080/langchain",  # Point to Bifrost
-    openai_api_key="dummy-key"  # Keys managed by Bifrost
+    openai_api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 response = llm.invoke([HumanMessage(content="Hello!")])
@@ -45,7 +45,7 @@ const llm = new ChatOpenAI({
   configuration: {
     baseURL: "http://localhost:8080/langchain",  // Point to Bifrost
   },
-  openAIApiKey: "dummy-key"  // Keys managed by Bifrost
+  openAIApiKey: "<YOUR-BIFROST-VIRTUAL-KEY>" // Replace with your actual Bifrost virtual key.
 });
 
 const response = await llm.invoke("Hello!");
@@ -155,7 +155,7 @@ llm = ChatOpenAI(
     model="gpt-4o-mini",
     openai_api_base="http://localhost:8080/langchain",
     default_headers={
-        "x-bf-vk": "your-virtual-key",
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",
     }
 )
 
@@ -175,7 +175,7 @@ llm = ChatAnthropic(
     model="claude-3-sonnet-20240229",
     anthropic_api_url="http://localhost:8080/langchain",
     default_headers={
-        "x-bf-vk": "your-virtual-key",  # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     }
 )
 
@@ -195,7 +195,7 @@ llm = ChatGoogleGenerativeAI(
     model="gemini-2.5-flash",
     google_api_base="http://localhost:8080/langchain",
     additional_headers={
-        "x-bf-vk": "your-virtual-key",  # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     }
 )
 
@@ -223,7 +223,7 @@ llm = ChatBedrockConverse(
 
 def add_bifrost_headers(request, **kwargs):
     """Add custom headers to Bedrock requests"""
-    request.headers.add_header("x-bf-vk", "your-virtual-key")
+    request.headers.add_header("x-bf-vk", "<YOUR-BIFROST-VIRTUAL-KEY>")  # Replace with your actual Bifrost virtual key.
 
 # Register header injection for all Bedrock operations
 llm.client.meta.events.register_first(
@@ -253,7 +253,7 @@ bedrock_client = boto3.client(
 
 def add_bifrost_headers(request, **kwargs):
     """Add custom headers to Bedrock requests"""
-    request.headers.add_header("x-bf-vk", "your-virtual-key")
+    request.headers.add_header("x-bf-vk", "<YOUR-BIFROST-VIRTUAL-KEY>")  # Replace with your actual Bifrost virtual key.
 
 # Register header injection before creating LLM
 bedrock_client.meta.events.register_first(
@@ -287,7 +287,7 @@ const llm = new ChatOpenAI({
   configuration: {
     baseURL: "http://localhost:8080/langchain",
     defaultHeaders: {
-      "x-bf-vk": "your-virtual-key",  // Virtual key for governance
+      "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  // Replace with your actual Bifrost virtual key.
     }
   }
 });
@@ -308,7 +308,7 @@ const llm = new ChatAnthropic({
   clientOptions: {
     baseURL: "http://localhost:8080/langchain",
     defaultHeaders: {
-      "x-bf-vk": "your-virtual-key",  // Virtual key for governance
+      "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  // Replace with your actual Bifrost virtual key.
     }
   }
 });
@@ -328,7 +328,7 @@ const llm = new ChatGoogleGenerativeAI({
   model: "gemini-2.5-flash",
   baseURL: "http://localhost:8080/langchain",
   additionalHeaders: {
-    "x-bf-vk": "your-virtual-key",  // Virtual key for governance
+    "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  // Replace with your actual Bifrost virtual key.
   }
 });
 
@@ -360,7 +360,7 @@ from langchain_core.messages import HumanMessage
 llm = ChatOpenAI(
     model="azure/gpt-5.1",  # Azure deployment name
     base_url="http://localhost:8080/langchain",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     reasoning={
         "effort": "high",      # "minimal" | "low" | "medium" | "high"
         "summary": "detailed"  # "auto" | "concise" | "detailed"
@@ -390,7 +390,7 @@ const llm = new ChatOpenAI({
       "x-bf-azure-endpoint": "https://your-resource.openai.azure.com"
     }
   },
-  openAIApiKey: "dummy-key",
+  openAIApiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   reasoning: {
     effort: "high",
     summary: "detailed"
@@ -418,7 +418,7 @@ from langchain_core.messages import HumanMessage
 llm = ChatOpenAI(
     model="gpt-5",
     base_url="http://localhost:8080/langchain",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     max_tokens=2000,
     reasoning={
         "effort": "high",
@@ -440,7 +440,7 @@ const llm = new ChatOpenAI({
   configuration: {
     baseURL: "http://localhost:8080/langchain"
   },
-  openAIApiKey: "dummy-key",
+  openAIApiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   reasoning: {
     effort: "high",
     summary: "detailed"
@@ -469,7 +469,7 @@ from langchain_core.messages import HumanMessage
 # Bedrock Claude with reasoning control
 llm = ChatBedrockConverse(
     model="us.anthropic.claude-opus-4-5-20251101-v1:0",
-    region_name="dummy-region",
+    region_name="<YOUR-AWS-REGION>",
     endpoint_url="http://localhost:8080/langchain",
     aws_access_key_id="dummy-access-key",
     aws_secret_access_key="dummy-secret-key",
@@ -534,7 +534,7 @@ from langchain_core.messages import HumanMessage
 llm = ChatGoogleGenerativeAI(
     model="gemini/gemini-2.5-flash",  # or "vertex/gemini-2.5-flash"
     base_url="http://localhost:8080/langchain",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     max_tokens=4000,
     thinking_budget=1024,    # 0=disable, -1=dynamic, >0=constrained token budget
     include_thoughts=True,   # Include reasoning in response
@@ -562,7 +562,7 @@ from langchain_openai import OpenAIEmbeddings
 embeddings = OpenAIEmbeddings(
     model="text-embedding-3-small",
     base_url="http://localhost:8080/langchain",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Embed a single query
@@ -593,7 +593,7 @@ from langchain_google_genai import GoogleGenerativeAIEmbeddings
 embeddings = GoogleGenerativeAIEmbeddings(
     model="cohere/cohere-embed-v4.0",  # or bedrock/..., gemini/..., etc.
     base_url="http://localhost:8080/langchain",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 query_embedding = embeddings.embed_query("What is machine learning?")

--- a/docs/integrations/litellm-sdk.mdx
+++ b/docs/integrations/litellm-sdk.mdx
@@ -99,7 +99,7 @@ response = completion(
     messages=[{"role": "user", "content": "Hello!"}],
     base_url="http://localhost:8080/litellm",
     extra_headers={
-        "x-bf-vk": "your-virtual-key",          # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",          # Replace with your actual Bifrost virtual key.
     }
 )
 

--- a/docs/integrations/openai-sdk/overview.mdx
+++ b/docs/integrations/openai-sdk/overview.mdx
@@ -25,7 +25,7 @@ import openai
 # Configure client to use Bifrost
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key"  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Make requests as usual
@@ -46,7 +46,7 @@ import OpenAI from "openai";
 // Configure client to use Bifrost
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key", // Keys handled by Bifrost
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Make requests as usual
@@ -75,7 +75,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # OpenAI models (default)
@@ -117,7 +117,7 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // OpenAI models (default)
@@ -168,9 +168,9 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     default_headers={
-        "x-bf-vk": "vk_12345",  # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     }
 )
 
@@ -188,9 +188,9 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   defaultHeaders: {
-    "x-bf-vk": "vk_12345", // Virtual key for governance
+    "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
   },
 });
 
@@ -224,7 +224,7 @@ import time
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Submit async request
@@ -259,7 +259,7 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Submit async request
@@ -307,7 +307,7 @@ import time
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # Submit async request
@@ -342,7 +342,7 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // Submit async request

--- a/docs/integrations/openai-sdk/overview.mdx
+++ b/docs/integrations/openai-sdk/overview.mdx
@@ -166,6 +166,7 @@ Pass custom headers required by Bifrost plugins (like governance, telemetry, etc
 ```python
 import openai
 
+# Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
     api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
@@ -186,6 +187,7 @@ response = client.chat.completions.create(
 ```javascript
 import OpenAI from "openai";
 
+// Sending the virtual key through both fields requires dual_credential_conflict_behavior to be set to "prefer_vk".
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
   apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.

--- a/docs/integrations/passthrough.mdx
+++ b/docs/integrations/passthrough.mdx
@@ -73,7 +73,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai_passthrough/v1",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 response = client.chat.completions.create(
@@ -90,7 +90,7 @@ print(response.choices[0].message.content)
 ```bash
 curl -X POST "http://localhost:8080/openai_passthrough/v1/chat/completions" \
   -H "content-type: application/json" \
-  -H "authorization: Bearer sk-your-openai-key" \
+  -H "authorization: Bearer <YOUR-BIFROST-VIRTUAL-KEY>" \
   -d '{
     "model": "gpt-4o-mini",
     "messages": [{"role":"user","content":"hello from passthrough"}]
@@ -110,7 +110,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/anthropic_passthrough",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 response = client.messages.create(
@@ -128,7 +128,7 @@ print(response.content[0].text)
 ```bash
 curl -X POST "http://localhost:8080/anthropic_passthrough/v1/messages" \
   -H "content-type: application/json" \
-  -H "x-api-key: your-anthropic-key" \
+  -H "x-api-key: <YOUR-ANTHROPIC-API-KEY>" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
     "model": "claude-sonnet-4-20250514",
@@ -150,7 +150,7 @@ from openai import AzureOpenAI
 
 client = AzureOpenAI(
     azure_endpoint="http://localhost:8080/azure_passthrough",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     api_version="2024-10-21",  # passed through as-is in the query string
 )
 
@@ -170,7 +170,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:8080/azure_passthrough/openai/v1/",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
 )
 
 response = client.responses.create(
@@ -189,7 +189,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     base_url="http://localhost:8080/azure_passthrough",
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
 )
 
 response = client.messages.create(
@@ -225,7 +225,7 @@ from google import genai
 from google.genai.types import HttpOptions
 
 client = genai.Client(
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     http_options=HttpOptions(base_url="http://localhost:8080/genai_passthrough")
 )
 
@@ -243,7 +243,7 @@ print(response.text)
 ```bash
 curl -X POST "http://localhost:8080/genai_passthrough/v1beta/models/gemini-2.5-flash:generateContent" \
   -H "content-type: application/json" \
-  -H "x-goog-api-key: your-gemini-key" \
+  -H "x-goog-api-key: <YOUR-GEMINI-API-KEY>" \
   -d '{
     "contents":[{"parts":[{"text":"hello from passthrough"}]}]
   }'
@@ -263,7 +263,7 @@ from google.genai.types import HttpOptions
 
 client = genai.Client(
     vertexai=True,
-    api_key="dummy-key",
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     http_options=HttpOptions(base_url="http://localhost:8080/genai_passthrough")
 )
 

--- a/docs/integrations/pydanticai-sdk.mdx
+++ b/docs/integrations/pydanticai-sdk.mdx
@@ -26,7 +26,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 # Configure provider to use Bifrost
 provider = OpenAIProvider(
     base_url="http://localhost:8080/pydanticai/v1",  # Point to Bifrost
-    api_key="dummy-key"  # Keys managed by Bifrost, Or add virtual key
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 model = OpenAIChatModel("gpt-4o-mini", provider=provider)
 
@@ -72,7 +72,8 @@ anthropic_model = AnthropicModel("claude-3-haiku-20240307", provider=anthropic_p
 anthropic_agent = Agent(anthropic_model)
 
 # Google Gemini models via Pydantic AI
-google_provider = GoogleProvider(base_url=base_url, api_key="dummy-key")
+# Replace with your actual Bifrost virtual key.
+google_provider = GoogleProvider(base_url=base_url, api_key="<YOUR-BIFROST-VIRTUAL-KEY>")
 google_model = GoogleModel("gemini-2.0-flash", provider=google_provider)
 google_agent = Agent(google_model)
 
@@ -270,7 +271,7 @@ from pydantic_ai.providers.openai import OpenAIProvider
 # Create HTTP client with custom headers
 http_client = AsyncClient(
     headers={
-        "x-bf-vk": "your-virtual-key",  # Virtual key for governance
+        "x-bf-vk": "<YOUR-BIFROST-VIRTUAL-KEY>",  # Replace with your actual Bifrost virtual key.
     }
 )
 

--- a/docs/integrations/what-is-an-integration.mdx
+++ b/docs/integrations/what-is-an-integration.mdx
@@ -22,7 +22,7 @@ Bifrost converts the request/response format of the provider API to the Bifrost 
 import openai
 
 client = openai.OpenAI(
-    api_key="your-openai-key"
+    api_key="<YOUR-OPENAI-API-KEY>"
 )
 ```
 
@@ -33,7 +33,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",  # Point to Bifrost
-    api_key="dummy-key" # Keys are handled in Bifrost now
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 ```
 
@@ -64,7 +64,7 @@ import openai
 # Single client, multiple providers
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy"  # API keys configured in Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # OpenAI models
@@ -191,7 +191,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",
-    api_key="dummy-key"
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 
 # List models from all providers (default behavior)
@@ -219,7 +219,7 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai",
-  apiKey: "dummy-key",
+  apiKey: "<YOUR-BIFROST-VIRTUAL-KEY>", // Replace with your actual Bifrost virtual key.
 });
 
 // List models from all providers (default behavior)

--- a/docs/quickstart/gateway/integrations.mdx
+++ b/docs/quickstart/gateway/integrations.mdx
@@ -19,7 +19,7 @@ Integrations are protocol adapters that make Bifrost **100% compatible** with ex
 import openai
 
 client = openai.OpenAI(
-    api_key="your-openai-key"
+    api_key="<YOUR-OPENAI-API-KEY>"
 )
 ```
 
@@ -29,7 +29,7 @@ import openai
 
 client = openai.OpenAI(
     base_url="http://localhost:8080/openai",  # Point to Bifrost
-    api_key="dummy-key"  # Keys handled by Bifrost
+    api_key="<YOUR-BIFROST-VIRTUAL-KEY>"  # Replace with your actual Bifrost virtual key.
 )
 ```
 


### PR DESCRIPTION
## Summary
Clarifies which credentials users must provide when connecting supported SDKs and integrations to Bifrost.

The examples now consistently use `<YOUR-BIFROST-VIRTUAL-KEY>` wherever Bifrost parses the SDK credential as a governance virtual key. This PR also documents how to make non-OpenAI models available in the Codex CLI model picker using a local model catalog.

## Changes
- Replaced ambiguous dummy-key examples with `<YOUR-BIFROST-VIRTUAL-KEY>` where appropriate.
- Added explicit replacement comments to SDK and integration examples.
- Updated OpenAI, Anthropic, Google GenAI, LangChain, LiteLLM, PydanticAI, passthrough, and related gateway documentation.
- Added Codex CLI documentation for:
   - Creating a local model catalog for non-OpenAI models.
   - Configuring `model_catalog_json`.
   - Supplying accurate model context-window and reasoning metadata.
   - The difference between Codex CLI and desktop-app model discovery.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

  ## Checklist

- [x] I read the contribution and pull-request guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (not run; documentation-only change)
- [ ] I verified the CI pipeline passes locally (not run; documentation-only change)