### PR TITLE
`refactor: make GetExpiringOauthTokens auth modes caller-configurable via AuthModes field`

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6562,8 +6562,12 @@ func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error 
 	return nil
 }
 
-// GetExpiringOauthTokens retrieves tokens that are expiring before the given time
-func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
+// GetExpiringOauthTokens retrieves tokens that are expiring before the given
+// time, restricted to the given AuthModes.
+func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error) {
+	if len(authModes) == 0 {
+		return nil, nil
+	}
 	var tokens []*tables.TableMCPOauthToken
 	// Only select tokens whose own status is 'active' — a token already
 	// flagged 'needs_reauth' (a prior refresh attempt was permanently
@@ -6579,11 +6583,10 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 	// client is re-enabled or attached later, GetAccessToken refreshes inline
 	// on first use.
 	result := s.DB().WithContext(ctx).
-		// mcp_oauth_tokens now also holds per-user rows; this worker is
-		// shared-only, so per-user proactive refresh doesn't start happening
-		// as a side effect of the table merge (that's a deliberate later
-		// change, not this one).
-		Where("auth_mode = ?", "shared").
+		// mcp_oauth_tokens holds both shared and per-user rows; callers
+		// decide which holder types get proactive background refresh via
+		// authModes (TokenRefreshWorker.AuthModes, shared-only by default).
+		Where("auth_mode IN ?", authModes).
 		Where("status = ?", "active").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
 		Where("EXISTS (?)",

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -95,7 +95,7 @@ func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id
 
 func expiringTokenIDs(t *testing.T, s *RDBConfigStore) map[string]bool {
 	t.Helper()
-	got, err := s.GetExpiringOauthTokens(context.Background(), time.Now().Add(time.Minute))
+	got, err := s.GetExpiringOauthTokens(context.Background(), time.Now().Add(time.Minute), []string{"shared"})
 	require.NoError(t, err)
 	ids := make(map[string]bool, len(got))
 	for _, tk := range got {
@@ -124,6 +124,49 @@ func TestGetExpiringOauthTokens_ExcludesNonActiveTokens(t *testing.T) {
 	ids := expiringTokenIDs(t, s)
 	assert.True(t, ids["tok-live"], "active token with an enabled client should be refreshed")
 	assert.False(t, ids["tok-needs-reauth"], "token already marked needs_reauth must be excluded")
+}
+
+// TestGetExpiringOauthTokens_FiltersByAuthMode verifies the caller-supplied
+// authModes slice, not a hardcoded "shared" clause, decides which token
+// holder types come back. With authModes=["shared"] (TokenRefreshWorker's
+// default), a same-config, same-expiry "user"-mode row must not be picked up
+// — the coverage the old hardcoded `auth_mode = 'shared'` filter gave for
+// free, now expressed as an explicit parameter instead.
+func TestGetExpiringOauthTokens_FiltersByAuthMode(t *testing.T) {
+	s := setupRDBTestStore(t)
+	mkToken, mkConfig, mkClient := seedExpiringTokenFixtures(t, s)
+	past := time.Now().Add(-time.Hour)
+
+	mkConfig("cfg-mixed")
+	mkToken("tok-shared", "cfg-mixed", "active")
+	mkClient("client-mixed", "cfg-mixed", false)
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-user", AuthMode: "user", OauthConfigID: "cfg-mixed", Status: "active",
+		AccessToken: "at-tok-user", TokenType: "Bearer",
+		ExpiresAt: &past, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}).Error)
+
+	shared, err := s.GetExpiringOauthTokens(context.Background(), time.Now().Add(time.Minute), []string{"shared"})
+	require.NoError(t, err)
+	sharedIDs := make(map[string]bool, len(shared))
+	for _, tk := range shared {
+		sharedIDs[tk.ID] = true
+	}
+	assert.True(t, sharedIDs["tok-shared"], "shared token must be returned when authModes=[shared]")
+	assert.False(t, sharedIDs["tok-user"], "user-mode token must be excluded when authModes=[shared]")
+
+	both, err := s.GetExpiringOauthTokens(context.Background(), time.Now().Add(time.Minute), []string{"shared", "user"})
+	require.NoError(t, err)
+	bothIDs := make(map[string]bool, len(both))
+	for _, tk := range both {
+		bothIDs[tk.ID] = true
+	}
+	assert.True(t, bothIDs["tok-shared"], "shared token must be returned when authModes=[shared,user]")
+	assert.True(t, bothIDs["tok-user"], "user-mode token must be returned when authModes=[shared,user]")
+
+	empty, err := s.GetExpiringOauthTokens(context.Background(), time.Now().Add(time.Minute), nil)
+	require.NoError(t, err)
+	assert.Empty(t, empty, "an empty authModes must match nothing rather than falling back to all modes")
 }
 
 // TestGetExpiringOauthTokens_RequiresEnabledClient verifies the refresh worker

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -512,12 +512,12 @@ type ConfigStore interface {
 	// needs to reach the row regardless of status to delete it. Returns
 	// (nil, nil) when no shared token exists for this config.
 	GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
-	// GetExpiringOauthTokens is filtered to auth_mode='shared'. It backs the
-	// shared-only TokenRefreshWorker; per-user tokens refresh lazily/inline
-	// on lookup (GetOauthUserTokenByMode), and folding them into this
-	// proactive sweep is a deliberate later change, not a side effect of
-	// this table merge.
-	GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error)
+	// GetExpiringOauthTokens is filtered to authModes via `auth_mode IN
+	// (...)`. Backs TokenRefreshWorker, whose AuthModes field decides which
+	// holder types get proactive background refresh (defaults to
+	// shared-only — per-user tokens otherwise refresh lazily/inline on
+	// lookup via GetOauthUserTokenByMode).
+	GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error)
 	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthToken(ctx context.Context, id string) error

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -14,10 +14,24 @@ type TokenRefreshWorker struct {
 	provider        *OAuth2Provider
 	refreshInterval time.Duration
 	lookAheadWindow time.Duration // How far ahead to look for expiring tokens
-	stopCh          chan struct{}
-	stopOnce        sync.Once
-	cancel          context.CancelFunc
-	logger          schemas.Logger
+	// AuthModes restricts proactive refresh to tokens whose AuthMode is in
+	// this set. Defaults to {"shared"} — shared-client tokens are the only
+	// ones with no live caller to trigger a lazy/inline refresh, so they're
+	// the only ones that need a background sweep by default. Widening this
+	// (e.g. to include "user"/"vk"/"session") opts specific per-identity
+	// auth modes into the same proactive sweep.
+	//
+	// Set this before calling Start, not after: the background goroutine
+	// reads this field directly on every sweep with no synchronization, so a
+	// mutation concurrent with a running sweep is a data race. Every current
+	// caller already treats this as write-once-before-Start; there is no
+	// supported way to change an already-started worker's scope short of
+	// Stop and constructing a new worker.
+	AuthModes []string
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	cancel    context.CancelFunc
+	logger    schemas.Logger
 }
 
 // NewTokenRefreshWorker creates a new token refresh worker
@@ -31,8 +45,9 @@ func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *Tok
 	}
 	return &TokenRefreshWorker{
 		provider:        provider,
-		refreshInterval: 5 * time.Minute, // Check every 5 minutes
-		lookAheadWindow: 5 * time.Minute, // Refresh tokens expiring in next 5 minutes
+		refreshInterval: 5 * time.Minute,    // Check every 5 minutes
+		lookAheadWindow: 5 * time.Minute,    // Refresh tokens expiring in next 5 minutes
+		AuthModes:       []string{"shared"}, // Proactive refresh is shared-only by default
 		stopCh:          make(chan struct{}),
 		logger:          logger,
 	}
@@ -85,8 +100,9 @@ func (w *TokenRefreshWorker) run(ctx context.Context) {
 func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 	expiryThreshold := time.Now().Add(w.lookAheadWindow)
 
-	// Get tokens expiring before the threshold
-	tokens, err := w.provider.configStore.GetExpiringOauthTokens(ctx, expiryThreshold)
+	// Get tokens expiring before the threshold, restricted to the configured
+	// auth modes (defaults to shared-only — see AuthModes' doc comment).
+	tokens, err := w.provider.configStore.GetExpiringOauthTokens(ctx, expiryThreshold, w.AuthModes)
 	if err != nil {
 		w.logger.Error("Failed to get expiring tokens: %v", err)
 		return

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -111,11 +112,14 @@ func (s *testConfigStore) GetClientConfig(_ context.Context) (*configstore.Clien
 	return bifrost.Ptr(*s.clientConfig), nil
 }
 
-func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
+func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var expiring []*tables.TableMCPOauthToken
 	for _, token := range s.oauthTokens {
+		if !slices.Contains(authModes, token.AuthMode) {
+			continue
+		}
 		if token.ExpiresAt != nil && token.ExpiresAt.Before(before) {
 			expiring = append(expiring, bifrost.Ptr(*token))
 		}
@@ -236,6 +240,7 @@ func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
 
 		store.oauthTokens["nil-expiry"] = &tables.TableMCPOauthToken{
 			ID:           "nil-expiry",
+			AuthMode:     "shared",
 			AccessToken:  "access-token",
 			RefreshToken: "refresh-token",
 			TokenType:    "bearer",
@@ -244,6 +249,7 @@ func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
 		}
 		store.oauthTokens["expiring"] = &tables.TableMCPOauthToken{
 			ID:           "expiring",
+			AuthMode:     "shared",
 			AccessToken:  "access-token-2",
 			RefreshToken: "refresh-token-2",
 			TokenType:    "bearer",
@@ -251,11 +257,90 @@ func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
 			Scopes:       "[]",
 		}
 
-		tokens, err := store.GetExpiringOauthTokens(context.Background(), before)
+		tokens, err := store.GetExpiringOauthTokens(context.Background(), before, []string{"shared"})
 		require.NoError(t, err)
 		require.Len(t, tokens, 1)
 		assert.Equal(t, "expiring", tokens[0].ID)
 	})
+
+	t.Run("filters by the given auth modes", func(t *testing.T) {
+		store := newTestConfigStore()
+		now := time.Now()
+		before := now.Add(5 * time.Minute)
+
+		store.oauthTokens["shared-tok"] = &tables.TableMCPOauthToken{
+			ID:           "shared-tok",
+			AuthMode:     "shared",
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			TokenType:    "bearer",
+			ExpiresAt:    bifrost.Ptr(now.Add(1 * time.Minute)),
+			Scopes:       "[]",
+		}
+		store.oauthTokens["user-tok"] = &tables.TableMCPOauthToken{
+			ID:           "user-tok",
+			AuthMode:     "user",
+			AccessToken:  "access-token-2",
+			RefreshToken: "refresh-token-2",
+			TokenType:    "bearer",
+			ExpiresAt:    bifrost.Ptr(now.Add(1 * time.Minute)),
+			Scopes:       "[]",
+		}
+
+		tokens, err := store.GetExpiringOauthTokens(context.Background(), before, []string{"shared"})
+		require.NoError(t, err)
+		require.Len(t, tokens, 1)
+		assert.Equal(t, "shared-tok", tokens[0].ID)
+
+		tokens, err = store.GetExpiringOauthTokens(context.Background(), before, []string{"shared", "user"})
+		require.NoError(t, err)
+		assert.Len(t, tokens, 2)
+	})
+}
+
+// TestTokenRefreshWorker_DefaultAuthModes_ExcludesUserModeTokens confirms the
+// worker's default AuthModes ({"shared"}) leaves a per-user (auth_mode=
+// "user") token that's expiring untouched — the same coverage the previous
+// hardcoded `auth_mode = 'shared'` SQL filter gave for free, now that the
+// scoping lives in the worker's configurable field instead.
+func TestTokenRefreshWorker_DefaultAuthModes_ExcludesUserModeTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID, sharedTokenID := seedFixtures(t, store, server.URL+"/token")
+
+	userTokenID := "test-user-token-id"
+	store.oauthTokens[userTokenID] = &tables.TableMCPOauthToken{
+		ID:            userTokenID,
+		AuthMode:      "user",
+		OauthConfigID: oauthConfigID,
+		Status:        "active",
+		AccessToken:   "old-user-access-token",
+		RefreshToken:  "user-refresh-token",
+		TokenType:     "bearer",
+		ExpiresAt:     bifrost.Ptr(time.Now().Add(1 * time.Minute)),
+		Scopes:        "[]",
+	}
+
+	worker := newTestWorker(store)
+	assert.Equal(t, []string{"shared"}, worker.AuthModes, "constructor must default AuthModes to shared-only")
+	worker.refreshExpiredTokens(context.Background())
+
+	sharedToken, err := store.GetOauthTokenByID(context.Background(), sharedTokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", sharedToken.AccessToken, "shared token must be refreshed under the default auth modes")
+
+	userToken, err := store.GetOauthTokenByID(context.Background(), userTokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "old-user-access-token", userToken.AccessToken, "user-mode token must not be picked up under the default auth modes")
 }
 
 func TestMCPTempTokenAuthEnabled(t *testing.T) {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1434,7 +1434,7 @@ func (m *MockConfigStore) GetSharedOauthTokenByConfigID(ctx context.Context, oau
 	return nil, nil
 }
 
-func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableMCPOauthToken, error) {
+func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

`GetExpiringOauthTokens` previously had a hardcoded `auth_mode = 'shared'` SQL filter, meaning the background token refresh sweep was permanently locked to shared-mode tokens with no way to extend it to other auth modes. This PR replaces that hardcoded clause with a caller-supplied `authModes []string` parameter and adds a corresponding `AuthModes` field on `TokenRefreshWorker`, defaulting to `["shared"]` to preserve existing behavior.

## Changes

- `GetExpiringOauthTokens` now accepts an `authModes []string` parameter and uses `auth_mode IN (...)` instead of `auth_mode = 'shared'`. An empty slice returns nothing rather than falling back to all rows.
- `TokenRefreshWorker` gains an exported `AuthModes []string` field (default `["shared"]`) that is passed through to `GetExpiringOauthTokens` on each sweep, making the set of proactively refreshed token holder types configurable without code changes.
- The `ConfigStore` interface, the RDB implementation, the in-test stub, and the HTTP transport mock are all updated to match the new signature.
- Tests are added to cover: filtering by a single auth mode, filtering by multiple auth modes, an empty `authModes` returning nothing, and the worker's default `AuthModes` leaving per-user (`auth_mode = "user"`) tokens untouched.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/lib/...
```

Key scenarios to verify:
- `TestGetExpiringOauthTokens_FiltersByAuthMode` — confirms `authModes` controls which rows are returned and that `nil` returns nothing.
- `TestTokenRefreshWorker_DefaultAuthModes_ExcludesUserModeTokens` — confirms the worker's default `AuthModes = ["shared"]` refreshes shared tokens and leaves user-mode tokens untouched.

## Breaking changes

- [x] Yes
- [ ] No

`GetExpiringOauthTokens` has a new required `authModes []string` parameter. Any implementation of the `ConfigStore` interface outside this repository must be updated to add this parameter. Callers that previously relied on the implicit shared-only filter should pass `[]string{"shared"}` to preserve existing behavior.

## Security considerations

The `authModes` filter is applied server-side via a parameterized `IN` clause, so there is no SQL injection risk. Defaulting to `["shared"]` ensures per-user tokens are not swept into background refresh unless explicitly opted in, avoiding unintended cross-user token activity.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable