### PR TITLE
adds CalculateCost and GetModelConfig for ctx in plugins

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -88,6 +88,7 @@ type Bifrost struct {
 	bifrostRequestPool  sync.Pool                           // Pool for BifrostRequest objects
 	logger              schemas.Logger                      // logger instance, default logger is used if not provided
 	tracer              atomic.Value                        // tracer for distributed tracing (stores schemas.Tracer, NoOpTracer if not configured)
+	modelCatalog        schemas.ModelInfoProvider           // model pricing/capability catalog exposed to plugins via ctx.GetModelInfo (nil if not configured); set once from BifrostConfig at Init
 	MCPManager          mcp.MCPManagerInterface             // MCP integration manager (nil if MCP not configured)
 	mcpCredStore        schemas.MCPCredentialStore          // Per-call credential resolver for MCP tool execution (wraps oauth2Provider for OAuth-flavored auth types)
 	mcpInitOnce         sync.Once                           // Ensures MCP manager is initialized only once
@@ -245,6 +246,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 		mcpCredStore:  credstore.NewCredStore(config.OAuth2Provider, config.MCPHeadersProvider, config.Logger),
 		logger:        config.Logger,
 		kvStore:       config.KVStore,
+		modelCatalog:  config.ModelCatalog,
 	}
 	bifrost.tracer.Store(&tracerWrapper{tracer: tracer})
 	if config.LLMPlugins == nil {
@@ -388,6 +390,33 @@ func (bifrost *Bifrost) SetTracer(tracer schemas.Tracer) {
 // getTracer returns the tracer from atomic storage with type assertion.
 func (bifrost *Bifrost) getTracer() schemas.Tracer {
 	return bifrost.tracer.Load().(*tracerWrapper).tracer
+}
+
+// getModelCatalog returns the catalog supplied at Init, or nil if none was.
+func (bifrost *Bifrost) getModelCatalog() schemas.ModelInfoProvider {
+	return bifrost.modelCatalog
+}
+
+// setModelCatalogOnContext stamps the catalog handle onto a request context so
+// plugin hooks can reach it. Scoped plugin contexts delegate Value lookups to
+// the root (see BifrostContext.WithPluginScope), so stamping the root once is
+// enough for every plugin in the pipeline.
+//
+// The no-catalog case clears rather than skips: reused long-lived contexts
+// (realtime WS connections re-enter this per message) would otherwise keep
+// serving a catalog that a later SetModelCatalog(nil) already retired.
+// ClearValue is itself a no-op on a context with no values map, so SDK users
+// who never wire a catalog still pay nothing.
+func (bifrost *Bifrost) setModelCatalogOnContext(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	catalog := bifrost.getModelCatalog()
+	if catalog == nil {
+		ctx.ClearValue(schemas.BifrostContextKeyModelCatalog)
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyModelCatalog, catalog)
 }
 
 // ReloadConfig reloads the config from DB
@@ -2877,6 +2906,7 @@ func (bifrost *Bifrost) ExecuteChatMCPTool(ctx *schemas.BifrostContext, toolCall
 	} else {
 		ensureMCPRawStorageContext(ctx)
 		ensureMCPTracerContext(ctx, bifrost.getTracer())
+		bifrost.setModelCatalogOnContext(ctx)
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{
@@ -2896,6 +2926,7 @@ func (bifrost *Bifrost) ExecuteResponsesMCPTool(ctx *schemas.BifrostContext, too
 	} else {
 		ensureMCPRawStorageContext(ctx)
 		ensureMCPTracerContext(ctx, bifrost.getTracer())
+		bifrost.setModelCatalogOnContext(ctx)
 	}
 	if bifrost.MCPManager == nil {
 		return nil, &schemas.BifrostError{
@@ -4551,6 +4582,7 @@ func (bifrost *Bifrost) RunPreRequestHooks(ctx *schemas.BifrostContext, req *sch
 	if _, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok {
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
 	}
+	bifrost.setModelCatalogOnContext(ctx)
 
 	pipeline := bifrost.getPluginPipeline()
 	defer bifrost.releasePluginPipeline(pipeline)
@@ -4575,6 +4607,7 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 
 	tracer := bifrost.getTracer()
 	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
+	bifrost.setModelCatalogOnContext(ctx)
 
 	// Create a trace so the logging plugin can accumulate streaming chunks.
 	// The traceID is used as the accumulator key in ProcessStreamingChunk.
@@ -4710,6 +4743,7 @@ func (bifrost *Bifrost) RunRealtimeTurnPreHooks(ctx *schemas.BifrostContext, req
 
 	tracer := bifrost.getTracer()
 	ctx.SetValue(schemas.BifrostContextKeyTracer, tracer)
+	bifrost.setModelCatalogOnContext(ctx)
 
 	if _, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); !ok {
 		traceID := tracer.CreateTrace("")
@@ -5021,6 +5055,9 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		requestID := uuid.New().String()
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
 	}
+	// Expose the model catalog to plugins (ctx.GetModelInfo / ctx.CalculateCost)
+	// before any hook runs.
+	bifrost.setModelCatalogOnContext(ctx)
 
 	// PreRequestHook: once-per-request phase where plugins decide provider/model/fallbacks
 	// (and may mutate other request fields). Mutations commit to req and are observed by
@@ -5153,6 +5190,9 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 		requestID := uuid.New().String()
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
 	}
+	// Expose the model catalog to plugins (ctx.GetModelInfo / ctx.CalculateCost)
+	// before any hook runs.
+	bifrost.setModelCatalogOnContext(ctx)
 
 	// PreRequestHook: once-per-request phase. See handleRequest for semantics.
 	preReqPipeline := bifrost.getPluginPipeline()

--- a/core/modelcataloghooks_test.go
+++ b/core/modelcataloghooks_test.go
@@ -1,0 +1,196 @@
+package bifrost
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// probeCatalog is a schemas.ModelInfoProvider returning known values, so a hook
+// reading a real one proves the handle reached it rather than that some other
+// lookup happened to succeed.
+type probeCatalog struct {
+	info *schemas.Model
+	cost float64
+
+	gotProvider schemas.ModelProvider
+	gotModel    string
+	infoCalls   int
+	costCalls   int
+}
+
+func (p *probeCatalog) GetModelInfo(provider schemas.ModelProvider, model string) *schemas.Model {
+	p.infoCalls++
+	p.gotProvider = provider
+	p.gotModel = model
+	return p.info
+}
+
+func (p *probeCatalog) CalculateRequestCost(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) float64 {
+	p.costCalls++
+	return p.cost
+}
+
+// catalogProbePlugin reads ctx.GetModelInfo / ctx.CalculateCost from each hook
+// and records what it saw, then short-circuits so no provider is called.
+type catalogProbePlugin struct {
+	preRequestInfo *schemas.Model
+	preLLMInfo     *schemas.Model
+	postInfo       *schemas.Model
+	postCost       float64
+
+	preRequestRan bool
+	preLLMRan     bool
+	postRan       bool
+}
+
+func (d *catalogProbePlugin) GetName() string { return "catalog-probe" }
+func (d *catalogProbePlugin) Cleanup() error  { return nil }
+
+func (d *catalogProbePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
+	d.preRequestRan = true
+	d.preRequestInfo = ctx.GetModelInfo(schemas.OpenAI, "gpt-4o")
+	return nil
+}
+
+func (d *catalogProbePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	d.preLLMRan = true
+	d.preLLMInfo = ctx.GetModelInfo(schemas.OpenAI, "gpt-4o")
+
+	// Short-circuit rather than call a provider: this test is about the handle
+	// reaching every hook, and a short-circuited response still runs
+	// PostLLMHook, which is the hook cost is usually read from.
+	return req, &schemas.LLMPluginShortCircuit{
+		Response: &schemas.BifrostResponse{
+			ChatResponse: &schemas.BifrostChatResponse{
+				Model: "gpt-4o",
+				Usage: &schemas.BifrostLLMUsage{
+					PromptTokens:     5,
+					CompletionTokens: 10,
+					TotalTokens:      15,
+				},
+			},
+		},
+	}, nil
+}
+
+func (d *catalogProbePlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	d.postRan = true
+	d.postInfo = ctx.GetModelInfo(schemas.OpenAI, "gpt-4o")
+	d.postCost = ctx.CalculateCost(resp)
+	return resp, bifrostErr, nil
+}
+
+func newCatalogProbeClient(t *testing.T, catalog schemas.ModelInfoProvider, plugin schemas.LLMPlugin) *Bifrost {
+	t.Helper()
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 1, 1)
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{{
+		ID:     "openai-key-1",
+		Value:  *schemas.NewSecretVar("sk-test"),
+		Models: schemas.WhiteList{"*"},
+	}})
+
+	client, initErr := Init(context.Background(), schemas.BifrostConfig{
+		Account:      account,
+		Logger:       NewNoOpLogger(),
+		ModelCatalog: catalog,
+		LLMPlugins:   []schemas.LLMPlugin{plugin},
+	})
+	if initErr != nil {
+		t.Fatalf("Init failed: %v", initErr)
+	}
+	t.Cleanup(client.Shutdown)
+	return client
+}
+
+func chatProbeRequest() *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+		},
+	}
+}
+
+// The accessors are unit-tested in schemas and the catalog is unit-tested in
+// framework, but nothing covered the two meeting on a real request. This drives
+// an actual ChatCompletionRequest through Init-supplied wiring and asserts a
+// plugin reads the catalog from every hook it runs in.
+//
+// Worth having as a test rather than a manual check: no shipped plugin calls
+// these accessors yet, so a break in the stamping would otherwise surface only
+// in a third-party plugin.
+func TestModelCatalogReachesPluginHooksOnRealRequest(t *testing.T) {
+	want := &schemas.Model{ID: "gpt-4o", ContextLength: new(128000)}
+	catalog := &probeCatalog{info: want, cost: 0.25}
+	plugin := &catalogProbePlugin{}
+	client := newCatalogProbeClient(t, catalog, plugin)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	defer ctx.Cancel()
+
+	if _, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest()); bfErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
+	}
+
+	if !plugin.preRequestRan || !plugin.preLLMRan || !plugin.postRan {
+		t.Fatalf("hooks ran: preRequest=%v preLLM=%v post=%v, want all three",
+			plugin.preRequestRan, plugin.preLLMRan, plugin.postRan)
+	}
+
+	// Every hook phase stamps the handle, so all three must resolve it.
+	if plugin.preRequestInfo != want {
+		t.Errorf("PreRequestHook GetModelInfo = %v, want the catalog's model", plugin.preRequestInfo)
+	}
+	if plugin.preLLMInfo != want {
+		t.Errorf("PreLLMHook GetModelInfo = %v, want the catalog's model", plugin.preLLMInfo)
+	}
+	if plugin.postInfo != want {
+		t.Errorf("PostLLMHook GetModelInfo = %v, want the catalog's model", plugin.postInfo)
+	}
+	if plugin.postCost != 0.25 {
+		t.Errorf("PostLLMHook CalculateCost = %v, want 0.25", plugin.postCost)
+	}
+
+	// The arguments must arrive unchanged; a mangled provider would silently
+	// return nil for every real model.
+	if catalog.gotProvider != schemas.OpenAI || catalog.gotModel != "gpt-4o" {
+		t.Errorf("catalog saw (%q, %q), want (openai, gpt-4o)", catalog.gotProvider, catalog.gotModel)
+	}
+	if catalog.costCalls != 1 {
+		t.Errorf("CalculateRequestCost called %d times, want 1", catalog.costCalls)
+	}
+}
+
+// Core is usable as a Go SDK with no catalog wired. Plugins written against the
+// accessors must then degrade to zero values rather than panicking, or a plugin
+// would be unusable outside the gateway.
+func TestModelCatalogAbsentLeavesHooksInert(t *testing.T) {
+	plugin := &catalogProbePlugin{}
+	client := newCatalogProbeClient(t, nil, plugin)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	defer ctx.Cancel()
+
+	if _, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest()); bfErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
+	}
+
+	// Guard every hook, not just the last: a nil reading from a hook that never
+	// ran would satisfy the assertions below for entirely the wrong reason.
+	if !plugin.preRequestRan || !plugin.preLLMRan || !plugin.postRan {
+		t.Fatalf("hooks ran: preRequest=%v preLLM=%v post=%v, want all three",
+			plugin.preRequestRan, plugin.preLLMRan, plugin.postRan)
+	}
+	if plugin.preRequestInfo != nil || plugin.preLLMInfo != nil || plugin.postInfo != nil {
+		t.Errorf("GetModelInfo returned non-nil with no catalog wired: preRequest=%v preLLM=%v post=%v",
+			plugin.preRequestInfo, plugin.preLLMInfo, plugin.postInfo)
+	}
+	if plugin.postCost != 0 {
+		t.Errorf("CalculateCost = %v with no catalog wired, want 0", plugin.postCost)
+	}
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -36,6 +36,7 @@ type BifrostConfig struct {
 	KeySelector        KeySelector   // Custom key selector function
 	KeyPoolFilter      KeyPoolFilter // Optional hook to filter available keys before selection; nil = all keys eligible
 	KVStore            KVStore       // shared KV store for clustering/session stickiness; nil = disabled
+	ModelCatalog       ModelInfoProvider
 }
 
 // ModelProvider represents the different AI model providers supported by Bifrost.
@@ -286,6 +287,7 @@ const (
 	BifrostContextKeyParentSpanID                        BifrostContextKey = "bifrost-parent-span-id"                           // string (parent span ID from W3C traceparent header - set by tracing middleware)
 	BifrostContextKeyStreamStartTime                     BifrostContextKey = "bifrost-stream-start-time"                        // time.Time (start time for streaming TTFT calculation - set by bifrost)
 	BifrostContextKeyTracer                              BifrostContextKey = "bifrost-tracer"                                   // Tracer (tracer instance for completing deferred spans - set by bifrost)
+	BifrostContextKeyModelCatalog                        BifrostContextKey = "bifrost-model-catalog"                            // ModelInfoProvider (model pricing/capability catalog backing ctx.GetModelInfo and ctx.CalculateCost - set by bifrost)
 	BifrostContextKeyDeferTraceCompletion                BifrostContextKey = "bifrost-defer-trace-completion"                   // bool (signals trace completion should be deferred for streaming - set by streaming handlers)
 	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func([]PluginLogEntry) (callback to complete trace after streaming, receives transport plugin logs - set by tracing middleware)
 	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -579,6 +579,60 @@ func (bc *BifrostContext) GetAccumulatedResponse() *BifrostResponse {
 	return tr.GetAccumulatedResponse(tid)
 }
 
+// GetModelInfo returns pricing and capability metadata for a (provider, model)
+// pair: the same information the /v1/models endpoint reports, including
+// per-token pricing, context length, max input/output tokens, architecture and
+// deprecation status.
+//
+// Returns nil when the model is unknown to the catalog, and also when no
+// catalog is wired into this Bifrost instance (e.g. core used directly as a Go
+// SDK without the framework). Callers must nil-check.
+//
+// The returned *Model is freshly built and owned by the caller. Mutating it
+// does not affect the catalog or any other caller.
+//
+// PLUGIN AUTHORS: provider must be the concrete provider that serves the model
+// (e.g. schemas.Anthropic), not an empty string. Inside a hook, read it from
+// req.GetRequestFields() or the response's RoutingInfo rather than guessing
+// from the model string.
+func (bc *BifrostContext) GetModelInfo(provider ModelProvider, model string) *Model {
+	catalog, _ := bc.Value(BifrostContextKeyModelCatalog).(ModelInfoProvider)
+	if catalog == nil || model == "" {
+		return nil
+	}
+	return catalog.GetModelInfo(provider, model)
+}
+
+// CalculateCost returns the dollar cost of a completed response.
+//
+// Prefer this over doing arithmetic on GetModelInfo(...).Pricing: that field
+// carries only flat prompt/completion rates, whereas this path applies the full
+// pricing resolution: long-context tiers (128k/200k/272k), batch/priority/flex
+// /fast rates, cache read/write costs, the provider and request-mode fallback
+// chain, and any virtual-key / user / provider-key pricing overrides in effect
+// for this request.
+//
+// Returns 0 when no catalog is wired or the response has no billable usage.
+//
+// PLUGIN AUTHORS: call this synchronously inside your hook. It reads the
+// governance scopes (user ID, virtual key ID, selected key ID) off the context,
+// and that read is not safe once the request context has been cancelled. If you
+// need the cost in a background goroutine, compute it in the hook and close over
+// the float64:
+//
+//	func (p *Plugin) PostLLMHook(ctx *schemas.BifrostContext, resp ...) (...) {
+//	    cost := ctx.CalculateCost(resp) // synchronous
+//	    go func() { p.report(cost) }()
+//	    return resp, nil, nil
+//	}
+func (bc *BifrostContext) CalculateCost(resp *BifrostResponse) float64 {
+	catalog, _ := bc.Value(BifrostContextKeyModelCatalog).(ModelInfoProvider)
+	if catalog == nil || resp == nil {
+		return 0
+	}
+	return catalog.CalculateRequestCost(bc, resp)
+}
+
 // AppendRoutingEngineLog appends a routing engine log entry to the context.
 // Parameters:
 //   - ctx: The Bifrost context

--- a/core/schemas/modelcatalog.go
+++ b/core/schemas/modelcatalog.go
@@ -1,0 +1,25 @@
+package schemas
+
+// ModelInfoProvider is the narrow slice of the model catalog that core exposes
+// to plugins. The catalog itself lives in framework/modelcatalog, which core
+// cannot import (framework depends on core, not the other way round), so the
+// concrete instance arrives as an interface value stamped onto the request
+// context under BifrostContextKeyModelCatalog.
+//
+// This mirrors how Tracer is wired: interface declared here, implemented in
+// framework, reached from BifrostContext via a lookup-and-delegate accessor.
+//
+// Implemented by *modelcatalog.ModelCatalog.
+type ModelInfoProvider interface {
+	// GetModelInfo returns pricing and capability metadata for a
+	// (provider, model) pair, or nil when the catalog has no entry.
+	GetModelInfo(provider ModelProvider, model string) *Model
+
+	// CalculateRequestCost returns the dollar cost of a completed response,
+	// resolving governance pricing overrides from ctx.
+	//
+	// Named CalculateRequestCost rather than CalculateCost because
+	// *modelcatalog.ModelCatalog already has a CalculateCost method with a
+	// different signature; a plugin-facing ctx.CalculateCost wraps this.
+	CalculateRequestCost(ctx *BifrostContext, resp *BifrostResponse) float64
+}

--- a/core/schemas/modelcatalog_test.go
+++ b/core/schemas/modelcatalog_test.go
@@ -1,0 +1,131 @@
+package schemas
+
+import (
+	"testing"
+)
+
+// stubModelInfoProvider records what the context delegated to it.
+type stubModelInfoProvider struct {
+	model    *Model
+	cost     float64
+	gotProv  ModelProvider
+	gotModel string
+	gotCtx   *BifrostContext
+	calls    int
+}
+
+func (s *stubModelInfoProvider) GetModelInfo(provider ModelProvider, model string) *Model {
+	s.calls++
+	s.gotProv = provider
+	s.gotModel = model
+	return s.model
+}
+
+func (s *stubModelInfoProvider) CalculateRequestCost(ctx *BifrostContext, resp *BifrostResponse) float64 {
+	s.calls++
+	s.gotCtx = ctx
+	return s.cost
+}
+
+// A context with no catalog wired must stay silently inert rather than panic;
+// core is usable as a standalone SDK without the framework, and plugins run
+// unchanged in both setups.
+func TestModelInfoAccessorsNoCatalogWired(t *testing.T) {
+	ctx := NewBifrostContext(nil, NoDeadline)
+
+	if got := ctx.GetModelInfo(Anthropic, "claude-opus-5"); got != nil {
+		t.Fatalf("GetModelInfo with no catalog = %v, want nil", got)
+	}
+	if got := ctx.CalculateCost(&BifrostResponse{}); got != 0 {
+		t.Fatalf("CalculateCost with no catalog = %v, want 0", got)
+	}
+}
+
+func TestModelInfoAccessorsDelegate(t *testing.T) {
+	want := &Model{ID: "claude-opus-5"}
+	stub := &stubModelInfoProvider{model: want, cost: 1.25}
+
+	ctx := NewBifrostContext(nil, NoDeadline)
+	ctx.SetValue(BifrostContextKeyModelCatalog, stub)
+
+	got := ctx.GetModelInfo(Anthropic, "claude-opus-5")
+	if got != want {
+		t.Fatalf("GetModelInfo = %v, want %v", got, want)
+	}
+	if stub.gotProv != Anthropic || stub.gotModel != "claude-opus-5" {
+		t.Fatalf("delegated (%q, %q), want (anthropic, claude-opus-5)", stub.gotProv, stub.gotModel)
+	}
+
+	if cost := ctx.CalculateCost(&BifrostResponse{}); cost != 1.25 {
+		t.Fatalf("CalculateCost = %v, want 1.25", cost)
+	}
+}
+
+// Guard the arguments that make the delegate call pointless, so a catalog
+// never sees an empty model or a nil response.
+func TestModelInfoAccessorsSkipEmptyArgs(t *testing.T) {
+	stub := &stubModelInfoProvider{model: &Model{ID: "x"}, cost: 9}
+	ctx := NewBifrostContext(nil, NoDeadline)
+	ctx.SetValue(BifrostContextKeyModelCatalog, stub)
+
+	if got := ctx.GetModelInfo(Anthropic, ""); got != nil {
+		t.Fatalf("GetModelInfo with empty model = %v, want nil", got)
+	}
+	if got := ctx.CalculateCost(nil); got != 0 {
+		t.Fatalf("CalculateCost with nil response = %v, want 0", got)
+	}
+	if stub.calls != 0 {
+		t.Fatalf("delegated %d times for empty args, want 0", stub.calls)
+	}
+}
+
+// The whole design rests on plugin-scoped contexts delegating Value lookups to
+// the root: core stamps the catalog once per request, and every plugin scope
+// minted from it must see the handle without any extra wiring.
+func TestModelInfoVisibleFromPluginScope(t *testing.T) {
+	want := &Model{ID: "gpt-5"}
+	stub := &stubModelInfoProvider{model: want, cost: 2}
+
+	root := NewBifrostContext(nil, NoDeadline)
+	root.SetValue(BifrostContextKeyModelCatalog, stub)
+
+	name := "my-plugin"
+	scoped := root.WithPluginScope(&name)
+	defer scoped.ReleasePluginScope()
+
+	if got := scoped.GetModelInfo(OpenAI, "gpt-5"); got != want {
+		t.Fatalf("GetModelInfo from plugin scope = %v, want %v", got, want)
+	}
+	if got := scoped.CalculateCost(&BifrostResponse{}); got != 2 {
+		t.Fatalf("CalculateCost from plugin scope = %v, want 2", got)
+	}
+	// CalculateRequestCost receives the scoped context, which is what the
+	// governance scope lookup reads request identity from.
+	if stub.gotCtx != scoped {
+		t.Fatal("CalculateRequestCost did not receive the scoped context")
+	}
+
+	// Nested scopes (plugin pipelines that re-scope) must still resolve.
+	inner := scoped.WithPluginScope(&name)
+	defer inner.ReleasePluginScope()
+	if got := inner.GetModelInfo(OpenAI, "gpt-5"); got != want {
+		t.Fatalf("GetModelInfo from nested scope = %v, want %v", got, want)
+	}
+}
+
+// Fallbacks and per-provider fan-out derive a fresh BifrostContext from the
+// request context rather than scoping it. Those children inherit through the
+// parent chain, not valueDelegate. That is the reason the handle lives in the value
+// map instead of a struct field.
+func TestModelInfoVisibleFromDerivedContext(t *testing.T) {
+	want := &Model{ID: "gemini-3-pro"}
+	stub := &stubModelInfoProvider{model: want}
+
+	root := NewBifrostContext(nil, NoDeadline)
+	root.SetValue(BifrostContextKeyModelCatalog, stub)
+
+	derived := NewBifrostContext(root, NoDeadline)
+	if got := derived.GetModelInfo(Gemini, "gemini-3-pro"); got != want {
+		t.Fatalf("GetModelInfo from derived context = %v, want %v", got, want)
+	}
+}

--- a/docs/architecture/core/plugins.mdx
+++ b/docs/architecture/core/plugins.mdx
@@ -561,6 +561,16 @@ graph TB
 - **Message Queues:** Integration with message queue systems
 - **Caching Systems:** Redis, Memcached integration for state storage
 
+**Plugin-to-Bifrost Communication:**
+
+Bifrost exposes internal services to plugins as methods on the request context, so a plugin never has to be handed a service handle at construction time. The context carries a small interface handle; the implementation stays in Bifrost.
+
+- **Model catalog:** `ctx.GetModelInfo(provider, model)` returns pricing, context window and capability metadata; `ctx.CalculateCost(resp)` prices a completed response with governance overrides applied
+- **Tracing:** `ctx.SetTraceAttribute(key, value)` and the stream-control methods delegate to the active tracer
+- **Logging:** `ctx.Log(level, msg)` writes plugin-scoped entries collected per request
+
+Because these handles live on the request context rather than in plugin constructors, they reach plugins compiled as standalone `.so` binaries with no Bifrost framework dependency. Every accessor is inert - returning a zero value rather than panicking - when the backing service is not configured, which keeps a plugin portable between the HTTP gateway and Go SDK embeddings.
+
 > **📖 Integration Examples:** [Plugin Development Guide →](../../plugins/writing-go-plugin)
 
 ---

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -420,6 +420,76 @@ Key points:
 - **No-op when unscoped** - safe to call in any context; silently ignored outside plugin hooks
 - Logs are retrievable via `ctx.GetPluginLogs()` (read copy) or `ctx.DrainPluginLogs()` (transfer ownership)
 
+#### `ctx.GetModelInfo(provider, model)` <sup>v1.7.x+</sup>
+
+Returns pricing and capability metadata for a model - the same information the `/v1/models` endpoint reports. Available from every hook, and from plugins built without a `framework` dependency.
+
+```go
+info := ctx.GetModelInfo(schemas.Anthropic, "claude-opus-5")
+if info == nil {
+	return // unknown model, or no catalog configured
+}
+
+if info.ContextLength != nil {
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("context window: %d tokens", *info.ContextLength))
+}
+if info.IsDeprecated {
+	ctx.Log(schemas.LogLevelWarn, "model is deprecated")
+}
+```
+
+**What comes back** - a `*schemas.Model`:
+
+| Field | Type | Description |
+|---|---|---|
+| `ID` | `string` | The model string you asked for |
+| `Pricing` | `*schemas.Pricing` | Flat per-token rates as decimal strings - `Prompt`, `Completion`, `Image`, `InputCacheRead`, `InputCacheWrite`, `WebSearch` |
+| `ContextLength` | `*int` | Total context window; falls back to max input tokens when the catalog has no separate value |
+| `MaxInputTokens` | `*int` | Input token ceiling |
+| `MaxOutputTokens` | `*int` | Output token ceiling |
+| `Architecture` | `*schemas.Architecture` | Modality, tokenizer, input/output modalities |
+| `SupportedParameters` | `[]string` | Request parameters the model accepts |
+| `IsDeprecated` | `bool` | Whether the model is retired |
+| `AdditionalAttributes` | `map[string]string` | Editorial metadata (description, tags) |
+
+Key points:
+- **Returns `nil`** when the model is unknown to the catalog, and also when no catalog is configured - always nil-check
+- **Fresh copy** - the returned `*schemas.Model` belongs to you; mutating it affects nothing else
+- **Provider is required** - pass the concrete provider that serves the model. Read it from `req.GetRequestFields()` in a pre-hook, or from the response's `RoutingInfo` in a post-hook, rather than inferring it from the model string
+- **Every field is optional** - the catalog is only as complete as the provider datasheet, so nil-check individual pointers too
+
+#### `ctx.CalculateCost(resp)` <sup>v1.7.x+</sup>
+
+Returns the dollar cost of a completed response.
+
+```go
+func (p *MyPlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	cost := ctx.CalculateCost(resp) // compute synchronously
+	go func() {
+		p.reportToBilling(cost) // then use the value anywhere
+	}()
+	return resp, bifrostErr, nil
+}
+```
+
+Prefer this over doing arithmetic on `GetModelInfo(...).Pricing`. That field carries only flat prompt and completion rates, while `CalculateCost` applies the full pricing resolution:
+
+- Long-context tiers (128k / 200k / 272k)
+- Batch, priority, flex and fast rates
+- Cache read and cache write costs
+- The provider and request-mode fallback chain, so aliased and provider-prefixed models still resolve
+- Any virtual key, user, or provider key pricing override in effect for this request
+
+<Warning>
+Call `ctx.CalculateCost` **synchronously inside your hook**. It reads governance scopes (user ID, virtual key ID, selected key ID) off the request context, and that read is not safe once the request has been cancelled. If you need the cost in a background goroutine, compute it in the hook and close over the `float64` as shown above.
+</Warning>
+
+Returns `0` when no catalog is configured or the response carries no billable usage.
+
+<Note>
+Both methods are inert rather than fatal when no model catalog is wired - `GetModelInfo` returns `nil` and `CalculateCost` returns `0`. This keeps plugins portable between the Bifrost HTTP gateway, which always configures a catalog, and Go SDK embeddings of `core`, which may not.
+</Note>
+
 <Tabs>
   <Tab title="v1.5.x+">
 #### `HTTPTransportPreHook(ctx, req)`

--- a/docs/plugins/writing-wasm-plugin.mdx
+++ b/docs/plugins/writing-wasm-plugin.mdx
@@ -46,6 +46,10 @@ Functions returning data use a packed `u64` format:
 
 All complex data is exchanged as JSON strings. The host allocates memory using `malloc`, writes JSON data, and passes pointers to the plugin functions.
 
+<Note>
+The WASM contract is one-way: the host calls into your exports and passes JSON, and your plugin returns JSON. There are no host functions to call back into, so the request context accessors available to Go plugins - such as `ctx.GetModelInfo` and `ctx.CalculateCost` - are not reachable from WASM. A WASM plugin sees only what arrives in its hook input payload. If you need model pricing or capability lookups inside the plugin, write a [Go plugin](./writing-go-plugin) instead.
+</Note>
+
 ## Getting Started
 
 Choose your preferred language:

--- a/framework/modelcatalog/modelinfo.go
+++ b/framework/modelcatalog/modelinfo.go
@@ -1,0 +1,162 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// GetModelInfo returns pricing and capability metadata for a (provider, model)
+// pair in the same shape the /v1/models endpoint reports, or nil when the
+// catalog has no entry for it.
+//
+// Lookup order is pricing-row first (exact model+provider across every request
+// mode), then the capability entry, which additionally resolves through the
+// canonical base model and the wider model family. That ordering keeps dated
+// model IDs like "gpt-4o-2024-08-06" resolvable even when only the family row
+// carries capability data.
+//
+// The returned *schemas.Model is freshly allocated and owned by the caller.
+func (mc *ModelCatalog) GetModelInfo(provider schemas.ModelProvider, model string) *schemas.Model {
+	if mc == nil || model == "" {
+		return nil
+	}
+
+	entry := mc.datasheet.GetPricingEntryForModel(model, provider)
+	if entry == nil {
+		entry = mc.datasheet.GetCapabilityEntry(model, provider)
+	}
+	if entry == nil {
+		return nil
+	}
+
+	info := &schemas.Model{ID: model}
+	ApplyModelInfo(info, entry)
+
+	if params := mc.datasheet.GetSupportedParameters(model); len(params) > 0 {
+		info.SupportedParameters = params
+	}
+	return info
+}
+
+// ApplyModelInfo merges catalog metadata from entry into model, filling only
+// fields the caller has not already populated. Provider-reported values always
+// win: the catalog is a backfill for what a provider's list-models response
+// leaves out, never an override of what it did report.
+//
+// Exported so the list-models handlers can enrich provider responses through
+// the same mapping that GetModelInfo uses.
+//
+// Every reference-typed field is cloned on the way in. An Entry's maps,
+// pointers and slices alias the datasheet's shared pricing row (reading a
+// struct out of that map is a shallow copy), so assigning them straight
+// through would hand callers - including third-party plugins via
+// ctx.GetModelInfo - a live handle into catalog state. A write through such a
+// handle silently rewrites the catalog for every later request, and racing the
+// pricing sync on the map is a fatal concurrent map access, not a recoverable
+// panic.
+func ApplyModelInfo(model *schemas.Model, entry *PricingEntry) {
+	if model == nil || entry == nil {
+		return
+	}
+
+	model.IsDeprecated = model.IsDeprecated || entry.IsDeprecated
+
+	if entry.BaseModel != "" && model.NormalizedName == nil {
+		model.NormalizedName = new(providerUtils.NormalizeBaseModelSlug(entry.BaseModel))
+	}
+	if len(entry.AdditionalAttributes) > 0 && model.AdditionalAttributes == nil {
+		// A shallow clone is the right depth here: the values are strings, which
+		// are immutable, so there is nothing further down to alias.
+		model.AdditionalAttributes = maps.Clone(entry.AdditionalAttributes)
+	}
+
+	// ContextLength falls back to MaxInputTokens: some datasheet rows carry only
+	// the input limit, and callers treat context length as the headline number.
+	if model.ContextLength == nil {
+		if entry.ContextLength != nil {
+			model.ContextLength = new(*entry.ContextLength)
+		} else if entry.MaxInputTokens != nil {
+			model.ContextLength = new(*entry.MaxInputTokens)
+		}
+	}
+	if entry.MaxInputTokens != nil && model.MaxInputTokens == nil {
+		model.MaxInputTokens = new(*entry.MaxInputTokens)
+	}
+	if entry.MaxOutputTokens != nil && model.MaxOutputTokens == nil {
+		model.MaxOutputTokens = new(*entry.MaxOutputTokens)
+	}
+	if entry.Architecture != nil && model.Architecture == nil {
+		arch := *entry.Architecture
+		// The scalar pointers need copying too, not just the slices: a struct
+		// copy carries them straight through, and the entry's Architecture is
+		// the very pointer the datasheet stores.
+		if entry.Architecture.Modality != nil {
+			arch.Modality = new(*entry.Architecture.Modality)
+		}
+		if entry.Architecture.Tokenizer != nil {
+			arch.Tokenizer = new(*entry.Architecture.Tokenizer)
+		}
+		if entry.Architecture.InstructType != nil {
+			arch.InstructType = new(*entry.Architecture.InstructType)
+		}
+		arch.InputModalities = slices.Clone(entry.Architecture.InputModalities)
+		arch.OutputModalities = slices.Clone(entry.Architecture.OutputModalities)
+		model.Architecture = &arch
+	}
+
+	if model.Pricing != nil {
+		return
+	}
+	pricing := &schemas.Pricing{}
+	if entry.InputCostPerToken != nil {
+		pricing.Prompt = new(formatCost(*entry.InputCostPerToken))
+	}
+	if entry.OutputCostPerToken != nil {
+		pricing.Completion = new(formatCost(*entry.OutputCostPerToken))
+	}
+	if entry.InputCostPerImage != nil {
+		pricing.Image = new(formatCost(*entry.InputCostPerImage))
+	}
+	if entry.CacheReadInputTokenCost != nil {
+		pricing.InputCacheRead = new(formatCost(*entry.CacheReadInputTokenCost))
+	}
+	if entry.CacheCreationInputTokenCost != nil {
+		pricing.InputCacheWrite = new(formatCost(*entry.CacheCreationInputTokenCost))
+	}
+	if entry.SearchContextCostPerQuery != nil {
+		pricing.WebSearch = new(formatCost(*entry.SearchContextCostPerQuery))
+	}
+	model.Pricing = pricing
+}
+
+// CalculateRequestCost returns the dollar cost of resp, resolving governance
+// pricing overrides (virtual key / user / provider key scopes) from ctx.
+//
+// This is the plugin-facing entry point behind ctx.CalculateCost. It is a thin
+// wrapper over CalculateCost so tiered pricing, batch/priority/flex rates and
+// the provider/mode fallback chain all apply unchanged.
+//
+// Must be called synchronously while ctx is still live; the scope lookup reads
+// request identity off the context.
+func (mc *ModelCatalog) CalculateRequestCost(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) float64 {
+	if mc == nil || resp == nil {
+		return 0
+	}
+	extraFields := resp.GetExtraFields()
+	provider := extraFields.RoutingInfo.Provider
+	if provider == "" {
+		provider = extraFields.Provider
+	}
+	return mc.CalculateCost(resp, PricingLookupScopesFromContext(ctx, string(provider)))
+}
+
+// formatCost renders a per-unit rate the way the models API reports it. Fixed
+// 10-decimal notation rather than %g so sub-cent token rates never surface in
+// scientific notation, which clients parsing these as decimals choke on.
+func formatCost(v float64) string {
+	return fmt.Sprintf("%.10f", v)
+}

--- a/framework/modelcatalog/modelinfo_test.go
+++ b/framework/modelcatalog/modelinfo_test.go
@@ -1,0 +1,295 @@
+package modelcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+func modelInfoCatalog(t *testing.T) *ModelCatalog {
+	t.Helper()
+	pricingPath := filepath.Join(t.TempDir(), "pricing.json")
+	pricingJSON := []byte(`{
+		"claude-opus-5": {
+			"provider": "anthropic",
+			"mode": "chat",
+			"base_model": "claude-opus-5",
+			"max_input_tokens": 200000,
+			"max_output_tokens": 64000,
+			"input_cost_per_token": 0.000005,
+			"output_cost_per_token": 0.000025,
+			"cache_read_input_token_cost": 0.0000005,
+			"cache_creation_input_token_cost": 0.00000625
+		},
+		"retired-model": {
+			"provider": "anthropic",
+			"mode": "chat",
+			"base_model": "retired-model",
+			"is_deprecated": true
+		}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing testdata: %v", err)
+	}
+
+	// Supported parameters live in a separate index fed by its own feed, so
+	// seeding pricing alone leaves SupportedParameters empty and any assertion
+	// about it passes for the wrong reason.
+	paramsPath := filepath.Join(filepath.Dir(pricingPath), "params.json")
+	paramsJSON := []byte(`{
+		"claude-opus-5": {
+			"mode": "chat",
+			"model_parameters": [{"id": "temperature"}, {"id": "top_p"}]
+		}
+	}`)
+	if err := os.WriteFile(paramsPath, paramsJSON, 0o600); err != nil {
+		t.Fatalf("write model-parameters testdata: %v", err)
+	}
+
+	ds := datasheet.New(nil, nil, datasheet.Config{
+		URL:                "file://" + pricingPath,
+		ModelParametersURL: "file://" + paramsPath,
+	})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing testdata: %v", err)
+	}
+	if err := ds.LoadModelParamsFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load model-parameters testdata: %v", err)
+	}
+	return &ModelCatalog{
+		datasheet: ds,
+		live:      live.New(nil),
+		keyconf:   keyconfig.New(nil),
+		done:      make(chan struct{}),
+	}
+}
+
+func TestGetModelInfoPopulatesPricingAndLimits(t *testing.T) {
+	mc := modelInfoCatalog(t)
+
+	info := mc.GetModelInfo(schemas.Anthropic, "claude-opus-5")
+	if info == nil {
+		t.Fatal("GetModelInfo = nil, want populated model")
+	}
+	if info.ID != "claude-opus-5" {
+		t.Errorf("ID = %q, want claude-opus-5", info.ID)
+	}
+	// context_length is absent from the row, so it falls back to max_input_tokens.
+	if info.ContextLength == nil || *info.ContextLength != 200000 {
+		t.Errorf("ContextLength = %v, want 200000", info.ContextLength)
+	}
+	if info.MaxInputTokens == nil || *info.MaxInputTokens != 200000 {
+		t.Errorf("MaxInputTokens = %v, want 200000", info.MaxInputTokens)
+	}
+	if info.MaxOutputTokens == nil || *info.MaxOutputTokens != 64000 {
+		t.Errorf("MaxOutputTokens = %v, want 64000", info.MaxOutputTokens)
+	}
+	if info.Pricing == nil {
+		t.Fatal("Pricing = nil, want populated")
+	}
+	// Fixed-decimal, never scientific notation: clients parse these as decimals.
+	if info.Pricing.Prompt == nil || *info.Pricing.Prompt != "0.0000050000" {
+		t.Errorf("Pricing.Prompt = %v, want 0.0000050000", info.Pricing.Prompt)
+	}
+	if info.Pricing.Completion == nil || *info.Pricing.Completion != "0.0000250000" {
+		t.Errorf("Pricing.Completion = %v, want 0.0000250000", info.Pricing.Completion)
+	}
+	if info.Pricing.InputCacheRead == nil || *info.Pricing.InputCacheRead != "0.0000005000" {
+		t.Errorf("Pricing.InputCacheRead = %v, want 0.0000005000", info.Pricing.InputCacheRead)
+	}
+	if info.Pricing.InputCacheWrite == nil || *info.Pricing.InputCacheWrite != "0.0000062500" {
+		t.Errorf("Pricing.InputCacheWrite = %v, want 0.0000062500", info.Pricing.InputCacheWrite)
+	}
+}
+
+func TestGetModelInfoReportsDeprecation(t *testing.T) {
+	mc := modelInfoCatalog(t)
+
+	info := mc.GetModelInfo(schemas.Anthropic, "retired-model")
+	if info == nil {
+		t.Fatal("GetModelInfo = nil, want populated model")
+	}
+	if !info.IsDeprecated {
+		t.Error("IsDeprecated = false, want true")
+	}
+}
+
+func TestGetModelInfoUnknownModel(t *testing.T) {
+	mc := modelInfoCatalog(t)
+
+	if got := mc.GetModelInfo(schemas.Anthropic, "not-a-real-model"); got != nil {
+		t.Errorf("GetModelInfo for unknown model = %v, want nil", got)
+	}
+	if got := mc.GetModelInfo(schemas.Anthropic, ""); got != nil {
+		t.Errorf("GetModelInfo for empty model = %v, want nil", got)
+	}
+}
+
+// The catalog backfills what a provider's list-models response omitted; it must
+// never overwrite what the provider actually reported.
+func TestApplyModelInfoDoesNotOverwriteProviderValues(t *testing.T) {
+	mc := modelInfoCatalog(t)
+	entry := mc.datasheet.GetPricingEntryForModel("claude-opus-5", schemas.Anthropic)
+	if entry == nil {
+		t.Fatal("seeded pricing entry not found")
+	}
+
+	providerReported := 999
+	model := &schemas.Model{
+		ID:             "claude-opus-5",
+		ContextLength:  &providerReported,
+		MaxInputTokens: &providerReported,
+		Pricing:        &schemas.Pricing{},
+	}
+	ApplyModelInfo(model, entry)
+
+	if *model.ContextLength != providerReported {
+		t.Errorf("ContextLength = %d, want provider-reported %d", *model.ContextLength, providerReported)
+	}
+	if *model.MaxInputTokens != providerReported {
+		t.Errorf("MaxInputTokens = %d, want provider-reported %d", *model.MaxInputTokens, providerReported)
+	}
+	if model.Pricing.Prompt != nil {
+		t.Errorf("Pricing.Prompt = %v, want untouched nil on a caller-set Pricing", model.Pricing.Prompt)
+	}
+	// Fields the provider left empty still get filled.
+	if model.MaxOutputTokens == nil || *model.MaxOutputTokens != 64000 {
+		t.Errorf("MaxOutputTokens = %v, want backfilled 64000", model.MaxOutputTokens)
+	}
+}
+
+// GetModelInfo hands its result to third-party plugin code via ctx.GetModelInfo,
+// and its doc promises the caller owns it. Entry fields alias the shared
+// datasheet row, so every reference-typed field must be cloned on the way out:
+// a write through an escaped handle would rewrite the catalog for all later
+// requests, and racing the pricing sync on the attributes map is a fatal
+// concurrent map access rather than a recoverable panic.
+func TestGetModelInfoReturnsCallerOwnedCopy(t *testing.T) {
+	mc := modelInfoCatalog(t)
+
+	first := mc.GetModelInfo(schemas.Anthropic, "claude-opus-5")
+	if first == nil {
+		t.Fatal("GetModelInfo = nil, want populated model")
+	}
+
+	*first.ContextLength = 1
+	*first.MaxInputTokens = 2
+	*first.MaxOutputTokens = 3
+	first.AdditionalAttributes = map[string]string{"tier": "mutated"}
+	if len(first.SupportedParameters) == 0 {
+		t.Fatal("SupportedParameters is empty, so mutating it would prove nothing")
+	}
+	first.SupportedParameters[0] = "mutated"
+
+	second := mc.GetModelInfo(schemas.Anthropic, "claude-opus-5")
+	if second == nil {
+		t.Fatal("second GetModelInfo = nil, want populated model")
+	}
+	if *second.ContextLength != 200000 {
+		t.Errorf("ContextLength = %d after caller mutation, want untouched 200000", *second.ContextLength)
+	}
+	if *second.MaxInputTokens != 200000 {
+		t.Errorf("MaxInputTokens = %d after caller mutation, want untouched 200000", *second.MaxInputTokens)
+	}
+	if *second.MaxOutputTokens != 64000 {
+		t.Errorf("MaxOutputTokens = %d after caller mutation, want untouched 64000", *second.MaxOutputTokens)
+	}
+	if second.AdditionalAttributes["tier"] == "mutated" {
+		t.Error("AdditionalAttributes leaked a caller mutation into the catalog")
+	}
+	// SupportedParameters comes straight off the datasheet lookup rather than
+	// through ApplyModelInfo's clones, so it needs its own check that the
+	// lookup hands back a fresh slice.
+	if slices.Contains(second.SupportedParameters, "mutated") {
+		t.Errorf("SupportedParameters leaked a caller mutation into the catalog: %v", second.SupportedParameters)
+	}
+
+	// The pointers themselves must differ, else a later caller mutating through
+	// one handle would still be seen by the other.
+	if first.ContextLength == second.ContextLength {
+		t.Error("ContextLength pointer is shared between calls, want a fresh allocation per call")
+	}
+	if first.MaxOutputTokens == second.MaxOutputTokens {
+		t.Error("MaxOutputTokens pointer is shared between calls, want a fresh allocation per call")
+	}
+}
+
+// The rows reached through ApplyModelInfo carry an Architecture and an
+// attributes map, which GetModelInfo's seeded rows do not - cover those clones
+// directly against the shared entry.
+func TestApplyModelInfoClonesMutableEntryFields(t *testing.T) {
+	entry := &PricingEntry{
+		AdditionalAttributes: map[string]string{"tier": "original"},
+		Architecture: &schemas.Architecture{
+			// Architecture's scalar pointers are as shareable as its slices: a
+			// struct copy carries them through untouched, and the entry's
+			// Architecture is the pointer the datasheet itself stores.
+			Modality:         new("text->text"),
+			Tokenizer:        new("cl100k"),
+			InstructType:     new("none"),
+			InputModalities:  []string{"text"},
+			OutputModalities: []string{"text"},
+		},
+	}
+
+	model := &schemas.Model{ID: "claude-opus-5"}
+	ApplyModelInfo(model, entry)
+
+	if model.Architecture == entry.Architecture {
+		t.Fatal("Architecture pointer is shared with the entry, want a clone")
+	}
+	if model.Architecture.Modality == entry.Architecture.Modality {
+		t.Error("Architecture.Modality pointer is shared with the entry, want a clone")
+	}
+	if model.Architecture.Tokenizer == entry.Architecture.Tokenizer {
+		t.Error("Architecture.Tokenizer pointer is shared with the entry, want a clone")
+	}
+	if model.Architecture.InstructType == entry.Architecture.InstructType {
+		t.Error("Architecture.InstructType pointer is shared with the entry, want a clone")
+	}
+
+	model.AdditionalAttributes["tier"] = "mutated"
+	model.Architecture.InputModalities[0] = "mutated"
+	model.Architecture.OutputModalities[0] = "mutated"
+	*model.Architecture.Modality = "mutated"
+	*model.Architecture.Tokenizer = "mutated"
+	*model.Architecture.InstructType = "mutated"
+
+	if entry.AdditionalAttributes["tier"] != "original" {
+		t.Errorf("entry AdditionalAttributes[tier] = %q, want untouched original", entry.AdditionalAttributes["tier"])
+	}
+	if entry.Architecture.InputModalities[0] != "text" {
+		t.Errorf("entry InputModalities[0] = %q, want untouched text", entry.Architecture.InputModalities[0])
+	}
+	if entry.Architecture.OutputModalities[0] != "text" {
+		t.Errorf("entry OutputModalities[0] = %q, want untouched text", entry.Architecture.OutputModalities[0])
+	}
+	if *entry.Architecture.Modality != "text->text" {
+		t.Errorf("entry Modality = %q, want untouched text->text", *entry.Architecture.Modality)
+	}
+	if *entry.Architecture.Tokenizer != "cl100k" {
+		t.Errorf("entry Tokenizer = %q, want untouched cl100k", *entry.Architecture.Tokenizer)
+	}
+	if *entry.Architecture.InstructType != "none" {
+		t.Errorf("entry InstructType = %q, want untouched none", *entry.Architecture.InstructType)
+	}
+}
+
+func TestApplyModelInfoNilSafe(t *testing.T) {
+	ApplyModelInfo(nil, nil)
+	ApplyModelInfo(&schemas.Model{}, nil)
+
+	var nilCatalog *ModelCatalog
+	if got := nilCatalog.GetModelInfo(schemas.Anthropic, "claude-opus-5"); got != nil {
+		t.Errorf("GetModelInfo on nil catalog = %v, want nil", got)
+	}
+	if got := nilCatalog.CalculateRequestCost(nil, nil); got != 0 {
+		t.Errorf("CalculateRequestCost on nil catalog = %v, want 0", got)
+	}
+}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -22,7 +22,6 @@ import (
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
 
-	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -902,51 +901,8 @@ func enrichListModelsResponse(resp *schemas.BifrostListModelsResponse, catalog *
 		if pricingEntry == nil && modelEntry.Alias != nil {
 			pricingEntry = catalog.GetPricingEntryForModel(*modelEntry.Alias, provider)
 		}
-		if pricingEntry != nil {
-			modelEntry.IsDeprecated = modelEntry.IsDeprecated || pricingEntry.IsDeprecated
-			if pricingEntry.BaseModel != "" && modelEntry.NormalizedName == nil {
-				modelEntry.NormalizedName = bifrost.Ptr(providerUtils.NormalizeBaseModelSlug(pricingEntry.BaseModel))
-			}
-			if len(pricingEntry.AdditionalAttributes) > 0 && modelEntry.AdditionalAttributes == nil {
-				modelEntry.AdditionalAttributes = pricingEntry.AdditionalAttributes
-			}
-			if pricingEntry.ContextLength != nil && modelEntry.ContextLength == nil {
-				modelEntry.ContextLength = pricingEntry.ContextLength
-			} else if pricingEntry.MaxInputTokens != nil && modelEntry.ContextLength == nil {
-				modelEntry.ContextLength = pricingEntry.MaxInputTokens
-			}
-			if pricingEntry.MaxInputTokens != nil && modelEntry.MaxInputTokens == nil {
-				modelEntry.MaxInputTokens = pricingEntry.MaxInputTokens
-			}
-			if pricingEntry.MaxOutputTokens != nil && modelEntry.MaxOutputTokens == nil {
-				modelEntry.MaxOutputTokens = pricingEntry.MaxOutputTokens
-			}
-			if pricingEntry.Architecture != nil && modelEntry.Architecture == nil {
-				modelEntry.Architecture = pricingEntry.Architecture
-			}
-			if modelEntry.Pricing == nil {
-				pricing := &schemas.Pricing{}
-				if pricingEntry.InputCostPerToken != nil {
-					pricing.Prompt = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerToken))
-				}
-				if pricingEntry.OutputCostPerToken != nil {
-					pricing.Completion = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.OutputCostPerToken))
-				}
-				if pricingEntry.InputCostPerImage != nil {
-					pricing.Image = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerImage))
-				}
-				if pricingEntry.CacheReadInputTokenCost != nil {
-					pricing.InputCacheRead = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheReadInputTokenCost))
-				}
-				if pricingEntry.CacheCreationInputTokenCost != nil {
-					pricing.InputCacheWrite = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheCreationInputTokenCost))
-				}
-				if pricingEntry.SearchContextCostPerQuery != nil {
-					pricing.WebSearch = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.SearchContextCostPerQuery))
-				}
-				modelEntry.Pricing = pricing
-			}
-		}
+		// Same mapping ctx.GetModelInfo hands to plugins, so the two never drift.
+		modelcatalog.ApplyModelInfo(&modelEntry, pricingEntry)
 		resp.Data[i] = modelEntry
 	}
 }

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -399,6 +399,12 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 			}
 			// Get or create BifrostContext from fasthttp context
 			bifrostCtx := getBifrostContextFromFastHTTP(ctx)
+			// Transport pre-hooks run before the inference path stamps the
+			// catalog, so stamp it here too — otherwise ctx.GetModelInfo would
+			// be nil in HTTPTransportPreHook but populated in every other hook.
+			if config.ModelCatalog != nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyModelCatalog, config.ModelCatalog)
+			}
 			// Acquire pooled request
 			req := schemas.AcquireHTTPRequest()
 			defer schemas.ReleaseHTTPRequest(req)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2176,6 +2176,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		MCPHeadersProvider: s.Config.MCPHeadersProvider,
 		Logger:             logger,
 		KVStore:            s.Config.KVStore,
+		ModelCatalog:       s.Config.ModelCatalog,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize bifrost: %v", err)


### PR DESCRIPTION
## Summary

Plugins running inside Bifrost hooks had no way to look up model pricing or capability metadata without taking a direct dependency on the framework package, which core cannot import. This PR wires a `ModelInfoProvider` interface into the request context so every plugin hook — pre-request, pre-LLM, post-LLM, streaming, realtime, and MCP tool execution — can call `ctx.GetModelInfo(provider, model)` and `ctx.CalculateCost(resp)` without any extra construction-time wiring.

## Changes

- **`core/schemas/modelcatalog.go`** — introduces the `ModelInfoProvider` interface (declared in core, implemented in framework) mirroring how `Tracer` is wired: interface here, concrete type there, handle stamped onto the context per request.
- **`core/schemas/bifrost.go`** — adds `BifrostContextKeyModelCatalog` context key and `ModelCatalog ModelInfoProvider` field to `BifrostConfig`.
- **`core/schemas/context.go`** — adds `GetModelInfo` and `CalculateCost` accessor methods on `BifrostContext`. Both are inert (return nil / 0) when no catalog is configured, keeping plugins portable between the HTTP gateway and bare Go SDK embeddings.
- **`core/bifrost.go`** — stores the catalog from `BifrostConfig` at `Init`, adds `setModelCatalogOnContext` which stamps (or clears) the handle on every entry point: `handleRequest`, `handleStreamRequest`, `RunPreRequestHooks`, `RunStreamPreHooks`, `RunRealtimeTurnPreHooks`, `ExecuteChatMCPTool`, and `ExecuteResponsesMCPTool`. The clear-on-nil path ensures long-lived realtime contexts don't serve a catalog that was subsequently removed.
- **`framework/modelcatalog/modelinfo.go`** — adds `GetModelInfo` and `CalculateRequestCost` on `*ModelCatalog`, and extracts `ApplyModelInfo` as an exported function. All reference-typed fields (pointer scalars, slices, maps, `Architecture`) are deep-cloned on the way out so third-party plugin code cannot accidentally mutate catalog state or race the pricing sync.
- **`transports/bifrost-http/handlers/inference.go`** — replaces the inline enrichment block in `enrichListModelsResponse` with a call to `modelcatalog.ApplyModelInfo`, so the list-models endpoint and `ctx.GetModelInfo` always use identical mapping logic.
- **`transports/bifrost-http/handlers/middlewares.go`** — stamps the catalog onto the context in `TransportInterceptorMiddleware` so `HTTPTransportPreHook` sees it before the inference path runs.
- **`transports/bifrost-http/server/server.go`** — passes `ModelCatalog` through to `BifrostConfig` at bootstrap.
- **Docs** — `plugins.mdx` documents the plugin-to-Bifrost communication model; `writing-go-plugin.mdx` adds full reference entries for both accessors; `writing-wasm-plugin.mdx` notes that these accessors are not reachable from WASM.

Notable design decisions:
- The interface is declared in `core/schemas` and implemented in `framework/modelcatalog` to preserve the existing dependency direction (framework → core, never core → framework).
- `CalculateRequestCost` is named differently from `ModelCatalog.CalculateCost` to avoid a signature collision on the concrete type while still letting the plugin-facing wrapper apply the full governance pricing chain.
- The clear-on-nil behaviour in `setModelCatalogOnContext` is intentional: reused WebSocket contexts re-enter the stamping path on every message, so skipping the clear would leave a stale handle after `SetModelCatalog(nil)`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/... ./core/schemas/... ./framework/modelcatalog/... ./transports/bifrost-http/...
```

Two new integration tests in `core/modelcataloghooks_test.go` drive a real `ChatCompletionRequest` through a probe plugin and assert:
- `TestModelCatalogReachesPluginHooksOnRealRequest` — all three hook phases (`PreRequestHook`, `PreLLMHook`, `PostLLMHook`) receive the catalog handle and return the expected model info and cost.
- `TestModelCatalogAbsentLeavesHooksInert` — with no catalog wired, all accessors return zero values and no panic occurs.

Unit tests in `core/schemas/modelcatalog_test.go` cover delegation, empty-argument guards, plugin-scope visibility, and derived-context inheritance.

Unit tests in `framework/modelcatalog/modelinfo_test.go` cover pricing population, deprecation reporting, unknown model handling, provider-value preservation, and deep-clone correctness for all mutable fields.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `ModelInfoProvider` handle is stamped onto the request context and read back via a typed assertion. No credentials or secrets pass through this path. The deep-clone in `ApplyModelInfo` prevents a plugin from mutating shared catalog state, which would otherwise be a data-race vector on the pricing sync goroutine.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable