### PR TITLE
refactor: unify shared and per-user OAuth refresh under a single `RefreshAccessToken(tokenID)` path, dropping `oauth_configs.token_id` FK shortcut

### DIFF
--- a/core/mcp/credstore/per_user_oauth_test.go
+++ b/core/mcp/credstore/per_user_oauth_test.go
@@ -20,10 +20,6 @@ func (f *fakeOAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID s
 	return "", errors.New("not implemented")
 }
 
-func (f *fakeOAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID string) error {
-	return errors.New("not implemented")
-}
-
 func (f *fakeOAuth2Provider) ValidateToken(ctx context.Context, oauthConfigID string) (bool, error) {
 	return false, errors.New("not implemented")
 }
@@ -44,7 +40,7 @@ func (f *fakeOAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state st
 	return "", errors.New("not implemented")
 }
 
-func (f *fakeOAuth2Provider) RefreshUserAccessToken(ctx context.Context, tokenID string) error {
+func (f *fakeOAuth2Provider) RefreshAccessToken(ctx context.Context, tokenID string) error {
 	return errors.New("not implemented")
 }
 

--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -10,9 +10,6 @@ type OAuth2Provider interface {
 	// GetAccessToken retrieves the access token for a given oauth_config_id (server-level OAuth)
 	GetAccessToken(ctx context.Context, oauthConfigID string) (string, error)
 
-	// RefreshAccessToken refreshes the access token for a given oauth_config_id
-	RefreshAccessToken(ctx context.Context, oauthConfigID string) error
-
 	// ValidateToken checks if the token is still valid
 	ValidateToken(ctx context.Context, oauthConfigID string) (bool, error)
 
@@ -43,9 +40,12 @@ type OAuth2Provider interface {
 	// empty otherwise).
 	CompleteUserOAuthFlow(ctx context.Context, state string, code string) (string, error)
 
-	// RefreshUserAccessToken refreshes a per-user OAuth access token, looked up
-	// by the token row's primary-key ID.
-	RefreshUserAccessToken(ctx context.Context, tokenID string) error
+	// RefreshAccessToken refreshes any MCP OAuth token — the single shared
+	// client credential or a per-identity credential alike — looked up by the
+	// token row's own primary-key ID. The one refresh path for every kind of
+	// MCP OAuth credential; GetAccessToken and GetUserAccessTokenByMode both
+	// funnel their lazy pre-flight refresh through this.
+	RefreshAccessToken(ctx context.Context, tokenID string) error
 }
 
 // OauthConfig represents OAuth client configuration

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -461,6 +461,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"merge_oauth_token_tables"}, run: migrationMergeOauthTokenTables},
 	{IDs: []string{"create_mcp_oauth_flows_table"}, run: migrationCreateMCPOauthFlowsTable},
 	{IDs: []string{"drop_oauth_config_pkce_columns"}, run: migrationDropOauthConfigPKCEColumns},
+	{IDs: []string{"drop_oauth_config_token_id_column"}, run: migrationDropOauthConfigTokenIDColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -11233,7 +11234,23 @@ func migrationMergeOauthTokenTables(ctx context.Context, db *gorm.DB, logger sch
 			// rather than being excluded — see the MCPClientID field comment
 			// on TableMCPOauthToken.
 			if mg.HasTable(&tables.TableOauthToken{}) {
-				if err := tx.Exec(`
+				// oauth_configs.token_id (the legacy FK shortcut this
+				// derivation reads) is itself dropped by a later migration in
+				// this chain (migrationDropOauthConfigTokenIDColumn). A fresh
+				// install's earlier CreateTable(&tables.TableOauthConfig{})
+				// call already builds the table from today's TokenID-free Go
+				// struct, so the column never exists at all on such an
+				// install — same guard shape (HasColumn before referencing a
+				// since-retired column in raw SQL) as
+				// migrationWidenEncryptedVarcharColumns uses for
+				// code_verifier elsewhere in this file, for the identical
+				// reason. When the column is absent there is nothing to
+				// derive mcp_client_id/oauth_config_id from; both fall back
+				// to '', the same tolerated-empty shape the COALESCE below
+				// already produces for a row whose oauth_config was deleted
+				// or never linked (see the MCPClientID field comment on
+				// TableMCPOauthToken).
+				backfillSQL := `
 					INSERT INTO mcp_oauth_tokens (
 						id, auth_mode, mcp_client_id, oauth_config_id, session_id,
 						virtual_key_id, user_id, status, access_token, refresh_token,
@@ -11267,7 +11284,38 @@ func migrationMergeOauthTokenTables(ctx context.Context, db *gorm.DB, logger sch
 						oauth_tokens.updated_at
 					FROM oauth_tokens
 					WHERE NOT EXISTS (SELECT 1 FROM mcp_oauth_tokens WHERE mcp_oauth_tokens.id = oauth_tokens.id)
-				`).Error; err != nil {
+				`
+				if !mg.HasColumn(&tables.TableOauthConfig{}, "token_id") {
+					backfillSQL = `
+						INSERT INTO mcp_oauth_tokens (
+							id, auth_mode, mcp_client_id, oauth_config_id, session_id,
+							virtual_key_id, user_id, status, access_token, refresh_token,
+							token_type, expires_at, scopes, last_refreshed_at,
+							encryption_status, created_at, updated_at
+						)
+						SELECT
+							oauth_tokens.id,
+							'shared',
+							'',
+							'',
+							'',
+							NULL,
+							NULL,
+							'active',
+							oauth_tokens.access_token,
+							oauth_tokens.refresh_token,
+							oauth_tokens.token_type,
+							oauth_tokens.expires_at,
+							oauth_tokens.scopes,
+							oauth_tokens.last_refreshed_at,
+							oauth_tokens.encryption_status,
+							oauth_tokens.created_at,
+							oauth_tokens.updated_at
+						FROM oauth_tokens
+						WHERE NOT EXISTS (SELECT 1 FROM mcp_oauth_tokens WHERE mcp_oauth_tokens.id = oauth_tokens.id)
+					`
+				}
+				if err := tx.Exec(backfillSQL).Error; err != nil {
 					return fmt.Errorf("backfill mcp_oauth_tokens from oauth_tokens: %w", err)
 				}
 			}
@@ -11569,6 +11617,69 @@ func migrationDropOauthConfigPKCEColumns(ctx context.Context, db *gorm.DB, logge
 	}
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_oauth_config_pkce_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationDropOauthConfigTokenIDColumn drops the token_id column from
+// oauth_configs. TokenID was an FK shortcut onto the single shared-mode
+// token row, populated once by CompleteOAuthFlow and read by every
+// shared-token lookup thereafter. Once every read site resolves the token
+// row via (oauth_config_id, auth_mode='shared') on mcp_oauth_tokens instead
+// (see the application-code change that shipped alongside this migration),
+// nothing populates or reads token_id any longer. Unlike the PKCE columns
+// dropped by the preceding migration, token_id was never NOT NULL at the DB
+// level, so there's no constraint to relax first — dropping it outright is
+// safe the moment the write side stops.
+func migrationDropOauthConfigTokenIDColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "drop_oauth_config_token_id_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db.WithContext(ctx), migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			if !mg.HasTable(&tables.TableOauthConfig{}) {
+				return nil
+			}
+
+			return dropColumnIfExists(tx, logger, &tables.TableOauthConfig{}, "token_id")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Forward-only: token_id was a pure FK shortcut with no data
+			// meaning of its own once the token row is reachable via
+			// (oauth_config_id, auth_mode) on mcp_oauth_tokens — re-adding an
+			// empty column would not restore anything a rollback needs.
+			return nil
+		},
+	}})
+	// SQLite workaround — same reasoning as migrationDropOauthConfigPKCEColumns:
+	// GORM's SQLite DropColumn rebuilds oauth_configs via DROP+RENAME, which fails
+	// when config_mcp_clients.oauth_config_id holds an FK into it and foreign_keys is
+	// ON. PRAGMA foreign_keys cannot change inside a transaction, so disable it on a
+	// pinned single connection before the migrator opens its transaction, then restore it.
+	if db.Dialector.Name() == "sqlite" {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return fmt.Errorf("failed to get underlying sql.DB: %w", err)
+		}
+		prevMaxOpenConns := sqlDB.Stats().MaxOpenConnections
+		sqlDB.SetMaxOpenConns(1)
+		defer sqlDB.SetMaxOpenConns(prevMaxOpenConns)
+
+		if err := db.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+			return fmt.Errorf("failed to disable SQLite foreign keys: %w", err)
+		}
+		defer func() {
+			if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+				log.Fatalf("[Migration] FATAL: failed to re-enable SQLite foreign keys: %v", err)
+			}
+		}()
+	}
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running drop_oauth_config_token_id_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_perf_test.go
+++ b/framework/configstore/migrations_perf_test.go
@@ -193,17 +193,31 @@ func seedSyntheticMCPClients(t *testing.T, db *gorm.DB, count int) {
 }
 
 // bulkInsertOauthTokens seeds count rows into oauth_tokens (the pre-merge
-// shared-credential table), each linked to its own oauth_configs row (via
-// the legacy TokenID shortcut) and config_mcp_clients row (via
-// oauth_config_id) — the exact join path migrationMergeOauthTokenTables
-// walks to derive mcp_oauth_tokens.oauth_config_id/mcp_client_id for shared
-// tokens. Without these linked rows every seeded token would only exercise
-// that join's COALESCE(...,'') miss branch, never a real hit. Batched
-// multi-row INSERTs wrapped in a single transaction — not one .Create() call
-// per row — so seeding time stays a small fraction of the migration time
-// being measured.
+// shared-credential table), each linked to its own oauth_configs row and
+// config_mcp_clients row (via oauth_config_id) — the exact join path
+// migrationMergeOauthTokenTables walks to derive
+// mcp_oauth_tokens.oauth_config_id/mcp_client_id for shared tokens. Without
+// these linked rows every seeded token would only exercise that join's
+// COALESCE(...,'') miss branch, never a real hit.
+//
+// The join reads oauth_configs.token_id — a column TableOauthConfig no
+// longer maps a Go field to (see its doc comment: the FK shortcut is
+// retired) and, per migrationMergeOauthTokenTables's own comment, doesn't
+// even exist on a fresh install, since runPreMergeMigrationChain's
+// CreateTable(&tables.TableOauthConfig{}) call builds the table from
+// today's TokenID-free struct. This test simulates the other real
+// deployment shape the migration's HasColumn guard exists for — an
+// existing installation that predates the column's retirement — by adding
+// the column back with a raw ALTER TABLE before seeding it, rather than
+// leaving the join's hit branch permanently untestable.
+//
+// Batched multi-row INSERTs wrapped in a single transaction — not one
+// .Create() call per row — so seeding time stays a small fraction of the
+// migration time being measured.
 func bulkInsertOauthTokens(t *testing.T, db *gorm.DB, count int) {
 	t.Helper()
+	require.NoError(t, db.Exec(`ALTER TABLE oauth_configs ADD COLUMN token_id VARCHAR(255)`).Error,
+		"simulate a pre-retirement install so the shared-token join has a token_id column to hit")
 	now := time.Now()
 	expiresAt := now.Add(24 * time.Hour)
 	tokenBatch := make([]tables.TableOauthToken, 0, perfSeedInsertBatchSize)
@@ -248,7 +262,6 @@ func bulkInsertOauthTokens(t *testing.T, db *gorm.DB, count int) {
 			})
 			configBatch = append(configBatch, tables.TableOauthConfig{
 				ID:          configID,
-				TokenID:     &tokenID,
 				RedirectURI: "https://perf.example.com/callback",
 				Status:      "authorized",
 				CreatedAt:   now,
@@ -271,6 +284,13 @@ func bulkInsertOauthTokens(t *testing.T, db *gorm.DB, count int) {
 		}
 		return flush(tx)
 	}))
+
+	// Backfill the legacy oauth_configs.token_id column (see the doc comment
+	// above): a plain string match on the deterministic ID pattern this
+	// function uses, so it can run as one statement instead of per-row.
+	require.NoError(t, db.Exec(
+		`UPDATE oauth_configs SET token_id = REPLACE(id, 'perf-shared-cfg-', 'perf-shared-tok-') WHERE id LIKE 'perf-shared-cfg-%'`,
+	).Error)
 }
 
 // bulkInsertOauthUserTokens seeds count rows into oauth_user_tokens (the

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6448,6 +6448,58 @@ func (s *RDBConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tab
 	return &token, nil
 }
 
+// GetSharedOauthTokenByConfigID resolves the single shared-mode token row for
+// a config — the replacement for the retired TableOauthConfig.TokenID FK
+// shortcut. Not filtered by status: RevokeToken needs to reach a
+// 'needs_reauth' row too, to delete it; GetAccessToken (the one caller that
+// only wants a usable credential) checks token.Status itself after the load.
+func (s *RDBConfigStore) GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+	if oauthConfigID == "" {
+		return nil, nil
+	}
+	var token tables.TableMCPOauthToken
+	// Nothing in the schema guarantees at most one auth_mode='shared' row per
+	// oauth_config_id (idx_mcp_oauth_tokens_shared_mcp is unique on
+	// mcp_client_id only, and explicitly excludes rows where mcp_client_id =
+	// '' — exactly the shape a stale/orphaned row can carry). Prefer an
+	// active row, then the most recently updated, so a stale row left behind
+	// by an earlier bug or a partial cleanup can't shadow the live one.
+	result := s.DB().WithContext(ctx).
+		Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "shared").
+		Order("CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC, id DESC").
+		First(&token)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get shared oauth token by config id: %w", result.Error)
+	}
+	return &token, nil
+}
+
+// DeleteSharedOauthTokensByConfigID deletes every auth_mode='shared' token
+// row for oauthConfigID. Used both by RevokeToken (so revocation can't leave
+// a duplicate shared row usable — see GetSharedOauthTokenByConfigID's doc
+// comment) and by CompleteOAuthFlow's shared-token branch (so re-running the
+// shared OAuth flow for an already-authorized config, e.g. via the
+// reauthorize endpoint, can't accumulate a second row in the first place).
+func (s *RDBConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+	if oauthConfigID == "" {
+		return nil
+	}
+	db := s.DB()
+	if len(tx) > 0 {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).
+		Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "shared").
+		Delete(&tables.TableMCPOauthToken{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete shared oauth tokens by config id: %w", result.Error)
+	}
+	return nil
+}
+
 // CreateOauthConfig creates a new OAuth config
 func (s *RDBConfigStore) CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
 	result := s.DB().WithContext(ctx).Create(config)
@@ -6483,25 +6535,6 @@ func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.T
 	return nil
 }
 
-// DeleteOauthTokensByConfigAndMode deletes every oauth token row for the
-// given oauth_config_id scoped to a single auth_mode (e.g. "shared").
-// Used by the shared-OAuth callback to clear the prior credential before
-// inserting its replacement — CreateOauthToken is a plain insert with no
-// upsert semantics (see its call sites), so without this the old row would
-// be silently orphaned once oauth_configs.token_id repoints to the new one.
-func (s *RDBConfigStore) DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error {
-	db := s.DB()
-	if len(tx) > 0 {
-		db = tx[0]
-	}
-	if err := db.WithContext(ctx).
-		Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, authMode).
-		Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
-		return fmt.Errorf("failed to delete existing oauth tokens for config %s (mode=%s): %w", oauthConfigID, authMode, err)
-	}
-	return nil
-}
-
 // UpdateOauthToken updates an existing OAuth token
 func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	result := s.DB().WithContext(ctx).Save(token)
@@ -6532,12 +6565,12 @@ func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error 
 // GetExpiringOauthTokens retrieves tokens that are expiring before the given time
 func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
 	var tokens []*tables.TableMCPOauthToken
-	// Exclude tokens whose owning oauth_config has already reached a terminal
-	// state — "expired" (set when a refresh is permanently rejected, e.g.
-	// invalid_grant / Grant not found) or "revoked". Without this, the refresh
-	// worker re-selects a permanently-dead token on every tick (its expires_at
-	// stays in the past) and logs the same failure indefinitely; a dead grant
-	// needs re-authorization, not perpetual retries.
+	// Only select tokens whose own status is 'active' — a token already
+	// flagged 'needs_reauth' (a prior refresh attempt was permanently
+	// rejected, e.g. invalid_grant / 401) stays dead until a human
+	// re-authorizes it. Without this, the refresh worker would re-select a
+	// confirmed-dead token on every tick and log the same failure
+	// indefinitely.
 	//
 	// Refresh is also limited to tokens whose oauth_config is referenced by
 	// at least one enabled MCP client: nothing consumes a token while every
@@ -6551,34 +6584,18 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 		// as a side effect of the table merge (that's a deliberate later
 		// change, not this one).
 		Where("auth_mode = ?", "shared").
+		Where("status = ?", "active").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
-		Where("NOT EXISTS (?)",
-			s.DB().Model(&tables.TableOauthConfig{}).
-				Select("1").
-				Where("oauth_configs.token_id = mcp_oauth_tokens.id AND oauth_configs.status IN ?", []string{"expired", "revoked"})).
 		Where("EXISTS (?)",
 			s.DB().Model(&tables.TableMCPClient{}).
 				Select("1").
 				Joins("JOIN oauth_configs ON oauth_configs.id = config_mcp_clients.oauth_config_id").
-				Where("oauth_configs.token_id = mcp_oauth_tokens.id AND config_mcp_clients.disabled = ?", false)).
+				Where("oauth_configs.id = mcp_oauth_tokens.oauth_config_id AND config_mcp_clients.disabled = ?", false)).
 		Find(&tokens)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get expiring tokens: %w", result.Error)
 	}
 	return tokens, nil
-}
-
-// GetOauthConfigByTokenID retrieves an OAuth config that references a specific token
-func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error) {
-	var config tables.TableOauthConfig
-	result := s.DB().WithContext(ctx).Where("token_id = ?", tokenID).First(&config)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to get oauth config by token id: %w", result.Error)
-	}
-	return &config, nil
 }
 
 // ---------- OAuth Flow CRUD (mcp_oauth_flows) ----------
@@ -6592,12 +6609,19 @@ func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID st
 var perUserOauthFlowModes = perUserOauthAuthModes
 
 // GetOauthUserSessionByID retrieves a flow row by its ID
+// GetOauthUserSessionByID looks up a per-identity flow row by its own ID —
+// fed a caller-supplied ID from a URL path parameter (BuildUpstreamAuthorizeURL,
+// mcpsessions.go's loadAuthorizedFlow), so the flow_mode filter matters here
+// the same way it does on GetOauthUserTokenByID: without it, an admin-mode
+// row (the shared client's or a bootstrap-test's one-time setup flow) could
+// be fetched through a per-user-facing endpoint just by guessing/reusing its
+// ID. Both current callers are documented as per-user-only.
 func (s *RDBConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error) {
 	var flow tables.TableMCPOauthFlow
 	result := s.ScopedDB(ctx).
 		Preload("MCPClient", func(db *gorm.DB) *gorm.DB { return db.Select("client_id, name") }).
 		Preload("VirtualKey", func(db *gorm.DB) *gorm.DB { return db.Select("id, name") }).
-		Where("id = ?", id).First(&flow)
+		Where("id = ? AND flow_mode IN ?", id, perUserOauthFlowModes).First(&flow)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -6911,18 +6935,22 @@ func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schem
 }
 
 // MarkOauthUserTokenNeedsReauthByID flips status to 'needs_reauth' on a single
-// token row. Called by the refresh-failure path when the upstream credential
-// is permanently rejected: the row stays (preserves audit + binding for
-// re-auth), but is filtered from active lookups so the next inference
-// triggers a fresh OAuth flow. Scoped to auth_mode IN ('user','vk','session')
-// so this per-user-only path can never flip a shared token to needs_reauth.
+// token row, regardless of auth_mode. Called by the unified refresh function
+// when the upstream credential is permanently rejected: the row stays
+// (preserves audit + binding for re-auth), but is filtered from active
+// lookups so the next inference/access triggers a fresh OAuth flow. Not
+// scoped by auth_mode (unlike GetOauthUserTokenByID/UpdateOauthUserToken
+// below): the ID handed in always comes from an internal lookup already
+// (a token row just loaded by its own refresh path), never an arbitrary
+// caller-supplied ID, so a 'shared' row is just as safe to flip here as a
+// per-identity one.
 func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error {
 	if tokenID == "" {
 		return nil
 	}
 	result := s.DB().WithContext(ctx).
 		Model(&tables.TableMCPOauthToken{}).
-		Where("id = ? AND auth_mode IN ?", tokenID, perUserOauthAuthModes).
+		Where("id = ?", tokenID).
 		Update("status", "needs_reauth")
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark oauth user token %s needs_reauth: %w", tokenID, result.Error)

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -237,6 +237,32 @@ func TestListPendingOauthUserSessions_FlowModeFilter(t *testing.T) {
 	require.Empty(t, got, "fixture's only session is user-mode; vk filter should match none")
 }
 
+func TestGetOauthUserSessionByID_ExcludesAdminMode(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+
+	// The fixture's own user-mode flow is still reachable by ID.
+	got, err := store.GetOauthUserSessionByID(context.Background(), "sess-pending")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "sess-pending", got.ID)
+
+	// An admin-mode flow (the shared client's or a bootstrap-test's one-time
+	// setup flow) must never be reachable through this per-user-facing
+	// lookup, even by exact ID — this is the same auth_mode discipline
+	// GetOauthUserTokenByID already applies on the token side.
+	adminFlow := &tables.TableMCPOauthFlow{
+		ID: "sess-admin", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
+		FlowMode: "admin", Status: "pending",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, store.DB().WithContext(context.Background()).Create(adminFlow).Error)
+
+	got, err = store.GetOauthUserSessionByID(context.Background(), "sess-admin")
+	require.NoError(t, err)
+	require.Nil(t, got, "admin-mode flow must not be returned by a per-user-facing ID lookup")
+}
+
 func TestListMCPPerUserHeaderCredentials_NoFilters(t *testing.T) {
 	store := setupMCPSessionsTestStore(t)
 	seedMCPSessionsFixture(t, store)

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -62,26 +62,25 @@ func makeRefreshToken(id, familyID, clientID, hash string) *tables.TableOAuth2Re
 
 // seedExpiringTokenFixtures installs the token/config/client helpers shared by
 // the GetExpiringOauthTokens tests. Every token is created already-expired so
-// only the config/client conditions decide whether it is selected.
-func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id string), mkConfig func(id, tokenID, status, state string), mkClient func(name, oauthConfigID string, disabled bool)) {
+// only the token-status/client conditions decide whether it is selected.
+// Tokens link to their owning config via OauthConfigID — the replacement for
+// the retired TableOauthConfig.TokenID FK shortcut.
+func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id, oauthConfigID, status string), mkConfig func(id string), mkClient func(name, oauthConfigID string, disabled bool)) {
 	t.Helper()
 	require.NoError(t, s.DB().AutoMigrate(&tables.TableOauthConfig{}, &tables.TableMCPOauthToken{}, &tables.TableMCPClient{}))
 	past := time.Now().Add(-time.Hour)
 
-	mkToken = func(id string) {
+	mkToken = func(id, oauthConfigID, status string) {
 		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
-			ID: id, AuthMode: "shared", AccessToken: "at-" + id, TokenType: "Bearer",
+			ID: id, AuthMode: "shared", OauthConfigID: oauthConfigID, Status: status,
+			AccessToken: "at-" + id, TokenType: "Bearer",
 			ExpiresAt: &past, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}).Error)
 	}
-	// state is accepted for readability at call sites (mirrors each fixture's
-	// intent, e.g. "state-live") but no longer stored — state moved off
-	// TableOauthConfig onto TableMCPOauthFlow and isn't part of what this
-	// fixture set (GetExpiringOauthTokens) exercises.
-	mkConfig = func(id, tokenID, status, state string) {
+	mkConfig = func(id string) {
 		require.NoError(t, s.DB().Create(&tables.TableOauthConfig{
-			ID: id, RedirectURI: "http://127.0.0.1/cb", Status: status,
-			TokenID: &tokenID, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+			ID: id, RedirectURI: "http://127.0.0.1/cb", Status: "authorized",
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}).Error)
 	}
 	mkClient = func(name, oauthConfigID string, disabled bool) {
@@ -105,28 +104,26 @@ func expiringTokenIDs(t *testing.T, s *RDBConfigStore) map[string]bool {
 	return ids
 }
 
-// TestGetExpiringOauthTokens_ExcludesTerminalConfigs verifies the refresh worker
-// query skips tokens whose oauth_config is already terminal (expired/revoked), so
-// a permanently-dead grant is not retried — and re-logged — on every tick. Each
-// config gets an enabled MCP client so status is the only deciding condition.
-func TestGetExpiringOauthTokens_ExcludesTerminalConfigs(t *testing.T) {
+// TestGetExpiringOauthTokens_ExcludesNonActiveTokens verifies the refresh
+// worker query skips tokens whose own status is already 'needs_reauth', so a
+// permanently-dead grant is not retried — and re-logged — on every tick. Each
+// config gets an enabled MCP client so token status is the only deciding
+// condition.
+func TestGetExpiringOauthTokens_ExcludesNonActiveTokens(t *testing.T) {
 	s := setupRDBTestStore(t)
 	mkToken, mkConfig, mkClient := seedExpiringTokenFixtures(t, s)
 
-	mkToken("tok-live")
-	mkConfig("cfg-live", "tok-live", "authorized", "state-live")
+	mkConfig("cfg-live")
+	mkToken("tok-live", "cfg-live", "active")
 	mkClient("client-live", "cfg-live", false)
-	mkToken("tok-expired")
-	mkConfig("cfg-expired", "tok-expired", "expired", "state-expired")
-	mkClient("client-expired", "cfg-expired", false)
-	mkToken("tok-revoked")
-	mkConfig("cfg-revoked", "tok-revoked", "revoked", "state-revoked")
-	mkClient("client-revoked", "cfg-revoked", false)
+
+	mkConfig("cfg-needs-reauth")
+	mkToken("tok-needs-reauth", "cfg-needs-reauth", "needs_reauth")
+	mkClient("client-needs-reauth", "cfg-needs-reauth", false)
 
 	ids := expiringTokenIDs(t, s)
-	assert.True(t, ids["tok-live"], "token with an authorized config and enabled client should be refreshed")
-	assert.False(t, ids["tok-expired"], "token with an expired config must be excluded")
-	assert.False(t, ids["tok-revoked"], "token with a revoked config must be excluded")
+	assert.True(t, ids["tok-live"], "active token with an enabled client should be refreshed")
+	assert.False(t, ids["tok-needs-reauth"], "token already marked needs_reauth must be excluded")
 }
 
 // TestGetExpiringOauthTokens_RequiresEnabledClient verifies the refresh worker
@@ -137,23 +134,23 @@ func TestGetExpiringOauthTokens_RequiresEnabledClient(t *testing.T) {
 	s := setupRDBTestStore(t)
 	mkToken, mkConfig, mkClient := seedExpiringTokenFixtures(t, s)
 
-	mkToken("tok-enabled")
-	mkConfig("cfg-enabled", "tok-enabled", "authorized", "state-enabled")
+	mkConfig("cfg-enabled")
+	mkToken("tok-enabled", "cfg-enabled", "active")
 	mkClient("client-enabled", "cfg-enabled", false)
 
-	mkToken("tok-disabled")
-	mkConfig("cfg-disabled", "tok-disabled", "authorized", "state-disabled")
+	mkConfig("cfg-disabled")
+	mkToken("tok-disabled", "cfg-disabled", "active")
 	mkClient("client-disabled", "cfg-disabled", true)
 
-	mkToken("tok-shared")
-	mkConfig("cfg-shared", "tok-shared", "authorized", "state-shared")
+	mkConfig("cfg-shared")
+	mkToken("tok-shared", "cfg-shared", "active")
 	mkClient("client-shared-off", "cfg-shared", true)
 	mkClient("client-shared-on", "cfg-shared", false)
 
-	mkToken("tok-no-client")
-	mkConfig("cfg-no-client", "tok-no-client", "authorized", "state-no-client")
+	mkConfig("cfg-no-client")
+	mkToken("tok-no-client", "cfg-no-client", "active")
 
-	mkToken("tok-orphan") // no owning config at all
+	mkToken("tok-orphan", "", "active") // no owning config at all
 
 	ids := expiringTokenIDs(t, s)
 	assert.True(t, ids["tok-enabled"], "token with an enabled client should be refreshed")

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -491,7 +491,6 @@ type ConfigStore interface {
 	// OAuth config CRUD
 	GetOauthConfigByID(ctx context.Context, id string) (*tables.TableOauthConfig, error)
 	GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error)
-	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error
 
@@ -499,14 +498,20 @@ type ConfigStore interface {
 	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session'), not
 	// just the shared-client credential the method names below still imply.
 	//
-	// GetOauthTokenByID and GetOauthConfigByTokenID are not filtered by
-	// auth_mode: both are looked up exclusively via TableOauthConfig.TokenID,
-	// which only the shared-client flow ever populates, so the ID handed in
-	// is already guaranteed to resolve to a 'shared' row (or nothing) — a
-	// primary-key lookup, already unambiguous. An auth_mode filter here
-	// would be inert, unlike GetOauthUserTokenByID below, which a caller
-	// does feed an arbitrary externally-sourced ID.
+	// GetOauthTokenByID is not filtered by auth_mode: callers always feed it
+	// an ID already resolved from a trusted internal lookup (a token row just
+	// loaded, or GetSharedOauthTokenByConfigID's result), never an arbitrary
+	// externally-sourced ID — a primary-key lookup, already unambiguous. An
+	// auth_mode filter here would be inert, unlike GetOauthUserTokenByID
+	// below, which a caller does feed an arbitrary externally-sourced ID.
 	GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error)
+	// GetSharedOauthTokenByConfigID resolves the single shared-mode token row
+	// for a config, the replacement for the retired TableOauthConfig.TokenID
+	// FK shortcut. Not filtered by status — callers that only want a usable
+	// credential (GetAccessToken) check token.Status themselves; RevokeToken
+	// needs to reach the row regardless of status to delete it. Returns
+	// (nil, nil) when no shared token exists for this config.
+	GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
 	// GetExpiringOauthTokens is filtered to auth_mode='shared'. It backs the
 	// shared-only TokenRefreshWorker; per-user tokens refresh lazily/inline
 	// on lookup (GetOauthUserTokenByMode), and folding them into this
@@ -516,10 +521,12 @@ type ConfigStore interface {
 	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthToken(ctx context.Context, id string) error
-	// DeleteOauthTokensByConfigAndMode deletes every token row for a given
-	// (oauth_config_id, auth_mode) pair. Used by the shared-OAuth callback
-	// to clear the prior credential before inserting its replacement.
-	DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error
+	// DeleteSharedOauthTokensByConfigID deletes every auth_mode='shared' row
+	// for oauthConfigID, not just the one GetSharedOauthTokenByConfigID would
+	// pick. Used to guarantee revocation and shared-flow re-completion can't
+	// leave a duplicate row behind (see GetSharedOauthTokenByConfigID's doc
+	// comment for why more than one can otherwise exist).
+	DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
 
 	// Flow-row CRUD (mcp_oauth_flows / TableMCPOauthFlow). Method names keep
 	// their historical "OauthUserSession" naming even though the backing
@@ -581,12 +588,18 @@ type ConfigStore interface {
 	// rows matching the given identity column + MCP client. Used by revoke
 	// across all auth modes so subsequent OAuth init starts from a clean slate.
 	DeleteOauthUserSessionsByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) error
-	// MarkOauthUserTokenNeedsReauthByID flips status to 'needs_reauth'
-	// on a single token row. Called by the refresh-failure path when
-	// the upstream credential is permanently rejected: the row stays
-	// (preserves audit + binding for re-auth), but is filtered from
-	// active lookups so the next inference triggers a fresh OAuth
-	// flow that upserts the row back to 'active'.
+	// MarkOauthUserTokenNeedsReauthByID flips status to 'needs_reauth' on a
+	// single token row, regardless of auth_mode ('shared' included). Called
+	// by the unified refresh function when the upstream credential is
+	// permanently rejected: the row stays (preserves audit + binding for
+	// re-auth), but is filtered from active lookups so the next
+	// inference/access triggers a fresh OAuth flow that upserts (per-identity)
+	// or reauthorizes (shared) the row back to 'active'. Despite the
+	// "UserToken" name (kept for historical continuity with the other
+	// per-user-named methods on this merged table, see GetOauthUserTokenByMode's
+	// comment), this is not scoped away from 'shared' — the tokenID handed in
+	// always comes from an internal lookup already, never an arbitrary
+	// caller-supplied ID.
 	MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error
 	// GetOauthUserTokenByID looks up a single per-user token row by primary
 	// key. Returns nil, nil when not found. Unlike GetOauthTokenByID above,

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -12,26 +12,40 @@ import (
 // TableOauthConfig represents an OAuth configuration in the database. Past
 // the bootstrap flow, this is a pure registration/credential template row —
 // client_id/client_secret/endpoints/scopes plus the bootstrap lifecycle
-// Status ("pending"/"authorized"/"failed"). CSRF state and PKCE fields
-// (state, code_verifier, code_challenge) and the flow's own expiry live on
-// TableMCPOauthFlow instead — one config row is a durable, reusable
-// credential template, while a flow row is scoped to a single authorize
-// attempt and is disposed of once that attempt completes.
+// Status ("pending"/"authorized"/"failed" — a completed bootstrap never
+// regresses this to anything else; ongoing credential health lives entirely
+// on the token row's own Status instead, see TableMCPOauthToken). CSRF state
+// and PKCE fields (state, code_verifier, code_challenge) and the flow's own
+// expiry live on TableMCPOauthFlow instead — one config row is a durable,
+// reusable credential template, while a flow row is scoped to a single
+// authorize attempt and is disposed of once that attempt completes. There is
+// likewise no FK shortcut onto the token row here (a retired TokenID field
+// used to serve that purpose for the shared-mode holder only) — every
+// holder's token, shared or per-identity alike, is reached by querying
+// mcp_oauth_tokens on (oauth_config_id, auth_mode) instead. The lookup
+// contract differs by holder type: a shared lookup filters on
+// (oauth_config_id, auth_mode = "shared") alone, which is not unique by
+// itself — see the shared-mode uniqueness index below for what actually
+// constrains it to one row. A per-identity lookup additionally requires
+// mcp_client_id and the matching user_id, virtual_key_id, or session_id,
+// plus status = "active". A refresh, once a token row is already in hand,
+// looks it up directly by its own ID instead of re-deriving either of the
+// above. FlowMode = "admin" on the originating TableMCPOauthFlow is what
+// produces a token row with AuthMode = "shared".
 type TableOauthConfig struct {
-	ID                  string             `gorm:"type:varchar(255);primaryKey" json:"id"`         // UUID
-	ClientID            *schemas.SecretVar `gorm:"type:varchar(512)" json:"client_id"`             // OAuth provider's client ID (optional for public clients)
-	ClientSecret        *schemas.SecretVar `gorm:"type:text" json:"-"`                             // Encrypted OAuth client secret (optional for public clients)
-	AuthorizeURL        string             `gorm:"type:text" json:"authorize_url"`                 // Provider's authorization endpoint (optional, can be discovered)
-	TokenURL            string             `gorm:"type:text" json:"token_url"`                     // Provider's token endpoint (optional, can be discovered)
-	RegistrationURL     *string            `gorm:"type:text" json:"registration_url,omitempty"`    // Provider's dynamic registration endpoint (optional, can be discovered)
-	RedirectURI         string             `gorm:"type:text;not null" json:"redirect_uri"`         // Callback URL
-	Scopes              string             `gorm:"type:text" json:"scopes"`                        // JSON array of scopes (optional, can be discovered)
-	Status              string             `gorm:"type:varchar(50);not null;index" json:"status"`  // "pending", "authorized", "failed", "expired", "revoked"
-	TokenID             *string            `gorm:"type:varchar(255);index" json:"token_id"`        // Foreign key to mcp_oauth_tokens.ID (set after callback)
-	ServerURL           string             `gorm:"type:text" json:"server_url"`                    // MCP server URL for OAuth discovery
-	Resource            string             `gorm:"type:text" json:"resource,omitempty"`            // OAuth resource indicator (RFC 8707), typically the MCP server URL
-	UseDiscovery        bool               `gorm:"default:false" json:"use_discovery"`             // Flag to enable OAuth discovery
-	MCPClientConfigJSON *string            `gorm:"type:text" json:"-"`                             // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
+	ID                  string             `gorm:"type:varchar(255);primaryKey" json:"id"`        // UUID
+	ClientID            *schemas.SecretVar `gorm:"type:varchar(512)" json:"client_id"`            // OAuth provider's client ID (optional for public clients)
+	ClientSecret        *schemas.SecretVar `gorm:"type:text" json:"-"`                            // Encrypted OAuth client secret (optional for public clients)
+	AuthorizeURL        string             `gorm:"type:text" json:"authorize_url"`                // Provider's authorization endpoint (optional, can be discovered)
+	TokenURL            string             `gorm:"type:text" json:"token_url"`                    // Provider's token endpoint (optional, can be discovered)
+	RegistrationURL     *string            `gorm:"type:text" json:"registration_url,omitempty"`   // Provider's dynamic registration endpoint (optional, can be discovered)
+	RedirectURI         string             `gorm:"type:text;not null" json:"redirect_uri"`        // Callback URL
+	Scopes              string             `gorm:"type:text" json:"scopes"`                       // JSON array of scopes (optional, can be discovered)
+	Status              string             `gorm:"type:varchar(50);not null;index" json:"status"` // "pending", "authorized", "failed" — the one-time bootstrap lifecycle only
+	ServerURL           string             `gorm:"type:text" json:"server_url"`                   // MCP server URL for OAuth discovery
+	Resource            string             `gorm:"type:text" json:"resource,omitempty"`           // OAuth resource indicator (RFC 8707), typically the MCP server URL
+	UseDiscovery        bool               `gorm:"default:false" json:"use_discovery"`            // Flag to enable OAuth discovery
+	MCPClientConfigJSON *string            `gorm:"type:text" json:"-"`                            // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
 	EncryptionStatus    string             `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
 	CreatedAt           time.Time          `gorm:"index;not null" json:"created_at"`
 	UpdatedAt           time.Time          `gorm:"index;not null" json:"updated_at"`

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -22,12 +22,22 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/temptoken"
+	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 )
 
 const (
 	maxTokenRetries = 3
 	networkTimeout  = 30 * time.Second
+	// refreshAccessTokenTimeout bounds the detached work RefreshAccessToken
+	// hands to refreshGroup: up to maxTokenRetries network attempts at
+	// networkTimeout each, plus retry backoff, can approach 100s worst case —
+	// rounded up with headroom so a stuck upstream can't wedge the
+	// singleflight entry forever.
+	refreshAccessTokenTimeout = 2 * time.Minute
+	// terminalStatusUpdateTimeout bounds the detached needs_reauth status
+	// write after a permanent OAuth rejection (see refreshAccessTokenLocked).
+	terminalStatusUpdateTimeout = 10 * time.Second
 )
 
 // OAuth2Provider implements the schemas.OAuth2Provider interface
@@ -37,6 +47,16 @@ type OAuth2Provider struct {
 	mu             sync.RWMutex
 	retryBaseDelay time.Duration // base delay for token endpoint retry backoff; doubles each attempt (1×, 2×, 4×)
 
+	// refreshGroup serializes RefreshAccessToken per token ID instead of
+	// provider-wide: exchangeRefreshToken can make up to maxTokenRetries
+	// network attempts at networkTimeout each, and one slow identity
+	// provider's refresh must not stall every other token's refresh on this
+	// provider. Concurrent refreshes of the *same* token still collapse into
+	// a single call and share its result, which is what actually needs to
+	// be prevented (a racing double refresh_token redemption, most upstreams
+	// reject the second as replay).
+	refreshGroup singleflight.Group
+
 	// tempTokens, when non-nil and enabled in client config, is used by
 	// InitiateUserOAuthFlow to mint a short-lived mcp_auth temp token and
 	// embed it in the returned auth-page URL as a fragment. Optional — when
@@ -45,8 +65,8 @@ type OAuth2Provider struct {
 	//
 	// Held as an atomic.Pointer rather than under p.mu: it is written once at
 	// startup and read on the request path, and p.mu is write-locked across
-	// token-refresh network I/O (RefreshAccessToken/RevokeToken). Sharing p.mu
-	// would stall flow init/cleanup reads behind unrelated refresh traffic.
+	// RevokeToken's database I/O. Sharing p.mu would stall flow init/cleanup
+	// reads behind unrelated revoke traffic.
 	tempTokens atomic.Pointer[temptoken.Service]
 }
 
@@ -98,7 +118,7 @@ func (p *OAuth2Provider) mcpTempTokenAuthEnabled(ctx context.Context) bool {
 // Detached from the caller's context via WithoutCancel so a client cancellation
 // (e.g. the browser closing the tab after the upstream OAuth bounce) can't
 // short-circuit the deletes and leave the rows alive until the sweep. Mirrors
-// the pattern used by markExpiredIfPermanent in this file.
+// the pattern used by RefreshAccessToken's terminal status flip in this file.
 func (p *OAuth2Provider) cleanupFlow(ctx context.Context, sessionID string) {
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer cancel()
@@ -123,34 +143,33 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 		return "", schemas.ErrOAuth2ConfigNotFound
 	}
 
-	// Check if OAuth is authorized
-	if oauthConfig.Status != "authorized" {
-		return "", fmt.Errorf("oauth not authorized yet, status: %s", oauthConfig.Status)
-	}
-
-	// Check if token is linked
-	if oauthConfig.TokenID == nil {
-		return "", fmt.Errorf("no token linked to oauth config")
-	}
-
-	// Load oauth_token by TokenID
-	token, err := p.configStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
+	// Resolve the shared token row via (oauth_config_id, auth_mode='shared')
+	// — the replacement for the retired TableOauthConfig.TokenID FK shortcut.
+	token, err := p.configStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID)
 	if err != nil {
 		return "", fmt.Errorf("failed to load oauth token: %w", err)
 	}
 	if token == nil {
-		return "", fmt.Errorf("oauth token not found")
+		return "", fmt.Errorf("no token linked to oauth config")
+	}
+
+	// The token's own Status ('active' | 'orphaned' | 'needs_reauth') is the
+	// sole source of truth for whether this credential is usable.
+	// oauthConfig.Status only tracks the one-time bootstrap lifecycle
+	// (pending/authorized/failed) and is never consulted here — matching how
+	// GetUserAccessTokenByMode has always worked.
+	if token.Status != "active" {
+		return "", fmt.Errorf("oauth token is not active, status: %s: %w", token.Status, schemas.ErrOAuth2TokenExpired)
 	}
 
 	// Refresh only when the token has known expiry and a refresh token is available.
 	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
 		// Attempt automatic refresh
-		if err := p.RefreshAccessToken(ctx, oauthConfigID); err != nil {
-			p.markExpiredIfPermanent(ctx, oauthConfig, err)
+		if err := p.RefreshAccessToken(ctx, token.ID); err != nil {
 			return "", fmt.Errorf("token expired and refresh failed: %w", err)
 		}
 		// Reload token after refresh
-		token, err = p.configStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
+		token, err = p.configStore.GetOauthTokenByID(ctx, token.ID)
 		if err != nil || token == nil {
 			return "", fmt.Errorf("failed to reload token after refresh: %w", err)
 		}
@@ -167,41 +186,111 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 	return accessToken, nil
 }
 
-// RefreshAccessToken refreshes the access token for a given oauth_config_id
-func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	// Load oauth_config
-	oauthConfig, err := p.configStore.GetOauthConfigByID(ctx, oauthConfigID)
-	if err != nil || oauthConfig == nil {
-		return fmt.Errorf("oauth config not found: %w", err)
+// RefreshAccessToken refreshes any MCP OAuth token row — the single shared
+// client credential (AuthMode="shared") or a per-identity credential
+// (AuthMode "user"/"vk"/"session") alike — looked up by the token row's own
+// primary-key ID. This is the one refresh path for every kind of MCP OAuth
+// credential: GetAccessToken and GetUserAccessTokenByMode both funnel their
+// lazy pre-flight refresh through here, unifying what used to be two
+// separate functions (one keyed by oauth_config_id and reachable only via
+// TableOauthConfig.TokenID, one keyed by token ID directly).
+//
+// Never writes to TableOauthConfig: the template config row (client_id,
+// token_url, etc.) is read-only input to the token exchange here. Credential
+// health lives entirely on the token row's own Status field.
+//
+// The actual refresh runs on a context detached from any single caller —
+// via DoChan rather than Do — because it is shared work: with Do, the first
+// caller's ctx backs the whole call, so that caller disconnecting (client
+// abort, gateway timeout) would cancel the in-flight upstream request and
+// deliver that same cancellation error to every other concurrent caller
+// waiting on the same token, even though their own requests are still live.
+// Each caller here instead only ever stops waiting on its own ctx; the
+// shared refresh keeps running to completion (bounded by
+// refreshAccessTokenTimeout) for whoever else still needs its result.
+func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, tokenID string) error {
+	ch := p.refreshGroup.DoChan(tokenID, func() (any, error) {
+		refreshCtx, cancel := context.WithTimeout(context.Background(), refreshAccessTokenTimeout)
+		defer cancel()
+		return nil, p.refreshAccessTokenLocked(refreshCtx, tokenID)
+	})
+	select {
+	case res := <-ch:
+		return res.Err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+}
 
-	if oauthConfig.TokenID == nil {
-		return fmt.Errorf("no token linked to oauth config")
+// refreshAccessTokenLocked is RefreshAccessToken's body, run inside
+// p.refreshGroup.DoChan so concurrent refreshes of the same token ID
+// collapse into one call instead of each redeeming the refresh token
+// independently.
+func (p *OAuth2Provider) refreshAccessTokenLocked(ctx context.Context, tokenID string) error {
+	token, err := p.configStore.GetOauthTokenByID(ctx, tokenID)
+	if err != nil {
+		return fmt.Errorf("failed to load oauth token: %w", err)
 	}
-
-	// Load oauth_token
-	token, err := p.configStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
-	if err != nil || token == nil {
-		return fmt.Errorf("oauth token not found: %w", err)
+	if token == nil {
+		return fmt.Errorf("oauth token not found: %s", tokenID)
 	}
 
 	if strings.TrimSpace(token.RefreshToken) == "" {
 		return fmt.Errorf("no refresh token available")
 	}
 
+	// Load template OAuth config for token_url, client_id, etc. Split nil
+	// from a real lookup failure so a missing config doesn't surface as a
+	// useless "%!w(<nil>)" wrapped error.
+	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, token.OauthConfigID)
+	if err != nil {
+		return fmt.Errorf("failed to load template oauth config for refresh: %w", err)
+	}
+	if templateConfig == nil {
+		return schemas.ErrOAuth2ConfigNotFound
+	}
+
 	// Call OAuth provider's token endpoint with refresh_token
 	newTokenResponse, err := p.exchangeRefreshToken(
 		ctx,
-		oauthConfig.TokenURL,
-		oauthConfig.GetResolvedClientID(),
-		oauthConfig.GetResolvedClientSecret(),
+		templateConfig.TokenURL,
+		templateConfig.GetResolvedClientID(),
+		templateConfig.GetResolvedClientSecret(),
 		token.RefreshToken,
-		strings.TrimSpace(oauthConfig.Resource),
+		strings.TrimSpace(templateConfig.Resource),
 	)
 	if err != nil {
+		// Permanent rejection (HTTP 401, or 400 with invalid_grant /
+		// unauthorized_client per RFC 6749 §5.2) means the refresh token is
+		// dead — revoked, expired, or bound to a grant the AS no longer
+		// honors. Flip the row to 'needs_reauth' and signal
+		// re-authentication via the ErrOAuth2TokenExpired sentinel,
+		// regardless of which kind of holder (shared client or per-identity)
+		// this row belongs to. Keeping the row (rather than deleting)
+		// preserves binding identity + audit history; a fresh OAuth
+		// completion (reauthorize for shared, re-auth flow for per-identity)
+		// updates the same row back to 'active'.
+		if permErr, ok := errors.AsType[*PermanentOAuthError](err); ok {
+			// Detached, bounded context for the terminal status flip: ctx
+			// here is already refreshAccessTokenTimeout-bounded and detached
+			// from any single caller (see RefreshAccessToken), but it may be
+			// close to its own deadline by the time we get the
+			// 'invalid_grant' / 401 after retries. A fresh, short-timeout
+			// context ensures this write isn't starved by that budget, and
+			// isn't unbounded either — an unbounded write here could wedge
+			// the singleflight entry indefinitely if the store hangs.
+			statusCtx, cancel := context.WithTimeout(context.Background(), terminalStatusUpdateTimeout)
+			defer cancel()
+			if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(statusCtx, token.ID); markErr != nil {
+				return fmt.Errorf("oauth refresh permanently rejected but status update failed (mcp_client=%s auth_mode=%s upstream_status=%d): %w",
+					token.MCPClientID, token.AuthMode, permErr.StatusCode, markErr)
+			}
+			logger.Debug("OAuth refresh permanently rejected; token marked needs_reauth: mcp_client=%s auth_mode=%s upstream_status=%d",
+				token.MCPClientID, token.AuthMode, permErr.StatusCode)
+			return fmt.Errorf("refresh token rejected by upstream OAuth server, re-authentication required: %w", schemas.ErrOAuth2TokenExpired)
+		}
+		// Transient failure (5xx, network blip, non-permanent 400) — keep the
+		// row so the next call retries refresh.
 		return fmt.Errorf("token refresh failed: %w", err)
 	}
 	// Update token in database (sanitize tokens to prevent header formatting issues)
@@ -221,7 +310,7 @@ func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID s
 		return fmt.Errorf("failed to update token: %w", err)
 	}
 
-	logger.Debug("OAuth token refreshed successfully oauth_config_id : %s", oauthConfigID)
+	logger.Debug("OAuth token refreshed successfully: token_id=%s auth_mode=%s", token.ID, token.AuthMode)
 
 	return nil
 }
@@ -233,12 +322,15 @@ func (p *OAuth2Provider) ValidateToken(ctx context.Context, oauthConfigID string
 		return false, nil
 	}
 
-	if oauthConfig.TokenID == nil {
+	token, err := p.configStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID)
+	if err != nil || token == nil {
 		return false, nil
 	}
 
-	token, err := p.configStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
-	if err != nil || token == nil {
+	// Status is the sole source of truth for usability, same as GetAccessToken:
+	// a needs_reauth/orphaned row must not report valid just because its
+	// ExpiresAt happens to be nil or in the future.
+	if token.Status != "active" {
 		return false, nil
 	}
 
@@ -259,28 +351,28 @@ func (p *OAuth2Provider) RevokeToken(ctx context.Context, oauthConfigID string) 
 		return fmt.Errorf("oauth config not found: %w", err)
 	}
 
-	if oauthConfig.TokenID == nil {
-		return fmt.Errorf("no token linked to oauth config")
+	token, err := p.configStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID)
+	if err != nil {
+		return fmt.Errorf("failed to load oauth token: %w", err)
 	}
-
-	token, err := p.configStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
-	if err != nil || token == nil {
-		return fmt.Errorf("oauth token not found: %w", err)
+	if token == nil {
+		return fmt.Errorf("no token linked to oauth config")
 	}
 
 	// Optionally call provider's revocation endpoint (if supported)
 	// This is best-effort - we'll delete the token even if revocation fails
 
-	// Delete token from database
-	if err := p.configStore.DeleteOauthToken(ctx, token.ID); err != nil {
+	// Delete every shared token row for this config, not just the one
+	// GetSharedOauthTokenByConfigID picked above (used only to confirm a
+	// token exists) — nothing guarantees at most one auth_mode='shared' row
+	// per oauth_config_id (see GetSharedOauthTokenByConfigID's doc comment),
+	// and deleting a single row would leave a stale duplicate usable.
+	// oauth_configs itself is left untouched — it's a reusable credential
+	// template (client_id/client_secret/endpoints) independent of any one
+	// token's lifecycle, and no longer carries a token reference or a
+	// revoked-ness of its own to clean up.
+	if err := p.configStore.DeleteSharedOauthTokensByConfigID(ctx, oauthConfigID); err != nil {
 		return fmt.Errorf("failed to delete token: %w", err)
-	}
-
-	// Update oauth_config to remove token reference and mark as revoked
-	oauthConfig.TokenID = nil
-	oauthConfig.Status = "revoked"
-	if err := p.configStore.UpdateOauthConfig(ctx, oauthConfig); err != nil {
-		return fmt.Errorf("failed to update oauth config: %w", err)
 	}
 
 	logger.Debug("OAuth token revoked", "oauth_config_id", oauthConfigID)
@@ -622,9 +714,11 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		return fmt.Errorf("oauth config not found for flow %s", flow.ID)
 	}
 
-	// Check expiry
+	// Check expiry. "failed" (not a since-retired "expired") is the terminal
+	// bootstrap status here — the same value the token-exchange failure branch
+	// below uses for a different kind of bootstrap-attempt failure.
 	if time.Now().After(flow.ExpiresAt) {
-		oauthConfig.Status = "expired"
+		oauthConfig.Status = "failed"
 		p.configStore.UpdateOauthConfig(ctx, oauthConfig)
 		p.cleanupFlow(ctx, flow.ID)
 		return fmt.Errorf("oauth flow expired")
@@ -712,17 +806,17 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		return fmt.Errorf("failed to look up mcp client for oauth config: %w", err)
 	}
 
-	// Replace the shared credential atomically: delete any existing
-	// auth_mode="shared" rows for this oauth_config_id (a reauth otherwise
-	// leaves the old token orphaned once oauth_configs.token_id repoints to
-	// the new one), insert the new token, and link it on oauth_configs — all
-	// in one transaction, so a failure partway through never leaves an
-	// unlinked or stale token row behind.
-	oauthConfig.TokenID = &tokenID
+	// A shared config can be re-authorized (e.g. via the reauthorize
+	// endpoint) after already having a live token row. Clear any existing
+	// shared rows for this config, create the replacement, and link the
+	// config, all in one transaction: a failure partway through must not be
+	// able to leave the client with zero working shared credentials (delete
+	// succeeded, create/update didn't) any more than it should leave a live
+	// credential unlinked and untracked as "authorized" (CWE-459).
 	oauthConfig.Status = "authorized"
 	if err := p.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		if err := p.configStore.DeleteOauthTokensByConfigAndMode(ctx, tokenRecord.OauthConfigID, "shared", tx); err != nil {
-			return err
+		if err := p.configStore.DeleteSharedOauthTokensByConfigID(ctx, oauthConfig.ID, tx); err != nil {
+			return fmt.Errorf("failed to clear existing shared oauth tokens before re-completion: %w", err)
 		}
 		if err := p.configStore.CreateOauthToken(ctx, tokenRecord, tx); err != nil {
 			return fmt.Errorf("failed to create oauth token: %w", err)
@@ -862,21 +956,6 @@ func (p *OAuth2Provider) exchangeCodeForTokensWithPKCE(ctx context.Context, toke
 	}
 
 	return p.callTokenEndpoint(ctx, tokenURL, data)
-}
-
-// markExpiredIfPermanent marks oauth_config.status as "expired" when a refresh failure
-// is a permanent auth rejection (PermanentOAuthError). Transient failures are ignored —
-// the TokenRefreshWorker will retry on the next tick.
-func (p *OAuth2Provider) markExpiredIfPermanent(ctx context.Context, oauthConfig *tables.TableOauthConfig, err error) {
-	var permErr *PermanentOAuthError
-	if errors.As(err, &permErr) {
-		oauthConfig.Status = "expired"
-		updateCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer cancel()
-		if updateErr := p.configStore.UpdateOauthConfig(updateCtx, oauthConfig); updateErr != nil {
-			logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
-		}
-	}
 }
 
 // exchangeRefreshToken exchanges refresh token for new access token
@@ -1335,7 +1414,7 @@ func (p *OAuth2Provider) GetUserAccessTokenByMode(ctx context.Context, mode sche
 
 	// Refresh only when known-expired and refresh token exists.
 	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
-		if err := p.RefreshUserAccessToken(ctx, token.ID); err != nil {
+		if err := p.RefreshAccessToken(ctx, token.ID); err != nil {
 			return "", fmt.Errorf("per-user token expired and refresh failed: %w", err)
 		}
 		token, err = p.configStore.GetOauthUserTokenByMode(ctx, mode, identity, mcpClientID)
@@ -1352,91 +1431,4 @@ func (p *OAuth2Provider) GetUserAccessTokenByMode(ctx context.Context, mode sche
 		return "", fmt.Errorf("per-user access token is empty after sanitization")
 	}
 	return accessToken, nil
-}
-
-// RefreshUserAccessToken refreshes a per-user OAuth access token, looked up
-// by the token row's primary-key ID.
-func (p *OAuth2Provider) RefreshUserAccessToken(ctx context.Context, tokenID string) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	token, err := p.configStore.GetOauthUserTokenByID(ctx, tokenID)
-	if err != nil || token == nil {
-		return fmt.Errorf("per-user oauth token not found: %w", err)
-	}
-
-	if token.RefreshToken == "" {
-		return fmt.Errorf("no refresh token available for per-user oauth token")
-	}
-
-	// Load template OAuth config for token_url, client_id, etc. Split nil
-	// from a real lookup failure so a missing config doesn't surface as a
-	// useless "%!w(<nil>)" wrapped error.
-	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, token.OauthConfigID)
-	if err != nil {
-		return fmt.Errorf("failed to load template oauth config for refresh: %w", err)
-	}
-	if templateConfig == nil {
-		return schemas.ErrOAuth2ConfigNotFound
-	}
-
-	// Exchange refresh token
-	newTokenResponse, err := p.exchangeRefreshToken(
-		ctx,
-		templateConfig.TokenURL,
-		templateConfig.GetResolvedClientID(),
-		templateConfig.GetResolvedClientSecret(),
-		token.RefreshToken,
-		strings.TrimSpace(templateConfig.Resource),
-	)
-	if err != nil {
-		// Permanent rejection (HTTP 401, or 400 with invalid_grant /
-		// unauthorized_client per RFC 6749 §5.2) means the refresh token is
-		// dead — revoked, expired, or bound to a grant the AS no longer
-		// honors. Flip the row to 'needs_reauth' and signal re-authentication
-		// via the ErrOAuth2TokenExpired sentinel, which ResolvePerUserOAuthToken
-		// converts into an inline MCPUserOAuthRequiredError with auth URL.
-		// Keeping the row (rather than deleting) preserves binding identity +
-		// audit history; the OAuth callback at re-auth completion upserts
-		// the same row back to 'active' with fresh access/refresh tokens.
-		var permErr *PermanentOAuthError
-		if errors.As(err, &permErr) {
-			// Use context.Background for the terminal status flip — the
-			// caller's ctx may already be canceled (request abort, upstream
-			// timeout) by the time we get the 'invalid_grant' / 401, and if
-			// the UPDATE fails because of that, the row stays 'active' and
-			// every subsequent inference call keeps retrying a dead refresh
-			// token instead of surfacing the re-auth requirement.
-			if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(context.Background(), token.ID); markErr != nil {
-				return fmt.Errorf("per-user oauth refresh permanently rejected but status update failed (mcp_client=%s upstream_status=%d): %w",
-					token.MCPClientID, permErr.StatusCode, markErr)
-			}
-			logger.Debug("Per-user OAuth refresh permanently rejected; row marked needs_reauth: mcp_client=%s upstream_status=%d",
-				token.MCPClientID, permErr.StatusCode)
-			return fmt.Errorf("refresh token rejected by upstream OAuth server, re-authentication required: %w", schemas.ErrOAuth2TokenExpired)
-		}
-		// Transient failure (5xx, network blip, non-permanent 400) — keep the
-		// row so the next call retries refresh.
-		return fmt.Errorf("per-user token refresh failed: %w", err)
-	}
-
-	// Update token
-	now := time.Now()
-	token.ExpiresAt = nil
-	if newTokenResponse.ExpiresIn > 0 {
-		exp := now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
-		token.ExpiresAt = bifrost.Ptr(exp)
-	}
-	token.AccessToken = strings.TrimSpace(newTokenResponse.AccessToken)
-	if newTokenResponse.RefreshToken != "" {
-		token.RefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
-	}
-	token.LastRefreshedAt = bifrost.Ptr(now)
-
-	if err := p.configStore.UpdateOauthUserToken(ctx, token); err != nil {
-		return fmt.Errorf("failed to update per-user token after refresh: %w", err)
-	}
-
-	logger.Debug("Per-user OAuth token refreshed: token_id=%s", token.ID)
-	return nil
 }

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -97,33 +97,19 @@ func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 	}
 	w.logger.Debug("Found expiring tokens to refresh: %d", len(tokens))
 
-	// Refresh each expiring token
+	// Refresh each expiring token directly by its own ID — RefreshAccessToken
+	// resolves the owning oauth_config internally, and (on permanent
+	// rejection) flips the token's own Status to 'needs_reauth' itself, so
+	// there's nothing left for this loop to do on failure beyond logging.
 	for _, token := range tokens {
-		// Find the oauth_config that references this token
-		oauthConfig, err := w.provider.configStore.GetOauthConfigByTokenID(ctx, token.ID)
-		if err != nil {
-			w.logger.Error("Failed to find oauth config for token: %s, error: %s", token.ID, err.Error())
-			continue
-		}
-
-		if oauthConfig == nil {
-			w.logger.Warn("No oauth config found for token: %s", token.ID)
-			continue
-		}
-
-		// Attempt to refresh the token. Logged at Debug: transient failures
-		// (DNS, timeout, offline) recur on every tick and would spam the
-		// error log, while permanent rejections are already surfaced by the
-		// oauth_config status flipping to "expired" below.
-		if err := w.provider.RefreshAccessToken(ctx, oauthConfig.ID); err != nil {
-			w.logger.Debug("Failed to refresh token: oauth_config_id: %s, error: %s", oauthConfig.ID, err.Error())
-
-			// Only mark as expired for permanent auth rejections (e.g. invalid_grant, 401).
-			// Transient failures (DNS, timeout, offline) are skipped — the worker will
-			// retry on the next tick and the connection heals automatically when online.
-			w.provider.markExpiredIfPermanent(ctx, oauthConfig, err)
+		// Logged at Debug: transient failures (DNS, timeout, offline) recur
+		// on every tick and would spam the error log, while permanent
+		// rejections are already surfaced by the token's Status flipping to
+		// "needs_reauth" inside RefreshAccessToken.
+		if err := w.provider.RefreshAccessToken(ctx, token.ID); err != nil {
+			w.logger.Debug("Failed to refresh token: token_id: %s, mcp_client_id: %s, error: %s", token.ID, token.MCPClientID, err.Error())
 		} else {
-			w.logger.Debug("Successfully refreshed token: %s", oauthConfig.ID)
+			w.logger.Debug("Successfully refreshed token: %s", token.ID)
 		}
 	}
 }

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -48,17 +48,6 @@ func (s *testConfigStore) GetOauthConfigByID(_ context.Context, id string) (*tab
 	return bifrost.Ptr(*cfg), nil
 }
 
-func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID string) (*tables.TableOauthConfig, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, cfg := range s.oauthConfigs {
-		if cfg.TokenID != nil && *cfg.TokenID == tokenID {
-			return bifrost.Ptr(*cfg), nil
-		}
-	}
-	return nil, nil
-}
-
 func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.TableOauthConfig, _ ...*gorm.DB) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -76,10 +65,40 @@ func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tabl
 	return bifrost.Ptr(*token), nil
 }
 
+// GetSharedOauthTokenByConfigID resolves the shared-mode token row for a
+// config — the test-double equivalent of the real store's
+// (oauth_config_id, auth_mode='shared') lookup, the replacement for the
+// retired TableOauthConfig.TokenID FK shortcut.
+func (s *testConfigStore) GetSharedOauthTokenByConfigID(_ context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, token := range s.oauthTokens {
+		if token.OauthConfigID == oauthConfigID && token.AuthMode == "shared" {
+			return bifrost.Ptr(*token), nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableMCPOauthToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.oauthTokens[token.ID] = bifrost.Ptr(*token)
+	return nil
+}
+
+// MarkOauthUserTokenNeedsReauthByID flips a token's status to 'needs_reauth',
+// the test-double equivalent of the real store's method of the same name —
+// which, despite the historical "UserToken" naming, is not scoped away from
+// auth_mode='shared' (see its doc comment on the real ConfigStore interface).
+func (s *testConfigStore) MarkOauthUserTokenNeedsReauthByID(_ context.Context, tokenID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token := s.oauthTokens[tokenID]
+	if token == nil {
+		return nil
+	}
+	token.Status = "needs_reauth"
 	return nil
 }
 
@@ -104,20 +123,12 @@ func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.
 	return expiring, nil
 }
 
-// seedFixtures inserts an authorized oauth_config + token pair into the store.
-// The token expires 1 minute from now so GetExpiringOauthTokens will find it.
-func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthConfigID string) {
+// seedFixtures inserts an authorized oauth_config + shared-mode token pair
+// into the store, linked via the token's OauthConfigID (the replacement for
+// the retired TableOauthConfig.TokenID FK shortcut). The token expires 1
+// minute from now so GetExpiringOauthTokens will find it.
+func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthConfigID, tokenID string) {
 	t.Helper()
-
-	tokenID := "test-token-id"
-	store.oauthTokens[tokenID] = &tables.TableMCPOauthToken{
-		ID:           tokenID,
-		AccessToken:  "old-access-token",
-		RefreshToken: "refresh-token",
-		TokenType:    "bearer",
-		ExpiresAt:    new(time.Now().Add(1 * time.Minute)),
-		Scopes:       "[]",
-	}
 
 	oauthConfigID = "test-oauth-config-id"
 	store.oauthConfigs[oauthConfigID] = &tables.TableOauthConfig{
@@ -127,10 +138,22 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 		RedirectURI: "http://localhost/callback",
 		Scopes:      `["read"]`,
 		Status:      "authorized",
-		TokenID:     new(tokenID),
 	}
 
-	return oauthConfigID
+	tokenID = "test-token-id"
+	store.oauthTokens[tokenID] = &tables.TableMCPOauthToken{
+		ID:            tokenID,
+		AuthMode:      "shared",
+		OauthConfigID: oauthConfigID,
+		Status:        "active",
+		AccessToken:   "old-access-token",
+		RefreshToken:  "refresh-token",
+		TokenType:     "bearer",
+		ExpiresAt:     new(time.Now().Add(1 * time.Minute)),
+		Scopes:        "[]",
+	}
+
+	return oauthConfigID, tokenID
 }
 
 func newTestWorker(store *testConfigStore) *TokenRefreshWorker {
@@ -138,6 +161,71 @@ func newTestWorker(store *testConfigStore) *TokenRefreshWorker {
 	provider := NewOAuth2Provider(store, noopLogger)
 	provider.retryBaseDelay = 1 * time.Millisecond // speed up retry backoff in tests
 	return NewTokenRefreshWorker(provider, noopLogger)
+}
+
+func newTestProvider(store *testConfigStore) *OAuth2Provider {
+	noopLogger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	provider := NewOAuth2Provider(store, noopLogger)
+	provider.retryBaseDelay = 1 * time.Millisecond
+	return provider
+}
+
+// TestRefreshAccessToken_CallerCancellationDoesNotAbortOtherWaiters exercises
+// the race RefreshAccessToken's DoChan (rather than Do) shape exists to
+// close: a caller's own context cancellation must only stop that caller from
+// waiting, never abort the shared refresh work other concurrent callers for
+// the same token are depending on.
+func TestRefreshAccessToken_CallerCancellationDoesNotAbortOtherWaiters(t *testing.T) {
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	var startedOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedOnce.Do(func() { close(started) })
+		<-unblock
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"token_type":    "bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
+	provider := newTestProvider(store)
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var leaderErr error
+	go func() {
+		defer wg.Done()
+		leaderErr = provider.RefreshAccessToken(leaderCtx, tokenID)
+	}()
+
+	<-started
+	// The leader disconnects before the upstream call finishes. Its own
+	// RefreshAccessToken call returns immediately on this (it only selects
+	// on its own ctx vs the shared result), without waiting for or
+	// affecting the shared work still blocked in the handler below.
+	cancelLeader()
+	wg.Wait()
+
+	// Only now let the shared refresh's upstream call actually complete.
+	close(unblock)
+
+	// A second caller for the same token, with its own live context, must
+	// get the refresh's real result — not the leader's cancellation.
+	followerErr := provider.RefreshAccessToken(context.Background(), tokenID)
+
+	assert.ErrorIs(t, leaderErr, context.Canceled, "the leader itself should observe its own cancellation")
+	assert.NoError(t, followerErr, "a follower with its own live context must not inherit the leader's cancellation")
+
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken, "the shared refresh must have completed and persisted, unaffected by the leader's cancellation")
 }
 
 func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
@@ -341,29 +429,29 @@ func TestExchangeRefreshToken_OmitsEmptyResource(t *testing.T) {
 	assert.False(t, exists)
 }
 
-func TestTokenRefreshWorker_TransientError_DoesNotMarkExpired(t *testing.T) {
+func TestTokenRefreshWorker_TransientError_DoesNotMarkNeedsReauth(t *testing.T) {
 	// A 503 response from the token server is a transient failure.
-	// The oauth_config must stay "authorized" so the connection can
-	// heal automatically when the server recovers.
+	// The token must stay "active" so the connection can heal
+	// automatically when the server recovers.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "authorized", cfg.Status, "transient server error must not mark config as expired")
+	assert.Equal(t, "active", token.Status, "transient server error must not mark token needs_reauth")
 }
 
-func TestTokenRefreshWorker_PermanentError_MarksExpired(t *testing.T) {
+func TestTokenRefreshWorker_PermanentError_MarksNeedsReauth(t *testing.T) {
 	// A 401 invalid_grant response is a permanent rejection from the auth server.
-	// The oauth_config must be marked "expired" to prompt the user to re-authorize.
+	// The token must be marked "needs_reauth" to prompt the user to re-authorize.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -375,19 +463,19 @@ func TestTokenRefreshWorker_PermanentError_MarksExpired(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "expired", cfg.Status, "permanent auth rejection must mark config as expired")
+	assert.Equal(t, "needs_reauth", token.Status, "permanent auth rejection must mark token needs_reauth")
 }
 
 func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
 	// A successful refresh must update the stored access token and
-	// leave the oauth_config status as "authorized".
+	// leave the token status as "active".
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
@@ -400,42 +488,39 @@ func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "authorized", cfg.Status)
-
-	token, err := store.GetOauthTokenByID(context.Background(), *cfg.TokenID)
-	require.NoError(t, err)
+	assert.Equal(t, "active", token.Status)
 	assert.Equal(t, "new-access-token", token.AccessToken)
 }
 
-func TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkExpired(t *testing.T) {
+func TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkNeedsReauth(t *testing.T) {
 	// This is the exact failure mode that triggered this fix: the machine goes
 	// offline, DNS fails, and the token endpoint is unreachable. The transport
-	// error (client.Do fails) must not mark the config expired.
+	// error (client.Do fails) must not mark the token needs_reauth.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	tokenURL := server.URL + "/token"
 	server.Close() // close immediately so all connection attempts are refused
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, tokenURL)
+	_, tokenID := seedFixtures(t, store, tokenURL)
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "authorized", cfg.Status, "connection refused must not mark config as expired")
+	assert.Equal(t, "active", token.Status, "connection refused must not mark token needs_reauth")
 }
 
-func TestTokenRefreshWorker_400InvalidGrant_MarksExpired(t *testing.T) {
+func TestTokenRefreshWorker_400InvalidGrant_MarksNeedsReauth(t *testing.T) {
 	// 400 invalid_grant is the canonical RFC 6749 signal that a refresh token
-	// has been revoked. Must mark the config expired.
+	// has been revoked. Must mark the token needs_reauth.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -447,19 +532,19 @@ func TestTokenRefreshWorker_400InvalidGrant_MarksExpired(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "expired", cfg.Status, "400 invalid_grant must mark config as expired")
+	assert.Equal(t, "needs_reauth", token.Status, "400 invalid_grant must mark token needs_reauth")
 }
 
-func TestTokenRefreshWorker_429RateLimit_DoesNotMarkExpired(t *testing.T) {
+func TestTokenRefreshWorker_429RateLimit_DoesNotMarkNeedsReauth(t *testing.T) {
 	// 429 Too Many Requests is a transient rate limit — not a permanent auth
-	// rejection. Must not mark the config expired.
+	// rejection. Must not mark the token needs_reauth.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "1")
 		w.WriteHeader(http.StatusTooManyRequests)
@@ -467,17 +552,17 @@ func TestTokenRefreshWorker_429RateLimit_DoesNotMarkExpired(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "authorized", cfg.Status, "429 rate limit must not mark config as expired")
+	assert.Equal(t, "active", token.Status, "429 rate limit must not mark token needs_reauth")
 }
 
-func TestTokenRefreshWorker_400InvalidRequest_DoesNotMarkExpired(t *testing.T) {
+func TestTokenRefreshWorker_400InvalidRequest_DoesNotMarkNeedsReauth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -489,17 +574,17 @@ func TestTokenRefreshWorker_400InvalidRequest_DoesNotMarkExpired(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "authorized", cfg.Status, "400 invalid_request must not mark config as expired")
+	assert.Equal(t, "active", token.Status, "400 invalid_request must not mark token needs_reauth")
 }
 
-func TestTokenRefreshWorker_400UnauthorizedClient_MarksExpired(t *testing.T) {
+func TestTokenRefreshWorker_400UnauthorizedClient_MarksNeedsReauth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -511,12 +596,12 @@ func TestTokenRefreshWorker_400UnauthorizedClient_MarksExpired(t *testing.T) {
 	defer server.Close()
 
 	store := newTestConfigStore()
-	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
 
 	worker := newTestWorker(store)
 	worker.refreshExpiredTokens(context.Background())
 
-	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
-	assert.Equal(t, "expired", cfg.Status, "400 unauthorized_client must mark config as expired")
+	assert.Equal(t, "needs_reauth", token.Status, "400 unauthorized_client must mark token needs_reauth")
 }

--- a/transports/bifrost-http/handlers/mcpoauth2.go
+++ b/transports/bifrost-http/handlers/mcpoauth2.go
@@ -197,12 +197,12 @@ func (h *OAuthHandler) getOAuthConfigStatus(ctx *fasthttp.RequestCtx) {
 		"created_at": oauthConfig.CreatedAt,
 	}
 
-	if oauthConfig.Status == "authorized" && oauthConfig.TokenID != nil {
-		response["token_id"] = *oauthConfig.TokenID
-
-		// Get token metadata
-		token, err := h.store.ConfigStore.GetOauthTokenByID(ctx, *oauthConfig.TokenID)
+	if oauthConfig.Status == "authorized" {
+		// Resolve the shared token row via (oauth_config_id, auth_mode='shared')
+		// — the replacement for the retired TableOauthConfig.TokenID FK shortcut.
+		token, err := h.store.ConfigStore.GetSharedOauthTokenByConfigID(ctx, configID)
 		if err == nil && token != nil {
+			response["token_id"] = token.ID
 			if token.ExpiresAt != nil {
 				response["token_expires_at"] = token.ExpiresAt
 			}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1417,10 +1417,6 @@ func (m *MockConfigStore) UpsertPlugin(ctx context.Context, plugin *tables.Table
 
 // OAuth config
 
-func (m *MockConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error) {
-	return nil, nil
-}
-
 func (m *MockConfigStore) CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
 	return nil
 }
@@ -1431,6 +1427,10 @@ func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.
 
 // OAuth token
 func (m *MockConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
@@ -1450,7 +1450,7 @@ func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error
 	return nil
 }
 
-func (m *MockConfigStore) DeleteOauthTokensByConfigAndMode(ctx context.Context, oauthConfigID, authMode string, tx ...*gorm.DB) error {
+func (m *MockConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR removes the `token_id` FK shortcut column from `oauth_configs` and unifies the two separate OAuth token refresh paths (one keyed by `oauth_config_id` for shared tokens, one keyed by token ID for per-user tokens) into a single `RefreshAccessToken(ctx, tokenID)` method. Credential health tracking moves entirely onto the token row's own `Status` field (`active` / `needs_reauth`), replacing the previous pattern of flipping `oauth_configs.status` to `expired` or `revoked` on permanent refresh failures.

## Changes

- **Retired `TableOauthConfig.TokenID`**: The FK shortcut that pointed from an oauth config to its single shared-mode token row is dropped. All callers that previously read `oauthConfig.TokenID` now resolve the token via `GetSharedOauthTokenByConfigID(ctx, oauthConfigID)`, which queries `mcp_oauth_tokens` on `(oauth_config_id, auth_mode='shared')`.
- **Unified `RefreshAccessToken`**: `RefreshUserAccessToken` (per-identity, keyed by token ID) and the old `RefreshAccessToken` (shared, keyed by `oauth_config_id`) are merged into one method keyed by token ID. Both `GetAccessToken` and `GetUserAccessTokenByMode` funnel their lazy pre-flight refresh through this single path.
- **Credential health on the token row**: Permanent refresh rejections (HTTP 401, `invalid_grant`, `unauthorized_client`) now flip `mcp_oauth_tokens.status` to `needs_reauth` via `MarkOauthUserTokenNeedsReauthByID`, which is no longer scoped away from `auth_mode='shared'`. The `oauth_configs.status` column is now a one-time bootstrap lifecycle field only (`pending` / `authorized` / `failed`) and is never written by the refresh path.
- **`GetExpiringOauthTokens` filter change**: The query previously excluded tokens whose owning `oauth_config` had a terminal status (`expired` / `revoked`). It now filters directly on `mcp_oauth_tokens.status = 'active'`, and the join to `oauth_configs` for the enabled-client check uses `oauth_configs.id = mcp_oauth_tokens.oauth_config_id` instead of the retired `token_id` column.
- **`TokenRefreshWorker` simplification**: The worker no longer looks up the owning `oauth_config` for each expiring token before calling refresh. It calls `RefreshAccessToken(ctx, token.ID)` directly; permanent-failure handling is entirely inside `RefreshAccessToken`.
- **`GetOauthUserSessionByID` flow-mode filter**: Added `flow_mode IN (perUserOauthFlowModes)` to prevent an admin-mode flow row from being reachable through the per-user-facing ID lookup endpoint.
- **DB migration**: A new `migrationDropOauthConfigTokenIDColumn` migration drops `oauth_configs.token_id`. The existing `migrationMergeOauthTokenTables` backfill is guarded with a `HasColumn` check so it skips the `token_id`-referencing SQL on fresh installs where the column never existed.
- **`CompleteOAuthFlow` expiry branch**: Changed the terminal bootstrap status written on flow expiry from the since-retired `"expired"` to `"failed"`, consistent with the other bootstrap-failure branch.
- **`GetOauthConfigByTokenID` removed**: No longer needed; replaced by `GetSharedOauthTokenByConfigID`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/credstore/... ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/...
```

- Verify that a shared OAuth config whose token has been permanently rejected shows `status = needs_reauth` on the `mcp_oauth_tokens` row and that `oauth_configs.status` remains `authorized`.
- Verify that the `TokenRefreshWorker` does not retry a token already marked `needs_reauth`.
- Verify that a fresh install (no prior `token_id` column) runs all migrations without error.
- Verify that an upgrade from a schema that has `token_id` populated correctly backfills `mcp_oauth_tokens.oauth_config_id` and then drops the column.

## Breaking changes

- [x] Yes
- [ ] No

`GetOauthConfigByTokenID` is removed from the `ConfigStore` interface. Any external implementation of `ConfigStore` must add `GetSharedOauthTokenByConfigID` and remove `GetOauthConfigByTokenID`. The `OAuth2Provider` interface loses `RefreshAccessToken(ctx, oauthConfigID)` and `RefreshUserAccessToken(ctx, tokenID)` and gains a single `RefreshAccessToken(ctx, tokenID)`. The `oauth_configs.token_id` column is dropped by migration; any raw SQL or tooling that references it will need updating.

## Related issues

N/A

## Security considerations

`GetOauthUserSessionByID` now filters by `flow_mode IN (perUserOauthFlowModes)`, preventing an admin-mode flow row from being fetched through a per-user-facing endpoint by ID. `MarkOauthUserTokenNeedsReauthByID` is intentionally not scoped by `auth_mode` because the token ID it receives always comes from a trusted internal lookup, never an arbitrary caller-supplied value.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable