### PR TITLE
fix(modelcatalog): preserve output token limits

### DIFF
--- a/framework/modelcatalog/datasheet/capabilities_test.go
+++ b/framework/modelcatalog/datasheet/capabilities_test.go
@@ -1,6 +1,7 @@
 package datasheet
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -280,5 +281,26 @@ func TestExtractSupportedParams_WebSearchAbsent(t *testing.T) {
 		if slices.Contains(got, unexpected) {
 			t.Errorf("expected supported params to omit %q, got %v", unexpected, got)
 		}
+	}
+}
+
+func TestExtractSupportedParams_OutputTokenLimits(t *testing.T) {
+	for _, raw := range []string{
+		`{"max_tokens":128000}`,
+		`{"max_output_tokens":128000}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			var parsed modelParametersParseResult
+			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+				t.Fatalf("unmarshal model parameters: %v", err)
+			}
+
+			got := extractSupportedParams(&parsed)
+			for _, want := range []string{"max_tokens", "max_completion_tokens", "max_output_tokens"} {
+				if !slices.Contains(got, want) {
+					t.Errorf("expected supported params to contain %q, got %v", want, got)
+				}
+			}
+		})
 	}
 }

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -326,6 +326,8 @@ type customPricingData struct {
 type modelParametersParseResult struct {
 	Mode               *string  `json:"mode,omitempty"`
 	SupportedEndpoints []string `json:"supported_endpoints,omitempty"`
+	MaxTokens          *int     `json:"max_tokens,omitempty"`
+	MaxOutputTokens    *int     `json:"max_output_tokens,omitempty"`
 	ModelParameters    []struct {
 		ID string `json:"id"`
 	} `json:"model_parameters,omitempty"`
@@ -502,6 +504,15 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 		default:
 			addParam(mp.ID)
 		}
+	}
+
+	if parsed.MaxTokens != nil || parsed.MaxOutputTokens != nil {
+		// The datasheet uses max_tokens/max_output_tokens as capability fields.
+		// Treat all token-cap spellings as equivalent so the compat plugin keeps
+		// the canonical field for both Chat Completions and Responses requests.
+		addParam("max_tokens")
+		addParam("max_completion_tokens")
+		addParam("max_output_tokens")
 	}
 
 	if parsed.SupportsAssistantPrefill != nil && *parsed.SupportsAssistantPrefill {


### PR DESCRIPTION
## What changed

- Parse `max_tokens` and `max_output_tokens` capability fields from model-catalog datasheets.
- Advertise all equivalent output-token parameter spellings when either capability is present:
  - `max_tokens`
  - `max_completion_tokens`
  - `max_output_tokens`
- Add regression coverage for both datasheet field variants.

## Why

The compatibility plugin drops request parameters that the model catalog does not report as supported. Some catalog entries, including `gpt-5.6-luna`, describe output limits with top-level `max_tokens` or `max_output_tokens` fields instead of `model_parameters`.

Those fields were not parsed, so the compatibility layer removed `max_completion_tokens` before forwarding the request. Requests could therefore exceed their configured output limit.

## Impact

Models whose datasheets expose either output-token capability now retain the appropriate output limit for Chat Completions and Responses requests.

## Validation

- `framework/modelcatalog/datasheet` package tests pass.
- `plugins/compat` package tests pass.
- A patched local Bifrost image enforced a 32-token Luna limit:
  - before: 350 completion tokens, `finish_reason=stop`
  - after: 32 completion tokens, `finish_reason=length`
- The downstream FIRE/Bifrost integration matrix passed all 8 contract tests against the patched image.
