### PR TITLE
feat: add `SyncRoutingRules` for atomic batch routing rule sync with deferred priority check

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4910,6 +4910,117 @@ func (s *RDBConfigStore) UpdateRoutingRule(ctx context.Context, rule *tables.Tab
 	}))
 }
 
+// SyncRoutingRules applies a batch of routing rule creates and updates atomically, deferring the
+// unique-priority-per-scope check until every rule is written. This lets a valid permutation (e.g.
+// swapping two rules' priorities) succeed despite a transient intermediate collision, while a
+// genuine end-state duplicate still errors. Used by config-file reloads that apply many rules at once.
+func (s *RDBConfigStore) SyncRoutingRules(ctx context.Context, toAdd []tables.TableRoutingRule, toUpdate []tables.TableRoutingRule, tx ...*gorm.DB) error {
+	database := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		database = tx[0]
+	}
+
+	// Validate scopeID is required for non-global scope (same guard as CreateRoutingRule/UpdateRoutingRule).
+	for _, list := range [][]tables.TableRoutingRule{toAdd, toUpdate} {
+		for i := range list {
+			if list[i].Scope != "" && list[i].Scope != "global" && list[i].ScopeID == nil {
+				return fmt.Errorf("scopeID is required for non-global scope '%s'", list[i].Scope)
+			}
+		}
+	}
+
+	type scopeRef struct {
+		scope   string
+		scopeID *string
+	}
+
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		seen := make(map[string]bool)
+		scopes := make([]scopeRef, 0, len(toAdd)+len(toUpdate))
+		record := func(rule *tables.TableRoutingRule) {
+			key := rule.Scope
+			if rule.ScopeID != nil {
+				key += "\x00" + *rule.ScopeID
+			}
+			if !seen[key] {
+				seen[key] = true
+				scopes = append(scopes, scopeRef{scope: rule.Scope, scopeID: rule.ScopeID})
+			}
+		}
+
+		putTargets := func(rule *tables.TableRoutingRule) error {
+			for i := range rule.Targets {
+				rule.Targets[i].RuleID = rule.ID
+				if err := tx.Create(&rule.Targets[i]).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		// Insert new rules.
+		for i := range toAdd {
+			rule := &toAdd[i]
+			targets := rule.Targets
+			rule.Targets = nil
+			if err := tx.Omit("Targets").Create(rule).Error; err != nil {
+				return err
+			}
+			rule.Targets = targets
+			if err := putTargets(rule); err != nil {
+				return err
+			}
+			record(rule)
+		}
+
+		// Update changed rules and replace their targets.
+		for i := range toUpdate {
+			rule := &toUpdate[i]
+			var existing tables.TableRoutingRule
+			if err := dbForUpdate(tx).First(&existing, "id = ?", rule.ID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return ErrNotFound
+				}
+				return err
+			}
+			targets := rule.Targets
+			rule.Targets = nil
+			if err := tx.Omit("Targets").Save(rule).Error; err != nil {
+				return err
+			}
+			rule.Targets = targets
+			if err := tx.Where("rule_id = ?", rule.ID).Delete(&tables.TableRoutingTarget{}).Error; err != nil {
+				return err
+			}
+			if err := putTargets(rule); err != nil {
+				return err
+			}
+			record(rule)
+		}
+
+		// Deferred invariant: no two rules may share a priority within a scope's final state.
+		for _, sc := range scopes {
+			q := tx.Model(&tables.TableRoutingRule{}).Where("scope = ?", sc.scope)
+			if sc.scopeID != nil {
+				q = q.Where("scope_id = ?", *sc.scopeID)
+			} else {
+				q = q.Where("scope_id IS NULL")
+			}
+			var dup []int
+			if err := q.Group("priority").Having("COUNT(*) > 1").Pluck("priority", &dup).Error; err != nil {
+				return err
+			}
+			if len(dup) > 0 {
+				if sc.scopeID != nil {
+					return fmt.Errorf("routing rule with priority %d already exists for scope '%s' with scopeID '%s'", dup[0], sc.scope, *sc.scopeID)
+				}
+				return fmt.Errorf("routing rule with priority %d already exists for scope '%s'", dup[0], sc.scope)
+			}
+		}
+		return nil
+	}))
+}
+
 // DeleteRoutingRule deletes a routing rule and its targets from the database.
 func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ...*gorm.DB) error {
 	database := s.DB()

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -3323,3 +3323,73 @@ func TestWebhookEndpointTuningRoundTripAndHash(t *testing.T) {
 	invalid.MaxRetries = -1
 	assert.Error(t, invalid.Validate())
 }
+
+// TestRDBConfigStore_SyncRoutingRules covers the batch path used by config-file reloads.
+// It defers the unique-priority-per-scope check to the final state, so a valid permutation
+// (e.g. swapping two priorities) succeeds despite a transient intermediate collision, while a
+// genuine end-state duplicate still errors and a missing update target returns ErrNotFound.
+func TestRDBConfigStore_SyncRoutingRules(t *testing.T) {
+	ctx := context.Background()
+
+	rule := func(id string, priority int) tables.TableRoutingRule {
+		return *routingRuleFixture(id, priority, "openai")
+	}
+
+	tests := []struct {
+		name       string
+		toAdd      []tables.TableRoutingRule
+		toUpdate   []tables.TableRoutingRule
+		wantErrIs  error
+		wantErrSub string
+		wantFinal  map[string]int // expected priority per rule ID after the call
+	}{
+		{
+			name:      "valid priority swap succeeds",
+			toUpdate:  []tables.TableRoutingRule{rule("rule-a", 1), rule("rule-b", 0)},
+			wantFinal: map[string]int{"rule-a": 1, "rule-b": 0},
+		},
+		{
+			name:      "batch add plus swap succeeds",
+			toAdd:     []tables.TableRoutingRule{rule("rule-c", 2)},
+			toUpdate:  []tables.TableRoutingRule{rule("rule-a", 1), rule("rule-b", 0)},
+			wantFinal: map[string]int{"rule-a": 1, "rule-b": 0, "rule-c": 2},
+		},
+		{
+			name:       "final-state duplicate priority fails and rolls back",
+			toUpdate:   []tables.TableRoutingRule{rule("rule-a", 1), rule("rule-b", 1)},
+			wantErrSub: "already exists",
+			wantFinal:  map[string]int{"rule-a": 0, "rule-b": 1}, // unchanged (rolled back)
+		},
+		{
+			name:      "missing update ID returns ErrNotFound",
+			toUpdate:  []tables.TableRoutingRule{rule("rule-missing", 5)},
+			wantErrIs: ErrNotFound,
+			wantFinal: map[string]int{"rule-a": 0, "rule-b": 1}, // unchanged
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := setupRDBTestStore(t)
+			require.NoError(t, store.CreateRoutingRule(ctx, routingRuleFixture("rule-a", 0, "openai")))
+			require.NoError(t, store.CreateRoutingRule(ctx, routingRuleFixture("rule-b", 1, "openai")))
+
+			err := store.SyncRoutingRules(ctx, tc.toAdd, tc.toUpdate)
+			switch {
+			case tc.wantErrIs != nil:
+				require.ErrorIs(t, err, tc.wantErrIs)
+			case tc.wantErrSub != "":
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrSub)
+			default:
+				require.NoError(t, err)
+			}
+
+			for id, want := range tc.wantFinal {
+				got, getErr := store.GetRoutingRule(ctx, id)
+				require.NoError(t, getErr)
+				require.Equalf(t, want, got.Priority, "priority for %s", id)
+			}
+		})
+	}
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -377,6 +377,10 @@ type ConfigStore interface {
 	GetRoutingRulesPaginated(ctx context.Context, params RoutingRulesQueryParams) ([]tables.TableRoutingRule, int64, error)
 	CreateRoutingRule(ctx context.Context, rule *tables.TableRoutingRule, tx ...*gorm.DB) error
 	UpdateRoutingRule(ctx context.Context, rule *tables.TableRoutingRule, tx ...*gorm.DB) error
+	// SyncRoutingRules applies a batch of creates and updates atomically, deferring the
+	// unique-priority-per-scope check until all rules are written so that a valid permutation
+	// (e.g. swapping two rules' priorities) succeeds despite a transient intermediate collision.
+	SyncRoutingRules(ctx context.Context, toAdd []tables.TableRoutingRule, toUpdate []tables.TableRoutingRule, tx ...*gorm.DB) error
 	DeleteRoutingRule(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// Model config CRUD

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3383,18 +3383,12 @@ func updateGovernanceConfigInStore(
 			}
 		}
 
-		// Create routing rules (new from config.json)
-		for _, rule := range routingRulesToAdd {
-			if err := config.ConfigStore.CreateRoutingRule(ctx, &rule, tx); err != nil {
-				return fmt.Errorf("failed to create routing rule %s: %w", rule.ID, err)
-			}
-		}
-
-		// Update routing rules (config.json changed)
-		for _, rule := range routingRulesToUpdate {
-			if err := config.ConfigStore.UpdateRoutingRule(ctx, &rule, tx); err != nil {
-				return fmt.Errorf("failed to update routing rule %s: %w", rule.ID, err)
-			}
+		// Apply routing rules as a batch so the unique-priority-per-scope check runs against
+		// the final state, not intermediate steps. A valid permutation (e.g. swapping two
+		// rules' priorities) transiently duplicates a priority mid-sync but is not a real
+		// conflict; a genuine end-state duplicate still errors.
+		if err := config.ConfigStore.SyncRoutingRules(ctx, routingRulesToAdd, routingRulesToUpdate, tx); err != nil {
+			return fmt.Errorf("failed to sync routing rules: %w", err)
 		}
 
 		// Create pricing overrides (new from config.json)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1588,6 +1588,10 @@ func (m *MockConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx .
 	return nil
 }
 
+func (m *MockConfigStore) SyncRoutingRules(ctx context.Context, toAdd []tables.TableRoutingRule, toUpdate []tables.TableRoutingRule, tx ...*gorm.DB) error {
+	return nil
+}
+
 // Sidekiq
 func (m *MockConfigStore) CreateSidekiqJob(ctx context.Context, job *tables.TableSidekiqJob) error {
 	return nil


### PR DESCRIPTION
## Summary

When reloading routing rules from a config file, creates and updates were applied one-by-one, causing the unique-priority-per-scope constraint to be checked after each individual write. This meant valid permutations — such as swapping the priorities of two existing rules — would fail with a spurious duplicate-priority error mid-sync, even though the final state was valid.

## Changes

- Added `SyncRoutingRules` to `RDBConfigStore` and the `ConfigStore` interface, which accepts batches of rules to create and update, applies them all within a single transaction, and defers the unique-priority-per-scope check until every rule has been written. Genuine end-state duplicates still produce an error.
- Replaced the sequential `CreateRoutingRule` / `UpdateRoutingRule` loop in `updateGovernanceConfigInStore` with a single `SyncRoutingRules` call, so config-file reloads that permute priorities no longer fail on transient intermediate collisions.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that swapping the priorities of two existing routing rules in a config file reload succeeds without a duplicate-priority error, and that a config file with a genuine end-state priority collision still returns an error.

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing implications. The deferred constraint check ensures the same invariant is enforced as before — only the point in the transaction at which it is evaluated has changed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable