### PR TITLE
feat: support matview_refresh_interval "off" to disable logstore matview maintenance

### DIFF
--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -279,7 +279,7 @@ Set `matview_refresh_interval` (Go duration string) to slow down refreshes when 
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `matview_refresh_interval` | `"1m"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"1m"`, `"5m"`, `"1h"`). Minimum `5s`. Set `"off"` to disable matview maintenance entirely. |
+| `matview_refresh_interval` | `"1m"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"1m"`, `"5m"`, `"1h"`); positive values below `5s` are clamped up to `5s`. Set `"off"` or a zero duration (`"0s"`) to disable matview maintenance entirely. |
 
 **Notes**
 

--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -279,7 +279,7 @@ Set `matview_refresh_interval` (Go duration string) to slow down refreshes when 
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `matview_refresh_interval` | `"1m"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"1m"`, `"5m"`, `"1h"`). Minimum `5s`. |
+| `matview_refresh_interval` | `"1m"` | How often to refresh dashboard materialized views. Accepts any Go duration string (`"1m"`, `"5m"`, `"1h"`). Minimum `5s`. Set `"off"` to disable matview maintenance entirely. |
 
 **Notes**
 
@@ -296,6 +296,10 @@ Set `matview_refresh_interval` (Go duration string) to slow down refreshes when 
 
 - The database has consistent CPU headroom.
 - Operators rely on near-real-time dashboards (e.g. live incident triage).
+
+**When to turn it off:**
+
+- You don't use the Bifrost dashboard (e.g. Bifrost runs headless behind your own observability stack). With `"off"`, the views are neither created nor refreshed, and any dashboard query transparently uses the raw tables.
 
 ### Object Storage for Logs
 

--- a/framework/logstore/matviewheal.go
+++ b/framework/logstore/matviewheal.go
@@ -82,6 +82,13 @@ const matViewHealCooldown = 30 * time.Second
 // - the next query against a still-stale view falls back raw and re-triggers
 // the heal, converging once the lock holder finishes.
 func (s *RDBLogStore) triggerMatViewSelfHeal() {
+	if s.matViewMaintenanceDisabled {
+		// Unreachable today (the matview read path never enables when
+		// maintenance is disabled, so no shape error can arrive), but guards
+		// the contract against a future caller: a heal would recreate views
+		// the configuration says must not exist.
+		return
+	}
 	if !s.matViewHealInFlight.CompareAndSwap(false, true) {
 		return // a heal is already running
 	}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -854,7 +854,12 @@ func refreshMatViews(ctx context.Context, db *gorm.DB) error {
 // refreshes materialized views. If readyFlag is provided and not yet true,
 // it will be set to true on the first successful refresh (recovery path when
 // the initial refresh failed). Returns a stop function for graceful shutdown.
+// A non-positive interval means maintenance is disabled: no goroutine starts
+// and the stop function is a no-op.
 func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval, timeout time.Duration, logger schemas.Logger, readyFlag *atomic.Bool) func() {
+	if interval <= 0 {
+		return func() {}
+	}
 	stopCh := make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(interval)

--- a/framework/logstore/matviews_lock_test.go
+++ b/framework/logstore/matviews_lock_test.go
@@ -16,6 +16,18 @@ func TestResolveMatViewRefreshIntervalDefaults(t *testing.T) {
 	assert.Equal(t, time.Minute, resolveMatViewRefreshInterval("not-a-duration", testLogger{}))
 	assert.Equal(t, minMatViewRefreshInterval, resolveMatViewRefreshInterval("1s", testLogger{}))
 	assert.Equal(t, 5*time.Minute, resolveMatViewRefreshInterval("5m", testLogger{}))
+	// "off" and non-positive durations disable maintenance rather than clamping
+	// up to the floor.
+	assert.Equal(t, time.Duration(0), resolveMatViewRefreshInterval("off", testLogger{}))
+	assert.Equal(t, time.Duration(0), resolveMatViewRefreshInterval("0s", testLogger{}))
+	assert.Equal(t, time.Duration(0), resolveMatViewRefreshInterval("-1m", testLogger{}))
+}
+
+func TestStartMatViewRefresherDisabled(t *testing.T) {
+	// A disabled interval must not start a ticker (time.NewTicker panics on
+	// non-positive intervals); the returned stop function is a no-op.
+	stop := startMatViewRefresher(context.Background(), nil, 0, time.Minute, testLogger{}, nil)
+	stop()
 }
 
 func TestResolveMatViewRefreshTimeoutDefaults(t *testing.T) {

--- a/framework/logstore/matviews_lock_test.go
+++ b/framework/logstore/matviews_lock_test.go
@@ -30,6 +30,15 @@ func TestStartMatViewRefresherDisabled(t *testing.T) {
 	stop()
 }
 
+func TestSelfHealSkippedWhenMaintenanceDisabled(t *testing.T) {
+	// With maintenance disabled, self-heal must not recreate the views (a nil
+	// db would panic if the repair goroutine ran) and must not arm the
+	// single-flight state.
+	s := &RDBLogStore{matViewMaintenanceDisabled: true}
+	s.triggerMatViewSelfHeal()
+	assert.False(t, s.matViewHealInFlight.Load())
+}
+
 func TestResolveMatViewRefreshTimeoutDefaults(t *testing.T) {
 	// Unset derives from the interval: 5x, floored at 5m.
 	assert.Equal(t, matViewRefreshTimeoutFloor, resolveMatViewRefreshTimeout("", time.Minute, testLogger{}))

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -20,7 +20,9 @@ type PostgresConfig struct {
 	// material on the database instance — the matview path already has
 	// activity-gated short-circuiting (see matViewRefreshGate), so the longer
 	// interval mostly affects how quickly idle clusters notice the rolling
-	// 30-day filter window has aged.
+	// 30-day filter window has aged. Set "off" (or any non-positive duration)
+	// to disable materialized-view maintenance entirely: views are neither
+	// created nor refreshed and dashboard queries use the raw tables.
 	MatViewRefreshInterval string `json:"matview_refresh_interval,omitempty"`
 
 	// MatViewRefreshTimeout bounds a single refresh pass. A refresh holds a pooled
@@ -100,14 +102,23 @@ func resolveMatViewRefreshTimeout(raw string, interval time.Duration, logger sch
 
 // resolveMatViewRefreshInterval parses the configured duration string with
 // fallback + clamp. Logs a warning on a bad string so misconfig is noticed.
+// Returns 0 when maintenance is disabled ("off" or a non-positive duration).
 func resolveMatViewRefreshInterval(raw string, logger schemas.Logger) time.Duration {
 	if raw == "" {
 		return defaultMatViewRefreshInterval
+	}
+	if raw == "off" {
+		logger.Info("logstore: matview maintenance disabled via config")
+		return 0
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("logstore: invalid matview_refresh_interval %q (%s); using default %s", raw, err, defaultMatViewRefreshInterval))
 		return defaultMatViewRefreshInterval
+	}
+	if d <= 0 {
+		logger.Info("logstore: matview maintenance disabled via config")
+		return 0
 	}
 	if d < minMatViewRefreshInterval {
 		logger.Warn(fmt.Sprintf("logstore: matview_refresh_interval %s is below floor %s; clamping to %s", d, minMatViewRefreshInterval, minMatViewRefreshInterval))
@@ -263,11 +274,14 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		if db.Dialector.Name() != "postgres" {
 			return
 		}
+		refreshInterval := resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger)
+		if refreshInterval <= 0 {
+			return
+		}
 		if err := ensureMatViews(context.Background(), db); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: matview creation failed: %s (dashboard queries will use raw tables)", err))
 			return
 		}
-		refreshInterval := resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger)
 		refreshTimeout := resolveMatViewRefreshTimeout(config.MatViewRefreshTimeout, refreshInterval, logger)
 
 		// The initial refresh gets the same budget as a periodic tick; on a large

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -226,7 +226,8 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		return nil, err
 	}
 	logger.Info("logstore: runtime connection pool ready")
-	d := &RDBLogStore{db: db, logger: logger}
+	refreshInterval := resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger)
+	d := &RDBLogStore{db: db, logger: logger, matViewMaintenanceDisabled: refreshInterval <= 0}
 
 	// Run all index builds sequentially in a single goroutine to prevent
 	// deadlocks from concurrent CREATE INDEX CONCURRENTLY on the same table.
@@ -271,11 +272,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 
 	// Create materialized views and start periodic refresh for dashboard queries.
 	go func() {
-		if db.Dialector.Name() != "postgres" {
-			return
-		}
-		refreshInterval := resolveMatViewRefreshInterval(config.MatViewRefreshInterval, logger)
-		if refreshInterval <= 0 {
+		if db.Dialector.Name() != "postgres" || refreshInterval <= 0 {
 			return
 		}
 		if err := ensureMatViews(context.Background(), db); err != nil {

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -70,6 +70,9 @@ type RDBLogStore struct {
 	db            *gorm.DB
 	logger        schemas.Logger
 	matViewsReady atomic.Bool
+	// matViewMaintenanceDisabled records that matview_refresh_interval resolved
+	// to disabled, so the self-heal path must not recreate the views either.
+	matViewMaintenanceDisabled bool
 	// Self-heal state for the matview read path (see matviewheal.go).
 	matViewHealInFlight    atomic.Bool
 	matViewHealLastAttempt atomic.Int64 // unix nanos of the last repair attempt

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1876,7 +1876,7 @@
                   },
                   "matview_refresh_interval": {
                     "type": "string",
-                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '1m', '5m', '1h'). Default 1m. Raise this when matview refresh CPU cost is material on the database instance. Minimum 5s. Set 'off' to disable materialized-view maintenance entirely; dashboard queries fall back to the raw tables.",
+                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '1m', '5m', '1h'). Default 1m. Raise this when matview refresh CPU cost is material on the database instance. Positive values below 5s are clamped up to 5s. Set 'off' or a zero duration (e.g. '0s') to disable materialized-view maintenance entirely; dashboard queries fall back to the raw tables.",
                     "pattern": "^(off|[0-9]+(ns|us|µs|ms|s|m|h))$",
                     "default": "1m"
                   },

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1876,8 +1876,8 @@
                   },
                   "matview_refresh_interval": {
                     "type": "string",
-                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '1m', '5m', '1h'). Default 1m. Raise this when matview refresh CPU cost is material on the database instance. Minimum 5s.",
-                    "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                    "description": "How often to refresh dashboard materialized views. Go duration string (e.g. '1m', '5m', '1h'). Default 1m. Raise this when matview refresh CPU cost is material on the database instance. Minimum 5s. Set 'off' to disable materialized-view maintenance entirely; dashboard queries fall back to the raw tables.",
+                    "pattern": "^(off|[0-9]+(ns|us|µs|ms|s|m|h))$",
                     "default": "1m"
                   },
                   "matview_refresh_timeout": {


### PR DESCRIPTION
## Summary

The Postgres logs store's materialized views back only the dashboard UI. Deployments that run Bifrost headless behind their own observability stack pay `REFRESH MATERIALIZED VIEW CONCURRENTLY` on every tick for views nothing reads, and on large `logs` tables that refresh is a material, recurring CPU cost on the database instance. Because `matview_refresh_interval` clamps to a 5s floor, the interval alone cannot turn maintenance off.

This adds `matview_refresh_interval: "off"` to disable materialized-view maintenance entirely.

## Changes

- `resolveMatViewRefreshInterval` returns 0 for `"off"` or a non-positive duration (logged at Info); anything else keeps the existing default/clamp behavior.
- `newPostgresLogStore` resolves the interval before `ensureMatViews` and skips view creation, the initial refresh, and the periodic refresher when disabled. `matViewsReady` stays false, so every dashboard query uses the existing raw-table fallback.
- `startMatViewRefresher` returns a no-op stop function for a non-positive interval (`time.NewTicker` panics on non-positive intervals), so the disabled value is safe even if a future caller passes it directly.
- The runtime self-heal path (`matviewheal.go`) cannot re-arm maintenance: it only triggers from shape errors on matview-path queries, and with `matViewsReady` never set, no query takes that path.
- `transports/config.schema.json`: pattern and description accept `"off"`.
- `docs/deployment-guides/config-json/storage.mdx`: documents the new value and when to use it.

Not included: the Helm chart's `storage.logsStore.matviewRefreshInterval` schema pattern still rejects `"off"` (`helm-charts/bifrost/values.schema.json`). The template passes the value through untouched, so allowing it there is a one-line pattern change, but chart changes ship as a separate chart release; happy to follow up with that PR if you want it.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
cd framework
go test ./logstore/ -run 'TestResolveMatViewRefreshIntervalDefaults|TestStartMatViewRefresherDisabled|TestResolveMatViewRefreshTimeoutDefaults' -v
```

Runtime validation: set `logs_store.config.matview_refresh_interval: "off"` against a Postgres logs store, start Bifrost, and observe the `logstore: matview maintenance disabled via config` log line. `pg_stat_activity` / `pg_stat_statements` show no `REFRESH MATERIALIZED VIEW` or `mv_*` activity, and `/api/logs/stats` keeps serving from the raw tables.

New config value: `matview_refresh_interval: "off"` (documented in `storage.mdx` and both schema descriptions).

## Screenshots/Recordings

N/A (no UI changes).

## Breaking changes

- [ ] Yes
- [x] No

Existing values behave exactly as before; `"off"` was previously rejected by the schema pattern and treated as unparseable (falling back to the default) by the Go code.

## Related issues

N/A

## Security considerations

None. The change only gates existing background maintenance; no new inputs, endpoints, or privileges.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
