### PR TITLE
refactor: migrate OAuth flow state/PKCE fields from `oauth_configs` to new `mcp_oauth_flows` table

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -81255,11 +81255,6 @@
             "format": "date-time",
             "description": "When this OAuth config was created"
           },
-          "expires_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "When this OAuth config expires (becomes invalid if not completed)"
-          },
           "token_id": {
             "type": "string",
             "description": "ID of the associated OAuth token (only present if status is authorized)"

--- a/docs/openapi/schemas/management/oauth.yaml
+++ b/docs/openapi/schemas/management/oauth.yaml
@@ -86,10 +86,6 @@ OAuthConfigStatus:
       type: string
       format: date-time
       description: When this OAuth config was created
-    expires_at:
-      type: string
-      format: date-time
-      description: When this OAuth config expires (becomes invalid if not completed)
     token_id:
       type: string
       description: ID of the associated OAuth token (only present if status is authorized)

--- a/framework/configstore/encryption.go
+++ b/framework/configstore/encryption.go
@@ -254,12 +254,16 @@ func (s *RDBConfigStore) encryptPlaintextOAuthTokens(ctx context.Context) (int, 
 
 // encryptPlaintextOAuthConfigs finds all oauth_configs rows with plaintext encryption status
 // and re-saves them in batches. The TableOauthConfig.BeforeSave hook handles encryption.
+// client_secret is the only sensitive column left on this table — state/
+// code_verifier/code_challenge/expires_at moved to mcp_oauth_flows (see that
+// migration) and code_verifier was the only one of those that was ever
+// encrypted, so the WHERE clause below no longer needs an OR branch for it.
 func (s *RDBConfigStore) encryptPlaintextOAuthConfigs(ctx context.Context) (int, error) {
 	var count int
 	for {
 		var configs []tables.TableOauthConfig
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND (client_secret != '' OR code_verifier != '')", encryptionStatusPlainText).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND client_secret != ''", encryptionStatusPlainText).
 			Limit(encryptionBatchSize).
 			Find(&configs).Error; err != nil {
 			return count, err

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -103,9 +103,9 @@ func TestEncryptPlaintextRows_EncryptsAllTables(t *testing.T) {
 		"tok-1", "plaintext-access-token", "plaintext-refresh-token", future, now, now)
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_configs (id, client_secret, code_verifier, redirect_uri, state, status, encryption_status, created_at, updated_at, expires_at)
-		 VALUES (?, ?, ?, ?, ?, 'pending', 'plain_text', ?, ?, ?)`,
-		"cfg-1", "plaintext-client-secret", "plaintext-verifier", "https://example.com/cb", "csrf-state", now, now, future)
+		`INSERT INTO oauth_configs (id, client_secret, redirect_uri, status, encryption_status, created_at, updated_at)
+		 VALUES (?, ?, ?, 'pending', 'plain_text', ?, ?)`,
+		"cfg-1", "plaintext-client-secret", "https://example.com/cb", now, now)
 
 	insertPlaintextRow(t, db,
 		`INSERT INTO config_mcp_clients (client_id, name, connection_type, connection_string, headers_json, encryption_status, created_at, updated_at)
@@ -435,12 +435,11 @@ func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T)
 	store, db := setupEncryptionTestStore(t)
 	ctx := context.Background()
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
-	future := time.Now().Add(time.Hour).UTC().Format("2006-01-02 15:04:05")
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_configs (id, client_secret, code_verifier, redirect_uri, state, status, encryption_status, created_at, updated_at, expires_at)
-		 VALUES (?, ?, ?, ?, ?, 'pending', 'plain_text', ?, ?, ?)`,
-		"cfg-batch-1", "batch-client-secret", "batch-verifier", "https://example.com/cb", "csrf", now, now, future)
+		`INSERT INTO oauth_configs (id, client_secret, redirect_uri, status, encryption_status, created_at, updated_at)
+		 VALUES (?, ?, ?, 'pending', 'plain_text', ?, ?)`,
+		"cfg-batch-1", "batch-client-secret", "https://example.com/cb", now, now)
 
 	count, err := store.encryptPlaintextOAuthConfigs(ctx)
 	require.NoError(t, err)
@@ -451,13 +450,11 @@ func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T)
 	db.Table("oauth_configs").Where("id = ?", "cfg-batch-1").Take(&raw)
 	assert.Equal(t, "encrypted", raw["encryption_status"])
 	assert.NotEqual(t, "batch-client-secret", raw["client_secret"])
-	assert.NotEqual(t, "batch-verifier", raw["code_verifier"])
 
 	// GORM hooks should decrypt on read
 	var found tables.TableOauthConfig
 	require.NoError(t, db.Where("id = ?", "cfg-batch-1").First(&found).Error)
 	assert.Equal(t, "batch-client-secret", found.ClientSecret.GetValue())
-	assert.Equal(t, "batch-verifier", found.CodeVerifier)
 }
 
 func TestEncryptPlaintextMCPClients_EncryptsAndDecryptsCorrectly(t *testing.T) {
@@ -1215,19 +1212,18 @@ func TestEncryptPlaintextRows_EmptyDatabase(t *testing.T) {
 }
 
 // ============================================================================
-// OAuthConfigs skip when both secrets are empty
+// OAuthConfigs skip when client_secret is empty
 // ============================================================================
 
-func TestEncryptPlaintextOAuthConfigs_SkipsBothEmptySecrets(t *testing.T) {
+func TestEncryptPlaintextOAuthConfigs_SkipsEmptySecret(t *testing.T) {
 	store, db := setupEncryptionTestStore(t)
 	ctx := context.Background()
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
-	future := time.Now().Add(time.Hour).UTC().Format("2006-01-02 15:04:05")
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO oauth_configs (id, client_secret, code_verifier, redirect_uri, state, status, encryption_status, created_at, updated_at, expires_at)
-		 VALUES (?, '', '', ?, ?, 'pending', 'plain_text', ?, ?, ?)`,
-		"cfg-empty-secrets", "https://example.com/cb", "csrf-state", now, now, future)
+		`INSERT INTO oauth_configs (id, client_secret, redirect_uri, status, encryption_status, created_at, updated_at)
+		 VALUES (?, '', ?, 'pending', 'plain_text', ?, ?)`,
+		"cfg-empty-secrets", "https://example.com/cb", now, now)
 
 	count, err := store.encryptPlaintextOAuthConfigs(ctx)
 	require.NoError(t, err)

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -459,6 +459,8 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_pricing_override_user_id_column"}, run: migrationAddPricingOverrideUserIDColumn},
 	{IDs: []string{"add_mcp_client_pending_oauth_config_json_column"}, run: migrationAddMCPClientPendingOAuthConfigJSONColumn},
 	{IDs: []string{"merge_oauth_token_tables"}, run: migrationMergeOauthTokenTables},
+	{IDs: []string{"create_mcp_oauth_flows_table"}, run: migrationCreateMCPOauthFlowsTable},
+	{IDs: []string{"drop_oauth_config_pkce_columns"}, run: migrationDropOauthConfigPKCEColumns},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -5792,6 +5794,20 @@ func migrationWidenEncryptedVarcharColumns(ctx context.Context, db *gorm.DB, log
 					return fmt.Errorf("failed to widen column azure_api_version: %w", err)
 				}
 			}
+			// oauth_configs.code_verifier was later dropped by
+			// migrationDropOauthConfigPKCEColumns (the column moved to
+			// mcp_oauth_flows) — same guard as azure_api_version above. A
+			// deployment provisioned after that migration shipped never had
+			// this column at all: migrationAddOAuthTables creates
+			// oauth_configs from today's TableOauthConfig struct, which no
+			// longer declares CodeVerifier, so an unconditional ALTER here
+			// would fail with "column does not exist" on any such fresh
+			// install.
+			if tx.Migrator().HasColumn(&tables.TableOauthConfig{}, "code_verifier") {
+				if err := tx.Exec("ALTER TABLE oauth_configs ALTER COLUMN code_verifier TYPE TEXT").Error; err != nil {
+					return fmt.Errorf("failed to widen column oauth_configs.code_verifier: %w", err)
+				}
+			}
 
 			stmts := []string{
 				// config_keys table - all encrypted SecretVar fields
@@ -5806,8 +5822,6 @@ func migrationWidenEncryptedVarcharColumns(ctx context.Context, db *gorm.DB, log
 				"ALTER TABLE sessions ALTER COLUMN token TYPE TEXT",
 				// governance_virtual_keys table
 				"ALTER TABLE governance_virtual_keys ALTER COLUMN value TYPE TEXT",
-				// oauth_configs table
-				"ALTER TABLE oauth_configs ALTER COLUMN code_verifier TYPE TEXT",
 			}
 			logger.Info("[configstore] %s: processing %d stmts", migrationName, len(stmts))
 			for _, stmt := range stmts {
@@ -11373,4 +11387,188 @@ func migrationMergeOauthTokenTables(ctx context.Context, db *gorm.DB, logger sch
 			return nil
 		},
 	})
+}
+
+// migrationCreateMCPOauthFlowsTable creates mcp_oauth_flows, the table
+// backing TableMCPOauthFlow, and backfills it from the legacy
+// oauth_user_sessions table (TableOauthUserSession). Same overall shape as
+// migrationMergeOauthTokenTables above, simplified: there is only one source
+// table here, and flow_mode already exists on it (added by an earlier
+// migration), so nothing needs deriving the way auth_mode did for the
+// shared-token backfill.
+func migrationCreateMCPOauthFlowsTable(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "create_mcp_oauth_flows_table"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	return RunSingleMigration(ctx, nil, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// 1) Create mcp_oauth_flows if it doesn't already exist. Wholly
+			// new as of this migration, same as mcp_oauth_tokens before it —
+			// this check is normally true on every deployment that reaches
+			// this step. TableMCPOauthFlow.State deliberately carries a
+			// plain (non-unique) index in its struct tag rather than
+			// uniqueIndex: CreateTable would otherwise build a unique index
+			// as part of table creation, before the backfill in step 2 runs.
+			// Step 3 below adds the real unique index after the backfill
+			// instead — the same create-after-backfill ordering
+			// migrationMergeOauthTokenTables needed for its partial unique
+			// indexes, applied here even though (unlike that migration) a
+			// real collision isn't expected: oauth_user_sessions.state
+			// already carries its own uniqueIndex today, so a straight copy
+			// of already-distinct values into an empty destination table
+			// can't collide against itself. Applied anyway rather than
+			// relying on that reasoning holding forever.
+			if !mg.HasTable(&tables.TableMCPOauthFlow{}) {
+				logger.Info("[configstore] %s: creating table TableMCPOauthFlow", migrationName)
+				if err := mg.CreateTable(&tables.TableMCPOauthFlow{}); err != nil {
+					return fmt.Errorf("create mcp_oauth_flows table: %w", err)
+				}
+			}
+
+			// 2) Backfill from oauth_user_sessions — a straight field-for-
+			// field copy. Raw table references rather than
+			// TableOauthUserSession model reads: GORM has no native
+			// cross-table INSERT...SELECT, and this is a bulk copy where a
+			// struct-based read-all/write-all loop buys nothing over one SQL
+			// statement. Guarded on table existence for the same
+			// fresh-install reason as mcp_oauth_tokens's backfill
+			// (oauth_user_sessions is still created — empty — by the
+			// historical migration that introduced it).
+			if mg.HasTable(&tables.TableOauthUserSession{}) {
+				if err := tx.Exec(`
+					INSERT INTO mcp_oauth_flows (
+						id, mcp_client_id, oauth_config_id, state, redirect_uri,
+						code_verifier, session_id, virtual_key_id, user_id,
+						flow_mode, status, encryption_status, expires_at,
+						created_at, updated_at
+					)
+					SELECT
+						id, mcp_client_id, oauth_config_id, state, redirect_uri,
+						code_verifier, session_id, virtual_key_id, user_id,
+						flow_mode, status, encryption_status, expires_at,
+						created_at, updated_at
+					FROM oauth_user_sessions
+					WHERE NOT EXISTS (SELECT 1 FROM mcp_oauth_flows WHERE mcp_oauth_flows.id = oauth_user_sessions.id)
+				`).Error; err != nil {
+					return fmt.Errorf("backfill mcp_oauth_flows from oauth_user_sessions: %w", err)
+				}
+			}
+
+			// 3) Unique index on state, created after the backfill above —
+			// see the field comment on TableMCPOauthFlow.State and the note
+			// in step 1 for why this can't come from the struct tag.
+			if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_flows_state ON mcp_oauth_flows (state)`).Error; err != nil {
+				return fmt.Errorf("create unique index on mcp_oauth_flows.state: %w", err)
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// mcp_oauth_flows is wholly new as of this migration, so rolling
+			// back simply drops it — oauth_user_sessions was never written
+			// to by Migrate above and needs no repair.
+			if mg.HasTable(&tables.TableMCPOauthFlow{}) {
+				logger.Info("[configstore] %s: dropping table TableMCPOauthFlow", migrationName)
+				if err := mg.DropTable(&tables.TableMCPOauthFlow{}); err != nil {
+					return fmt.Errorf("drop mcp_oauth_flows table: %w", err)
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+// migrationDropOauthConfigPKCEColumns drops the CSRF-state and PKCE columns
+// (state, code_verifier, code_challenge, expires_at) from oauth_configs.
+// Once InitiateOAuthFlow/CompleteOAuthFlow write these onto mcp_oauth_flows
+// instead (see the preceding migration and the application-code change that
+// shipped alongside it), nothing populates them on oauth_configs any
+// longer — and state/expires_at are NOT NULL at the DB level, so leaving the
+// columns in place would fail every future INSERT into oauth_configs the
+// moment the Go struct stops setting them. Dropped outright rather than just
+// relaxing the NOT NULL constraints and the unique index on state: nothing
+// reads these columns once the write side stops, so keeping them around as
+// dead weight buys nothing and only adds confusion for anyone inspecting the
+// table later. dropColumnIfExists (see its doc comment) handles both
+// Postgres and SQLite, including a column that still carries an index —
+// Postgres drops a dependent index automatically as part of DROP COLUMN, and
+// GORM's own SQLite migrator (the non-Postgres fallback path) rebuilds the
+// table without the column and its index rather than emitting a bare ALTER
+// TABLE DROP COLUMN (which SQLite refuses when an index still references the
+// column being dropped).
+//
+// The preceding migration only backfills mcp_oauth_flows from
+// oauth_user_sessions; any admin-mode flow with its state/code_verifier
+// still on oauth_configs at upgrade time is not carried forward, so an
+// in-flight admin authorize attempt spanning the upgrade fails its callback
+// with "flow not found" and must be re-initiated. That is a reasonable
+// tradeoff for the short window these columns typically live in, but it is
+// a real forward-migration consequence, not just a rollback non-issue.
+func migrationDropOauthConfigPKCEColumns(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "drop_oauth_config_pkce_columns"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db.WithContext(ctx), migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			if !mg.HasTable(&tables.TableOauthConfig{}) {
+				return nil
+			}
+
+			for _, column := range []string{"state", "code_verifier", "code_challenge", "expires_at"} {
+				if err := dropColumnIfExists(tx, logger, &tables.TableOauthConfig{}, column); err != nil {
+					return fmt.Errorf("drop oauth_configs.%s column: %w", column, err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Forward-only: the dropped columns carried no data worth
+			// resurrecting. CSRF state and PKCE verifiers only ever mattered
+			// for the lifetime of a single in-flight flow (now tracked on
+			// mcp_oauth_flows instead, untouched by this migration), and
+			// expires_at's meaning moved there too. Re-adding empty columns
+			// would not restore anything a rollback needs.
+			return nil
+		},
+	}})
+	// SQLite workaround — same reasoning as migrationAddCustomerBudgetsToBudgetsTable:
+	// GORM's SQLite DropColumn rebuilds oauth_configs via DROP+RENAME, which fails
+	// when config_mcp_clients.oauth_config_id holds an FK into it and foreign_keys is
+	// ON. PRAGMA foreign_keys cannot change inside a transaction, so disable it on a
+	// pinned single connection before the migrator opens its transaction, then restore it.
+	if db.Dialector.Name() == "sqlite" {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return fmt.Errorf("failed to get underlying sql.DB: %w", err)
+		}
+		prevMaxOpenConns := sqlDB.Stats().MaxOpenConnections
+		sqlDB.SetMaxOpenConns(1)
+		defer sqlDB.SetMaxOpenConns(prevMaxOpenConns)
+
+		if err := db.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+			return fmt.Errorf("failed to disable SQLite foreign keys: %w", err)
+		}
+		defer func() {
+			if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+				log.Fatalf("[Migration] FATAL: failed to re-enable SQLite foreign keys: %v", err)
+			}
+		}()
+	}
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running drop_oauth_config_pkce_columns migration: %s", err.Error())
+	}
+	return nil
 }

--- a/framework/configstore/migrations_perf_test.go
+++ b/framework/configstore/migrations_perf_test.go
@@ -121,18 +121,30 @@ func trySetupPreMergePostgresDB(t *testing.T) *gorm.DB {
 	return db
 }
 
-// runPreMergeMigrationChain runs every configstoreMigrationSteps entry
-// except the last one (merge_oauth_token_tables) and asserts the resulting
+// migrationStepIndex returns the position of the migration step registered
+// under id in configstoreMigrationSteps, failing the test if it isn't found.
+// Locating steps by ID rather than by a fixed offset from the end of the
+// slice keeps the pre-chain helpers below correct as later migrations are
+// appended to the registry.
+func migrationStepIndex(t *testing.T, id string) int {
+	t.Helper()
+	for i, step := range configstoreMigrationSteps {
+		if len(step.IDs) == 1 && step.IDs[0] == id {
+			return i
+		}
+	}
+	require.Failf(t, "migration step not found", "expected %q to be a registered migration step", id)
+	return -1
+}
+
+// runPreMergeMigrationChain runs every configstoreMigrationSteps entry up to
+// (but not including) merge_oauth_token_tables and asserts the resulting
 // schema is genuinely pre-merge: oauth_tokens/oauth_user_tokens exist,
 // mcp_oauth_tokens does not.
 func runPreMergeMigrationChain(t *testing.T, db *gorm.DB) {
 	t.Helper()
 	require.NotEmpty(t, configstoreMigrationSteps)
-	lastStep := configstoreMigrationSteps[len(configstoreMigrationSteps)-1]
-	require.Equal(t, []string{"merge_oauth_token_tables"}, lastStep.IDs,
-		"expected merge_oauth_token_tables to be the last registered migration step; "+
-			"update the slice bound below if the registry changed")
-	preMergeSteps := configstoreMigrationSteps[:len(configstoreMigrationSteps)-1]
+	preMergeSteps := configstoreMigrationSteps[:migrationStepIndex(t, "merge_oauth_token_tables")]
 
 	ctx := context.Background()
 	require.NoError(t, runMigrationSteps(ctx, db, testMigrationLogger, preMergeSteps),
@@ -238,11 +250,9 @@ func bulkInsertOauthTokens(t *testing.T, db *gorm.DB, count int) {
 				ID:          configID,
 				TokenID:     &tokenID,
 				RedirectURI: "https://perf.example.com/callback",
-				State:       fmt.Sprintf("perf-shared-state-%d", i),
 				Status:      "authorized",
 				CreatedAt:   now,
 				UpdatedAt:   now,
-				ExpiresAt:   now.Add(15 * time.Minute),
 			})
 			clientBatch = append(clientBatch, tables.TableMCPClient{
 				ClientID:       fmt.Sprintf("perf-shared-mcp-client-%d", i),
@@ -389,6 +399,225 @@ func TestMigrationMergeOauthTokenTablesPerf(t *testing.T) {
 				Count(&linkedCount).Error)
 			require.EqualValues(t, perfSharedTokenCount, linkedCount,
 				"every migrated shared token should retain the oauth_config_id/mcp_client_id derived from its linked oauth_configs/config_mcp_clients rows")
+		})
+	}
+}
+
+// perfFlowRowCount is the row count for the create_mcp_oauth_flows_table
+// perf test below. Unlike the token-table merge above, there is only one
+// source table here (oauth_user_sessions) and no shared/per-user split to
+// mirror, so this is a single flat ~1,000,000-row seed.
+const perfFlowRowCount = 1_000_000
+
+// setupPreCreateFlowsSQLiteDB runs every configstore migration EXCEPT the
+// final two steps (create_mcp_oauth_flows_table and its follow-on
+// drop_oauth_config_pkce_columns), leaving oauth_user_sessions in its real
+// pre-migration shape (complete with the uniqueIndex on state that
+// TableOauthUserSession's struct tag has always carried) and mcp_oauth_flows
+// not yet created — the exact starting state migrationCreateMCPOauthFlowsTable
+// expects to run against on an existing deployment.
+func setupPreCreateFlowsSQLiteDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	n := time.Now().UnixNano() + testDBCounter
+	testDBCounter++
+	dsn := fmt.Sprintf("file:perftestdb_flows_%d?mode=memory&cache=shared", n)
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "failed to open perf test sqlite db")
+
+	runPreCreateFlowsMigrationChain(t, db)
+	return db
+}
+
+// trySetupPreCreateFlowsPostgresDB is trySetupPreMergePostgresDB's
+// counterpart for the flows migration — same fallback-to-nil-on-unavailable
+// behavior, same dedicated pgPerfTestSchema (safe to reuse across both perf
+// tests in this file: each wipes and recreates the schema fresh before
+// seeding, and the two perf tests never run concurrently against it).
+func trySetupPreCreateFlowsPostgresDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil
+	}
+	// Closed on every failure path below via this defer; once schema setup
+	// succeeds and t.Cleanup takes over ownership, ok flips to true and this
+	// becomes a no-op (avoids a double-close). Mirrors
+	// trySetupPreMergePostgresDB's identical pattern above.
+	ok := false
+	defer func() {
+		if !ok {
+			sqlDB.Close()
+		}
+	}()
+	if err := sqlDB.Ping(); err != nil {
+		return nil
+	}
+	// postgresDSN already pins search_path=configstore_test for every pooled
+	// connection. `SET search_path` below only changes the single session
+	// that happens to run it, so without limiting the pool to that one
+	// connection, later queries on a different pooled connection would
+	// silently run against configstore_test instead of pgPerfTestSchema.
+	sqlDB.SetMaxOpenConns(1)
+
+	if err := db.Exec("DROP SCHEMA IF EXISTS " + pgPerfTestSchema + " CASCADE").Error; err != nil {
+		return nil
+	}
+	if err := db.Exec("CREATE SCHEMA " + pgPerfTestSchema).Error; err != nil {
+		return nil
+	}
+	if err := db.Exec("SET search_path TO " + pgPerfTestSchema).Error; err != nil {
+		return nil
+	}
+
+	t.Cleanup(func() {
+		db.Exec("DROP SCHEMA IF EXISTS " + pgPerfTestSchema + " CASCADE")
+		sqlDB.Close()
+	})
+	ok = true
+
+	runPreCreateFlowsMigrationChain(t, db)
+
+	return db
+}
+
+// runPreCreateFlowsMigrationChain runs every configstoreMigrationSteps entry
+// up to (but not including) create_mcp_oauth_flows_table and asserts the
+// resulting schema is genuinely pre-flows-migration: oauth_user_sessions
+// exists, mcp_oauth_flows does not. Everything from create_mcp_oauth_flows_table
+// onward (including drop_oauth_config_pkce_columns) is excluded — the latter
+// runs after create_mcp_oauth_flows_table and touches oauth_configs, not
+// oauth_user_sessions, so leaving it out changes nothing this test cares about.
+func runPreCreateFlowsMigrationChain(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NotEmpty(t, configstoreMigrationSteps)
+	preFlowSteps := configstoreMigrationSteps[:migrationStepIndex(t, "create_mcp_oauth_flows_table")]
+
+	ctx := context.Background()
+	require.NoError(t, runMigrationSteps(ctx, db, testMigrationLogger, preFlowSteps),
+		"failed to run the pre-flows-migration chain")
+
+	require.False(t, db.Migrator().HasTable(&tables.TableMCPOauthFlow{}),
+		"mcp_oauth_flows should not exist before migrationCreateMCPOauthFlowsTable runs")
+	require.True(t, db.Migrator().HasTable(&tables.TableOauthUserSession{}),
+		"oauth_user_sessions should exist in its pre-migration shape")
+}
+
+// bulkInsertOauthUserSessions seeds count rows into oauth_user_sessions (the
+// pre-migration flow table), all in 'user' flow_mode, cycling through
+// numClients distinct MCP clients — same batched-INSERT-in-one-transaction
+// approach as bulkInsertOauthTokens/bulkInsertOauthUserTokens above. Every
+// row gets a distinct State (the column's real uniqueIndex would otherwise
+// reject the batch) and a distinct UserID.
+func bulkInsertOauthUserSessions(t *testing.T, db *gorm.DB, count int, numClients int) {
+	t.Helper()
+	now := time.Now()
+	expiresAt := now.Add(15 * time.Minute)
+	batch := make([]tables.TableOauthUserSession, 0, perfSeedInsertBatchSize)
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		for i := 0; i < count; i++ {
+			userID := fmt.Sprintf("perf-flow-user-%d", i)
+			batch = append(batch, tables.TableOauthUserSession{
+				ID:               fmt.Sprintf("perf-flow-%d", i),
+				MCPClientID:      fmt.Sprintf("perf-mcp-client-%d", i%numClients),
+				OauthConfigID:    fmt.Sprintf("perf-oauth-config-%d", i%numClients),
+				State:            fmt.Sprintf("perf-flow-state-%d", i),
+				RedirectURI:      "https://example.com/callback",
+				CodeVerifier:     fmt.Sprintf("perf-flow-verifier-%d", i),
+				UserID:           &userID,
+				FlowMode:         "user",
+				Status:           "pending",
+				EncryptionStatus: tables.EncryptionStatusPlainText,
+				ExpiresAt:        expiresAt,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			})
+			if len(batch) == perfSeedInsertBatchSize {
+				if err := tx.Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+		if len(batch) > 0 {
+			return tx.Create(&batch).Error
+		}
+		return nil
+	}))
+}
+
+// TestMigrationCreateMCPOauthFlowsTablePerf seeds ~1,000,000 rows into the
+// pre-migration oauth_user_sessions table and measures how long the real
+// migrationCreateMCPOauthFlowsTable takes to run against that data. Same
+// rationale as TestMigrationMergeOauthTokenTablesPerf above (see its doc
+// comment) — this is also a CREATE-new-table +
+// INSERT...SELECT-from-old-table migration that runs synchronously at boot
+// behind a Postgres advisory lock.
+//
+// Gated behind BIFROST_RUN_MIGRATION_PERF_TESTS=1 — never runs as part of a
+// normal `go test ./...` or CI invocation.
+func TestMigrationCreateMCPOauthFlowsTablePerf(t *testing.T) {
+	if os.Getenv(migrationPerfTestEnvVar) != "1" {
+		t.Skipf("set %s=1 to run this migration performance test (seeds ~1,000,000 rows; slow by design)", migrationPerfTestEnvVar)
+	}
+
+	dbs := []namedDB{{"sqlite", setupPreCreateFlowsSQLiteDB(t)}}
+	if pgDB := trySetupPreCreateFlowsPostgresDB(t); pgDB != nil {
+		dbs = append(dbs, namedDB{"postgres", pgDB})
+	} else {
+		t.Log("postgres unavailable for this run; measuring against sqlite only")
+	}
+
+	for _, ndb := range dbs {
+		ndb := ndb
+		t.Run(ndb.name, func(t *testing.T) {
+			db := ndb.db
+			ctx := context.Background()
+
+			// Close the SQLite pool once this subtest finishes so the shared
+			// in-memory database (and its ~1M seeded rows) is freed before
+			// the Postgres subtest runs, rather than staying open for the
+			// rest of the test.
+			if ndb.name == "sqlite" {
+				t.Cleanup(func() {
+					sqlDB, err := db.DB()
+					if err == nil {
+						_ = sqlDB.Close()
+					}
+				})
+			}
+
+			seedStart := time.Now()
+			seedSyntheticMCPClients(t, db, perfSyntheticClientCount)
+			bulkInsertOauthUserSessions(t, db, perfFlowRowCount, perfSyntheticClientCount)
+			t.Logf("[%s] seeded %d oauth_user_sessions rows in %v",
+				ndb.name, perfFlowRowCount, time.Since(seedStart))
+
+			var sessionCount int64
+			require.NoError(t, db.Table("oauth_user_sessions").Count(&sessionCount).Error)
+			require.EqualValues(t, perfFlowRowCount, sessionCount)
+
+			// This is the real function, invoked exactly like the migration
+			// registry invokes it — not a reimplementation of its SQL.
+			migrateStart := time.Now()
+			err := migrationCreateMCPOauthFlowsTable(ctx, db, testMigrationLogger)
+			elapsed := time.Since(migrateStart)
+			require.NoError(t, err, "migrationCreateMCPOauthFlowsTable should succeed against the seeded dataset")
+
+			t.Logf("[%s] migrationCreateMCPOauthFlowsTable took %v against %d seeded rows",
+				ndb.name, elapsed, perfFlowRowCount)
+
+			var flowCount int64
+			require.NoError(t, db.Table("mcp_oauth_flows").Count(&flowCount).Error)
+			require.EqualValues(t, perfFlowRowCount, flowCount,
+				"every seeded row should have been copied into mcp_oauth_flows")
 		})
 	}
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2422,18 +2422,21 @@ func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) e
 
 		// Delete every mcp_oauth_tokens row for this MCP client — the shared
 		// credential (auth_mode='shared') and every per-identity credential
-		// (user/vk/session) alike — plus per-user OAuth flow rows and
-		// per-user header credentials/flows. All reference mcp_client_id by
-		// the string client_id; nothing auto-cascades, so we do it
-		// explicitly inside the same transaction to keep cleanup atomic.
-		// Before the token-table merge this needed two separate deletes
-		// (oauth_user_tokens for per-identity rows, nothing at all for the
-		// shared row — the latter was a real leak); now that both live in
-		// mcp_oauth_tokens, one delete by mcp_client_id covers both.
+		// (user/vk/session) alike — plus every mcp_oauth_flows row (per-user
+		// AND admin-mode alike) and per-user header credentials/flows. All
+		// reference mcp_client_id by the string client_id; nothing
+		// auto-cascades, so we do it explicitly inside the same transaction
+		// to keep cleanup atomic. Before the token-table merge this needed
+		// two separate deletes (oauth_user_tokens for per-identity rows,
+		// nothing at all for the shared row — the latter was a real leak);
+		// now that both live in mcp_oauth_tokens, one delete by
+		// mcp_client_id covers both — same reasoning applies to
+		// mcp_oauth_flows now that admin-mode rows live alongside
+		// per-identity ones there too.
 		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
 			return err
 		}
-		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
+		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableMCPOauthFlow{}).Error; err != nil {
 			return err
 		}
 		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ClientID).Delete(&tables.TableMCPPerUserHeaderCredential{}).Error; err != nil {
@@ -3725,8 +3728,11 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...
 		if err := txDB.WithContext(ctx).Delete(&tables.TableVirtualKeyMCPConfig{}, "virtual_key_id = ?", id).Error; err != nil {
 			return err
 		}
-		// Delete upstream OAuth user sessions tied to this VK
-		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
+		// Delete upstream OAuth flow rows tied to this VK. No flow_mode
+		// filter needed: an admin-mode flow row never populates
+		// virtual_key_id (see InitiateOAuthFlow), so this can't match one by
+		// construction — same reasoning as the auth_mode note below.
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableMCPOauthFlow{}).Error; err != nil {
 			return err
 		}
 		// Delete upstream OAuth user tokens tied to this VK. Reads/writes
@@ -6429,20 +6435,6 @@ func (s *RDBConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string)
 	return result, nil
 }
 
-// GetOauthConfigByState retrieves an OAuth config by its state token
-// State is unique per OAuth flow (used for CSRF protection on callback)
-func (s *RDBConfigStore) GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error) {
-	var config tables.TableOauthConfig
-	result := s.DB().WithContext(ctx).Where("state = ?", state).First(&config)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to get oauth config by state: %w", result.Error)
-	}
-	return &config, nil
-}
-
 // GetOauthTokenByID retrieves an OAuth token by its ID
 func (s *RDBConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
 	var token tables.TableMCPOauthToken
@@ -6466,8 +6458,12 @@ func (s *RDBConfigStore) CreateOauthConfig(ctx context.Context, config *tables.T
 }
 
 // CreateOauthToken creates a new OAuth token
-func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
-	result := s.DB().WithContext(ctx).Create(token)
+func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).Create(token)
 	if result.Error != nil {
 		return fmt.Errorf("failed to create oauth token: %w", result.Error)
 	}
@@ -6475,10 +6471,33 @@ func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.Tab
 }
 
 // UpdateOauthConfig updates an existing OAuth config
-func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
-	result := s.DB().WithContext(ctx).Save(config)
+func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).Save(config)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update oauth config: %w", result.Error)
+	}
+	return nil
+}
+
+// DeleteOauthTokensByConfigAndMode deletes every oauth token row for the
+// given oauth_config_id scoped to a single auth_mode (e.g. "shared").
+// Used by the shared-OAuth callback to clear the prior credential before
+// inserting its replacement — CreateOauthToken is a plain insert with no
+// upsert semantics (see its call sites), so without this the old row would
+// be silently orphaned once oauth_configs.token_id repoints to the new one.
+func (s *RDBConfigStore) DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 {
+		db = tx[0]
+	}
+	if err := db.WithContext(ctx).
+		Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, authMode).
+		Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
+		return fmt.Errorf("failed to delete existing oauth tokens for config %s (mode=%s): %w", oauthConfigID, authMode, err)
 	}
 	return nil
 }
@@ -6562,57 +6581,117 @@ func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID st
 	return &config, nil
 }
 
-// ---------- Per-User OAuth Session CRUD ----------
+// ---------- OAuth Flow CRUD (mcp_oauth_flows) ----------
 
-// GetOauthUserSessionByID retrieves a per-user OAuth session by its ID
-func (s *RDBConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error) {
-	var session tables.TableOauthUserSession
+// perUserOauthFlowModes is the set of TableMCPOauthFlow.FlowMode values that
+// identify a per-identity flow row, as opposed to the admin flow_mode='admin'
+// row an MCP client's shared/bootstrap-test authorize can also produce.
+// Mirrors perUserOauthAuthModes (same three string values) — kept as its own
+// name rather than reused directly since it documents the flow-table's own
+// column (flow_mode, not auth_mode) at each call site.
+var perUserOauthFlowModes = perUserOauthAuthModes
+
+// GetOauthUserSessionByID retrieves a flow row by its ID
+func (s *RDBConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error) {
+	var flow tables.TableMCPOauthFlow
 	result := s.ScopedDB(ctx).
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Where("id = ?", id).First(&session)
+		Where("id = ?", id).First(&flow)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get oauth user session: %w", result.Error)
+		return nil, fmt.Errorf("failed to get oauth flow: %w", result.Error)
 	}
-	return &session, nil
+	return &flow, nil
 }
 
-// ClaimOauthUserSessionByState atomically claims a pending per-user OAuth session by its state token.
-// Returns nil if the session doesn't exist or has already been claimed by another request.
-func (s *RDBConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
-	var session tables.TableOauthUserSession
-	result := s.DB().WithContext(ctx).Where("state = ? AND status = ?", state, "pending").First(&session)
+// GetOauthUserSessionByState is a non-mutating lookup by state token, any
+// status or flow_mode. Used by callback-error handling to classify and mark
+// a flow failed without consuming it the way Claim*ByState does.
+func (s *RDBConfigStore) GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	var flow tables.TableMCPOauthFlow
+	result := s.DB().WithContext(ctx).Where("state = ?", state).First(&flow)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to claim oauth user session by state: %w", result.Error)
+		return nil, fmt.Errorf("failed to get oauth flow by state: %w", result.Error)
 	}
-	// Atomically transition from "pending" to "claiming" to prevent concurrent claims
-	updateResult := s.DB().WithContext(ctx).Model(&tables.TableOauthUserSession{}).
-		Where("id = ? AND status = ?", session.ID, "pending").
+	return &flow, nil
+}
+
+// ClaimOauthUserSessionByState atomically claims a pending per-identity flow
+// row by its state token. Scoped to flow_mode IN ('user','vk','session') so
+// it can never claim the flow_mode='admin' row ClaimOauthFlowByState is
+// scoped to — the two partition mcp_oauth_flows by flow_mode, so a given
+// state can only ever satisfy one of them. Returns nil if the row doesn't
+// exist, doesn't match this mode partition, or has already been claimed by
+// another request.
+func (s *RDBConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	return s.claimOauthFlowByStateAndModes(ctx, state, perUserOauthFlowModes)
+}
+
+// ClaimOauthFlowByState is ClaimOauthUserSessionByState's admin-mode
+// counterpart, atomically claiming a pending flow_mode='admin' row by state.
+// Covers both the one-time shared-client production authorize and a
+// per-user client's admin bootstrap-test authorize — the two are
+// indistinguishable at this layer (see the FlowMode field comment on
+// TableMCPOauthFlow).
+func (s *RDBConfigStore) ClaimOauthFlowByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	return s.claimOauthFlowByStateAndModes(ctx, state, []string{"admin"})
+}
+
+// claimOauthFlowByStateAndModes is the shared atomic-claim implementation
+// behind ClaimOauthUserSessionByState and ClaimOauthFlowByState: look up the
+// pending row matching state AND flow_mode IN modes, then atomically
+// transition it from "pending" to "claiming" so a concurrent duplicate
+// callback can't also grab it.
+func (s *RDBConfigStore) claimOauthFlowByStateAndModes(ctx context.Context, state string, modes []string) (*tables.TableMCPOauthFlow, error) {
+	// Claim first, read second — not the other way around. A prior
+	// read-then-update shape (SELECT the pending row, then UPDATE by id+
+	// status) left a window where a concurrent reauth (InitiateUserOAuthFlow)
+	// could rewrite the same still-pending row's State/OauthConfigID/
+	// CodeVerifier between the two: the UPDATE would still match (same id,
+	// still 'pending' at that instant) and this method would return the
+	// SELECT's now-stale field values instead of what the row actually holds.
+	// Doing the transition atomically in one UPDATE keyed on (state, status)
+	// closes that window: it can only succeed against the exact row this
+	// state token names, in whatever state it was in at that instant.
+	updateResult := s.DB().WithContext(ctx).Model(&tables.TableMCPOauthFlow{}).
+		Where("state = ? AND status = ? AND flow_mode IN ?", state, "pending", modes).
 		Update("status", "claiming")
 	if updateResult.Error != nil {
-		return nil, fmt.Errorf("failed to claim oauth user session: %w", updateResult.Error)
+		return nil, fmt.Errorf("failed to claim oauth flow: %w", updateResult.Error)
 	}
 	if updateResult.RowsAffected == 0 {
-		return nil, nil // Another request already claimed this session
+		return nil, nil // No matching pending flow, or another request already claimed it.
 	}
-	session.Status = "claiming"
-	return &session, nil
+	// Safe to read fresh now: state is enforced unique at the DB level (see
+	// TableMCPOauthFlow.State's doc comment), and the row is already
+	// status='claiming', so InitiateUserOAuthFlow's pending-only reuse guard
+	// can no longer rewrite it out from under us.
+	var flow tables.TableMCPOauthFlow
+	if err := s.DB().WithContext(ctx).Where("state = ? AND status = ?", state, "claiming").First(&flow).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to load claimed oauth flow: %w", err)
+	}
+	return &flow, nil
 }
 
 // GetOauthUserSessionByModeIdentityAndMCPClient returns the single flow row
 // bound to (mode, identity, mcp_client_id). This is the canonical lookup at
 // flow-init time: there's exactly one flow row per binding, and reauth always
-// updates it in place rather than inserting a new one.
+// updates it in place rather than inserting a new one. mode is always one of
+// the per-identity modes here (the admin flow has no identity binding to
+// look up by — every InitiateOAuthFlow call mints a fresh row instead).
 //
 // identity per mode: AuthModeUser=user_id, AuthModeVK=virtual_key_id,
 // AuthModeSession=raw session token (hashed for the lookup column).
-func (s *RDBConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserSession, error) {
+func (s *RDBConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthFlow, error) {
 	if strings.TrimSpace(identity) == "" || strings.TrimSpace(mcpClientID) == "" {
 		return nil, nil
 	}
@@ -6627,30 +6706,30 @@ func (s *RDBConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx conte
 	default:
 		return nil, fmt.Errorf("unknown auth mode: %s", mode)
 	}
-	var session tables.TableOauthUserSession
-	if err := q.First(&session).Error; err != nil {
+	var flow tables.TableMCPOauthFlow
+	if err := q.First(&flow).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get oauth user session (mode=%s): %w", mode, err)
+		return nil, fmt.Errorf("failed to get oauth flow (mode=%s): %w", mode, err)
 	}
-	return &session, nil
+	return &flow, nil
 }
 
-// CreateOauthUserSession creates a new per-user OAuth session
-func (s *RDBConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+// CreateOauthUserSession creates a new flow row (any flow_mode, including 'admin').
+func (s *RDBConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error {
 	result := s.DB().WithContext(ctx).Create(session)
 	if result.Error != nil {
-		return fmt.Errorf("failed to create oauth user session: %w", result.Error)
+		return fmt.Errorf("failed to create oauth flow: %w", result.Error)
 	}
 	return nil
 }
 
-// UpdateOauthUserSession updates an existing per-user OAuth session
-func (s *RDBConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+// UpdateOauthUserSession updates an existing flow row in place.
+func (s *RDBConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error {
 	result := s.DB().WithContext(ctx).Save(session)
 	if result.Error != nil {
-		return fmt.Errorf("failed to update oauth user session: %w", result.Error)
+		return fmt.Errorf("failed to update oauth flow: %w", result.Error)
 	}
 	return nil
 }
@@ -6755,18 +6834,20 @@ func (s *RDBConfigStore) DeleteOauthUserSession(ctx context.Context, id string) 
 	if id == "" {
 		return nil
 	}
-	if err := s.DB().WithContext(ctx).Where("id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
-		return fmt.Errorf("failed to delete oauth user session %s: %w", id, err)
+	if err := s.DB().WithContext(ctx).Where("id = ?", id).Delete(&tables.TableMCPOauthFlow{}).Error; err != nil {
+		return fmt.Errorf("failed to delete oauth flow %s: %w", id, err)
 	}
 	return nil
 }
 
-// DeleteOauthUserSessionsByModeIdentityAndMCPClient hard-deletes any oauth_user_sessions
-// (pending or completed flow) rows matching the given identity column + MCP client.
+// DeleteOauthUserSessionsByModeIdentityAndMCPClient hard-deletes any flow
+// (pending or completed) rows matching the given identity column + MCP client.
 // Used by revoke so a subsequent OAuth init for the same identity starts from a clean
 // slate instead of upserting the stale row (session mode) or accumulating dead flow
 // rows over time (vk/user modes, whose flow rows have random server-generated
 // session tokens and therefore never get reused, but linger as 'authorized').
+// mode is always a per-identity mode here — an admin flow has no identity
+// binding to match against, so the switch below has no 'admin' case.
 //
 // identity meaning per mode:
 //   - AuthModeUser:    user_id
@@ -6787,8 +6868,8 @@ func (s *RDBConfigStore) DeleteOauthUserSessionsByModeIdentityAndMCPClient(ctx c
 	default:
 		return fmt.Errorf("unknown auth mode: %s", mode)
 	}
-	if err := q.Delete(&tables.TableOauthUserSession{}).Error; err != nil {
-		return fmt.Errorf("failed to delete oauth user sessions (mode=%s): %w", mode, err)
+	if err := q.Delete(&tables.TableMCPOauthFlow{}).Error; err != nil {
+		return fmt.Errorf("failed to delete oauth flows (mode=%s): %w", mode, err)
 	}
 	return nil
 }
@@ -6896,37 +6977,48 @@ func (s *RDBConfigStore) ListOauthUserTokens(ctx context.Context, params MCPSess
 	return tokens, nil
 }
 
-// ListPendingOauthUserSessions returns pending OAuth flow rows matching params
-// whose expiry is in the future. Companion to ListOauthUserTokens.
-func (s *RDBConfigStore) ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error) {
-	query := s.ScopedDB(ctx).Model(&tables.TableOauthUserSession{}).
-		Where("oauth_user_sessions.status = ? AND oauth_user_sessions.expires_at > ?", "pending", time.Now())
+// ListPendingOauthUserSessions returns pending per-identity OAuth flow rows
+// matching params whose expiry is in the future. Companion to
+// ListOauthUserTokens. Always excludes flow_mode='admin' so an admin-mode
+// flow row (the shared client's production authorize, or a per-user
+// client's bootstrap-test authorize) never leaks into the per-identity
+// sessions UI — mirrors ListOauthUserTokens' auth_mode='shared' exclusion.
+func (s *RDBConfigStore) ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPOauthFlow, error) {
+	query := s.ScopedDB(ctx).Model(&tables.TableMCPOauthFlow{}).
+		Where("mcp_oauth_flows.status = ? AND mcp_oauth_flows.expires_at > ?", "pending", time.Now()).
+		Where("mcp_oauth_flows.flow_mode IN ?", perUserOauthFlowModes)
 	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
-		table:          "oauth_user_sessions",
+		table:          "mcp_oauth_flows",
 		authModeColumn: "flow_mode",
 	})
-	var sessions []tables.TableOauthUserSession
+	var flows []tables.TableMCPOauthFlow
 	if err := query.
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Order("oauth_user_sessions.created_at DESC").
-		Find(&sessions).Error; err != nil {
-		return nil, fmt.Errorf("failed to list pending oauth user sessions: %w", err)
+		Order("mcp_oauth_flows.created_at DESC").
+		Find(&flows).Error; err != nil {
+		return nil, fmt.Errorf("failed to list pending oauth flows: %w", err)
 	}
-	return sessions, nil
+	return flows, nil
 }
 
 // DeleteExpiredOauthUserSessions hard-deletes pending and claiming OAuth flow
 // rows whose ExpiresAt has passed. Including 'claiming' covers callbacks that
-// died after ClaimOauthUserSessionByState flipped the status — otherwise that
-// row outlives its expiry and any new flow init for the same (mode, identity,
-// mcp_client) binding keeps seeing the dead row.
+// died after a Claim*ByState call flipped the status — otherwise that row
+// outlives its expiry and any new flow init for the same (mode, identity,
+// mcp_client) binding keeps seeing the dead row. Deliberately unfiltered by
+// flow_mode, unlike the per-identity-only methods above: a stuck admin flow
+// (e.g. an abandoned shared-client authorize) is exactly as safe and useful
+// to sweep on expiry as a per-identity one — there's no analogous risk here
+// to the one auth_mode='shared' orphan-sweep guard exists for on the token
+// table, since this method only ever deletes rows already in a dead-end
+// pending/claiming state, never a live credential.
 func (s *RDBConfigStore) DeleteExpiredOauthUserSessions(ctx context.Context) (int64, error) {
 	result := s.DB().WithContext(ctx).
 		Where("expires_at < ? AND status IN ?", time.Now(), []string{"pending", "claiming"}).
-		Delete(&tables.TableOauthUserSession{})
+		Delete(&tables.TableMCPOauthFlow{})
 	if result.Error != nil {
-		return 0, fmt.Errorf("failed to delete expired oauth user sessions: %w", result.Error)
+		return 0, fmt.Errorf("failed to delete expired oauth flows: %w", result.Error)
 	}
 	return result.RowsAffected, nil
 }
@@ -7429,7 +7521,7 @@ func reconcileVKDirectTokensDB(tx *gorm.DB, vkID string) error {
 	if len(allowedClientIDs) > 0 {
 		flowsQ = flowsQ.Where("mcp_client_id NOT IN ?", allowedClientIDs)
 	}
-	if err := flowsQ.Delete(&tables.TableOauthUserSession{}).Error; err != nil {
+	if err := flowsQ.Delete(&tables.TableMCPOauthFlow{}).Error; err != nil {
 		return fmt.Errorf("delete vk-keyed flow rows for vk %s: %w", vkID, err)
 	}
 	return nil
@@ -7477,20 +7569,25 @@ func reconcileVKDirectHeaderRowsDB(tx *gorm.DB, vkID string) error {
 }
 
 // readVKsHoldingOauthCredsForMCP returns the distinct virtual_key_ids
-// with an active or pending OAuth row (token or session) for the given
+// with an active or pending OAuth row (token or flow) for the given
 // MCP client. Used by ReconcileOauthAfterMCPChange to know which VKs
 // need re-evaluation. The token-side query reads mcp_oauth_tokens (not
 // oauth_user_tokens — that table no longer takes writes) and is scoped to
 // auth_mode='vk' as defense-in-depth: a shared row can never carry a
-// virtual_key_id, but the filter keeps that true by construction.
+// virtual_key_id, but the filter keeps that true by construction. The
+// flow-side query reads mcp_oauth_flows (not oauth_user_sessions — that
+// table no longer takes writes) with the same flow_mode='vk' defense-in-depth
+// filter: an admin-mode flow row never populates virtual_key_id either, so
+// this can't match one by construction, but the filter keeps that true
+// rather than relying on the column always being empty by coincidence.
 func readVKsHoldingOauthCredsForMCP(tx *gorm.DB, mcpClientID string) ([]string, error) {
 	var vkIDs []string
 	if err := tx.Raw(`
 		SELECT DISTINCT virtual_key_id FROM mcp_oauth_tokens
 		WHERE mcp_client_id = ? AND auth_mode = 'vk' AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''
 		UNION
-		SELECT DISTINCT virtual_key_id FROM oauth_user_sessions
-		WHERE mcp_client_id = ? AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''
+		SELECT DISTINCT virtual_key_id FROM mcp_oauth_flows
+		WHERE mcp_client_id = ? AND flow_mode = 'vk' AND virtual_key_id IS NOT NULL AND virtual_key_id <> ''
 	`, mcpClientID, mcpClientID).Scan(&vkIDs).Error; err != nil {
 		return nil, fmt.Errorf("read VK owners of OAuth creds for mcp %s: %w", mcpClientID, err)
 	}

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -63,8 +63,8 @@ func seedMCPSessionsFixture(t *testing.T, store *RDBConfigStore) {
 	require.NoError(t, store.DB().WithContext(ctx).Create(tok2).Error)
 	require.NoError(t, store.DB().WithContext(ctx).Create(tok3).Error)
 
-	// Pending OAuth session
-	sess := &tables.TableOauthUserSession{
+	// Pending OAuth flow
+	sess := &tables.TableMCPOauthFlow{
 		ID: "sess-pending", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
 		FlowMode: "user", Status: "pending", UserID: &uid,
 		ExpiresAt: time.Now().Add(time.Hour),

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -74,11 +74,14 @@ func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id
 			ExpiresAt: &past, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}).Error)
 	}
+	// state is accepted for readability at call sites (mirrors each fixture's
+	// intent, e.g. "state-live") but no longer stored — state moved off
+	// TableOauthConfig onto TableMCPOauthFlow and isn't part of what this
+	// fixture set (GetExpiringOauthTokens) exercises.
 	mkConfig = func(id, tokenID, status, state string) {
 		require.NoError(t, s.DB().Create(&tables.TableOauthConfig{
-			ID: id, RedirectURI: "http://127.0.0.1/cb", State: state, Status: status,
+			ID: id, RedirectURI: "http://127.0.0.1/cb", Status: status,
 			TokenID: &tokenID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
-			ExpiresAt: time.Now().Add(time.Hour),
 		}).Error)
 	}
 	mkClient = func(name, oauthConfigID string, disabled bool) {

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -58,6 +58,7 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TableOauthUserToken{},
 		&tables.TableOauthToken{},
 		&tables.TableMCPOauthToken{},
+		&tables.TableMCPOauthFlow{},
 		&tables.TableMCPPerUserHeaderCredential{},
 		&tables.TableMCPPerUserHeaderFlow{},
 		&tables.TableOAuth2RefreshToken{},

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -491,10 +491,9 @@ type ConfigStore interface {
 	// OAuth config CRUD
 	GetOauthConfigByID(ctx context.Context, id string) (*tables.TableOauthConfig, error)
 	GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error)
-	GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error)
 	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
-	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
+	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error
 
 	// OAuth token CRUD. TableMCPOauthToken now holds every holder of an MCP
 	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session'), not
@@ -514,20 +513,43 @@ type ConfigStore interface {
 	// proactive sweep is a deliberate later change, not a side effect of
 	// this table merge.
 	GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error)
-	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
+	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthToken(ctx context.Context, id string) error
+	// DeleteOauthTokensByConfigAndMode deletes every token row for a given
+	// (oauth_config_id, auth_mode) pair. Used by the shared-OAuth callback
+	// to clear the prior credential before inserting its replacement.
+	DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error
 
-	// Per-user OAuth session CRUD
-	GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error)
-	ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error)
+	// Flow-row CRUD (mcp_oauth_flows / TableMCPOauthFlow). Method names keep
+	// their historical "OauthUserSession" naming even though the backing
+	// table now also carries FlowMode='admin' rows — same convention PR1
+	// used for the token-table merge (GetOauthTokenByID etc. kept their
+	// names when retargeted to the unified table).
+	GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error)
+	// GetOauthUserSessionByState is a non-mutating lookup by state, any
+	// status or flow_mode. Unlike ClaimOauthUserSessionByState /
+	// ClaimOauthFlowByState it does not gate on status='pending' or flip it
+	// to 'claiming' — used by callback-error handling, which only needs to
+	// classify the flow and mark it failed, not consume it.
+	GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error)
+	// ClaimOauthUserSessionByState atomically claims a pending per-identity
+	// flow row (flow_mode IN ('user','vk','session')) by its state token.
+	// Scoped away from flow_mode='admin' so it can never claim the row an
+	// in-flight ClaimOauthFlowByState call is targeting on the same table.
+	ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error)
+	// ClaimOauthFlowByState is ClaimOauthUserSessionByState's admin-mode
+	// counterpart: atomically claims a pending flow_mode='admin' row by
+	// state. The two claim methods partition the table by flow_mode, so a
+	// given state can only ever be claimed by one of them.
+	ClaimOauthFlowByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error)
 	// GetOauthUserSessionByModeIdentityAndMCPClient returns the canonical flow
 	// row for an (identity, mcp_client) binding. Used at flow-init time as the
 	// single source of truth: reauth updates this row in place rather than
 	// inserting a new one. Returns (nil, nil) when no row exists.
-	GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserSession, error)
-	CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
-	UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
+	GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthFlow, error)
+	CreateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error
+	UpdateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error
 
 	// Per-user OAuth token CRUD. These operate on the same TableMCPOauthToken /
 	// oauth_tokens rows as the shared-token methods above, scoped to
@@ -591,9 +613,12 @@ type ConfigStore interface {
 	ListOauthUserTokens(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPOauthToken, error)
 	// ListPendingOauthUserSessions returns pending OAuth flow rows matching
 	// the supplied filters. Companion to ListOauthUserTokens for the admin
-	// view. Always restricted to status='pending' AND expires_at > now;
-	// params.Statuses further narrows within that set.
-	ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error)
+	// view. Always restricted to status='pending' AND expires_at > now, and
+	// always excludes flow_mode='admin' — mirrors ListOauthUserTokens'
+	// auth_mode='shared' exclusion so an admin-mode flow row never leaks
+	// into the per-identity sessions UI. params.Statuses further narrows
+	// within that set.
+	ListPendingOauthUserSessions(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPOauthFlow, error)
 	// DeleteExpiredOauthUserSessions hard-deletes pending OAuth flow rows
 	// whose ExpiresAt has passed. Returns the number of rows removed.
 	DeleteExpiredOauthUserSessions(ctx context.Context) (int64, error)

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -39,6 +39,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&SessionsTable{},
 		&TableOauthConfig{},
 		&TableOauthToken{},
+		&TableMCPOauthFlow{},
 		&TableVectorStoreConfig{},
 		&TableWebhookEndpoint{},
 	)
@@ -503,9 +504,6 @@ func TestTableOauthConfig_EncryptDecrypt(t *testing.T) {
 		ClientID:     schemas.NewSecretVar("client-id-public"),
 		ClientSecret: schemas.NewSecretVar("super-secret-client-secret"),
 		RedirectURI:  "https://example.com/callback",
-		State:        "csrf-state-token",
-		CodeVerifier: "pkce-code-verifier-secret",
-		ExpiresAt:    time.Now().Add(15 * time.Minute),
 	}
 
 	require.NoError(t, db.Create(config).Error)
@@ -513,12 +511,10 @@ func TestTableOauthConfig_EncryptDecrypt(t *testing.T) {
 	raw := rawRow(t, db, "oauth_configs", "oauth-cfg-1")
 	assert.Equal(t, "encrypted", raw["encryption_status"])
 	assert.NotEqual(t, "super-secret-client-secret", raw["client_secret"])
-	assert.NotEqual(t, "pkce-code-verifier-secret", raw["code_verifier"])
 
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-1").Error)
 	assert.Equal(t, "super-secret-client-secret", found.ClientSecret.GetValue())
-	assert.Equal(t, "pkce-code-verifier-secret", found.CodeVerifier)
 	// Non-sensitive fields should be unchanged
 	assert.Equal(t, "client-id-public", found.ClientID.GetValue())
 	assert.Equal(t, "https://example.com/callback", found.RedirectURI)
@@ -530,8 +526,6 @@ func TestTableOauthConfig_EmptySecret_NoError(t *testing.T) {
 	config := &TableOauthConfig{
 		ID:          "oauth-cfg-empty",
 		RedirectURI: "https://example.com/callback",
-		State:       "csrf-state-2",
-		ExpiresAt:   time.Now().Add(15 * time.Minute),
 	}
 
 	require.NoError(t, db.Create(config).Error)
@@ -539,6 +533,54 @@ func TestTableOauthConfig_EmptySecret_NoError(t *testing.T) {
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-empty").Error)
 	assert.Equal(t, "", found.ClientSecret.GetValue())
+}
+
+// TestTableMCPOauthFlow_EncryptDecrypt covers the CodeVerifier encrypt/decrypt
+// round trip that TestTableOauthConfig_EncryptDecrypt used to exercise before
+// PKCE fields moved off TableOauthConfig onto TableMCPOauthFlow (see that
+// migration).
+func TestTableMCPOauthFlow_EncryptDecrypt(t *testing.T) {
+	db := setupTestDB(t)
+
+	flow := &TableMCPOauthFlow{
+		ID:            "flow-1",
+		MCPClientID:   "mcp-1",
+		OauthConfigID: "oauth-cfg-1",
+		State:         "csrf-state-token",
+		CodeVerifier:  "pkce-code-verifier-secret",
+		FlowMode:      "admin",
+		ExpiresAt:     time.Now().Add(15 * time.Minute),
+	}
+
+	require.NoError(t, db.Create(flow).Error)
+
+	raw := rawRow(t, db, "mcp_oauth_flows", "flow-1")
+	assert.Equal(t, "encrypted", raw["encryption_status"])
+	assert.NotEqual(t, "pkce-code-verifier-secret", raw["code_verifier"])
+
+	var found TableMCPOauthFlow
+	require.NoError(t, db.First(&found, "id = ?", "flow-1").Error)
+	assert.Equal(t, "pkce-code-verifier-secret", found.CodeVerifier)
+	// Non-sensitive fields should be unchanged
+	assert.Equal(t, "csrf-state-token", found.State)
+}
+
+func TestTableMCPOauthFlow_EmptyCodeVerifier_NoError(t *testing.T) {
+	db := setupTestDB(t)
+
+	flow := &TableMCPOauthFlow{
+		ID:            "flow-empty",
+		MCPClientID:   "mcp-1",
+		OauthConfigID: "oauth-cfg-1",
+		State:         "csrf-state-empty",
+		FlowMode:      "admin",
+		ExpiresAt:     time.Now().Add(15 * time.Minute),
+	}
+
+	require.NoError(t, db.Create(flow).Error)
+
+	var found TableMCPOauthFlow
+	require.NoError(t, db.First(&found, "id = ?", "flow-empty").Error)
 	assert.Equal(t, "", found.CodeVerifier)
 }
 
@@ -958,8 +1000,6 @@ func TestTableOauthConfig_UpdatePreservesDecryption(t *testing.T) {
 		ID:           "oauth-cfg-update",
 		ClientSecret: schemas.NewSecretVar("original-secret"),
 		RedirectURI:  "https://example.com/callback",
-		State:        "csrf-update",
-		ExpiresAt:    time.Now().Add(15 * time.Minute),
 	}
 	require.NoError(t, db.Create(config).Error)
 
@@ -1416,11 +1456,8 @@ func TestTableOauthConfig_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	cfg := &TableOauthConfig{
 		ID:           "cfg-dis-1",
 		ClientSecret: schemas.NewSecretVar("client-secret-plain"),
-		CodeVerifier: "verifier-plain",
 		RedirectURI:  "https://example.com/cb",
-		State:        "csrf-state",
 		Status:       "pending",
-		ExpiresAt:    time.Now().Add(time.Hour),
 	}
 
 	require.NoError(t, db.Create(cfg).Error)
@@ -1430,12 +1467,39 @@ func TestTableOauthConfig_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	db.Table("oauth_configs").Where("id = ?", "cfg-dis-1").Take(&raw)
 	assert.Equal(t, "plain_text", raw["encryption_status"])
 	assert.Equal(t, "client-secret-plain", raw["client_secret"])
-	assert.Equal(t, "verifier-plain", raw["code_verifier"])
 
 	// GORM read should return same plaintext
 	var found TableOauthConfig
 	require.NoError(t, db.Where("id = ?", "cfg-dis-1").First(&found).Error)
 	assert.Equal(t, "client-secret-plain", found.ClientSecret.GetValue())
+}
+
+func TestTableMCPOauthFlow_EncryptionDisabled_StoresPlaintext(t *testing.T) {
+	disableEncryption(t)
+	db := setupTestDB(t)
+
+	flow := &TableMCPOauthFlow{
+		ID:            "flow-dis-1",
+		MCPClientID:   "mcp-1",
+		OauthConfigID: "oauth-cfg-1",
+		State:         "csrf-state",
+		CodeVerifier:  "verifier-plain",
+		FlowMode:      "admin",
+		Status:        "pending",
+		ExpiresAt:     time.Now().Add(time.Hour),
+	}
+
+	require.NoError(t, db.Create(flow).Error)
+
+	// Raw DB should have plaintext
+	var raw map[string]any
+	db.Table("mcp_oauth_flows").Where("id = ?", "flow-dis-1").Take(&raw)
+	assert.Equal(t, "plain_text", raw["encryption_status"])
+	assert.Equal(t, "verifier-plain", raw["code_verifier"])
+
+	// GORM read should return same plaintext
+	var found TableMCPOauthFlow
+	require.NoError(t, db.Where("id = ?", "flow-dis-1").First(&found).Error)
 	assert.Equal(t, "verifier-plain", found.CodeVerifier)
 }
 

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -9,30 +9,32 @@ import (
 	"gorm.io/gorm"
 )
 
-// TableOauthConfig represents an OAuth configuration in the database
-// This stores the OAuth client configuration and flow state
+// TableOauthConfig represents an OAuth configuration in the database. Past
+// the bootstrap flow, this is a pure registration/credential template row —
+// client_id/client_secret/endpoints/scopes plus the bootstrap lifecycle
+// Status ("pending"/"authorized"/"failed"). CSRF state and PKCE fields
+// (state, code_verifier, code_challenge) and the flow's own expiry live on
+// TableMCPOauthFlow instead — one config row is a durable, reusable
+// credential template, while a flow row is scoped to a single authorize
+// attempt and is disposed of once that attempt completes.
 type TableOauthConfig struct {
-	ID                  string             `gorm:"type:varchar(255);primaryKey" json:"id"`          // UUID
-	ClientID            *schemas.SecretVar `gorm:"type:varchar(512)" json:"client_id"`              // OAuth provider's client ID (optional for public clients)
-	ClientSecret        *schemas.SecretVar `gorm:"type:text" json:"-"`                              // Encrypted OAuth client secret (optional for public clients)
-	AuthorizeURL        string             `gorm:"type:text" json:"authorize_url"`                  // Provider's authorization endpoint (optional, can be discovered)
-	TokenURL            string             `gorm:"type:text" json:"token_url"`                      // Provider's token endpoint (optional, can be discovered)
-	RegistrationURL     *string            `gorm:"type:text" json:"registration_url,omitempty"`     // Provider's dynamic registration endpoint (optional, can be discovered)
-	RedirectURI         string             `gorm:"type:text;not null" json:"redirect_uri"`          // Callback URL
-	Scopes              string             `gorm:"type:text" json:"scopes"`                         // JSON array of scopes (optional, can be discovered)
-	State               string             `gorm:"type:varchar(255);uniqueIndex;not null" json:"-"` // CSRF state token
-	CodeVerifier        string             `gorm:"type:text" json:"-"`                              // PKCE code verifier (generated, kept secret)
-	CodeChallenge       string             `gorm:"type:varchar(255)" json:"code_challenge"`         // PKCE code challenge (sent to provider)
-	Status              string             `gorm:"type:varchar(50);not null;index" json:"status"`   // "pending", "authorized", "failed", "expired", "revoked"
-	TokenID             *string            `gorm:"type:varchar(255);index" json:"token_id"`         // Foreign key to mcp_oauth_tokens.ID (set after callback)
-	ServerURL           string             `gorm:"type:text" json:"server_url"`                     // MCP server URL for OAuth discovery
-	Resource            string             `gorm:"type:text" json:"resource,omitempty"`             // OAuth resource indicator (RFC 8707), typically the MCP server URL
-	UseDiscovery        bool               `gorm:"default:false" json:"use_discovery"`              // Flag to enable OAuth discovery
-	MCPClientConfigJSON *string            `gorm:"type:text" json:"-"`                              // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
+	ID                  string             `gorm:"type:varchar(255);primaryKey" json:"id"`         // UUID
+	ClientID            *schemas.SecretVar `gorm:"type:varchar(512)" json:"client_id"`             // OAuth provider's client ID (optional for public clients)
+	ClientSecret        *schemas.SecretVar `gorm:"type:text" json:"-"`                             // Encrypted OAuth client secret (optional for public clients)
+	AuthorizeURL        string             `gorm:"type:text" json:"authorize_url"`                 // Provider's authorization endpoint (optional, can be discovered)
+	TokenURL            string             `gorm:"type:text" json:"token_url"`                     // Provider's token endpoint (optional, can be discovered)
+	RegistrationURL     *string            `gorm:"type:text" json:"registration_url,omitempty"`    // Provider's dynamic registration endpoint (optional, can be discovered)
+	RedirectURI         string             `gorm:"type:text;not null" json:"redirect_uri"`         // Callback URL
+	Scopes              string             `gorm:"type:text" json:"scopes"`                        // JSON array of scopes (optional, can be discovered)
+	Status              string             `gorm:"type:varchar(50);not null;index" json:"status"`  // "pending", "authorized", "failed", "expired", "revoked"
+	TokenID             *string            `gorm:"type:varchar(255);index" json:"token_id"`        // Foreign key to mcp_oauth_tokens.ID (set after callback)
+	ServerURL           string             `gorm:"type:text" json:"server_url"`                    // MCP server URL for OAuth discovery
+	Resource            string             `gorm:"type:text" json:"resource,omitempty"`            // OAuth resource indicator (RFC 8707), typically the MCP server URL
+	UseDiscovery        bool               `gorm:"default:false" json:"use_discovery"`             // Flag to enable OAuth discovery
+	MCPClientConfigJSON *string            `gorm:"type:text" json:"-"`                             // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
 	EncryptionStatus    string             `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
 	CreatedAt           time.Time          `gorm:"index;not null" json:"created_at"`
 	UpdatedAt           time.Time          `gorm:"index;not null" json:"updated_at"`
-	ExpiresAt           time.Time          `gorm:"index;not null" json:"expires_at"` // State expiry (15 min)
 }
 
 // TableName sets the table name
@@ -48,20 +50,10 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 	}
 
 	if encrypt.IsEnabled() {
-		encrypted := false
 		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
 			if err := encryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 			}
-			encrypted = true
-		}
-		if c.CodeVerifier != "" {
-			if err := encryptString(&c.CodeVerifier); err != nil {
-				return fmt.Errorf("failed to encrypt oauth code verifier: %w", err)
-			}
-			encrypted = true
-		}
-		if encrypted {
 			c.EncryptionStatus = EncryptionStatusEncrypted
 		}
 	}
@@ -76,9 +68,6 @@ func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 			if err := decryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
 			}
-		}
-		if err := decryptString(&c.CodeVerifier); err != nil {
-			return fmt.Errorf("failed to decrypt oauth code verifier: %w", err)
 		}
 	}
 	return nil
@@ -257,11 +246,102 @@ func (t *TableMCPOauthToken) AfterFind(tx *gorm.DB) error {
 	return nil
 }
 
-// ---------- Per-User OAuth Tables ----------
+// TableMCPOauthFlow tracks a single in-flight OAuth authorize attempt — the
+// CSRF state token, PKCE verifier, originating identity, and expiry for the
+// duration of that attempt. Covers every flow kind that lands on the
+// /api/oauth/callback redirect_uri: per-identity flows ('user' | 'vk' |
+// 'session', formerly the entire contents of this table's predecessor) and
+// 'admin' flows (the one-time shared-client production authorize, and a
+// per-user client's admin bootstrap-test authorize — indistinguishable at
+// this layer; the keep-vs-discard-token decision downstream branches on the
+// MCP client's AuthType, not on anything here). A config row
+// (TableOauthConfig) is a durable, reusable credential template; a flow row
+// is scoped to one authorize attempt and is deleted once that attempt
+// reaches a terminal state.
+//
+// Lives in mcp_oauth_flows, a table created fresh by the migration that
+// introduced this struct — it does not alter or extend oauth_user_sessions,
+// this type's predecessor's table. See that migration for why the old table
+// is left in place unused.
+type TableMCPOauthFlow struct {
+	ID            string `gorm:"type:varchar(255);primaryKey" json:"id"`                  // Flow UUID
+	MCPClientID   string `gorm:"type:varchar(255);not null;index" json:"mcp_client_id"`   // Which MCP server this auth is for
+	OauthConfigID string `gorm:"type:varchar(255);not null;index" json:"oauth_config_id"` // Template OAuth config (holds client_id, token_url, etc.)
+	// State carries a plain (non-unique) index in the struct tag rather than
+	// uniqueIndex: the migration that creates this table needs to run its
+	// oauth_user_sessions backfill before a unique index on state exists (a
+	// gorm-tag-driven uniqueIndex would instead be created as part of
+	// CreateTable, ahead of the backfill) — see that migration for the
+	// ordering rationale. The real uniqueness is enforced there via a raw
+	// CREATE UNIQUE INDEX issued after the backfill completes.
+	State            string    `gorm:"type:varchar(255);index;not null" json:"-"`               // CSRF state token sent to OAuth provider
+	RedirectURI      string    `gorm:"type:text" json:"-"`                                      // Per-request redirect URI used in authorize step
+	CodeVerifier     string    `gorm:"type:text" json:"-"`                                      // PKCE code verifier (kept secret)
+	SessionID        string    `gorm:"type:varchar(255);index" json:"session_id,omitempty"`     // Session-mode identity: client-asserted x-bf-mcp-session-id. Empty for admin/vk/user mode rows. Stored plaintext (not a bearer credential; same trust model as a VK value).
+	VirtualKeyID     *string   `gorm:"type:varchar(255);index" json:"virtual_key_id"`           // VK identity (propagated to mcp_oauth_tokens)
+	UserID           *string   `gorm:"type:varchar(255);index" json:"user_id"`                  // User identity (propagated to mcp_oauth_tokens); populated only for user-mode rows, nil otherwise
+	FlowMode         string    `gorm:"type:varchar(20);not null;default:'vk'" json:"flow_mode"` // 'user' | 'vk' | 'session' | 'admin' — mirrors the eventual token row's AuthMode; immutable after creation; no DB-level CHECK constraint, validated at the application layer only (same reasoning as TableMCPOauthToken.AuthMode)
+	Status           string    `gorm:"type:varchar(50);not null;index" json:"status"`           // "pending", "authorized", "failed", "expired" (plus a transient "claiming" between an atomic claim-by-state and the token exchange it guards)
+	EncryptionStatus string    `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
+	ExpiresAt        time.Time `gorm:"index;not null" json:"expires_at"` // Flow expiration (15 min)
+	CreatedAt        time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"index;not null" json:"updated_at"`
+
+	// Display-only relations (no DB-level FK constraint; preloaded for
+	// sessions/admin UI). "-:migration" is load-bearing, not decorative — see
+	// the matching comment on TableMCPOauthToken.MCPClient/VirtualKey above
+	// for the full reasoning: a flow row is written before its MCP client row
+	// exists (the client is only persisted once the admin completes OAuth
+	// consent), and the oauth_user_sessions backfill this table's migration
+	// runs can carry the same orphaned-client-id hazard, so a real FK here
+	// would reject inserts a plain "constraint:-" doesn't reliably prevent.
+	MCPClient  *TableMCPClient  `gorm:"-:migration;foreignKey:MCPClientID;references:ClientID" json:"-"`
+	VirtualKey *TableVirtualKey `gorm:"-:migration;foreignKey:VirtualKeyID;references:ID" json:"-"`
+
+	// User mirrors TableOauthUserSession.User — see OauthUserSummary below.
+	User *OauthUserSummary `gorm:"-" json:"-"`
+}
+
+// TableName sets the table name
+func (TableMCPOauthFlow) TableName() string {
+	return "mcp_oauth_flows"
+}
+
+func (s *TableMCPOauthFlow) BeforeSave(tx *gorm.DB) error {
+	if s.Status == "" {
+		s.Status = "pending"
+	}
+	if encrypt.IsEnabled() {
+		if s.CodeVerifier != "" {
+			if err := encryptString(&s.CodeVerifier); err != nil {
+				return fmt.Errorf("failed to encrypt oauth flow code verifier: %w", err)
+			}
+		}
+		s.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	return nil
+}
+
+func (s *TableMCPOauthFlow) AfterFind(tx *gorm.DB) error {
+	if s.EncryptionStatus == EncryptionStatusEncrypted && s.CodeVerifier != "" {
+		if err := decryptString(&s.CodeVerifier); err != nil {
+			return fmt.Errorf("failed to decrypt oauth flow code verifier: %w", err)
+		}
+	}
+	return nil
+}
+
+// ---------- Per-User OAuth Tables (deprecated) ----------
 
 // TableOauthUserSession tracks pending per-user OAuth flows.
 // Each record maps an OAuth state token to a specific MCP client, allowing
 // the callback to associate the resulting tokens with the correct user session.
+//
+// Deprecated: no longer read or written by any application code as of the
+// TableMCPOauthFlow merge; this type exists only so the migration that
+// introduced TableMCPOauthFlow can reference its table (oauth_user_sessions)
+// via normal GORM model access. Both this type and its backing table will be
+// removed in the next major version.
 type TableOauthUserSession struct {
 	ID               string    `gorm:"type:varchar(255);primaryKey" json:"id"`                  // Session UUID
 	MCPClientID      string    `gorm:"type:varchar(255);not null;index" json:"mcp_client_id"`   // Which MCP server this auth is for

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/temptoken"
+	"gorm.io/gorm"
 )
 
 const (
@@ -316,8 +317,15 @@ func (p *OAuth2Provider) StorePendingMCPClient(oauthConfigID string, mcpClientCo
 	return nil
 }
 
-// GetPendingMCPClient retrieves an MCP client config by oauth_config_id
-// Returns nil if no pending config is found or if the oauth config has expired
+// GetPendingMCPClient retrieves an MCP client config by oauth_config_id.
+// Returns nil if no pending config is found. Unlike before PKCE/expiry
+// fields moved off TableOauthConfig, this no longer applies its own expiry
+// gate: the only caller (completeMCPClientOAuth) already requires
+// oauthConfig.Status=="authorized" before reaching this call, which is a
+// stronger, more truthful signal than a raw timestamp comparison — a config
+// row that reached "authorized" represents a real completed OAuth exchange
+// regardless of how much wall-clock time has passed since the bootstrap
+// stash was written.
 func (p *OAuth2Provider) GetPendingMCPClient(oauthConfigID string) (*schemas.MCPClientConfig, error) {
 	ctx := context.Background()
 
@@ -326,11 +334,6 @@ func (p *OAuth2Provider) GetPendingMCPClient(oauthConfigID string) (*schemas.MCP
 		return nil, fmt.Errorf("failed to get oauth config: %w", err)
 	}
 	if oauthConfig == nil {
-		return nil, nil
-	}
-
-	// Check if expired
-	if time.Now().After(oauthConfig.ExpiresAt) {
 		return nil, nil
 	}
 
@@ -344,36 +347,6 @@ func (p *OAuth2Provider) GetPendingMCPClient(oauthConfigID string) (*schemas.MCP
 	}
 
 	return &config, nil
-}
-
-// GetPendingMCPClientByState retrieves an MCP client config by OAuth state token
-// This is useful when the callback only has the state parameter
-func (p *OAuth2Provider) GetPendingMCPClientByState(state string) (*schemas.MCPClientConfig, string, error) {
-	ctx := context.Background()
-
-	oauthConfig, err := p.configStore.GetOauthConfigByState(ctx, state)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get oauth config by state: %w", err)
-	}
-	if oauthConfig == nil {
-		return nil, "", nil
-	}
-
-	// Check if expired
-	if time.Now().After(oauthConfig.ExpiresAt) {
-		return nil, "", nil
-	}
-
-	if oauthConfig.MCPClientConfigJSON == nil || *oauthConfig.MCPClientConfigJSON == "" {
-		return nil, oauthConfig.ID, nil
-	}
-
-	var config schemas.MCPClientConfig
-	if err := json.Unmarshal([]byte(*oauthConfig.MCPClientConfigJSON), &config); err != nil {
-		return nil, oauthConfig.ID, fmt.Errorf("failed to unmarshal MCP client config: %w", err)
-	}
-
-	return &config, oauthConfig.ID, nil
 }
 
 // RemovePendingMCPClient clears the pending MCP client config from the oauth config
@@ -529,7 +502,14 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		return nil, fmt.Errorf("failed to serialize scopes: %w", err)
 	}
 
-	// Create oauth_config record (using dynamically registered or user-provided client_id)
+	// Create oauth_config record (using dynamically registered or user-provided client_id).
+	// This row is a pure registration/credential template past this point —
+	// State/CodeVerifier/RedirectURI/ExpiresAt live on the flow row created
+	// below instead (FlowMode='admin'), not here. CodeChallenge is used only
+	// to build the authorize URL below and is never persisted at all — the
+	// per-user flow (InitiateUserOAuthFlow) has never stored it either, since
+	// it's recomputed deterministically from CodeVerifier when needed again
+	// (see BuildUpstreamAuthorizeURL).
 	expiresAt := time.Now().Add(15 * time.Minute)
 	oauthConfigRecord := &tables.TableOauthConfig{
 		ID:              oauthConfigID,
@@ -541,17 +521,53 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		RedirectURI:     config.RedirectURI,
 		Scopes:          string(scopesJSON),
 		Resource:        resource,
-		State:           state,
-		CodeVerifier:    codeVerifier,
-		CodeChallenge:   codeChallenge,
 		Status:          "pending",
 		ServerURL:       config.ServerURL,
 		UseDiscovery:    config.UseDiscovery,
-		ExpiresAt:       expiresAt,
 	}
 
-	if err := p.configStore.CreateOauthConfig(ctx, oauthConfigRecord); err != nil {
-		return nil, fmt.Errorf("failed to create oauth config: %w", err)
+	// MCPClientID: best-effort, same lookup CompleteOAuthFlow uses at
+	// callback time (see the comment there). Nothing has linked
+	// config_mcp_clients.oauth_config_id to this row yet at this point in
+	// either caller (the link is established after this function returns —
+	// initiateMCPClientVerification for a re-authorizing client, or the
+	// StorePendingMCPClient bootstrap path for one still being created), so
+	// this is expected to resolve empty in the common case — same
+	// tolerated-empty shape as TableMCPOauthToken's MCPClientID (see its
+	// field comment).
+	//
+	// The config row and its flow row are created in one transaction: before
+	// PKCE/state moved onto a separate flow row, this was a single INSERT and
+	// therefore atomic by construction. A partial failure here (config
+	// committed, flow row not) would otherwise leak a permanently orphaned
+	// 'pending' oauth_configs row — nothing sweeps stale configs the way
+	// DeleteExpiredOauthUserSessions sweeps stale flows.
+	flowRow := &tables.TableMCPOauthFlow{
+		ID:            uuid.New().String(),
+		OauthConfigID: oauthConfigID,
+		State:         state,
+		RedirectURI:   config.RedirectURI,
+		CodeVerifier:  codeVerifier,
+		FlowMode:      "admin",
+		Status:        "pending",
+		ExpiresAt:     expiresAt,
+	}
+	if err := p.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		if err := tx.Create(oauthConfigRecord).Error; err != nil {
+			return fmt.Errorf("failed to create oauth config: %w", err)
+		}
+		var mcpClient tables.TableMCPClient
+		if err := tx.Where("oauth_config_id = ?", oauthConfigID).First(&mcpClient).Error; err == nil {
+			flowRow.MCPClientID = mcpClient.ClientID
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to look up mcp client for oauth config: %w", err)
+		}
+		if err := tx.Create(flowRow).Error; err != nil {
+			return fmt.Errorf("failed to create oauth flow: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	// Resolve env var reference to actual value for use in the authorize URL.
@@ -580,22 +596,43 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 }
 
 // CompleteOAuthFlow handles the OAuth callback and exchanges code for tokens
-// Supports PKCE verification
+// Supports PKCE verification. Handles the admin-mode flow — the shared
+// client's production authorize and a per-user client's bootstrap-test
+// authorize alike (see the FlowMode field comment on TableMCPOauthFlow).
 func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code string) error {
-	// Lookup oauth_config by state
-	oauthConfig, err := p.configStore.GetOauthConfigByState(ctx, state)
+	// Atomically claim the admin-mode flow row by state. Scoped to
+	// FlowMode='admin' so this can never claim a per-identity flow row out
+	// from under CompleteUserOAuthFlow's own claim on the same table (see
+	// ClaimOauthFlowByState).
+	flow, err := p.configStore.ClaimOauthFlowByState(ctx, state)
 	if err != nil {
-		return fmt.Errorf("failed to lookup oauth config: %w", err)
+		return fmt.Errorf("failed to claim oauth flow: %w", err)
 	}
-	if oauthConfig == nil {
+	if flow == nil {
 		return fmt.Errorf("invalid state token")
 	}
 
+	oauthConfig, err := p.configStore.GetOauthConfigByID(ctx, flow.OauthConfigID)
+	if err != nil {
+		p.cleanupFlow(ctx, flow.ID)
+		return fmt.Errorf("failed to lookup oauth config: %w", err)
+	}
+	if oauthConfig == nil {
+		p.cleanupFlow(ctx, flow.ID)
+		return fmt.Errorf("oauth config not found for flow %s", flow.ID)
+	}
+
 	// Check expiry
-	if time.Now().After(oauthConfig.ExpiresAt) {
+	if time.Now().After(flow.ExpiresAt) {
 		oauthConfig.Status = "expired"
 		p.configStore.UpdateOauthConfig(ctx, oauthConfig)
+		p.cleanupFlow(ctx, flow.ID)
 		return fmt.Errorf("oauth flow expired")
+	}
+
+	redirectURI := flow.RedirectURI
+	if redirectURI == "" {
+		redirectURI = oauthConfig.RedirectURI
 	}
 
 	// Log token exchange attempt for debugging
@@ -603,7 +640,7 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		"token_url", oauthConfig.TokenURL,
 		"client_id", oauthConfig.GetResolvedClientID(),
 		"has_client_secret", oauthConfig.GetResolvedClientSecret() != "",
-		"has_pkce_verifier", oauthConfig.CodeVerifier != "")
+		"has_pkce_verifier", flow.CodeVerifier != "")
 
 	// Exchange code for tokens with PKCE verifier
 	tokenResponse, err := p.exchangeCodeForTokensWithPKCE(
@@ -612,8 +649,8 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		code,
 		oauthConfig.GetResolvedClientID(),
 		oauthConfig.GetResolvedClientSecret(),
-		oauthConfig.RedirectURI,
-		oauthConfig.CodeVerifier, // PKCE verifier
+		redirectURI,
+		flow.CodeVerifier, // PKCE verifier
 		strings.TrimSpace(oauthConfig.Resource),
 	)
 	if err != nil {
@@ -623,6 +660,7 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 			"error", err.Error(),
 			"client_id", oauthConfig.GetResolvedClientID(),
 			"token_url", oauthConfig.TokenURL)
+		p.cleanupFlow(ctx, flow.ID)
 		return fmt.Errorf("token exchange failed: %w", err)
 	}
 
@@ -652,36 +690,57 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		Scopes:        string(scopesJSON),
 	}
 
-	// MCPClientID: unlike the per-user flow's session row (which stores
-	// mcp_client_id at InitiateUserOAuthFlow time — see
-	// CompleteUserOAuthFlow), the shared flow's oauth_configs row carries no
-	// client reference of its own. For a client re-authorizing an existing
-	// credential, initiateMCPClientVerification links
-	// config_mcp_clients.oauth_config_id to this row's ID before the browser
-	// ever leaves for the upstream provider, so the client is derivable by
-	// walking that link backwards. For a client still being created (the
-	// StorePendingMCPClient bootstrap path, where the config_mcp_clients row
-	// isn't inserted until after this callback completes), no such row
-	// exists yet — GetMCPClientByOauthConfigID returns ErrNotFound and
-	// MCPClientID is left as "", the same tolerated-empty shape the
-	// migration backfill uses for the equivalent case (see the MCPClientID
-	// field comment on TableMCPOauthToken).
+	// MCPClientID: seeded from the flow row (populated best-effort at
+	// InitiateOAuthFlow time), then re-resolved here — for a client
+	// re-authorizing an existing credential, initiateMCPClientVerification
+	// links config_mcp_clients.oauth_config_id to this row's ID before the
+	// browser ever leaves for the upstream provider, which happens AFTER
+	// InitiateOAuthFlow returns, so the flow row's own MCPClientID is stale
+	// (empty) for that case even though the link exists by the time we get
+	// here. For a client still being created (the StorePendingMCPClient
+	// bootstrap path, where the config_mcp_clients row isn't inserted until
+	// after this callback completes), no such row exists yet either way —
+	// GetMCPClientByOauthConfigID returns ErrNotFound and MCPClientID stays
+	// "", the same tolerated-empty shape the migration backfill uses for the
+	// equivalent case (see the MCPClientID field comment on
+	// TableMCPOauthToken).
+	tokenRecord.MCPClientID = flow.MCPClientID
 	if mcpClient, err := p.configStore.GetMCPClientByOauthConfigID(ctx, oauthConfig.ID); err == nil {
 		tokenRecord.MCPClientID = mcpClient.ClientID
 	} else if !errors.Is(err, configstore.ErrNotFound) {
+		p.cleanupFlow(ctx, flow.ID)
 		return fmt.Errorf("failed to look up mcp client for oauth config: %w", err)
 	}
 
-	if err := p.configStore.CreateOauthToken(ctx, tokenRecord); err != nil {
-		return fmt.Errorf("failed to create oauth token: %w", err)
-	}
-
-	// Update oauth_config: link token and set status="authorized"
+	// Replace the shared credential atomically: delete any existing
+	// auth_mode="shared" rows for this oauth_config_id (a reauth otherwise
+	// leaves the old token orphaned once oauth_configs.token_id repoints to
+	// the new one), insert the new token, and link it on oauth_configs — all
+	// in one transaction, so a failure partway through never leaves an
+	// unlinked or stale token row behind.
 	oauthConfig.TokenID = &tokenID
 	oauthConfig.Status = "authorized"
-	if err := p.configStore.UpdateOauthConfig(ctx, oauthConfig); err != nil {
-		return fmt.Errorf("failed to update oauth config: %w", err)
+	if err := p.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		if err := p.configStore.DeleteOauthTokensByConfigAndMode(ctx, tokenRecord.OauthConfigID, "shared", tx); err != nil {
+			return err
+		}
+		if err := p.configStore.CreateOauthToken(ctx, tokenRecord, tx); err != nil {
+			return fmt.Errorf("failed to create oauth token: %w", err)
+		}
+		if err := p.configStore.UpdateOauthConfig(ctx, oauthConfig, tx); err != nil {
+			return fmt.Errorf("failed to update oauth config: %w", err)
+		}
+		return nil
+	}); err != nil {
+		p.cleanupFlow(ctx, flow.ID)
+		return err
 	}
+
+	// Flow row's purpose ends here — same reasoning as CompleteUserOAuthFlow
+	// (see cleanupFlow): the token row is the durable record now. Harmless
+	// no-op for the temp-token half of cleanupFlow, since admin flows never
+	// mint one (only InitiateUserOAuthFlow does).
+	p.cleanupFlow(ctx, flow.ID)
 
 	logger.Debug("OAuth flow completed successfully", "oauth_config_id", oauthConfig.ID)
 
@@ -1025,7 +1084,7 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	//    state/PKCE here would invalidate that callback's state token and
 	//    leave the user with an "OAuth flow not found" error. Falling through
 	//    to insert a fresh row lets both flows complete independently.
-	var existing *tables.TableOauthUserSession
+	var existing *tables.TableMCPOauthFlow
 	found, lookupErr := p.configStore.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, flowMode, lookupID, mcpClientID)
 	if lookupErr != nil {
 		return nil, "", fmt.Errorf("failed to look up existing flow row: %w", lookupErr)
@@ -1053,7 +1112,7 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 		// session-mode (the caller's x-bf-mcp-session-id); vk/user-mode rows
 		// have an empty SessionID — their identity lives in virtual_key_id /
 		// user_id.
-		row := &tables.TableOauthUserSession{
+		row := &tables.TableMCPOauthFlow{
 			ID:            uuid.New().String(),
 			MCPClientID:   mcpClientID,
 			OauthConfigID: oauthConfigID,

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"gorm.io/gorm"
 )
 
 // testConfigStore is a minimal in-memory implementation of configstore.ConfigStore
@@ -58,7 +59,7 @@ func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID str
 	return nil, nil
 }
 
-func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.TableOauthConfig) error {
+func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.TableOauthConfig, _ ...*gorm.DB) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.oauthConfigs[cfg.ID] = bifrost.Ptr(*cfg)
@@ -127,7 +128,6 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 		Scopes:      `["read"]`,
 		Status:      "authorized",
 		TokenID:     new(tokenID),
-		ExpiresAt:   time.Now().Add(24 * time.Hour),
 	}
 
 	return oauthConfigID

--- a/transports/bifrost-http/handlers/mcpoauth2.go
+++ b/transports/bifrost-http/handlers/mcpoauth2.go
@@ -99,20 +99,27 @@ func (h *OAuthHandler) handleOAuthCallback(ctx *fasthttp.RequestCtx) {
 }
 
 // handleCallbackError handles ?error= responses from upstream providers.
-// Marks the OAuth config row as failed (for admin UI's pending-setup display),
-// then redirects to the route that matches the originating flow:
+// Marks the admin-mode flow row as failed (for admin UI's pending-setup
+// display), then redirects to the route that matches the originating flow:
 //   - admin-test popup flow → /workspace/mcp-registry/oauth-callback (posts a
 //     message to window.opener and closes itself)
 //   - per-user runtime flow → /workspace/mcp-sessions (full-page, no opener)
 //
-// We infer the flow by looking up the state in oauth_configs; if it's there
-// it's the admin-test flow, otherwise we assume per-user. The upstream-supplied
-// error code/description is logged server-side; only a generic message reaches
+// Every flow — admin and per-user alike — shares one state-token namespace on
+// mcp_oauth_flows, so classifying by FlowMode on a single lookup replaces the
+// old two-step "does a row exist in oauth_configs, else assume per-user"
+// inference (oauth_configs no longer carries a state column at all). Only
+// the admin-mode row's status is written here: a per-user flow row is
+// deliberately left 'pending' on an upstream error/deny so the same link can
+// still be retried within its TTL, matching today's behavior for that path
+// (CompleteUserOAuthFlow's own expiry/failure handling covers the cases that
+// do need a per-user row mutated or removed). The upstream-supplied error
+// code/description is logged server-side; only a generic message reaches
 // the URL so provider error text doesn't leak into history / Referer.
 func (h *OAuthHandler) handleCallbackError(ctx *fasthttp.RequestCtx, state, errorParam, errorDescription string) {
 	isAdminTestFlow := false
 	if state != "" {
-		oauthConfig, err := h.store.ConfigStore.GetOauthConfigByState(ctx, state)
+		flow, err := h.store.ConfigStore.GetOauthUserSessionByState(ctx, state)
 		switch {
 		case err != nil:
 			// Lookup failed — we can't reliably classify the flow. Default
@@ -120,12 +127,14 @@ func (h *OAuthHandler) handleCallbackError(ctx *fasthttp.RequestCtx, state, erro
 			// case; the popup-callback page expects window.opener and would
 			// strand a per-user caller on a "you can close this tab" view.
 			// Log the underlying cause for diagnostics.
-			logger.Error("[oauth] failed to look up oauth config by state for callback error: err=%v", err)
-		case oauthConfig != nil:
-			isAdminTestFlow = true
-			oauthConfig.Status = "failed"
-			if updateErr := h.store.ConfigStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
-				logger.Warn("[oauth] failed to mark oauth config as failed: id=%s err=%v", oauthConfig.ID, updateErr)
+			logger.Error("[oauth] failed to look up oauth flow by state for callback error: err=%v", err)
+		case flow != nil:
+			isAdminTestFlow = flow.FlowMode == "admin"
+			if isAdminTestFlow {
+				flow.Status = "failed"
+				if updateErr := h.store.ConfigStore.UpdateOauthUserSession(ctx, flow); updateErr != nil {
+					logger.Warn("[oauth] failed to mark oauth flow as failed: id=%s err=%v", flow.ID, updateErr)
+				}
 			}
 		}
 	}
@@ -177,11 +186,15 @@ func (h *OAuthHandler) getOAuthConfigStatus(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// expires_at (the flow's own PKCE-attempt deadline) lived on this row
+	// before the flow table split it out onto TableMCPOauthFlow — dropped
+	// from this response rather than joined in: the popup UI that polls this
+	// endpoint (oauth2Authorizer.tsx) only ever branches on status, never
+	// reads a deadline for a live countdown.
 	response := map[string]interface{}{
 		"id":         oauthConfig.ID,
 		"status":     oauthConfig.Status,
 		"created_at": oauthConfig.CreatedAt,
-		"expires_at": oauthConfig.ExpiresAt,
 	}
 
 	if oauthConfig.Status == "authorized" && oauthConfig.TokenID != nil {
@@ -273,11 +286,6 @@ func (h *OAuthHandler) StorePendingMCPClient(oauthConfigID string, mcpClientConf
 // GetPendingMCPClient retrieves a pending MCP client config by oauth_config_id
 func (h *OAuthHandler) GetPendingMCPClient(oauthConfigID string) (*schemas.MCPClientConfig, error) {
 	return h.oauthProvider.GetPendingMCPClient(oauthConfigID)
-}
-
-// GetPendingMCPClientByState retrieves a pending MCP client config by OAuth state token
-func (h *OAuthHandler) GetPendingMCPClientByState(state string) (*schemas.MCPClientConfig, string, error) {
-	return h.oauthProvider.GetPendingMCPClientByState(state)
 }
 
 // RemovePendingMCPClient removes a pending MCP client after OAuth completion.

--- a/transports/bifrost-http/handlers/mcpsessions.go
+++ b/transports/bifrost-http/handlers/mcpsessions.go
@@ -220,7 +220,7 @@ func (h *MCPSessionsHandler) list(ctx *fasthttp.RequestCtx) {
 	// matching token/header credential exists) needs that data.
 	var (
 		tokens      []tables.TableMCPOauthToken
-		flows       []tables.TableOauthUserSession
+		flows       []tables.TableMCPOauthFlow
 		headerCreds []tables.TableMCPPerUserHeaderCredential
 		headerFlows []tables.TableMCPPerUserHeaderFlow
 		err         error
@@ -353,7 +353,7 @@ func bindingKeyFromToken(t tables.TableMCPOauthToken) sessionBindingKey {
 	return k
 }
 
-func bindingKeyFromFlow(f tables.TableOauthUserSession) sessionBindingKey {
+func bindingKeyFromFlow(f tables.TableMCPOauthFlow) sessionBindingKey {
 	k := sessionBindingKey{Mode: f.FlowMode, MCPClientID: f.MCPClientID}
 	switch schemas.MCPAuthMode(f.FlowMode) {
 	case schemas.MCPAuthModeUser:
@@ -813,7 +813,7 @@ func (h *MCPSessionsHandler) flowStart(ctx *fasthttp.RequestCtx) {
 // GetOauthUserSessionByID: if the caller is not allowed to see this row,
 // the store returns (nil, nil) and we surface 404. Writes the appropriate
 // HTTP error response and returns a sentinel error on failure.
-func (h *MCPSessionsHandler) loadAuthorizedFlow(ctx *fasthttp.RequestCtx, flowID string) (*tables.TableOauthUserSession, error) {
+func (h *MCPSessionsHandler) loadAuthorizedFlow(ctx *fasthttp.RequestCtx, flowID string) (*tables.TableMCPOauthFlow, error) {
 	flow, err := h.store.ConfigStore.GetOauthUserSessionByID(ctx, flowID)
 	if err != nil {
 		logger.Error("[mcp/sessions] load flow failed: flow=%s err=%v", flowID, err)
@@ -919,7 +919,7 @@ func tokenRow(t tables.TableMCPOauthToken) mcpSessionRow {
 }
 
 // flowRow maps an oauth_user_sessions (pending flow) row to the wire shape.
-func flowRow(f tables.TableOauthUserSession) mcpSessionRow {
+func flowRow(f tables.TableMCPOauthFlow) mcpSessionRow {
 	exp := f.ExpiresAt.UTC().Format(rfc3339Nano)
 	row := mcpSessionRow{
 		ID:            f.ID,

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1417,10 +1417,6 @@ func (m *MockConfigStore) UpsertPlugin(ctx context.Context, plugin *tables.Table
 
 // OAuth config
 
-func (m *MockConfigStore) GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error) {
-	return nil, nil
-}
-
 func (m *MockConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error) {
 	return nil, nil
 }
@@ -1429,7 +1425,7 @@ func (m *MockConfigStore) CreateOauthConfig(ctx context.Context, config *tables.
 	return nil
 }
 
-func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
+func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
 	return nil
 }
 
@@ -1442,7 +1438,7 @@ func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before tim
 	return nil, nil
 }
 
-func (m *MockConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
+func (m *MockConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error {
 	return nil
 }
 
@@ -1454,24 +1450,36 @@ func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error
 	return nil
 }
 
-// Per-user OAuth session CRUD
-func (m *MockConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error) {
-	return nil, nil
-}
-
-func (m *MockConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
-	return nil, nil
-}
-
-func (m *MockConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableOauthUserSession, error) {
-	return nil, nil
-}
-
-func (m *MockConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+func (m *MockConfigStore) DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error {
 	return nil
 }
 
-func (m *MockConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+// Flow-row CRUD (mcp_oauth_flows / TableMCPOauthFlow)
+func (m *MockConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) ClaimOauthFlowByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error {
+	return nil
+}
+
+func (m *MockConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableMCPOauthFlow) error {
 	return nil
 }
 
@@ -1512,7 +1520,7 @@ func (m *MockConfigStore) ListOauthUserTokens(ctx context.Context, params config
 	return nil, nil
 }
 
-func (m *MockConfigStore) ListPendingOauthUserSessions(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableOauthUserSession, error) {
+func (m *MockConfigStore) ListPendingOauthUserSessions(ctx context.Context, params configstore.MCPSessionsFilterParams) ([]tables.TableMCPOauthFlow, error) {
 	return nil, nil
 }
 

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -127,7 +127,6 @@ export interface OAuthStatusResponse {
 	id: string;
 	status: "pending" | "authorized" | "failed" | "expired" | "revoked";
 	created_at: string;
-	expires_at: string;
 	token_id?: string;
 	token_expires_at?: string;
 	token_scopes?: string;


### PR DESCRIPTION
## Summary

Introduces `mcp_oauth_flows` as a dedicated table for in-flight OAuth authorize attempts, replacing the dual-purpose `oauth_user_sessions` table and removing CSRF/PKCE columns (`state`, `code_verifier`, `code_challenge`, `expires_at`) from `oauth_configs`. The new `TableMCPOauthFlow` covers all flow kinds — per-identity (`user`, `vk`, `session`) and admin-mode (`admin`) alike — while `TableOauthConfig` becomes a pure, durable credential template.

## Changes

- **New `TableMCPOauthFlow` struct and `mcp_oauth_flows` table**: Carries `state`, `code_verifier`, `redirect_uri`, `expires_at`, and `flow_mode` for a single authorize attempt. `CodeVerifier` is encrypted via `BeforeSave`/`AfterFind` hooks, matching the behavior previously on `TableOauthConfig`.
- **Two new migrations**:
  - `create_mcp_oauth_flows_table`: Creates `mcp_oauth_flows` and backfills from `oauth_user_sessions` via `INSERT...SELECT`. The unique index on `state` is created after the backfill to avoid ordering issues.
  - `drop_oauth_config_pkce_columns`: Drops `state`, `code_verifier`, `code_challenge`, and `expires_at` from `oauth_configs`. These columns were `NOT NULL` at the DB level and would have broken future INSERTs once the Go struct stopped setting them.
- **`TableOauthConfig` simplified**: PKCE/CSRF fields removed from the struct, `BeforeSave`/`AfterFind` hooks updated to only encrypt/decrypt `client_secret`. The `EncryptionStatus` is now set only when `client_secret` is present.
- **`InitiateOAuthFlow` updated**: Creates the `oauth_configs` row and a `flow_mode='admin'` flow row atomically in a single transaction to prevent orphaned config rows on partial failure.
- **`CompleteOAuthFlow` updated**: Claims the admin-mode flow row via the new `ClaimOauthFlowByState` (scoped to `flow_mode='admin'`), reads `CodeVerifier` and `RedirectURI` from the flow row, and deletes the flow row on completion.
- **New `ClaimOauthFlowByState` method**: Admin-mode counterpart to `ClaimOauthUserSessionByState`. The two methods partition `mcp_oauth_flows` by `flow_mode` so a given state token can only be claimed by one of them.
- **New `GetOauthUserSessionByState` method**: Non-mutating lookup by state for any `flow_mode` or status, used by callback error handling to classify and mark a flow failed without consuming it.
- **`GetOauthConfigByState` removed**: No longer needed; `oauth_configs` no longer has a `state` column.
- **`GetPendingMCPClientByState` removed**: Callers now use `GetPendingMCPClient` directly after resolving the config ID from the flow row.
- **`handleCallbackError` updated**: Classifies admin vs. per-user flows via `flow.FlowMode` on a single `mcp_oauth_flows` lookup instead of the old two-step `oauth_configs`-then-assume-per-user inference.
- **`ListPendingOauthUserSessions` updated**: Now queries `mcp_oauth_flows` and explicitly excludes `flow_mode='admin'` rows, mirroring `ListOauthUserTokens`' `auth_mode='shared'` exclusion.
- **`DeleteExpiredOauthUserSessions` updated**: Targets `mcp_oauth_flows`; deliberately unfiltered by `flow_mode` since expiry-based sweeping is safe for all flow kinds.
- **Cascade deletes updated**: `DeleteMCPClientConfig` and `DeleteVirtualKey` now delete from `mcp_oauth_flows` instead of `oauth_user_sessions`.
- **`reconcileVKDirectTokensDB` and `readVKsHoldingOauthCredsForMCP` updated**: Reference `mcp_oauth_flows` with a `flow_mode='vk'` defense-in-depth filter.
- **`migrationWidenEncryptedVarcharColumns` guarded**: The `ALTER COLUMN code_verifier` statement is now conditional on the column existing, since fresh installs after `drop_oauth_config_pkce_columns` ships will never have it on `oauth_configs`.
- **`TableOauthUserSession` marked deprecated**: Retained only so the backfill migration can reference its table via GORM; flagged for removal in the next major version.
- **Performance test added**: `TestMigrationCreateMCPOauthFlowsTablePerf` seeds ~1,000,000 rows into `oauth_user_sessions` and measures `migrationCreateMCPOauthFlowsTable` against both SQLite and Postgres, gated behind `BIFROST_RUN_MIGRATION_PERF_TESTS=1`.
- **Encryption tests updated**: `TestTableOauthConfig_EncryptDecrypt` and related tests drop `code_verifier`/`state`/`expires_at` assertions; new `TestTableMCPOauthFlow_EncryptDecrypt` and `TestTableMCPOauthFlow_EncryptionDisabled_StoresPlaintext` cover the equivalent round-trips on the new table.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/...
```

To run the migration performance test against a live Postgres instance:

```sh
BIFROST_RUN_MIGRATION_PERF_TESTS=1 go test ./framework/configstore/... -run TestMigrationCreateMCPOauthFlowsTablePerf -v
```

For an existing deployment, apply the two new migrations (`create_mcp_oauth_flows_table`, `drop_oauth_config_pkce_columns`) and verify:
- `mcp_oauth_flows` exists and contains all rows previously in `oauth_user_sessions`.
- `oauth_configs` no longer has `state`, `code_verifier`, `code_challenge`, or `expires_at` columns.
- New OAuth flows (admin and per-user) complete end-to-end without error.
- Expired flow cleanup (`DeleteExpiredOauthUserSessions`) removes rows from `mcp_oauth_flows`.

## Breaking changes

- [x] Yes
- [ ] No

`GetOauthConfigByState` and `GetPendingMCPClientByState` are removed from the `ConfigStore` interface. Any external implementation of `ConfigStore` must add `GetOauthUserSessionByState` and `ClaimOauthFlowByState`, and remove the deleted methods. The `oauth_configs` table loses four columns; any direct SQL queries against those columns will fail after the migration runs.

## Security considerations

- CSRF state tokens and PKCE verifiers now live exclusively on `mcp_oauth_flows`, which has a unique index on `state` and a 15-minute `expires_at`. The atomic claim-by-state pattern (pending → claiming) is preserved and extended to admin-mode flows via `ClaimOauthFlowByState`, preventing duplicate callback processing.
- The config row and its flow row are created in a single transaction in `InitiateOAuthFlow`, eliminating the window where a committed config row with no corresponding flow row could be exploited or leak state.
- `CodeVerifier` encryption is unchanged in behavior; it has moved from `TableOauthConfig` to `TableMCPOauthFlow`.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable