### PR TITLE
feat: retain admin bootstrap credential for periodic per-user MCP tool discovery refresh

### DIFF
--- a/core/mcp/admin_tool_discovery_test.go
+++ b/core/mcp/admin_tool_discovery_test.go
@@ -1,0 +1,290 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Test doubles and helpers shared by the performAdminToolDiscovery tests
+// below and the ClientToolSyncer.performSync tests in toolsync_test.go.
+// =============================================================================
+
+// fakeAdminCredStore is a schemas.MCPCredentialStore test double whose
+// AdminConnectionHeaders return value (and call count) is fully
+// configurable. The other methods are unused by performAdminToolDiscovery /
+// performSync but must exist to satisfy the interface.
+type fakeAdminCredStore struct {
+	mu      sync.Mutex
+	headers http.Header
+	err     error
+	calls   int
+}
+
+func (f *fakeAdminCredStore) ConnectionHeaders(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return http.Header{}, nil
+}
+
+func (f *fakeAdminCredStore) RequestHeaders(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return http.Header{}, nil
+}
+
+func (f *fakeAdminCredStore) RequiresPerCallConnection(_ *schemas.MCPClientConfig) bool {
+	return true
+}
+
+func (f *fakeAdminCredStore) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
+	return nil
+}
+
+func (f *fakeAdminCredStore) AdminConnectionHeaders(_ context.Context, _ *schemas.MCPClientConfig) (http.Header, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.headers, nil
+}
+
+func (f *fakeAdminCredStore) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// adminDiscoveryRecorder captures the inbound headers of every HTTP request
+// the fake upstream MCP server (below) receives, so tests can assert on
+// exactly what performAdminToolDiscovery put on the wire.
+type adminDiscoveryRecorder struct {
+	mu      sync.Mutex
+	headers []http.Header
+	methods []string
+}
+
+func (r *adminDiscoveryRecorder) add(method string, h http.Header) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.headers = append(r.headers, h.Clone())
+	r.methods = append(r.methods, method)
+}
+
+// headerValues returns every recorded value for name, one per POST (JSON-RPC)
+// request received. An ephemeral admin-discovery connection issues at least
+// an "initialize" and a "tools/list" call over the same transport, both
+// carrying whatever headers transport.WithHTTPHeaders configured, so a
+// non-empty caller-supplied header should show up on every entry. DELETE
+// requests (session termination on client.Close(), issued by the underlying
+// MCP client library without the custom headers) are excluded — they carry
+// no application-level data and aren't part of what this test verifies.
+func (r *adminDiscoveryRecorder) headerValues(name string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []string
+	for i, h := range r.headers {
+		if r.methods[i] == http.MethodDelete {
+			continue
+		}
+		out = append(out, h.Get(name))
+	}
+	return out
+}
+
+// buildAdminDiscoveryHTTPServer starts a real streamable-HTTP MCP server
+// (one "echo" tool) behind an httptest server whose middleware records the
+// inbound headers of every request. Used to drive
+// VerifyPerUserOAuthConnection / VerifyHeadersConnection (and therefore
+// performAdminToolDiscovery) through a real connect-discover-close cycle
+// instead of mocking them out, so the header plumbing is verified at the
+// wire rather than assumed.
+func buildAdminDiscoveryHTTPServer(t *testing.T) (*httptest.Server, *adminDiscoveryRecorder) {
+	t.Helper()
+
+	s := server.NewMCPServer("test-admin-discovery", "1.0.0", server.WithToolCapabilities(true))
+	echoTool := mcpgo.NewTool("echo",
+		mcpgo.WithDescription("Echo tool"),
+		mcpgo.WithString("message", mcpgo.Required(), mcpgo.Description("message")),
+	)
+	s.AddTool(echoTool, func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		msg, _ := req.GetArguments()["message"].(string)
+		return mcpgo.NewToolResultText(msg), nil
+	})
+
+	streamable := server.NewStreamableHTTPServer(s)
+	rec := &adminDiscoveryRecorder{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.add(r.Method, r.Header)
+		streamable.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts, rec
+}
+
+// =============================================================================
+// MCPManager.performAdminToolDiscovery
+// =============================================================================
+
+// TestPerformAdminToolDiscovery_PerUserOAuth_ExtractsBearerTokenAndDispatches
+// confirms the per_user_oauth branch trims the "Bearer " prefix off the
+// resolved Authorization header and reaches VerifyPerUserOAuthConnection —
+// verified at the wire (the fake upstream sees the exact same bearer token),
+// not just by dispatch happening.
+func TestPerformAdminToolDiscovery_PerUserOAuth_ExtractsBearerTokenAndDispatches(t *testing.T) {
+	ts, rec := buildAdminDiscoveryHTTPServer(t)
+
+	cred := &fakeAdminCredStore{headers: http.Header{"Authorization": []string{"Bearer admin-secret-token"}}}
+	m := &MCPManager{credStore: cred, logger: &MockLogger{}}
+
+	config := &schemas.MCPClientConfig{
+		ID:               "client-1",
+		Name:             "oauth-client",
+		AuthType:         schemas.MCPAuthTypePerUserOauth,
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar(ts.URL),
+	}
+
+	tools, mapping, err := m.performAdminToolDiscovery(context.Background(), config)
+	require.NoError(t, err)
+	require.Contains(t, tools, "oauth-client-echo", "discovered tool should be present, prefixed by client name")
+	require.Equal(t, "echo", mapping["echo"])
+	require.Equal(t, 1, cred.callCount())
+
+	authVals := rec.headerValues("Authorization")
+	require.NotEmpty(t, authVals, "upstream should have received at least one request carrying Authorization")
+	for _, v := range authVals {
+		require.Equal(t, "Bearer admin-secret-token", v, "the exact resolved bearer token must reach the upstream unmodified")
+	}
+}
+
+// TestPerformAdminToolDiscovery_PerUserOAuth_EmptyBearerToken_ErrorsWithoutDialing
+// pins the empty-token guard: if the resolved Authorization header trims
+// down to an empty token, performAdminToolDiscovery must fail fast with its
+// own error instead of ever attempting a connection.
+func TestPerformAdminToolDiscovery_PerUserOAuth_EmptyBearerToken_ErrorsWithoutDialing(t *testing.T) {
+	cred := &fakeAdminCredStore{headers: http.Header{}} // no Authorization header at all
+	m := &MCPManager{credStore: cred, logger: &MockLogger{}}
+
+	config := &schemas.MCPClientConfig{
+		ID:       "client-1b",
+		Name:     "oauth-client",
+		AuthType: schemas.MCPAuthTypePerUserOauth,
+		// Deliberately no ConnectionString: if the code tried to dial, it
+		// would fail on this instead, masking whether the empty-token guard
+		// ran first. Its absence here proves the guard short-circuits.
+	}
+
+	tools, mapping, err := m.performAdminToolDiscovery(context.Background(), config)
+	require.Error(t, err)
+	require.Nil(t, tools)
+	require.Nil(t, mapping)
+	require.Contains(t, err.Error(), "admin credential resolved no access token")
+}
+
+// TestPerformAdminToolDiscovery_PerUserHeaders_ConvertsHeadersAndDispatches
+// confirms the per_user_headers branch converts the resolved http.Header
+// into a map[string]string correctly (every declared value present, none
+// dropped or duplicated) and reaches VerifyHeadersConnection — verified at
+// the wire.
+func TestPerformAdminToolDiscovery_PerUserHeaders_ConvertsHeadersAndDispatches(t *testing.T) {
+	ts, rec := buildAdminDiscoveryHTTPServer(t)
+
+	cred := &fakeAdminCredStore{headers: http.Header{
+		"X-Api-Key":   []string{"admin-key-1"},
+		"X-Tenant-Id": []string{"tenant-42"},
+	}}
+	m := &MCPManager{credStore: cred, logger: &MockLogger{}}
+
+	config := &schemas.MCPClientConfig{
+		ID:                "client-2",
+		Name:              "headers-client",
+		AuthType:          schemas.MCPAuthTypePerUserHeaders,
+		ConnectionType:    schemas.MCPConnectionTypeHTTP,
+		ConnectionString:  schemas.NewSecretVar(ts.URL),
+		PerUserHeaderKeys: []string{"x-api-key", "x-tenant-id"},
+	}
+
+	tools, mapping, err := m.performAdminToolDiscovery(context.Background(), config)
+	require.NoError(t, err)
+	require.Contains(t, tools, "headers-client-echo")
+	require.Equal(t, "echo", mapping["echo"])
+	require.Equal(t, 1, cred.callCount())
+
+	apiKeyVals := rec.headerValues("X-Api-Key")
+	require.NotEmpty(t, apiKeyVals)
+	for _, v := range apiKeyVals {
+		require.Equal(t, "admin-key-1", v)
+	}
+
+	tenantVals := rec.headerValues("X-Tenant-Id")
+	require.NotEmpty(t, tenantVals)
+	for _, v := range tenantVals {
+		require.Equal(t, "tenant-42", v)
+	}
+}
+
+// TestPerformAdminToolDiscovery_UnsupportedAuthType_ReturnsError confirms
+// every non-per-user auth type falls into the default branch and errors
+// instead of attempting discovery — shared auth types have no distinct
+// "admin" credential to sync with.
+func TestPerformAdminToolDiscovery_UnsupportedAuthType_ReturnsError(t *testing.T) {
+	authTypes := []schemas.MCPAuthType{
+		schemas.MCPAuthTypeNone,
+		schemas.MCPAuthTypeHeaders,
+		schemas.MCPAuthTypeOauth,
+		schemas.MCPAuthType("something_unknown"),
+	}
+
+	for _, authType := range authTypes {
+		t.Run(string(authType), func(t *testing.T) {
+			cred := &fakeAdminCredStore{headers: http.Header{"Authorization": []string{"Bearer x"}}}
+			m := &MCPManager{credStore: cred, logger: &MockLogger{}}
+
+			config := &schemas.MCPClientConfig{
+				ID:       "client-3",
+				Name:     "shared-client",
+				AuthType: authType,
+			}
+
+			tools, mapping, err := m.performAdminToolDiscovery(context.Background(), config)
+			require.Error(t, err)
+			require.Nil(t, tools)
+			require.Nil(t, mapping)
+			require.True(t, strings.Contains(err.Error(), "admin tool discovery not supported for auth_type"))
+			require.Zero(t, cred.callCount(), "unsupported auth types must not resolve admin credentials")
+		})
+	}
+}
+
+// TestPerformAdminToolDiscovery_CredStoreError_Propagates confirms a
+// credStore.AdminConnectionHeaders failure is wrapped and returned as-is,
+// without attempting any connection.
+func TestPerformAdminToolDiscovery_CredStoreError_Propagates(t *testing.T) {
+	credErr := errors.New("admin credential store unavailable")
+	cred := &fakeAdminCredStore{err: credErr}
+	m := &MCPManager{credStore: cred, logger: &MockLogger{}}
+
+	config := &schemas.MCPClientConfig{
+		ID:       "client-4",
+		Name:     "oauth-client",
+		AuthType: schemas.MCPAuthTypePerUserOauth,
+	}
+
+	tools, mapping, err := m.performAdminToolDiscovery(context.Background(), config)
+	require.Error(t, err)
+	require.Nil(t, tools)
+	require.Nil(t, mapping)
+	require.True(t, errors.Is(err, credErr), "expected the credStore error to be wrapped (%%w), got: %v", err)
+	require.Contains(t, err.Error(), "failed to resolve admin credential")
+}

--- a/core/mcp/auth_retry_test.go
+++ b/core/mcp/auth_retry_test.go
@@ -240,6 +240,10 @@ func (s *authRetryCredStore) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.
 	return s.forceRefreshErr
 }
 
+func (s *authRetryCredStore) AdminConnectionHeaders(_ context.Context, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return http.Header{}, nil
+}
+
 // newAuthRetryClientState builds a minimal MCPClientState + prefixed tool
 // name pair for the tests below. destructive/idempotent (both optional,
 // nil = unset) populate the tool's MCPToolAnnotations so the opt-out gate

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -790,6 +790,40 @@ func (m *MCPManager) VerifyHeadersConnection(ctx context.Context, config *schema
 	return tools, toolNameMapping, nil
 }
 
