### PR TITLE
`feat: add needs_reauth state and replace per-user connection badge with sessions link`

### DIFF
--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -50,6 +50,8 @@ Per-user auth applies to the **HTTP** and **SSE** connection types. STDIO connec
 
 Per-user auth requires every request to carry an identity. See [Identity modes](#identity-modes) below.
 
+Connection-state semantics (`connected`, `disconnected`, `error`, `needs_reauth`, etc., shown on the MCP client list) describe a persistent upstream connection, so they only apply to server-level clients. Per-user clients are stateless by design: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it.
+
 ---
 
 ## Pick your auth type

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -458,7 +458,9 @@ export default function MCPClientSheet({
 										? mcpClient.config.auth_type === "per_user_oauth"
 											? "This client was declared in config.json. A one-time admin test login is needed to verify the OAuth setup and discover tools — each user will authenticate individually afterward."
 											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
-										: "MCP server configuration and available tools"}
+										: mcpClient.state === "needs_reauth"
+											? "This connection's credentials have expired and need to be re-authorized. Re-authorization from the dashboard isn't available yet: recreating this client is the current workaround."
+											: "MCP server configuration and available tools"}
 								</SheetDescription>
 							</div>
 							<SheetNavigationButtons

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -117,7 +117,7 @@ function MCPClientActionsMenu({
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
-						disabled={isPerUserAuth || client.config.disabled || isReconnecting || client.state === "pending_verification"}
+						disabled={isPerUserAuth || client.config.disabled || isReconnecting || client.state === "pending_verification" || client.state === "needs_reauth"}
 						onSelect={(e) => {
 							e.preventDefault();
 							onReconnect(client);
@@ -644,8 +644,22 @@ export default function MCPClientsTable({
 													"-"
 												)}
 											</TableCell>
-											<TableCell>
-												<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												{isPerUserAuth ? (
+													// Per-user clients never hold a shared upstream connection, so a
+													// connection-state badge here would be misleading: point to the
+													// per-user sessions this client actually has instead.
+													<Link
+														to="/workspace/mcp-sessions"
+														search={{ mcp_client_id: [c.config.client_id] }}
+														className="text-primary text-xs font-medium hover:underline"
+														data-testid={`mcp-client-view-sessions-${c.config.client_id}`}
+													>
+														View sessions
+													</Link>
+												) : (
+													<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
+												)}
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<Switch

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -128,6 +128,10 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 	pending_tools: "bg-yellow-100 text-yellow-800",
 	pending_verification: "bg-yellow-100 text-yellow-800",
 	disabled: "bg-orange-100 text-orange-800",
+	// Same red as `error`: the client's credential has died and it can't be
+	// used until a human reauthorizes it, mirroring the "destructive" treatment
+	// this status already gets on the MCP sessions table.
+	needs_reauth: "bg-red-100 text-red-800",
 };
 
 // Mapping of what IS supported by each base provider

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -3,7 +3,7 @@ import { SecretVar } from "./schemas";
 
 export type MCPConnectionType = "http" | "stdio" | "sse";
 
-export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "pending_verification" | "disabled";
+export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "pending_verification" | "disabled" | "needs_reauth";
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers";
 


### PR DESCRIPTION
## Summary

Per-user auth clients (`per_user_oauth` and `per_user_headers`) don't hold a persistent upstream connection, so displaying a connection-state badge for them is misleading. This PR replaces that badge with a "View sessions" link pointing to the MCP Sessions table filtered by the client. It also adds proper handling for the `needs_reauth` state, which previously had no color mapping and no explanatory copy.

## Changes

- Per-user auth clients now show a "View sessions" link instead of a connection-state badge in both the clients table and the client detail sheet, since their stateless design means connection state is not meaningful for them.
- The "Reconnect" action in the client actions menu is now disabled when a client is in the `needs_reauth` state, since reconnecting is not a valid recovery path for expired credentials.
- A `needs_reauth` color mapping (`bg-red-100 text-red-800`) has been added to `MCP_STATUS_COLORS` so the badge renders correctly for server-level clients in that state.
- A descriptive sheet subtitle is shown when a client is in the `needs_reauth` state, explaining that credentials have expired and that recreating the client is the current workaround.
- `MCPConnectionState` type has been extended to include `needs_reauth`.
- Documentation has been updated to explain why per-user clients show sessions instead of a connection state.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Create an MCP client with `per_user_oauth` or `per_user_headers` auth type.
2. Verify the clients table shows a "View sessions" link instead of a connection-state badge for that client.
3. Click the link and confirm it navigates to the MCP Sessions page filtered by that client's ID.
4. Open the client detail sheet and confirm the same "View sessions" link appears in the title area.
5. Create or simulate a server-level client in the `needs_reauth` state and confirm the badge renders in red and the sheet description explains the reauth requirement.
6. Confirm the "Reconnect" action is disabled for clients in the `needs_reauth` state.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Per-user auth clients displayed a connection-state badge (e.g., `connected`) that did not reflect their actual stateless behavior.

After: Per-user auth clients display a "View sessions" link. Server-level clients in `needs_reauth` show a red badge with an explanatory description.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. This is a display-layer change; no auth logic or credential handling was modified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable