### PR TITLE
feat: replace OAuth config pin-and-warn with in-place rotation and needs_reauth cascade

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4204,6 +4204,22 @@ func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
 	return bifrost.MCPManager.ReconnectClient(id)
 }
 
+// CloseAndMarkNeedsReauth closes a shared MCP client's live upstream
+// connection and flips it to needs_reauth, without attempting a new dial.
+// Used after OAuth credential rotation.
+//
+// Parameters:
+//   - id: ID of the client to close and flip to needs_reauth
+//
+// Returns:
+//   - error: if the client does not exist or has no persistent connection
+func (bifrost *Bifrost) CloseAndMarkNeedsReauth(id string) error {
+	if bifrost.MCPManager == nil {
+		return fmt.Errorf("mcp is not configured in this bifrost instance")
+	}
+	return bifrost.MCPManager.CloseAndMarkNeedsReauth(id)
+}
+
 // DisableMCPClient shuts down an MCP client's connection, health monitor, and tool
 // syncer without removing it. The client entry is kept in a "disabled" state so it
 // can be re-enabled via EnableMCPClient.

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -223,6 +223,57 @@ func (m *MCPManager) GetClients() []schemas.MCPClientState {
 	return clients
 }
 
+// CloseAndMarkNeedsReauth tears down a shared client's live upstream
+// connection and flips it to NeedsReauth, without attempting a new dial.
+// Used after OAuth credential rotation: RotateMCPOAuthConfig has already
+// cascaded every token bound to this client's oauth_config to
+// needs_reauth in the DB, so the in-memory connection is still open on the
+// now-invalidated Authorization header, and calling ReconnectClient instead
+// would just fail immediately (GetAccessToken refuses to hand out a token
+// for a needs_reauth row) while leaving the stale connection in place.
+//
+// Parameters:
+//   - id: ID of the client to close and flip to needs_reauth
+//
+// Returns:
+//   - error: if the client does not exist or has no persistent connection
+func (m *MCPManager) CloseAndMarkNeedsReauth(id string) error {
+	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
+	}
+	defer m.reconnectingClients.Delete(id)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	clientState, ok := m.clientMap[id]
+	if !ok {
+		return fmt.Errorf("client %s not found", id)
+	}
+	if clientState.ExecutionConfig != nil && m.credStore.RequiresPerCallConnection(clientState.ExecutionConfig) {
+		return fmt.Errorf("per-user auth clients do not maintain a shared upstream connection (each user manages their own auth): %w", schemas.ErrMCPReconnectNotApplicable)
+	}
+	if clientState.State == schemas.MCPConnectionStateDisabled {
+		// DisableClient is authoritative; a rotation racing a disable must
+		// not resurrect the client into needs_reauth.
+		return nil
+	}
+
+	if clientState.CancelFunc != nil {
+		clientState.CancelFunc()
+		clientState.CancelFunc = nil
+	}
+	if clientState.Conn != nil {
+		if err := clientState.Conn.Close(); err != nil {
+			m.logger.Error("%s Failed to close connection for MCP client '%s': %v", MCPLogPrefix, clientState.ExecutionConfig.Name, err)
+		}
+		clientState.Conn = nil
+	}
+	clientState.State = schemas.MCPConnectionStateNeedsReauth
+	m.logger.Debug("%s MCP client '%s' closed and marked needs_reauth after credential rotation", MCPLogPrefix, clientState.ExecutionConfig.Name)
+	return nil
+}
+
 // ReconnectClient attempts to reconnect an MCP client if it is disconnected.
 // It validates that the client exists and then establishes a new connection using
 // the client's existing configuration. Retry logic is handled internally by

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +74,95 @@ func TestCreateSTDIOConnectionRejectsEmptyEnvAssignmentName(t *testing.T) {
 	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "environment variable name is empty")
+}
+
+// TestCloseAndMarkNeedsReauth_ClosesLiveConnectionAndFlipsState covers the
+// core behavior this method exists for: after OAuth credential rotation, a
+// shared client's live connection (still bound to the now-invalidated
+// Authorization header) must be torn down and the entry flipped to
+// needs_reauth, without attempting a new dial.
+func TestCloseAndMarkNeedsReauth_ClosesLiveConnectionAndFlipsState(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-rotated")
+
+	cancelCalled := false
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateConnected,
+		CancelFunc:      func() { cancelCalled = true },
+	}
+	m.mu.Unlock()
+
+	require.NoError(t, m.CloseAndMarkNeedsReauth("client-rotated"))
+
+	m.mu.RLock()
+	state := *m.clientMap["client-rotated"]
+	m.mu.RUnlock()
+
+	assert.True(t, cancelCalled, "the live connection's cancel func must be invoked")
+	assert.Nil(t, state.CancelFunc)
+	assert.Nil(t, state.Conn)
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state.State)
+}
+
+// TestCloseAndMarkNeedsReauth_MissingClient_Errors covers the not-found path.
+func TestCloseAndMarkNeedsReauth_MissingClient_Errors(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	require.Error(t, m.CloseAndMarkNeedsReauth("does-not-exist"))
+}
+
+// TestCloseAndMarkNeedsReauth_PerUserAuth_ReturnsNotApplicable covers
+// per_user_oauth/per_user_headers clients, which hold no persistent shared
+// connection: rotation for these auth types must not error out the caller
+// (the HTTP handler filters ErrMCPReconnectNotApplicable), and must not
+// touch the entry's state.
+func TestCloseAndMarkNeedsReauth_PerUserAuth_ReturnsNotApplicable(t *testing.T) {
+	// nil credStore: NewMCPManager defaults to a real credstore.CredStore,
+	// whose RequiresPerCallConnection actually varies by auth type — unlike
+	// expiredOAuthCredStore (used by the other tests here), which hardcodes
+	// false regardless of AuthType.
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := &schemas.MCPClientConfig{ID: "client-per-user", Name: "per-user-client", AuthType: schemas.MCPAuthTypePerUserOauth}
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateConnected,
+	}
+	m.mu.Unlock()
+
+	err := m.CloseAndMarkNeedsReauth(config.ID)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateConnected, state.State, "state must be untouched for a not-applicable auth type")
+}
+
+// TestCloseAndMarkNeedsReauth_Disabled_IsNoOp covers a rotation racing a
+// disable: DisableClient's state is authoritative and must not be
+// resurrected into needs_reauth by a rotation that started before it.
+func TestCloseAndMarkNeedsReauth_Disabled_IsNoOp(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-disabled")
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	require.NoError(t, m.CloseAndMarkNeedsReauth("client-disabled"))
+
+	m.mu.RLock()
+	state := *m.clientMap["client-disabled"]
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State)
 }

--- a/core/mcp/healthmonitor.go
+++ b/core/mcp/healthmonitor.go
@@ -145,11 +145,13 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 	chm.manager.mu.RLock()
 	clientState, exists := chm.manager.clientMap[chm.clientID]
 	var isDisabled bool
+	var needsReauth bool
 	var conn *client.Client
 	var clientName string
 	if exists && clientState != nil {
 		conn = clientState.Conn
 		isDisabled = clientState.State == schemas.MCPConnectionStateDisabled
+		needsReauth = clientState.State == schemas.MCPConnectionStateNeedsReauth
 		if clientState.ExecutionConfig != nil {
 			clientName = clientState.ExecutionConfig.Name
 		}
@@ -165,6 +167,20 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 	// Health monitoring is already stopped for disabled clients. This is just a sanity check.
 	if isDisabled {
 		chm.Stop()
+		return
+	}
+
+	// A NeedsReauth client (e.g. CloseAndMarkNeedsReauth after OAuth
+	// credential rotation) has Conn == nil by design — pinging it would
+	// only observe the failure that's already been diagnosed and recorded
+	// in the state itself. Skip the tick entirely rather than counting it
+	// as a fresh failure and eventually spawning a reconnect attempt: the
+	// credential that connection needed is already known-dead, so
+	// ReconnectClient would just fail immediately, burning its full
+	// backoff-retry budget for nothing. Keep monitoring alive (don't Stop)
+	// so a future tick picks up cleanly once reauthorization moves the
+	// state back to Connected.
+	if needsReauth {
 		return
 	}
 
@@ -230,9 +246,19 @@ func (chm *ClientHealthMonitor) attemptReconnect() {
 	chm.manager.mu.RLock()
 	clientState, exists := chm.manager.clientMap[chm.clientID]
 	isDisabled := exists && clientState != nil && clientState.State == schemas.MCPConnectionStateDisabled
+	needsReauth := exists && clientState != nil && clientState.State == schemas.MCPConnectionStateNeedsReauth
 	chm.manager.mu.RUnlock()
 	if isDisabled {
 		chm.logger.Debug("%s Skipping reconnect for disabled MCP client %s", MCPLogPrefix, chm.clientID)
+		return
+	}
+	// Sanity check mirroring performHealthCheck's guard: this path is only
+	// reached via a caller that already saw a live (non-NeedsReauth) state,
+	// but the state could have moved to NeedsReauth between that read and
+	// here (e.g. a concurrent credential rotation). ReconnectClient would
+	// just fail immediately against the known-dead credential.
+	if needsReauth {
+		chm.logger.Debug("%s Skipping reconnect for needs_reauth MCP client %s", MCPLogPrefix, chm.clientID)
 		return
 	}
 

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -75,6 +75,11 @@ type MCPManagerInterface interface {
 	// ReconnectClient reconnects an MCP client by ID
 	ReconnectClient(id string) error
 
+	// CloseAndMarkNeedsReauth closes a shared client's live upstream
+	// connection and flips it to needs_reauth, without attempting a new
+	// dial. Used after OAuth credential rotation.
+	CloseAndMarkNeedsReauth(id string) error
+
 	// DisableClient shuts down a client's connection and workers without removing it
 	DisableClient(id string) error
 

--- a/core/mcp/reauth_state_test.go
+++ b/core/mcp/reauth_state_test.go
@@ -183,6 +183,42 @@ func TestUpdateClientState_PreservesNeedsReauth(t *testing.T) {
 	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, stateAfterSuccessTick, "a successful health-check tick must not clobber NeedsReauth back to Connected")
 }
 
+// TestPerformHealthCheck_SkipsNeedsReauthClients covers the health monitor's
+// entry-point guard, one level up from TestUpdateClientState_PreservesNeedsReauth:
+// a NeedsReauth client (e.g. CloseAndMarkNeedsReauth after OAuth credential
+// rotation) has Conn == nil by design. Without a skip, performHealthCheck
+// would treat that nil Conn as a fresh failure, increment the counter, and
+// eventually spawn attemptReconnect — which dials with the already-known-dead
+// credential for nothing. The tick must be a complete no-op: no failure
+// counted, no reconnect scheduled, state untouched.
+func TestPerformHealthCheck_SkipsNeedsReauthClients(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-needs-reauth-healthcheck")
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateNeedsReauth,
+		Conn:            nil,
+	}
+	m.mu.Unlock()
+
+	chm := NewClientHealthMonitor(m, config.ID, DefaultHealthCheckInterval, true, nil)
+	chm.performHealthCheck()
+
+	assert.Equal(t, 0, chm.getConsecutiveFailures(), "a NeedsReauth tick must not count as a failure")
+	chm.mu.Lock()
+	reconnecting := chm.isReconnecting
+	chm.mu.Unlock()
+	assert.False(t, reconnecting, "a NeedsReauth tick must not spawn a reconnect attempt")
+
+	m.mu.RLock()
+	state := m.clientMap[config.ID].State
+	m.mu.RUnlock()
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state)
+}
+
 // TestUpdateClientState_StillPreservesDisabled is a regression guard for the
 // pre-existing Disabled-preservation behavior updateClientState had before
 // this change — the new NeedsReauth branch must be additive, not a

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -307,19 +307,27 @@ const (
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
-	ID                string               `json:"client_id"`                     // Client ID
-	Name              string               `json:"name"`                          // Client name
-	IsCodeModeClient  bool                 `json:"is_code_mode_client"`           // Whether the client is a code mode client
-	ConnectionType    MCPConnectionType    `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
-	ConnectionString  *SecretVar           `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)
-	StdioConfig       *MCPStdioConfig      `json:"stdio_config,omitempty"`        // STDIO configuration (required for STDIO connections)
-	TLSConfig         *MCPTLSConfig        `json:"tls_config,omitempty"`          // TLS configuration for HTTP/SSE connections
-	AuthType          MCPAuthType          `json:"auth_type"`                     // Authentication type (none, headers, or oauth)
-	OauthConfigID     *string              `json:"oauth_config_id,omitempty"`     // OAuth config ID (references oauth_configs table)
-	OauthClientID     *SecretVar           `json:"oauth_client_id,omitempty"`     // Redacted OAuth client ID (populated on GET, not stored here)
-	OauthClientSecret *SecretVar           `json:"oauth_client_secret,omitempty"` // Redacted OAuth client secret (populated on GET, not stored here)
-	State             string               `json:"state,omitempty"`               // Connection state (connected, disconnected, error)
-	Headers           map[string]SecretVar `json:"headers,omitempty"`             // Headers to send with the request (for headers auth type)
+	ID                string            `json:"client_id"`                     // Client ID
+	Name              string            `json:"name"`                          // Client name
+	IsCodeModeClient  bool              `json:"is_code_mode_client"`           // Whether the client is a code mode client
+	ConnectionType    MCPConnectionType `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
+	ConnectionString  *SecretVar        `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)
+	StdioConfig       *MCPStdioConfig   `json:"stdio_config,omitempty"`        // STDIO configuration (required for STDIO connections)
+	TLSConfig         *MCPTLSConfig     `json:"tls_config,omitempty"`          // TLS configuration for HTTP/SSE connections
+	AuthType          MCPAuthType       `json:"auth_type"`                     // Authentication type (none, headers, or oauth)
+	OauthConfigID     *string           `json:"oauth_config_id,omitempty"`     // OAuth config ID (references oauth_configs table)
+	OauthClientID     *SecretVar        `json:"oauth_client_id,omitempty"`     // Redacted OAuth client ID (populated on GET, not stored here)
+	OauthClientSecret *SecretVar        `json:"oauth_client_secret,omitempty"` // Redacted OAuth client secret (populated on GET, not stored here)
+	// The remaining OAuth fields are populated on GET (not stored here) so the
+	// full oauth_config, not just client_id/client_secret, can be reviewed and
+	// edited without a separate lookup.
+	OauthAuthorizeURL    string               `json:"oauth_authorize_url,omitempty"`
+	OauthTokenURL        string               `json:"oauth_token_url,omitempty"`
+	OauthRegistrationURL string               `json:"oauth_registration_url,omitempty"`
+	OauthScopes          []string             `json:"oauth_scopes,omitempty"`
+	OauthResource        string               `json:"oauth_resource,omitempty"`
+	State                string               `json:"state,omitempty"`   // Connection state (connected, disconnected, error)
+	Headers              map[string]SecretVar `json:"headers,omitempty"` // Headers to send with the request (for headers auth type)
 	// PerUserHeaderKeys lists the header *names* each caller must supply for
 	// MCPAuthTypePerUserHeaders clients. Admin-declared schema only — the
 	// values live per-user in the mcp_per_user_header_credentials table and
@@ -343,13 +351,13 @@ type MCPClientConfig struct {
 	// - nil/omitted => treated as [] (no tools)
 	// - ["tool1", "tool2"] => auto-execute only the specified tools
 	// Note: If a tool is in ToolsToAutoExecute but not in ToolsToExecute, it will be skipped.
-	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`       // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
-	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`      // Per-client override for tool sync interval (0 = use global, negative = disabled)
-	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"`  // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
-	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`            // Tool pricing for each tool (cost per execution)
-	Disabled              bool               `json:"disabled"`                     // Whether the client is intentionally disabled (stops connection and workers)
-	ConfigHash            string             `json:"-"`                            // Config hash for reconciliation (not serialized)
-	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`    // Whether to allow the MCP client to run on all virtual keys
+	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`      // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
+	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"`     // Per-client override for tool sync interval (0 = use global, negative = disabled)
+	ToolExecutionTimeout  time.Duration      `json:"tool_execution_timeout,omitempty"` // Per-client override for tool execution timeout (0 = use global from tool_manager_config)
+	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`           // Tool pricing for each tool (cost per execution)
+	Disabled              bool               `json:"disabled"`                         // Whether the client is intentionally disabled (stops connection and workers)
+	ConfigHash            string             `json:"-"`                                // Config hash for reconciliation (not serialized)
+	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`        // Whether to allow the MCP client to run on all virtual keys
 
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name

--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -258,6 +258,17 @@ func (e *SecretVar) Equals(other *SecretVar) bool {
 		e.SecretType == other.SecretType
 }
 
+// Clone returns a SecretVar holding the same value as e, backed by a
+// distinct pointer — so a caller mutating the clone's fields (e.g. in-place
+// encryption before a DB write) never touches e itself.
+func (e *SecretVar) Clone() *SecretVar {
+	if e == nil {
+		return nil
+	}
+	clone := *e
+	return &clone
+}
+
 // Redacted returns a new SecretVar with the value redacted.
 func (e *SecretVar) Redacted() *SecretVar {
 	if e == nil {

--- a/framework/configstore/mcp_oauth_rotate_test.go
+++ b/framework/configstore/mcp_oauth_rotate_test.go
@@ -1,0 +1,309 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedRotateOauthConfig inserts an oauth_configs row with the given
+// client_id/client_secret and returns a freshly re-fetched copy (via
+// GetOauthConfigByID, mirroring how real callers load it before rotating).
+// Re-fetching matters when the package's encryption key is initialized (see
+// encryption_test.go's package-level encrypt.Init): the row's BeforeSave hook
+// encrypts ClientSecret.Val on the very struct passed to Create, mutating it
+// in place, so the pointer used to insert the row is left holding ciphertext
+// rather than the plaintext value the test declared.
+func seedRotateOauthConfig(t *testing.T, s *RDBConfigStore, id, clientID, clientSecret string) *tables.TableOauthConfig {
+	t.Helper()
+	cfg := &tables.TableOauthConfig{
+		ID:           id,
+		ClientID:     schemas.NewSecretVar(clientID),
+		ClientSecret: schemas.NewSecretVar(clientSecret),
+		AuthorizeURL: "https://auth.example.com/authorize",
+		TokenURL:     "https://auth.example.com/token",
+		Scopes:       `["read"]`,
+		RedirectURI:  "http://127.0.0.1/cb",
+		Status:       "authorized",
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	require.NoError(t, s.DB().Create(cfg).Error)
+	fresh, err := s.GetOauthConfigByID(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, fresh)
+	return fresh
+}
+
+// baseRotateFields returns an MCPOAuthConfigFields that resolves to exactly
+// what seedRotateOauthConfig stored — the starting point for tests that only
+// want to change one field.
+func baseRotateFields(clientID, clientSecret string) MCPOAuthConfigFields {
+	return MCPOAuthConfigFields{
+		ClientID:     schemas.NewSecretVar(clientID),
+		ClientSecret: schemas.NewSecretVar(clientSecret),
+		AuthorizeURL: "https://auth.example.com/authorize",
+		TokenURL:     "https://auth.example.com/token",
+		Scopes:       []string{"read"},
+	}
+}
+
+// seedRotateToken inserts a mcp_oauth_tokens row bound to oauthConfigID with
+// the given auth_mode and initial status.
+func seedRotateToken(t *testing.T, s *RDBConfigStore, id, oauthConfigID, authMode, status string) {
+	t.Helper()
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID:            id,
+		AuthMode:      authMode,
+		OauthConfigID: oauthConfigID,
+		Status:        status,
+		AccessToken:   "at-" + id,
+		TokenType:     "Bearer",
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}).Error)
+}
+
+func tokenStatus(t *testing.T, s *RDBConfigStore, id string) string {
+	t.Helper()
+	tok, err := s.GetOauthTokenByID(context.Background(), id)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	return tok.Status
+}
+
+// TestRotateMCPOAuthConfig_ChangedCredentialsCascadesAllAuthModes pins the
+// core rotation behavior: when the resolved client_id/client_secret actually
+// differ from what's stored, the oauth_configs row is updated in place and
+// every bound token is cascaded to needs_reauth regardless of auth_mode —
+// shared and per-user rows alike, since rotation is security-driven and must
+// not leave any holder silently still trusted.
+func TestRotateMCPOAuthConfig_ChangedCredentialsCascadesAllAuthModes(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	cfg := seedRotateOauthConfig(t, s, "cfg-1", "old-client-id", "old-client-secret")
+	seedRotateToken(t, s, "tok-shared", cfg.ID, "shared", "active")
+	seedRotateToken(t, s, "tok-user", cfg.ID, "user", "active")
+
+	fields := baseRotateFields("new-client-id", "new-client-secret")
+	rotated, err := s.RotateMCPOAuthConfig(ctx, cfg, fields)
+	require.NoError(t, err)
+	assert.True(t, rotated, "changed credentials must report a rotation happened")
+
+	stored, err := s.GetOauthConfigByID(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "new-client-id", stored.GetResolvedClientID(), "stored client_id must reflect the new value")
+	assert.Equal(t, "new-client-secret", stored.GetResolvedClientSecret(), "stored client_secret must reflect the new value")
+
+	assert.Equal(t, "needs_reauth", tokenStatus(t, s, "tok-shared"), "shared-mode token must be cascaded")
+	assert.Equal(t, "needs_reauth", tokenStatus(t, s, "tok-user"), "user-mode token must be cascaded too, since rotation has no auth_mode filter")
+}
+
+// TestRotateMCPOAuthConfig_ChangedSecondaryFieldsCascadesToo proves the
+// widened scope: authorize_url/token_url/registration_url/resource/scopes
+// drift is treated exactly like client_id/client_secret drift — any of them
+// changing alone (with credentials unchanged) still rotates the row and
+// cascades needs_reauth, since a changed authorize_url/token_url can point
+// at a different identity provider and changed scopes/resource mean
+// already-issued tokens were consented under permissions that no longer
+// apply.
+func TestRotateMCPOAuthConfig_ChangedSecondaryFieldsCascadesToo(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	cfg := seedRotateOauthConfig(t, s, "cfg-secondary", "same-client-id", "same-client-secret")
+	seedRotateToken(t, s, "tok-secondary", cfg.ID, "shared", "active")
+
+	fields := MCPOAuthConfigFields{
+		ClientID:        schemas.NewSecretVar("same-client-id"),
+		ClientSecret:    schemas.NewSecretVar("same-client-secret"),
+		AuthorizeURL:    "https://auth.example.com/v2/authorize",
+		TokenURL:        "https://auth.example.com/v2/token",
+		RegistrationURL: "https://auth.example.com/register",
+		Resource:        "https://mcp.example.com",
+		Scopes:          []string{"read", "write"},
+	}
+	rotated, err := s.RotateMCPOAuthConfig(ctx, cfg, fields)
+	require.NoError(t, err)
+	assert.True(t, rotated, "secondary-field-only drift must still rotate")
+
+	stored, err := s.GetOauthConfigByID(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "https://auth.example.com/v2/authorize", stored.AuthorizeURL)
+	assert.Equal(t, "https://auth.example.com/v2/token", stored.TokenURL)
+	require.NotNil(t, stored.RegistrationURL)
+	assert.Equal(t, "https://auth.example.com/register", *stored.RegistrationURL)
+	assert.Equal(t, "https://mcp.example.com", stored.Resource)
+
+	assert.Equal(t, "needs_reauth", tokenStatus(t, s, "tok-secondary"))
+}
+
+// TestRotateMCPOAuthConfig_ScopesComparisonIsOrderIndependent verifies scope
+// drift detection compares sets, not sequences — reordering the same scopes
+// in the file must not be treated as drift.
+func TestRotateMCPOAuthConfig_ScopesComparisonIsOrderIndependent(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	cfg := seedRotateOauthConfig(t, s, "cfg-scopes", "client-id", "client-secret")
+	// seedRotateOauthConfig stores Scopes: `["read"]`; give it two scopes to
+	// reorder against. Re-fetch afterward rather than reusing cfg directly:
+	// UpdateOauthConfig's Save triggers BeforeSave, which would otherwise
+	// leave cfg.ClientSecret encrypted in place (see
+	// TestRotateMCPOAuthConfig_DoesNotMutateCallerSecretVar's doc comment),
+	// making the plaintext fields below spuriously "differ" on ClientSecret
+	// instead of testing what this test is actually about.
+	cfg.Scopes = `["read","write"]`
+	require.NoError(t, s.UpdateOauthConfig(ctx, cfg))
+	cfg, err := s.GetOauthConfigByID(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	fields := baseRotateFields("client-id", "client-secret")
+	fields.Scopes = []string{"write", "read"}
+	rotated, err := s.RotateMCPOAuthConfig(ctx, cfg, fields)
+	require.NoError(t, err)
+	assert.False(t, rotated, "reordered-but-equal scopes must not be treated as drift")
+}
+
+// TestRotateMCPOAuthConfig_IdenticalCredentialsIsNoop verifies that
+// resolving to byte-identical values across every field skips both the DB
+// write and the reauth cascade entirely: a caller that resends the same
+// real values (or round-trips a fetch-modify-put unchanged) must not
+// invalidate every existing holder's token for no reason.
+func TestRotateMCPOAuthConfig_IdenticalCredentialsIsNoop(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	cfg := seedRotateOauthConfig(t, s, "cfg-2", "same-client-id", "same-client-secret")
+	seedRotateToken(t, s, "tok-shared-2", cfg.ID, "shared", "active")
+	seedRotateToken(t, s, "tok-user-2", cfg.ID, "user", "active")
+
+	beforeUpdatedAt := cfg.UpdatedAt
+
+	fields := baseRotateFields("same-client-id", "same-client-secret")
+	rotated, err := s.RotateMCPOAuthConfig(ctx, cfg, fields)
+	require.NoError(t, err)
+	assert.False(t, rotated, "identical values must report no rotation happened")
+
+	stored, err := s.GetOauthConfigByID(ctx, cfg.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.True(t, stored.UpdatedAt.Equal(beforeUpdatedAt), "no-op rotation must not write the oauth_configs row")
+	assert.Equal(t, "same-client-id", stored.GetResolvedClientID())
+	assert.Equal(t, "same-client-secret", stored.GetResolvedClientSecret())
+
+	assert.Equal(t, "active", tokenStatus(t, s, "tok-shared-2"), "no-op rotation must not cascade shared token")
+	assert.Equal(t, "active", tokenStatus(t, s, "tok-user-2"), "no-op rotation must not cascade user token")
+}
+
+// TestRotateMCPOAuthConfig_NilConfigErrors verifies a nil
+// existingOauthConfig is rejected with an error rather than panicking or
+// silently doing nothing.
+func TestRotateMCPOAuthConfig_NilConfigErrors(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	rotated, err := s.RotateMCPOAuthConfig(ctx, nil, baseRotateFields("a", "b"))
+	assert.Error(t, err)
+	assert.False(t, rotated)
+}
+
+// TestRotateMCPOAuthConfig_DoesNotMutateCallerSecretVar pins the fix for a
+// real aliasing bug: UpdateOauthConfig's GORM Save triggers
+// TableOauthConfig.BeforeSave, which encrypts ClientSecret.Val in place when
+// encryption is enabled (this package's tests run with it enabled, see
+// encryption_test.go). If existingOauthConfig.ClientSecret were assigned the
+// caller's fields.ClientSecret pointer directly instead of a clone, that
+// encryption would silently corrupt the caller's own SecretVar into
+// ciphertext as a side effect of this call — e.g. turning a config.json
+// sync's in-memory authorizedOauth.ClientSecret, or the HTTP handler's
+// req.OauthConfig.ClientSecret, into garbage the caller never expected to
+// change.
+func TestRotateMCPOAuthConfig_DoesNotMutateCallerSecretVar(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	cfg := seedRotateOauthConfig(t, s, "cfg-3", "old-client-id", "old-client-secret")
+
+	fields := baseRotateFields("new-client-id-3", "new-client-secret-3")
+
+	rotated, err := s.RotateMCPOAuthConfig(ctx, cfg, fields)
+	require.NoError(t, err)
+	assert.True(t, rotated)
+
+	assert.Equal(t, "new-client-id-3", fields.ClientID.GetValue(), "caller's ClientID SecretVar must stay plaintext and untouched")
+	assert.Equal(t, "new-client-secret-3", fields.ClientSecret.GetValue(), "caller's ClientSecret SecretVar must stay plaintext and untouched, not encrypted in place")
+	assert.NotSame(t, fields.ClientID, cfg.ClientID, "the row must hold a clone, not the caller's own ClientID pointer")
+	assert.NotSame(t, fields.ClientSecret, cfg.ClientSecret, "the row must hold a clone, not the caller's own ClientSecret pointer")
+}
+
+// TestMCPOAuthConfigFields_DiffersFrom pins the comparison rules in
+// isolation, independent of any DB write.
+func TestMCPOAuthConfigFields_DiffersFrom(t *testing.T) {
+	stored := &tables.TableOauthConfig{
+		ClientID:     schemas.NewSecretVar("stored-client-id"),
+		ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+		AuthorizeURL: "https://auth.example.com/authorize",
+		TokenURL:     "https://auth.example.com/token",
+		Resource:     "https://mcp.example.com",
+		Scopes:       `["read","write"]`,
+	}
+
+	t.Run("nil existing config always differs", func(t *testing.T) {
+		assert.True(t, baseRotateFields("a", "b").DiffersFrom(nil))
+	})
+
+	t.Run("identical fields do not differ", func(t *testing.T) {
+		fields := MCPOAuthConfigFields{
+			ClientID:     schemas.NewSecretVar("stored-client-id"),
+			ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+			AuthorizeURL: "https://auth.example.com/authorize",
+			TokenURL:     "https://auth.example.com/token",
+			Resource:     "https://mcp.example.com",
+			Scopes:       []string{"write", "read"}, // reordered, still equal as a set
+		}
+		assert.False(t, fields.DiffersFrom(stored))
+	})
+
+	t.Run("registration_url nil-vs-empty is not a difference", func(t *testing.T) {
+		fields := MCPOAuthConfigFields{
+			ClientID:     schemas.NewSecretVar("stored-client-id"),
+			ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+			AuthorizeURL: "https://auth.example.com/authorize",
+			TokenURL:     "https://auth.example.com/token",
+			Resource:     "https://mcp.example.com",
+			Scopes:       []string{"read", "write"},
+			// RegistrationURL left "" — stored.RegistrationURL is also nil.
+		}
+		assert.False(t, fields.DiffersFrom(stored))
+	})
+
+	t.Run("a changed registration_url is a difference", func(t *testing.T) {
+		fields := MCPOAuthConfigFields{
+			ClientID:        schemas.NewSecretVar("stored-client-id"),
+			ClientSecret:    schemas.NewSecretVar("stored-client-secret"),
+			AuthorizeURL:    "https://auth.example.com/authorize",
+			TokenURL:        "https://auth.example.com/token",
+			Resource:        "https://mcp.example.com",
+			Scopes:          []string{"read", "write"},
+			RegistrationURL: "https://auth.example.com/register",
+		}
+		assert.True(t, fields.DiffersFrom(stored))
+	})
+
+	t.Run("a changed resource is a difference", func(t *testing.T) {
+		fields := MCPOAuthConfigFields{
+			ClientID:     schemas.NewSecretVar("stored-client-id"),
+			ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+			AuthorizeURL: "https://auth.example.com/authorize",
+			TokenURL:     "https://auth.example.com/token",
+			Resource:     "https://elsewhere.example.com",
+			Scopes:       []string{"read", "write"},
+		}
+		assert.True(t, fields.DiffersFrom(stored))
+	})
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6524,11 +6524,13 @@ func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.Tab
 
 // UpdateOauthConfig updates an existing OAuth config
 func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
-	db := s.DB()
+	var txDB *gorm.DB
 	if len(tx) > 0 {
-		db = tx[0]
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
 	}
-	result := db.WithContext(ctx).Save(config)
+	result := txDB.WithContext(ctx).Save(config)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update oauth config: %w", result.Error)
 	}
@@ -6542,6 +6544,45 @@ func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.Tab
 		return fmt.Errorf("failed to update oauth token: %w", result.Error)
 	}
 	return nil
+}
+
+// RefreshOauthTokenFieldsIfActive persists a successful refresh's new
+// credential fields, but only while the row is still 'active' at write time.
+// Reads the row FOR UPDATE (a Postgres row lock; a no-op on SQLite, see
+// dbForUpdate) inside a transaction so the status check and the write are
+// atomic with respect to a concurrent RotateMCPOAuthConfig cascade flipping
+// the same row to 'needs_reauth' — without this, a plain full-row Save keyed
+// only on ID could silently overwrite that flip back to 'active' with a
+// refresh that started before the rotation but finished after it. Loads
+// through the model (not a raw column UPDATE) so BeforeSave's encryption
+// hook still runs exactly as it does for every other token write.
+func (s *RDBConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+	updated := false
+	err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var current tables.TableMCPOauthToken
+		if err := dbForUpdate(tx).Where("id = ?", id).First(&current).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return err
+		}
+		if current.Status != "active" {
+			return nil
+		}
+		current.AccessToken = accessToken
+		current.RefreshToken = refreshToken
+		current.ExpiresAt = expiresAt
+		current.LastRefreshedAt = &lastRefreshedAt
+		if err := tx.Save(&current).Error; err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to refresh oauth token fields: %w", err)
+	}
+	return updated, nil
 }
 
 // DeleteOauthToken deletes an OAuth token by its ID
@@ -6959,6 +7000,160 @@ func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, 
 		return fmt.Errorf("failed to mark oauth user token %s needs_reauth: %w", tokenID, result.Error)
 	}
 	return nil
+}
+
+// MarkTokensNeedsReauthByConfigID flips status to 'needs_reauth' on every
+// token row bound to an OAuth config, in a single bulk UPDATE — no auth_mode
+// filter, unlike MarkOauthUserTokenNeedsReauthByID's single-row counterpart.
+// Called when an admin rotates an oauth_configs row's client_id/client_secret:
+// every existing holder (shared, per-user, vk, session, admin) loses Bifrost's
+// cached credential equally, since rotation is typically security-driven and
+// must not leave any holder silently still trusted. Precedent for the
+// single-statement bulk UPDATE shape: reconcileVKDirectTokensDB.
+func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+	if oauthConfigID == "" {
+		return nil
+	}
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	result := txDB.WithContext(ctx).
+		Model(&tables.TableMCPOauthToken{}).
+		Where("oauth_config_id = ?", oauthConfigID).
+		Update("status", "needs_reauth")
+	if result.Error != nil {
+		return fmt.Errorf("failed to mark tokens needs_reauth for oauth config %s: %w", oauthConfigID, result.Error)
+	}
+	return nil
+}
+
+// MCPOAuthConfigFields is a fully-resolved set of oauth_configs row values —
+// callers (the update-MCP-client API handler and the config.json sync path)
+// each apply their own "field not provided means keep the stored value"
+// semantics BEFORE constructing this struct; RotateMCPOAuthConfig only
+// diffs the fully-resolved values against what's stored and, if anything at
+// all differs, applies all of them together and cascades needs_reauth.
+//
+// UseDiscovery is deliberately absent: TableOauthConfig.UseDiscovery is
+// already marked deprecated ("discovery now happens automatically when URLs
+// are missing") and nothing reads it, so there is no live behavior to wire
+// a rotation path for.
+type MCPOAuthConfigFields struct {
+	ClientID        *schemas.SecretVar
+	ClientSecret    *schemas.SecretVar
+	AuthorizeURL    string
+	TokenURL        string
+	RegistrationURL string // "" means no registration URL stored (maps to a nil *string on the row)
+	Resource        string
+	Scopes          []string
+}
+
+// DiffersFrom reports whether ANY field in fields differs from what's
+// currently stored on existingOauthConfig. Exported so callers that need to
+// know "would this actually rotate" before deciding something else (e.g. the
+// update-MCP-client API handler rejects rotating while disabling a client,
+// but must not reject a no-op resubmission paired with a disable) can check
+// without duplicating this comparison logic — RotateMCPOAuthConfig uses this
+// same method internally.
+func (fields MCPOAuthConfigFields) DiffersFrom(existingOauthConfig *tables.TableOauthConfig) bool {
+	if existingOauthConfig == nil {
+		return true
+	}
+
+	var existingScopes []string
+	if existingOauthConfig.Scopes != "" {
+		_ = json.Unmarshal([]byte(existingOauthConfig.Scopes), &existingScopes)
+	}
+	newScopesSorted := slices.Clone(fields.Scopes)
+	slices.Sort(newScopesSorted)
+	existingScopesSorted := slices.Clone(existingScopes)
+	slices.Sort(existingScopesSorted)
+
+	existingRegistrationURL := ""
+	if existingOauthConfig.RegistrationURL != nil {
+		existingRegistrationURL = *existingOauthConfig.RegistrationURL
+	}
+
+	return !fields.ClientID.Equals(existingOauthConfig.ClientID) ||
+		!fields.ClientSecret.Equals(existingOauthConfig.ClientSecret) ||
+		fields.AuthorizeURL != existingOauthConfig.AuthorizeURL ||
+		fields.TokenURL != existingOauthConfig.TokenURL ||
+		fields.RegistrationURL != existingRegistrationURL ||
+		fields.Resource != existingOauthConfig.Resource ||
+		!slices.Equal(newScopesSorted, existingScopesSorted)
+}
+
+// RotateMCPOAuthConfig updates every field of an oauth_configs row in place
+// when ANY of them differs from what's stored, and — only when something
+// actually changed — cascades every token bound to that config to
+// needs_reauth in the same transaction, regardless of which auth_mode holds
+// it (shared/user/vk/session/admin alike).
+//
+// Every field is treated uniformly on purpose: a changed authorize_url or
+// token_url can point a client at a different identity provider entirely,
+// and a changed scopes/resource set means already-issued tokens were
+// consented under permissions that no longer match — cascading needs_reauth
+// for those is exactly as necessary as it is for client_id/client_secret.
+// Erring toward over-invalidating a session is the safer default here, not
+// a heavier one.
+//
+// Shared by the update-MCP-client API handler and the config.json sync path
+// so OAuth config changes behave identically from both entry points.
+//
+// existingOauthConfig is assigned CLONES of fields.ClientID/ClientSecret,
+// not the caller's own pointers: UpdateOauthConfig's GORM Save triggers
+// TableOauthConfig.BeforeSave, which encrypts ClientSecret.Val in place when
+// encryption is enabled. Aliasing would silently turn the caller's own
+// SecretVar (e.g. the request body's or a reused authorizedOauth row's) into
+// ciphertext as a side effect of this call.
+//
+// Returns whether a rotation actually happened.
+func (s *RDBConfigStore) RotateMCPOAuthConfig(ctx context.Context, existingOauthConfig *tables.TableOauthConfig, fields MCPOAuthConfigFields) (bool, error) {
+	if existingOauthConfig == nil {
+		return false, fmt.Errorf("oauth config is nil")
+	}
+	if !fields.DiffersFrom(existingOauthConfig) {
+		return false, nil
+	}
+
+	existingOauthConfig.ClientID = fields.ClientID.Clone()
+	existingOauthConfig.ClientSecret = fields.ClientSecret.Clone()
+	existingOauthConfig.AuthorizeURL = fields.AuthorizeURL
+	existingOauthConfig.TokenURL = fields.TokenURL
+	if fields.RegistrationURL == "" {
+		existingOauthConfig.RegistrationURL = nil
+	} else {
+		registrationURL := fields.RegistrationURL
+		existingOauthConfig.RegistrationURL = &registrationURL
+	}
+	existingOauthConfig.Resource = fields.Resource
+	if len(fields.Scopes) == 0 {
+		existingOauthConfig.Scopes = ""
+	} else {
+		scopesJSON, marshalErr := json.Marshal(fields.Scopes)
+		if marshalErr != nil {
+			return false, fmt.Errorf("failed to encode scopes: %w", marshalErr)
+		}
+		existingOauthConfig.Scopes = string(scopesJSON)
+	}
+
+	oauthConfigID := existingOauthConfig.ID
+	err := s.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		if err := s.UpdateOauthConfig(ctx, existingOauthConfig, tx); err != nil {
+			return fmt.Errorf("failed to update oauth config: %w", err)
+		}
+		if err := s.MarkTokensNeedsReauthByConfigID(ctx, oauthConfigID, tx); err != nil {
+			return fmt.Errorf("failed to invalidate existing tokens: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // GetOauthUserTokenByID looks up a single per-user token row by primary key.

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -520,6 +520,16 @@ type ConfigStore interface {
 	GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error)
 	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
+	// RefreshOauthTokenFieldsIfActive persists a successful refresh's new
+	// access_token/refresh_token/expires_at/last_refreshed_at onto the row
+	// with the given id, but ONLY while the row's status is still 'active' —
+	// a targeted column update, not a full-row Save, so it can't clobber a
+	// status a concurrent credential rotation (RotateMCPOAuthConfig) already
+	// flipped to 'needs_reauth' while this refresh's network round-trip was
+	// in flight. Returns updated=false (no error) when the row's status was
+	// no longer 'active' at write time; the caller must treat that as
+	// requiring reauthentication rather than a successful refresh.
+	RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (updated bool, err error)
 	DeleteOauthToken(ctx context.Context, id string) error
 	// DeleteSharedOauthTokensByConfigID deletes every auth_mode='shared' row
 	// for oauthConfigID, not just the one GetSharedOauthTokenByConfigID would
@@ -601,6 +611,22 @@ type ConfigStore interface {
 	// always comes from an internal lookup already, never an arbitrary
 	// caller-supplied ID.
 	MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error
+	// MarkTokensNeedsReauthByConfigID flips status to 'needs_reauth' on every
+	// token row bound to an OAuth config in one bulk UPDATE, with no
+	// auth_mode filter — rotating an oauth_configs row's client_id/client_secret
+	// invalidates every existing holder's cached credential (shared, per-user,
+	// vk, session, admin alike), not just the shared one.
+	MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
+	// RotateMCPOAuthConfig updates every field of an oauth_configs row in
+	// place when ANY of them differs from what's stored (client_id,
+	// client_secret, authorize_url, token_url, registration_url, resource,
+	// scopes), and — only when something actually changed — cascades every
+	// token bound to that config to needs_reauth in the same transaction,
+	// regardless of which auth_mode holds it. Shared by the
+	// update-MCP-client API handler and the config.json sync path so OAuth
+	// config changes behave identically from both entry points. Returns
+	// whether a rotation actually happened.
+	RotateMCPOAuthConfig(ctx context.Context, existingOauthConfig *tables.TableOauthConfig, fields MCPOAuthConfigFields) (bool, error)
 	// GetOauthUserTokenByID looks up a single per-user token row by primary
 	// key. Returns nil, nil when not found. Unlike GetOauthTokenByID above,
 	// this DOES filter to auth_mode IN ('user','vk','session'): the sessions

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -293,21 +293,31 @@ func (p *OAuth2Provider) refreshAccessTokenLocked(ctx context.Context, tokenID s
 		// row so the next call retries refresh.
 		return fmt.Errorf("token refresh failed: %w", err)
 	}
-	// Update token in database (sanitize tokens to prevent header formatting issues)
+	// Persist the refreshed credentials (sanitize tokens to prevent header
+	// formatting issues). Sent as a status-gated write, not a blind full-row
+	// Save keyed on token — this call started before the network round-trip
+	// above and can finish after a concurrent credential rotation
+	// (RotateMCPOAuthConfig) has already flipped this same row to
+	// 'needs_reauth'; a plain Save of the in-memory (pre-rotation) token
+	// would silently overwrite that back to 'active'.
 	now := time.Now()
-	token.ExpiresAt = nil
+	var newExpiresAt *time.Time
 	if newTokenResponse.ExpiresIn > 0 {
 		exp := now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
-		token.ExpiresAt = bifrost.Ptr(exp)
+		newExpiresAt = bifrost.Ptr(exp)
 	}
-	token.AccessToken = strings.TrimSpace(newTokenResponse.AccessToken)
+	newAccessToken := strings.TrimSpace(newTokenResponse.AccessToken)
+	newRefreshToken := token.RefreshToken
 	if newTokenResponse.RefreshToken != "" {
-		token.RefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
+		newRefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
 	}
-	token.LastRefreshedAt = bifrost.Ptr(now)
 
-	if err := p.configStore.UpdateOauthToken(ctx, token); err != nil {
+	updated, err := p.configStore.RefreshOauthTokenFieldsIfActive(ctx, token.ID, newAccessToken, newRefreshToken, newExpiresAt, now)
+	if err != nil {
 		return fmt.Errorf("failed to update token: %w", err)
+	}
+	if !updated {
+		return fmt.Errorf("token was reauthorized or rotated during refresh, discarding this refresh: %w", schemas.ErrOAuth2TokenExpired)
 	}
 
 	logger.Debug("OAuth token refreshed successfully: token_id=%s auth_mode=%s", token.ID, token.AuthMode)

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -88,6 +88,25 @@ func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.Tabl
 	return nil
 }
 
+// RefreshOauthTokenFieldsIfActive is the test-double equivalent of the real
+// store's status-gated refresh write (see its doc comment on the interface):
+// applies the new credential fields only while the row is still 'active'.
+func (s *testConfigStore) RefreshOauthTokenFieldsIfActive(_ context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token, ok := s.oauthTokens[id]
+	if !ok || token.Status != "active" {
+		return false, nil
+	}
+	updated := *token
+	updated.AccessToken = accessToken
+	updated.RefreshToken = refreshToken
+	updated.ExpiresAt = expiresAt
+	updated.LastRefreshedAt = &lastRefreshedAt
+	s.oauthTokens[id] = &updated
+	return true, nil
+}
+
 // MarkOauthUserTokenNeedsReauthByID flips a token's status to 'needs_reauth',
 // the test-double equivalent of the real store's method of the same name —
 // which, despite the historical "UserToken" naming, is not scoped away from
@@ -100,6 +119,19 @@ func (s *testConfigStore) MarkOauthUserTokenNeedsReauthByID(_ context.Context, t
 		return nil
 	}
 	token.Status = "needs_reauth"
+	return nil
+}
+
+// MarkTokensNeedsReauthByConfigID is the test-double equivalent of the real
+// store's bulk, auth_mode-agnostic cascade used by OAuth credential rotation.
+func (s *testConfigStore) MarkTokensNeedsReauthByConfigID(_ context.Context, oauthConfigID string, _ ...*gorm.DB) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, token := range s.oauthTokens {
+		if token.OauthConfigID == oauthConfigID {
+			token.Status = "needs_reauth"
+		}
+	}
 	return nil
 }
 
@@ -582,6 +614,52 @@ func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "active", token.Status)
 	assert.Equal(t, "new-access-token", token.AccessToken)
+}
+
+func TestTokenRefreshWorker_ConcurrentReauth_DoesNotOverwriteStaleRefresh(t *testing.T) {
+	// If the token flips to needs_reauth (e.g. a user-initiated reauth, or a
+	// credential-rotation cascade) while a refresh request is already in
+	// flight, the in-flight refresh's stale success response must not
+	// resurrect the old credentials as "active" — this exercises the
+	// store's RefreshOauthTokenFieldsIfActive status gate under an actual race,
+	// not just the update path in isolation.
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-unblock
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "stale-refreshed-access-token",
+			"refresh_token": "stale-refreshed-refresh-token",
+			"token_type":    "bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.refreshExpiredTokens(context.Background())
+	}()
+
+	<-started
+	require.NoError(t, store.MarkOauthUserTokenNeedsReauthByID(context.Background(), tokenID))
+	close(unblock)
+	wg.Wait()
+
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "needs_reauth", token.Status, "status flip during an in-flight refresh must not be overwritten by the stale response")
+	assert.Equal(t, "old-access-token", token.AccessToken, "stale refresh response must not overwrite credentials once needs_reauth has been set")
+	assert.Equal(t, "refresh-token", token.RefreshToken)
 }
 
 func TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkNeedsReauth(t *testing.T) {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -35,6 +35,10 @@ type MCPManager interface {
 	// UpdateMCPClientConnection reconnects an existing MCP client using updated headers
 	UpdateMCPClientConnection(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error
 	ReconnectMCPClient(ctx context.Context, id string) error
+	// CloseAndMarkNeedsReauth closes a shared client's live upstream
+	// connection and flips it to needs_reauth, without attempting a new
+	// dial. Used after OAuth credential rotation.
+	CloseAndMarkNeedsReauth(ctx context.Context, id string) error
 	DisableMCPClient(ctx context.Context, id string) error
 	EnableMCPClient(ctx context.Context, id string) error
 	// VerifyPerUserOAuthConnection verifies an MCP server using a temporary access
@@ -804,6 +808,15 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			if oauthCfg, ok := oauthConfigsByID[*dbClient.OauthConfigID]; ok {
 				clientConfig.OauthClientID = oauthCfg.ClientID
 				clientConfig.OauthClientSecret = oauthCfg.GetClientSecretAsSecretVar()
+				clientConfig.OauthAuthorizeURL = oauthCfg.AuthorizeURL
+				clientConfig.OauthTokenURL = oauthCfg.TokenURL
+				if oauthCfg.RegistrationURL != nil {
+					clientConfig.OauthRegistrationURL = *oauthCfg.RegistrationURL
+				}
+				clientConfig.OauthResource = oauthCfg.Resource
+				if oauthCfg.Scopes != "" {
+					_ = json.Unmarshal([]byte(oauthCfg.Scopes), &clientConfig.OauthScopes)
+				}
 			}
 		}
 		// Enrich VK assignments using the pre-fetched batch result.
@@ -1535,87 +1548,127 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	// OAuth credential rotation is temporarily disabled.
-	if req.OauthConfig != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, "updating oauth_config is not supported")
+	// OAuth config rotation: update every oauth_configs field in place (no new
+	// row, no re-discovery/re-registration triggered here) when ANY of them
+	// differs from what's stored, then cascade every token bound to that
+	// config to needs_reauth regardless of which auth_mode holds it. Every
+	// field is treated uniformly — not just client_id/client_secret — since a
+	// changed authorize_url/token_url can point at a different identity
+	// provider, and changed scopes/resource mean already-issued tokens were
+	// consented under permissions that no longer apply. The next reconnect
+	// (shared clients) or next tool call (per-user, via the existing
+	// needs_reauth->reauth-URL path) surfaces the requirement to
+	// re-authenticate — no new plumbing needed.
+	shouldRotateOAuthConfig := req.OauthConfig != nil &&
+		(existingConfig.AuthType == schemas.MCPAuthTypeOauth || existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth)
+	if req.OauthConfig != nil && !shouldRotateOAuthConfig {
+		SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
 		return
 	}
-	// shouldRotateOAuthConfig := req.OauthConfig != nil && (existingConfig.AuthType == schemas.MCPAuthTypeOauth || existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth)
-	// var oauthClientID *schemas.SecretVar
-	// var oauthClientSecret *schemas.SecretVar
-	// oauthAuthorizeURL := ""
-	// oauthTokenURL := ""
-	// oauthRegistrationURL := ""
-	// oauthScopes := []string{}
-	// if req.OauthConfig != nil && !shouldRotateOAuthConfig {
-	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
-	// 	return
-	// }
-	// if shouldRotateOAuthConfig && disabled {
-	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
-	// 	return
-	// }
-	// if shouldRotateOAuthConfig {
-	// 	if req.OauthConfig.ClientID.ShouldPreserveStored() && req.OauthConfig.ClientSecret.ShouldPreserveStored() {
-	// 		shouldRotateOAuthConfig = false
-	// 	}
-	// }
-	// if shouldRotateOAuthConfig {
-	// 	oauthClientID = req.OauthConfig.ClientID
-	// 	oauthClientSecret = req.OauthConfig.ClientSecret
-	// 	oauthAuthorizeURL = strings.TrimSpace(req.OauthConfig.AuthorizeURL)
-	// 	oauthTokenURL = strings.TrimSpace(req.OauthConfig.TokenURL)
-	// 	oauthRegistrationURL = strings.TrimSpace(req.OauthConfig.RegistrationURL)
-	// 	oauthScopes = req.OauthConfig.Scopes
-	// 	if !oauthClientID.IsSet() && !oauthClientSecret.IsSet() {
-	// 		SendError(ctx, fasthttp.StatusBadRequest, "oauth_config.client_id or oauth_config.client_secret is required when updating OAuth credentials")
-	// 		return
-	// 	}
-	// 	var existingOauthConfig *configstoreTables.TableOauthConfig
-	// 	if existingConfig.OauthConfigID != nil && *existingConfig.OauthConfigID != "" {
-	// 		existingOauthConfig, err = h.store.ConfigStore.GetOauthConfigByID(ctx, *existingConfig.OauthConfigID)
-	// 		if err != nil {
-	// 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing OAuth config: %v", err))
-	// 			return
-	// 		}
-	// 		if existingOauthConfig != nil {
-	// 			if oauthAuthorizeURL == "" {
-	// 				oauthAuthorizeURL = strings.TrimSpace(existingOauthConfig.AuthorizeURL)
-	// 			}
-	// 			if oauthTokenURL == "" {
-	// 				oauthTokenURL = strings.TrimSpace(existingOauthConfig.TokenURL)
-	// 			}
-	// 			if oauthRegistrationURL == "" && existingOauthConfig.RegistrationURL != nil {
-	// 				oauthRegistrationURL = strings.TrimSpace(*existingOauthConfig.RegistrationURL)
-	// 			}
-	// 			if len(oauthScopes) == 0 && strings.TrimSpace(existingOauthConfig.Scopes) != "" {
-	// 				var existingScopes []string
-	// 				if err := json.Unmarshal([]byte(existingOauthConfig.Scopes), &existingScopes); err != nil {
-	// 					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to parse existing OAuth scopes: %v", err))
-	// 					return
-	// 				}
-	// 				oauthScopes = existingScopes
-	// 			}
-	// 		}
-	// 	}
-	// 	if !oauthClientID.IsSet() || oauthClientID.ShouldPreserveStored() {
-	// 		if existingOauthConfig == nil || !existingOauthConfig.ClientID.IsSet() {
-	// 			SendError(ctx, fasthttp.StatusBadRequest, "existing OAuth client_id not found; provide oauth_config.client_id")
-	// 			return
-	// 		}
-	// 		oauthClientID = existingOauthConfig.ClientID // preserve env var reference
-	// 	}
-	// 	if !oauthClientSecret.IsSet() || oauthClientSecret.ShouldPreserveStored() {
-	// 		if existingOauthConfig != nil {
-	// 			oauthClientSecret = existingOauthConfig.ClientSecret // preserve stored secret
-	// 		}
-	// 	}
-	// 	requiresDiscoveryOrRegistration := !oauthClientID.IsSet() || oauthAuthorizeURL == "" || oauthTokenURL == ""
-	// 	if requiresDiscoveryOrRegistration && (existingConfig.ConnectionString == nil || existingConfig.ConnectionString.GetValue() == "") {
-	// 		SendError(ctx, fasthttp.StatusBadRequest, "existing connection_string is required when OAuth discovery or dynamic registration is needed")
-	// 		return
-	// 	}
-	// }
+	var existingOauthConfig *configstoreTables.TableOauthConfig
+	var resolvedOauthFields configstore.MCPOAuthConfigFields
+	if shouldRotateOAuthConfig {
+		if existingConfig.OauthConfigID == nil || *existingConfig.OauthConfigID == "" {
+			// Not a server fault: a legitimate pre-authorization state (the
+			// client hasn't completed its one-time OAuth verification yet,
+			// so there's no oauth_configs row to rotate against).
+			SendError(ctx, fasthttp.StatusConflict, "oauth_config cannot be updated before this MCP client's OAuth verification is completed")
+			return
+		}
+		var err error
+		existingOauthConfig, err = h.store.ConfigStore.GetOauthConfigByID(ctx, *existingConfig.OauthConfigID)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing OAuth config: %v", err))
+			return
+		}
+		if existingOauthConfig == nil {
+			// Unlike the missing-link case above, this IS a server-side data
+			// integrity fault: the client has a link, but the row it points
+			// at is gone.
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("oauth config %s referenced by this MCP client no longer exists", *existingConfig.OauthConfigID))
+			return
+		}
+		// Resolve what every field would become: preserve the stored value
+		// for any field the caller left unset. client_id/client_secret use
+		// SecretVar's own masked-placeholder convention; the plain-string/
+		// slice fields use the same "empty means not provided" convention
+		// the config.json path already uses for this block.
+		resolvedOauthFields = configstore.MCPOAuthConfigFields{
+			ClientID:        existingOauthConfig.ClientID,
+			ClientSecret:    existingOauthConfig.ClientSecret,
+			AuthorizeURL:    existingOauthConfig.AuthorizeURL,
+			TokenURL:        existingOauthConfig.TokenURL,
+			RegistrationURL: "",
+			Resource:        existingOauthConfig.Resource,
+			Scopes:          nil,
+		}
+		if existingOauthConfig.RegistrationURL != nil {
+			resolvedOauthFields.RegistrationURL = *existingOauthConfig.RegistrationURL
+		}
+		if existingOauthConfig.Scopes != "" {
+			_ = json.Unmarshal([]byte(existingOauthConfig.Scopes), &resolvedOauthFields.Scopes)
+		}
+		if !req.OauthConfig.ClientID.ShouldPreserveStored() {
+			resolvedOauthFields.ClientID = req.OauthConfig.ClientID
+		}
+		if !req.OauthConfig.ClientSecret.ShouldPreserveStored() {
+			resolvedOauthFields.ClientSecret = req.OauthConfig.ClientSecret
+		}
+		if trimmed := strings.TrimSpace(req.OauthConfig.AuthorizeURL); trimmed != "" {
+			resolvedOauthFields.AuthorizeURL = trimmed
+		}
+		if trimmed := strings.TrimSpace(req.OauthConfig.TokenURL); trimmed != "" {
+			resolvedOauthFields.TokenURL = trimmed
+		}
+		if trimmed := strings.TrimSpace(req.OauthConfig.RegistrationURL); trimmed != "" {
+			resolvedOauthFields.RegistrationURL = trimmed
+		}
+		if trimmed := strings.TrimSpace(req.OauthConfig.Resource); trimmed != "" {
+			resolvedOauthFields.Resource = trimmed
+		}
+		// nil vs non-nil-empty distinguishes omitted (leave stored scopes
+		// alone) from an explicit empty list (clear them) — encoding/json
+		// leaves the field nil for an omitted "scopes" key and sets a
+		// non-nil empty slice for an explicit "scopes": []. A length check
+		// alone couldn't tell these apart and always preserved the stored
+		// value, so a request to clear scopes silently no-op'd.
+		if req.OauthConfig.Scopes != nil {
+			resolvedOauthFields.Scopes = req.OauthConfig.Scopes
+		}
+		// Changing where credentials get sent (token_url/authorize_url) while
+		// silently carrying over the stored client_secret would POST that
+		// secret to a caller-supplied endpoint the admin never explicitly
+		// paired it with — require the secret to be resent explicitly
+		// whenever either endpoint changes, rather than trusting the old
+		// pairing across an endpoint change.
+		endpointChanged := resolvedOauthFields.AuthorizeURL != existingOauthConfig.AuthorizeURL ||
+			resolvedOauthFields.TokenURL != existingOauthConfig.TokenURL
+		if endpointChanged && req.OauthConfig.ClientSecret.ShouldPreserveStored() {
+			SendError(ctx, fasthttp.StatusBadRequest, "client_secret must be resent explicitly when authorize_url or token_url changes")
+			return
+		}
+		if !resolvedOauthFields.DiffersFrom(existingOauthConfig) {
+			// Every field resolved to what's already stored — either the
+			// caller left everything unset, or resent the same real values
+			// verbatim. Nothing actually changed, so skip the write and the
+			// reauth cascade entirely: a fetch-modify-put caller that
+			// round-trips oauth_config unchanged, or a request that pairs an
+			// unchanged oauth_config with a disable, must not invalidate
+			// every existing holder's token for no reason.
+			shouldRotateOAuthConfig = false
+		}
+	}
+	if shouldRotateOAuthConfig && disabled {
+		SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
+		return
+	}
+	// Rotation is deferred until after the DB and in-memory client updates
+	// below both succeed (see the call site further down): RotateMCPOAuthConfig
+	// opens its own transaction and, once it commits, cascades every existing
+	// token on this config to needs_reauth — an effect no later rollback in
+	// this handler can undo. Rotating here, before UpdateMCPClientConfig/
+	// UpdateMCPClient even run, would mean a later failure in either reports
+	// this request as failed while every holder was already signed out.
 
 	var oldDBConfig *configstoreTables.TableMCPClient
 	if h.store.ConfigStore != nil {
@@ -1726,6 +1779,33 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		logger.Error(fmt.Sprintf("Failed to update MCP client: %v", err))
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client: %v", err))
 		return
+	}
+
+	// Rotate OAuth credentials only now that both the DB row and the runtime
+	// config update above have succeeded — see the comment where
+	// shouldRotateOAuthConfig was computed for why this can't run earlier.
+	if shouldRotateOAuthConfig {
+		if _, err := h.store.ConfigStore.RotateMCPOAuthConfig(ctx, existingOauthConfig, resolvedOauthFields); err != nil {
+			// The rest of the update already committed; only credential
+			// rotation failed. Report it as a partial success rather than a
+			// full failure so the caller doesn't retry the whole request
+			// (which would redundantly repeat the client/DB update above).
+			logger.Error(fmt.Sprintf("[PARTIAL SUCCESS] MCP client %s was updated but rotating its OAuth credentials failed: %v", id, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("MCP client updated but rotating its OAuth credentials failed: %v", err))
+			return
+		}
+		// Rotation just cascaded every token bound to this oauth_config to
+		// needs_reauth in the DB, but the in-memory client above only had its
+		// ExecutionConfig replaced — its live connection, if any, is still
+		// open on the now-invalidated Authorization header. Close it and
+		// flip the in-memory state to match, rather than leaving a stale
+		// connection serving calls until the health monitor eventually
+		// notices. Not a hard failure: the DB rotation is what actually
+		// matters for correctness, and the health monitor's next cycle would
+		// eventually catch a connection this call failed to close.
+		if err := h.mcpManager.CloseAndMarkNeedsReauth(ctx, id); err != nil && !errors.Is(err, schemas.ErrMCPReconnectNotApplicable) {
+			logger.Error(fmt.Sprintf("Failed to close MCP client %s's connection after OAuth credential rotation: %v", id, err))
+		}
 	}
 
 	// If the per-user-headers schema now requires additional keys, flip every
@@ -1860,44 +1940,6 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			}
 		}
 	}
-
-	// if shouldRotateOAuthConfig {
-	// 	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
-	// 	serverURL := ""
-	// 	if existingConfig.ConnectionString != nil {
-	// 		serverURL = existingConfig.ConnectionString.GetValue()
-	// 	}
-	// 	flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-	// 		ClientID:        oauthClientID,
-	// 		ClientSecret:    oauthClientSecret,
-	// 		AuthorizeURL:    oauthAuthorizeURL,
-	// 		TokenURL:        oauthTokenURL,
-	// 		RegistrationURL: oauthRegistrationURL,
-	// 		RedirectURI:     redirectURI,
-	// 		Scopes:          oauthScopes,
-	// 		ServerURL:       serverURL,
-	// 	})
-	// 	if err != nil {
-	// 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
-	// 		return
-	// 	}
-	// 	pendingConfig := *schemasConfig
-	// 	pendingConfig.OauthConfigID = &flowInitiation.OauthConfigID
-	// 	pendingConfig.Headers = req.Headers
-	// 	if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
-	// 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client update: %v", err))
-	// 		return
-	// 	}
-	// 	SendJSON(ctx, map[string]any{
-	// 		"status":          "pending_oauth",
-	// 		"message":         "MCP client updated. OAuth re-authorization is required to apply credential rotation.",
-	// 		"oauth_config_id": flowInitiation.OauthConfigID,
-	// 		"authorize_url":   flowInitiation.AuthorizeURL,
-	// 		"expires_at":      flowInitiation.ExpiresAt,
-	// 		"mcp_client_id":   req.ClientID,
-	// 	})
-	// 	return
-	// }
 
 	// Per-user credential reconciliation for changes that mutate who can
 	// access this MCP. Two trigger conditions:

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1811,7 +1811,7 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 // oauth_configs row backing an already-authorized client (nil when the client
 // is unauthorized or the row is unavailable); it is only read, and only to
 // detect oauth_config drift.
-func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig, authorizedOauth *configstoreTables.TableOauthConfig) []string {
+func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig) []string {
 	if fileClient == nil || existing == nil {
 		return nil
 	}
@@ -1845,9 +1845,12 @@ func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig, 
 	}
 	fileClient.StdioConfig = existing.StdioConfig
 
-	if mcpOauthBlockChanged(fileClient.PendingOAuthConfig, existing.PendingOAuthConfig, authorizedOauth) {
-		changed = append(changed, "oauth_config")
-	}
+	// oauth_config drift is not pinned here: it is fully handled by
+	// rotateMCPOauthConfigFromFile at the call sites below, which applies any
+	// declared change (client_id/client_secret/authorize_url/token_url/
+	// registration_url/resource/scopes) and cascades needs_reauth. Only the
+	// pre-authorization pending stash is preserved here — once authorized,
+	// PendingOAuthConfig is cleared and this is a no-op.
 	fileClient.PendingOAuthConfig = existing.PendingOAuthConfig
 
 	// Not immutable, but a per_user_headers client must keep a non-empty key
@@ -1866,60 +1869,105 @@ func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig, 
 	return changed
 }
 
-// mcpOauthBlockChanged reports whether the file's inline oauth_config block
-// drifts from the OAuth configuration the client actually runs on. Only
-// fields the file explicitly sets are compared: absent fields are filled in
-// by discovery / dynamic client registration at authorization time, so a
-// stored value with no file counterpart is not drift. The reference is the
-// stored pending stash while verification is pending, and the authorized
-// oauth_configs row afterwards; with neither available there is nothing to
-// compare against.
-func mcpOauthBlockChanged(fileBlock, storedStash *schemas.OAuth2Config, authorizedOauth *configstoreTables.TableOauthConfig) bool {
-	if fileBlock == nil {
+// rotateMCPOauthConfigFromFile applies any oauth_config drift declared in
+// the file to the authorized oauth_configs row backing clientName, mirroring
+// the update-MCP-client API's rotation via the same
+// store.RotateMCPOAuthConfig: every field the file explicitly sets
+// (client_id/client_secret/authorize_url/token_url/registration_url/
+// resource/scopes) is resolved against what's stored, and if anything
+// differs the row is updated in place and every token bound to it — shared,
+// per-user, vk, session, admin alike — is cascaded to needs_reauth. Only
+// fields the file explicitly sets participate: an absent field means "not
+// declared" (e.g. filled in by discovery/dynamic registration at
+// authorization time), not a request to clear it.
+//
+// No-op when authorizedOauth is nil — verification is still pending (no
+// authorized row to rotate yet) or the client isn't OAuth-based; the pending
+// stash case is handled separately by pinMCPClientImmutableFields preserving
+// the stored PendingOAuthConfig.
+//
+// Returns incomplete=true when a declared client_id/client_secret secret
+// reference failed to resolve, or when the stored row's scopes column isn't
+// valid JSON, so a field was skipped rather than applied. Callers must not
+// advance ConfigHash to this boot's file hash in that case:
+// doing so would checkpoint a partially-applied rotation as fully synced,
+// and the next boot's identical file content would hash-match and skip
+// reconciliation entirely — even after the underlying secret becomes
+// resolvable — until the file itself changes again.
+func rotateMCPOauthConfigFromFile(ctx context.Context, store configstore.ConfigStore, clientName string, fileBlock *schemas.OAuth2Config, authorizedOauth *configstoreTables.TableOauthConfig) (incomplete bool) {
+	if store == nil || fileBlock == nil || authorizedOauth == nil {
 		return false
 	}
-	var refClientID, refClientSecret, refAuthorizeURL, refTokenURL string
-	var refScopes []string
-	switch {
-	case storedStash != nil:
-		refClientID = storedStash.ClientID
-		refClientSecret = storedStash.ClientSecret
-		refAuthorizeURL = storedStash.AuthorizeURL
-		refTokenURL = storedStash.TokenURL
-		refScopes = storedStash.Scopes
-	case authorizedOauth != nil:
-		refClientID = authorizedOauth.GetResolvedClientID()
-		refClientSecret = authorizedOauth.GetResolvedClientSecret()
-		refAuthorizeURL = authorizedOauth.AuthorizeURL
-		refTokenURL = authorizedOauth.TokenURL
-		if authorizedOauth.Scopes != "" {
-			_ = json.Unmarshal([]byte(authorizedOauth.Scopes), &refScopes)
-		}
-	default:
-		return false
+	fields := configstore.MCPOAuthConfigFields{
+		ClientID:     authorizedOauth.ClientID,
+		ClientSecret: authorizedOauth.ClientSecret,
+		AuthorizeURL: authorizedOauth.AuthorizeURL,
+		TokenURL:     authorizedOauth.TokenURL,
+		Resource:     authorizedOauth.Resource,
 	}
-	if fileBlock.ClientID != "" && fileBlock.ClientID != refClientID {
-		return true
+	if authorizedOauth.RegistrationURL != nil {
+		fields.RegistrationURL = *authorizedOauth.RegistrationURL
 	}
-	if fileBlock.ClientSecret != "" && fileBlock.ClientSecret != refClientSecret {
-		return true
-	}
-	if fileBlock.AuthorizeURL != "" && fileBlock.AuthorizeURL != refAuthorizeURL {
-		return true
-	}
-	if fileBlock.TokenURL != "" && fileBlock.TokenURL != refTokenURL {
-		return true
-	}
-	if len(fileBlock.Scopes) > 0 {
-		fileScopes := slices.Clone(fileBlock.Scopes)
-		storedScopes := slices.Clone(refScopes)
-		slices.Sort(fileScopes)
-		slices.Sort(storedScopes)
-		if !slices.Equal(fileScopes, storedScopes) {
+	if authorizedOauth.Scopes != "" {
+		if err := json.Unmarshal([]byte(authorizedOauth.Scopes), &fields.Scopes); err != nil {
+			// A decode failure would otherwise silently collapse fields.Scopes
+			// to nil — indistinguishable from "the file declared nothing about
+			// scopes" — and a file that never mentions scopes would then look
+			// like drift against the (unreadable) stored value, rotating and
+			// cascading needs_reauth for a field it never touched. Skip this
+			// rotation attempt instead so a later boot retries once the stored
+			// row is repaired.
+			logger.Warn("stored oauth scopes for MCP client %q are not valid JSON; skipping OAuth rotation: %v", clientName, err)
 			return true
 		}
 	}
-	return false
+	// NewSecretVar resolves env./vault. references immediately and sets Val
+	// to "" when the reference doesn't resolve (e.g. the env var isn't set
+	// on this boot). Guard against persisting that empty value: it would
+	// silently blank a real stored credential and RotateMCPOAuthConfig would
+	// see it as drift, cascading every bound token to needs_reauth over a
+	// transient env var absence. Skip the field (keep the stored value) and
+	// warn instead.
+	if fileBlock.ClientID != "" {
+		if declared := schemas.NewSecretVar(fileBlock.ClientID); declared.GetValue() != "" {
+			fields.ClientID = declared
+		} else {
+			logger.Warn("oauth client_id declared for MCP client %q resolves to an empty value; keeping the stored value", clientName)
+			incomplete = true
+		}
+	}
+	if fileBlock.ClientSecret != "" {
+		if declared := schemas.NewSecretVar(fileBlock.ClientSecret); declared.GetValue() != "" {
+			fields.ClientSecret = declared
+		} else {
+			logger.Warn("oauth client_secret declared for MCP client %q resolves to an empty value; keeping the stored value", clientName)
+			incomplete = true
+		}
+	}
+	if fileBlock.AuthorizeURL != "" {
+		fields.AuthorizeURL = fileBlock.AuthorizeURL
+	}
+	if fileBlock.TokenURL != "" {
+		fields.TokenURL = fileBlock.TokenURL
+	}
+	if fileBlock.RegistrationURL != nil && *fileBlock.RegistrationURL != "" {
+		fields.RegistrationURL = *fileBlock.RegistrationURL
+	}
+	if fileBlock.Resource != "" {
+		fields.Resource = fileBlock.Resource
+	}
+	if fileBlock.Scopes != nil {
+		fields.Scopes = fileBlock.Scopes
+	}
+	rotated, err := store.RotateMCPOAuthConfig(ctx, authorizedOauth, fields)
+	if err != nil {
+		logger.Warn("failed to rotate OAuth config for MCP client %q from config file: %v", clientName, err)
+		return true
+	}
+	if rotated {
+		logger.Warn("rotated OAuth config for MCP client %q from config file; existing sessions must re-authenticate", clientName)
+	}
+	return incomplete
 }
 
 // authorizedOauthRowForComparison loads the oauth_configs row backing an
@@ -2020,16 +2068,25 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 				if existingClientConfig.ConfigHash != fileHash {
 					logger.Debug("config hash mismatch for MCP client %q, syncing from config file", newClientConfig.Name)
 					newClientConfig.ID = existingClientConfig.ID
-					newClientConfig.ConfigHash = fileHash
 					// Pin immutable fields to their stored values and carry
 					// server-side verification state (authorized OAuth link,
 					// discovered tools) the file cannot express, so a config
 					// edit does not reset a verified client.
 					authorizedOauth := authorizedOauthRowForComparison(ctx, config.ConfigStore, newClientConfig, existingClientConfig)
-					warnIgnoredImmutableMCPFields(existingClientConfig.Name, pinMCPClientImmutableFields(newClientConfig, existingClientConfig, authorizedOauth))
+					incompleteRotation := rotateMCPOauthConfigFromFile(ctx, config.ConfigStore, existingClientConfig.Name, newClientConfig.PendingOAuthConfig, authorizedOauth)
+					warnIgnoredImmutableMCPFields(existingClientConfig.Name, pinMCPClientImmutableFields(newClientConfig, existingClientConfig))
 					applyMCPClientPinnedStateToRow(&fileClientRow, newClientConfig)
 					fileClientRow.ClientID = existingClientConfig.ID
-					fileClientRow.ConfigHash = fileHash
+					if incompleteRotation {
+						// Keep the prior stored hash so this file version is
+						// not checkpointed as fully synced — see
+						// rotateMCPOauthConfigFromFile's doc comment.
+						newClientConfig.ConfigHash = existingClientConfig.ConfigHash
+						fileClientRow.ConfigHash = existingClientConfig.ConfigHash
+					} else {
+						newClientConfig.ConfigHash = fileHash
+						fileClientRow.ConfigHash = fileHash
+					}
 					clientConfigsToUpdate = append(clientConfigsToUpdate, fileClientRow)
 					mcpConfig.ClientConfigs[i] = newClientConfig
 				} else {
@@ -2233,12 +2290,18 @@ func syncMCPConfigFromFile(ctx context.Context, config *Config, configData *Conf
 			// overwrite does not reset a verified client. The advisory log
 			// is gated on the stored hash so it fires once per file edit,
 			// not on every boot.
-			var authorizedOauth *configstoreTables.TableOauthConfig
 			fileEdited := existing.ConfigHash != fileHash
 			if fileEdited {
-				authorizedOauth = authorizedOauthRowForComparison(ctx, config.ConfigStore, fileClient, existing)
+				authorizedOauth := authorizedOauthRowForComparison(ctx, config.ConfigStore, fileClient, existing)
+				if rotateMCPOauthConfigFromFile(ctx, config.ConfigStore, existing.Name, fileClient.PendingOAuthConfig, authorizedOauth) {
+					// Keep the prior stored hash so this file version is not
+					// checkpointed as fully synced — see
+					// rotateMCPOauthConfigFromFile's doc comment.
+					fileClient.ConfigHash = existing.ConfigHash
+					fileRow.ConfigHash = existing.ConfigHash
+				}
 			}
-			changedImmutable := pinMCPClientImmutableFields(fileClient, existing, authorizedOauth)
+			changedImmutable := pinMCPClientImmutableFields(fileClient, existing)
 			if fileEdited {
 				warnIgnoredImmutableMCPFields(existing.Name, changedImmutable)
 			}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -397,6 +397,16 @@ type MockConfigStore struct {
 	logsConfig       *logstore.Config
 	plugins          []*tables.TablePlugin
 
+	// oauthConfigsByID/oauthTokensByConfigID back GetOauthConfigByID,
+	// CreateOauthConfig, UpdateOauthConfig, and MarkTokensNeedsReauthByConfigID
+	// with real in-memory state (rather than no-op stubs), following the
+	// testConfigStore shape in framework/oauth2/sync_test.go, so tests can
+	// assert that a credential-rotation call path actually wrote through:
+	// the oauth_configs row was updated and bound tokens were cascaded to
+	// needs_reauth, not just that no panic occurred.
+	oauthConfigsByID      map[string]*tables.TableOauthConfig
+	oauthTokensByConfigID map[string][]*tables.TableMCPOauthToken
+
 	// Track update calls for verification
 	clientConfigUpdated    bool
 	providersConfigUpdated bool
@@ -419,13 +429,21 @@ type MockConfigStore struct {
 		budgets []tables.TableBudget
 	}
 	flushSessionsCalled bool
+
+	// updateOauthConfigCalls/markTokensNeedsReauthCalls record the oauth
+	// config IDs passed to each call, in call order, for tests to assert a
+	// rotation call path was (or was not) actually exercised.
+	updateOauthConfigCalls     []string
+	markTokensNeedsReauthCalls []string
 }
 
 // NewMockConfigStore creates a new mock config store
 func NewMockConfigStore() *MockConfigStore {
 	return &MockConfigStore{
-		providers:     make(map[schemas.ModelProvider]configstore.ProviderConfig),
-		configEntries: make(map[string]string),
+		providers:             make(map[schemas.ModelProvider]configstore.ProviderConfig),
+		configEntries:         make(map[string]string),
+		oauthConfigsByID:      make(map[string]*tables.TableOauthConfig),
+		oauthTokensByConfigID: make(map[string][]*tables.TableMCPOauthToken),
 	}
 }
 
@@ -500,7 +518,10 @@ func (m *MockConfigStore) ExecuteTransaction(ctx context.Context, fn func(tx *go
 }
 
 func (m *MockConfigStore) GetOauthConfigByID(ctx context.Context, id string) (*tables.TableOauthConfig, error) {
-	return nil, nil
+	if m.oauthConfigsByID == nil {
+		return nil, nil
+	}
+	return m.oauthConfigsByID[id], nil
 }
 
 func (m *MockConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error) {
@@ -1418,10 +1439,19 @@ func (m *MockConfigStore) UpsertPlugin(ctx context.Context, plugin *tables.Table
 // OAuth config
 
 func (m *MockConfigStore) CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
+	if m.oauthConfigsByID == nil {
+		m.oauthConfigsByID = make(map[string]*tables.TableOauthConfig)
+	}
+	m.oauthConfigsByID[config.ID] = config
 	return nil
 }
 
 func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
+	if m.oauthConfigsByID == nil {
+		m.oauthConfigsByID = make(map[string]*tables.TableOauthConfig)
+	}
+	m.oauthConfigsByID[config.ID] = config
+	m.updateOauthConfigCalls = append(m.updateOauthConfigCalls, config.ID)
 	return nil
 }
 
@@ -1444,6 +1474,10 @@ func (m *MockConfigStore) CreateOauthToken(ctx context.Context, token *tables.Ta
 
 func (m *MockConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
 	return nil
+}
+
+func (m *MockConfigStore) RefreshOauthTokenFieldsIfActive(ctx context.Context, id string, accessToken, refreshToken string, expiresAt *time.Time, lastRefreshedAt time.Time) (bool, error) {
+	return true, nil
 }
 
 func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error {
@@ -1510,6 +1544,55 @@ func (m *MockConfigStore) DeleteOauthUserSessionsByModeIdentityAndMCPClient(ctx 
 
 func (m *MockConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error {
 	return nil
+}
+
+func (m *MockConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+	m.markTokensNeedsReauthCalls = append(m.markTokensNeedsReauthCalls, oauthConfigID)
+	for _, tok := range m.oauthTokensByConfigID[oauthConfigID] {
+		tok.Status = "needs_reauth"
+	}
+	return nil
+}
+
+// RotateMCPOAuthConfig mirrors the real RDBConfigStore implementation's
+// diff-then-apply-then-cascade behavior on top of this mock's own in-memory
+// state, so rotation-path tests can assert on actual writes (via
+// updateOauthConfigCalls/markTokensNeedsReauthCalls and the mutated
+// oauthConfigsByID/oauthTokensByConfigID entries) rather than "no panic
+// occurred". Unlike RDBConfigStore, no SecretVar cloning is needed here:
+// this mock's UpdateOauthConfig is a plain map write with no GORM Save/
+// BeforeSave encryption hook to alias against.
+func (m *MockConfigStore) RotateMCPOAuthConfig(ctx context.Context, existingOauthConfig *tables.TableOauthConfig, fields configstore.MCPOAuthConfigFields) (bool, error) {
+	if existingOauthConfig == nil {
+		return false, fmt.Errorf("oauth config is nil")
+	}
+	if !fields.DiffersFrom(existingOauthConfig) {
+		return false, nil
+	}
+	existingOauthConfig.ClientID = fields.ClientID
+	existingOauthConfig.ClientSecret = fields.ClientSecret
+	existingOauthConfig.AuthorizeURL = fields.AuthorizeURL
+	existingOauthConfig.TokenURL = fields.TokenURL
+	if fields.RegistrationURL == "" {
+		existingOauthConfig.RegistrationURL = nil
+	} else {
+		registrationURL := fields.RegistrationURL
+		existingOauthConfig.RegistrationURL = &registrationURL
+	}
+	existingOauthConfig.Resource = fields.Resource
+	scopesJSON, err := json.Marshal(fields.Scopes)
+	if err != nil {
+		return false, fmt.Errorf("failed to encode scopes: %w", err)
+	}
+	existingOauthConfig.Scopes = string(scopesJSON)
+
+	if err := m.UpdateOauthConfig(ctx, existingOauthConfig); err != nil {
+		return false, err
+	}
+	if err := m.MarkTokensNeedsReauthByConfigID(ctx, existingOauthConfig.ID); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (m *MockConfigStore) GetOauthUserTokenByID(ctx context.Context, id string) (*tables.TableMCPOauthToken, error) {
@@ -3044,7 +3127,7 @@ func TestPinMCPClientImmutableFields(t *testing.T) {
 			ConnectionString: schemas.NewSecretVar("https://elsewhere.example.com"),
 			AuthType:         schemas.MCPAuthTypePerUserOauth,
 		}
-		changed := pinMCPClientImmutableFields(fileClient, existing, nil)
+		changed := pinMCPClientImmutableFields(fileClient, existing)
 		require.ElementsMatch(t, []string{"auth_type", "connection_type", "connection_string"}, changed)
 		require.Equal(t, existing.ConnectionType, fileClient.ConnectionType)
 		require.True(t, fileClient.ConnectionString.Equals(existing.ConnectionString))
@@ -3055,40 +3138,25 @@ func TestPinMCPClientImmutableFields(t *testing.T) {
 
 	t.Run("unchanged entry reports nothing", func(t *testing.T) {
 		existing := baseExisting()
-		require.Empty(t, pinMCPClientImmutableFields(fileClientFor(existing), existing, nil))
+		require.Empty(t, pinMCPClientImmutableFields(fileClientFor(existing), existing))
 	})
 
-	t.Run("pending stash edits are detected and the stored stash kept", func(t *testing.T) {
+	t.Run("pending stash is always preserved regardless of file edits", func(t *testing.T) {
+		// pinMCPClientImmutableFields no longer detects or reports oauth_config
+		// drift itself (see TestRotateMCPOAuthConfigFromFile_* below for that,
+		// applied via the shared configstore.RotateMCPOAuthConfig instead of
+		// pinned-and-warned) — it unconditionally keeps the stored
+		// PendingOAuthConfig for a still-unauthorized client, since the pending
+		// stash feeds an in-flight OAuth flow that a config.json edit must not
+		// perturb mid-flight.
 		existing := baseExisting()
 		existing.OauthConfigID = nil
 		existing.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "abc", Scopes: []string{"read"}}
 		fileClient := fileClientFor(existing)
 		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "xyz", Scopes: []string{"read"}}
-		changed := pinMCPClientImmutableFields(fileClient, existing, nil)
-		require.Equal(t, []string{"oauth_config"}, changed)
+		changed := pinMCPClientImmutableFields(fileClient, existing)
+		require.Empty(t, changed, "oauth_config is no longer part of the immutable-fields report")
 		require.Equal(t, "abc", fileClient.PendingOAuthConfig.ClientID)
-	})
-
-	t.Run("authorized oauth drift detected via oauth row, absent fields not drift", func(t *testing.T) {
-		existing := baseExisting()
-		row := &tables.TableOauthConfig{
-			ID:           oauthID,
-			ClientID:     schemas.NewSecretVar("dcr-client"),
-			AuthorizeURL: "https://auth.example.com/authorize",
-			Scopes:       `["read","write"]`,
-		}
-
-		// File omits client_id (DCR-provisioned) and reorders scopes — not drift.
-		fileClient := fileClientFor(existing)
-		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{Scopes: []string{"write", "read"}}
-		require.Empty(t, pinMCPClientImmutableFields(fileClient, existing, row))
-		require.Nil(t, fileClient.PendingOAuthConfig, "authorized client keeps a cleared stash")
-
-		// An explicitly different client_id is drift.
-		fileClient = fileClientFor(existing)
-		fileClient.PendingOAuthConfig = &schemas.OAuth2Config{ClientID: "different"}
-		require.Equal(t, []string{"oauth_config"}, pinMCPClientImmutableFields(fileClient, existing, row))
-		require.Nil(t, fileClient.PendingOAuthConfig)
 	})
 
 	t.Run("per_user_headers key schema cannot be emptied", func(t *testing.T) {
@@ -3098,9 +3166,353 @@ func TestPinMCPClientImmutableFields(t *testing.T) {
 		existing.DiscoveredTools = nil
 		existing.PerUserHeaderKeys = []string{"x-api-key"}
 		fileClient := fileClientFor(existing)
-		require.Empty(t, pinMCPClientImmutableFields(fileClient, existing, nil))
+		require.Empty(t, pinMCPClientImmutableFields(fileClient, existing))
 		require.Equal(t, []string{"x-api-key"}, fileClient.PerUserHeaderKeys)
 	})
+}
+
+// mergeMCPConfigOauthDriftFixture builds the shared shape both
+// TestMergeMCPConfig_OauthCredentialDriftTriggersRotation and
+// TestMergeMCPConfig_OauthNonCredentialDriftDoesNotTriggerRotation exercise:
+// a store already holding an authorized oauth_configs row plus an MCP client
+// bound to it (PendingOAuthConfig nil — verification complete), so the
+// config.json edit under test is the only variable between the two cases.
+func mergeMCPConfigOauthDriftFixture(t *testing.T, oauthID string) (*MockConfigStore, *schemas.MCPClientConfig) {
+	t.Helper()
+	store := NewMockConfigStore()
+	store.oauthConfigsByID[oauthID] = &configstoreTables.TableOauthConfig{
+		ID:           oauthID,
+		ClientID:     schemas.NewSecretVar("stored-client-id"),
+		ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+		AuthorizeURL: "https://auth.example.com/authorize",
+		TokenURL:     "https://auth.example.com/token",
+		Scopes:       `["read"]`,
+		Status:       "authorized",
+	}
+
+	existing := &schemas.MCPClientConfig{
+		ID:               "mcp-existing-" + oauthID,
+		Name:             "notion-" + oauthID,
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+		AuthType:         schemas.MCPAuthTypeOauth,
+		OauthConfigID:    &oauthID,
+		// PendingOAuthConfig left nil: verification already completed, so
+		// authorizedOauthRowForComparison compares against the stored
+		// oauth_configs row above rather than a pending stash.
+	}
+	existingTable, err := mcpClientConfigToTable(existing)
+	require.NoError(t, err)
+	existingHash, err := configstore.GenerateMCPClientHash(existingTable)
+	require.NoError(t, err)
+	existing.ConfigHash = existingHash
+
+	store.mcpConfig = &schemas.MCPConfig{ClientConfigs: []*schemas.MCPClientConfig{existing}}
+	return store, existing
+}
+
+// TestMergeMCPConfig_OauthCredentialDriftTriggersRotation exercises the real
+// config.json sync call path (mergeMCPConfig, as loadConfig calls it — the
+// same function TestMergeMCPConfig_HashReconciliationUpdatesAndCreates
+// exercises) end to end: when the file's inline oauth_config declares a
+// client_id that differs from the authorized oauth_configs row backing an
+// existing client, the sync must actually call through (rotateMCPOauthConfigFromFile
+// -> configstore.RotateMCPOAuthConfig) and rotate it — not just log a
+// warning — leaving the oauth_configs row updated and every bound token
+// cascaded to needs_reauth.
+func TestMergeMCPConfig_OauthCredentialDriftTriggersRotation(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	const oauthID = "oauth-rotate-1"
+	store, existing := mergeMCPConfigOauthDriftFixture(t, oauthID)
+
+	// A pre-existing token bound to this config, so the cascade has
+	// something concrete to flip.
+	store.oauthTokensByConfigID[oauthID] = []*tables.TableMCPOauthToken{
+		{ID: "tok-1", OauthConfigID: oauthID, AuthMode: "shared", Status: "active"},
+	}
+
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:             existing.Name,
+				ConnectionType:   schemas.MCPConnectionTypeHTTP,
+				ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+				AuthType:         schemas.MCPAuthTypeOauth,
+				PendingOAuthConfig: &schemas.OAuth2Config{
+					ClientID: "new-client-id",
+				},
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	require.Contains(t, store.updateOauthConfigCalls, oauthID, "rotation must actually write the oauth_configs row, not just warn")
+	require.Contains(t, store.markTokensNeedsReauthCalls, oauthID, "rotation must cascade bound tokens to needs_reauth")
+
+	updated := store.oauthConfigsByID[oauthID]
+	require.NotNil(t, updated)
+	assert.Equal(t, "new-client-id", updated.GetResolvedClientID(), "stored client_id must reflect the file's new value")
+	assert.Equal(t, "stored-client-secret", updated.GetResolvedClientSecret(), "client_secret omitted from the file must be preserved, not cleared")
+	assert.Equal(t, "needs_reauth", store.oauthTokensByConfigID[oauthID][0].Status, "the bound token must be cascaded")
+}
+
+// TestMergeMCPConfig_OauthSecondaryFieldDriftTriggersRotation is the
+// companion case for the fields that used to be pin-and-warn-only:
+// authorize_url/token_url/scopes/resource/registration_url drift (with
+// client_id/client_secret unchanged from the file's perspective) now rotates
+// exactly like client_id/client_secret drift does — any oauth_config field
+// changing is treated as security-relevant and cascades needs_reauth, since
+// a changed authorize_url/token_url can point at a different identity
+// provider and changed scopes/resource mean already-issued tokens were
+// consented under permissions that no longer apply.
+func TestMergeMCPConfig_OauthSecondaryFieldDriftTriggersRotation(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	const oauthID = "oauth-rotate-2"
+	store, existing := mergeMCPConfigOauthDriftFixture(t, oauthID)
+
+	store.oauthTokensByConfigID[oauthID] = []*tables.TableMCPOauthToken{
+		{ID: "tok-2", OauthConfigID: oauthID, AuthMode: "shared", Status: "active"},
+		{ID: "tok-2-user", OauthConfigID: oauthID, AuthMode: "user", Status: "active"},
+	}
+
+	registrationURL := "https://auth.example.com/register"
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:             existing.Name,
+				ConnectionType:   schemas.MCPConnectionTypeHTTP,
+				ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+				AuthType:         schemas.MCPAuthTypeOauth,
+				PendingOAuthConfig: &schemas.OAuth2Config{
+					// client_id/client_secret omitted (unchanged); every other
+					// field differs from what's stored.
+					AuthorizeURL:    "https://auth.example.com/v2/authorize",
+					TokenURL:        "https://auth.example.com/v2/token",
+					Scopes:          []string{"read", "write"},
+					Resource:        "https://mcp.notion.so",
+					RegistrationURL: &registrationURL,
+				},
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	require.Contains(t, store.updateOauthConfigCalls, oauthID, "secondary-field drift must now rotate too, not just warn")
+	require.Contains(t, store.markTokensNeedsReauthCalls, oauthID, "rotation must cascade every bound token regardless of auth_mode")
+
+	stored := store.oauthConfigsByID[oauthID]
+	require.NotNil(t, stored)
+	assert.Equal(t, "stored-client-id", stored.GetResolvedClientID(), "client_id omitted from the file must be preserved")
+	assert.Equal(t, "https://auth.example.com/v2/authorize", stored.AuthorizeURL)
+	assert.Equal(t, "https://auth.example.com/v2/token", stored.TokenURL)
+	assert.Equal(t, "https://mcp.notion.so", stored.Resource)
+	require.NotNil(t, stored.RegistrationURL)
+	assert.Equal(t, registrationURL, *stored.RegistrationURL)
+	assert.Equal(t, "needs_reauth", store.oauthTokensByConfigID[oauthID][0].Status, "shared token must be cascaded")
+	assert.Equal(t, "needs_reauth", store.oauthTokensByConfigID[oauthID][1].Status, "per-user token must be cascaded too")
+}
+
+// TestMergeMCPConfig_OauthNoDriftDoesNotTriggerRotation confirms a file
+// entry that matches the stored oauth_configs row exactly (or omits every
+// field) never rotates — the write and the reauth cascade only ever happen
+// when something actually changed.
+func TestMergeMCPConfig_OauthNoDriftDoesNotTriggerRotation(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	const oauthID = "oauth-rotate-3"
+	store, existing := mergeMCPConfigOauthDriftFixture(t, oauthID)
+	store.oauthTokensByConfigID[oauthID] = []*tables.TableMCPOauthToken{
+		{ID: "tok-3", OauthConfigID: oauthID, AuthMode: "shared", Status: "active"},
+	}
+
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:             existing.Name,
+				ConnectionType:   schemas.MCPConnectionTypeHTTP,
+				ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+				AuthType:         schemas.MCPAuthTypeOauth,
+				PendingOAuthConfig: &schemas.OAuth2Config{
+					ClientID:     "stored-client-id",
+					AuthorizeURL: "https://auth.example.com/authorize",
+					TokenURL:     "https://auth.example.com/token",
+					Scopes:       []string{"read"},
+				},
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	assert.Empty(t, store.updateOauthConfigCalls, "identical values must not rotate")
+	assert.Empty(t, store.markTokensNeedsReauthCalls, "no tokens should be cascaded when nothing changed")
+	assert.Equal(t, "active", store.oauthTokensByConfigID[oauthID][0].Status)
+}
+
+// TestMergeMCPConfig_UnresolvedSecretRefDoesNotCheckpointConfigHash covers
+// the case rotateMCPOauthConfigFromFile's incomplete return exists for: the
+// file declares a client_id via an env./vault. reference that doesn't
+// resolve on this boot (e.g. the env var isn't set yet). The stored
+// client_id must be preserved (already covered elsewhere), but critically
+// the persisted ConfigHash must NOT advance to this boot's file hash —
+// otherwise an identical file on the next boot would hash-match and skip
+// reconciliation forever, even after the env var becomes available.
+func TestMergeMCPConfig_UnresolvedSecretRefDoesNotCheckpointConfigHash(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	const oauthID = "oauth-rotate-unresolved"
+	store, existing := mergeMCPConfigOauthDriftFixture(t, oauthID)
+	originalHash := existing.ConfigHash
+
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:             existing.Name,
+				ConnectionType:   schemas.MCPConnectionTypeHTTP,
+				ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+				AuthType:         schemas.MCPAuthTypeOauth,
+				PendingOAuthConfig: &schemas.OAuth2Config{
+					ClientID: "env.BIFROST_TEST_UNSET_CLIENT_ID_XYZ",
+				},
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	require.Len(t, store.mcpClientConfigUpdates, 1, "the hash mismatch must still trigger a sync attempt")
+	assert.Equal(t, originalHash, store.mcpClientConfigUpdates[0].Config.ConfigHash,
+		"ConfigHash must not advance past an unresolved secret reference, or the next boot's identical file would skip reconciliation forever")
+
+	stored := store.oauthConfigsByID[oauthID]
+	require.NotNil(t, stored)
+	assert.Equal(t, "stored-client-id", stored.GetResolvedClientID(), "unresolved client_id reference must not overwrite the stored value")
+}
+
+// TestMergeMCPConfig_MalformedStoredScopesDoesNotCheckpointConfigHash covers
+// the other incomplete-rotation source: the stored row's scopes column isn't
+// valid JSON (e.g. a pre-existing bad row from a manual edit or migration
+// bug, not something this rotation path itself could write). Decoding it
+// must not silently collapse to "no scopes" — which would look identical to
+// a file that never mentions scopes at all and falsely trigger a rotation +
+// needs_reauth cascade — and must not checkpoint ConfigHash either, so a
+// later boot retries once the row is repaired.
+func TestMergeMCPConfig_MalformedStoredScopesDoesNotCheckpointConfigHash(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	const oauthID = "oauth-rotate-malformed-scopes"
+	store, existing := mergeMCPConfigOauthDriftFixture(t, oauthID)
+	originalHash := existing.ConfigHash
+	store.oauthConfigsByID[oauthID].Scopes = `not valid json`
+
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:               existing.Name,
+				ConnectionType:     schemas.MCPConnectionTypeHTTP,
+				ConnectionString:   schemas.NewSecretVar("https://mcp.notion.so/sse"),
+				AuthType:           schemas.MCPAuthTypeOauth,
+				PendingOAuthConfig: &schemas.OAuth2Config{}, // declares nothing about scopes
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	assert.Empty(t, store.updateOauthConfigCalls, "a scopes decode failure must skip rotation entirely, not just some fields")
+	require.Len(t, store.mcpClientConfigUpdates, 1, "the hash mismatch must still trigger a sync attempt")
+	assert.Equal(t, originalHash, store.mcpClientConfigUpdates[0].Config.ConfigHash,
+		"ConfigHash must not advance past a scopes decode failure, or the next boot's identical file would skip reconciliation forever")
+}
+
+// TestSyncMCPConfigFromFile_OauthCredentialDriftTriggersRotation exercises
+// the OTHER config.json call site (syncMCPConfigFromFile, taken when
+// config.json is the declared source of truth — see
+// isConfigJSONSourceOfTruth) via the real dispatch path in loadMCPConfig,
+// mirroring TestMergeMCPConfig_OauthCredentialDriftTriggersRotation for the
+// non-source-of-truth call site. Both call sites wire the same
+// rotateMCPOauthConfigFromFile function, which is already covered in depth
+// by the mergeMCPConfig tests above; this test exists to catch a
+// wiring-only bug at this second call site (e.g. the rotation call being
+// dropped or misordered relative to pinMCPClientImmutableFields), not to
+// re-verify the shared logic itself.
+func TestSyncMCPConfigFromFile_OauthCredentialDriftTriggersRotation(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	oauthID := "oauth_rotate_sync_1"
+	// Not reusing mergeMCPConfigOauthDriftFixture's "notion-<id>" naming here:
+	// this test drives the real loadMCPConfig entry point (unlike the
+	// mergeMCPConfig tests above, which call mergeMCPConfig directly), and
+	// loadMCPConfig validates file-declared names via
+	// mcp.ValidateMCPClientName before syncMCPConfigFromFile ever sees them —
+	// which rejects hyphens. A hyphenated name would be silently skipped
+	// ("skipping MCP client config..."), and the test would wrongly appear to
+	// prove no rotation occurred.
+	const clientName = "notion_rotate_sync_1"
+	store := NewMockConfigStore()
+	store.oauthConfigsByID[oauthID] = &configstoreTables.TableOauthConfig{
+		ID:           oauthID,
+		ClientID:     schemas.NewSecretVar("stored-client-id"),
+		ClientSecret: schemas.NewSecretVar("stored-client-secret"),
+		AuthorizeURL: "https://auth.example.com/authorize",
+		TokenURL:     "https://auth.example.com/token",
+		Scopes:       `["read"]`,
+		Status:       "authorized",
+	}
+	existing := &schemas.MCPClientConfig{
+		ID:               "mcp-existing-" + oauthID,
+		Name:             clientName,
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+		AuthType:         schemas.MCPAuthTypeOauth,
+		OauthConfigID:    &oauthID,
+	}
+	existingTable, err := mcpClientConfigToTable(existing)
+	require.NoError(t, err)
+	existingHash, err := configstore.GenerateMCPClientHash(existingTable)
+	require.NoError(t, err)
+	existing.ConfigHash = existingHash
+	store.mcpConfig = &schemas.MCPConfig{ClientConfigs: []*schemas.MCPClientConfig{existing}}
+	store.oauthTokensByConfigID[oauthID] = []*tables.TableMCPOauthToken{
+		{ID: "tok-sync-1", OauthConfigID: oauthID, AuthMode: "shared", Status: "active"},
+	}
+
+	cfg := &Config{ConfigStore: store, ClientConfig: &configstore.ClientConfig{}}
+	configData := &ConfigData{
+		SourceOfTruth: SourceOfTruthConfigJSON,
+		MCP: &schemas.MCPConfig{
+			ClientConfigs: []*schemas.MCPClientConfig{
+				{
+					Name:             clientName,
+					ConnectionType:   schemas.MCPConnectionTypeHTTP,
+					ConnectionString: schemas.NewSecretVar("https://mcp.notion.so/sse"),
+					AuthType:         schemas.MCPAuthTypeOauth,
+					PendingOAuthConfig: &schemas.OAuth2Config{
+						ClientID: "new-client-id-sync",
+					},
+				},
+			},
+		},
+	}
+
+	loadMCPConfig(ctx, cfg, configData)
+
+	require.Contains(t, store.updateOauthConfigCalls, oauthID, "syncMCPConfigFromFile must actually write the oauth_configs row, not just warn")
+	require.Contains(t, store.markTokensNeedsReauthCalls, oauthID, "syncMCPConfigFromFile must cascade bound tokens to needs_reauth")
+
+	updated := store.oauthConfigsByID[oauthID]
+	require.NotNil(t, updated)
+	assert.Equal(t, "new-client-id-sync", updated.GetResolvedClientID(), "stored client_id must reflect the file's new value")
+	assert.Equal(t, "needs_reauth", store.oauthTokensByConfigID[oauthID][0].Status, "the bound token must be cascaded")
 }
 
 // TestSourceOfTruthConfigJSON_MCPMissingLeavesDBUntouched verifies missing mcp does not prune DB MCP clients.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -134,6 +134,10 @@ type ServerCallbacks interface {
 	// SetClientTools updates the tool map for an existing client.
 	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 	ReconnectMCPClient(ctx context.Context, id string) error
+	// CloseAndMarkNeedsReauth closes a shared client's live upstream
+	// connection and flips it to needs_reauth, without attempting a new
+	// dial. Used after OAuth credential rotation.
+	CloseAndMarkNeedsReauth(ctx context.Context, id string) error
 	DisableMCPClient(ctx context.Context, id string) error
 	EnableMCPClient(ctx context.Context, id string) error
 }
@@ -320,6 +324,13 @@ func (s *BifrostHTTPServer) RemoveMCPClient(ctx context.Context, id string) erro
 		logger.Warn("failed to sync MCP servers after removing client: %v", err)
 	}
 	return nil
+}
+
+// CloseAndMarkNeedsReauth closes a shared MCP client's live upstream
+// connection and flips it to needs_reauth, without attempting a new dial.
+// Used after OAuth credential rotation.
+func (s *BifrostHTTPServer) CloseAndMarkNeedsReauth(_ context.Context, id string) error {
+	return s.Client.CloseAndMarkNeedsReauth(id)
 }
 
 // DisableMCPClient shuts down an MCP client's connection and workers without removing it.

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -70,12 +70,25 @@ function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): n
 	while ((match = re.exec(v)) !== null) {
 		const n = parseFloat(match[1]);
 		switch (match[2]) {
-			case "ns": total += n / 1e9; break;
-			case "us": case "µs": total += n / 1e6; break;
-			case "ms": total += n / 1e3; break;
-			case "s": total += n; break;
-			case "m": total += n * 60; break;
-			case "h": total += n * 3600; break;
+			case "ns":
+				total += n / 1e9;
+				break;
+			case "us":
+			case "µs":
+				total += n / 1e6;
+				break;
+			case "ms":
+				total += n / 1e3;
+				break;
+			case "s":
+				total += n;
+				break;
+			case "m":
+				total += n * 60;
+				break;
+			case "h":
+				total += n * 3600;
+				break;
 		}
 	}
 	return Math.ceil(total);
@@ -113,12 +126,7 @@ export default function MCPClientSheet({
 	const [vkConfigsDirty, setVKConfigsDirty] = useState(false);
 	const [allowedExtraHeadersRaw, setAllowedExtraHeadersRaw] = useState<string>((mcpClient.config.allowed_extra_headers || []).join(", "));
 	const [perUserHeaderKeysRaw, setPerUserHeaderKeysRaw] = useState<string>((mcpClient.config.per_user_header_keys || []).join(", "));
-	const [oauthFlow, setOauthFlow] = useState<{
-		authorizeUrl: string;
-		oauthConfigId: string;
-		mcpClientId: string;
-		isPerUserOauth?: boolean;
-	} | null>(null);
+	const [oauthScopesRaw, setOauthScopesRaw] = useState<string>((mcpClient.config.oauth_scopes || []).join(", "));
 	// Persists names for newly added VKs so they survive search result changes
 	const [localVKNames, setLocalVKNames] = useState<Record<string, string>>({});
 
@@ -138,6 +146,10 @@ export default function MCPClientSheet({
 		setPerUserHeaderKeysRaw((mcpClient.config.per_user_header_keys || []).join(", "));
 	}, [mcpClient.config.per_user_header_keys]);
 
+	useEffect(() => {
+		setOauthScopesRaw((mcpClient.config.oauth_scopes || []).join(", "));
+	}, [mcpClient.config.oauth_scopes]);
+
 	// Name lookup: server response names → names captured when a key was picked.
 	// Every row is one or the other, so the selector's results aren't needed here.
 	const vkNameByID = useMemo<Record<string, string>>(() => {
@@ -156,8 +168,7 @@ export default function MCPClientSheet({
 		],
 		[allToolNames],
 	);
-	const supportsOAuthCredentialUpdate = false;
-	// mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
+	const supportsOAuthCredentialUpdate = mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
 
 	const addVKConfig = ({ value: vkId, label }: { value: string; label: string }) => {
 		setLocalVKNames((prev) => ({ ...prev, [vkId]: label }));
@@ -205,7 +216,14 @@ export default function MCPClientSheet({
 			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
-				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
+				? {
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
@@ -234,7 +252,14 @@ export default function MCPClientSheet({
 			tool_execution_timeout: toolExecutionTimeoutToSeconds(mcpClient.config.tool_execution_timeout),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
-				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
+				? {
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
@@ -243,9 +268,25 @@ export default function MCPClientSheet({
 				}
 				: undefined,
 		});
-	}, [form, mcpClient]);
+	}, [form, mcpClient, supportsOAuthCredentialUpdate]);
 
-	const isDirty = form.formState.isDirty || vkConfigsDirty;
+	const initialOauthScopesRaw = (mcpClient.config.oauth_scopes || []).join(", ");
+	const oauthScopesDirty = oauthScopesRaw !== initialOauthScopesRaw;
+	const isDirty = form.formState.isDirty || vkConfigsDirty || oauthScopesDirty;
+	// dirtyFields tracks deep changes vs. the pre-populated default values —
+	// used both to gate the rotation warning below and, in onSubmit, to only
+	// rotate when the user actually changed a field. Every oauth_config field
+	// triggers the same rotation and reauth cascade server-side (not just
+	// client_id/client_secret), so any of them counts as "dirty" here.
+	const oauthCredentialsDirty = !!(
+		form.formState.dirtyFields.oauth_config?.client_id ||
+		form.formState.dirtyFields.oauth_config?.client_secret ||
+		form.formState.dirtyFields.oauth_config?.authorize_url ||
+		form.formState.dirtyFields.oauth_config?.token_url ||
+		form.formState.dirtyFields.oauth_config?.registration_url ||
+		form.formState.dirtyFields.oauth_config?.resource ||
+		oauthScopesDirty
+	);
 
 	const handleNavigate = useCallback(
 		(direction: "prev" | "next") => {
@@ -277,11 +318,26 @@ export default function MCPClientSheet({
 			}
 			const oauthClientID = data.oauth_config?.client_id;
 			const oauthClientSecret = data.oauth_config?.client_secret;
-			// Only rotate when the user actually changed a credential field.
-			// dirtyFields tracks deep changes vs. the pre-populated default values.
-			const oauthDirty = !!(form.formState.dirtyFields.oauth_config?.client_id || form.formState.dirtyFields.oauth_config?.client_secret);
-			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && oauthDirty;
-			const response = await updateMCPClient({
+			// Omitted (undefined) preserves the stored scopes; an explicit
+			// empty array clears them. Only send either when the user
+			// actually touched this field — otherwise an untouched-but-empty
+			// initial value would clear scopes nobody asked to change.
+			const oauthScopes = !oauthScopesDirty
+				? undefined
+				: oauthScopesRaw.trim()
+					? oauthScopesRaw
+						.split(",")
+						.map((s) => s.trim())
+						.filter(Boolean)
+					: [];
+			// Only rotate when the user actually changed a field, and never
+			// alongside a disable (the backend rejects that combination
+			// outright — disabling and rotating credentials must be two
+			// separate requests). The oauth_config draft itself is left in
+			// form state either way, so re-enabling before a later save still
+			// submits the edited values.
+			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && !data.disabled && oauthCredentialsDirty;
+			await updateMCPClient({
 				id: mcpClient.config.client_id,
 				data: {
 					name: data.name,
@@ -301,6 +357,11 @@ export default function MCPClientSheet({
 						? {
 							client_id: oauthClientID,
 							client_secret: oauthClientSecret,
+							authorize_url: data.oauth_config?.authorize_url || undefined,
+							token_url: data.oauth_config?.token_url || undefined,
+							registration_url: data.oauth_config?.registration_url || undefined,
+							scopes: oauthScopes,
+							resource: data.oauth_config?.resource || undefined,
 						}
 						: undefined,
 					tls_config:
@@ -313,16 +374,6 @@ export default function MCPClientSheet({
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
 			}).unwrap();
-
-			if (response.status === "pending_oauth" && response.authorize_url) {
-				setOauthFlow({
-					authorizeUrl: response.authorize_url,
-					oauthConfigId: response.oauth_config_id,
-					mcpClientId: response.mcp_client_id,
-					isPerUserOauth: mcpClient.config.auth_type === "per_user_oauth",
-				});
-				return;
-			}
 
 			toast({
 				title: "Success",
@@ -444,7 +495,7 @@ export default function MCPClientSheet({
 
 	return (
 		<>
-			<Sheet open onOpenChange={(open) => !open && !oauthFlow && onClose()}>
+			<Sheet open onOpenChange={(open) => !open && onClose()}>
 				<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4 sm:max-w-[60%]">
 					<SheetHeader className="w-full p-0 px-8 py-4" showCloseButton={false} headerClassName="mb-0 sticky -top-4 bg-card z-10">
 						<div className="flex w-full items-center justify-between">
@@ -673,9 +724,6 @@ export default function MCPClientSheet({
 														checked={field.value === true}
 														onCheckedChange={(checked) => {
 															field.onChange(checked);
-															if (checked) {
-																form.setValue("oauth_config", undefined);
-															}
 														}}
 														data-testid="mcpclient-disabled-switch"
 													/>
@@ -808,8 +856,8 @@ export default function MCPClientSheet({
 																	</TooltipTrigger>
 																	<TooltipContent className="max-w-xs">
 																		<p>
-																			Override the global tool execution timeout for this server. Leave empty or set to 0 to use
-																			the global setting.
+																			Override the global tool execution timeout for this server. Leave empty or set to 0 to use the global
+																			setting.
 																		</p>
 																	</TooltipContent>
 																</Tooltip>
@@ -962,64 +1010,171 @@ export default function MCPClientSheet({
 									/>
 								</div>
 								{supportsOAuthCredentialUpdate ? (
-									<div className="space-y-4">
-										<h3 className="font-semibold">OAuth Credentials</h3>
-										{isDisabled ? (
-											<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-												<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-												<p>OAuth credentials cannot be rotated while the client is disabled. Re-enable the client to update credentials.</p>
-											</div>
-										) : (
-											<p className="text-muted-foreground text-sm">
-												Update OAuth client credentials only. Connection type, auth type, and connection URL cannot be changed.
-											</p>
-										)}
-										<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-											<FormField
-												control={form.control}
-												name="oauth_config.client_id"
-												render={({ field }) => (
-													<FormItem className="flex flex-col gap-2">
-														<FormLabel>Client ID</FormLabel>
-														<FormControl>
-															<SecretVarInput
-																data-testid="mcpclient-input-oauth-client-id"
-																placeholder="Enter new OAuth client ID"
-																disabled={isDisabled}
-																value={field.value}
-																onChange={field.onChange}
-															/>
-														</FormControl>
-														{!isDisabled && (
-															<p className="text-muted-foreground text-xs">Leave empty to keep existing credentials unchanged.</p>
+									<Accordion type="single" collapsible className="w-full">
+										<AccordionItem value="oauth-advanced" className="border-b-0">
+											<AccordionTrigger className="py-0" data-testid="oauth-advanced-trigger">
+												<span className="text-sm font-medium">OAuth Client Advanced Settings</span>
+											</AccordionTrigger>
+											<AccordionContent className="space-y-4 pt-4 pb-0">
+												{isDisabled ? (
+													<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+														<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+														<p>OAuth config cannot be rotated while the client is disabled. Re-enable the client to update it.</p>
+													</div>
+												) : (
+													<>
+														<p className="text-muted-foreground text-sm">
+															Connection type, auth type, and connection URL cannot be changed. Leave any field empty to keep its stored
+															value.
+														</p>
+														{oauthCredentialsDirty && (
+															<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+																<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+																<p>
+																	Changing any OAuth config field immediately signs out every current session on this MCP client, shared and
+																	per-user alike. Everyone will need to re-authenticate.
+																</p>
+															</div>
 														)}
-														<FormMessage />
-													</FormItem>
+													</>
 												)}
-											/>
-											<FormField
-												control={form.control}
-												name="oauth_config.client_secret"
-												render={({ field }) => (
+												<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+													<FormField
+														control={form.control}
+														name="oauth_config.client_id"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Client ID</FormLabel>
+																<FormControl>
+																	<SecretVarInput
+																		data-testid="mcpclient-input-oauth-client-id"
+																		placeholder="Enter new OAuth client ID"
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		value={field.value}
+																		onChange={field.onChange}
+																	/>
+																</FormControl>
+																{!isDisabled && (
+																	<p className="text-muted-foreground text-xs">Leave empty to keep existing credentials unchanged.</p>
+																)}
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="oauth_config.client_secret"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Client Secret</FormLabel>
+																<FormControl>
+																	<SecretVarInput
+																		data-testid="mcpclient-input-oauth-client-secret"
+																		placeholder="Enter new OAuth client secret"
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		hideValueWhenEnv
+																		maskNonEnvValue
+																		value={field.value}
+																		onChange={field.onChange}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="oauth_config.authorize_url"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Authorization URL</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		placeholder="https://provider.com/oauth/authorize"
+																		data-testid="mcpclient-input-oauth-authorize-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="oauth_config.token_url"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Token URL</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		placeholder="https://provider.com/oauth/token"
+																		data-testid="mcpclient-input-oauth-token-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="oauth_config.registration_url"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Registration URL</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		placeholder="https://provider.com/oauth/register"
+																		data-testid="mcpclient-input-oauth-registration-url"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
 													<FormItem className="flex flex-col gap-2">
-														<FormLabel>Client Secret</FormLabel>
+														<FormLabel>Scopes</FormLabel>
 														<FormControl>
-															<SecretVarInput
-																data-testid="mcpclient-input-oauth-client-secret"
-																placeholder="Enter new OAuth client secret"
-																disabled={isDisabled}
-																hideValueWhenEnv
-																maskNonEnvValue
-																value={field.value}
-																onChange={field.onChange}
+															<Input
+																value={oauthScopesRaw}
+																disabled={isDisabled || !hasUpdateMCPClientAccess}
+																onChange={(e) => setOauthScopesRaw(e.target.value)}
+																placeholder="read, write, admin"
+																data-testid="mcpclient-input-oauth-scopes"
 															/>
 														</FormControl>
-														<FormMessage />
+														<p className="text-muted-foreground text-xs">Comma-separated.</p>
 													</FormItem>
-												)}
-											/>
-										</div>
-									</div>
+													<FormField
+														control={form.control}
+														name="oauth_config.resource"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Resource</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		placeholder="https://provider.example.com/mcp or urn:example:mcp"
+																		data-testid="mcpclient-input-oauth-resource"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+												</div>
+											</AccordionContent>
+										</AccordionItem>
+									</Accordion>
 								) : null}
 								{/* Tools Section */}
 								<div className="space-y-4 pb-10">
@@ -1422,7 +1577,7 @@ export default function MCPClientSheet({
 								</Button>
 								<Button
 									type="submit"
-									disabled={isUpdating || (!form.formState.isDirty && !vkConfigsDirty) || !hasUpdateMCPClientAccess}
+									disabled={isUpdating || !isDirty || !hasUpdateMCPClientAccess}
 									isLoading={isUpdating}
 								>
 									Save Changes
@@ -1431,24 +1586,6 @@ export default function MCPClientSheet({
 						</form>
 					</Form>
 				</SheetContent>
-				{oauthFlow && (
-					<OAuth2Authorizer
-						open={!!oauthFlow}
-						onClose={() => setOauthFlow(null)}
-						onSuccess={() => {
-							toast({ title: "Success", description: "MCP client OAuth credentials updated successfully" });
-							onSubmitSuccess();
-							onClose();
-						}}
-						onError={(error) => {
-							toast({ title: "Error", description: error, variant: "destructive" });
-						}}
-						authorizeUrl={oauthFlow.authorizeUrl}
-						oauthConfigId={oauthFlow.oauthConfigId}
-						mcpClientId={oauthFlow.mcpClientId}
-						isPerUserOauth={oauthFlow.isPerUserOauth}
-					/>
-				)}
 			</Sheet>
 			<AlertDialog open={!!pendingNavDirection} onOpenChange={(open) => !open && setPendingNavDirection(null)}>
 				<AlertDialogContent>

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -14,7 +14,7 @@ import {
 import { baseApi } from "./baseApi";
 
 type CreateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
-type UpdateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
+type UpdateMCPClientResponse = { status: "success"; message: string };
 
 // Response of POST /mcp/client/{id}/initiate-verification — same flow fields as
 // OAuthFlowResponse but without a required message, plus polling/completion hints.
@@ -159,11 +159,7 @@ export const mcpApi = baseApi.injectEndpoints({
 			}),
 			async onQueryStarted({ id, data }, { dispatch, getState, queryFulfilled }) {
 				try {
-					const { data: response } = await queryFulfilled;
-					if (response.status === "pending_oauth") {
-						dispatch(mcpApi.util.invalidateTags(["MCPClients"]));
-						return;
-					}
+					await queryFulfilled;
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getMCPClients" || entry?.status !== "fulfilled") continue;

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -3,7 +3,14 @@ import { SecretVar } from "./schemas";
 
 export type MCPConnectionType = "http" | "stdio" | "sse";
 
-export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "pending_verification" | "disabled" | "needs_reauth";
+export type MCPConnectionState =
+	| "connected"
+	| "disconnected"
+	| "error"
+	| "pending_tools"
+	| "pending_verification"
+	| "disabled"
+	| "needs_reauth";
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers";
 
@@ -40,10 +47,15 @@ export interface OAuthConfig {
 	resource?: string; // Optional OAuth resource indicator; omitted when empty
 }
 
-/** OAuth fields allowed on MCP client update (e.g. client_secret-only rotation). */
+/** OAuth fields allowed on MCP client update. Any field left unset keeps its stored value. */
 export interface OAuthConfigUpdate {
 	client_id?: SecretVar;
 	client_secret?: SecretVar;
+	authorize_url?: string;
+	token_url?: string;
+	registration_url?: string;
+	scopes?: string[];
+	resource?: string;
 }
 
 export interface MCPClientConfig {
@@ -58,6 +70,13 @@ export interface MCPClientConfig {
 	oauth_config_id?: string;
 	oauth_client_id?: SecretVar; // Redacted existing client ID (populated on GET for oauth clients)
 	oauth_client_secret?: SecretVar; // Redacted existing client secret (populated on GET for oauth clients)
+	// Remaining oauth_config fields, populated on GET for oauth clients so the
+	// full config can be reviewed and edited, not just the credentials.
+	oauth_authorize_url?: string;
+	oauth_token_url?: string;
+	oauth_registration_url?: string;
+	oauth_scopes?: string[];
+	oauth_resource?: string;
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	headers?: Record<string, SecretVar>;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1180,6 +1180,20 @@ export const mcpClientUpdateSchema = z.object({
 		.object({
 			client_id: secretVarSchema.optional(),
 			client_secret: secretVarSchema.optional(),
+			authorize_url: z
+				.string()
+				.optional()
+				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Authorize URL must start with http:// or https://" }),
+			token_url: z
+				.string()
+				.optional()
+				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Token URL must start with http:// or https://" }),
+			registration_url: z
+				.string()
+				.optional()
+				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Registration URL must start with http:// or https://" }),
+			scopes: z.array(z.string()).optional(),
+			resource: z.string().optional(),
 		})
 		.optional(),
 	tls_config: z


### PR DESCRIPTION
## Summary

OAuth config rotation was previously disabled behind commented-out code. This PR re-enables it with a simpler, safer approach: instead of initiating a new OAuth flow (re-discovery, re-registration, redirect), credential updates now apply in-place to the existing `oauth_configs` row and immediately cascade every bound token to `needs_reauth`, regardless of auth mode. This eliminates the pending-OAuth redirect round-trip for credential updates while ensuring no existing session silently retains trust after a rotation.

## Changes

- **`SecretVar.Clone()`** added to prevent GORM's `BeforeSave` encryption hook from mutating the caller's own `SecretVar` in place when `UpdateOauthConfig` is called (aliasing bug fix).
- **`RotateMCPOAuthConfig`** introduced on `RDBConfigStore` and the `ConfigStore` interface: diffs all oauth config fields (client_id, client_secret, authorize_url, token_url, registration_url, resource, scopes) against what's stored, and if anything differs, updates the row and bulk-cascades all bound tokens to `needs_reauth` in a single transaction.
- **`MCPOAuthConfigFields` and `DiffersFrom`** extracted as a shared struct/method so both the HTTP handler and the config.json sync path use identical comparison and rotation logic.
- **`MarkTokensNeedsReauthByConfigID`** added: a single bulk `UPDATE` with no `auth_mode` filter, cascading shared, per-user, vk, session, and admin tokens alike.
- **`UpdateOauthConfig`** now accepts an optional `*gorm.DB` transaction argument so `RotateMCPOAuthConfig` can wrap the update and cascade in one atomic transaction.
- **`pinMCPClientImmutableFields`** no longer detects or reports oauth_config drift itself. Drift is now handled by the new `rotateMCPOauthConfigFromFile`, which calls `RotateMCPOAuthConfig` directly at both `mergeMCPConfig` and `syncMCPConfigFromFile` call sites.
- **`mcpOauthBlockChanged`** removed; its logic is superseded by `MCPOAuthConfigFields.DiffersFrom`.
- **HTTP handler (`updateMCPClient`)**: the commented-out rotation block is replaced with the new `RotateMCPOAuthConfig` path. The `pending_oauth` response branch is removed entirely — rotation no longer triggers a new OAuth flow.
- **UI (`mcpClientSheet`)**: `supportsOAuthCredentialUpdate` is re-enabled for `oauth`/`per_user_oauth` clients. The `oauthFlow` state and `OAuth2Authorizer` triggered by credential updates are removed. An inline amber warning is shown when the user edits client_id or client_secret, explaining that all sessions will be signed out immediately.
- **`UpdateMCPClientResponse`** type narrowed to remove the `OAuthFlowResponse` union; the `pending_oauth` branch in `onQueryStarted` is removed.
- Comprehensive tests added: `mcp_oauth_rotate_test.go` covers changed credentials, secondary field drift, scope reordering, no-op, nil config, and the aliasing/mutation bug. `config_test.go` covers both `mergeMCPConfig` and `syncMCPConfigFromFile` call sites end-to-end.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (React)

## How to test

```sh
go test ./core/schemas/... ./framework/configstore/... ./transports/bifrost-http/lib/... ./framework/oauth2/...
```

For the UI:
```sh
cd ui
pnpm build
```

To validate end-to-end: update an authorized OAuth MCP client's `client_id` or `client_secret` via the MCP client sheet or the update-MCP-client API, then confirm the `oauth_configs` row reflects the new values and all previously active tokens for that config show `needs_reauth`.

## Breaking changes

- [x] Yes

`UpdateOauthConfig` signature changed to accept a variadic `tx ...*gorm.DB`. Any external implementations of the `ConfigStore` interface must update their `UpdateOauthConfig` signature accordingly. The `UpdateMCPClientResponse` type no longer includes `OAuthFlowResponse`; callers expecting a `pending_oauth` status from credential rotation must be updated.

## Security considerations

Rotating any oauth config field (not just client_id/client_secret) now immediately invalidates all bound tokens. This is intentional: a changed `authorize_url` or `token_url` can redirect authentication to a different identity provider, and changed scopes/resource mean existing tokens were consented under permissions that no longer apply. Over-invalidating on rotation is the safer default.

The `SecretVar.Clone()` fix prevents GORM's in-place encryption from silently corrupting the caller's in-memory credential values as a side effect of a DB write.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)