+// performAdminToolDiscovery resolves the retained admin bootstrap credential
+// for a per_user_oauth/per_user_headers client (via credStore.AdminConnectionHeaders)
+// and runs a one-shot ephemeral connect-discover-close cycle, reusing the
+// exact same verification functions the one-time bootstrap flow itself uses
+// (VerifyPerUserOAuthConnection / VerifyHeadersConnection) — this is the
+// periodic tool-syncer's per-user counterpart to reusing a live Conn for
+// shared clients (see ClientToolSyncer.performSync).
+func (m *MCPManager) performAdminToolDiscovery(ctx context.Context, config *schemas.MCPClientConfig) (map[string]schemas.ChatTool, map[string]string, error) {
+	if config.AuthType != schemas.MCPAuthTypePerUserOauth && config.AuthType != schemas.MCPAuthTypePerUserHeaders {
+		return nil, nil, fmt.Errorf("admin tool discovery not supported for auth_type %q", config.AuthType)
+	}
+
+	headers, err := m.credStore.AdminConnectionHeaders(ctx, config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve admin credential: %w", err)
+	}
+	switch config.AuthType {
+	case schemas.MCPAuthTypePerUserOauth:
+		accessToken := strings.TrimPrefix(headers.Get("Authorization"), "Bearer ")
+		if accessToken == "" {
+			return nil, nil, fmt.Errorf("admin credential resolved no access token")
+		}
+		return m.VerifyPerUserOAuthConnection(ctx, config, accessToken)
+	case schemas.MCPAuthTypePerUserHeaders:
+		userHeaders := make(map[string]string, len(headers))
+		for k := range headers {
+			userHeaders[k] = headers.Get(k)
+		}
+		return m.VerifyHeadersConnection(ctx, config, userHeaders)
+	default:
+		return nil, nil, fmt.Errorf("admin tool discovery not supported for auth_type %q", config.AuthType)
+	}
+}
+
 // SetClientTools updates the tool map and name mapping for an existing client.
 // This is used to populate tools discovered during per-user OAuth verification,
 // where tool discovery happens separately from client creation.

--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -7,6 +7,7 @@
 package credstore
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -23,6 +24,10 @@ type resolver interface {
 	// ForceRefresh unconditionally refreshes the credential backing config.
 	// See schemas.MCPCredentialStore.ForceRefresh for the full contract.
 	ForceRefresh(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) error
+	// AdminConnectionHeaders resolves the retained admin bootstrap-verification
+	// credential's connection headers. See schemas.MCPCredentialStore.AdminConnectionHeaders
+	// for the full contract.
+	AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error)
 }
 
 // CredStore routes credential resolution by MCPAuthType. Implements
@@ -93,6 +98,15 @@ func (s *CredStore) ForceRefresh(ctx *schemas.BifrostContext, config *schemas.MC
 		return err
 	}
 	return r.ForceRefresh(ctx, config)
+}
+
+// AdminConnectionHeaders implements schemas.MCPCredentialStore.
+func (s *CredStore) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	r, err := s.resolverFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return r.AdminConnectionHeaders(ctx, config)
 }
 
 // resolverFor returns the resolver matching config.AuthType, or an error if

--- a/core/mcp/credstore/none.go
+++ b/core/mcp/credstore/none.go
@@ -1,6 +1,8 @@
 package credstore
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -21,4 +23,10 @@ func (r *noneResolver) RequiresPerCallConnection() bool { return false }
 // ForceRefresh is a no-op — there is no credential to refresh.
 func (r *noneResolver) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
 	return nil
+}
+
+// AdminConnectionHeaders is not supported for this auth type — there is no
+// separate "admin" credential distinct from the one used for real calls.
+func (r *noneResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("admin connection headers not supported for auth_type %q", "none")
 }

--- a/core/mcp/credstore/none_test.go
+++ b/core/mcp/credstore/none_test.go
@@ -1,0 +1,26 @@
+package credstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestNoneResolverAdminConnectionHeadersReturnsError confirms noneResolver's
+// stub AdminConnectionHeaders returns a plain (non-nil, non-panicking) error
+// rather than ever being reachable in production — auth_type "none" has no
+// separate admin credential, so the periodic tool syncer's per-user
+// discovery path (see ClientToolSyncer.performSync) never dispatches here.
+func TestNoneResolverAdminConnectionHeadersReturnsError(t *testing.T) {
+	resolver := &noneResolver{}
+	config := &schemas.MCPClientConfig{ID: "client-1", Name: "Test Client"}
+
+	headers, err := resolver.AdminConnectionHeaders(context.Background(), config)
+	if err == nil {
+		t.Fatal("expected a non-nil error for auth_type \"none\"")
+	}
+	if headers != nil {
+		t.Errorf("expected nil headers alongside the error, got %v", headers)
+	}
+}

--- a/core/mcp/credstore/per_user_headers.go
+++ b/core/mcp/credstore/per_user_headers.go
@@ -1,6 +1,7 @@
 package credstore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -73,6 +74,25 @@ func (r *perUserHeadersResolver) RequiresPerCallConnection() bool { return true 
 // refresh.
 func (r *perUserHeadersResolver) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
 	return nil
+}
+
+// AdminConnectionHeaders resolves the retained admin header credential (see
+// verifyMCPClientHeaders' persistence call in transports/bifrost-http/handlers/mcp.go)
+// for periodic tool-discovery refresh. Reuses missingRequiredHeaderKeys and
+// buildPerUserHeaderValues below — same schema-drift and value-filtering
+// logic ConnectionHeaders applies for a real caller's credential.
+func (r *perUserHeadersResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	if r.provider == nil {
+		return nil, fmt.Errorf("per-user headers requires an MCPHeadersProvider but none is configured")
+	}
+	cred, err := r.provider.GetCredentialByMode(ctx, schemas.MCPAuthModeAdmin, "", config.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load admin header credential for %s: %w", config.Name, err)
+	}
+	if missing := missingRequiredHeaderKeys(config.PerUserHeaderKeys, cred.Headers); len(missing) > 0 {
+		return nil, fmt.Errorf("admin header credential for %s is missing required keys: %v", config.Name, missing)
+	}
+	return buildPerUserHeaderValues(config.PerUserHeaderKeys, cred.Headers), nil
 }
 
 // buildAuthRequiredError creates a pending mcp_per_user_header_flows row

--- a/core/mcp/credstore/per_user_headers_test.go
+++ b/core/mcp/credstore/per_user_headers_test.go
@@ -12,11 +12,23 @@ import (
 // fakeMCPHeadersProvider implements schemas.MCPHeadersProvider. Only
 // GetCredentialByMode and InitiateUserSubmissionFlow need real behavior for
 // the ConnectionHeaders re-auth path exercised here; the rest are unused.
+// GetCredentialByMode is configurable via credential/credentialErr for the
+// AdminConnectionHeaders tests below — neither field set (the zero value)
+// preserves the original ErrHeadersCredentialNotFound stub behavior.
 type fakeMCPHeadersProvider struct {
 	frontendURL string
+
+	credential    *schemas.MCPHeadersUserCredential
+	credentialErr error
 }
 
 func (f *fakeMCPHeadersProvider) GetCredentialByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*schemas.MCPHeadersUserCredential, error) {
+	if f.credentialErr != nil {
+		return nil, f.credentialErr
+	}
+	if f.credential != nil {
+		return f.credential, nil
+	}
 	return nil, schemas.ErrHeadersCredentialNotFound
 }
 
@@ -83,4 +95,94 @@ func TestPerUserHeadersResolverConnectionHeadersTempTokenReminder(t *testing.T) 
 			}
 		})
 	}
+}
+
+// TestPerUserHeadersResolverAdminConnectionHeaders covers
+// perUserHeadersResolver.AdminConnectionHeaders: the retained admin header
+// credential lookup used by the periodic tool syncer's per-user path (see
+// ClientToolSyncer.performSync / MCPManager.performAdminToolDiscovery), as
+// distinct from ConnectionHeaders' real-caller path exercised above.
+func TestPerUserHeadersResolverAdminConnectionHeaders(t *testing.T) {
+	config := &schemas.MCPClientConfig{
+		ID:                "client-1",
+		Name:              "Test Client",
+		PerUserHeaderKeys: []string{"authorization", "x-tenant-id"},
+	}
+
+	t.Run("success delegates to provider and returns filtered header values", func(t *testing.T) {
+		provider := &fakeMCPHeadersProvider{credential: &schemas.MCPHeadersUserCredential{
+			MCPClientID: config.ID,
+			AuthMode:    schemas.MCPAuthModeAdmin,
+			Headers: map[string]string{
+				"authorization": "Bearer admin-value",
+				"x-tenant-id":   "tenant-42",
+				"x-extra":       "should-not-appear", // not declared in PerUserHeaderKeys
+			},
+			Status: schemas.MCPHeadersUserCredentialStatusActive,
+		}}
+		resolver := &perUserHeadersResolver{provider: provider}
+
+		headers, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := headers.Get("Authorization"), "Bearer admin-value"; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		if got, want := headers.Get("X-Tenant-Id"), "tenant-42"; got != want {
+			t.Errorf("X-Tenant-Id = %q, want %q", got, want)
+		}
+		if got := headers.Get("X-Extra"); got != "" {
+			t.Errorf("X-Extra leaked into output: %q, want empty (not declared in PerUserHeaderKeys)", got)
+		}
+	})
+
+	t.Run("nil provider returns an error", func(t *testing.T) {
+		resolver := &perUserHeadersResolver{provider: nil}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err == nil {
+			t.Fatal("expected an error when provider is nil")
+		}
+		if !strings.Contains(err.Error(), "MCPHeadersProvider") {
+			t.Errorf("error = %q, expected to mention the missing MCPHeadersProvider", err.Error())
+		}
+	})
+
+	t.Run("provider error propagates", func(t *testing.T) {
+		providerErr := errors.New("credential store unavailable")
+		resolver := &perUserHeadersResolver{provider: &fakeMCPHeadersProvider{credentialErr: providerErr}}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err == nil {
+			t.Fatal("expected an error when the provider fails")
+		}
+		if !errors.Is(err, providerErr) {
+			t.Errorf("expected error to wrap the provider error, got: %v", err)
+		}
+	})
+
+	t.Run("missing required header key returns an error", func(t *testing.T) {
+		provider := &fakeMCPHeadersProvider{credential: &schemas.MCPHeadersUserCredential{
+			MCPClientID: config.ID,
+			AuthMode:    schemas.MCPAuthModeAdmin,
+			Headers: map[string]string{
+				"authorization": "Bearer admin-value",
+				// x-tenant-id intentionally absent — required by config.PerUserHeaderKeys
+			},
+			Status: schemas.MCPHeadersUserCredentialStatusNeedsUpdate,
+		}}
+		resolver := &perUserHeadersResolver{provider: provider}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err == nil {
+			t.Fatal("expected an error when a required header key is missing from the stored credential")
+		}
+		if !strings.Contains(err.Error(), "missing required keys") {
+			t.Errorf("error = %q, expected to mention missing required keys", err.Error())
+		}
+		if !strings.Contains(err.Error(), "x-tenant-id") {
+			t.Errorf("error = %q, expected to name the missing key x-tenant-id", err.Error())
+		}
+	})
 }

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -1,6 +1,7 @@
 package credstore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -104,4 +105,22 @@ func (r *perUserOAuthResolver) ForceRefresh(ctx *schemas.BifrostContext, config 
 		return fmt.Errorf("per-user OAuth requires an OAuth2Provider but none is configured")
 	}
 	return r.provider.ForceRefreshAccessToken(ctx, config)
+}
+
+// AdminConnectionHeaders resolves the retained admin bootstrap token (see
+// GetAdminAccessToken's doc comment) for periodic tool-discovery refresh.
+func (r *perUserOAuthResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	if r.provider == nil {
+		return nil, fmt.Errorf("per-user OAuth requires an OAuth2Provider but none is configured")
+	}
+	if config.OauthConfigID == nil || *config.OauthConfigID == "" {
+		return nil, fmt.Errorf("per-user OAuth client %q has no linked oauth config", config.Name)
+	}
+	accessToken, err := r.provider.GetAdminAccessToken(ctx, *config.OauthConfigID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get admin access token for MCP server %s: %w", config.Name, err)
+	}
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+accessToken)
+	return headers, nil
 }

--- a/core/mcp/credstore/per_user_oauth_test.go
+++ b/core/mcp/credstore/per_user_oauth_test.go
@@ -11,12 +11,30 @@ import (
 
 // fakeOAuth2Provider implements schemas.OAuth2Provider. Only
 // GetUserAccessTokenByMode and InitiateUserOAuthFlow need real behavior for
-// the ConnectionHeaders re-auth path exercised here; the rest are unused.
+// the ConnectionHeaders re-auth path exercised here, plus GetAdminAccessToken
+// (configurable via adminAccessToken/adminAccessTokenErr) for the
+// AdminConnectionHeaders tests below; the rest are unused.
 type fakeOAuth2Provider struct {
 	authorizeURL string
+
+	adminAccessToken    string
+	adminAccessTokenErr error
 }
 
 func (f *fakeOAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
+	return "", errors.New("not implemented")
+}
+
+// GetAdminAccessToken returns adminAccessTokenErr if set, else
+// adminAccessToken. Neither field set (the zero value) preserves the
+// original "not implemented" stub behavior for callers that don't care.
+func (f *fakeOAuth2Provider) GetAdminAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
+	if f.adminAccessTokenErr != nil {
+		return "", f.adminAccessTokenErr
+	}
+	if f.adminAccessToken != "" {
+		return f.adminAccessToken, nil
+	}
 	return "", errors.New("not implemented")
 }
 
@@ -100,4 +118,82 @@ func TestPerUserOAuthResolverConnectionHeadersTempTokenReminder(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPerUserOAuthResolverAdminConnectionHeaders covers
+// perUserOAuthResolver.AdminConnectionHeaders: the retained admin
+// bootstrap-token lookup used by the periodic tool syncer's per-user path
+// (see ClientToolSyncer.performSync / MCPManager.performAdminToolDiscovery),
+// as distinct from ConnectionHeaders' real-caller path exercised above.
+func TestPerUserOAuthResolverAdminConnectionHeaders(t *testing.T) {
+	oauthConfigID := "oauth-config-1"
+	baseConfig := &schemas.MCPClientConfig{
+		ID:            "client-1",
+		Name:          "Test Client",
+		OauthConfigID: &oauthConfigID,
+	}
+
+	t.Run("success delegates to provider and returns a Bearer header", func(t *testing.T) {
+		resolver := &perUserOAuthResolver{provider: &fakeOAuth2Provider{adminAccessToken: "admin-access-token-123"}}
+
+		headers, err := resolver.AdminConnectionHeaders(context.Background(), baseConfig)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := headers.Get("Authorization"), "Bearer admin-access-token-123"; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nil provider returns an error", func(t *testing.T) {
+		resolver := &perUserOAuthResolver{provider: nil}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), baseConfig)
+		if err == nil {
+			t.Fatal("expected an error when provider is nil")
+		}
+		if !strings.Contains(err.Error(), "OAuth2Provider") {
+			t.Errorf("error = %q, expected to mention the missing OAuth2Provider", err.Error())
+		}
+	})
+
+	t.Run("missing OauthConfigID returns an error", func(t *testing.T) {
+		resolver := &perUserOAuthResolver{provider: &fakeOAuth2Provider{adminAccessToken: "unused"}}
+		config := &schemas.MCPClientConfig{ID: "client-2", Name: "No Oauth Config"}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err == nil {
+			t.Fatal("expected an error when OauthConfigID is nil")
+		}
+		if !strings.Contains(err.Error(), "no linked oauth config") {
+			t.Errorf("error = %q, expected to mention the missing linked oauth config", err.Error())
+		}
+	})
+
+	t.Run("empty OauthConfigID returns an error", func(t *testing.T) {
+		empty := ""
+		resolver := &perUserOAuthResolver{provider: &fakeOAuth2Provider{adminAccessToken: "unused"}}
+		config := &schemas.MCPClientConfig{ID: "client-3", Name: "Empty Oauth Config", OauthConfigID: &empty}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), config)
+		if err == nil {
+			t.Fatal("expected an error when OauthConfigID is empty")
+		}
+		if !strings.Contains(err.Error(), "no linked oauth config") {
+			t.Errorf("error = %q, expected to mention the missing linked oauth config", err.Error())
+		}
+	})
+
+	t.Run("provider error propagates", func(t *testing.T) {
+		providerErr := errors.New("admin token store unavailable")
+		resolver := &perUserOAuthResolver{provider: &fakeOAuth2Provider{adminAccessTokenErr: providerErr}}
+
+		_, err := resolver.AdminConnectionHeaders(context.Background(), baseConfig)
+		if err == nil {
+			t.Fatal("expected an error when the provider fails")
+		}
+		if !errors.Is(err, providerErr) {
+			t.Errorf("expected error to wrap the provider error, got: %v", err)
+		}
+	})
 }

--- a/core/mcp/credstore/shared_headers.go
+++ b/core/mcp/credstore/shared_headers.go
@@ -1,6 +1,8 @@
 package credstore
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -39,4 +41,10 @@ func (r *sharedHeadersResolver) RequiresPerCallConnection() bool { return false 
 // ForceRefresh is a no-op — static admin-configured headers have nothing to refresh.
 func (r *sharedHeadersResolver) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
 	return nil
+}
+
+// AdminConnectionHeaders is not supported for this auth type — there is no
+// separate "admin" credential distinct from the one used for real calls.
+func (r *sharedHeadersResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("admin connection headers not supported for auth_type %q", "headers")
 }

--- a/core/mcp/credstore/shared_headers_test.go
+++ b/core/mcp/credstore/shared_headers_test.go
@@ -1,0 +1,27 @@
+package credstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestSharedHeadersResolverAdminConnectionHeadersReturnsError confirms
+// sharedHeadersResolver's stub AdminConnectionHeaders returns a plain
+// (non-nil, non-panicking) error — auth_type "headers" has no separate admin
+// credential distinct from the shared one, so the periodic tool syncer's
+// per-user discovery path (see ClientToolSyncer.performSync) never
+// dispatches here.
+func TestSharedHeadersResolverAdminConnectionHeadersReturnsError(t *testing.T) {
+	resolver := &sharedHeadersResolver{}
+	config := &schemas.MCPClientConfig{ID: "client-1", Name: "Test Client"}
+
+	headers, err := resolver.AdminConnectionHeaders(context.Background(), config)
+	if err == nil {
+		t.Fatal("expected a non-nil error for auth_type \"headers\"")
+	}
+	if headers != nil {
+		t.Errorf("expected nil headers alongside the error, got %v", headers)
+	}
+}

--- a/core/mcp/credstore/shared_oauth.go
+++ b/core/mcp/credstore/shared_oauth.go
@@ -1,6 +1,8 @@
 package credstore
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -42,4 +44,10 @@ func (r *sharedOAuthResolver) ForceRefresh(ctx *schemas.BifrostContext, config *
 		return schemas.ErrOAuth2ProviderNotAvailable
 	}
 	return r.provider.ForceRefreshAccessToken(ctx, config)
+}
+
+// AdminConnectionHeaders is not supported for this auth type — there is no
+// separate "admin" credential distinct from the one used for real calls.
+func (r *sharedOAuthResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("admin connection headers not supported for auth_type %q", "oauth")
 }

--- a/core/mcp/credstore/shared_oauth_test.go
+++ b/core/mcp/credstore/shared_oauth_test.go
@@ -1,0 +1,27 @@
+package credstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestSharedOAuthResolverAdminConnectionHeadersReturnsError confirms
+// sharedOAuthResolver's stub AdminConnectionHeaders returns a plain
+// (non-nil, non-panicking) error — auth_type "oauth" has no separate admin
+// credential distinct from the shared one, so the periodic tool syncer's
+// per-user discovery path (see ClientToolSyncer.performSync) never
+// dispatches here.
+func TestSharedOAuthResolverAdminConnectionHeadersReturnsError(t *testing.T) {
+	resolver := &sharedOAuthResolver{}
+	config := &schemas.MCPClientConfig{ID: "client-1", Name: "Test Client"}
+
+	headers, err := resolver.AdminConnectionHeaders(context.Background(), config)
+	if err == nil {
+		t.Fatal("expected a non-nil error for auth_type \"oauth\"")
+	}
+	if headers != nil {
+		t.Errorf("expected nil headers alongside the error, got %v", headers)
+	}
+}

--- a/core/mcp/reauth_state_test.go
+++ b/core/mcp/reauth_state_test.go
@@ -64,6 +64,10 @@ func (expiredOAuthCredStore) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.
 	return fmt.Errorf("refresh token rejected by upstream OAuth server, re-authentication required: %w", schemas.ErrOAuth2TokenExpired)
 }
 
+func (expiredOAuthCredStore) AdminConnectionHeaders(_ context.Context, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 // newSharedOAuthClientConfig builds a minimal shared-OAuth (auth_type=oauth,
 // persistent-connection) MCP client config for the connectToMCPClient tests
 // below. ConnectionType is HTTP so the failure happens at the
@@ -129,6 +133,10 @@ func (genericFailureCredStore) RequiresPerCallConnection(_ *schemas.MCPClientCon
 
 func (genericFailureCredStore) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
 	return nil
+}
+
+func (genericFailureCredStore) AdminConnectionHeaders(_ context.Context, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func TestConnectToMCPClient_GenericFailure_StaysDisconnected(t *testing.T) {

--- a/core/mcp/toolsync.go
+++ b/core/mcp/toolsync.go
@@ -115,22 +115,33 @@ func (cts *ClientToolSyncer) performSync() {
 		return
 	}
 
-	if clientState.Conn == nil {
-		cts.manager.mu.RUnlock()
-		cts.logger.Debug("%s Skipping tool sync for %s: client not connected", MCPLogPrefix, cts.clientID)
-		return
-	}
-
-	// Get the connection reference while holding the lock
 	conn := clientState.Conn
-	clientName := clientState.ExecutionConfig.Name
+	config := clientState.ExecutionConfig
+	clientName := config.Name
 	cts.manager.mu.RUnlock()
 
 	// Perform tool sync with timeout (outside of lock)
 	ctx, cancel := context.WithTimeout(context.Background(), cts.timeout)
 	defer cancel()
 
-	newTools, newMapping, err := cts.manager.runListToolsWithHooks(ctx, conn, clientName)
+	var newTools map[string]schemas.ChatTool
+	var newMapping map[string]string
+	var err error
+
+	switch {
+	case conn != nil:
+		// Shared-connection path (unchanged): reuse the live conn.
+		newTools, newMapping, err = cts.manager.runListToolsWithHooks(ctx, conn, clientName)
+	case config.AuthType == schemas.MCPAuthTypePerUserOauth || config.AuthType == schemas.MCPAuthTypePerUserHeaders:
+		// Per-user auth types never hold a persistent conn (RequiresPerCallConnection
+		// is true for both). Resolve the retained admin bootstrap credential and
+		// run a one-shot ephemeral connect-discover-close cycle instead.
+		newTools, newMapping, err = cts.manager.performAdminToolDiscovery(ctx, config)
+	default:
+		cts.logger.Debug("%s Skipping tool sync for %s: client not connected", MCPLogPrefix, cts.clientID)
+		return
+	}
+
 	if err != nil {
 		// On failure, keep existing tools intact
 		cts.logger.Warn("%s Tool sync failed for %s, keeping existing tools: %v", MCPLogPrefix, cts.clientID, err)

--- a/core/mcp/toolsync_test.go
+++ b/core/mcp/toolsync_test.go
@@ -1,0 +1,147 @@
+package mcp
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// ClientToolSyncer.performSync — the conn==nil branch widened by this
+// change. Uses fakeAdminCredStore / buildAdminDiscoveryHTTPServer from
+// admin_tool_discovery_test.go (same package).
+// =============================================================================
+
+// newSyncTestClientState builds a minimal MCPClientState + config pair for
+// the performSync tests below, mirroring newAuthRetryClientState's shape
+// (auth_retry_test.go) but with a settable AuthType and Conn.
+func newSyncTestClientState(clientID, clientName string, authType schemas.MCPAuthType, tools map[string]schemas.ChatTool) (*schemas.MCPClientState, *schemas.MCPClientConfig) {
+	config := &schemas.MCPClientConfig{
+		ID:       clientID,
+		Name:     clientName,
+		AuthType: authType,
+	}
+	state := &schemas.MCPClientState{
+		Name:            clientName,
+		ExecutionConfig: config,
+		Conn:            nil, // every test here exercises the conn==nil branch
+		ToolMap:         tools,
+		ToolNameMapping: map[string]string{},
+	}
+	return state, config
+}
+
+// TestClientToolSyncer_PerformSync_NilConn_PerUserOAuth_AttemptsAdminDiscovery
+// confirms the new behavior: a per_user_oauth client with no live conn is
+// no longer silently skipped — performSync now attempts admin tool
+// discovery (observed here via the credStore.AdminConnectionHeaders call
+// count, since RequiresPerCallConnection auth types never hold a conn to
+// reuse in the first place).
+func TestClientToolSyncer_PerformSync_NilConn_PerUserOAuth_AttemptsAdminDiscovery(t *testing.T) {
+	cred := &fakeAdminCredStore{err: errors.New("admin credential unavailable")}
+	manager := &MCPManager{
+		credStore: cred,
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+
+	existingTools := map[string]schemas.ChatTool{"oauth-client-existing": {}}
+	state, config := newSyncTestClientState("client-1", "oauth-client", schemas.MCPAuthTypePerUserOauth, existingTools)
+	manager.clientMap[config.ID] = state
+
+	syncer := NewClientToolSyncer(manager, config.ID, config.Name, time.Minute, &MockLogger{})
+	syncer.performSync()
+
+	require.Equal(t, 1, cred.callCount(), "performSync should attempt admin tool discovery (calling credStore.AdminConnectionHeaders) instead of silently skipping")
+	// Admin discovery failed, so existing tools must be kept intact (same
+	// "keep existing tools on error" contract as the shared-conn path).
+	require.Equal(t, existingTools, manager.clientMap[config.ID].ToolMap)
+}
+
+// TestClientToolSyncer_PerformSync_NilConn_PerUserHeaders_AttemptsAdminDiscovery
+// is the per_user_headers counterpart of the test above.
+func TestClientToolSyncer_PerformSync_NilConn_PerUserHeaders_AttemptsAdminDiscovery(t *testing.T) {
+	cred := &fakeAdminCredStore{err: errors.New("admin credential unavailable")}
+	manager := &MCPManager{
+		credStore: cred,
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+
+	existingTools := map[string]schemas.ChatTool{"headers-client-existing": {}}
+	state, config := newSyncTestClientState("client-2", "headers-client", schemas.MCPAuthTypePerUserHeaders, existingTools)
+	manager.clientMap[config.ID] = state
+
+	syncer := NewClientToolSyncer(manager, config.ID, config.Name, time.Minute, &MockLogger{})
+	syncer.performSync()
+
+	require.Equal(t, 1, cred.callCount(), "performSync should attempt admin tool discovery instead of silently skipping")
+	require.Equal(t, existingTools, manager.clientMap[config.ID].ToolMap)
+}
+
+// TestClientToolSyncer_PerformSync_NilConn_SharedAuthType_StillSkips is the
+// regression-risk case: a shared-connection client (e.g. "headers" or
+// "none") with Conn==nil is mid-(re)connect, not per-user. performSync must
+// keep silently skipping it exactly as before this change — it must NOT be
+// routed into admin discovery, which would be meaningless (and would call a
+// credStore method shared resolvers don't meaningfully implement).
+func TestClientToolSyncer_PerformSync_NilConn_SharedAuthType_StillSkips(t *testing.T) {
+	for _, authType := range []schemas.MCPAuthType{schemas.MCPAuthTypeHeaders, schemas.MCPAuthTypeNone, schemas.MCPAuthTypeOauth} {
+		t.Run(string(authType), func(t *testing.T) {
+			cred := &fakeAdminCredStore{err: errors.New("must never be called for shared auth types")}
+			manager := &MCPManager{
+				credStore: cred,
+				logger:    &MockLogger{},
+				clientMap: map[string]*schemas.MCPClientState{},
+			}
+
+			existingTools := map[string]schemas.ChatTool{"shared-client-existing": {}}
+			state, config := newSyncTestClientState("client-3", "shared-client", authType, existingTools)
+			manager.clientMap[config.ID] = state
+
+			syncer := NewClientToolSyncer(manager, config.ID, config.Name, time.Minute, &MockLogger{})
+			syncer.performSync()
+
+			require.Equal(t, 0, cred.callCount(), "shared clients mid-reconnect (Conn==nil) must still be silently skipped, not routed into admin discovery")
+			require.Equal(t, existingTools, manager.clientMap[config.ID].ToolMap, "skipped sync must leave the existing tool map untouched")
+			// The client must still be present (not removed) — performSync's
+			// skip path is a no-op, distinct from the "client no longer in
+			// clientMap" early-return above it.
+			_, stillExists := manager.clientMap[config.ID]
+			require.True(t, stillExists)
+		})
+	}
+}
+
+// TestClientToolSyncer_PerformSync_NilConn_PerUserOAuth_SuccessUpdatesToolMap
+// is an end-to-end happy-path check: when admin discovery succeeds, the
+// discovered tools actually replace the client's ToolMap, using a real
+// upstream HTTP MCP server (buildAdminDiscoveryHTTPServer, shared with
+// admin_tool_discovery_test.go) rather than mocking the connect/discover
+// cycle away.
+func TestClientToolSyncer_PerformSync_NilConn_PerUserOAuth_SuccessUpdatesToolMap(t *testing.T) {
+	ts, _ := buildAdminDiscoveryHTTPServer(t)
+
+	cred := &fakeAdminCredStore{headers: http.Header{"Authorization": []string{"Bearer admin-token"}}}
+	manager := &MCPManager{
+		credStore: cred,
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+
+	state, config := newSyncTestClientState("client-4", "oauth-client", schemas.MCPAuthTypePerUserOauth, map[string]schemas.ChatTool{})
+	config.ConnectionType = schemas.MCPConnectionTypeHTTP
+	config.ConnectionString = schemas.NewSecretVar(ts.URL)
+	manager.clientMap[config.ID] = state
+
+	syncer := NewClientToolSyncer(manager, config.ID, config.Name, time.Minute, &MockLogger{})
+	syncer.performSync()
+
+	require.Equal(t, 1, cred.callCount())
+	updated := manager.clientMap[config.ID].ToolMap
+	require.Contains(t, updated, "oauth-client-echo", "a successful admin-discovery cycle should populate the client's tool map")
+}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -167,6 +167,19 @@ type MCPCredentialStore interface {
 	// stale, not necessarily the credential. A no-op returning nil for auth
 	// types with nothing to refresh (none, static headers, per-user headers).
 	ForceRefresh(ctx *BifrostContext, config *MCPClientConfig) error
+
+	// AdminConnectionHeaders resolves the retained admin bootstrap-verification
+	// credential's connection headers, for periodic tool-discovery refresh
+	// (the tool syncer's per-user path — see ClientToolSyncer.performSync)
+	// rather than a real caller's per-call credential (that's ConnectionHeaders'
+	// job, which raises an interactive *MCPAuthRequiredError on a miss since
+	// there's a real caller to redirect). The syncer has no caller to redirect,
+	// so a miss here is just a plain error the syncer logs and retries next
+	// cycle. Meaningful only for per_user_oauth/per_user_headers resolvers,
+	// which keep this credential alive specifically for this purpose. Every
+	// other resolver type errors: there's no separate "admin" credential
+	// distinct from the shared one for those auth types.
+	AdminConnectionHeaders(ctx context.Context, config *MCPClientConfig) (http.Header, error)
 }
 
 // MCPConfig represents the configuration for MCP integration in Bifrost.

--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -10,6 +10,13 @@ type OAuth2Provider interface {
 	// GetAccessToken retrieves the access token for a given oauth_config_id (server-level OAuth)
 	GetAccessToken(ctx context.Context, oauthConfigID string) (string, error)
 
+	// GetAdminAccessToken is GetAccessToken's admin-mode counterpart:
+	// resolves the retained bootstrap-verification credential for a
+	// per_user_oauth client's periodic tool-discovery refresh (see
+	// ClientToolSyncer.performSync's per-user branch), rather than the
+	// shared-mode production credential.
+	GetAdminAccessToken(ctx context.Context, oauthConfigID string) (string, error)
+
 	// ValidateToken checks if the token is still valid
 	ValidateToken(ctx context.Context, oauthConfigID string) (bool, error)
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -462,6 +462,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"create_mcp_oauth_flows_table"}, run: migrationCreateMCPOauthFlowsTable},
 	{IDs: []string{"drop_oauth_config_pkce_columns"}, run: migrationDropOauthConfigPKCEColumns},
 	{IDs: []string{"drop_oauth_config_token_id_column"}, run: migrationDropOauthConfigTokenIDColumn},
+	{IDs: []string{"add_mcp_admin_auth_mode_indexes"}, run: migrationAddMCPAdminAuthModeIndexes},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -11682,4 +11683,55 @@ func migrationDropOauthConfigTokenIDColumn(ctx context.Context, db *gorm.DB, log
 		return fmt.Errorf("error running drop_oauth_config_token_id_column migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationAddMCPAdminAuthModeIndexes adds partial unique indexes for
+// auth_mode='admin' rows on mcp_oauth_tokens and mcp_per_user_header_credentials,
+// mirroring each table's existing partial unique indexes for its other
+// auth_mode values (see idx_mcp_oauth_tokens_shared_mcp and the
+// idx_mcp_per_user_header_credentials_{user,vk,session}_mcp trio). An
+// 'admin'-mode row is the retained bootstrap-verification credential for a
+// per_user_oauth/per_user_headers MCP client — exactly one per mcp_client_id,
+// used only for periodic tool-discovery refresh, never real end-user calls.
+func migrationAddMCPAdminAuthModeIndexes(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_admin_auth_mode_indexes"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	return RunSingleMigration(ctx, nil, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasTable(&tables.TableMCPOauthToken{}) {
+				if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_oauth_tokens_admin_mcp
+					ON mcp_oauth_tokens (mcp_client_id)
+					WHERE auth_mode = 'admin' AND mcp_client_id IS NOT NULL AND mcp_client_id != ''`).Error; err != nil {
+					return fmt.Errorf("create admin partial unique index on mcp_oauth_tokens: %w", err)
+				}
+			}
+			if mg.HasTable(&tables.TableMCPPerUserHeaderCredential{}) {
+				if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_per_user_header_credentials_admin_mcp
+					ON mcp_per_user_header_credentials (mcp_client_id)
+					WHERE auth_mode = 'admin' AND mcp_client_id IS NOT NULL AND mcp_client_id != ''`).Error; err != nil {
+					return fmt.Errorf("create admin partial unique index on mcp_per_user_header_credentials: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasTable(&tables.TableMCPOauthToken{}) {
+				if err := tx.Exec(`DROP INDEX IF EXISTS idx_mcp_oauth_tokens_admin_mcp`).Error; err != nil {
+					return fmt.Errorf("drop admin partial unique index on mcp_oauth_tokens: %w", err)
+				}
+			}
+			if mg.HasTable(&tables.TableMCPPerUserHeaderCredential{}) {
+				if err := tx.Exec(`DROP INDEX IF EXISTS idx_mcp_per_user_header_credentials_admin_mcp`).Error; err != nil {
+					return fmt.Errorf("drop admin partial unique index on mcp_per_user_header_credentials: %w", err)
+				}
+			}
+			return nil
+		},
+	})
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6500,6 +6500,46 @@ func (s *RDBConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, 
 	return nil
 }
 
+// DeleteAdminOauthTokenByMCPClientID deletes the retained admin-mode token
+// row for mcpClientID, if one exists. idx_mcp_oauth_tokens_admin_mcp allows
+// at most one auth_mode='admin' row per mcp_client_id, so this must run
+// before retagging a fresh bootstrap-verification row to 'admin' for a
+// client that already has one from an earlier bootstrap — otherwise the
+// retag's write collides with that existing row instead of replacing it.
+func (s *RDBConfigStore) DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error {
+	if mcpClientID == "" {
+		return nil
+	}
+	result := s.DB().WithContext(ctx).
+		Where("mcp_client_id = ? AND auth_mode = ?", mcpClientID, "admin").
+		Delete(&tables.TableMCPOauthToken{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete admin oauth token by mcp client id: %w", result.Error)
+	}
+	return nil
+}
+
+// GetAdminOauthTokenByConfigID resolves the single retained admin-mode token
+// row for a config — the bootstrap-verification credential kept alive for a
+// per_user_oauth client's periodic tool-discovery refresh (see
+// GetSharedOauthTokenByConfigID's doc comment for the parallel shared-mode
+// case; this mirrors it exactly, just auth_mode='admin' instead of 'shared').
+// Returns (nil, nil) when no admin token exists for this config.
+func (s *RDBConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+	if oauthConfigID == "" {
+		return nil, nil
+	}
+	var token tables.TableMCPOauthToken
+	result := s.DB().WithContext(ctx).Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "admin").First(&token)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get admin oauth token by config id: %w", result.Error)
+	}
+	return &token, nil
+}
+
 // CreateOauthConfig creates a new OAuth config
 func (s *RDBConfigStore) CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
 	result := s.DB().WithContext(ctx).Create(config)
@@ -6548,6 +6588,11 @@ func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.Tab
 			Where("auth_mode = ? AND mcp_client_id = ?", "shared", token.MCPClientID).
 			First(&existing).Error
 	case token.AuthMode == "admin" && token.MCPClientID != "":
+		// Mirrors the shared-mode branch above: exactly one admin-mode
+		// row per mcp_client_id (idx_mcp_oauth_tokens_admin_mcp), so a
+		// second admin verification for the same client must reuse this
+		// row rather than falling through to Create and violating that
+		// unique index.
 		lookupErr = dbForUpdate(txDB).
 			Where("auth_mode = ? AND mcp_client_id = ?", "admin", token.MCPClientID).
 			First(&existing).Error
@@ -6694,7 +6739,7 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 	result := s.DB().WithContext(ctx).
 		// mcp_oauth_tokens holds both shared and per-user rows; callers
 		// decide which holder types get proactive background refresh via
-		// authModes (TokenRefreshWorker.AuthModes, shared-only by default).
+		// authModes (TokenRefreshWorker.AuthModes, shared + admin by default).
 		Where("auth_mode IN ?", authModes).
 		Where("status = ?", "active").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
@@ -7324,9 +7369,14 @@ func (s *RDBConfigStore) DeleteOrphanedOauthUserTokens(ctx context.Context, olde
 // resolution nor the flow-detail prefill UX should surface them. Mirrors
 // GetOauthUserTokenByMode (which is stricter — OAuth has no needs_update
 // equivalent because tokens are opaque and resubmission is the full IdP
-// dance).
+// dance). mode can also be MCPAuthModeAdmin: the retained bootstrap
+// credential has no per-caller identity, so that case is scoped by
+// mcp_client_id + auth_mode='admin' alone.
 func (s *RDBConfigStore) GetMCPPerUserHeaderCredentialByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPPerUserHeaderCredential, error) {
-	if identity == "" || mcpClientID == "" {
+	if mcpClientID == "" {
+		return nil, nil
+	}
+	if mode != schemas.MCPAuthModeAdmin && identity == "" {
 		return nil, nil
 	}
 	var cred tables.TableMCPPerUserHeaderCredential
@@ -7344,6 +7394,10 @@ func (s *RDBConfigStore) GetMCPPerUserHeaderCredentialByMode(ctx context.Context
 	case schemas.MCPAuthModeSession:
 		result = s.DB().WithContext(ctx).
 			Where("auth_mode = ? AND session_id = ? AND mcp_client_id = ? AND status IN ?", string(schemas.MCPAuthModeSession), identity, mcpClientID, statuses).
+			First(&cred)
+	case schemas.MCPAuthModeAdmin:
+		result = s.DB().WithContext(ctx).
+			Where("auth_mode = ? AND mcp_client_id = ? AND status IN ?", "admin", mcpClientID, statuses).
 			First(&cred)
 	default:
 		return nil, fmt.Errorf("unknown auth mode: %s", mode)
@@ -7374,14 +7428,20 @@ func (s *RDBConfigStore) GetMCPPerUserHeaderCredentialByID(ctx context.Context, 
 }
 
 // UpsertMCPPerUserHeaderCredential atomically inserts or updates a credential
-// row keyed by (auth_mode, identity, mcp_client_id). Mirrors CreateOauthToken's
-// per-identity upsert branches — the row represents the (identity, mcp_client)
-// binding, so a re-submit preserves CreatedAt.
+// row keyed by (auth_mode, identity, mcp_client_id) — or, for auth_mode='admin',
+// by mcp_client_id alone, since the retained bootstrap-verification credential
+// has no per-caller identity. Mirrors CreateOauthToken's per-identity upsert
+// branches — the row represents the (identity, mcp_client) binding, so a
+// re-submit preserves CreatedAt.
 func (s *RDBConfigStore) UpsertMCPPerUserHeaderCredential(ctx context.Context, cred *tables.TableMCPPerUserHeaderCredential) error {
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var existing tables.TableMCPPerUserHeaderCredential
 		var lookupErr error
 		switch {
+		case cred.AuthMode == string(schemas.MCPAuthModeAdmin) && cred.MCPClientID != "":
+			lookupErr = dbForUpdate(tx).
+				Where("auth_mode = ? AND mcp_client_id = ?", "admin", cred.MCPClientID).
+				First(&existing).Error
 		case cred.UserID != nil && *cred.UserID != "":
 			lookupErr = dbForUpdate(tx).
 				Where("auth_mode = ? AND user_id = ? AND mcp_client_id = ?", string(schemas.MCPAuthModeUser), *cred.UserID, cred.MCPClientID).

--- a/framework/configstore/rdb_mcp_admin_auth_mode_test.go
+++ b/framework/configstore/rdb_mcp_admin_auth_mode_test.go
@@ -1,0 +1,125 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAdminOauthTokenByConfigID pins the admin-mode counterpart of
+// GetSharedOauthTokenByConfigID: it must resolve the auth_mode='admin' row
+// for a config and must not cross-match a 'shared'-mode row on the same
+// oauth_config_id, since the two modes back entirely different callers
+// (GetAdminAccessToken vs GetAccessToken).
+func TestGetAdminOauthTokenByConfigID(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-admin", AuthMode: "admin", OauthConfigID: "cfg-1", Status: "active",
+		AccessToken: "at-admin", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+		AccessToken: "at-shared", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	got, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "tok-admin", got.ID, "must resolve the admin-mode row, not the shared-mode row for the same config")
+
+	// A config with no admin-mode row at all resolves to (nil, nil).
+	got, err = s.GetAdminOauthTokenByConfigID(ctx, "cfg-no-admin")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+
+	// Empty oauthConfigID short-circuits to (nil, nil) without querying.
+	got, err = s.GetAdminOauthTokenByConfigID(ctx, "")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestGetMCPPerUserHeaderCredentialByMode_AdminMode pins the new admin
+// branch: an admin-mode row is scoped by mcp_client_id alone (identity is
+// allowed empty), while every other mode is unaffected by the widening and
+// still rejects an empty identity by returning (nil, nil).
+func TestGetMCPPerUserHeaderCredentialByMode_AdminMode(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPPerUserHeaderCredential{
+		ID: "cred-admin", MCPClientID: "client-1", AuthMode: "admin", Status: "active",
+		HeadersJSON: "{}", CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	got, err := s.GetMCPPerUserHeaderCredentialByMode(ctx, schemas.MCPAuthModeAdmin, "", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, got, "admin mode must resolve by mcp_client_id alone, with an empty identity")
+	assert.Equal(t, "cred-admin", got.ID)
+
+	for _, mode := range []schemas.MCPAuthMode{schemas.MCPAuthModeUser, schemas.MCPAuthModeVK, schemas.MCPAuthModeSession} {
+		got, err := s.GetMCPPerUserHeaderCredentialByMode(ctx, mode, "", "client-1")
+		require.NoError(t, err)
+		assert.Nil(t, got, "mode %s with an empty identity must still return nil, nil — unaffected by the admin widening", mode)
+	}
+}
+
+// TestUpsertMCPPerUserHeaderCredential_AdminMode pins the new admin
+// upsert-key case: since an admin-mode row has no per-caller identity to key
+// on, a second upsert for the same mcp_client_id must update the SAME row
+// (reusing its ID and preserving CreatedAt) instead of inserting a second
+// row — which would violate the migration's new partial unique index on
+// (mcp_client_id) WHERE auth_mode='admin'.
+func TestUpsertMCPPerUserHeaderCredential_AdminMode(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	cred := &tables.TableMCPPerUserHeaderCredential{
+		MCPClientID: "client-1",
+		AuthMode:    "admin",
+		Status:      "active",
+	}
+	require.NoError(t, cred.SetHeaders(map[string]string{"X-Api-Key": "v1"}))
+	require.NoError(t, s.UpsertMCPPerUserHeaderCredential(ctx, cred))
+	require.NotEmpty(t, cred.ID)
+	firstID := cred.ID
+	firstCreatedAt := cred.CreatedAt
+
+	// Re-upsert with a fresh in-memory row (no ID set) for the same
+	// mcp_client_id — the caller-side shape a re-submitted admin credential
+	// takes (see credentialToRow, which always builds a fresh row).
+	cred2 := &tables.TableMCPPerUserHeaderCredential{
+		MCPClientID: "client-1",
+		AuthMode:    "admin",
+		Status:      "active",
+	}
+	require.NoError(t, cred2.SetHeaders(map[string]string{"X-Api-Key": "v2"}))
+	require.NoError(t, s.UpsertMCPPerUserHeaderCredential(ctx, cred2))
+
+	assert.Equal(t, firstID, cred2.ID, "second upsert for the same mcp_client_id must reuse the same row ID")
+	// SQLite round-trips time.Time with a bare UTC-offset Location rather than
+	// time.Local, so assert.Equal (which also compares the Location pointer)
+	// would spuriously fail on an identical instant; .Equal compares the
+	// instant only.
+	assert.True(t, firstCreatedAt.Equal(cred2.CreatedAt), "second upsert must preserve the original CreatedAt: got %v, want %v", cred2.CreatedAt, firstCreatedAt)
+
+	var count int64
+	require.NoError(t, s.DB().Model(&tables.TableMCPPerUserHeaderCredential{}).
+		Where("mcp_client_id = ? AND auth_mode = ?", "client-1", "admin").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "must not insert a duplicate row for the same mcp_client_id")
+
+	got, err := s.GetMCPPerUserHeaderCredentialByMode(ctx, schemas.MCPAuthModeAdmin, "", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	headers, err := got.GetHeaders()
+	require.NoError(t, err)
+	assert.Equal(t, "v2", headers["X-Api-Key"], "stored row must reflect the second upsert's values, confirming it was an update")
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -495,9 +495,8 @@ type ConfigStore interface {
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error
 
 	// OAuth token CRUD. TableMCPOauthToken now holds every holder of an MCP
-	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session' |
-	// 'admin'), not just the shared-client credential the method names below
-	// still imply.
+	// OAuth credential (auth_mode 'shared' | 'user' | 'vk' | 'session' | 'admin'),
+	// not just the shared-client credential the method names below still imply.
 	//
 	// GetOauthTokenByID is not filtered by auth_mode: callers always feed it
 	// an ID already resolved from a trusted internal lookup (a token row just
@@ -513,10 +512,14 @@ type ConfigStore interface {
 	// needs to reach the row regardless of status to delete it. Returns
 	// (nil, nil) when no shared token exists for this config.
 	GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
+	// GetAdminOauthTokenByConfigID is GetSharedOauthTokenByConfigID's
+	// admin-mode counterpart — resolves the retained bootstrap-verification
+	// token for a per_user_oauth client's periodic tool-discovery refresh.
+	GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
 	// GetExpiringOauthTokens is filtered to authModes via `auth_mode IN
 	// (...)`. Backs TokenRefreshWorker, whose AuthModes field decides which
-	// holder types get proactive background refresh (defaults to
-	// shared-only — per-user tokens otherwise refresh lazily/inline on
+	// holder types get proactive background refresh (defaults to shared +
+	// admin — other per-user tokens otherwise refresh lazily/inline on
 	// lookup via GetOauthUserTokenByMode).
 	GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error)
 	// CreateOauthToken creates or replaces an MCP OAuth token row, any
@@ -551,6 +554,11 @@ type ConfigStore interface {
 	// leave a duplicate row behind (see GetSharedOauthTokenByConfigID's doc
 	// comment for why more than one can otherwise exist).
 	DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
+	// DeleteAdminOauthTokenByMCPClientID deletes the retained admin-mode
+	// token row for mcpClientID, if one exists — must run before retagging a
+	// fresh bootstrap-verification row to 'admin' for a client that already
+	// has one, so the retag can't collide with idx_mcp_oauth_tokens_admin_mcp.
+	DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error
 
 	// Flow-row CRUD (mcp_oauth_flows / TableMCPOauthFlow). Method names keep
 	// their historical "OauthUserSession" naming even though the backing

--- a/framework/configstore/tables/mcpheaders.go
+++ b/framework/configstore/tables/mcpheaders.go
@@ -71,7 +71,7 @@ type TableMCPPerUserHeaderCredential struct {
 	VirtualKeyID     *string   `gorm:"type:varchar(255);index" json:"virtual_key_id"`            // VK identity (vk-mode rows)
 	UserID           *string   `gorm:"type:varchar(255);index" json:"user_id"`                   // User identity (user-mode rows)
 	MCPClientID      string    `gorm:"type:varchar(255);not null;index" json:"mcp_client_id"`    // Which MCP server
-	AuthMode         string    `gorm:"type:varchar(20);not null" json:"auth_mode"`               // 'user' | 'vk' | 'session' — which identity column keys this row
+	AuthMode         string    `gorm:"type:varchar(20);not null" json:"auth_mode"`               // 'user' | 'vk' | 'session' | 'admin' — which identity column keys this row; 'admin' has none, keyed by mcp_client_id alone
 	Status           string    `gorm:"type:varchar(20);not null;default:'active'" json:"status"` // 'active' | 'orphaned' | 'needs_update'
 	HeadersJSON      string    `gorm:"type:text;not null" json:"-"`                              // Encrypted JSON map[string]string of user-supplied header values
 	EncryptionStatus string    `gorm:"type:varchar(20);default:'plain_text'" json:"-"`

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -179,7 +179,7 @@ func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
 // unused.
 type TableMCPOauthToken struct {
 	ID       string `gorm:"type:varchar(255);primaryKey" json:"id"`     // UUID
-	AuthMode string `gorm:"type:varchar(20);not null" json:"auth_mode"` // 'shared' | 'user' | 'vk' | 'session' — no DB-level CHECK constraint; validated at the application layer only, so adding a new mode later is a pure data change, not a migration
+	AuthMode string `gorm:"type:varchar(20);not null" json:"auth_mode"` // 'shared' | 'user' | 'vk' | 'session' | 'admin' — no DB-level CHECK constraint; validated at the application layer only, so adding a new mode later is a pure data change, not a migration
 	// MCPClientID and OauthConfigID are not DB-level NOT NULL: rows written by
 	// current code always populate both, but a pre-existing row whose owning
 	// oauth_config was deleted before the orphan-cleanup fix (see

--- a/framework/mcp_headers/credential_test.go
+++ b/framework/mcp_headers/credential_test.go
@@ -1,0 +1,65 @@
+package mcp_headers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// TestGetCredentialByMode_AdminMode_EmptyIdentityReachesStore pins the
+// widened guard: MCPAuthModeAdmin with an empty identity must no longer be
+// rejected locally — it must reach the store layer and, when a row exists,
+// succeed.
+func TestGetCredentialByMode_AdminMode_EmptyIdentityReachesStore(t *testing.T) {
+	store := newTestConfigStore()
+	now := time.Now()
+	store.credentials["client-1"] = &tables.TableMCPPerUserHeaderCredential{
+		ID:          "cred-admin",
+		MCPClientID: "client-1",
+		AuthMode:    "admin",
+		Status:      "active",
+		HeadersJSON: `{"X-Api-Key":"v1"}`,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	provider := newTestProvider(store)
+
+	cred, err := provider.GetCredentialByMode(context.Background(), schemas.MCPAuthModeAdmin, "", "client-1")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, "cred-admin", cred.ID)
+	assert.Equal(t, "v1", cred.Headers["X-Api-Key"])
+	assert.Equal(t, 1, store.credentialLookupCalls, "admin mode with an empty identity must reach the store layer")
+}
+
+// TestGetCredentialByMode_UserMode_EmptyIdentityStillRejected verifies the
+// admin-only widening left every other mode's guard intact: MCPAuthModeUser
+// with an empty identity must still return ErrHeadersCredentialNotFound
+// without ever reaching the store — even though the store double would
+// happily return a matching row for this mcp_client_id if called, proving
+// the rejection comes from the guard itself, not from an absent row.
+func TestGetCredentialByMode_UserMode_EmptyIdentityStillRejected(t *testing.T) {
+	store := newTestConfigStore()
+	store.credentials["client-1"] = &tables.TableMCPPerUserHeaderCredential{
+		ID:          "cred-user",
+		MCPClientID: "client-1",
+		AuthMode:    "user",
+		Status:      "active",
+		HeadersJSON: `{}`,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	provider := newTestProvider(store)
+
+	cred, err := provider.GetCredentialByMode(context.Background(), schemas.MCPAuthModeUser, "", "client-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schemas.ErrHeadersCredentialNotFound)
+	assert.Nil(t, cred)
+	assert.Equal(t, 0, store.credentialLookupCalls, "the guard must short-circuit before reaching the store for non-admin modes with an empty identity")
+}

--- a/framework/mcp_headers/main.go
+++ b/framework/mcp_headers/main.go
@@ -89,12 +89,17 @@ func (p *Provider) mcpTempTokenAuthEnabled(ctx context.Context) bool {
 
 // GetCredentialByMode looks up the active credential row for the given
 // identity dimension. Returns ErrHeadersCredentialNotFound when the row is
-// absent so callers can switch on the sentinel.
+// absent so callers can switch on the sentinel. mode can also be
+// MCPAuthModeAdmin: the retained bootstrap credential has no per-caller
+// identity, so identity is allowed empty in that case alone.
 func (p *Provider) GetCredentialByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*schemas.MCPHeadersUserCredential, error) {
 	if p.configStore == nil {
 		return nil, schemas.ErrHeadersCredentialProviderNotAvailable
 	}
-	if strings.TrimSpace(identity) == "" || strings.TrimSpace(mcpClientID) == "" {
+	if strings.TrimSpace(mcpClientID) == "" {
+		return nil, schemas.ErrHeadersCredentialNotFound
+	}
+	if mode != schemas.MCPAuthModeAdmin && strings.TrimSpace(identity) == "" {
 		return nil, schemas.ErrHeadersCredentialNotFound
 	}
 	row, err := p.configStore.GetMCPPerUserHeaderCredentialByMode(ctx, mode, identity, mcpClientID)

--- a/framework/mcp_headers/main_test.go
+++ b/framework/mcp_headers/main_test.go
@@ -28,13 +28,39 @@ type testConfigStore struct {
 	clientConfig *configstore.ClientConfig
 	headerFlows  map[string]*tables.TableMCPPerUserHeaderFlow
 	tempTokens   map[string]*tables.TempToken
+
+	// credentials backs GetMCPPerUserHeaderCredentialByMode, keyed by
+	// mcp_client_id alone (deliberately ignoring mode/identity matching) so
+	// GetCredentialByMode's own guard — not incidental store-side filtering —
+	// is what's under test. credentialLookupCalls counts invocations so a
+	// test can assert the guard short-circuited before ever reaching the
+	// store.
+	credentials           map[string]*tables.TableMCPPerUserHeaderCredential
+	credentialLookupCalls int
 }
 
 func newTestConfigStore() *testConfigStore {
 	return &testConfigStore{
 		headerFlows: make(map[string]*tables.TableMCPPerUserHeaderFlow),
 		tempTokens:  make(map[string]*tables.TempToken),
+		credentials: make(map[string]*tables.TableMCPPerUserHeaderCredential),
 	}
+}
+
+// GetMCPPerUserHeaderCredentialByMode is the test-double equivalent of the
+// real store's method of the same name. Unlike the real implementation, it
+// matches on mcp_client_id alone regardless of mode/identity — the point of
+// this double is to prove GetCredentialByMode's own identity guard (not
+// store-side row absence) decides whether a lookup is attempted at all.
+func (s *testConfigStore) GetMCPPerUserHeaderCredentialByMode(_ context.Context, _ schemas.MCPAuthMode, _, mcpClientID string) (*tables.TableMCPPerUserHeaderCredential, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.credentialLookupCalls++
+	row, ok := s.credentials[mcpClientID]
+	if !ok {
+		return nil, nil
+	}
+	return bifrost.Ptr(*row), nil
 }
 
 func (s *testConfigStore) GetClientConfig(_ context.Context) (*configstore.ClientConfig, error) {

--- a/framework/oauth2/access_token_test.go
+++ b/framework/oauth2/access_token_test.go
@@ -1,0 +1,231 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// newAccessTokenTestStore seeds an authorized oauth_config row (no token yet)
+// pointed at tokenURL for refresh calls. Mirrors seedFixtures' config shape.
+func newAccessTokenTestStore(tokenURL string) (*testConfigStore, string) {
+	store := newTestConfigStore()
+	oauthConfigID := "cfg-access-token"
+	store.oauthConfigs[oauthConfigID] = &tables.TableOauthConfig{
+		ID:          oauthConfigID,
+		ClientID:    schemas.NewSecretVar("test-client-id"),
+		TokenURL:    tokenURL,
+		RedirectURI: "http://localhost/callback",
+		Scopes:      `["read"]`,
+		Status:      "authorized",
+	}
+	return store, oauthConfigID
+}
+
+// seedAccessToken inserts a token row of the given authMode ("shared" or
+// "admin") linked to oauthConfigID.
+func seedAccessToken(store *testConfigStore, oauthConfigID, authMode, tokenID, accessToken, refreshToken string, expiresAt *time.Time) {
+	store.oauthTokens[tokenID] = &tables.TableMCPOauthToken{
+		ID:            tokenID,
+		AuthMode:      authMode,
+		OauthConfigID: oauthConfigID,
+		Status:        "active",
+		AccessToken:   accessToken,
+		RefreshToken:  refreshToken,
+		TokenType:     "Bearer",
+		ExpiresAt:     expiresAt,
+		Scopes:        "[]",
+	}
+}
+
+// accessTokenGetter abstracts over GetAccessToken and GetAdminAccessToken so
+// the four resolution cases below (active / expired-with-refresh /
+// expired-without-refresh / missing token) run once per caller and pin that
+// both funnel through the same resolveAccessToken behavior.
+type accessTokenGetter struct {
+	name     string
+	authMode string
+	get      func(p *OAuth2Provider, ctx context.Context, oauthConfigID string) (string, error)
+}
+
+var accessTokenGetters = []accessTokenGetter{
+	{
+		name:     "GetAccessToken",
+		authMode: "shared",
+		get: func(p *OAuth2Provider, ctx context.Context, oauthConfigID string) (string, error) {
+			return p.GetAccessToken(ctx, oauthConfigID)
+		},
+	},
+	{
+		name:     "GetAdminAccessToken",
+		authMode: "admin",
+		get: func(p *OAuth2Provider, ctx context.Context, oauthConfigID string) (string, error) {
+			return p.GetAdminAccessToken(ctx, oauthConfigID)
+		},
+	},
+}
+
+// TestAccessToken_ActiveToken_ReturnsItDirectly verifies a live, non-expired
+// token is returned as-is (sanitized), with no refresh call made — for both
+// GetAccessToken (shared-mode) and GetAdminAccessToken (admin-mode), since
+// both funnel through the same resolveAccessToken helper.
+func TestAccessToken_ActiveToken_ReturnsItDirectly(t *testing.T) {
+	for _, g := range accessTokenGetters {
+		t.Run(g.name, func(t *testing.T) {
+			refreshCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				refreshCalled = true
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{"access_token": "should-not-be-used", "token_type": "bearer"})
+			}))
+			defer server.Close()
+
+			store, oauthConfigID := newAccessTokenTestStore(server.URL + "/token")
+			seedAccessToken(store, oauthConfigID, g.authMode, "tok-1", " current-access-token \n", "refresh-token", bifrost.Ptr(time.Now().Add(time.Hour)))
+
+			provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+			token, err := g.get(provider, context.Background(), oauthConfigID)
+			require.NoError(t, err)
+			assert.Equal(t, "current-access-token", token, "must return the sanitized (trimmed) access token")
+			assert.False(t, refreshCalled, "an unexpired token must not trigger a refresh call")
+		})
+	}
+}
+
+// TestAccessToken_ExpiredTokenWithRefresh_RefreshesAndReturnsNewToken
+// verifies an expired token with a refresh token available is refreshed via
+// the upstream token endpoint and the new access token is returned.
+func TestAccessToken_ExpiredTokenWithRefresh_RefreshesAndReturnsNewToken(t *testing.T) {
+	for _, g := range accessTokenGetters {
+		t.Run(g.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "refreshed-access-token",
+					"token_type":   "bearer",
+					"expires_in":   3600,
+				})
+			}))
+			defer server.Close()
+
+			store, oauthConfigID := newAccessTokenTestStore(server.URL + "/token")
+			seedAccessToken(store, oauthConfigID, g.authMode, "tok-1", "old-access-token", "refresh-token", bifrost.Ptr(time.Now().Add(-time.Minute)))
+
+			provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+			token, err := g.get(provider, context.Background(), oauthConfigID)
+			require.NoError(t, err)
+			assert.Equal(t, "refreshed-access-token", token)
+
+			stored, err := store.GetOauthTokenByID(context.Background(), "tok-1")
+			require.NoError(t, err)
+			assert.Equal(t, "refreshed-access-token", stored.AccessToken, "the reload-after-refresh path must persist the new token")
+		})
+	}
+}
+
+// TestAccessToken_ExpiredTokenNoRefresh_ReturnsExpiredError verifies an
+// expired token with no refresh token available returns ErrOAuth2TokenExpired
+// instead of attempting a refresh call.
+func TestAccessToken_ExpiredTokenNoRefresh_ReturnsExpiredError(t *testing.T) {
+	for _, g := range accessTokenGetters {
+		t.Run(g.name, func(t *testing.T) {
+			refreshCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				refreshCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			store, oauthConfigID := newAccessTokenTestStore(server.URL + "/token")
+			seedAccessToken(store, oauthConfigID, g.authMode, "tok-1", "old-access-token", "", bifrost.Ptr(time.Now().Add(-time.Minute)))
+
+			provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+			token, err := g.get(provider, context.Background(), oauthConfigID)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, schemas.ErrOAuth2TokenExpired)
+			assert.Empty(t, token)
+			assert.False(t, refreshCalled, "no refresh token available must short-circuit locally, never reach the token endpoint")
+		})
+	}
+}
+
+// TestAccessToken_MissingToken_ReturnsError verifies that when the oauth
+// config exists but has no token row of the caller's auth mode, a plain
+// (non-sentinel) "no token linked" error is returned — even when an active
+// token exists under the *other* auth mode, which pins the shared/admin
+// credential boundary: a resolver bug that ignored auth_mode entirely would
+// otherwise still pass this test with no token row seeded at all.
+func TestAccessToken_MissingToken_ReturnsError(t *testing.T) {
+	for _, g := range accessTokenGetters {
+		t.Run(g.name, func(t *testing.T) {
+			store, oauthConfigID := newAccessTokenTestStore("http://unused/token")
+			// No token row seeded for this case's own auth mode, but one is
+			// seeded under the opposite mode so the resolver can't accidentally
+			// "succeed" by ignoring auth_mode.
+			otherMode := "shared"
+			if g.authMode == "shared" {
+				otherMode = "admin"
+			}
+			seedAccessToken(store, oauthConfigID, otherMode, "tok-other-mode", "other-mode-token", "refresh-token", bifrost.Ptr(time.Now().Add(time.Hour)))
+
+			provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+			token, err := g.get(provider, context.Background(), oauthConfigID)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no")
+			assert.Contains(t, err.Error(), "token linked to oauth config")
+			assert.Empty(t, token)
+		})
+	}
+}
+
+// TestAccessToken_InactiveTokenStatus_ReturnsExpiredErrorWithoutNetworkCall
+// verifies that a token whose own Status is not "active" (e.g. needs_reauth)
+// is rejected locally, regardless of ExpiresAt — resolveAccessToken's Status
+// check runs before the expiry/refresh check.
+func TestAccessToken_InactiveTokenStatus_ReturnsExpiredErrorWithoutNetworkCall(t *testing.T) {
+	for _, g := range accessTokenGetters {
+		t.Run(g.name, func(t *testing.T) {
+			refreshCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				refreshCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			store, oauthConfigID := newAccessTokenTestStore(server.URL + "/token")
+			seedAccessToken(store, oauthConfigID, g.authMode, "tok-1", "old-access-token", "refresh-token", bifrost.Ptr(time.Now().Add(time.Hour)))
+			store.oauthTokens["tok-1"].Status = "needs_reauth"
+
+			provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+			token, err := g.get(provider, context.Background(), oauthConfigID)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, schemas.ErrOAuth2TokenExpired)
+			assert.Empty(t, token)
+			assert.False(t, refreshCalled)
+		})
+	}
+}
+
+// TestGetAccessToken_MissingConfig_ReturnsConfigNotFoundError pins
+// GetAccessToken's own pre-check (not shared with GetAdminAccessToken, which
+// has no equivalent oauth_config lookup): a nonexistent oauth_config_id
+// returns the ErrOAuth2ConfigNotFound sentinel.
+func TestGetAccessToken_MissingConfig_ReturnsConfigNotFoundError(t *testing.T) {
+	store := newTestConfigStore()
+	provider := NewOAuth2Provider(store, bifrost.NewDefaultLogger(schemas.LogLevelError))
+
+	token, err := provider.GetAccessToken(context.Background(), "does-not-exist")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, schemas.ErrOAuth2ConfigNotFound)
+	assert.Empty(t, token)
+}

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -153,6 +153,14 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 		return "", fmt.Errorf("no token linked to oauth config")
 	}
 
+	return p.resolveAccessToken(ctx, token)
+}
+
+// resolveAccessToken takes an already-loaded MCP OAuth token row, refreshes
+// it if needed, and returns a usable access token. Factored out of
+// GetAccessToken so GetAdminAccessToken (same status/refresh/expiry/sanitize
+// logic, just resolving the row via a different lookup) doesn't duplicate it.
+func (p *OAuth2Provider) resolveAccessToken(ctx context.Context, token *tables.TableMCPOauthToken) (string, error) {
 	// The token's own Status ('active' | 'orphaned' | 'needs_reauth') is the
 	// sole source of truth for whether this credential is usable.
 	// oauthConfig.Status only tracks the one-time bootstrap lifecycle
@@ -169,6 +177,7 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 			return "", fmt.Errorf("token expired and refresh failed: %w", err)
 		}
 		// Reload token after refresh
+		var err error
 		token, err = p.configStore.GetOauthTokenByID(ctx, token.ID)
 		if err != nil || token == nil {
 			return "", fmt.Errorf("failed to reload token after refresh: %w", err)
@@ -184,6 +193,21 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 		return "", fmt.Errorf("access token is empty after sanitization")
 	}
 	return accessToken, nil
+}
+
+// GetAdminAccessToken is GetAccessToken's admin-mode counterpart: resolves
+// the retained bootstrap-verification credential for a per_user_oauth
+// client's periodic tool-discovery refresh (ClientToolSyncer.performSync),
+// rather than the shared-mode production credential.
+func (p *OAuth2Provider) GetAdminAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
+	token, err := p.configStore.GetAdminOauthTokenByConfigID(ctx, oauthConfigID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load admin oauth token: %w", err)
+	}
+	if token == nil {
+		return "", fmt.Errorf("no admin token linked to oauth config")
+	}
+	return p.resolveAccessToken(ctx, token)
 }
 
 // RefreshAccessToken refreshes any MCP OAuth token row — the single shared

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -15,11 +15,13 @@ type TokenRefreshWorker struct {
 	refreshInterval time.Duration
 	lookAheadWindow time.Duration // How far ahead to look for expiring tokens
 	// AuthModes restricts proactive refresh to tokens whose AuthMode is in
-	// this set. Defaults to {"shared"} — shared-client tokens are the only
-	// ones with no live caller to trigger a lazy/inline refresh, so they're
-	// the only ones that need a background sweep by default. Widening this
-	// (e.g. to include "user"/"vk"/"session") opts specific per-identity
-	// auth modes into the same proactive sweep.
+	// this set. Defaults to {"shared", "admin"} — shared-client tokens and
+	// retained per_user_oauth bootstrap credentials (auth_mode='admin') are
+	// the only ones with no live caller to trigger a lazy/inline refresh:
+	// admin-mode tokens back only the periodic tool-discovery syncer, never
+	// real end-user traffic, so nothing else would ever refresh them.
+	// Widening this further (e.g. to include "user"/"vk"/"session") opts
+	// specific per-identity auth modes into the same proactive sweep.
 	//
 	// Set this before calling Start, not after: the background goroutine
 	// reads this field directly on every sweep with no synchronization, so a
@@ -45,9 +47,9 @@ func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *Tok
 	}
 	return &TokenRefreshWorker{
 		provider:        provider,
-		refreshInterval: 5 * time.Minute,    // Check every 5 minutes
-		lookAheadWindow: 5 * time.Minute,    // Refresh tokens expiring in next 5 minutes
-		AuthModes:       []string{"shared"}, // Proactive refresh is shared-only by default
+		refreshInterval: 5 * time.Minute,             // Check every 5 minutes
+		lookAheadWindow: 5 * time.Minute,             // Refresh tokens expiring in next 5 minutes
+		AuthModes:       []string{"shared", "admin"}, // Proactive refresh is shared + admin (retained bootstrap credentials) by default
 		stopCh:          make(chan struct{}),
 		logger:          logger,
 	}
@@ -101,7 +103,7 @@ func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 	expiryThreshold := time.Now().Add(w.lookAheadWindow)
 
 	// Get tokens expiring before the threshold, restricted to the configured
-	// auth modes (defaults to shared-only — see AuthModes' doc comment).
+	// auth modes (defaults to shared + admin — see AuthModes' doc comment).
 	tokens, err := w.provider.configStore.GetExpiringOauthTokens(ctx, expiryThreshold, w.AuthModes)
 	if err != nil {
 		w.logger.Error("Failed to get expiring tokens: %v", err)

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -83,6 +83,20 @@ func (s *testConfigStore) GetSharedOauthTokenByConfigID(_ context.Context, oauth
 	return nil, nil
 }
 
+// GetAdminOauthTokenByConfigID is GetSharedOauthTokenByConfigID's admin-mode
+// counterpart — the test-double equivalent of the real store's
+// (oauth_config_id, auth_mode='admin') lookup, used by GetAdminAccessToken.
+func (s *testConfigStore) GetAdminOauthTokenByConfigID(_ context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, token := range s.oauthTokens {
+		if token.OauthConfigID == oauthConfigID && token.AuthMode == "admin" {
+			return bifrost.Ptr(*token), nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableMCPOauthToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -436,7 +450,7 @@ func TestTokenRefreshWorker_DefaultAuthModes_ExcludesUserModeTokens(t *testing.T
 	}
 
 	worker := newTestWorker(store)
-	assert.Equal(t, []string{"shared"}, worker.AuthModes, "constructor must default AuthModes to shared-only")
+	assert.Equal(t, []string{"shared", "admin"}, worker.AuthModes, "constructor must default AuthModes to shared + admin")
 	worker.refreshExpiredTokens(context.Background())
 
 	sharedToken, err := store.GetOauthTokenByID(context.Background(), sharedTokenID)

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -392,6 +392,23 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Retain the admin's sample header values instead of discarding them
+	// after this one-time verification: persist as an auth_mode='admin'
+	// credential so the periodic tool syncer (ClientToolSyncer.performSync)
+	// can use it for later tool-discovery refresh. Best-effort — a failure
+	// here doesn't fail the request, since verification already succeeded;
+	// it just means the tool list can't be refreshed later.
+	if h.store.MCPHeadersProvider != nil {
+		if err := h.store.MCPHeadersProvider.UpsertCredential(ctx, &schemas.MCPHeadersUserCredential{
+			MCPClientID: clientConfig.ID,
+			AuthMode:    schemas.MCPAuthModeAdmin,
+			Headers:     canonUserHeaders,
+			Status:      schemas.MCPHeadersUserCredentialStatusActive,
+		}); err != nil {
+			logger.Warn(fmt.Sprintf("failed to retain admin header credential for MCP client %s: %v", clientConfig.ID, err))
+		}
+	}
+
 	// Re-load the row before activating and persisting: discovery above
 	// holds an upstream network round-trip, and pushing the pre-discovery
 	// snapshot into the runtime refresh and the full-row write below would
@@ -2337,13 +2354,19 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get admin access token for verification: %v", err))
 			return
 		}
-		// Always clean up admin's temp token and pending config, even on failure
-		defer h.oauthHandler.RevokeToken(ctx, oauthConfigID)
+		// Always clean up admin's pending config, even on failure
 		defer h.oauthHandler.RemovePendingMCPClient(oauthConfigID)
 
 		// Verify connection and discover tools using admin's temp token
 		tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(bifrostCtx, mcpClientConfig, accessToken)
 		if err != nil {
+			// Nothing worth retaining on a failed verification: revoke the
+			// admin's temp token immediately so it isn't left behind (it
+			// used to get this for free from an unconditional defer, before
+			// retention on success made cleanup conditional).
+			if revokeErr := h.oauthHandler.RevokeToken(ctx, oauthConfigID); revokeErr != nil {
+				logger.Warn(fmt.Sprintf("failed to revoke admin bootstrap token after verification failure for MCP client %s: %v", mcpClientConfig.ID, revokeErr))
+			}
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth configuration test failed: %v", err))
 			return
 		}
@@ -2419,6 +2442,34 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 
 		// Set discovered tools on the client
 		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
+
+		// Retain the admin's bootstrap-verification token instead of
+		// discarding it via RevokeToken: re-tag the same row from
+		// auth_mode='shared' (CompleteOAuthFlow's default write for any
+		// admin-flow-mode completion) to 'admin', so the periodic tool
+		// syncer (ClientToolSyncer.performSync) can use it for later
+		// tool-discovery refresh. Deferred until here (after the client's DB
+		// row and runtime registration above have both succeeded) so a
+		// failure in either doesn't leave a retagged admin credential
+		// pointing at a client that was never actually persisted. Best-effort
+		// beyond that point — a failure here doesn't fail the request, since
+		// the client is otherwise fully verified and working; it just means
+		// the tool list can't be refreshed later until the admin
+		// re-bootstraps.
+		if delErr := h.store.ConfigStore.DeleteAdminOauthTokenByMCPClientID(ctx, mcpClientConfig.ID); delErr != nil {
+			logger.Warn(fmt.Sprintf("failed to clear any previous admin bootstrap token before retaining a new one for MCP client %s: %v", mcpClientConfig.ID, delErr))
+		}
+		if sharedToken, tokErr := h.store.ConfigStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID); tokErr == nil && sharedToken != nil {
+			sharedToken.AuthMode = string(schemas.MCPAuthModeAdmin)
+			sharedToken.MCPClientID = mcpClientConfig.ID
+			if updErr := h.store.ConfigStore.UpdateOauthToken(ctx, sharedToken); updErr != nil {
+				logger.Warn(fmt.Sprintf("failed to retain admin bootstrap token for MCP client %s: %v", mcpClientConfig.ID, updErr))
+			}
+		} else if tokErr != nil {
+			logger.Warn(fmt.Sprintf("failed to load bootstrap token to retain for MCP client %s: %v", mcpClientConfig.ID, tokErr))
+		} else {
+			logger.Warn(fmt.Sprintf("no bootstrap token found to retain for MCP client %s", mcpClientConfig.ID))
+		}
 
 		// For clients bootstrapped from config.json, drop the
 		// pending_oauth_config_json stash now that verification succeeded.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1464,6 +1464,10 @@ func (m *MockConfigStore) GetSharedOauthTokenByConfigID(ctx context.Context, oau
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
@@ -1485,6 +1489,10 @@ func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error
 }
 
 func (m *MockConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error {
 	return nil
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -507,7 +507,7 @@ export default function MCPClientSheet({
 								<SheetDescription>
 									{mcpClient.state === "pending_verification"
 										? mcpClient.config.auth_type === "per_user_oauth"
-											? "This client was declared in config.json. A one-time admin test login is needed to verify the OAuth setup and discover tools — each user will authenticate individually afterward."
+											? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
 											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
 										: mcpClient.state === "needs_reauth"
 											? "This connection's credentials need to be re-authorized. Click Reauthorize to redo the OAuth consent flow."

--- a/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
@@ -116,7 +116,7 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 				<DialogHeader>
 					<DialogTitle>{status === "confirm" ? "Test Header Configuration" : "Header Authorization"}</DialogTitle>
 					<DialogDescription>
-						{status === "confirm" && "A one-time test is needed to verify your header setup."}
+						{status === "confirm" && "Verify your header setup to discover available tools."}
 						{status === "input" && "Enter sample values to verify the connection."}
 						{status === "testing" && "Verifying connection..."}
 						{status === "success" && "Verification successful!"}
@@ -132,8 +132,8 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 									To set up this MCP server, we need to verify that your header configuration is correct and discover the available tools.
 								</p>
 								<p>
-									You will be asked to provide sample values for the required headers. This is a <strong>one-time test</strong> to confirm
-									the setup works. Your sample values will <strong>not</strong> be stored or used for any other purpose.
+									You will be asked to provide sample values for the required headers. Bifrost keeps these values on file
+									to periodically refresh the available tool list; they are never used for real end-user requests.
 								</p>
 								<p>Once verified, each user will submit their own header values when they use this MCP server.</p>
 							</div>
@@ -151,7 +151,8 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 					{status === "input" && (
 						<>
 							<p className="text-muted-foreground text-sm">
-								These values are used only for this verification. They are <strong>not</strong> persisted.
+								These values verify the connection now and are kept on file so Bifrost can periodically refresh the
+								available tool list. Each user still submits their own values when they use this server.
 							</p>
 							<HeadersForm
 								requiredKeys={perUserHeaderKeys}

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -317,7 +317,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	};
 
 	const subtitles: Record<Status, string> = {
-		confirm: "Run a one-time OAuth test before enabling this server.",
+		confirm: "Sign in to verify the OAuth setup and discover available tools.",
 		polling: "Complete sign-in in the popup window to continue.",
 		blocked: "Allow popups for this site, then try again.",
 		success: "OAuth authorization completed successfully.",
@@ -363,7 +363,8 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 									We'll open <strong>{authorizationHost}</strong> to verify the OAuth setup and discover available tools.
 								</p>
 								<p className="text-muted-foreground/80 text-xs">
-									This login is for setup only. Each user authenticates individually when they connect.
+									Bifrost keeps this sign-in on file to periodically refresh the available tool list. Each user still
+									authenticates individually when they use this server; this credential is never used for their requests.
 								</p>
 							</InfoBox>
 							<div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary

Per-user MCP clients (`per_user_oauth` and `per_user_headers`) never hold a persistent connection, so the periodic tool syncer was silently skipping them entirely — their tool lists could never be refreshed after initial bootstrap. This PR introduces an "admin credential" retention mechanism: the bootstrap-verification credential (OAuth token or header values) submitted by the admin during one-time setup is now persisted under `auth_mode='admin'` and reused by the tool syncer to run ephemeral connect-discover-close cycles, keeping per-user clients' tool lists up to date without requiring a real end-user request.

## Changes

- **Admin credential retention at bootstrap time**: `completeMCPClientOAuth` now re-tags the admin's bootstrap OAuth token from `auth_mode='shared'` to `auth_mode='admin'` (instead of revoking it) after a successful verification. `verifyMCPClientHeaders` now persists the admin's sample header values as an `auth_mode='admin'` credential row. Both are best-effort — a retention failure does not fail the request.

- **`performAdminToolDiscovery` on `MCPManager`**: New method that resolves the retained admin credential via `credStore.AdminConnectionHeaders` and runs a one-shot ephemeral connect-discover-close cycle using the same `VerifyPerUserOAuthConnection` / `VerifyHeadersConnection` functions the bootstrap flow uses.

- **`ClientToolSyncer.performSync` widened**: The `conn == nil` branch now distinguishes per-user auth types (`per_user_oauth`, `per_user_headers`) from shared-connection types. Per-user clients with no live conn are routed into `performAdminToolDiscovery` instead of being silently skipped; shared-connection clients mid-reconnect continue to be skipped as before.

- **`AdminConnectionHeaders` added to `MCPCredentialStore` interface and all resolvers**: `per_user_oauth` and `per_user_headers` resolvers implement it meaningfully (OAuth token lookup via `GetAdminAccessToken`; header credential lookup via `GetCredentialByMode` with `MCPAuthModeAdmin`). All shared-credential resolvers (`none`, `headers`, `oauth`) return an explicit unsupported error.

- **`GetAdminAccessToken` added to `OAuth2Provider`**: Resolves the `auth_mode='admin'` token row via `GetAdminOauthTokenByConfigID` and funnels it through the extracted `resolveAccessToken` helper (shared with `GetAccessToken` to avoid duplicating status/expiry/refresh/sanitize logic).

- **`TokenRefreshWorker` default `AuthModes` widened to `["shared", "admin"]`**: Admin-mode tokens back only the tool syncer and have no live caller to trigger lazy refresh, so they need the same proactive background sweep as shared tokens.

- **`MCPAuthModeAdmin` support in `GetMCPPerUserHeaderCredentialByMode` and `UpsertMCPPerUserHeaderCredential`**: Admin-mode rows are scoped by `mcp_client_id` alone (no per-caller identity). The identity guard in `mcp_headers.Provider.GetCredentialByMode` is widened to allow an empty identity for `MCPAuthModeAdmin` only.

- **Database migration `add_mcp_admin_auth_mode_indexes`**: Adds partial unique indexes on `mcp_oauth_tokens` and `mcp_per_user_header_credentials` for `auth_mode='admin'`, enforcing exactly one admin credential per MCP client.

- **UI copy updates**: Admin bootstrap flows for both OAuth and headers now accurately describe that the credential is retained for periodic tool-list refresh rather than discarded after a one-time test.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/mcp/... ./core/schemas/... ./framework/configstore/... ./framework/mcp_headers/... ./framework/oauth2/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

- Bootstrap a `per_user_oauth` MCP client through the admin OAuth flow and confirm the token row in `mcp_oauth_tokens` has `auth_mode='admin'` after completion.
- Bootstrap a `per_user_headers` MCP client and confirm a row with `auth_mode='admin'` appears in `mcp_per_user_header_credentials`.
- Wait for or manually trigger a tool-sync cycle and confirm the per-user client's tool list is updated (previously it would be silently skipped).
- Confirm shared-connection clients (`headers`, `none`, `oauth`) with `conn == nil` (mid-reconnect) are still silently skipped and not routed into admin discovery.

## Breaking changes

- [x] Yes
- [ ] No

`MCPCredentialStore` and `OAuth2Provider` are interfaces with new required methods (`AdminConnectionHeaders` and `GetAdminAccessToken` respectively). Any external implementations of these interfaces must add stub or real implementations of these methods. The `ConfigStore` interface also gains `GetAdminOauthTokenByConfigID`. The `TokenRefreshWorker` default `AuthModes` changes from `["shared"]` to `["shared", "admin"]`, which may cause additional token refresh queries if admin-mode rows exist.

## Security considerations

The retained admin credential (`auth_mode='admin'`) is used exclusively by the internal tool syncer for tool-list discovery — it is never injected into real end-user requests. The `per_user_oauth` resolver's `AdminConnectionHeaders` and the `per_user_headers` resolver's `AdminConnectionHeaders` both enforce this separation at the resolver level. The partial unique indexes ensure at most one admin credential exists per MCP client, preventing accumulation of stale bootstrap credentials.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable