### PR TITLE
feat: add `MCPAuthModeAdmin` + reauthorize endpoint for shared OAuth MCP clients

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -214,6 +214,15 @@ const (
 	// Used when there's no VK or user; the caller owns the session ID and must
 	// present it on every subsequent request to use the bound OAuth token.
 	MCPAuthModeSession MCPAuthMode = "session"
+	// MCPAuthModeAdmin: no identity dimension, the flow belongs to an MCP
+	// client's shared credential itself, not any caller. Used by
+	// InitiateUserOAuthFlow for redoing consent on an already-authorized
+	// shared client (see the MCP client reauthorize endpoint); the
+	// resulting token is still written with AuthMode "shared" (a
+	// TableMCPOauthToken-column distinction from the flow row's FlowMode
+	// "admin", see TableMCPOauthFlow's FlowMode field comment for why
+	// those two are named differently on purpose).
+	MCPAuthModeAdmin MCPAuthMode = "admin"
 	// MCPAuthModeNone: no identity dimension is present on the request (no
 	// user, no VK, no session header). Lets callers branch on the mode
 	// without mistaking an unauthenticated request for a session-mode caller.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -9058,7 +9058,7 @@ func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB, logger s
 // on session_token_hash was conflating "uniqueness of token value" with
 // "uniqueness of binding" — the latter is now enforced at the application
 // layer by the (mode, identity, mcp_client_id) lookup in
-// InitiateUserOAuthFlow and CreateOauthUserToken.
+// InitiateUserOAuthFlow and CreateOauthToken.
 //
 // Order: add SessionID first, then drop the legacy columns + their indexes.
 // No data backfill: existing rows are dev-only test data; production hasn't

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6509,15 +6509,83 @@ func (s *RDBConfigStore) CreateOauthConfig(ctx context.Context, config *tables.T
 	return nil
 }
 
-// CreateOauthToken creates a new OAuth token
+// CreateOauthToken creates or replaces an MCP OAuth token row, any auth_mode
+// alike (shared/user/vk/session/admin). Upserts by looking up any existing
+// row for the same binding and reusing its ID, mirroring reconcileVKDirectTokensDB's
+// row-locked read-then-write discipline against the same table:
+//   - shared: (auth_mode='shared', mcp_client_id) — matches the
+//     idx_mcp_oauth_tokens_shared_mcp partial unique index. A shared row with
+//     no mcp_client_id yet (still-linking bootstrap) always inserts fresh —
+//     that empty-mcp_client_id case is deliberately excluded from the index
+//     too, so multiple such rows can coexist without a collision.
+//   - per-identity: (auth_mode, identity_column, mcp_client_id) — matches
+//     idx_mcp_oauth_tokens_{user,vk,session}_mcp.
+//
+// Was two separate methods (a plain-insert CreateOauthToken for the shared
+// flow, an upserting CreateOauthUserToken for per-identity) until the shared
+// flow gained its own upsert need: reauthorizing an already-authorized
+// shared client must update its existing token row, not insert a duplicate
+// that would violate the partial unique index above.
+//
+// SELECT + CREATE/UPDATE must be atomic under concurrent same-binding races,
+// so this always runs inside a transaction: its own (opened here) when
+// called standalone, or the caller-supplied tx when it needs to participate
+// in a larger atomic operation — same tx ...*gorm.DB convention as
+// DeleteVirtualKeyMCPConfig.
 func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error {
-	db := s.DB()
-	if len(tx) > 0 {
-		db = tx[0]
+	if len(tx) == 0 {
+		return s.DB().WithContext(ctx).Transaction(func(transaction *gorm.DB) error {
+			return s.CreateOauthToken(ctx, token, transaction)
+		})
 	}
-	result := db.WithContext(ctx).Create(token)
-	if result.Error != nil {
-		return fmt.Errorf("failed to create oauth token: %w", result.Error)
+	txDB := tx[0]
+
+	var existing tables.TableMCPOauthToken
+	var lookupErr error
+	switch {
+	case token.AuthMode == "shared" && token.MCPClientID != "":
+		lookupErr = dbForUpdate(txDB).
+			Where("auth_mode = ? AND mcp_client_id = ?", "shared", token.MCPClientID).
+			First(&existing).Error
+	case token.AuthMode == "admin" && token.MCPClientID != "":
+		lookupErr = dbForUpdate(txDB).
+			Where("auth_mode = ? AND mcp_client_id = ?", "admin", token.MCPClientID).
+			First(&existing).Error
+	case token.UserID != nil && *token.UserID != "":
+		lookupErr = dbForUpdate(txDB).
+			Where("auth_mode = ? AND user_id = ? AND mcp_client_id = ?", token.AuthMode, *token.UserID, token.MCPClientID).
+			First(&existing).Error
+	case token.VirtualKeyID != nil && *token.VirtualKeyID != "":
+		lookupErr = dbForUpdate(txDB).
+			Where("auth_mode = ? AND virtual_key_id = ? AND mcp_client_id = ?", token.AuthMode, *token.VirtualKeyID, token.MCPClientID).
+			First(&existing).Error
+	case token.SessionID != "":
+		lookupErr = dbForUpdate(txDB).
+			Where("auth_mode = ? AND session_id = ? AND mcp_client_id = ?", token.AuthMode, token.SessionID, token.MCPClientID).
+			First(&existing).Error
+	default:
+		lookupErr = gorm.ErrRecordNotFound
+	}
+
+	if lookupErr == nil {
+		token.ID = existing.ID // reuse the row so the unique index sees an UPDATE, not INSERT
+		// Preserve the original binding's creation time; the row
+		// represents the binding, not the individual credential, so a
+		// re-auth shouldn't move CreatedAt forward.
+		token.CreatedAt = existing.CreatedAt
+		// Stamp LastRefreshedAt so the dashboard surfaces "refreshed Xm
+		// ago" after a successful re-auth (this path is only hit on
+		// upsert, which always means new credentials replacing old).
+		now := time.Now()
+		token.LastRefreshedAt = &now
+		return txDB.Save(token).Error
+	}
+	if !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
+		return fmt.Errorf("failed to query oauth token: %w", lookupErr)
+	}
+
+	if err := txDB.Create(token).Error; err != nil {
+		return fmt.Errorf("failed to create oauth token: %w", err)
 	}
 	return nil
 }
@@ -6675,6 +6743,29 @@ func (s *RDBConfigStore) GetOauthUserSessionByID(ctx context.Context, id string)
 	return &flow, nil
 }
 
+// GetOauthFlowByID is GetOauthUserSessionByID's admin-mode counterpart:
+// looks up a flow_mode='admin' row by its own ID. Kept as a separate,
+// separately-scoped method rather than widening GetOauthUserSessionByID's
+// filter, the same reason ClaimOauthFlowByState is kept separate from
+// ClaimOauthUserSessionByState (see that pair's doc comments): a
+// caller-supplied flow ID fed to a per-user-facing endpoint must never be
+// able to reach an admin-mode row's PKCE/state by guessing or reusing its
+// ID. This method exists for the reverse direction: an admin-facing
+// endpoint (MCP client reauthorize) building the real upstream authorize
+// URL for an admin-mode row, and must never be called from anywhere a
+// caller-supplied ID could originate from an untrusted per-user context.
+func (s *RDBConfigStore) GetOauthFlowByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error) {
+	var flow tables.TableMCPOauthFlow
+	result := s.DB().WithContext(ctx).Where("id = ? AND flow_mode = ?", id, "admin").First(&flow)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth flow: %w", result.Error)
+	}
+	return &flow, nil
+}
+
 // GetOauthUserSessionByState is a non-mutating lookup by state token, any
 // status or flow_mode. Used by callback-error handling to classify and mark
 // a flow failed without consuming it the way Claim*ByState does.
@@ -6754,13 +6845,17 @@ func (s *RDBConfigStore) claimOauthFlowByStateAndModes(ctx context.Context, stat
 // bound to (mode, identity, mcp_client_id). This is the canonical lookup at
 // flow-init time: there's exactly one flow row per binding, and reauth always
 // updates it in place rather than inserting a new one. mode is always one of
-// the per-identity modes here (the admin flow has no identity binding to
-// look up by — every InitiateOAuthFlow call mints a fresh row instead).
+// the per-identity modes here (including MCPAuthModeAdmin as of the MCP client
+// reauthorize endpoint: scoped by flow_mode='admin' + mcp_client_id alone,
+// no identity column).
 //
 // identity per mode: AuthModeUser=user_id, AuthModeVK=virtual_key_id,
 // AuthModeSession=raw session token (hashed for the lookup column).
 func (s *RDBConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthFlow, error) {
-	if strings.TrimSpace(identity) == "" || strings.TrimSpace(mcpClientID) == "" {
+	if strings.TrimSpace(mcpClientID) == "" {
+		return nil, nil
+	}
+	if mode != schemas.MCPAuthModeAdmin && strings.TrimSpace(identity) == "" {
 		return nil, nil
 	}
 	q := s.DB().WithContext(ctx).Where("mcp_client_id = ?", mcpClientID)
@@ -6771,6 +6866,8 @@ func (s *RDBConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(ctx conte
 		q = q.Where("virtual_key_id = ?", identity)
 	case schemas.MCPAuthModeSession:
 		q = q.Where("session_id = ?", identity)
+	case schemas.MCPAuthModeAdmin:
+		q = q.Where("flow_mode = ?", "admin")
 	default:
 		return nil, fmt.Errorf("unknown auth mode: %s", mode)
 	}
@@ -6813,61 +6910,6 @@ var perUserOauthAuthModes = []string{
 	string(schemas.MCPAuthModeUser),
 	string(schemas.MCPAuthModeVK),
 	string(schemas.MCPAuthModeSession),
-}
-
-// CreateOauthUserToken creates or replaces a per-user OAuth token. Looks up
-// any existing row matching the populated identity column + MCP client and
-// reuses its ID, ensuring the partial-unique index never trips. SessionToken's
-// hash is set in BeforeSave; the upsert lookup uses the hash column to match
-// the unique index. Wrapped in a transaction so SELECT + CREATE/UPDATE is
-// atomic under concurrent same-identity races. Every lookup branch also
-// pins auth_mode = token.AuthMode: shared-mode rows never populate an
-// identity column so they couldn't match anyway, but this keeps the upsert
-// from ever reusing a row of a different mode if that invariant is ever
-// violated (same defense-in-depth convention as reconcileVKDirectTokensDB).
-func (s *RDBConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
-	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var existing tables.TableMCPOauthToken
-		var lookupErr error
-		switch {
-		case token.UserID != nil && *token.UserID != "":
-			lookupErr = dbForUpdate(tx).
-				Where("auth_mode = ? AND user_id = ? AND mcp_client_id = ?", token.AuthMode, *token.UserID, token.MCPClientID).
-				First(&existing).Error
-		case token.VirtualKeyID != nil && *token.VirtualKeyID != "":
-			lookupErr = dbForUpdate(tx).
-				Where("auth_mode = ? AND virtual_key_id = ? AND mcp_client_id = ?", token.AuthMode, *token.VirtualKeyID, token.MCPClientID).
-				First(&existing).Error
-		case token.SessionID != "":
-			lookupErr = dbForUpdate(tx).
-				Where("auth_mode = ? AND session_id = ? AND mcp_client_id = ?", token.AuthMode, token.SessionID, token.MCPClientID).
-				First(&existing).Error
-		default:
-			lookupErr = gorm.ErrRecordNotFound
-		}
-
-		if lookupErr == nil {
-			token.ID = existing.ID // reuse the row so unique index sees an UPDATE, not INSERT
-			// Preserve the original binding's creation time; the row represents
-			// the (identity, mcp_client) link, not the individual credential, so
-			// a re-auth shouldn't move CreatedAt forward.
-			token.CreatedAt = existing.CreatedAt
-			// Stamp LastRefreshedAt so the dashboard surfaces "refreshed Xm ago"
-			// after a successful re-auth (this path is only hit on upsert, which
-			// always means new credentials replacing old).
-			now := time.Now()
-			token.LastRefreshedAt = &now
-			return tx.Save(token).Error
-		}
-		if !errors.Is(lookupErr, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("failed to query oauth user token: %w", lookupErr)
-		}
-
-		if err := tx.Create(token).Error; err != nil {
-			return fmt.Errorf("failed to create oauth user token: %w", err)
-		}
-		return nil
-	})
 }
 
 // UpdateOauthUserToken updates an existing per-user OAuth token. Rejects
@@ -7332,8 +7374,8 @@ func (s *RDBConfigStore) GetMCPPerUserHeaderCredentialByID(ctx context.Context, 
 }
 
 // UpsertMCPPerUserHeaderCredential atomically inserts or updates a credential
-// row keyed by (auth_mode, identity, mcp_client_id). Mirrors
-// CreateOauthUserToken — the row represents the (identity, mcp_client)
+// row keyed by (auth_mode, identity, mcp_client_id). Mirrors CreateOauthToken's
+// per-identity upsert branches — the row represents the (identity, mcp_client)
 // binding, so a re-submit preserves CreatedAt.
 func (s *RDBConfigStore) UpsertMCPPerUserHeaderCredential(ctx context.Context, cred *tables.TableMCPPerUserHeaderCredential) error {
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -263,6 +263,148 @@ func TestGetOauthUserSessionByID_ExcludesAdminMode(t *testing.T) {
 	require.Nil(t, got, "admin-mode flow must not be returned by a per-user-facing ID lookup")
 }
 
+// TestGetOauthUserSessionByModeIdentityAndMCPClient_AdminMode covers the
+// admin branch added alongside MCPAuthModeAdmin: unlike the per-identity
+// modes, an admin-mode flow has no identity column at all, so the lookup is
+// scoped by (flow_mode='admin', mcp_client_id) alone. It also pins that the
+// pre-existing per-identity modes (user/vk/session) keep their original
+// behavior — still rejecting an empty identity, still resolving their own
+// rows by identity.
+func TestGetOauthUserSessionByModeIdentityAndMCPClient_AdminMode(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	ctx := context.Background()
+
+	client1 := &tables.TableMCPClient{ClientID: "mcp-1", Name: "MCP One", ConnectionType: "stdio"}
+	client2 := &tables.TableMCPClient{ClientID: "mcp-2", Name: "MCP Two", ConnectionType: "stdio"}
+	client3 := &tables.TableMCPClient{ClientID: "mcp-3", Name: "MCP Three", ConnectionType: "stdio"}
+	require.NoError(t, store.DB().WithContext(ctx).Create(client1).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(client2).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(client3).Error)
+
+	uid := "user-1"
+	vkID := "vk-1"
+	adminFlow1 := &tables.TableMCPOauthFlow{
+		ID: "flow-admin-1", MCPClientID: "mcp-1", OauthConfigID: "cfg-1",
+		FlowMode: "admin", Status: "pending", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	adminFlow2 := &tables.TableMCPOauthFlow{
+		ID: "flow-admin-2", MCPClientID: "mcp-2", OauthConfigID: "cfg-1",
+		FlowMode: "admin", Status: "pending", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	userFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-user-1", MCPClientID: "mcp-1", OauthConfigID: "cfg-1",
+		FlowMode: "user", Status: "pending", UserID: &uid, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	vkFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-vk-1", MCPClientID: "mcp-1", OauthConfigID: "cfg-1",
+		FlowMode: "vk", Status: "pending", VirtualKeyID: &vkID, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	sessionFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-session-1", MCPClientID: "mcp-1", OauthConfigID: "cfg-1",
+		FlowMode: "session", Status: "pending", SessionID: "sess-tok-1", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(adminFlow1).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(adminFlow2).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(userFlow).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(vkFlow).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(sessionFlow).Error)
+
+	// Admin mode is found with an empty identity — admin rows have none.
+	got, err := store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeAdmin, "", "mcp-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-admin-1", got.ID)
+
+	// A different mcp_client_id's admin row is a distinct binding — resolves
+	// to its own row, not mcp-1's.
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeAdmin, "", "mcp-2")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-admin-2", got.ID)
+
+	// A client with no admin row of its own must not fall through to another
+	// client's admin row.
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeAdmin, "", "mcp-3")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// Per-identity modes still require a non-empty identity (unaffected by
+	// the admin branch's identity-optional carve-out).
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeUser, "", "mcp-1")
+	require.NoError(t, err)
+	require.Nil(t, got, "user mode must still require non-empty identity")
+
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeVK, "", "mcp-1")
+	require.NoError(t, err)
+	require.Nil(t, got, "vk mode must still require non-empty identity")
+
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeSession, "", "mcp-1")
+	require.NoError(t, err)
+	require.Nil(t, got, "session mode must still require non-empty identity")
+
+	// Per-identity modes still resolve their own rows correctly by identity.
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeUser, uid, "mcp-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-user-1", got.ID)
+
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeVK, vkID, "mcp-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-vk-1", got.ID)
+
+	got, err = store.GetOauthUserSessionByModeIdentityAndMCPClient(ctx, schemas.MCPAuthModeSession, "sess-tok-1", "mcp-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-session-1", got.ID)
+}
+
+// TestGetOauthFlowByID covers GetOauthUserSessionByID's admin-mode
+// counterpart, pinning the security boundary it exists for: a
+// caller-supplied ID must only ever resolve a flow_mode='admin' row through
+// this method, never a per-identity row, even when the ID is an exact match.
+func TestGetOauthFlowByID(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	ctx := context.Background()
+
+	adminFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-admin-x", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
+		FlowMode: "admin", Status: "pending", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	vkID := "vk-alpha"
+	vkFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-vk-x", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
+		FlowMode: "vk", Status: "pending", VirtualKeyID: &vkID, ExpiresAt: time.Now().Add(time.Hour),
+	}
+	sessionFlow := &tables.TableMCPOauthFlow{
+		ID: "flow-session-x", MCPClientID: "github-prod", OauthConfigID: "cfg-1",
+		FlowMode: "session", Status: "pending", SessionID: "sess-tok-x", ExpiresAt: time.Now().Add(time.Hour),
+	}
+	require.NoError(t, store.DB().WithContext(ctx).Create(adminFlow).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(vkFlow).Error)
+	require.NoError(t, store.DB().WithContext(ctx).Create(sessionFlow).Error)
+
+	// Finds a flow_mode='admin' row by ID.
+	got, err := store.GetOauthFlowByID(ctx, "flow-admin-x")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "flow-admin-x", got.ID)
+
+	// Returns nil for flow_mode='user'/'vk'/'session' rows even with the
+	// correct ID — the security boundary this whole method exists for.
+	for _, id := range []string{"sess-pending" /* user-mode, from the shared fixture */, "flow-vk-x", "flow-session-x"} {
+		got, err := store.GetOauthFlowByID(ctx, id)
+		require.NoError(t, err)
+		require.Nil(t, got, "non-admin flow %q must not be returned by the admin-only ID lookup", id)
+	}
+
+	// Nonexistent ID.
+	got, err = store.GetOauthFlowByID(ctx, "does-not-exist")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
 func TestListMCPPerUserHeaderCredentials_NoFilters(t *testing.T) {
 	store := setupMCPSessionsTestStore(t)
 	seedMCPSessionsFixture(t, store)

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -203,6 +203,64 @@ func TestGetExpiringOauthTokens_RequiresEnabledClient(t *testing.T) {
 	assert.False(t, ids["tok-orphan"], "token with no owning config must be excluded")
 }
 
+// TestCreateOauthToken_AdminMode_UpsertsByMCPClientIDNotDuplicate guards the
+// gap CodeRabbit flagged in CreateOauthToken's upsert-lookup switch: an
+// admin-mode token (no UserID/VirtualKeyID/SessionID, bound only by
+// MCPClientID — see InitiateUserOAuthFlow's MCPAuthModeAdmin case) matched no
+// case and fell through to the default "not found" branch, so every call
+// always inserted a fresh row instead of reusing the existing binding's row.
+// RetainExchangeAdminCredential calls CreateOauthToken with exactly this
+// shape on every token_exchange admin-credential repair, and its own doc
+// comment promises "a repair replaces the existing row's credential" — this
+// pins that an admin-mode call is a true upsert, not an unconditional insert.
+func TestCreateOauthToken_AdminMode_UpsertsByMCPClientIDNotDuplicate(t *testing.T) {
+	s := setupRDBTestStore(t)
+	require.NoError(t, s.DB().AutoMigrate(&tables.TableMCPOauthToken{}))
+	ctx := context.Background()
+
+	first := &tables.TableMCPOauthToken{
+		ID:          "tok-admin-1",
+		AuthMode:    "admin",
+		MCPClientID: "client-1",
+		AccessToken: "first-access-token",
+		TokenType:   "Bearer",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateOauthToken(ctx, first))
+
+	// A second call for the same (auth_mode='admin', mcp_client_id) binding —
+	// a repair, per RetainExchangeAdminCredential's own doc comment — must
+	// update the existing row, not insert a second one.
+	second := &tables.TableMCPOauthToken{
+		ID:          "tok-admin-2",
+		AuthMode:    "admin",
+		MCPClientID: "client-1",
+		AccessToken: "second-access-token",
+		TokenType:   "Bearer",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateOauthToken(ctx, second))
+
+	var rows []tables.TableMCPOauthToken
+	require.NoError(t, s.DB().Where("auth_mode = ? AND mcp_client_id = ?", "admin", "client-1").Find(&rows).Error)
+	require.Len(t, rows, 1, "must reuse the existing row for this binding, not insert a duplicate")
+	assert.Equal(t, "second-access-token", rows[0].AccessToken, "the repair's new credential must win")
+
+	// A different mcp_client_id is a different binding — it must get its own row.
+	other := &tables.TableMCPOauthToken{
+		ID:          "tok-admin-3",
+		AuthMode:    "admin",
+		MCPClientID: "client-2",
+		AccessToken: "other-client-access-token",
+		TokenType:   "Bearer",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateOauthToken(ctx, other))
+	var allAdminRows []tables.TableMCPOauthToken
+	require.NoError(t, s.DB().Where("auth_mode = ?", "admin").Find(&allAdminRows).Error)
+	assert.Len(t, allAdminRows, 2, "a different mcp_client_id must not reuse another client's admin row")
+}
+
 func TestGetOAuth2SigningKey_AutoGeneratesAndIsStable(t *testing.T) {
 	s := setupOAuth2TestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -495,8 +495,9 @@ type ConfigStore interface {
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error
 
 	// OAuth token CRUD. TableMCPOauthToken now holds every holder of an MCP
-	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session'), not
-	// just the shared-client credential the method names below still imply.
+	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session' |
+	// 'admin'), not just the shared-client credential the method names below
+	// still imply.
 	//
 	// GetOauthTokenByID is not filtered by auth_mode: callers always feed it
 	// an ID already resolved from a trusted internal lookup (a token row just
@@ -518,6 +519,19 @@ type ConfigStore interface {
 	// shared-only — per-user tokens otherwise refresh lazily/inline on
 	// lookup via GetOauthUserTokenByMode).
 	GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error)
+	// CreateOauthToken creates or replaces an MCP OAuth token row, any
+	// auth_mode alike (shared/user/vk/session/admin). Upserts by looking up
+	// any existing row for the same binding (mcp_client_id alone for shared
+	// and admin; identity column + mcp_client_id for per-identity modes) and
+	// reusing its ID, matching this table's partial unique indexes. Was two separate
+	// methods (a plain-insert CreateOauthToken for the shared flow, an
+	// upserting CreateOauthUserToken for per-identity) until the shared flow
+	// gained its own upsert need too: reauthorizing an already-authorized
+	// shared client must update its existing token row, not insert a
+	// duplicate. Accepts an optional caller-supplied transaction (tx) so it
+	// can participate atomically in a larger operation (e.g. CompleteOAuthFlow
+	// linking the new/updated token to its oauth_config in the same
+	// transaction) instead of always committing on its own.
 	CreateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken, tx ...*gorm.DB) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	// RefreshOauthTokenFieldsIfActive persists a successful refresh's new
@@ -544,6 +558,11 @@ type ConfigStore interface {
 	// used for the token-table merge (GetOauthTokenByID etc. kept their
 	// names when retargeted to the unified table).
 	GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error)
+	// GetOauthFlowByID is GetOauthUserSessionByID's admin-mode counterpart:
+	// looks up a flow_mode='admin' row by its own ID. See GetOauthUserSessionByID's
+	// implementation doc for why these stay separate (a per-user-facing
+	// caller-supplied-ID lookup must never reach an admin-mode row).
+	GetOauthFlowByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error)
 	// GetOauthUserSessionByState is a non-mutating lookup by state, any
 	// status or flow_mode. Unlike ClaimOauthUserSessionByState /
 	// ClaimOauthFlowByState it does not gate on status='pending' or flip it
@@ -578,15 +597,6 @@ type ConfigStore interface {
 	// AuthModeUser, the VK row ID for AuthModeVK, and the session ID for
 	// AuthModeSession.
 	GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthToken, error)
-	// CreateOauthUserToken creates or replaces a per-user OAuth token row.
-	// Deliberately kept separate from CreateOauthToken (used by the shared
-	// flow) rather than merged into one method: it upserts by looking up any
-	// existing row for the same (identity, mcp_client) binding and reusing
-	// its ID, while CreateOauthToken is (and, for this table merge, remains)
-	// a plain insert — the shared flow has never needed upsert semantics.
-	// Folding them into one function would silently give the shared path
-	// upsert behavior it doesn't ask for.
-	CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	UpdateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error
 	DeleteOauthUserToken(ctx context.Context, id string) error
 	// DeleteOauthUserSession hard-deletes a single flow row by primary key.

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -918,11 +918,42 @@ func (p *OAuth2Provider) BuildUpstreamAuthorizeURL(ctx context.Context, flowID s
 	if flow == nil {
 		return "", schemas.ErrOAuth2NotPerUserSession
 	}
+	return p.buildUpstreamAuthorizeURLForFlow(ctx, flow)
+}
+
+// BuildAdminUpstreamAuthorizeURL is BuildUpstreamAuthorizeURL's admin-mode
+// counterpart: reconstructs the upstream provider authorization URL for a
+// pending flow_mode='admin' row, used by the MCP client reauthorize endpoint
+// to hand OAuth2Authorizer's popup a real provider URL to open directly
+// (unlike the per-user page-based flow, which navigates to a Bifrost page
+// that itself resolves the upstream URL later). Reads through GetOauthFlowByID
+// rather than widening BuildUpstreamAuthorizeURL's own GetOauthUserSessionByID
+// call: that lookup is deliberately scoped away from admin-mode rows (see its
+// doc comment) so a caller-supplied flow ID from a per-user-facing endpoint
+// can never reach an admin flow's PKCE state.
+func (p *OAuth2Provider) BuildAdminUpstreamAuthorizeURL(ctx context.Context, flowID string) (string, error) {
+	flow, err := p.configStore.GetOauthFlowByID(ctx, flowID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load pending oauth flow: %w", err)
+	}
+	if flow == nil {
+		return "", fmt.Errorf("oauth flow not found")
+	}
+	return p.buildUpstreamAuthorizeURLForFlow(ctx, flow)
+}
+
+// buildUpstreamAuthorizeURLForFlow is the shared core of
+// BuildUpstreamAuthorizeURL and BuildAdminUpstreamAuthorizeURL: given an
+// already-loaded, already-mode-scoped flow row, validate it's still usable
+// and reconstruct the upstream authorize URL. The code_challenge is
+// recomputed deterministically from the stored verifier so we don't have to
+// persist it separately.
+func (p *OAuth2Provider) buildUpstreamAuthorizeURLForFlow(ctx context.Context, flow *tables.TableMCPOauthFlow) (string, error) {
 	if flow.Status != "pending" {
-		return "", fmt.Errorf("oauth flow %s is %s: %w", flowID, flow.Status, schemas.ErrOAuth2FlowNotPending)
+		return "", fmt.Errorf("oauth flow %s is %s: %w", flow.ID, flow.Status, schemas.ErrOAuth2FlowNotPending)
 	}
 	if time.Now().After(flow.ExpiresAt) {
-		return "", fmt.Errorf("oauth flow %s: %w", flowID, schemas.ErrOAuth2FlowExpired)
+		return "", fmt.Errorf("oauth flow %s: %w", flow.ID, schemas.ErrOAuth2FlowExpired)
 	}
 	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, flow.OauthConfigID)
 	if err != nil {
@@ -938,7 +969,7 @@ func (p *OAuth2Provider) BuildUpstreamAuthorizeURL(ctx context.Context, flowID s
 	var scopes []string
 	if templateConfig.Scopes != "" {
 		if err := json.Unmarshal([]byte(templateConfig.Scopes), &scopes); err != nil {
-			return "", fmt.Errorf("failed to parse oauth scopes for flow %s: %w", flowID, err)
+			return "", fmt.Errorf("failed to parse oauth scopes for flow %s: %w", flow.ID, err)
 		}
 	}
 	redirectURI := flow.RedirectURI
@@ -1202,6 +1233,12 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 		}
 		sessionID = v
 		lookupID = v
+	case schemas.MCPAuthModeAdmin:
+		// No identity dimension, a shared credential's reauth is scoped to
+		// the MCP client alone (see GetOauthUserSessionByModeIdentityAndMCPClient's
+		// admin branch). lookupID stays "" and vkId/uid/sessionID all stay
+		// nil/empty; the row this creates/reuses is found again purely by
+		// (flow_mode='admin', mcp_client_id).
 	default:
 		return nil, "", fmt.Errorf("unknown auth mode for flow: %s", flowMode)
 	}
@@ -1297,7 +1334,12 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	// bypasses cookie resolution, leaving caller user_id empty and the gate
 	// would 403 even legitimate users. VK and session-mode flows are
 	// intentionally shareable and continue to mint.
-	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) && flowMode != schemas.MCPAuthModeUser {
+	//
+	// Admin-mode flows skip the mint too: this flow is always admin-initiated
+	// from an authenticated dashboard session (the MCP client reauthorize
+	// endpoint), never a shareable magic link, there is no
+	// caller-without-a-session case to support here, unlike vk/session-mode.
+	if svc := p.tempTokenService(); svc != nil && p.mcpTempTokenAuthEnabled(ctx) && flowMode != schemas.MCPAuthModeUser && flowMode != schemas.MCPAuthModeAdmin {
 		ttl := time.Until(expiresAt)
 		if ttl > 0 {
 			plaintext, mintErr := svc.Mint(ctx, temptoken.MCPAuthScopeName, sessionID, ttl)
@@ -1439,7 +1481,7 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 		AuthMode:      string(flowMode),
 		Status:        "active",
 	}
-	if err := p.configStore.CreateOauthUserToken(ctx, tokenRecord); err != nil {
+	if err := p.configStore.CreateOauthToken(ctx, tokenRecord); err != nil {
 		// The flow row has already been claimed and the auth code has been
 		// exchanged; leaving the row in 'claiming' state would block the
 		// next initiation for this binding indefinitely. Drop it so the

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -29,6 +29,7 @@ type testConfigStore struct {
 	mu           sync.Mutex
 	oauthConfigs map[string]*tables.TableOauthConfig
 	oauthTokens  map[string]*tables.TableMCPOauthToken
+	oauthFlows   map[string]*tables.TableMCPOauthFlow
 	clientConfig *configstore.ClientConfig
 }
 
@@ -36,6 +37,7 @@ func newTestConfigStore() *testConfigStore {
 	return &testConfigStore{
 		oauthConfigs: make(map[string]*tables.TableOauthConfig),
 		oauthTokens:  make(map[string]*tables.TableMCPOauthToken),
+		oauthFlows:   make(map[string]*tables.TableMCPOauthFlow),
 	}
 }
 
@@ -157,6 +159,77 @@ func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.
 		}
 	}
 	return expiring, nil
+}
+
+// CreateOauthUserSession is the test-double equivalent of the real store's
+// flow-row insert (any flow_mode, including 'admin').
+func (s *testConfigStore) CreateOauthUserSession(_ context.Context, session *tables.TableMCPOauthFlow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.oauthFlows[session.ID] = bifrost.Ptr(*session)
+	return nil
+}
+
+// UpdateOauthUserSession is the test-double equivalent of the real store's
+// in-place flow-row update, used by InitiateUserOAuthFlow's reauth path.
+func (s *testConfigStore) UpdateOauthUserSession(_ context.Context, session *tables.TableMCPOauthFlow) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.oauthFlows[session.ID] = bifrost.Ptr(*session)
+	return nil
+}
+
+// GetOauthUserSessionByModeIdentityAndMCPClient is the test-double
+// equivalent of the real store's canonical flow-row lookup by binding. Mirrors
+// the real implementation's admin carve-out: admin mode matches on
+// (flow_mode='admin', mcp_client_id) alone, every other mode requires a
+// non-empty identity and matches on its own identity column.
+func (s *testConfigStore) GetOauthUserSessionByModeIdentityAndMCPClient(_ context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthFlow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if mcpClientID == "" {
+		return nil, nil
+	}
+	if mode != schemas.MCPAuthModeAdmin && identity == "" {
+		return nil, nil
+	}
+	for _, flow := range s.oauthFlows {
+		if flow.MCPClientID != mcpClientID {
+			continue
+		}
+		switch mode {
+		case schemas.MCPAuthModeUser:
+			if flow.UserID != nil && *flow.UserID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		case schemas.MCPAuthModeVK:
+			if flow.VirtualKeyID != nil && *flow.VirtualKeyID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		case schemas.MCPAuthModeSession:
+			if flow.SessionID == identity {
+				return bifrost.Ptr(*flow), nil
+			}
+		case schemas.MCPAuthModeAdmin:
+			if flow.FlowMode == "admin" {
+				return bifrost.Ptr(*flow), nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// GetOauthFlowByID is the test-double equivalent of the real store's
+// admin-mode-only flow lookup by ID: only ever returns a flow_mode='admin'
+// row, mirroring the security boundary the real implementation enforces.
+func (s *testConfigStore) GetOauthFlowByID(_ context.Context, id string) (*tables.TableMCPOauthFlow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	flow := s.oauthFlows[id]
+	if flow == nil || flow.FlowMode != "admin" {
+		return nil, nil
+	}
+	return bifrost.Ptr(*flow), nil
 }
 
 // seedFixtures inserts an authorized oauth_config + shared-mode token pair
@@ -767,4 +840,80 @@ func TestTokenRefreshWorker_400UnauthorizedClient_MarksNeedsReauth(t *testing.T)
 	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
 	assert.Equal(t, "needs_reauth", token.Status, "400 unauthorized_client must mark token needs_reauth")
+}
+
+// seedAdminOauthConfig inserts a minimal authorized oauth_config row —
+// enough for InitiateUserOAuthFlow's admin-mode path, which never reaches
+// the fields (token URL, scopes) only needed once a flow reaches token
+// exchange or upstream-URL construction.
+func seedAdminOauthConfig(store *testConfigStore, oauthConfigID string) {
+	store.oauthConfigs[oauthConfigID] = &tables.TableOauthConfig{
+		ID:          oauthConfigID,
+		ClientID:    schemas.NewSecretVar("test-client-id"),
+		RedirectURI: "http://localhost/callback",
+		Status:      "authorized",
+	}
+}
+
+// TestInitiateUserOAuthFlow_AdminMode_CreatesFlowWithNoIdentity covers the
+// MCPAuthModeAdmin branch: unlike user/vk/session mode, the created row must
+// carry no identity at all — no user_id, virtual_key_id, or session_id — since
+// an admin-mode flow belongs to the MCP client's shared credential itself,
+// not any caller.
+func TestInitiateUserOAuthFlow_AdminMode_CreatesFlowWithNoIdentity(t *testing.T) {
+	store := newTestConfigStore()
+	oauthConfigID := "admin-oauth-config"
+	seedAdminOauthConfig(store, oauthConfigID)
+
+	provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	ctx := context.Background()
+
+	initiation, flowID, err := provider.InitiateUserOAuthFlow(ctx, oauthConfigID, "mcp-client-1", "http://localhost/api/oauth/callback", schemas.MCPAuthModeAdmin)
+	require.NoError(t, err)
+	require.NotEmpty(t, flowID)
+	require.NotNil(t, initiation)
+
+	flow := store.oauthFlows[flowID]
+	require.NotNil(t, flow, "flow row must be created")
+	assert.Equal(t, "admin", flow.FlowMode)
+	assert.Equal(t, "mcp-client-1", flow.MCPClientID)
+	assert.Equal(t, oauthConfigID, flow.OauthConfigID)
+	assert.Empty(t, flow.SessionID, "admin-mode flow must have no session identity")
+	assert.Nil(t, flow.UserID, "admin-mode flow must have no user identity")
+	assert.Nil(t, flow.VirtualKeyID, "admin-mode flow must have no vk identity")
+	assert.Equal(t, "pending", flow.Status)
+}
+
+// TestInitiateUserOAuthFlow_AdminMode_ReusesPendingRow mirrors the per-user
+// modes' reuse-in-place behavior (InitiateUserOAuthFlow's doc comment: "there
+// is exactly one flow row per binding... Reauth never duplicates rows"):
+// calling InitiateUserOAuthFlow again for the same (oauthConfigID,
+// mcpClientID) while the first admin flow is still 'pending' must update the
+// existing row rather than insert a second one.
+func TestInitiateUserOAuthFlow_AdminMode_ReusesPendingRow(t *testing.T) {
+	store := newTestConfigStore()
+	oauthConfigID := "admin-oauth-config"
+	seedAdminOauthConfig(store, oauthConfigID)
+
+	provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	ctx := context.Background()
+
+	_, flowID1, err := provider.InitiateUserOAuthFlow(ctx, oauthConfigID, "mcp-client-1", "http://localhost/api/oauth/callback", schemas.MCPAuthModeAdmin)
+	require.NoError(t, err)
+	require.Len(t, store.oauthFlows, 1, "exactly one flow row after first initiation")
+	firstState := store.oauthFlows[flowID1].State
+
+	_, flowID2, err := provider.InitiateUserOAuthFlow(ctx, oauthConfigID, "mcp-client-1", "http://localhost/api/oauth/callback", schemas.MCPAuthModeAdmin)
+	require.NoError(t, err)
+
+	assert.Equal(t, flowID1, flowID2, "second initiation for the same binding while pending must reuse the same row")
+	assert.Len(t, store.oauthFlows, 1, "must not insert a duplicate row")
+	assert.NotEqual(t, firstState, store.oauthFlows[flowID2].State, "reused row's CSRF state must still rotate on each initiation")
+
+	// A different mcp_client_id is a different binding — it must get its own
+	// row, not reuse mcp-client-1's.
+	_, flowID3, err := provider.InitiateUserOAuthFlow(ctx, oauthConfigID, "mcp-client-2", "http://localhost/api/oauth/callback", schemas.MCPAuthModeAdmin)
+	require.NoError(t, err)
+	assert.NotEqual(t, flowID1, flowID3, "a different mcp_client_id must not reuse another client's admin flow row")
+	assert.Len(t, store.oauthFlows, 2)
 }

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -87,6 +87,7 @@ func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.Bif
 	r.POST("/api/mcp/client/{id}/reconnect", lib.ChainMiddlewares(h.reconnectMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/complete-oauth", lib.ChainMiddlewares(h.completeMCPClientOAuth, middlewares...))
 	r.POST("/api/mcp/client/{id}/initiate-verification", lib.ChainMiddlewares(h.initiateMCPClientVerification, middlewares...))
+	r.POST("/api/mcp/client/{id}/reauthorize", lib.ChainMiddlewares(h.reauthorizeMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/verify-headers", lib.ChainMiddlewares(h.verifyMCPClientHeaders, middlewares...))
 }
 
@@ -137,6 +138,91 @@ type MCPVKConfigResponse struct {
 	VirtualKeyID   string            `json:"virtual_key_id"`
 	VirtualKeyName string            `json:"virtual_key_name"`
 	ToolsToExecute schemas.WhiteList `json:"tools_to_execute"`
+}
+
+// reauthorizeMCPClient handles POST /api/mcp/client/{id}/reauthorize.
+//
+// Redoes the OAuth consent dance for an already-authorized shared
+// (auth_type='oauth') MCP client, without delete-and-recreate. Serves two
+// cases with one endpoint: a standalone admin-triggered reauth (e.g. the
+// upstream provider revoked the credential) and the follow-up to rotating
+// client_id/client_secret (which cascades every bound token to
+// needs_reauth; this is how an admin actually redoes consent afterward).
+// Always redoes consent against whatever credentials are currently stored
+// on the oauth_configs row, no mode flag, no branching on why the token
+// needs it. per_user_oauth clients are out of scope: their admin flow is a
+// one-time bootstrap-test, not a repeatable reauth surface.
+func (h *MCPHandler) reauthorizeMCPClient(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid mcp client id: %v", err))
+		return
+	}
+
+	clientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("MCP client '%s' not found", id))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+		return
+	}
+	if clientConfig.AuthType != schemas.MCPAuthTypeOauth {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("reauthorize only applies to shared OAuth clients (auth_type 'oauth'), got %q", clientConfig.AuthType))
+		return
+	}
+	if clientConfig.OauthConfigID == nil || *clientConfig.OauthConfigID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has not completed initial OAuth authorization yet; use initiate-verification instead")
+		return
+	}
+	if clientConfig.PendingOAuthConfig != nil {
+		// A config.json-bootstrapped client links OauthConfigID before the
+		// admin ever completes consent (see InitiateOAuthFlow), so the check
+		// above alone doesn't catch this case. Reauthorizing here would
+		// resolve to the same flow_mode='admin' + mcp_client_id lookup as
+		// the in-flight bootstrap flow and rotate its state/code_verifier,
+		// breaking the bootstrap authorize URL the admin already has open.
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has not completed initial OAuth authorization yet; use initiate-verification instead")
+		return
+	}
+	if h.store.OAuthProvider == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "OAuth provider not configured")
+		return
+	}
+
+	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
+	flowInitiation, flowID, err := h.store.OAuthProvider.InitiateUserOAuthFlow(ctx, *clientConfig.OauthConfigID, clientConfig.ID, redirectURI, schemas.MCPAuthModeAdmin)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate reauthorization: %v", err))
+		return
+	}
+	authorizeURL, err := h.store.OAuthProvider.BuildAdminUpstreamAuthorizeURL(ctx, flowID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to build authorize URL: %v", err))
+		return
+	}
+
+	completeURL := fmt.Sprintf("/api/mcp/client/%s/complete-oauth", flowInitiation.OauthConfigID)
+	statusURL := fmt.Sprintf("/api/oauth/config/%s/status", flowInitiation.OauthConfigID)
+	SendJSON(ctx, map[string]any{
+		"status":          "pending_oauth",
+		"oauth_config_id": flowInitiation.OauthConfigID,
+		"authorize_url":   authorizeURL,
+		"expires_at":      flowInitiation.ExpiresAt,
+		"mcp_client_id":   clientConfig.ID,
+		"complete_url":    completeURL,
+		"status_url":      statusURL,
+		"next_steps": []string{
+			"1. Open authorize_url in a browser to approve access",
+			"2. Poll status_url to check when status becomes 'authorized'",
+			"3. POST complete_url to reconnect the MCP client",
+		},
+	})
 }
 
 // initiateMCPClientVerification handles
@@ -2193,7 +2279,29 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		if dbClient.PendingOAuthConfigJSON == nil || *dbClient.PendingOAuthConfigJSON == "" {
-			SendError(ctx, fasthttp.StatusConflict, "OAuth flow has already been completed for this MCP client")
+			// Not a bootstrap completion. Two possibilities: a genuine
+			// replay (client already active, this exact oauth_config_id's
+			// flow completed long ago, nothing new happened) or a pure
+			// reauth (client already active, a fresh admin flow via
+			// POST /reauthorize just replaced its token). Only auth_type
+			// 'oauth' supports reauth, per_user_oauth's admin flow is a
+			// one-time bootstrap test with no reauth trigger, so any hit
+			// here for that type is always a genuine replay.
+			if dbClient.AuthType != string(schemas.MCPAuthTypeOauth) {
+				SendError(ctx, fasthttp.StatusConflict, "OAuth flow has already been completed for this MCP client")
+				return
+			}
+			reauthClientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)
+			if err != nil || reauthClientConfig == nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+				return
+			}
+			if err := h.updateMCPClientConnectionWithRetry(bifrostCtx, reauthClientConfig.ID, reauthClientConfig); err != nil {
+				logger.Error(fmt.Sprintf("Failed to reconnect MCP client after reauthorization for client %s: %v", reauthClientConfig.ID, err))
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth credentials refreshed but reconnecting the client failed: %v", err))
+				return
+			}
+			SendJSON(ctx, map[string]any{"status": "success", "message": "MCP client re-authorized and reconnected successfully"})
 			return
 		}
 		mcpClientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1493,6 +1493,10 @@ func (m *MockConfigStore) GetOauthUserSessionByID(ctx context.Context, id string
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetOauthFlowByID(ctx context.Context, id string) (*tables.TableMCPOauthFlow, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableMCPOauthFlow, error) {
 	return nil, nil
 }
@@ -1520,10 +1524,6 @@ func (m *MockConfigStore) UpdateOauthUserSession(ctx context.Context, session *t
 // Per-user OAuth token CRUD
 func (m *MockConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
-}
-
-func (m *MockConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
-	return nil
 }
 
 func (m *MockConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableMCPOauthToken) error {

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -217,19 +217,19 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-					client_id: mcpClient.config.oauth_client_id,
-					client_secret: mcpClient.config.oauth_client_secret,
-					authorize_url: mcpClient.config.oauth_authorize_url,
-					token_url: mcpClient.config.oauth_token_url,
-					registration_url: mcpClient.config.oauth_registration_url,
-					resource: mcpClient.config.oauth_resource,
-				}
+						client_id: mcpClient.config.oauth_client_id,
+						client_secret: mcpClient.config.oauth_client_secret,
+						authorize_url: mcpClient.config.oauth_authorize_url,
+						token_url: mcpClient.config.oauth_token_url,
+						registration_url: mcpClient.config.oauth_registration_url,
+						resource: mcpClient.config.oauth_resource,
+					}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-				}
+						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+					}
 				: undefined,
 		},
 	});
@@ -253,19 +253,19 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-					client_id: mcpClient.config.oauth_client_id,
-					client_secret: mcpClient.config.oauth_client_secret,
-					authorize_url: mcpClient.config.oauth_authorize_url,
-					token_url: mcpClient.config.oauth_token_url,
-					registration_url: mcpClient.config.oauth_registration_url,
-					resource: mcpClient.config.oauth_resource,
-				}
+						client_id: mcpClient.config.oauth_client_id,
+						client_secret: mcpClient.config.oauth_client_secret,
+						authorize_url: mcpClient.config.oauth_authorize_url,
+						token_url: mcpClient.config.oauth_token_url,
+						registration_url: mcpClient.config.oauth_registration_url,
+						resource: mcpClient.config.oauth_resource,
+					}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-				}
+						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+					}
 				: undefined,
 		});
 	}, [form, mcpClient, supportsOAuthCredentialUpdate]);
@@ -355,21 +355,21 @@ export default function MCPClientSheet({
 					allowed_extra_headers: data.allowed_extra_headers,
 					oauth_config: shouldRotateOAuthCredentials
 						? {
-							client_id: oauthClientID,
-							client_secret: oauthClientSecret,
-							authorize_url: data.oauth_config?.authorize_url || undefined,
-							token_url: data.oauth_config?.token_url || undefined,
-							registration_url: data.oauth_config?.registration_url || undefined,
-							scopes: oauthScopes,
-							resource: data.oauth_config?.resource || undefined,
-						}
+								client_id: oauthClientID,
+								client_secret: oauthClientSecret,
+								authorize_url: data.oauth_config?.authorize_url || undefined,
+								token_url: data.oauth_config?.token_url || undefined,
+								registration_url: data.oauth_config?.registration_url || undefined,
+								scopes: oauthScopes,
+								resource: data.oauth_config?.resource || undefined,
+							}
 						: undefined,
 					tls_config:
 						data.tls_config !== undefined
 							? {
-								insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
-								ca_cert_pem: data.tls_config.ca_cert_pem,
-							}
+									insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
+									ca_cert_pem: data.tls_config.ca_cert_pem,
+								}
 							: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
@@ -510,7 +510,7 @@ export default function MCPClientSheet({
 											? "This client was declared in config.json. A one-time admin test login is needed to verify the OAuth setup and discover tools — each user will authenticate individually afterward."
 											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
 										: mcpClient.state === "needs_reauth"
-											? "This connection's credentials have expired and need to be re-authorized. Re-authorization from the dashboard isn't available yet: recreating this client is the current workaround."
+											? "This connection's credentials need to be re-authorized. Click Reauthorize to redo the OAuth consent flow."
 											: "MCP server configuration and available tools"}
 								</SheetDescription>
 							</div>
@@ -578,7 +578,7 @@ export default function MCPClientSheet({
 											<span className="font-mono break-all">
 												{mcpClient.config.connection_type === "stdio"
 													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
-													"-"
+														"-"
 													: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
 														? mcpClient.config.connection_string.ref
 														: mcpClient.config.connection_string?.value || "-"}
@@ -597,7 +597,7 @@ export default function MCPClientSheet({
 															return [name, valueParts.join("=")];
 														}),
 													)}
-													onChange={() => { }}
+													onChange={() => {}}
 													fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
 													valuePlaceholder="—"
 													label=""
@@ -992,9 +992,9 @@ export default function MCPClientSheet({
 														onBlur={() => {
 															const parsed = allowedExtraHeadersRaw.trim()
 																? allowedExtraHeadersRaw
-																	.split(",")
-																	.map((h) => h.trim())
-																	.filter(Boolean)
+																		.split(",")
+																		.map((h) => h.trim())
+																		.filter(Boolean)
 																: [];
 															field.onChange(parsed);
 															field.onBlur();

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -22,6 +22,7 @@ import {
 	getErrorMessage,
 	useDeleteMCPClientMutation,
 	useInitiateMCPClientVerificationMutation,
+	useReauthorizeMCPClientMutation,
 	useReconnectMCPClientMutation,
 	useUpdateMCPClientMutation,
 	useVerifyMCPClientHeadersMutation,
@@ -29,7 +30,20 @@ import {
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
-import { Box, ChevronLeft, ChevronRight, KeyRound, Loader2, MoreHorizontal, PencilIcon, Plus, RefreshCcw, Search, Trash2, X } from "lucide-react";
+import {
+	Box,
+	ChevronLeft,
+	ChevronRight,
+	KeyRound,
+	Loader2,
+	MoreHorizontal,
+	PencilIcon,
+	Plus,
+	RefreshCcw,
+	Search,
+	Trash2,
+	X,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import MCPClientSheet from "./mcpClientSheet";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
@@ -43,10 +57,12 @@ function MCPClientActionsMenu({
 	hasDeleteAccess,
 	isReconnecting,
 	isAuthorizing,
+	isReauthorizing,
 	isPerUserAuth,
 	onEdit,
 	onReconnect,
 	onAuthorize,
+	onReauthorize,
 	onDelete,
 }: {
 	client: MCPClient;
@@ -54,10 +70,12 @@ function MCPClientActionsMenu({
 	hasDeleteAccess: boolean;
 	isReconnecting: boolean;
 	isAuthorizing: boolean;
+	isReauthorizing: boolean;
 	isPerUserAuth: boolean;
 	onEdit: (client: MCPClient) => void;
 	onReconnect: (client: MCPClient) => void;
 	onAuthorize: (client: MCPClient) => void;
+	onReauthorize: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -71,8 +89,13 @@ function MCPClientActionsMenu({
 					className="h-8 w-8"
 					aria-label="MCP server actions"
 					data-testid={`mcp-client-actions-${client.config.client_id}-btn`}
+					disabled={isReconnecting || isReauthorizing}
 				>
-					{isReconnecting || isAuthorizing ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+					{isReconnecting || isAuthorizing || isReauthorizing ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<MoreHorizontal className="h-4 w-4" />
+					)}
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
@@ -117,7 +140,13 @@ function MCPClientActionsMenu({
 				{hasUpdateAccess && (
 					<DropdownMenuItem
 						className="cursor-pointer"
-						disabled={isPerUserAuth || client.config.disabled || isReconnecting || client.state === "pending_verification" || client.state === "needs_reauth"}
+						disabled={
+							isPerUserAuth ||
+							client.config.disabled ||
+							isReconnecting ||
+							client.state === "pending_verification" ||
+							client.state === "needs_reauth"
+						}
 						onSelect={(e) => {
 							e.preventDefault();
 							onReconnect(client);
@@ -128,6 +157,24 @@ function MCPClientActionsMenu({
 						Reconnect
 					</DropdownMenuItem>
 				)}
+				{hasUpdateAccess &&
+					client.state !== "pending_verification" &&
+					client.state !== "disabled" &&
+					client.config.auth_type === "oauth" && (
+						<DropdownMenuItem
+							className="cursor-pointer"
+							disabled={isReauthorizing}
+							data-testid={`mcp-client-reauthorize-${client.config.client_id}-menu-item`}
+							onSelect={(e) => {
+								e.preventDefault();
+								onReauthorize(client);
+								setIsOpen(false);
+							}}
+						>
+							<KeyRound className="h-4 w-4" />
+							Reauthorize
+						</DropdownMenuItem>
+					)}
 				{hasDeleteAccess && (
 					<DropdownMenuItem
 						variant="destructive"
@@ -188,6 +235,7 @@ export default function MCPClientsTable({
 
 	const [reconnectingClients, setReconnectingClients] = useState<string[]>([]);
 	const [authorizingClients, setAuthorizingClients] = useState<string[]>([]);
+	const [reauthorizingClients, setReauthorizingClients] = useState<string[]>([]);
 	const [togglingClientIds, setTogglingClientIds] = useState<Set<string>>(new Set());
 	// Drives the OAuth2Authorizer dialog for a config.json-bootstrapped client
 	// sitting in pending_verification, triggered from the row actions menu.
@@ -202,9 +250,13 @@ export default function MCPClientsTable({
 	// per_user_headers client sitting in pending_verification, triggered from
 	// the row actions menu.
 	const [bootstrapHeadersClient, setBootstrapHeadersClient] = useState<MCPClient | null>(null);
+	// Drives the OAuth2Authorizer dialog for a client redoing consent via
+	// POST /reauthorize, triggered from the row actions menu.
+	const [reauthorizeFlow, setReauthorizeFlow] = useState<{ authorizeUrl: string; oauthConfigId: string; mcpClientId: string } | null>(null);
 
 	// RTK Query mutations
 	const [reconnectMCPClient] = useReconnectMCPClientMutation();
+	const [reauthorizeMCPClient] = useReauthorizeMCPClientMutation();
 	const [deleteMCPClient] = useDeleteMCPClientMutation();
 	const [updateMCPClient] = useUpdateMCPClientMutation();
 	const [initiateVerification] = useInitiateMCPClientVerificationMutation();
@@ -277,6 +329,30 @@ export default function MCPClientsTable({
 			toast({ title: "Authorization failed", description: getErrorMessage(error), variant: "destructive" });
 		} finally {
 			setAuthorizingClients((prev) => prev.filter((id) => id !== client.config.client_id));
+		}
+	};
+
+	const handleReauthorize = async (client: MCPClient) => {
+		try {
+			setReauthorizingClients((prev) => [...prev, client.config.client_id]);
+			const response = await reauthorizeMCPClient(client.config.client_id).unwrap();
+			if (response.status === "pending_oauth" && response.authorize_url) {
+				setReauthorizeFlow({
+					authorizeUrl: response.authorize_url,
+					oauthConfigId: response.oauth_config_id,
+					mcpClientId: client.config.client_id,
+				});
+			} else {
+				toast({
+					title: "Reauthorization failed",
+					description: "Unexpected response from server. Please try again.",
+					variant: "destructive",
+				});
+			}
+		} catch (error) {
+			toast({ title: "Reauthorization failed", description: getErrorMessage(error), variant: "destructive" });
+		} finally {
+			setReauthorizingClients((prev) => prev.filter((id) => id !== client.config.client_id));
 		}
 	};
 
@@ -707,10 +783,12 @@ export default function MCPClientsTable({
 													hasDeleteAccess={hasDeleteMCPClientAccess}
 													isReconnecting={reconnectingClients.includes(c.config.client_id)}
 													isAuthorizing={authorizingClients.includes(c.config.client_id)}
+													isReauthorizing={reauthorizingClients.includes(c.config.client_id)}
 													isPerUserAuth={isPerUserAuth}
 													onEdit={handleRowClick}
 													onReconnect={(client) => void handleReconnect(client)}
 													onAuthorize={(client) => void handleStartBootstrap(client)}
+													onReauthorize={(client) => void handleReauthorize(client)}
 													onDelete={setClientToDelete}
 												/>
 											</TableCell>
@@ -764,6 +842,32 @@ export default function MCPClientsTable({
 			</div>
 
 			{formOpen && <ClientForm open={formOpen} onClose={() => setFormOpen(false)} onSaved={handleSaved} />}
+			{reauthorizeFlow && (
+				<OAuth2Authorizer
+					open={!!reauthorizeFlow}
+					onClose={() => setReauthorizeFlow(null)}
+					onSuccess={() => {
+						toast({ title: "Success", description: "MCP client re-authorized successfully" });
+						setReauthorizeFlow(null);
+						if (refetch) void refetch();
+					}}
+					onError={(error) => {
+						toast({ title: "Reauthorization failed", description: error, variant: "destructive" });
+					}}
+					onConflict={() => {
+						// 409: the flow's completion raced (popup postMessage vs.
+						// status polling both call complete-oauth) or this was a
+						// double submit. Either way the credential is already live
+						// server-side, so treat it as success rather than an error.
+						toast({ title: "Success", description: "MCP client re-authorized successfully" });
+						setReauthorizeFlow(null);
+						if (refetch) void refetch();
+					}}
+					authorizeUrl={reauthorizeFlow.authorizeUrl}
+					oauthConfigId={reauthorizeFlow.oauthConfigId}
+					mcpClientId={reauthorizeFlow.mcpClientId}
+				/>
+			)}
 		</div>
 	);
 }

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -259,6 +259,17 @@ export const mcpApi = baseApi.injectEndpoints({
 			}),
 		}),
 
+		// Redo the OAuth consent dance for an already-authorized shared
+		// (auth_type 'oauth') MCP client sitting in needs_reauth — without
+		// delete-and-recreate. Same response shape as initiateMCPClientVerification;
+		// the caller drives the same OAuth2Authorizer dialog.
+		reauthorizeMCPClient: builder.mutation<InitiateMCPClientVerificationResponse, string>({
+			query: (mcpClientId) => ({
+				url: `/mcp/client/${mcpClientId}/reauthorize`,
+				method: "POST",
+			}),
+		}),
+
 		// Verify a pending_verification per_user_headers MCP client by submitting
 		// admin sample header values. Backend runs verify + discover synchronously,
 		// persists DiscoveredTools, and reconnects.
@@ -291,5 +302,6 @@ export const {
 	useLazyGetOAuthConfigStatusQuery,
 	useCompleteOAuthFlowMutation,
 	useInitiateMCPClientVerificationMutation,
+	useReauthorizeMCPClientMutation,
 	useVerifyMCPClientHeadersMutation,
 } = mcpApi;


### PR DESCRIPTION
## Summary

Adds a `POST /api/mcp/client/{id}/reauthorize` endpoint that lets admins redo the OAuth consent flow for an already-authorized shared (`auth_type='oauth'`) MCP client without deleting and recreating it. Previously, when a shared client's token entered `needs_reauth`, the only workaround was to recreate the client entirely. This endpoint initiates a new admin-mode OAuth flow, opens the upstream provider's consent page via the existing `OAuth2Authorizer` dialog, and reconnects the client once the new token is written.

## Changes

- Adds `MCPAuthModeAdmin` to the `MCPAuthMode` enum. Unlike per-identity modes, an admin-mode flow has no identity column — it is scoped to the MCP client's shared credential alone, keyed by `(flow_mode='admin', mcp_client_id)`.

- Merges `CreateOauthToken` (previously a plain insert for shared flows) and `CreateOauthUserToken` (previously an upserting method for per-identity flows) into a single `CreateOauthToken` that upserts for all auth modes. The shared flow now needs upsert semantics too: reauthorizing an already-authorized shared client must update the existing token row rather than insert a duplicate that would violate the partial unique index.

- Removes `CreateOauthUserToken` from the `ConfigStore` interface and all implementations; all callers now use `CreateOauthToken`.

- Adds `GetOauthFlowByID`, a deliberately separate admin-mode-only counterpart to `GetOauthUserSessionByID`. The separation enforces a security boundary: a caller-supplied flow ID from a per-user-facing endpoint can never reach an admin-mode row's PKCE state, and vice versa.

- Adds `BuildAdminUpstreamAuthorizeURL` to `OAuth2Provider`, backed by `GetOauthFlowByID`, for the same reason — the per-user `BuildUpstreamAuthorizeURL` must never resolve an admin-mode flow.

- Extends `GetOauthUserSessionByModeIdentityAndMCPClient` to handle `MCPAuthModeAdmin`: admin mode skips the identity-required guard and matches on `(flow_mode='admin', mcp_client_id)` alone.

- Extends `InitiateUserOAuthFlow` with an `MCPAuthModeAdmin` branch that creates a flow row with no identity columns and skips the temp-token mint (admin reauth is always dashboard-initiated, never a shareable magic link).

- Adds the `reauthorizeMCPClient` HTTP handler and registers `POST /api/mcp/client/{id}/reauthorize`. Rejects non-`oauth` auth types and clients that have not completed initial authorization.

- Extends `completeMCPClientOAuth` to distinguish a genuine replay from a post-reauth completion when `PendingOAuthConfigJSON` is already cleared: for `auth_type='oauth'` clients, it now reconnects the client rather than returning a conflict error.

- Adds a **Reauthorize** button to `MCPClientSheet` that appears when `state === 'needs_reauth'`, drives the existing `OAuth2Authorizer` dialog with the URL returned by the new endpoint, and reconnects on success. Updates the `needs_reauth` description to reflect that reauth is now available.

- Adds `useReauthorizeMCPClientMutation` to the MCP API slice.

- Adds tests covering the admin-mode flow lookup, `GetOauthFlowByID`'s security boundary, `InitiateUserOAuthFlow` admin-mode row creation with no identity, and the row-reuse behavior on repeated initiation for the same binding.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/oauth2/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Create a shared `auth_type='oauth'` MCP client and complete its initial authorization.
2. Manually set the token's `status` to `needs_reauth` in the database (or trigger a 401/400 from the upstream provider during a refresh cycle).
3. Open the client's sheet in the dashboard — the **Reauthorize** button should appear.
4. Click **Reauthorize**; the `OAuth2Authorizer` popup should open pointing at the upstream provider's consent page.
5. Complete consent; the client should reconnect and the `needs_reauth` state should clear.
6. Confirm that calling `POST /reauthorize` on a `per_user_oauth` client returns `400`.
7. Confirm that calling `POST /reauthorize` on a client with no `oauth_config_id` returns `400`.

## Breaking changes

- [x] Yes
- [ ] No

`CreateOauthUserToken` has been removed from the `ConfigStore` interface. Any external implementation of `ConfigStore` must replace it with the unified `CreateOauthToken`, which now handles all auth modes including shared. The method signature is identical; the only behavioral difference is that `CreateOauthToken` now also upserts for shared-mode rows.

## Security considerations

- `GetOauthFlowByID` and `BuildAdminUpstreamAuthorizeURL` are scoped exclusively to `flow_mode='admin'` rows. A caller-supplied flow ID from any per-user-facing endpoint cannot reach an admin flow's PKCE verifier or state token through these paths.
- `GetOauthUserSessionByID` retains its existing exclusion of admin-mode rows, preserving the reverse boundary.
- The `MCPAuthModeAdmin` branch in `InitiateUserOAuthFlow` never mints a temp token, so no shareable magic link is produced for an admin reauth flow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable