### PR TITLE
chore: release Bifrost Helm chart v2.1.33 with OTEL schema fix

### DIFF
--- a/docs/changelogs/helm-v2.1.32.mdx
+++ b/docs/changelogs/helm-v2.1.32.mdx
@@ -5,6 +5,10 @@ description: "Helm v2.1.32 changelog - 2026-07-24"
 
 <Update label="Bifrost Helm" description="v2.1.32">
 
+<Warning>
+**Known issue - use v2.1.33 instead.** Multi-profile OTEL configs (`bifrost.plugins.otel.config.profiles`) fail Helm schema validation on this version (`Additional property export_timeout is not allowed`), blocking render and deploy. Fixed in v2.1.33.
+</Warning>
+
 ## Changelog
 
 - Extended `bifrost.accessProfiles[].provider_configs[]` with `blacklisted_models` (denylist that wins over `allowed_models`; `["*"]` blocks every model, while an empty or omitted list blocks none), `weight` (load-balancer seed weight; `null` opts out), and `model_budgets[]` (per-model budget groups; each entry requires `model_name` and may carry optional `budgets[]` and a `rate_limit`). These pass through into `access_profiles[].provider_configs[]`.

--- a/docs/changelogs/helm-v2.1.33.mdx
+++ b/docs/changelogs/helm-v2.1.33.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.33"
+description: "Helm v2.1.33 changelog - 2026-07-31"
+---
+
+<Update label="Bifrost Helm" description="v2.1.33">
+
+## Changelog
+
+- Fixed Helm schema validation failure for multi-profile OTEL configs (`bifrost.plugins.otel.config.profiles`), introduced by the `export_timeout` default in 2.1.32.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1053,6 +1053,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.33",
               "changelogs/helm-v2.1.32",
               "changelogs/helm-v2.1.31",
               "changelogs/helm-v2.1.30",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.32
+version: 2.1.33
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.32
+**Latest Version:** 2.1.33
 
 ## Changelog
+
+### 2.1.33
+
+- Fixed Helm schema validation failure for multi-profile OTEL configs (`bifrost.plugins.otel.config.profiles`), introduced by the `export_timeout` default in 2.1.32.
 
 ### 2.1.32
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5058,6 +5058,12 @@
           "maximum": 300,
           "description": "Deprecated in the profiles wrapper; configure metrics_push_interval per profile instead."
         },
+        "export_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 60,
+          "description": "Deprecated in the profiles wrapper; configure export_timeout per profile instead."
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -635,7 +635,7 @@ bifrost:
         # Max seconds for a single trace export (1-60). This is the only timeout on gRPC
         # exports: an endpoint that accepts the connection but never replies would
         # otherwise block an export goroutine indefinitely.
-        export_timeout: 5
+        # export_timeout: 5
         # Push-based metrics export via OTLP (recommended for multi-node clusters)
         metrics_enabled: false
         metrics_endpoint: "" # e.g., http://otel-collector:4318/v1/metrics (HTTP) or otel-collector:4317 (gRPC)


### PR DESCRIPTION
## Summary

Fixes a Helm schema validation failure introduced in v2.1.32 where multi-profile OTEL configs (`bifrost.plugins.otel.config.profiles`) would fail with `Additional property export_timeout is not allowed`, blocking Helm render and deploy.

## Changes

- Added `export_timeout` as an explicitly allowed (but deprecated) property in `values.schema.json` so that Helm's default map merge does not reject values when transitioning from the legacy flat config shape to the `profiles` wrapper shape.
- Commented out the `export_timeout: 5` default in `values.yaml` to prevent it from being injected into the config and triggering the schema conflict.
- Added a warning to the v2.1.32 changelog directing users to use v2.1.33 instead.
- Published the v2.1.33 changelog documenting the fix.
- Bumped the Helm chart version to `2.1.33`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Render the Helm chart with a multi-profile OTEL config to confirm schema validation passes
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.plugins.otel.config.profiles[0].endpoint="http://otel-collector:4318" \
  --set bifrost.plugins.otel.config.profiles[0].export_timeout=10

# Should render without errors; previously would fail with:
# "Additional property export_timeout is not allowed"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Regression introduced in v2.1.32 by the addition of the `export_timeout` default value.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable