### PR TITLE
[feat]: Expose calculated request cost in HTTP responses and final stream chunks

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5211,6 +5211,10 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	defer func() {
 		ctx.StampUpstreamLatency()
 		populateLatencyExtraFields(ctx, resp)
+		if resp != nil && bifrostErr == nil {
+			cost := ctx.CalculateCost(resp)
+			resp.GetExtraFields().Cost = &cost
+		}
 	}()
 
 	// Try the primary provider first

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5212,8 +5212,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		ctx.StampUpstreamLatency()
 		populateLatencyExtraFields(ctx, resp)
 		if resp != nil && bifrostErr == nil {
-			cost := ctx.CalculateCost(resp)
-			resp.GetExtraFields().Cost = &cost
+			resp.GetExtraFields().Cost = ctx.CalculateCostIfAvailable(resp)
 		}
 	}()
 

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6039,6 +6039,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			return nil, recoveredErr
 		}
 		if recoveredResp != nil {
+			populateFinalStreamCost(ctx, recoveredResp)
 			return newBifrostMessageChan(recoveredResp), nil
 		}
 		return nil, &bifrostErrVal

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4861,6 +4861,7 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 		} else if resp != nil {
 			resp.PopulateExtraFields(req.RequestType, wsProvider, wsModel, wsModel)
 		}
+		populateFinalStreamCost(ctx, resp)
 		return resp, nil
 	}
 
@@ -5853,6 +5854,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 				} else if resp != nil {
 					resp.PopulateExtraFields(shortCircuitRequestType, provider, model, model)
 				}
+				populateFinalStreamCost(ctx, resp)
 				return resp, nil
 			}
 
@@ -7155,6 +7157,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						resp.PopulateExtraFields(attemptRequestType, provider.GetProviderKey(), originalModelRequested, attemptResolvedModel)
 						resp.PopulateRoutingInfo(perAttemptRoutingInfo)
 					}
+					populateFinalStreamCost(ctx, resp)
 					return resp, nil
 				}
 				// Store a finalizer callback to create aggregated post-hook spans at stream end.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -895,15 +895,17 @@ func TestFilterProvidersByContext(t *testing.T) {
 	})
 }
 
-func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
+func TestRunStreamPreHooks_FinalChunkFlushesTraceAndAddsCost(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	account := NewMockAccount()
 	tracer := &countingTracer{}
+	catalog := &probeCatalog{cost: 0.25, costAvailable: true}
 
 	client, err := Init(ctx, schemas.BifrostConfig{
-		Account: account,
-		Tracer:  tracer,
-		Logger:  NewDefaultLogger(schemas.LogLevelError),
+		Account:      account,
+		Tracer:       tracer,
+		Logger:       NewDefaultLogger(schemas.LogLevelError),
+		ModelCatalog: catalog,
 	})
 	if err != nil {
 		t.Fatalf("Error initializing Bifrost: %v", err)
@@ -923,7 +925,7 @@ func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 	defer hooks.Cleanup()
 
 	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-	_, bifrostErr = hooks.PostHookRunner(ctx, &schemas.BifrostResponse{
+	resp, bifrostErr := hooks.PostHookRunner(ctx, &schemas.BifrostResponse{
 		ResponsesResponse: &schemas.BifrostResponsesResponse{
 			Object:    "response",
 			CreatedAt: int(time.Now().Unix()),
@@ -932,6 +934,9 @@ func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 	}, nil)
 	if bifrostErr != nil {
 		t.Fatalf("PostHookRunner returned error: %v", bifrostErr)
+	}
+	if resp.GetExtraFields().Cost == nil || *resp.GetExtraFields().Cost != 0.25 {
+		t.Fatalf("response cost = %v, want 0.25", resp.GetExtraFields().Cost)
 	}
 
 	if tracer.flushed.Load() != 1 {

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
+- feat: expose calculated cost on completed responses [@oritmosko](https://github.com/oritmosko)
 - fix: strip the encrypted reasoning signature when the upstream reports the field as unsupported (e.g. Bedrock Converse replaying a Claude signature onto a non-Anthropic model after a mid-conversation model switch), extending the existing unverifiable-signature fail-soft
 - fix: clear Anthropic raw-body passthrough based on the resolved provider and model pair, so non-Claude models on multi-family providers (Vertex, Azure, Bedrock Mantle) convert the request instead of passing the Anthropic payload through

--- a/core/modelcataloghooks_test.go
+++ b/core/modelcataloghooks_test.go
@@ -243,3 +243,48 @@ func TestModelCatalogUnavailableCostIsOmitted(t *testing.T) {
 		t.Errorf("response cost = %v, want nil", resp.ExtraFields.Cost)
 	}
 }
+
+func TestPopulateFinalStreamCost(t *testing.T) {
+	tests := []struct {
+		name          string
+		final         bool
+		cost          float64
+		costAvailable bool
+		wantCost      *float64
+	}{
+		{name: "final chunk", final: true, cost: 0.25, costAvailable: true, wantCost: schemas.Ptr(0.25)},
+		{name: "known zero", final: true, costAvailable: true, wantCost: schemas.Ptr(0.0)},
+		{name: "unavailable", final: true, cost: 0.25},
+		{name: "non-final chunk", cost: 0.25, costAvailable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			catalog := &probeCatalog{cost: tt.cost, costAvailable: tt.costAvailable}
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyModelCatalog, catalog)
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, tt.final)
+
+			resp := &schemas.BifrostResponse{
+				ChatResponse: &schemas.BifrostChatResponse{
+					Model: "gpt-4o",
+					Usage: &schemas.BifrostLLMUsage{PromptTokens: 5, CompletionTokens: 10, TotalTokens: 15},
+				},
+			}
+			resp.PopulateExtraFields(schemas.ChatCompletionStreamRequest, schemas.OpenAI, "gpt-4o", "gpt-4o")
+
+			populateFinalStreamCost(ctx, resp)
+
+			got := resp.GetExtraFields().Cost
+			if tt.wantCost == nil {
+				if got != nil {
+					t.Fatalf("cost = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.wantCost {
+				t.Fatalf("cost = %v, want %v", got, *tt.wantCost)
+			}
+		})
+	}
+}

--- a/core/modelcataloghooks_test.go
+++ b/core/modelcataloghooks_test.go
@@ -12,8 +12,9 @@ import (
 // reading a real one proves the handle reached it rather than that some other
 // lookup happened to succeed.
 type probeCatalog struct {
-	info *schemas.Model
-	cost float64
+	info          *schemas.Model
+	cost          float64
+	costAvailable bool
 
 	gotProvider schemas.ModelProvider
 	gotModel    string
@@ -31,6 +32,14 @@ func (p *probeCatalog) GetModelInfo(provider schemas.ModelProvider, model string
 func (p *probeCatalog) CalculateRequestCost(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) float64 {
 	p.costCalls++
 	return p.cost
+}
+
+func (p *probeCatalog) CalculateRequestCostIfAvailable(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) *float64 {
+	p.costCalls++
+	if !p.costAvailable {
+		return nil
+	}
+	return &p.cost
 }
 
 // catalogProbePlugin reads ctx.GetModelInfo / ctx.CalculateCost from each hook
@@ -126,7 +135,7 @@ func chatProbeRequest() *schemas.BifrostChatRequest {
 // in a third-party plugin.
 func TestModelCatalogReachesPluginHooksOnRealRequest(t *testing.T) {
 	want := &schemas.Model{ID: "gpt-4o", ContextLength: new(128000)}
-	catalog := &probeCatalog{info: want, cost: 0.25}
+	catalog := &probeCatalog{info: want, cost: 0.25, costAvailable: true}
 	plugin := &catalogProbePlugin{}
 	client := newCatalogProbeClient(t, catalog, plugin)
 
@@ -180,7 +189,8 @@ func TestModelCatalogAbsentLeavesHooksInert(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
 	defer ctx.Cancel()
 
-	if _, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest()); bfErr != nil {
+	resp, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest())
+	if bfErr != nil {
 		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
 	}
 
@@ -196,5 +206,40 @@ func TestModelCatalogAbsentLeavesHooksInert(t *testing.T) {
 	}
 	if plugin.postCost != 0 {
 		t.Errorf("CalculateCost = %v with no catalog wired, want 0", plugin.postCost)
+	}
+	if resp.ExtraFields.Cost != nil {
+		t.Errorf("response cost = %v with no catalog wired, want nil", resp.ExtraFields.Cost)
+	}
+}
+
+func TestModelCatalogCalculatedZeroCostIsRetained(t *testing.T) {
+	catalog := &probeCatalog{costAvailable: true}
+	client := newCatalogProbeClient(t, catalog, &catalogProbePlugin{})
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	defer ctx.Cancel()
+
+	resp, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest())
+	if bfErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
+	}
+	if resp.ExtraFields.Cost == nil || *resp.ExtraFields.Cost != 0 {
+		t.Errorf("response cost = %v, want pointer to zero", resp.ExtraFields.Cost)
+	}
+}
+
+func TestModelCatalogUnavailableCostIsOmitted(t *testing.T) {
+	catalog := &probeCatalog{cost: 0.25}
+	client := newCatalogProbeClient(t, catalog, &catalogProbePlugin{})
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	defer ctx.Cancel()
+
+	resp, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest())
+	if bfErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
+	}
+	if resp.ExtraFields.Cost != nil {
+		t.Errorf("response cost = %v, want nil", resp.ExtraFields.Cost)
 	}
 }

--- a/core/modelcataloghooks_test.go
+++ b/core/modelcataloghooks_test.go
@@ -133,7 +133,8 @@ func TestModelCatalogReachesPluginHooksOnRealRequest(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
 	defer ctx.Cancel()
 
-	if _, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest()); bfErr != nil {
+	resp, bfErr := client.ChatCompletionRequest(ctx, chatProbeRequest())
+	if bfErr != nil {
 		t.Fatalf("ChatCompletionRequest failed: %v", bfErr)
 	}
 
@@ -155,14 +156,17 @@ func TestModelCatalogReachesPluginHooksOnRealRequest(t *testing.T) {
 	if plugin.postCost != 0.25 {
 		t.Errorf("PostLLMHook CalculateCost = %v, want 0.25", plugin.postCost)
 	}
+	if resp.ExtraFields.Cost == nil || *resp.ExtraFields.Cost != 0.25 {
+		t.Errorf("response cost = %v, want 0.25", resp.ExtraFields.Cost)
+	}
 
 	// The arguments must arrive unchanged; a mangled provider would silently
 	// return nil for every real model.
 	if catalog.gotProvider != schemas.OpenAI || catalog.gotModel != "gpt-4o" {
 		t.Errorf("catalog saw (%q, %q), want (openai, gpt-4o)", catalog.gotProvider, catalog.gotModel)
 	}
-	if catalog.costCalls != 1 {
-		t.Errorf("CalculateRequestCost called %d times, want 1", catalog.costCalls)
+	if catalog.costCalls != 2 {
+		t.Errorf("CalculateRequestCost called %d times, want 2", catalog.costCalls)
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -1733,6 +1733,9 @@ type BifrostResponseExtraFields struct {
 	// consumers should read from RoutingInfo.
 	ResolvedModelUsed string `json:"resolved_model_used,omitempty"`
 	Latency           int64  `json:"latency"` // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
+	// Cost is the model-catalog-calculated request cost in US dollars. It is set
+	// on completed non-streaming responses after routing and fallbacks resolve.
+	Cost *float64 `json:"cost,omitempty"`
 	// UpstreamLatency is the total time spent blocked on upstream sockets across
 	// every attempt, in milliseconds. Unlike Latency it survives retries and
 	// fallbacks, so total-UpstreamLatency is Bifrost's own cost. Nil when the

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -1734,7 +1734,8 @@ type BifrostResponseExtraFields struct {
 	ResolvedModelUsed string `json:"resolved_model_used,omitempty"`
 	Latency           int64  `json:"latency"` // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
 	// Cost is the model-catalog-calculated request cost in US dollars. It is set
-	// on completed non-streaming responses after routing and fallbacks resolve.
+	// on completed responses after routing and fallbacks resolve. Streaming
+	// responses include it only on the final chunk.
 	Cost *float64 `json:"cost,omitempty"`
 	// UpstreamLatency is the total time spent blocked on upstream sockets across
 	// every attempt, in milliseconds. Unlike Latency it survives retries and

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -686,6 +686,23 @@ func (bc *BifrostContext) CalculateCost(resp *BifrostResponse) float64 {
 	return catalog.CalculateRequestCost(bc, resp)
 }
 
+// CalculateCostIfAvailable returns the calculated dollar cost, or nil when
+// the catalog cannot determine one. A non-nil pointer may contain zero.
+//
+// This is used when absence must remain distinguishable from a legitimate
+// zero. CalculateCost remains the backward-compatible plugin API.
+func (bc *BifrostContext) CalculateCostIfAvailable(resp *BifrostResponse) *float64 {
+	catalog, _ := bc.Value(BifrostContextKeyModelCatalog).(ModelInfoProvider)
+	if catalog == nil || resp == nil {
+		return nil
+	}
+	resolver, ok := catalog.(requestCostAvailabilityProvider)
+	if !ok {
+		return nil
+	}
+	return resolver.CalculateRequestCostIfAvailable(bc, resp)
+}
+
 // AppendRoutingEngineLog appends a routing engine log entry to the context.
 // Parameters:
 //   - ctx: The Bifrost context

--- a/core/schemas/modelcatalog.go
+++ b/core/schemas/modelcatalog.go
@@ -23,3 +23,11 @@ type ModelInfoProvider interface {
 	// different signature; a plugin-facing ctx.CalculateCost wraps this.
 	CalculateRequestCost(ctx *BifrostContext, resp *BifrostResponse) float64
 }
+
+// requestCostAvailabilityProvider is an optional extension implemented by
+// catalogs that can distinguish a calculated zero from unavailable pricing.
+// Keeping it separate preserves compatibility with existing ModelInfoProvider
+// implementations, whose CalculateRequestCost method only returns a number.
+type requestCostAvailabilityProvider interface {
+	CalculateRequestCostIfAvailable(ctx *BifrostContext, resp *BifrostResponse) *float64
+}

--- a/core/schemas/modelcatalog_test.go
+++ b/core/schemas/modelcatalog_test.go
@@ -39,6 +39,9 @@ func TestModelInfoAccessorsNoCatalogWired(t *testing.T) {
 	if got := ctx.CalculateCost(&BifrostResponse{}); got != 0 {
 		t.Fatalf("CalculateCost with no catalog = %v, want 0", got)
 	}
+	if got := ctx.CalculateCostIfAvailable(&BifrostResponse{}); got != nil {
+		t.Fatalf("CalculateCostIfAvailable with no catalog = %v, want nil", got)
+	}
 }
 
 func TestModelInfoAccessorsDelegate(t *testing.T) {

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -3826,6 +3826,7 @@ func (resp *BifrostResponsesStreamResponse) WithDefaults() *BifrostResponsesStre
 	result.Message = resp.Message
 	result.Param = resp.Param
 	result.LogProbs = resp.LogProbs
+	result.ExtraFields.Cost = resp.ExtraFields.Cost
 
 	// Apply event-specific defaults
 	switch resp.Type {

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -762,3 +762,16 @@ func TestStreamWithDefaultsStripsCodeExecutionCarry(t *testing.T) {
 		}
 	}
 }
+
+func TestStreamWithDefaultsPreservesCost(t *testing.T) {
+	cost := 0.25
+	src := &BifrostResponsesStreamResponse{
+		Type:        ResponsesStreamResponseTypeCompleted,
+		ExtraFields: BifrostResponseExtraFields{Cost: &cost},
+	}
+
+	out := src.WithDefaults()
+	if out.ExtraFields.Cost == nil || *out.ExtraFields.Cost != cost {
+		t.Fatalf("cost = %v, want %v", out.ExtraFields.Cost, cost)
+	}
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -550,6 +550,14 @@ func IsFinalChunk(ctx *schemas.BifrostContext) bool {
 	return false
 }
 
+// populateFinalStreamCost attaches the calculated cost after all post-hooks finish.
+func populateFinalStreamCost(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) {
+	if resp == nil || !IsFinalChunk(ctx) {
+		return
+	}
+	resp.GetExtraFields().Cost = ctx.CalculateCostIfAvailable(resp)
+}
+
 // GetResponseFields extracts the request type, provider, original model, and resolved model from the result or error.
 func GetResponseFields(result *schemas.BifrostResponse, err *schemas.BifrostError) (requestType schemas.RequestType, provider schemas.ModelProvider, originalModel string, resolvedModel string) {
 	if result != nil {

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -2524,6 +2524,36 @@ func TestCalculateCost_NoUsageData(t *testing.T) {
 	assert.Equal(t, 0.0, cost)
 }
 
+func TestCalculateCostBreakdown_UnavailablePricing(t *testing.T) {
+	s := testStoreWithPricing(nil)
+	resp := makeChatResponse(schemas.OpenAI, "unknown-model", &schemas.BifrostLLMUsage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+	})
+
+	cost := s.CalculateCostBreakdown(resp, nil)
+
+	assert.Nil(t, cost)
+}
+
+func TestCalculateCostBreakdown_CalculatedZero(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("free-model", "openai", "chat"): chatPricing(0, 0),
+	})
+	resp := makeChatResponse(schemas.OpenAI, "free-model", &schemas.BifrostLLMUsage{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+	})
+
+	cost := s.CalculateCostBreakdown(resp, nil)
+
+	if assert.NotNil(t, cost) {
+		assert.Equal(t, 0.0, cost.TotalCost)
+	}
+}
+
 func TestCalculateCost_ChatCompletion_GPT4o(t *testing.T) {
 	// GPT-4o: $5/M input, $15/M output, cache_read=$0.5/M
 	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{

--- a/framework/modelcatalog/modelinfo.go
+++ b/framework/modelcatalog/modelinfo.go
@@ -157,6 +157,24 @@ func (mc *ModelCatalog) CalculateRequestCost(ctx *schemas.BifrostContext, resp *
 	return mc.CalculateCost(resp, PricingLookupScopesFromContext(ctx, string(provider)))
 }
 
+// CalculateRequestCostIfAvailable is the availability-aware counterpart used
+// when a caller must distinguish unresolved pricing from a calculated zero.
+func (mc *ModelCatalog) CalculateRequestCostIfAvailable(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse) *float64 {
+	if mc == nil || resp == nil {
+		return nil
+	}
+	extraFields := resp.GetExtraFields()
+	provider := extraFields.RoutingInfo.Provider
+	if provider == "" {
+		provider = extraFields.Provider
+	}
+	breakdown := mc.CalculateCostBreakdown(resp, PricingLookupScopesFromContext(ctx, string(provider)))
+	if breakdown == nil {
+		return nil
+	}
+	return &breakdown.TotalCost
+}
+
 // formatCost renders a per-unit rate the way the models API reports it. Fixed
 // 10-decimal notation rather than %g so sub-cent token rates never surface in
 // scientific notation, which clients parsing these as decimals choke on.

--- a/framework/modelcatalog/modelinfo_test.go
+++ b/framework/modelcatalog/modelinfo_test.go
@@ -294,4 +294,7 @@ func TestApplyModelInfoNilSafe(t *testing.T) {
 	if got := nilCatalog.CalculateRequestCost(nil, nil); got != 0 {
 		t.Errorf("CalculateRequestCost on nil catalog = %v, want 0", got)
 	}
+	if got := nilCatalog.CalculateRequestCostIfAvailable(nil, nil); got != nil {
+		t.Errorf("CalculateRequestCostIfAvailable on nil catalog = %v, want nil", got)
+	}
 }

--- a/transports/bifrost-http/lib/responseheaders.go
+++ b/transports/bifrost-http/lib/responseheaders.go
@@ -32,6 +32,7 @@ const (
 	HeaderBifrostResolvedModel = "x-bifrost-resolved-model"
 	HeaderBifrostFallbackIndex = "x-bifrost-fallback-index"
 	HeaderBifrostRequestType   = "x-bifrost-request-type"
+	HeaderBifrostCostUSD       = "x-bifrost-cost-usd"
 	// Cumulative milliseconds this request spent blocked on upstream sockets,
 	// summed across every attempt and fallback. Subtract from the caller's own
 	// elapsed time to get what Bifrost cost. Distinct from the per-attempt
@@ -119,6 +120,9 @@ func ApplyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.B
 	}
 	if extra.RequestType != "" {
 		ctx.Response.Header.Set(HeaderBifrostRequestType, string(extra.RequestType))
+	}
+	if extra.Cost != nil {
+		ctx.Response.Header.Set(HeaderBifrostCostUSD, strconv.FormatFloat(*extra.Cost, 'f', -1, 64))
 	}
 	ri := extra.RoutingInfo
 	if ri.Provider != "" {

--- a/transports/bifrost-http/lib/responseheaders_test.go
+++ b/transports/bifrost-http/lib/responseheaders_test.go
@@ -25,12 +25,14 @@ func TestApplyBifrostResponseHeaders(t *testing.T) {
 	t.Run("routed identity emits all headers", func(t *testing.T) {
 		ctx := &fasthttp.RequestCtx{}
 		bifrostCtx := newBifrostCtx()
+		cost := 0.00125
 
 		extra := schemas.BifrostResponseExtraFields{
 			Provider:               schemas.Bedrock,
 			OriginalModelRequested: "claude-sonnet-4-6",
 			ResolvedModelUsed:      "us.anthropic.claude-sonnet-4-6",
 			RequestType:            schemas.ChatCompletionRequest,
+			Cost:                   &cost,
 			ProviderResponseHeaders: map[string]string{
 				"x-amzn-requestid": "req-789",
 			},
@@ -42,9 +44,20 @@ func TestApplyBifrostResponseHeaders(t *testing.T) {
 		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
 		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
 		assert.Equal(t, string(schemas.ChatCompletionRequest), string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Equal(t, "0.00125", string(ctx.Response.Header.Peek(HeaderBifrostCostUSD)))
 		assert.Equal(t, "req-789", string(ctx.Response.Header.Peek("x-amzn-requestid")))
 		// No fallback fired — header must be absent.
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("calculated zero cost remains distinguishable from missing cost", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newBifrostCtx()
+		cost := 0.0
+
+		ApplyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{Cost: &cost})
+
+		assert.Equal(t, "0", string(ctx.Response.Header.Peek(HeaderBifrostCostUSD)))
 	})
 
 	t.Run("fallback index from context emits when non-zero", func(t *testing.T) {
@@ -73,6 +86,7 @@ func TestApplyBifrostResponseHeaders(t *testing.T) {
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostCostUSD)))
 		// No accumulator installed — unmeasured must stay distinguishable from zero.
 		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostUpstreamLatency)))
 	})

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+[feat]: return calculated cost in x-bifrost-cost-usd [@oritmosko](https://github.com/oritmosko)
 ## ✨ Features
 
 - **Virtual Key Rotation Cooldown** - New `client.vk_rotation_cooldown` setting (duration string, e.g. "5m"): after a rotation the previous key value keeps authenticating until the grace window expires. config.json VK sync now treats a changed value as an explicit rotation (with console warning) and recognizes the previously rotated-out value as "no change".

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,4 @@
-[feat]: return calculated cost in x-bifrost-cost-usd [@oritmosko](https://github.com/oritmosko)
+[feat]: return calculated cost in HTTP responses and final stream chunks [@oritmosko](https://github.com/oritmosko)
 ## ✨ Features
 
 - **Virtual Key Rotation Cooldown** - New `client.vk_rotation_cooldown` setting (duration string, e.g. "5m"): after a rotation the previous key value keeps authenticating until the grace window expires. config.json VK sync now treats a changed value as an explicit rotation (with console warning) and recognizes the previously rotated-out value as "no change".


### PR DESCRIPTION
## Summary

Expose Bifrost authoritative model-catalog cost to clients without requiring them to duplicate pricing logic.

Completed non-streaming responses expose the cost in response metadata and through `x-bifrost-cost-usd`. Streaming responses expose it in the final chunk `extra_fields.cost`, because HTTP headers have already been sent by the time final usage is known.

## Changes

- Preserve the distinction between an unavailable cost (`nil`) and a legitimate calculated zero.
- Populate `BifrostResponseExtraFields.Cost` after routing, fallbacks, and post-hooks complete.
- Add the calculated cost only to final stream chunks, including post-hook-recovered responses.
- Preserve the final cost when Responses API stream chunks are normalized with `WithDefaults`.
- Emit `x-bifrost-cost-usd` for completed non-streaming HTTP responses when cost is available.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test . ./schemas -count=1

source .github/workflows/scripts/setup-go-workspace.sh
cd transports
go test ./bifrost-http/lib -run 'TestApplyBifrost(ResponseHeaders|StreamResponseHeaders|ErrorResponseHeaders)$' -count=1
```

The full affected core/schema suites and focused HTTP response-header tests pass.

No new configuration or environment variables are required.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5695. Streaming parity was added in response to review feedback.

## Security considerations

The response exposes only the calculated aggregate request cost. It does not expose credentials, prompts, responses, or model-catalog configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added or updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified the affected Go packages build and test successfully
