### PR TITLE
schema fixes

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -105,6 +105,10 @@ var ignoreGoFields = map[string]string{
 	// scope_name is a non-persisted (gorm:"-"), API-only display label populated by the
 	// HTTP layer on read (the scope target's human-readable name); never config.json input.
 	"/properties/governance/properties/model_configs/items|scope_name": "response-only; populated on GET as the scope target's display name, not user-configurable via config.json",
+	// virtual_key_count is a non-persisted (gorm:"-"), derived count populated by the
+	// read paths so list responses can report it without loading the full VirtualKeys
+	// relation; never config.json input.
+	"/properties/governance/properties/customers/items|virtual_key_count": "response-only; derived count populated on read (TableCustomer.VirtualKeyCount), not user-configurable via config.json",
 }
 
 // ignoreGoFieldNames are field names (regardless of parent path) that are

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -12,6 +12,8 @@ import (
 type BudgetOverrideMode string
 
 const (
+	// BudgetOverrideModeNone means no override is active (default/zero value).
+	BudgetOverrideModeNone BudgetOverrideMode = ""
 	// BudgetOverrideModeCycles keeps an override active for a finite number of reset cycles.
 	BudgetOverrideModeCycles BudgetOverrideMode = "cycles"
 	// BudgetOverrideModeForever keeps an override active until it is explicitly removed.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6973,6 +6973,10 @@
           "type": "string",
           "description": "Virtual key ID (required for virtual_key* scopes)"
         },
+        "user_id": {
+          "type": "string",
+          "description": "User ID (for user-scoped pricing overrides)"
+        },
         "provider_id": {
           "type": "string",
           "description": "Provider name (required for provider* scopes; field key remains provider_id for compatibility)"


### PR DESCRIPTION
## Summary

Adds support for user-scoped pricing overrides by introducing a `user_id` field to the model config scope schema, adds a `BudgetOverrideModeNone` constant for the zero/default override state, and excludes the derived `virtual_key_count` field from schema sync validation since it is a non-persisted, response-only field.

## Changes

- Added `user_id` field to `config.schema.json` under model config scopes to support user-scoped pricing overrides
- Added `BudgetOverrideModeNone` (`""`) as an explicit named constant for the default/zero value of `BudgetOverrideMode`
- Added `virtual_key_count` to the `ignoreGoFields` map in the schema sync script, since `TableCustomer.VirtualKeyCount` is a `gorm:"-"` derived field populated only on read and is not user-configurable via `config.json`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Verify that a model config scope with a `user_id` field passes schema validation.
- Verify that the schema sync script no longer flags `virtual_key_count` as an unrecognized field.
- Verify that `BudgetOverrideModeNone` correctly represents the default (empty string) override mode.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The `user_id` field in pricing override scopes should be validated server-side to ensure callers can only apply overrides to users within their authorized scope.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable