### PR TITLE
`refactor: merge oauth_tokens/oauth_user_tokens into unified mcp_oauth_tokens table`

### DIFF
--- a/framework/configstore/encryption.go
+++ b/framework/configstore/encryption.go
@@ -53,10 +53,10 @@ func (s *RDBConfigStore) EncryptPlaintextRows(ctx context.Context) error {
 	}
 	totalEncrypted += count
 
-	// oauth_tokens
+	// mcp_oauth_tokens
 	count, err = s.encryptPlaintextOAuthTokens(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to encrypt oauth_tokens: %w", err)
+		return fmt.Errorf("failed to encrypt mcp_oauth_tokens: %w", err)
 	}
 	totalEncrypted += count
 
@@ -222,12 +222,12 @@ func (s *RDBConfigStore) encryptPlaintextTempTokens(ctx context.Context) (int, e
 	return count, nil
 }
 
-// encryptPlaintextOAuthTokens finds all oauth_tokens rows with plaintext encryption status
-// and re-saves them in batches. The TableOauthToken.BeforeSave hook handles encryption.
+// encryptPlaintextOAuthTokens finds all mcp_oauth_tokens rows with plaintext encryption status
+// and re-saves them in batches. The TableMCPOauthToken.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextOAuthTokens(ctx context.Context) (int, error) {
 	var count int
 	for {
-		var tokens []tables.TableOauthToken
+		var tokens []tables.TableMCPOauthToken
 		if err := s.DB().WithContext(ctx).
 			Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
 			Limit(encryptionBatchSize).

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -40,7 +40,7 @@ func setupEncryptionTestStore(t *testing.T) (*RDBConfigStore, *gorm.DB) {
 		&tables.TableVirtualKey{},
 		&tables.SessionsTable{},
 		&tables.TableOauthConfig{},
-		&tables.TableOauthToken{},
+		&tables.TableMCPOauthToken{},
 		&tables.TableVectorStoreConfig{},
 		&tables.TableBudget{},
 		&tables.TableRateLimit{},
@@ -98,8 +98,8 @@ func TestEncryptPlaintextRows_EncryptsAllTables(t *testing.T) {
 		"session-plaintext-token", future, now, now)
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_tokens (id, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, 'Bearer', 'plain_text', ?, ?, ?)`,
+		`INSERT INTO mcp_oauth_tokens (id, auth_mode, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
+		 VALUES (?, 'shared', ?, ?, 'Bearer', 'plain_text', ?, ?, ?)`,
 		"tok-1", "plaintext-access-token", "plaintext-refresh-token", future, now, now)
 
 	insertPlaintextRow(t, db,
@@ -148,7 +148,7 @@ func TestEncryptPlaintextRows_EncryptsAllTables(t *testing.T) {
 	assert.NotEqual(t, "session-plaintext-token", sessionRow["token"])
 
 	var tokRow map[string]any
-	db.Table("oauth_tokens").Where("id = ?", "tok-1").Take(&tokRow)
+	db.Table("mcp_oauth_tokens").Where("id = ?", "tok-1").Take(&tokRow)
 	assert.Equal(t, "encrypted", tokRow["encryption_status"])
 	assert.NotEqual(t, "plaintext-access-token", tokRow["access_token"])
 
@@ -300,15 +300,15 @@ func TestEncryptPlaintextOAuthTokens(t *testing.T) {
 	future := time.Now().Add(time.Hour).UTC().Format("2006-01-02 15:04:05")
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_tokens (id, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
-		 VALUES (?, ?, ?, 'Bearer', 'plain_text', ?, ?, ?)`,
+		`INSERT INTO mcp_oauth_tokens (id, auth_mode, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
+		 VALUES (?, 'shared', ?, ?, 'Bearer', 'plain_text', ?, ?, ?)`,
 		"tok-batch-1", "access-1", "refresh-1", future, now, now)
 
 	count, err := store.encryptPlaintextOAuthTokens(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 
-	var found tables.TableOauthToken
+	var found tables.TableMCPOauthToken
 	require.NoError(t, db.First(&found, "id = ?", "tok-batch-1").Error)
 	assert.Equal(t, "access-1", found.AccessToken)
 	assert.Equal(t, "refresh-1", found.RefreshToken)
@@ -1375,8 +1375,8 @@ func TestEncryptPlaintextOAuthTokens_EmptyRefreshToken(t *testing.T) {
 	future := time.Now().Add(time.Hour).UTC().Format("2006-01-02 15:04:05")
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_tokens (id, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
-		 VALUES (?, ?, '', 'Bearer', 'plain_text', ?, ?, ?)`,
+		`INSERT INTO mcp_oauth_tokens (id, auth_mode, access_token, refresh_token, token_type, encryption_status, expires_at, created_at, updated_at)
+		 VALUES (?, 'shared', ?, '', 'Bearer', 'plain_text', ?, ?, ?)`,
 		"tok-no-refresh", "access-only-startup", future, now, now)
 
 	count, err := store.encryptPlaintextOAuthTokens(ctx)
@@ -1384,10 +1384,10 @@ func TestEncryptPlaintextOAuthTokens_EmptyRefreshToken(t *testing.T) {
 	assert.Equal(t, 1, count)
 
 	var raw map[string]any
-	db.Table("oauth_tokens").Where("id = ?", "tok-no-refresh").Take(&raw)
+	db.Table("mcp_oauth_tokens").Where("id = ?", "tok-no-refresh").Take(&raw)
 	assert.Equal(t, "encrypted", raw["encryption_status"])
 
-	var found tables.TableOauthToken
+	var found tables.TableMCPOauthToken
 	require.NoError(t, db.First(&found, "id = ?", "tok-no-refresh").Error)
 	assert.Equal(t, "access-only-startup", found.AccessToken)
 	assert.Equal(t, "", found.RefreshToken)

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -458,6 +458,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_live_models_sync_interval_column"}, run: migrationAddLiveModelsSyncIntervalColumn},
 	{IDs: []string{"add_pricing_override_user_id_column"}, run: migrationAddPricingOverrideUserIDColumn},
 	{IDs: []string{"add_mcp_client_pending_oauth_config_json_column"}, run: migrationAddMCPClientPendingOAuthConfigJSONColumn},
+	{IDs: []string{"merge_oauth_token_tables"}, run: migrationMergeOauthTokenTables},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -11146,4 +11147,230 @@ func migrationAddPricingOverrideUserIDColumn(ctx context.Context, db *gorm.DB, l
 		return fmt.Errorf("error while running pricing override user_id column migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationMergeOauthTokenTables introduces mcp_oauth_tokens, a new table
+// that from this point on is the single home for every holder of an MCP
+// OAuth credential — the shared client credential (auth_mode='shared') and
+// every per-identity credential (auth_mode 'user'|'vk'|'session') alike —
+// instead of splitting shared and per-user credentials across the two older
+// tables ('oauth_tokens', 'oauth_user_tokens') with diverging maturity.
+//
+// This does not ALTER either older table. It creates mcp_oauth_tokens fresh
+// (already carrying every column + constraint TableMCPOauthToken declares,
+// so no nullable-first/backfill/tighten dance is needed the way an in-place
+// ALTER would require), then populates it with two INSERT...SELECT passes —
+// one deriving shared rows out of oauth_tokens' old shared-only shape, one
+// copying oauth_user_tokens' per-identity rows field-for-field.
+//
+// oauth_tokens and oauth_user_tokens are left completely untouched and
+// undropped by this migration. Neither is read or written by any code path
+// as of this migration — every current read/write site targets
+// mcp_oauth_tokens exclusively. Both older tables are kept solely as a
+// rollback safety net (dropping them here would make this migration
+// irreversible for anyone who needs to back out) and will be dropped in a
+// future MAJOR version once the new table has proven itself in production.
+func migrationMergeOauthTokenTables(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "merge_oauth_token_tables"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	return RunSingleMigration(ctx, nil, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// 1) Create mcp_oauth_tokens if it doesn't already exist. Unlike
+			// oauth_tokens/oauth_user_tokens, no earlier bootstrap step ever
+			// creates this table under this name — mcp_oauth_tokens is wholly
+			// new as of this migration, so this check is normally true on
+			// every deployment that reaches this step. The two INSERT...SELECT
+			// passes below then populate it from whatever legacy data happens
+			// to be present.
+			if !mg.HasTable(&tables.TableMCPOauthToken{}) {
+				logger.Info("[configstore] %s: creating table TableMCPOauthToken", migrationName)
+				if err := mg.CreateTable(&tables.TableMCPOauthToken{}); err != nil {
+					return fmt.Errorf("create mcp_oauth_tokens table: %w", err)
+				}
+			}
+
+			// 2) Backfill from the old shared-only oauth_tokens table
+			// (TableOauthToken — still created on a fresh install by the
+			// historical bootstrap migrations, just empty in that case, same
+			// as oauth_user_tokens below). The bulk copy itself still goes
+			// through raw table/column references rather than TableOauthToken:
+			// GORM has no native cross-table INSERT...SELECT, and the target
+			// column set diverges from the source struct's field set (derived
+			// auth_mode/mcp_client_id/oauth_config_id, see below), so a
+			// struct-based read-then-write loop would just be a slower,
+			// more allocation-heavy version of the same SQL. auth_mode='shared'
+			// and status='active' are derived rather than read, matching what
+			// every row in this table has always implicitly meant — oauth_tokens
+			// held nothing else. Deriving oauth_config_id and mcp_client_id
+			// inline (rather than via a follow-up UPDATE, as an in-place ALTER
+			// approach would need) is possible because both are pure functions
+			// of the source row: oauth_config_id from the oauth_configs row
+			// that still points at this token via the legacy TokenID shortcut
+			// (retired in a later migration, once every read site moves off
+			// it), and mcp_client_id by walking that same join one step
+			// further to the MCP client. A row whose oauth_config was deleted
+			// before the DeleteMCPClientConfig orphan-cleanup fix (elsewhere
+			// in this PR) has no derivable client/config and gets '' for both
+			// rather than being excluded — see the MCPClientID field comment
+			// on TableMCPOauthToken.
+			if mg.HasTable(&tables.TableOauthToken{}) {
+				if err := tx.Exec(`
+					INSERT INTO mcp_oauth_tokens (
+						id, auth_mode, mcp_client_id, oauth_config_id, session_id,
+						virtual_key_id, user_id, status, access_token, refresh_token,
+						token_type, expires_at, scopes, last_refreshed_at,
+						encryption_status, created_at, updated_at
+					)
+					SELECT
+						oauth_tokens.id,
+						'shared',
+						COALESCE((
+							SELECT config_mcp_clients.client_id FROM config_mcp_clients
+							JOIN oauth_configs ON oauth_configs.id = config_mcp_clients.oauth_config_id
+							WHERE oauth_configs.token_id = oauth_tokens.id
+						), ''),
+						COALESCE((
+							SELECT oauth_configs.id FROM oauth_configs
+							WHERE oauth_configs.token_id = oauth_tokens.id
+						), ''),
+						'',
+						NULL,
+						NULL,
+						'active',
+						oauth_tokens.access_token,
+						oauth_tokens.refresh_token,
+						oauth_tokens.token_type,
+						oauth_tokens.expires_at,
+						oauth_tokens.scopes,
+						oauth_tokens.last_refreshed_at,
+						oauth_tokens.encryption_status,
+						oauth_tokens.created_at,
+						oauth_tokens.updated_at
+					FROM oauth_tokens
+					WHERE NOT EXISTS (SELECT 1 FROM mcp_oauth_tokens WHERE mcp_oauth_tokens.id = oauth_tokens.id)
+				`).Error; err != nil {
+					return fmt.Errorf("backfill mcp_oauth_tokens from oauth_tokens: %w", err)
+				}
+			}
+
+			// 3) Copy every oauth_user_tokens row into mcp_oauth_tokens,
+			// field for field — again via raw table references (the column
+			// set here matches TableOauthUserToken's one-for-one, but a
+			// struct-based read-all/write-all loop still buys nothing over a
+			// single SQL statement for what is fundamentally a bulk copy).
+			// Guarded on existence for the same from-scratch-install reason
+			// as step 2 (oauth_user_tokens IS still created on a fresh
+			// install by the historical migration that first introduced it,
+			// just empty). No dedupe pass is needed for these rows the way
+			// step 4 below dedupes the shared rows from step 2: the (mode,
+			// identity, mcp_client_id) uniqueness this copy relies on was
+			// already enforced on oauth_user_tokens itself by the partial
+			// unique indexes migrationAddOAuthAuthModeColumns created earlier
+			// in this migration chain, so a straight field-for-field copy
+			// can't introduce a collision that didn't already exist there.
+			if mg.HasTable(&tables.TableOauthUserToken{}) {
+				if err := tx.Exec(`
+					INSERT INTO mcp_oauth_tokens (
+						id, auth_mode, mcp_client_id, oauth_config_id, session_id,
+						virtual_key_id, user_id, status, access_token, refresh_token,
+						token_type, expires_at, scopes, last_refreshed_at,
+						encryption_status, created_at, updated_at
+					)
+					SELECT
+						id, auth_mode, mcp_client_id, oauth_config_id, session_id,
+						virtual_key_id, user_id, status, access_token, refresh_token,
+						token_type, expires_at, scopes, last_refreshed_at,
+						encryption_status, created_at, updated_at
+					FROM oauth_user_tokens
+					WHERE NOT EXISTS (SELECT 1 FROM mcp_oauth_tokens WHERE mcp_oauth_tokens.id = oauth_user_tokens.id)
+				`).Error; err != nil {
+					return fmt.Errorf("copy oauth_user_tokens into mcp_oauth_tokens: %w", err)
+				}
+			}
+
+			// 4) Dedupe shared-mode mcp_client_id collisions the backfill in
+			// step 2 may have introduced, before the partial unique index
+			// created in step 5 below can reject them. Normally there's at
+			// most one 'shared' row per client (oauth_configs.token_id is
+			// 1:1 with the client's oauth_config_id), but the
+			// shared-client-delete orphan leak fixed elsewhere in this PR
+			// (DeleteMCPClientConfig never cleaned up the shared
+			// oauth_tokens row) means a stale orphaned row can share
+			// mcp_client_id with a since-recreated client's current row.
+			// Keep the newest row per group (highest updated_at, ties
+			// broken by id) so the live credential survives, mirroring the
+			// dedupe pass in migrationAddOAuthAuthModeColumns above. This
+			// must run before the partial unique indexes are created —
+			// creating them first (as an earlier version of this migration
+			// did) would let the very collision this step exists to clean
+			// up abort the INSERT in step 2 and roll back the whole
+			// migration transaction.
+			if err := tx.Exec(`
+				DELETE FROM mcp_oauth_tokens
+				WHERE id IN (
+					SELECT id FROM (
+						SELECT id,
+							ROW_NUMBER() OVER (
+								PARTITION BY mcp_client_id
+								ORDER BY updated_at DESC, id DESC
+							) AS rn
+						FROM mcp_oauth_tokens
+						WHERE auth_mode = 'shared' AND mcp_client_id IS NOT NULL AND mcp_client_id != ''
+					) ranked
+					WHERE rn > 1
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("dedupe shared mcp_oauth_tokens by mcp_client_id: %w", err)
+			}
+
+			// 5) Partial unique indexes — one per auth_mode. Created last,
+			// after the backfills and the dedupe pass above, so the
+			// collision step 4 cleans up can't abort those INSERTs. 'shared'
+			// is new (nothing enforced one-shared-token-per-client before
+			// this table existed, since the link only ever existed
+			// one-directionally via oauth_configs.token_id); user/vk/session
+			// mirror the scheme migrationAddOAuthAuthModeColumns set up on
+			// oauth_user_tokens.
+			partialUniques := []string{
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_shared_mcp
+					ON mcp_oauth_tokens (mcp_client_id)
+					WHERE auth_mode = 'shared' AND mcp_client_id IS NOT NULL AND mcp_client_id != ''`,
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_user_mcp
+					ON mcp_oauth_tokens (user_id, mcp_client_id)
+					WHERE auth_mode = 'user' AND user_id IS NOT NULL AND user_id != ''`,
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_vk_mcp
+					ON mcp_oauth_tokens (virtual_key_id, mcp_client_id)
+					WHERE auth_mode = 'vk' AND virtual_key_id IS NOT NULL AND virtual_key_id != ''`,
+				`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_session_mcp
+					ON mcp_oauth_tokens (session_id, mcp_client_id)
+					WHERE auth_mode = 'session' AND session_id IS NOT NULL AND session_id != ''`,
+			}
+			for _, stmt := range partialUniques {
+				if err := tx.Exec(stmt).Error; err != nil {
+					return fmt.Errorf("create partial unique index on mcp_oauth_tokens: %w", err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Deliberately does NOT drop mcp_oauth_tokens. oauth_tokens and
+			// oauth_user_tokens were never written to by Migrate above, so
+			// rolling back the schema doesn't need to repair them — but
+			// every OAuth read/write path targets mcp_oauth_tokens
+			// exclusively from this migration onward, so any token created
+			// or refreshed after it ran lives only in this table. Dropping
+			// it here would silently destroy those credentials and force
+			// every affected holder to re-authorize. Leaving the table in
+			// place makes this rollback schema-only, not fully symmetric
+			// with Migrate, but it's the non-destructive choice.
+			logger.Info("[configstore] %s: rollback leaves table TableMCPOauthToken in place (see comment)", migrationName)
+			return nil
+		},
+	})
 }

--- a/framework/configstore/migrations_perf_test.go
+++ b/framework/configstore/migrations_perf_test.go
@@ -1,0 +1,394 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// migrationPerfTestEnvVar gates every test in this file. Seeding ~1,000,000
+// rows takes real wall-clock time, so these must never run as part of a
+// normal `go test`/CI invocation — only on demand, with this variable set.
+const migrationPerfTestEnvVar = "BIFROST_RUN_MIGRATION_PERF_TESTS"
+
+// Row counts for the merge_oauth_token_tables perf test. Shared (admin/
+// client-credential) OAuth connections are far rarer than per-user ones in a
+// real deployment — one shared token per shared-mode MCP client vs. one
+// per-user token per (identity, MCP client) pair — so the split is 1%/99%
+// rather than even, while still totaling ~1,000,000 rows.
+const (
+	perfSharedTokenCount     = 10_000
+	perfPerUserTokenCount    = 990_000
+	perfSyntheticClientCount = 2_000 // distinct MCP client rows the per-user tokens cycle through
+	perfSeedInsertBatchSize  = 500   // rows per INSERT statement; keeps param counts well under SQLite's variable limit
+)
+
+// pgPerfTestSchema is a schema dedicated to this file's Postgres perf runs,
+// separate from pgTestSchema (used by the rest of the package's functional
+// tests) so a full DROP SCHEMA .. CASCADE here can never clobber another
+// test's fixtures even if both happened to run in the same invocation.
+const pgPerfTestSchema = "configstore_perf_test"
+
+// setupPreMergeSQLiteDB runs every configstore migration EXCEPT the final
+// merge_oauth_token_tables step, leaving oauth_tokens/oauth_user_tokens in
+// their real pre-merge shape (created by the historical bootstrap
+// migrations, complete with the partial unique indexes
+// migrationAddOAuthAuthModeColumns adds) and mcp_oauth_tokens not yet
+// created — the exact starting state migrationMergeOauthTokenTables expects
+// to run against on an existing deployment.
+func setupPreMergeSQLiteDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	n := time.Now().UnixNano() + testDBCounter
+	testDBCounter++
+	dsn := fmt.Sprintf("file:perftestdb_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "failed to open perf test sqlite db")
+
+	runPreMergeMigrationChain(t, db)
+	return db
+}
+
+// trySetupPreMergePostgresDB attempts to run the same pre-merge migration
+// chain against a real Postgres connection. Returns nil (without failing the
+// test) if Postgres is unavailable, matching this package's existing
+// trySetupPostgresDBWithoutStoreRawColumn fallback pattern.
+func trySetupPreMergePostgresDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil
+	}
+	// Closed on every failure path below via this defer; once schema setup
+	// succeeds and t.Cleanup takes over ownership, ok flips to true and this
+	// becomes a no-op (avoids a double-close).
+	ok := false
+	defer func() {
+		if !ok {
+			sqlDB.Close()
+		}
+	}()
+	if err := sqlDB.Ping(); err != nil {
+		return nil
+	}
+	// postgresDSN already pins search_path=configstore_test for every pooled
+	// connection. `SET search_path` below only changes the single session
+	// that happens to run it, so without limiting the pool to that one
+	// connection, later queries on a different pooled connection would
+	// silently run against configstore_test instead of pgPerfTestSchema.
+	sqlDB.SetMaxOpenConns(1)
+
+	// Dedicated schema, dropped and recreated fresh so the full pre-merge
+	// chain always runs from a clean slate, same as a brand-new deployment.
+	if err := db.Exec("DROP SCHEMA IF EXISTS " + pgPerfTestSchema + " CASCADE").Error; err != nil {
+		return nil
+	}
+	if err := db.Exec("CREATE SCHEMA " + pgPerfTestSchema).Error; err != nil {
+		return nil
+	}
+	if err := db.Exec("SET search_path TO " + pgPerfTestSchema).Error; err != nil {
+		return nil
+	}
+
+	// Registered before runPreMergeMigrationChain (which asserts via
+	// `require` and can stop this goroutine immediately) so a chain failure
+	// still drops the schema and closes the connection instead of leaking
+	// both.
+	t.Cleanup(func() {
+		db.Exec("DROP SCHEMA IF EXISTS " + pgPerfTestSchema + " CASCADE")
+		sqlDB.Close()
+	})
+	ok = true
+
+	runPreMergeMigrationChain(t, db)
+
+	return db
+}
+
+// runPreMergeMigrationChain runs every configstoreMigrationSteps entry
+// except the last one (merge_oauth_token_tables) and asserts the resulting
+// schema is genuinely pre-merge: oauth_tokens/oauth_user_tokens exist,
+// mcp_oauth_tokens does not.
+func runPreMergeMigrationChain(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NotEmpty(t, configstoreMigrationSteps)
+	lastStep := configstoreMigrationSteps[len(configstoreMigrationSteps)-1]
+	require.Equal(t, []string{"merge_oauth_token_tables"}, lastStep.IDs,
+		"expected merge_oauth_token_tables to be the last registered migration step; "+
+			"update the slice bound below if the registry changed")
+	preMergeSteps := configstoreMigrationSteps[:len(configstoreMigrationSteps)-1]
+
+	ctx := context.Background()
+	require.NoError(t, runMigrationSteps(ctx, db, testMigrationLogger, preMergeSteps),
+		"failed to run the pre-merge migration chain")
+
+	require.False(t, db.Migrator().HasTable(&tables.TableMCPOauthToken{}),
+		"mcp_oauth_tokens should not exist before migrationMergeOauthTokenTables runs")
+	require.True(t, db.Migrator().HasTable(&tables.TableOauthToken{}),
+		"oauth_tokens should exist in its pre-merge shape")
+	require.True(t, db.Migrator().HasTable(&tables.TableOauthUserToken{}),
+		"oauth_user_tokens should exist in its pre-merge shape")
+}
+
+// seedSyntheticMCPClients bulk-inserts count real config_mcp_clients rows so
+// the per-user token rows below can reference genuinely existing MCP
+// clients (belt-and-suspenders against TableOauthUserToken.MCPClient's
+// foreignKey tag producing a real FK constraint on some backends — SQLite
+// doesn't enforce FKs without an explicit pragma this test doesn't set, but
+// Postgres would).
+func seedSyntheticMCPClients(t *testing.T, db *gorm.DB, count int) {
+	t.Helper()
+	now := time.Now()
+	clients := make([]tables.TableMCPClient, 0, perfSeedInsertBatchSize)
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		for i := 0; i < count; i++ {
+			clients = append(clients, tables.TableMCPClient{
+				ClientID:       fmt.Sprintf("perf-mcp-client-%d", i),
+				Name:           fmt.Sprintf("perf-mcp-client-%d", i),
+				ConnectionType: "streamable_http",
+				AuthType:       "per_user_oauth",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+			if len(clients) == perfSeedInsertBatchSize {
+				if err := tx.Create(&clients).Error; err != nil {
+					return err
+				}
+				clients = clients[:0]
+			}
+		}
+		if len(clients) > 0 {
+			return tx.Create(&clients).Error
+		}
+		return nil
+	}))
+}
+
+// bulkInsertOauthTokens seeds count rows into oauth_tokens (the pre-merge
+// shared-credential table), each linked to its own oauth_configs row (via
+// the legacy TokenID shortcut) and config_mcp_clients row (via
+// oauth_config_id) — the exact join path migrationMergeOauthTokenTables
+// walks to derive mcp_oauth_tokens.oauth_config_id/mcp_client_id for shared
+// tokens. Without these linked rows every seeded token would only exercise
+// that join's COALESCE(...,'') miss branch, never a real hit. Batched
+// multi-row INSERTs wrapped in a single transaction — not one .Create() call
+// per row — so seeding time stays a small fraction of the migration time
+// being measured.
+func bulkInsertOauthTokens(t *testing.T, db *gorm.DB, count int) {
+	t.Helper()
+	now := time.Now()
+	expiresAt := now.Add(24 * time.Hour)
+	tokenBatch := make([]tables.TableOauthToken, 0, perfSeedInsertBatchSize)
+	configBatch := make([]tables.TableOauthConfig, 0, perfSeedInsertBatchSize)
+	clientBatch := make([]tables.TableMCPClient, 0, perfSeedInsertBatchSize)
+	flush := func(tx *gorm.DB) error {
+		if len(tokenBatch) > 0 {
+			if err := tx.Create(&tokenBatch).Error; err != nil {
+				return err
+			}
+			tokenBatch = tokenBatch[:0]
+		}
+		if len(configBatch) > 0 {
+			if err := tx.Create(&configBatch).Error; err != nil {
+				return err
+			}
+			configBatch = configBatch[:0]
+		}
+		if len(clientBatch) > 0 {
+			if err := tx.Create(&clientBatch).Error; err != nil {
+				return err
+			}
+			clientBatch = clientBatch[:0]
+		}
+		return nil
+	}
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		for i := 0; i < count; i++ {
+			tokenID := fmt.Sprintf("perf-shared-tok-%d", i)
+			configID := fmt.Sprintf("perf-shared-cfg-%d", i)
+			tokenBatch = append(tokenBatch, tables.TableOauthToken{
+				ID:               tokenID,
+				AccessToken:      fmt.Sprintf("perf-shared-access-token-%d", i),
+				RefreshToken:     fmt.Sprintf("perf-shared-refresh-token-%d", i),
+				TokenType:        "Bearer",
+				ExpiresAt:        &expiresAt,
+				Scopes:           `["read","write"]`,
+				LastRefreshedAt:  &now,
+				EncryptionStatus: tables.EncryptionStatusPlainText,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			})
+			configBatch = append(configBatch, tables.TableOauthConfig{
+				ID:          configID,
+				TokenID:     &tokenID,
+				RedirectURI: "https://perf.example.com/callback",
+				State:       fmt.Sprintf("perf-shared-state-%d", i),
+				Status:      "authorized",
+				CreatedAt:   now,
+				UpdatedAt:   now,
+				ExpiresAt:   now.Add(15 * time.Minute),
+			})
+			clientBatch = append(clientBatch, tables.TableMCPClient{
+				ClientID:       fmt.Sprintf("perf-shared-mcp-client-%d", i),
+				Name:           fmt.Sprintf("perf-shared-mcp-client-%d", i),
+				ConnectionType: "streamable_http",
+				AuthType:       "oauth",
+				OauthConfigID:  &configID,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			})
+			if len(tokenBatch) == perfSeedInsertBatchSize {
+				if err := flush(tx); err != nil {
+					return err
+				}
+			}
+		}
+		return flush(tx)
+	}))
+}
+
+// bulkInsertOauthUserTokens seeds count rows into oauth_user_tokens (the
+// pre-merge per-identity table), all in 'user' auth_mode, cycling through
+// numClients distinct MCP clients — same batched-INSERT-in-one-transaction
+// approach as bulkInsertOauthTokens. Every row gets a distinct UserID, so no
+// row can collide with another under the (user_id, mcp_client_id) partial
+// unique index regardless of which client it lands on.
+func bulkInsertOauthUserTokens(t *testing.T, db *gorm.DB, count int, numClients int) {
+	t.Helper()
+	now := time.Now()
+	expiresAt := now.Add(24 * time.Hour)
+	batch := make([]tables.TableOauthUserToken, 0, perfSeedInsertBatchSize)
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		for i := 0; i < count; i++ {
+			userID := fmt.Sprintf("perf-user-%d", i)
+			batch = append(batch, tables.TableOauthUserToken{
+				ID:               fmt.Sprintf("perf-user-tok-%d", i),
+				UserID:           &userID,
+				MCPClientID:      fmt.Sprintf("perf-mcp-client-%d", i%numClients),
+				AuthMode:         "user",
+				Status:           "active",
+				OauthConfigID:    fmt.Sprintf("perf-oauth-config-%d", i%numClients),
+				AccessToken:      fmt.Sprintf("perf-user-access-token-%d", i),
+				RefreshToken:     fmt.Sprintf("perf-user-refresh-token-%d", i),
+				TokenType:        "Bearer",
+				ExpiresAt:        &expiresAt,
+				Scopes:           `["read","write"]`,
+				LastRefreshedAt:  &now,
+				EncryptionStatus: tables.EncryptionStatusPlainText,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			})
+			if len(batch) == perfSeedInsertBatchSize {
+				if err := tx.Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+		if len(batch) > 0 {
+			return tx.Create(&batch).Error
+		}
+		return nil
+	}))
+}
+
+// TestMigrationMergeOauthTokenTablesPerf seeds ~1,000,000 rows across the
+// pre-merge oauth_tokens/oauth_user_tokens tables and measures how long the
+// real migrationMergeOauthTokenTables takes to run against that data. Both
+// PR1's mcp_oauth_tokens migration and PR3's mcp_oauth_flows migration are
+// CREATE-new-table + INSERT...SELECT-from-old-table(s) migrations that run
+// synchronously at boot behind a Postgres advisory lock, so their wall-clock
+// cost at scale is an operational question worth measuring directly rather
+// than guessing at.
+//
+// Gated behind BIFROST_RUN_MIGRATION_PERF_TESTS=1 — never runs as part of a
+// normal `go test ./...` or CI invocation.
+func TestMigrationMergeOauthTokenTablesPerf(t *testing.T) {
+	if os.Getenv(migrationPerfTestEnvVar) != "1" {
+		t.Skipf("set %s=1 to run this migration performance test (seeds ~1,000,000 rows; slow by design)", migrationPerfTestEnvVar)
+	}
+
+	dbs := []namedDB{{"sqlite", setupPreMergeSQLiteDB(t)}}
+	if pgDB := trySetupPreMergePostgresDB(t); pgDB != nil {
+		dbs = append(dbs, namedDB{"postgres", pgDB})
+	} else {
+		t.Log("postgres unavailable for this run; measuring against sqlite only")
+	}
+
+	for _, ndb := range dbs {
+		ndb := ndb
+		t.Run(ndb.name, func(t *testing.T) {
+			db := ndb.db
+			ctx := context.Background()
+
+			// Close the SQLite pool once this subtest finishes so the shared
+			// in-memory database (and its ~1M seeded rows) is freed before
+			// the Postgres subtest runs, rather than staying open for the
+			// rest of the test.
+			if ndb.name == "sqlite" {
+				t.Cleanup(func() {
+					sqlDB, err := db.DB()
+					if err == nil {
+						_ = sqlDB.Close()
+					}
+				})
+			}
+
+			seedStart := time.Now()
+			seedSyntheticMCPClients(t, db, perfSyntheticClientCount)
+			bulkInsertOauthTokens(t, db, perfSharedTokenCount)
+			bulkInsertOauthUserTokens(t, db, perfPerUserTokenCount, perfSyntheticClientCount)
+			t.Logf("[%s] seeded %d oauth_tokens + %d oauth_user_tokens rows in %v",
+				ndb.name, perfSharedTokenCount, perfPerUserTokenCount, time.Since(seedStart))
+
+			var sharedCount, userCount int64
+			require.NoError(t, db.Table("oauth_tokens").Count(&sharedCount).Error)
+			require.NoError(t, db.Table("oauth_user_tokens").Count(&userCount).Error)
+			require.EqualValues(t, perfSharedTokenCount, sharedCount)
+			require.EqualValues(t, perfPerUserTokenCount, userCount)
+
+			// This is the real function, invoked exactly like the migration
+			// registry invokes it — not a reimplementation of its SQL.
+			migrateStart := time.Now()
+			err := migrationMergeOauthTokenTables(ctx, db, testMigrationLogger)
+			elapsed := time.Since(migrateStart)
+			require.NoError(t, err, "migrationMergeOauthTokenTables should succeed against the seeded dataset")
+
+			t.Logf("[%s] migrationMergeOauthTokenTables took %v against %d seeded rows (%d shared + %d per-user)",
+				ndb.name, elapsed, perfSharedTokenCount+perfPerUserTokenCount, perfSharedTokenCount, perfPerUserTokenCount)
+
+			var mergedCount int64
+			require.NoError(t, db.Table("mcp_oauth_tokens").Count(&mergedCount).Error)
+			require.EqualValues(t, perfSharedTokenCount+perfPerUserTokenCount, mergedCount,
+				"every seeded row should have been copied into mcp_oauth_tokens")
+
+			// Every shared token was seeded with a linked oauth_configs +
+			// config_mcp_clients row (see bulkInsertOauthTokens), so the
+			// migration's join must have derived a real, nonempty
+			// oauth_config_id/mcp_client_id for each one — not just fallen
+			// through to the COALESCE(...,'') miss branch.
+			var linkedCount int64
+			require.NoError(t, db.Table("mcp_oauth_tokens").
+				Where("auth_mode = ? AND oauth_config_id != '' AND mcp_client_id != ''", "shared").
+				Count(&linkedCount).Error)
+			require.EqualValues(t, perfSharedTokenCount, linkedCount,
+				"every migrated shared token should retain the oauth_config_id/mcp_client_id derived from its linked oauth_configs/config_mcp_clients rows")
+		})
+	}
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -2419,12 +2420,17 @@ func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) e
 			}
 		}
 
-		// Delete per-user OAuth token + flow rows AND per-user header
-		// credentials + per-user header flow rows for this MCP client. All
-		// four reference mcp_client_id by the string client_id; nothing
-		// auto-cascades, so we do it explicitly inside the same transaction
-		// to keep cleanup atomic.
-		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
+		// Delete every mcp_oauth_tokens row for this MCP client — the shared
+		// credential (auth_mode='shared') and every per-identity credential
+		// (user/vk/session) alike — plus per-user OAuth flow rows and
+		// per-user header credentials/flows. All reference mcp_client_id by
+		// the string client_id; nothing auto-cascades, so we do it
+		// explicitly inside the same transaction to keep cleanup atomic.
+		// Before the token-table merge this needed two separate deletes
+		// (oauth_user_tokens for per-identity rows, nothing at all for the
+		// shared row — the latter was a real leak); now that both live in
+		// mcp_oauth_tokens, one delete by mcp_client_id covers both.
+		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
 			return err
 		}
 		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
@@ -2437,7 +2443,31 @@ func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) e
 			return err
 		}
 
-		// Delete the client (this will also handle foreign key cascades)
+		// Delete the oauth_configs row this client owns, if any.
+		// OauthConfigID is effectively 1:1 with a client: every write path
+		// (InitiateOAuthFlow) creates a fresh oauth_configs row and links it
+		// to exactly one client (UpdateMCPClientOAuthConfigID at flow-init
+		// time, or directly on create) — no code path ever points two
+		// different clients at the same oauth_configs row, so deleting it
+		// outright here is safe. This also closes the leak noted above: pre-
+		// merge, nothing in this function ever cleaned up oauth_configs (or,
+		// prior to the token-table merge, the shared oauth_tokens row it
+		// pointed to via TokenID) for a deleted OAuth MCP client.
+		if existingClient.OauthConfigID != nil && *existingClient.OauthConfigID != "" {
+			if err := tx.WithContext(ctx).Where("id = ?", *existingClient.OauthConfigID).Delete(&tables.TableOauthConfig{}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Delete the client. config_mcp_clients.oauth_config_id is the only
+		// real DB-level FK this row carries (ON DELETE CASCADE onto
+		// oauth_configs.id, not the reverse), and that row was already
+		// deleted above — deleting it there may have already cascaded this
+		// client row away too, in which case this is a no-op (0 rows
+		// affected, not an error). Every other table cleaned up above is
+		// linked only by the string client_id with no DB-level constraint,
+		// which is why each needed its own explicit delete rather than
+		// relying on cascades.
 		return tx.WithContext(ctx).Delete(&existingClient).Error
 	})
 }
@@ -3699,8 +3729,12 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
 			return err
 		}
-		// Delete upstream OAuth user tokens tied to this VK
-		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
+		// Delete upstream OAuth user tokens tied to this VK. Reads/writes
+		// mcp_oauth_tokens (not oauth_user_tokens — that table no longer
+		// takes writes); auth_mode is redundant here since a shared row can never
+		// carry a virtual_key_id, but scoping explicitly matches the
+		// defense-in-depth convention used elsewhere in this file.
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ? AND auth_mode IN ?", id, perUserOauthAuthModes).Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
 			return err
 		}
 		// Revoke gateway-issued OAuth2 grants bound to this VK (vk-mode tokens are
@@ -6410,8 +6444,8 @@ func (s *RDBConfigStore) GetOauthConfigByState(ctx context.Context, state string
 }
 
 // GetOauthTokenByID retrieves an OAuth token by its ID
-func (s *RDBConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error) {
-	var token tables.TableOauthToken
+func (s *RDBConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
+	var token tables.TableMCPOauthToken
 	result := s.DB().WithContext(ctx).Where("id = ?", id).First(&token)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -6432,7 +6466,7 @@ func (s *RDBConfigStore) CreateOauthConfig(ctx context.Context, config *tables.T
 }
 
 // CreateOauthToken creates a new OAuth token
-func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableOauthToken) error {
+func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	result := s.DB().WithContext(ctx).Create(token)
 	if result.Error != nil {
 		return fmt.Errorf("failed to create oauth token: %w", result.Error)
@@ -6450,7 +6484,7 @@ func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.T
 }
 
 // UpdateOauthToken updates an existing OAuth token
-func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableOauthToken) error {
+func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	result := s.DB().WithContext(ctx).Save(token)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update oauth token: %w", result.Error)
@@ -6460,7 +6494,7 @@ func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.Tab
 
 // DeleteOauthToken deletes an OAuth token by its ID
 func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error {
-	var existing tables.TableOauthToken
+	var existing tables.TableMCPOauthToken
 	// Check if the token exists before attempting to delete
 	err := s.DB().WithContext(ctx).Where("id = ?", id).First(&existing).Error
 	if err != nil {
@@ -6477,8 +6511,8 @@ func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error 
 }
 
 // GetExpiringOauthTokens retrieves tokens that are expiring before the given time
-func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
-	var tokens []*tables.TableOauthToken
+func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
+	var tokens []*tables.TableMCPOauthToken
 	// Exclude tokens whose owning oauth_config has already reached a terminal
 	// state — "expired" (set when a refresh is permanently rejected, e.g.
 	// invalid_grant / Grant not found) or "revoked". Without this, the refresh
@@ -6493,16 +6527,21 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 	// client is re-enabled or attached later, GetAccessToken refreshes inline
 	// on first use.
 	result := s.DB().WithContext(ctx).
+		// mcp_oauth_tokens now also holds per-user rows; this worker is
+		// shared-only, so per-user proactive refresh doesn't start happening
+		// as a side effect of the table merge (that's a deliberate later
+		// change, not this one).
+		Where("auth_mode = ?", "shared").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
 		Where("NOT EXISTS (?)",
 			s.DB().Model(&tables.TableOauthConfig{}).
 				Select("1").
-				Where("oauth_configs.token_id = oauth_tokens.id AND oauth_configs.status IN ?", []string{"expired", "revoked"})).
+				Where("oauth_configs.token_id = mcp_oauth_tokens.id AND oauth_configs.status IN ?", []string{"expired", "revoked"})).
 		Where("EXISTS (?)",
 			s.DB().Model(&tables.TableMCPClient{}).
 				Select("1").
 				Joins("JOIN oauth_configs ON oauth_configs.id = config_mcp_clients.oauth_config_id").
-				Where("oauth_configs.token_id = oauth_tokens.id AND config_mcp_clients.disabled = ?", false)).
+				Where("oauth_configs.token_id = mcp_oauth_tokens.id AND config_mcp_clients.disabled = ?", false)).
 		Find(&tokens)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get expiring tokens: %w", result.Error)
@@ -6618,28 +6657,43 @@ func (s *RDBConfigStore) UpdateOauthUserSession(ctx context.Context, session *ta
 
 // ---------- Per-User OAuth Token CRUD ----------
 
+// perUserOauthAuthModes is the set of TableMCPOauthToken.AuthMode values that
+// identify a per-identity credential row, as opposed to the single
+// auth_mode='shared' row an MCP client can also hold. Every method in this
+// section filters on this set so a shared credential can never be read,
+// mutated, or deleted through a per-user-scoped code path.
+var perUserOauthAuthModes = []string{
+	string(schemas.MCPAuthModeUser),
+	string(schemas.MCPAuthModeVK),
+	string(schemas.MCPAuthModeSession),
+}
+
 // CreateOauthUserToken creates or replaces a per-user OAuth token. Looks up
 // any existing row matching the populated identity column + MCP client and
 // reuses its ID, ensuring the partial-unique index never trips. SessionToken's
 // hash is set in BeforeSave; the upsert lookup uses the hash column to match
 // the unique index. Wrapped in a transaction so SELECT + CREATE/UPDATE is
-// atomic under concurrent same-identity races.
-func (s *RDBConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+// atomic under concurrent same-identity races. Every lookup branch also
+// pins auth_mode = token.AuthMode: shared-mode rows never populate an
+// identity column so they couldn't match anyway, but this keeps the upsert
+// from ever reusing a row of a different mode if that invariant is ever
+// violated (same defense-in-depth convention as reconcileVKDirectTokensDB).
+func (s *RDBConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var existing tables.TableOauthUserToken
+		var existing tables.TableMCPOauthToken
 		var lookupErr error
 		switch {
 		case token.UserID != nil && *token.UserID != "":
 			lookupErr = dbForUpdate(tx).
-				Where("user_id = ? AND mcp_client_id = ?", *token.UserID, token.MCPClientID).
+				Where("auth_mode = ? AND user_id = ? AND mcp_client_id = ?", token.AuthMode, *token.UserID, token.MCPClientID).
 				First(&existing).Error
 		case token.VirtualKeyID != nil && *token.VirtualKeyID != "":
 			lookupErr = dbForUpdate(tx).
-				Where("virtual_key_id = ? AND mcp_client_id = ?", *token.VirtualKeyID, token.MCPClientID).
+				Where("auth_mode = ? AND virtual_key_id = ? AND mcp_client_id = ?", token.AuthMode, *token.VirtualKeyID, token.MCPClientID).
 				First(&existing).Error
 		case token.SessionID != "":
 			lookupErr = dbForUpdate(tx).
-				Where("session_id = ? AND mcp_client_id = ?", token.SessionID, token.MCPClientID).
+				Where("auth_mode = ? AND session_id = ? AND mcp_client_id = ?", token.AuthMode, token.SessionID, token.MCPClientID).
 				First(&existing).Error
 		default:
 			lookupErr = gorm.ErrRecordNotFound
@@ -6669,8 +6723,13 @@ func (s *RDBConfigStore) CreateOauthUserToken(ctx context.Context, token *tables
 	})
 }
 
-// UpdateOauthUserToken updates an existing per-user OAuth token
-func (s *RDBConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+// UpdateOauthUserToken updates an existing per-user OAuth token. Rejects
+// rows whose auth_mode isn't one of the per-identity modes so this
+// per-user-only API can never be used to silently rewrite a shared token.
+func (s *RDBConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
+	if !slices.Contains(perUserOauthAuthModes, string(token.AuthMode)) {
+		return fmt.Errorf("UpdateOauthUserToken: refusing to save row %s with non-per-user auth_mode %q", token.ID, token.AuthMode)
+	}
 	result := s.DB().WithContext(ctx).Save(token)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update oauth user token: %w", result.Error)
@@ -6678,9 +6737,13 @@ func (s *RDBConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables
 	return nil
 }
 
-// DeleteOauthUserToken deletes a per-user OAuth token by its ID
+// DeleteOauthUserToken deletes a per-user OAuth token by its ID. Scoped to
+// auth_mode IN ('user','vk','session') so a caller-supplied ID can never
+// delete a shared credential through this per-user-only path.
 func (s *RDBConfigStore) DeleteOauthUserToken(ctx context.Context, id string) error {
-	result := s.DB().WithContext(ctx).Where("id = ?", id).Delete(&tables.TableOauthUserToken{})
+	result := s.DB().WithContext(ctx).
+		Where("id = ? AND auth_mode IN ?", id, perUserOauthAuthModes).
+		Delete(&tables.TableMCPOauthToken{})
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete oauth user token: %w", result.Error)
 	}
@@ -6735,11 +6798,11 @@ func (s *RDBConfigStore) DeleteOauthUserSessionsByModeIdentityAndMCPClient(ctx c
 // a lookup. Also constrains on auth_mode so a row whose identity column was
 // accidentally populated by a different mode's write path cannot leak into a
 // mode it doesn't belong to.
-func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserToken, error) {
+func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthToken, error) {
 	if identity == "" || mcpClientID == "" {
 		return nil, nil
 	}
-	var token tables.TableOauthUserToken
+	var token tables.TableMCPOauthToken
 	var result *gorm.DB
 	switch mode {
 	case schemas.MCPAuthModeUser:
@@ -6770,14 +6833,15 @@ func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schem
 // token row. Called by the refresh-failure path when the upstream credential
 // is permanently rejected: the row stays (preserves audit + binding for
 // re-auth), but is filtered from active lookups so the next inference
-// triggers a fresh OAuth flow.
+// triggers a fresh OAuth flow. Scoped to auth_mode IN ('user','vk','session')
+// so this per-user-only path can never flip a shared token to needs_reauth.
 func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error {
 	if tokenID == "" {
 		return nil
 	}
 	result := s.DB().WithContext(ctx).
-		Model(&tables.TableOauthUserToken{}).
-		Where("id = ?", tokenID).
+		Model(&tables.TableMCPOauthToken{}).
+		Where("id = ? AND auth_mode IN ?", tokenID, perUserOauthAuthModes).
 		Update("status", "needs_reauth")
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark oauth user token %s needs_reauth: %w", tokenID, result.Error)
@@ -6785,14 +6849,19 @@ func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, 
 	return nil
 }
 
-// GetOauthUserTokenByID looks up a single token row by primary key. Returns
-// nil, nil when not found.
-func (s *RDBConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableOauthUserToken, error) {
+// GetOauthUserTokenByID looks up a single per-user token row by primary key.
+// Returns nil, nil when not found. Filtered to auth_mode IN
+// ('user','vk','session'): the sessions handler feeds this an ID taken
+// directly from a URL path parameter and then dispatches on the returned
+// row's AuthMode to decide how to re-authenticate or revoke it, so a
+// caller-supplied ID that happened to belong to a 'shared' row must not be
+// readable through an endpoint scoped to per-user credentials only.
+func (s *RDBConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
 	if id == "" {
 		return nil, nil
 	}
-	var token tables.TableOauthUserToken
-	if err := s.ScopedDB(ctx).Where("id = ?", id).First(&token).Error; err != nil {
+	var token tables.TableMCPOauthToken
+	if err := s.ScopedDB(ctx).Where("id = ? AND auth_mode IN ?", id, perUserOauthAuthModes).First(&token).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -6801,23 +6870,26 @@ func (s *RDBConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (
 	return &token, nil
 }
 
-// ListOauthUserTokens returns token rows matching params, regardless of status.
-// The sessions tab UI renders distinct affordances per state; default status
-// filtering here would only hide rows the user needs to see (especially
-// needs_reauth). Runtime lookups apply their own status='active' filter and
-// don't use this. Pagination is handler-side because cross-table de-dup with
-// the pending-session list happens after the merge.
-func (s *RDBConfigStore) ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error) {
-	query := s.ScopedDB(ctx).Model(&tables.TableOauthUserToken{})
+// ListOauthUserTokens returns per-user token rows matching params, regardless
+// of status. The sessions tab UI renders distinct affordances per state;
+// default status filtering here would only hide rows the user needs to see
+// (especially needs_reauth). Runtime lookups apply their own status='active'
+// filter and don't use this. Pagination is handler-side because cross-table
+// de-dup with the pending-session list happens after the merge. Always
+// excludes auth_mode='shared' so the shared credential never leaks into the
+// per-identity sessions UI.
+func (s *RDBConfigStore) ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPOauthToken, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableMCPOauthToken{}).
+		Where("mcp_oauth_tokens.auth_mode IN ?", perUserOauthAuthModes)
 	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
-		table:          "oauth_user_tokens",
+		table:          "mcp_oauth_tokens",
 		authModeColumn: "auth_mode",
 	})
-	var tokens []tables.TableOauthUserToken
+	var tokens []tables.TableMCPOauthToken
 	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Order("oauth_user_tokens.created_at DESC").
+		Order("mcp_oauth_tokens.created_at DESC").
 		Find(&tokens).Error; err != nil {
 		return nil, fmt.Errorf("failed to list oauth user tokens: %w", err)
 	}
@@ -6861,15 +6933,19 @@ func (s *RDBConfigStore) DeleteExpiredOauthUserSessions(ctx context.Context) (in
 
 // DeleteOrphanedOauthUserTokens hard-deletes token rows that have been in
 // 'orphaned' state longer than olderThan. Skipped silently when olderThan
-// is zero or negative.
+// is zero or negative. Scoped to auth_mode IN ('user','vk','session') — a
+// shared token can't reach status='orphaned' today (only VK/grant
+// reconciliation sets it, and that only ever touches vk-mode rows), but the
+// filter is here so that stays true by construction rather than by
+// coincidence now that shared tokens share this table.
 func (s *RDBConfigStore) DeleteOrphanedOauthUserTokens(ctx context.Context, olderThan time.Duration) (int64, error) {
 	if olderThan <= 0 {
 		return 0, nil
 	}
 	cutoff := time.Now().Add(-olderThan)
 	result := s.DB().WithContext(ctx).
-		Where("status = ? AND updated_at < ?", "orphaned", cutoff).
-		Delete(&tables.TableOauthUserToken{})
+		Where("status = ? AND updated_at < ? AND auth_mode IN ?", "orphaned", cutoff, perUserOauthAuthModes).
+		Delete(&tables.TableMCPOauthToken{})
 	if result.Error != nil {
 		return 0, fmt.Errorf("failed to delete orphaned oauth user tokens: %w", result.Error)
 	}
@@ -7325,7 +7401,7 @@ func reconcileVKDirectTokensDB(tx *gorm.DB, vkID string) error {
 	// UpsertCredential, ListPending* etc). Reconciliation matched on
 	// virtual_key_id alone; align with the convention so a stray non-VK
 	// row with virtual_key_id set can never be touched here.
-	orphanQ := tx.Model(&tables.TableOauthUserToken{}).
+	orphanQ := tx.Model(&tables.TableMCPOauthToken{}).
 		Where("auth_mode = ? AND virtual_key_id = ? AND status = ?", string(schemas.MCPAuthModeVK), vkID, "active")
 	if len(allowedClientIDs) > 0 {
 		orphanQ = orphanQ.Where("mcp_client_id NOT IN ?", allowedClientIDs)
@@ -7335,7 +7411,7 @@ func reconcileVKDirectTokensDB(tx *gorm.DB, vkID string) error {
 	}
 
 	if len(allowedClientIDs) > 0 {
-		if err := tx.Model(&tables.TableOauthUserToken{}).
+		if err := tx.Model(&tables.TableMCPOauthToken{}).
 			Where("auth_mode = ? AND virtual_key_id = ? AND status = ? AND mcp_client_id IN ?", string(schemas.MCPAuthModeVK), vkID, "orphaned", allowedClientIDs).
 			Update("status", "active").Error; err != nil {
 			return fmt.Errorf("reactivate vk-keyed tokens for vk %s: %w", vkID, err)
@@ -7403,12 +7479,15 @@ func reconcileVKDirectHeaderRowsDB(tx *gorm.DB, vkID string) error {
 // readVKsHoldingOauthCredsForMCP returns the distinct virtual_key_ids
 // with an active or pending OAuth row (token or session) for the given
 // MCP client. Used by ReconcileOauthAfterMCPChange to know which VKs
-// need re-evaluation.
+// need re-evaluation. The token-side query reads mcp_oauth_tokens (not
+// oauth_user_tokens — that table no longer takes writes) and is scoped to
+// auth_mode='vk' as defense-in-depth: a shared row can never carry a
+// virtual_key_id, but the filter keeps that true by construction.
 func readVKsHoldingOauthCredsForMCP(tx *gorm.DB, mcpClientID string) ([]string, error) {
 	var vkIDs []string
 	if err := tx.Raw(`
-		SELECT DISTINCT virtual_key_id FROM oauth_user_tokens
-		WHERE mcp_client_id = ? AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''
+		SELECT DISTINCT virtual_key_id FROM mcp_oauth_tokens
+		WHERE mcp_client_id = ? AND auth_mode = 'vk' AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''
 		UNION
 		SELECT DISTINCT virtual_key_id FROM oauth_user_sessions
 		WHERE mcp_client_id = ? AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -47,15 +47,15 @@ func seedMCPSessionsFixture(t *testing.T, store *RDBConfigStore) {
 	// OAuth token rows — one active vk-mode, one orphaned user-mode, one needs_reauth session-mode
 	vkID := "vk-alpha"
 	uid := "user-42"
-	tok1 := &tables.TableOauthUserToken{
+	tok1 := &tables.TableMCPOauthToken{
 		ID: "tok-active", MCPClientID: "github-prod", VirtualKeyID: &vkID, AuthMode: "vk",
 		Status: "active", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
 	}
-	tok2 := &tables.TableOauthUserToken{
+	tok2 := &tables.TableMCPOauthToken{
 		ID: "tok-orphan", MCPClientID: "github-prod", UserID: &uid, AuthMode: "user",
 		Status: "orphaned", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
 	}
-	tok3 := &tables.TableOauthUserToken{
+	tok3 := &tables.TableMCPOauthToken{
 		ID: "tok-reauth", MCPClientID: "github-prod", SessionID: "sess-xyz", AuthMode: "session",
 		Status: "needs_reauth", AccessToken: "x", TokenType: "Bearer", OauthConfigID: "cfg-1",
 	}

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -65,12 +65,12 @@ func makeRefreshToken(id, familyID, clientID, hash string) *tables.TableOAuth2Re
 // only the config/client conditions decide whether it is selected.
 func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id string), mkConfig func(id, tokenID, status, state string), mkClient func(name, oauthConfigID string, disabled bool)) {
 	t.Helper()
-	require.NoError(t, s.DB().AutoMigrate(&tables.TableOauthConfig{}, &tables.TableOauthToken{}, &tables.TableMCPClient{}))
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableOauthConfig{}, &tables.TableMCPOauthToken{}, &tables.TableMCPClient{}))
 	past := time.Now().Add(-time.Hour)
 
 	mkToken = func(id string) {
-		require.NoError(t, s.DB().Create(&tables.TableOauthToken{
-			ID: id, AccessToken: "at-" + id, TokenType: "Bearer",
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: id, AuthMode: "shared", AccessToken: "at-" + id, TokenType: "Bearer",
 			ExpiresAt: &past, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}).Error)
 	}

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -56,6 +56,8 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TablePromptSessionMessage{},
 		&tables.TableOauthUserSession{},
 		&tables.TableOauthUserToken{},
+		&tables.TableOauthToken{},
+		&tables.TableMCPOauthToken{},
 		&tables.TableMCPPerUserHeaderCredential{},
 		&tables.TableMCPPerUserHeaderFlow{},
 		&tables.TableOAuth2RefreshToken{},

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -496,11 +496,26 @@ type ConfigStore interface {
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
 
-	// OAuth token CRUD
-	GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error)
-	GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableOauthToken, error)
-	CreateOauthToken(ctx context.Context, token *tables.TableOauthToken) error
-	UpdateOauthToken(ctx context.Context, token *tables.TableOauthToken) error
+	// OAuth token CRUD. TableMCPOauthToken now holds every holder of an MCP
+	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session'), not
+	// just the shared-client credential the method names below still imply.
+	//
+	// GetOauthTokenByID and GetOauthConfigByTokenID are not filtered by
+	// auth_mode: both are looked up exclusively via TableOauthConfig.TokenID,
+	// which only the shared-client flow ever populates, so the ID handed in
+	// is already guaranteed to resolve to a 'shared' row (or nothing) — a
+	// primary-key lookup, already unambiguous. An auth_mode filter here
+	// would be inert, unlike GetOauthUserTokenByID below, which a caller
+	// does feed an arbitrary externally-sourced ID.
+	GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error)
+	// GetExpiringOauthTokens is filtered to auth_mode='shared'. It backs the
+	// shared-only TokenRefreshWorker; per-user tokens refresh lazily/inline
+	// on lookup (GetOauthUserTokenByMode), and folding them into this
+	// proactive sweep is a deliberate later change, not a side effect of
+	// this table merge.
+	GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error)
+	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
+	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthToken(ctx context.Context, id string) error
 
 	// Per-user OAuth session CRUD
@@ -514,14 +529,26 @@ type ConfigStore interface {
 	CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
 	UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
 
-	// Per-user OAuth token CRUD
+	// Per-user OAuth token CRUD. These operate on the same TableMCPOauthToken /
+	// oauth_tokens rows as the shared-token methods above, scoped to
+	// auth_mode IN ('user','vk','session') so a 'shared' row can never be
+	// read, mutated, or deleted through a per-user code path.
+	//
 	// GetOauthUserTokenByMode looks up the active token row keyed by a single
 	// identity dimension. Filters status='active'. identity is the user ID for
 	// AuthModeUser, the VK row ID for AuthModeVK, and the session ID for
 	// AuthModeSession.
-	GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserToken, error)
-	CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error
-	UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error
+	GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthToken, error)
+	// CreateOauthUserToken creates or replaces a per-user OAuth token row.
+	// Deliberately kept separate from CreateOauthToken (used by the shared
+	// flow) rather than merged into one method: it upserts by looking up any
+	// existing row for the same (identity, mcp_client) binding and reusing
+	// its ID, while CreateOauthToken is (and, for this table merge, remains)
+	// a plain insert — the shared flow has never needed upsert semantics.
+	// Folding them into one function would silently give the shared path
+	// upsert behavior it doesn't ask for.
+	CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error
+	UpdateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthUserToken(ctx context.Context, id string) error
 	// DeleteOauthUserSession hard-deletes a single flow row by primary key.
 	// Used by CompleteUserOAuthFlow on terminal transitions so completed,
@@ -539,9 +566,19 @@ type ConfigStore interface {
 	// active lookups so the next inference triggers a fresh OAuth
 	// flow that upserts the row back to 'active'.
 	MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error
-	// GetOauthUserTokenByID looks up a single token row by primary key.
-	// Returns nil, nil when not found.
-	GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableOauthUserToken, error)
+	// GetOauthUserTokenByID looks up a single per-user token row by primary
+	// key. Returns nil, nil when not found. Unlike GetOauthTokenByID above,
+	// this DOES filter to auth_mode IN ('user','vk','session'): the sessions
+	// handler feeds this an ID taken directly from a URL path parameter
+	// (POST /api/mcp/sessions/{id}/reauth, DELETE /api/mcp/sessions/{id})
+	// and then dispatches on the returned row's AuthMode to decide how to
+	// re-authenticate or revoke it — a caller-supplied ID that happened to
+	// belong to a 'shared' row would otherwise be readable (and, downstream,
+	// revocable) through an endpoint that's scoped to per-user credentials
+	// only. Primary-key uniqueness alone isn't enough here because the
+	// vulnerability isn't ambiguity, it's a per-user-only caller getting
+	// handed a row it never should have matched.
+	GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error)
 	// ListOauthUserTokens returns token rows matching the supplied filters,
 	// regardless of status. The sessions UI renders all three states
 	// (active / orphaned / needs_reauth) with distinct affordances, so
@@ -549,8 +586,9 @@ type ConfigStore interface {
 	// to act on rows that need their attention; status filtering is the
 	// caller's responsibility via params.Statuses. Runtime token lookups
 	// apply their own status='active' filter and don't go through this
-	// method.
-	ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error)
+	// method. Always excludes auth_mode='shared' so shared credentials never
+	// leak into the per-identity sessions UI.
+	ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPOauthToken, error)
 	// ListPendingOauthUserSessions returns pending OAuth flow rows matching
 	// the supplied filters. Companion to ListOauthUserTokens for the admin
 	// view. Always restricted to status='pending' AND expires_at > now;
@@ -561,6 +599,10 @@ type ConfigStore interface {
 	DeleteExpiredOauthUserSessions(ctx context.Context) (int64, error)
 	// DeleteOrphanedOauthUserTokens hard-deletes token rows where status='orphaned'
 	// and updated_at is older than olderThan. Returns the number of rows removed.
+	// Scoped to auth_mode IN ('user','vk','session') — a shared token can't
+	// reach status='orphaned' today (only VK/grant reconciliation sets it),
+	// but the filter is here so that stays true by construction rather than
+	// by coincidence once shared tokens share this table.
 	DeleteOrphanedOauthUserTokens(ctx context.Context, olderThan time.Duration) (int64, error)
 
 	// Per-user MCP header credential CRUD. Storage analog of per-user OAuth

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -24,7 +24,7 @@ type TableOauthConfig struct {
 	CodeVerifier        string             `gorm:"type:text" json:"-"`                              // PKCE code verifier (generated, kept secret)
 	CodeChallenge       string             `gorm:"type:varchar(255)" json:"code_challenge"`         // PKCE code challenge (sent to provider)
 	Status              string             `gorm:"type:varchar(50);not null;index" json:"status"`   // "pending", "authorized", "failed", "expired", "revoked"
-	TokenID             *string            `gorm:"type:varchar(255);index" json:"token_id"`         // Foreign key to oauth_tokens.ID (set after callback)
+	TokenID             *string            `gorm:"type:varchar(255);index" json:"token_id"`         // Foreign key to mcp_oauth_tokens.ID (set after callback)
 	ServerURL           string             `gorm:"type:text" json:"server_url"`                     // MCP server URL for OAuth discovery
 	Resource            string             `gorm:"type:text" json:"resource,omitempty"`             // OAuth resource indicator (RFC 8707), typically the MCP server URL
 	UseDiscovery        bool               `gorm:"default:false" json:"use_discovery"`              // Flag to enable OAuth discovery
@@ -103,8 +103,14 @@ func (c *TableOauthConfig) GetClientSecretAsSecretVar() *schemas.SecretVar {
 	return c.ClientSecret
 }
 
-// TableOauthToken represents an OAuth token in the database
-// This stores the actual access and refresh tokens
+// TableOauthToken represents the OAuth token record for the single shared
+// MCP OAuth client credential — one row per shared-mode connection.
+//
+// Deprecated: no longer read or written by any application code as of the
+// TableMCPOauthToken merge; this type exists only so the migration that
+// introduced TableMCPOauthToken can reference its table (oauth_tokens) via
+// normal GORM model access. Both this type and its backing table will be
+// removed in the next major version.
 type TableOauthToken struct {
 	ID               string     `gorm:"type:varchar(255);primaryKey" json:"id"`      // UUID
 	AccessToken      string     `gorm:"type:text;not null" json:"-"`                 // Encrypted access token
@@ -143,6 +149,103 @@ func (t *TableOauthToken) BeforeSave(tx *gorm.DB) error {
 
 // AfterFind hook to decrypt sensitive fields
 func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
+	if t.EncryptionStatus == EncryptionStatusEncrypted {
+		if err := decryptString(&t.AccessToken); err != nil {
+			return fmt.Errorf("failed to decrypt oauth access token: %w", err)
+		}
+		if err := decryptString(&t.RefreshToken); err != nil {
+			return fmt.Errorf("failed to decrypt oauth refresh token: %w", err)
+		}
+	}
+	return nil
+}
+
+// TableMCPOauthToken represents an OAuth token in the database. This stores
+// the actual access and refresh tokens for every holder of an MCP OAuth
+// credential — the single shared client credential ('shared' mode) as well
+// as per-identity credentials ('user' | 'vk' | 'session' mode). Exactly one
+// of MCPClientID+OauthConfigID's owning row shape applies regardless of mode;
+// for per-identity rows, exactly one of VirtualKeyID/UserID/SessionID is
+// populated per row, and AuthMode records which one (or 'shared', which
+// populates none of them).
+//
+// Lives in mcp_oauth_tokens, a table created fresh by the migration that
+// introduced this struct — it does not alter or extend either of the two
+// tables ('oauth_tokens', 'oauth_user_tokens') this type's predecessors used
+// to map to. See that migration for why both older tables are left in place
+// unused.
+type TableMCPOauthToken struct {
+	ID       string `gorm:"type:varchar(255);primaryKey" json:"id"`     // UUID
+	AuthMode string `gorm:"type:varchar(20);not null" json:"auth_mode"` // 'shared' | 'user' | 'vk' | 'session' — no DB-level CHECK constraint; validated at the application layer only, so adding a new mode later is a pure data change, not a migration
+	// MCPClientID and OauthConfigID are not DB-level NOT NULL: rows written by
+	// current code always populate both, but a pre-existing row whose owning
+	// oauth_config was deleted before the orphan-cleanup fix (see
+	// DeleteMCPClientConfig) may have no derivable client/config and is left
+	// with the empty string rather than rejected by a migration.
+	MCPClientID      string     `gorm:"type:varchar(255);index" json:"mcp_client_id"`             // Which MCP server
+	OauthConfigID    string     `gorm:"type:varchar(255);index" json:"oauth_config_id"`           // Template OAuth config (holds client_id, token_url, etc.)
+	SessionID        string     `gorm:"type:varchar(255);index" json:"session_id,omitempty"`      // Session-mode identity: client-asserted x-bf-mcp-session-id. Empty for shared/vk/user mode rows.
+	VirtualKeyID     *string    `gorm:"type:varchar(255);index" json:"virtual_key_id"`            // VK identity (vk-mode rows)
+	UserID           *string    `gorm:"type:varchar(255);index" json:"user_id"`                   // User identity (user-mode rows; populated by enterprise middleware/governance)
+	Status           string     `gorm:"type:varchar(20);not null;default:'active'" json:"status"` // 'active' | 'orphaned' | 'needs_reauth' — only 'active' satisfies a runtime lookup; the others are surfaced in the UI with distinct copy
+	AccessToken      string     `gorm:"type:text;not null" json:"-"`                              // Encrypted access token
+	RefreshToken     string     `gorm:"type:text" json:"-"`                                       // Encrypted refresh token (optional)
+	TokenType        string     `gorm:"type:varchar(50);not null" json:"token_type"`              // "Bearer"
+	ExpiresAt        *time.Time `gorm:"index" json:"expires_at,omitempty"`                        // Token expiration (nil means unknown/non-expiring)
+	Scopes           string     `gorm:"type:text" json:"scopes"`                                  // JSON array of granted scopes
+	LastRefreshedAt  *time.Time `gorm:"index" json:"last_refreshed_at,omitempty"`                 // Track when token was last refreshed
+	EncryptionStatus string     `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
+	CreatedAt        time.Time  `gorm:"index;not null" json:"created_at"`
+	UpdatedAt        time.Time  `gorm:"index;not null" json:"updated_at"`
+
+	// Display-only relations (no DB-level FK constraint — "-:migration" skips
+	// both constraint creation and ordinary column migration for these two
+	// fields; the actual FK values live in MCPClientID/VirtualKeyID above,
+	// which are ordinary migrated columns). Preloaded for the sessions UI.
+	// "-:migration" sidesteps a real constraint-violation hazard on
+	// MCPClientID specifically: a row backfilled from a shared oauth_tokens
+	// row whose oauth_config was deleted before the DeleteMCPClientConfig
+	// orphan-cleanup fix has no derivable client (see the MCPClientID field
+	// comment above) and is left with MCPClientID = "" rather than NULL — a
+	// real FK constraint against config_mcp_clients.client_id would reject
+	// that insert. Table-creation order is not the concern here:
+	// mcp_oauth_tokens is created by migrationMergeOauthTokenTables, the
+	// last migration registered in this file, long after config_mcp_clients
+	// and governance_virtual_keys already exist.
+	MCPClient  *TableMCPClient  `gorm:"-:migration;foreignKey:MCPClientID;references:ClientID" json:"-"`
+	VirtualKey *TableVirtualKey `gorm:"-:migration;foreignKey:VirtualKeyID;references:ID" json:"-"`
+
+	// User is a non-DB, enterprise-only annotation populated after fetch on
+	// user-keyed rows so the sessions UI can render name/email instead of a
+	// raw user_id. OSS has no users table; OSS leaves it nil.
+	User *OauthUserSummary `gorm:"-" json:"-"`
+}
+
+// TableName sets the table name
+func (TableMCPOauthToken) TableName() string {
+	return "mcp_oauth_tokens"
+}
+
+// BeforeSave hook
+func (t *TableMCPOauthToken) BeforeSave(tx *gorm.DB) error {
+	// Ensure token type is set
+	if t.TokenType == "" {
+		t.TokenType = "Bearer"
+	}
+	if encrypt.IsEnabled() {
+		if err := encryptString(&t.AccessToken); err != nil {
+			return fmt.Errorf("failed to encrypt oauth access token: %w", err)
+		}
+		if err := encryptString(&t.RefreshToken); err != nil {
+			return fmt.Errorf("failed to encrypt oauth refresh token: %w", err)
+		}
+		t.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	return nil
+}
+
+// AfterFind hook to decrypt sensitive fields
+func (t *TableMCPOauthToken) AfterFind(tx *gorm.DB) error {
 	if t.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&t.AccessToken); err != nil {
 			return fmt.Errorf("failed to decrypt oauth access token: %w", err)
@@ -223,10 +326,17 @@ func (s *TableOauthUserSession) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// TableOauthUserToken stores per-user OAuth credentials.
-// Each record holds the access/refresh tokens for a specific identity × MCP client pair.
-// Exactly one identity column (UserID, VirtualKeyID, or SessionID) is populated
-// per row; AuthMode records which one.
+// TableOauthUserToken stores per-user OAuth credentials — one row per
+// identity (user, VK, or session) × MCP client pair. Kept alongside
+// TableOauthToken so the historical schema-evolution migrations that
+// already shipped against oauth_user_tokens (column adds, index changes,
+// etc.) keep compiling and keep producing the exact DDL they always have.
+//
+// Deprecated: no longer read or written by any application code as of the
+// TableMCPOauthToken merge; this type exists only so the migration that
+// introduced TableMCPOauthToken can reference its table (oauth_user_tokens)
+// via normal GORM model access. Both this type and its backing table will be
+// removed in the next major version.
 type TableOauthUserToken struct {
 	ID               string     `gorm:"type:varchar(255);primaryKey" json:"id"`                   // Token UUID
 	SessionID        string     `gorm:"type:varchar(255);index" json:"session_id,omitempty"`      // Session-mode identity: client-asserted x-bf-mcp-session-id. Empty for vk/user mode rows.

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -640,13 +640,36 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		exp := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
 		expiresAt = bifrost.Ptr(exp)
 	}
-	tokenRecord := &tables.TableOauthToken{
-		ID:           tokenID,
-		AccessToken:  strings.TrimSpace(tokenResponse.AccessToken),
-		RefreshToken: strings.TrimSpace(tokenResponse.RefreshToken),
-		TokenType:    tokenResponse.TokenType,
-		ExpiresAt:    expiresAt,
-		Scopes:       string(scopesJSON),
+	tokenRecord := &tables.TableMCPOauthToken{
+		ID:            tokenID,
+		AuthMode:      "shared",
+		OauthConfigID: oauthConfig.ID,
+		Status:        "active",
+		AccessToken:   strings.TrimSpace(tokenResponse.AccessToken),
+		RefreshToken:  strings.TrimSpace(tokenResponse.RefreshToken),
+		TokenType:     tokenResponse.TokenType,
+		ExpiresAt:     expiresAt,
+		Scopes:        string(scopesJSON),
+	}
+
+	// MCPClientID: unlike the per-user flow's session row (which stores
+	// mcp_client_id at InitiateUserOAuthFlow time — see
+	// CompleteUserOAuthFlow), the shared flow's oauth_configs row carries no
+	// client reference of its own. For a client re-authorizing an existing
+	// credential, initiateMCPClientVerification links
+	// config_mcp_clients.oauth_config_id to this row's ID before the browser
+	// ever leaves for the upstream provider, so the client is derivable by
+	// walking that link backwards. For a client still being created (the
+	// StorePendingMCPClient bootstrap path, where the config_mcp_clients row
+	// isn't inserted until after this callback completes), no such row
+	// exists yet — GetMCPClientByOauthConfigID returns ErrNotFound and
+	// MCPClientID is left as "", the same tolerated-empty shape the
+	// migration backfill uses for the equivalent case (see the MCPClientID
+	// field comment on TableMCPOauthToken).
+	if mcpClient, err := p.configStore.GetMCPClientByOauthConfigID(ctx, oauthConfig.ID); err == nil {
+		tokenRecord.MCPClientID = mcpClient.ClientID
+	} else if !errors.Is(err, configstore.ErrNotFound) {
+		return fmt.Errorf("failed to look up mcp client for oauth config: %w", err)
 	}
 
 	if err := p.configStore.CreateOauthToken(ctx, tokenRecord); err != nil {
@@ -1202,7 +1225,7 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 		exp := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
 		expiresAt = bifrost.Ptr(exp)
 	}
-	tokenRecord := &tables.TableOauthUserToken{
+	tokenRecord := &tables.TableMCPOauthToken{
 		ID:            uuid.New().String(),
 		SessionID:     sessionID,
 		VirtualKeyID:  tokenVKID,

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -26,14 +26,14 @@ type testConfigStore struct {
 
 	mu           sync.Mutex
 	oauthConfigs map[string]*tables.TableOauthConfig
-	oauthTokens  map[string]*tables.TableOauthToken
+	oauthTokens  map[string]*tables.TableMCPOauthToken
 	clientConfig *configstore.ClientConfig
 }
 
 func newTestConfigStore() *testConfigStore {
 	return &testConfigStore{
 		oauthConfigs: make(map[string]*tables.TableOauthConfig),
-		oauthTokens:  make(map[string]*tables.TableOauthToken),
+		oauthTokens:  make(map[string]*tables.TableMCPOauthToken),
 	}
 }
 
@@ -65,7 +65,7 @@ func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.Table
 	return nil
 }
 
-func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tables.TableOauthToken, error) {
+func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tables.TableMCPOauthToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	token := s.oauthTokens[id]
@@ -75,7 +75,7 @@ func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tabl
 	return bifrost.Ptr(*token), nil
 }
 
-func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableOauthToken) error {
+func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableMCPOauthToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.oauthTokens[token.ID] = bifrost.Ptr(*token)
@@ -91,10 +91,10 @@ func (s *testConfigStore) GetClientConfig(_ context.Context) (*configstore.Clien
 	return bifrost.Ptr(*s.clientConfig), nil
 }
 
-func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
+func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var expiring []*tables.TableOauthToken
+	var expiring []*tables.TableMCPOauthToken
 	for _, token := range s.oauthTokens {
 		if token.ExpiresAt != nil && token.ExpiresAt.Before(before) {
 			expiring = append(expiring, bifrost.Ptr(*token))
@@ -109,7 +109,7 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 	t.Helper()
 
 	tokenID := "test-token-id"
-	store.oauthTokens[tokenID] = &tables.TableOauthToken{
+	store.oauthTokens[tokenID] = &tables.TableMCPOauthToken{
 		ID:           tokenID,
 		AccessToken:  "old-access-token",
 		RefreshToken: "refresh-token",
@@ -146,7 +146,7 @@ func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
 		now := time.Now()
 		before := now.Add(5 * time.Minute)
 
-		store.oauthTokens["nil-expiry"] = &tables.TableOauthToken{
+		store.oauthTokens["nil-expiry"] = &tables.TableMCPOauthToken{
 			ID:           "nil-expiry",
 			AccessToken:  "access-token",
 			RefreshToken: "refresh-token",
@@ -154,7 +154,7 @@ func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
 			ExpiresAt:    nil,
 			Scopes:       "[]",
 		}
-		store.oauthTokens["expiring"] = &tables.TableOauthToken{
+		store.oauthTokens["expiring"] = &tables.TableMCPOauthToken{
 			ID:           "expiring",
 			AccessToken:  "access-token-2",
 			RefreshToken: "refresh-token-2",

--- a/tests/scripts/migration-checker/main.go
+++ b/tests/scripts/migration-checker/main.go
@@ -82,14 +82,14 @@ func main() {
 // and extracts foreign key relationships from GORM struct tags
 //
 // GORM FK relationships:
-// 1. Belongs-to: `Budget *TableBudget gorm:"foreignKey:BudgetID"` 
-//    - FK column (BudgetID) is on THIS table
-//    - Referenced table (TableBudget) must be created FIRST
+// 1. Belongs-to: `Budget *TableBudget gorm:"foreignKey:BudgetID"`
+//   - FK column (BudgetID) is on THIS table
+//   - Referenced table (TableBudget) must be created FIRST
 //
 // 2. Has-many: `Keys []TableKey gorm:"foreignKey:ProviderID"`
-//    - FK column (ProviderID) is on the CHILD table (TableKey)
-//    - THIS table (parent) must be created FIRST
-//    - We don't track this as a dependency because the parent comes first naturally
+//   - FK column (ProviderID) is on the CHILD table (TableKey)
+//   - THIS table (parent) must be created FIRST
+//   - We don't track this as a dependency because the parent comes first naturally
 func parseTableDefinitions(tablesDir string) ([]TableDependency, error) {
 	var dependencies []TableDependency
 
@@ -177,7 +177,7 @@ func parseTableDefinitions(tablesDir string) ([]TableDependency, error) {
 				}
 
 				tag := field.Tag.Value
-				
+
 				// Skip fields that are not stored in DB
 				if strings.Contains(tag, `gorm:"-"`) {
 					continue
@@ -276,32 +276,33 @@ func parseMigrationOrder(migrationsPath string) ([]MigrationAction, error) {
 
 	// Table struct to table name mapping (simplified)
 	tableMapping := map[string]string{
-		"TableConfigHash":              "config_hashes",
-		"TableBudget":                  "governance_budgets",
-		"TableRateLimit":               "governance_rate_limits",
-		"TableProvider":                "config_providers",
-		"TableKey":                     "config_keys",
-		"TableModel":                   "config_models",
-		"TableOauthConfig":             "oauth_configs",
-		"TableOauthToken":              "oauth_tokens",
-		"TableMCPClient":               "config_mcp_clients",
-		"TableClientConfig":            "config_client",
-		"TableEnvKey":                  "config_env_keys",
-		"TableVectorStoreConfig":       "config_vector_stores",
-		"TableLogStoreConfig":          "config_log_stores",
-		"TableCustomer":                "governance_customers",
-		"TableTeam":                    "governance_teams",
-		"TableVirtualKey":              "governance_virtual_keys",
-		"TableGovernanceConfig":        "governance_configs",
-		"TableModelPricing":            "model_pricing",
-		"TablePlugin":                  "plugins",
-		"TableFrameworkConfig":         "framework_configs",
+		"TableConfigHash":               "config_hashes",
+		"TableBudget":                   "governance_budgets",
+		"TableRateLimit":                "governance_rate_limits",
+		"TableProvider":                 "config_providers",
+		"TableKey":                      "config_keys",
+		"TableModel":                    "config_models",
+		"TableOauthConfig":              "oauth_configs",
+		"TableOauthToken":               "oauth_tokens",
+		"TableMCPOauthToken":            "mcp_oauth_tokens",
+		"TableMCPClient":                "config_mcp_clients",
+		"TableClientConfig":             "config_client",
+		"TableEnvKey":                   "config_env_keys",
+		"TableVectorStoreConfig":        "config_vector_stores",
+		"TableLogStoreConfig":           "config_log_stores",
+		"TableCustomer":                 "governance_customers",
+		"TableTeam":                     "governance_teams",
+		"TableVirtualKey":               "governance_virtual_keys",
+		"TableGovernanceConfig":         "governance_configs",
+		"TableModelPricing":             "model_pricing",
+		"TablePlugin":                   "plugins",
+		"TableFrameworkConfig":          "framework_configs",
 		"TableVirtualKeyProviderConfig": "governance_virtual_key_provider_configs",
-		"TableVirtualKeyMCPConfig":     "governance_virtual_key_mcp_configs",
-		"SessionsTable":                "sessions",
-		"TableDistributedLock":         "distributed_locks",
-		"TableModelConfig":             "model_configs",
-		"TableRoutingRule":             "routing_rules",
+		"TableVirtualKeyMCPConfig":      "governance_virtual_key_mcp_configs",
+		"SessionsTable":                 "sessions",
+		"TableDistributedLock":          "distributed_locks",
+		"TableModelConfig":              "model_configs",
+		"TableRoutingRule":              "routing_rules",
 	}
 
 	ast.Inspect(node, func(n ast.Node) bool {

--- a/transports/bifrost-http/handlers/mcpsessions.go
+++ b/transports/bifrost-http/handlers/mcpsessions.go
@@ -219,7 +219,7 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 	// queried, because cross-table de-dup (suppress a flow row when a
 	// matching token/header credential exists) needs that data.
 	var (
-		tokens      []tables.TableOauthUserToken
+		tokens      []tables.TableMCPOauthToken
 		flows       []tables.TableOauthUserSession
 		headerCreds []tables.TableMCPPerUserHeaderCredential
 		headerFlows []tables.TableMCPPerUserHeaderFlow
@@ -336,7 +336,7 @@ type sessionBindingKey struct {
 	MCPClientID string
 }
 
-func bindingKeyFromToken(t tables.TableOauthUserToken) sessionBindingKey {
+func bindingKeyFromToken(t tables.TableMCPOauthToken) sessionBindingKey {
 	k := sessionBindingKey{Mode: t.AuthMode, MCPClientID: t.MCPClientID}
 	switch schemas.MCPAuthMode(t.AuthMode) {
 	case schemas.MCPAuthModeUser:
@@ -830,7 +830,7 @@ func (h *MCPSessionsHandler) loadAuthorizedFlow(ctx *fasthttp.RequestCtx, flowID
 // identityFromTokenRow returns the (mode, identity) pair recorded on the row.
 // Inverse of the mode/identity routing used when creating the row; the row's
 // AuthMode column is the source of truth for which identity column is keyed.
-func identityFromTokenRow(tok *tables.TableOauthUserToken) (schemas.MCPAuthMode, string) {
+func identityFromTokenRow(tok *tables.TableMCPOauthToken) (schemas.MCPAuthMode, string) {
 	switch schemas.MCPAuthMode(tok.AuthMode) {
 	case schemas.MCPAuthModeUser:
 		if tok.UserID != nil {
@@ -846,13 +846,16 @@ func identityFromTokenRow(tok *tables.TableOauthUserToken) (schemas.MCPAuthMode,
 	return schemas.MCPAuthMode(tok.AuthMode), ""
 }
 
-// loadRowAuthorizedForCaller loads a token row. Visibility is enforced at
-// the enterprise configstore layer via DAC scope on GetOauthUserTokenByID:
-// if the caller is not allowed to see this row, the store returns
-// (nil, nil) and we surface 404 — the same "if you can see it, you can
-// act on it" model used by GetVirtualKey / DeleteVirtualKey. Writes the
-// HTTP error response on failure.
-func (h *MCPSessionsHandler) loadRowAuthorizedForCaller(ctx *fasthttp.RequestCtx, rowID string) (*tables.TableOauthUserToken, error) {
+// loadRowAuthorizedForCaller loads a per-user token row. Visibility is
+// enforced at the enterprise configstore layer via DAC scope on
+// GetOauthUserTokenByID: if the caller is not allowed to see this row, the
+// store returns (nil, nil) and we surface 404 — the same "if you can see it,
+// you can act on it" model used by GetVirtualKey / DeleteVirtualKey.
+// GetOauthUserTokenByID also filters to auth_mode IN ('user','vk','session')
+// at the store layer, so a rowID belonging to the shared credential 404s
+// here rather than being readable through this per-user-scoped endpoint.
+// Writes the HTTP error response on failure.
+func (h *MCPSessionsHandler) loadRowAuthorizedForCaller(ctx *fasthttp.RequestCtx, rowID string) (*tables.TableMCPOauthToken, error) {
 	tok, err := h.store.ConfigStore.GetOauthUserTokenByID(ctx, rowID)
 	if err != nil {
 		logger.Error("[mcp/sessions] load row failed: token=%s err=%v", rowID, err)
@@ -874,8 +877,9 @@ type errSentinel string
 
 func (e errSentinel) Error() string { return string(e) }
 
-// tokenRow maps an oauth_user_tokens row to the wire shape.
-func tokenRow(t tables.TableOauthUserToken) mcpSessionRow {
+// tokenRow maps a per-user mcp_oauth_tokens row (auth_mode 'user'|'vk'|'session')
+// to the wire shape.
+func tokenRow(t tables.TableMCPOauthToken) mcpSessionRow {
 	row := mcpSessionRow{
 		ID:            t.ID,
 		Kind:          "token",

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1434,19 +1434,19 @@ func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.
 }
 
 // OAuth token
-func (m *MockConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error) {
+func (m *MockConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
+func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableOauthToken) error {
+func (m *MockConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return nil
 }
 
-func (m *MockConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableOauthToken) error {
+func (m *MockConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return nil
 }
 
@@ -1476,15 +1476,15 @@ func (m *MockConfigStore) UpdateOauthUserSession(ctx context.Context, session *t
 }
 
 // Per-user OAuth token CRUD
-func (m *MockConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserToken, error) {
+func (m *MockConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+func (m *MockConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return nil
 }
 
-func (m *MockConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+func (m *MockConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return nil
 }
 
@@ -1504,11 +1504,11 @@ func (m *MockConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context,
 	return nil
 }
 
-func (m *MockConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableOauthUserToken, error) {
+func (m *MockConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) ListOauthUserTokens(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableOauthUserToken, error) {
+func (m *MockConfigStore) ListOauthUserTokens(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

Merges the two legacy MCP OAuth token tables (`oauth_tokens` for shared client credentials and `oauth_user_tokens` for per-identity credentials) into a single unified table, `mcp_oauth_tokens`, distinguished by an `auth_mode` column (`shared` | `user` | `vk` | `session`). This eliminates the split storage model, closes a long-standing orphan leak where deleting an MCP client never cleaned up its shared `oauth_tokens` row or its `oauth_configs` row, and adds defense-in-depth guards so per-user code paths can never read, mutate, or delete a shared credential and vice versa.

## Changes

- Introduces `TableMCPOauthToken` mapped to `mcp_oauth_tokens`, carrying every column both predecessor tables held plus `auth_mode` and `status`. `TableOauthToken` and `TableOauthUserToken` are retained as deprecated stubs so historical migrations keep compiling; both will be dropped in the next major version.
- Adds migration `merge_oauth_token_tables` as the final registered step. It creates `mcp_oauth_tokens` fresh, backfills shared rows from `oauth_tokens` (deriving `auth_mode='shared'`, `mcp_client_id`, and `oauth_config_id` inline via subselect), copies per-identity rows from `oauth_user_tokens` field-for-field, dedupes any `shared`-mode `mcp_client_id` collisions introduced by the pre-existing orphan leak, then creates four partial unique indexes (one per `auth_mode`). Neither legacy table is dropped.
- All `ConfigStore` interface methods and their `RDBConfigStore` implementations are updated to operate on `TableMCPOauthToken`. Per-user-scoped methods (`GetOauthUserTokenByID`, `UpdateOauthUserToken`, `DeleteOauthUserToken`, `MarkOauthUserTokenNeedsReauthByID`, `DeleteOrphanedOauthUserTokens`, `ListOauthUserTokens`) now filter on `auth_mode IN ('user','vk','session')` so a shared row can never be reached through a per-user endpoint.
- `GetExpiringOauthTokens` gains an explicit `auth_mode = 'shared'` filter so the `TokenRefreshWorker` continues to handle only shared credentials; per-user proactive refresh remains a deliberate later change.
- `DeleteMCPClientConfig` now deletes all `mcp_oauth_tokens` rows for the client (shared and per-identity alike) in one pass and explicitly deletes the client's `oauth_configs` row, closing the orphan leak that previously left both untouched.
- `DeleteVirtualKey` and `reconcileVKDirectTokensDB` are updated to target `mcp_oauth_tokens` with `auth_mode` scoping.
- `CompleteOAuthFlow` populates `AuthMode='shared'`, `OauthConfigID`, `Status='active'`, and attempts to derive `MCPClientID` via `GetMCPClientByOauthConfigID` before creating the token record.
- Adds `migrations_perf_test.go` with `TestMigrationMergeOauthTokenTablesPerf`, gated behind `BIFROST_RUN_MIGRATION_PERF_TESTS=1`, which seeds ~1,000,000 rows across the pre-merge tables and measures the migration's wall-clock cost against both SQLite and Postgres.
- `perUserOauthAuthModes` is introduced as a package-level slice centralizing the set of non-shared auth modes used by all scoped queries.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/...

# To run the migration performance test against ~1,000,000 seeded rows:
BIFROST_RUN_MIGRATION_PERF_TESTS=1 go test ./framework/configstore/... -run TestMigrationMergeOauthTokenTablesPerf -v -timeout 30m
```

Validate that:
- A fresh install creates `mcp_oauth_tokens` and leaves `oauth_tokens`/`oauth_user_tokens` empty but present.
- An upgrade from a pre-merge schema runs the migration without error, copies all rows, and leaves the legacy tables untouched.
- Deleting an OAuth MCP client removes its `mcp_oauth_tokens` rows and its `oauth_configs` row.
- The sessions UI lists only per-identity rows (no `auth_mode='shared'` rows appear).
- Token refresh continues to work for shared-mode clients.

## Breaking changes

- [x] Yes
- [ ] No

The `ConfigStore` interface signatures for all OAuth token methods now use `*tables.TableMCPOauthToken` instead of `*tables.TableOauthToken` or `*tables.TableOauthUserToken`. Any external implementation of `ConfigStore` must be updated. The underlying storage moves from `oauth_tokens`/`oauth_user_tokens` to `mcp_oauth_tokens`; the migration handles existing data automatically, but rollback drops `mcp_oauth_tokens` entirely and restores reads/writes to the legacy tables.

## Security considerations

- Per-user-scoped store methods now explicitly filter `auth_mode IN ('user','vk','session')`, preventing a caller-supplied token ID from resolving to a shared credential through endpoints intended only for per-identity credentials (e.g. `POST /api/mcp/sessions/{id}/reauth`, `DELETE /api/mcp/sessions/{id}`).
- `UpdateOauthUserToken` rejects rows whose `auth_mode` is not one of the per-identity modes, preventing silent rewrites of shared credentials through the per-user API.
- The orphan leak in `DeleteMCPClientConfig` (shared `oauth_tokens` row and `oauth_configs` row never cleaned up on client deletion) is closed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable