### PR TITLE
[fix]: builtin disable reverts on restart, custom plugin config updates fail

### DIFF
--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -430,7 +431,8 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	// neither, and nulling `path` turns a custom plugin into a built-in lookup that
 	// then fails with "unknown built-in plugin" while the old instance keeps running.
 	// Presence is detected on the raw body because absent and explicit null both
-	// decode to a nil pointer.
+	// decode to a nil pointer. An explicit null is treated as "not provided" as well;
+	// an empty string is the documented way to detach a path.
 	var rawFields map[string]json.RawMessage
 	if err := json.Unmarshal(ctx.PostBody(), &rawFields); err != nil {
 		logger.Error("failed to unmarshal update plugin request fields: %v", err)
@@ -438,13 +440,13 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if existingPlugin != nil {
-		if _, sent := rawFields["path"]; !sent {
+		if !fieldProvided(rawFields, "path") {
 			request.Path = existingPlugin.Path
 		}
-		if _, sent := rawFields["placement"]; !sent {
+		if !fieldProvided(rawFields, "placement") {
 			request.Placement = existingPlugin.Placement
 		}
-		if _, sent := rawFields["order"]; !sent {
+		if !fieldProvided(rawFields, "order") {
 			request.Order = existingPlugin.Order
 		}
 	}
@@ -582,6 +584,17 @@ func (h *PluginsHandler) deletePlugin(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Plugin deleted successfully",
 	})
+}
+
+// fieldProvided reports whether a request body carried a usable value for a key.
+// A key that is absent, or present as JSON null, counts as not provided, so the
+// caller keeps whatever is already stored rather than writing a nil over it.
+func fieldProvided(rawFields map[string]json.RawMessage, key string) bool {
+	raw, ok := rawFields[key]
+	if !ok {
+		return false
+	}
+	return !bytes.Equal(bytes.TrimSpace(raw), []byte("null"))
 }
 
 // restoreRedactedFromExisting walks the incoming config map and, for any field whose

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -425,6 +425,29 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Invalid request body")
 		return
 	}
+	// A PUT that omits path/placement/order must not clear them. Clients that only
+	// toggle `enabled` or edit `config` (e.g. the update-plugin sheet in the UI) send
+	// neither, and nulling `path` turns a custom plugin into a built-in lookup that
+	// then fails with "unknown built-in plugin" while the old instance keeps running.
+	// Presence is detected on the raw body because absent and explicit null both
+	// decode to a nil pointer.
+	var rawFields map[string]json.RawMessage
+	if err := json.Unmarshal(ctx.PostBody(), &rawFields); err != nil {
+		logger.Error("failed to unmarshal update plugin request fields: %v", err)
+		SendError(ctx, 400, "Invalid request body")
+		return
+	}
+	if existingPlugin != nil {
+		if _, sent := rawFields["path"]; !sent {
+			request.Path = existingPlugin.Path
+		}
+		if _, sent := rawFields["placement"]; !sent {
+			request.Placement = existingPlugin.Placement
+		}
+		if _, sent := rawFields["order"]; !sent {
+			request.Order = existingPlugin.Order
+		}
+	}
 	// Validate placement value
 	if request.Placement != nil && *request.Placement != "" &&
 		*request.Placement != schemas.PluginPlacementPreBuiltin &&

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -16,9 +16,12 @@ import (
 // can assert that config merging occurred correctly.
 type capturePluginsStore struct {
 	configstore.ConfigStore
-	existingPlugin  *configstoreTables.TablePlugin
-	capturedConfig  map[string]any
-	capturedEnabled bool
+	existingPlugin    *configstoreTables.TablePlugin
+	capturedConfig    map[string]any
+	capturedEnabled   bool
+	capturedPath      *string
+	capturedPlacement *schemas.PluginPlacement
+	capturedOrder     *int
 }
 
 func (s *capturePluginsStore) GetPlugin(_ context.Context, name string) (*configstoreTables.TablePlugin, error) {
@@ -33,6 +36,9 @@ func (s *capturePluginsStore) UpdatePlugin(_ context.Context, plugin *configstor
 		s.capturedConfig = cfg
 	}
 	s.capturedEnabled = plugin.Enabled
+	s.capturedPath = plugin.Path
+	s.capturedPlacement = plugin.Placement
+	s.capturedOrder = plugin.Order
 	return nil
 }
 
@@ -63,6 +69,13 @@ func (noopPluginsLoader) ExpandPluginConfigForAPI(_ string, _ map[string]any) (m
 // buildUpdateRequest creates a PUT /api/plugins/{name} fasthttp context.
 func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {
 	t.Helper()
+	return buildUpdateRequestFor(t, "otel", body)
+}
+
+// buildUpdateRequestFor is buildUpdateRequest for a named plugin. Custom plugins need
+// their own name because built-ins have their path forced to nil by design.
+func buildUpdateRequestFor(t *testing.T, name string, body any) *fasthttp.RequestCtx {
+	t.Helper()
 	raw, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("marshal request body: %v", err)
@@ -70,7 +83,7 @@ func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod("PUT")
 	ctx.Request.SetBody(raw)
-	ctx.SetUserValue("name", "otel")
+	ctx.SetUserValue("name", name)
 	return ctx
 }
 
@@ -366,5 +379,97 @@ func TestGetLoadedPlugins(t *testing.T) {
 		if response.Plugins[i] != name {
 			t.Errorf("plugins[%d] = %q, want %q", i, response.Plugins[i], name)
 		}
+	}
+}
+
+// TestUpdatePlugin_PreservesPathWhenOmitted verifies that a PUT which does not carry
+// `path` leaves the stored path intact. The update-plugin sheet in the UI sends only
+// `enabled` and `config`; clearing the path on such a request turned a custom plugin
+// into a built-in lookup, which then failed with "unknown built-in plugin" while the
+// already loaded instance kept running with its old config.
+func TestUpdatePlugin_PreservesPathWhenOmitted(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	storedPath := "/app/plugins/custom.so"
+	placement := schemas.PluginPlacementPreBuiltin
+	order := 3
+
+	store := &capturePluginsStore{
+		existingPlugin: &configstoreTables.TablePlugin{
+			Name:      "custom-probe",
+			Enabled:   true,
+			Config:    map[string]any{"tag": "one"},
+			Path:      &storedPath,
+			Placement: &placement,
+			Order:     &order,
+			IsCustom:  true,
+		},
+	}
+
+	h := &PluginsHandler{
+		pluginsLoader: noopPluginsLoader{},
+		configStore:   store,
+	}
+
+	// Only enabled and config, exactly what the update-plugin sheet sends.
+	ctx := buildUpdateRequestFor(t, "custom-probe", map[string]any{
+		"enabled": true,
+		"config":  map[string]any{"tag": "two"},
+	})
+	h.updatePlugin(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if store.capturedPath == nil {
+		t.Fatal("path was cleared by an update that did not send it")
+	}
+	if *store.capturedPath != storedPath {
+		t.Errorf("path = %q, want %q", *store.capturedPath, storedPath)
+	}
+	if store.capturedPlacement == nil || *store.capturedPlacement != placement {
+		t.Errorf("placement = %v, want %v", store.capturedPlacement, placement)
+	}
+	if store.capturedOrder == nil || *store.capturedOrder != order {
+		t.Errorf("order = %v, want %d", store.capturedOrder, order)
+	}
+	if got := store.capturedConfig["tag"]; got != "two" {
+		t.Errorf("tag = %v, want two", got)
+	}
+}
+
+// TestUpdatePlugin_ClearsPathWhenExplicitlyEmpty verifies that a caller can still
+// detach a path by sending it as an empty string, which the handler normalizes to nil.
+func TestUpdatePlugin_ClearsPathWhenExplicitlyEmpty(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	storedPath := "/app/plugins/custom.so"
+	store := &capturePluginsStore{
+		existingPlugin: &configstoreTables.TablePlugin{
+			Name:     "custom-probe",
+			Enabled:  true,
+			Config:   map[string]any{},
+			Path:     &storedPath,
+			IsCustom: true,
+		},
+	}
+
+	h := &PluginsHandler{
+		pluginsLoader: noopPluginsLoader{},
+		configStore:   store,
+	}
+
+	ctx := buildUpdateRequestFor(t, "custom-probe", map[string]any{
+		"enabled": true,
+		"path":    "",
+		"config":  map[string]any{},
+	})
+	h.updatePlugin(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if store.capturedPath != nil {
+		t.Errorf("path = %q, want nil after an explicit empty path", *store.capturedPath)
 	}
 }

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -473,3 +473,44 @@ func TestUpdatePlugin_ClearsPathWhenExplicitlyEmpty(t *testing.T) {
 		t.Errorf("path = %q, want nil after an explicit empty path", *store.capturedPath)
 	}
 }
+
+// TestUpdatePlugin_PreservesPathWhenNull verifies that an explicit JSON null for `path`
+// is treated the same as omitting it. Null would otherwise persist a nil path and send
+// a custom plugin back down the built-in branch, which is the same failure as omitting
+// the field. An empty string remains the way to detach a path.
+func TestUpdatePlugin_PreservesPathWhenNull(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	storedPath := "/app/plugins/custom.so"
+	store := &capturePluginsStore{
+		existingPlugin: &configstoreTables.TablePlugin{
+			Name:     "custom-probe",
+			Enabled:  true,
+			Config:   map[string]any{},
+			Path:     &storedPath,
+			IsCustom: true,
+		},
+	}
+
+	h := &PluginsHandler{
+		pluginsLoader: noopPluginsLoader{},
+		configStore:   store,
+	}
+
+	ctx := buildUpdateRequestFor(t, "custom-probe", map[string]any{
+		"enabled": true,
+		"path":    nil,
+		"config":  map[string]any{},
+	})
+	h.updatePlugin(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+	if store.capturedPath == nil {
+		t.Fatal("path was cleared by an explicit null; null must behave like an omitted field")
+	}
+	if *store.capturedPath != storedPath {
+		t.Errorf("path = %q, want %q", *store.capturedPath, storedPath)
+	}
+}

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -170,6 +170,17 @@ func (s *BifrostHTTPServer) getPluginConfig(name string) *schemas.PluginConfig {
 	return nil
 }
 
+// isBuiltinPluginDisabled reports whether a stored plugin row explicitly disables a
+// built-in plugin. Default-on: a missing row is treated as enabled so upgraders keep
+// their current behavior, and only an explicit Enabled=false turns a plugin off.
+// Without this check, plugins whose load decision comes from ClientConfig rather than
+// the plugin row (logging, governance, compat, prompts) came back on every restart
+// after being disabled through the API, while the API kept reporting them disabled.
+func (s *BifrostHTTPServer) isBuiltinPluginDisabled(name string) bool {
+	cfg := s.getPluginConfig(name)
+	return cfg != nil && !cfg.Enabled
+}
+
 // loadBuiltinPlugins loads required built-in plugins in specific order
 func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	builtinPlacement := schemas.Ptr(schemas.PluginPlacementBuiltin)
@@ -190,7 +201,8 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	s.Config.SetPluginOrderInfo(telemetry.PluginName, builtinPlacement, schemas.Ptr(1))
 
 	// 2. Prompts (requires config store for prompt repository; disabled in enterprise)
-	if s.Config.ConfigStore != nil && ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil {
+	if s.Config.ConfigStore != nil && ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil &&
+		!s.isBuiltinPluginDisabled(prompts.PluginName) {
 		s.registerPluginWithStatus(ctx, prompts.PluginName, nil, nil, false)
 	} else {
 		s.markPluginDisabled(prompts.PluginName)
@@ -198,7 +210,8 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	s.Config.SetPluginOrderInfo(prompts.PluginName, builtinPlacement, schemas.Ptr(2))
 
 	// 3. Logging (if enabled)
-	if (s.Config.ClientConfig.EnableLogging == nil || *s.Config.ClientConfig.EnableLogging) && s.Config.LogsStore != nil {
+	if (s.Config.ClientConfig.EnableLogging == nil || *s.Config.ClientConfig.EnableLogging) && s.Config.LogsStore != nil &&
+		!s.isBuiltinPluginDisabled(logging.PluginName) {
 		config := &logging.Config{
 			DisableContentLogging:        &s.Config.ClientConfig.DisableContentLogging,
 			RetainContentInObjectStorage: &s.Config.ClientConfig.RetainContentInObjectStorage,
@@ -214,7 +227,7 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	s.Config.SetPluginOrderInfo(logging.PluginName, builtinPlacement, schemas.Ptr(3))
 
 	// 4. Governance (if enabled and not enterprise)
-	if ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil {
+	if ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil && !s.isBuiltinPluginDisabled(governance.PluginName) {
 		config := &governance.Config{
 			IsVkMandatory:         &s.Config.ClientConfig.EnforceAuthOnInference,
 			RequiredHeaders:       &s.Config.ClientConfig.RequiredHeaders,
@@ -253,7 +266,11 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 		ShouldDropParams:       cc.ShouldDropParams,
 		ShouldConvertParams:    cc.ShouldConvertParams,
 	}
-	s.registerPluginWithStatus(ctx, compat.PluginName, nil, compatCfg, false)
+	if !s.isBuiltinPluginDisabled(compat.PluginName) {
+		s.registerPluginWithStatus(ctx, compat.PluginName, nil, compatCfg, false)
+	} else {
+		s.markPluginDisabled(compat.PluginName)
+	}
 	s.Config.SetPluginOrderInfo(compat.PluginName, builtinPlacement, schemas.Ptr(7))
 
 	// 8. Maxim (if configured in PluginConfigs)

--- a/transports/bifrost-http/server/plugins_test.go
+++ b/transports/bifrost-http/server/plugins_test.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+)
+
+// TestIsBuiltinPluginDisabled covers the gate that lets a stored plugin row turn off a
+// built-in plugin whose load decision otherwise comes from ClientConfig. Default-on
+// matters here: a plugin with no stored row must keep loading, so that upgrading does
+// not silently drop logging, governance, compat or prompts.
+func TestIsBuiltinPluginDisabled(t *testing.T) {
+	s := &BifrostHTTPServer{
+		Config: &lib.Config{
+			PluginConfigs: []*schemas.PluginConfig{
+				{Name: "logging", Enabled: false},
+				{Name: "governance", Enabled: true},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		plugin string
+		want   bool
+	}{
+		{"explicitly disabled row disables the plugin", "logging", true},
+		{"explicitly enabled row keeps the plugin on", "governance", false},
+		{"missing row defaults to enabled", "compat", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.isBuiltinPluginDisabled(tt.plugin); got != tt.want {
+				t.Errorf("isBuiltinPluginDisabled(%q) = %v, want %v", tt.plugin, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsBuiltinPluginDisabled_NoStoredPlugins verifies the default-on path when the
+// config store holds no plugin rows at all, which is the state of a fresh install.
+func TestIsBuiltinPluginDisabled_NoStoredPlugins(t *testing.T) {
+	s := &BifrostHTTPServer{Config: &lib.Config{}}
+
+	for _, name := range []string{"logging", "governance", "compat", "prompts"} {
+		if s.isBuiltinPluginDisabled(name) {
+			t.Errorf("isBuiltinPluginDisabled(%q) = true on a fresh install, want false", name)
+		}
+	}
+}

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -116,6 +116,10 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 					name: plugin.name,
 					data: {
 						enabled: plugin.enabled,
+						// Send the path back unchanged: omitting it on a custom plugin used to
+						// clear the stored path, after which the reload fell through to the
+						// built-in lookup and failed.
+						path: plugin.path ?? undefined,
 						config: parsedConfig,
 					},
 				}).unwrap();


### PR DESCRIPTION
Fixes #5699

## Summary

Two plugin bugs, both reproducible on `dev`.

**`enabled=false` ignored at startup.** `logging`, `governance`, `compat` and `prompts` decide whether to load from `ClientConfig` and never read the stored row, so disabling them lasts until the next restart. The API reports them disabled the whole time, since the response uses the row rather than what is loaded. Startup now checks the row too. Missing row still means enabled, so nobody loses `/metrics` or logging on upgrade.

**Partial updates wiped `path`.** `path` is a `*string`, so a field that was never sent looks the same as an explicit null and got cleared either way. On a custom plugin the reload then took the builtin branch and failed with `unknown built-in plugin`, returning 500 while the old instance kept running with the old config. The row was left with `path=NULL` and `IsCustom=false`, breaking the next boot as well. Presence is now read off the raw body, so omitted `path`/`placement`/`order` keep their stored values. Sending `path: ""` still detaches it.

The Update Plugin sheet also sends `path` back now. The main plugins view already did, which is why this only broke on one of the two screens.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (React)

## How to test

```sh
go test ./bifrost-http/handlers/... ./bifrost-http/server/...
```

`TestUpdatePlugin_PreservesPathWhenOmitted` fails if you revert the handler change.

Manually: install a `.so` plugin, then `PUT {"enabled":true,"config":{...}}` without `path`. Before, 500 and the old config stays live. After, 200 and `Init` runs again with the new config. For the builtin half, disable `telemetry` and `logging`, restart, check `/api/plugins/loaded`. `/metrics` goes 404 while telemetry is off, 200 after re-enabling.

## Breaking changes

- [x] No

A row saying `enabled=false` now actually takes effect at startup. If you disabled `logging` or `governance` and were counting on a restart bringing it back, it will not.

## Security considerations

`governance` carries auth enforcement, so disabling it now sticks across restarts. That was already the runtime behaviour, this just makes restart agree.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)