### PR TITLE
fix: include `CachedWriteTokenDetails` in prompt token details response

### DIFF
--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -1563,6 +1563,7 @@ func buildResponseForRequestType(requestType schemas.RequestType, usage *schemas
 					ImageTokens:       usage.PromptTokensDetails.ImageTokens,
 					CachedReadTokens:  usage.PromptTokensDetails.CachedReadTokens,
 					CachedWriteTokens: usage.PromptTokensDetails.CachedWriteTokens,
+					CachedWriteTokenDetails: usage.PromptTokensDetails.CachedWriteTokenDetails,
 				}
 			}
 			if usage.CompletionTokensDetails != nil {


### PR DESCRIPTION
## Summary

Adds `CachedWriteTokenDetails` to the prompt token details mapping when building responses, ensuring this field is properly propagated from usage data into the response payload.

## Changes

- `CachedWriteTokenDetails` is now included when mapping `PromptTokensDetails` in `buildResponseForRequestType`, bringing it in line with the other fields already being mapped (`ImageTokens`, `CachedReadTokens`, `CachedWriteTokens`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that responses including prompt token usage with `CachedWriteTokenDetails` correctly reflect those details in the response output.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable