### PR TITLE
feat: add per-user OAuth/headers admin discovery credential repair flow with registry `needs_reauth` projection

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -633,14 +633,21 @@ const (
 	MCPConnectionStatePendingVerification MCPConnectionState = "pending_verification" // Declared (typically via config.json) but the one-time auth/test flow has not been completed by an admin yet
 	MCPConnectionStateDisabled            MCPConnectionState = "disabled"             // Client is intentionally disabled by the user
 	// MCPConnectionStateNeedsReauth means this client was previously authorized and
-	// connected at least once, but its credential can no longer be used — the upstream
-	// OAuth token died (refresh token rejected/expired with no way to silently recover,
-	// see ErrOAuth2TokenExpired) and a human has to reauthorize it. This is distinct from
+	// connected at least once, but a credential an admin is responsible for can no
+	// longer be used and needs a human to repair it. This is distinct from
 	// MCPConnectionStatePendingVerification, which means the one-time initial setup was
 	// never completed in the first place; NeedsReauth means setup succeeded once and the
-	// credential died later. Only reachable by shared-connection auth types (a persistent
-	// upstream connection to reconnect); per-user auth types resolve credentials per-call
-	// and never hold a connection this state describes.
+	// credential died later. What "the credential" is depends on the auth type:
+	//   - Shared-connection auth types: the connection credential itself died; the
+	//     upstream OAuth token was rejected/expired with no way to silently recover
+	//     (see ErrOAuth2TokenExpired) and the connection cannot be re-established
+	//     until an admin reauthorizes. The runtime manager holds this state.
+	//   - Per-user auth types: a response-only projection computed when listing the
+	//     registry, never stored in the runtime manager (whose state stays
+	//     connected). It means the retained admin credential used for periodic
+	//     tool-list discovery needs repair; end-user credentials and tool calls
+	//     keep working, only the tool list stops refreshing until an admin repairs
+	//     the discovery credential.
 	MCPConnectionStateNeedsReauth MCPConnectionState = "needs_reauth"
 )
 

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6500,25 +6500,6 @@ func (s *RDBConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, 
 	return nil
 }
 
-// DeleteAdminOauthTokenByMCPClientID deletes the retained admin-mode token
-// row for mcpClientID, if one exists. idx_mcp_oauth_tokens_admin_mcp allows
-// at most one auth_mode='admin' row per mcp_client_id, so this must run
-// before retagging a fresh bootstrap-verification row to 'admin' for a
-// client that already has one from an earlier bootstrap — otherwise the
-// retag's write collides with that existing row instead of replacing it.
-func (s *RDBConfigStore) DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error {
-	if mcpClientID == "" {
-		return nil
-	}
-	result := s.DB().WithContext(ctx).
-		Where("mcp_client_id = ? AND auth_mode = ?", mcpClientID, "admin").
-		Delete(&tables.TableMCPOauthToken{})
-	if result.Error != nil {
-		return fmt.Errorf("failed to delete admin oauth token by mcp client id: %w", result.Error)
-	}
-	return nil
-}
-
 // GetAdminOauthTokenByConfigID resolves the single retained admin-mode token
 // row for a config — the bootstrap-verification credential kept alive for a
 // per_user_oauth client's periodic tool-discovery refresh (see
@@ -6538,6 +6519,128 @@ func (s *RDBConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oauth
 		return nil, fmt.Errorf("failed to get admin oauth token by config id: %w", result.Error)
 	}
 	return &token, nil
+}
+
+// GetAdminOauthTokensByConfigIDs is GetAdminOauthTokenByConfigID's batch
+// counterpart, styled after GetOauthConfigsByIDs: one query resolving the
+// retained admin-mode token row for each of the given oauth_config_ids,
+// keyed by OauthConfigID. Not filtered by status: callers inspect
+// token.Status themselves (the registry list projects 'needs_reauth' rows
+// into a response-only state). Configs with no admin row are simply absent
+// from the map. Empty input returns an empty map without querying.
+func (s *RDBConfigStore) GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+	if len(oauthConfigIDs) == 0 {
+		return map[string]*tables.TableMCPOauthToken{}, nil
+	}
+	var tokens []tables.TableMCPOauthToken
+	if err := s.DB().WithContext(ctx).
+		Where("oauth_config_id IN ? AND auth_mode = ?", oauthConfigIDs, "admin").
+		Find(&tokens).Error; err != nil {
+		return nil, fmt.Errorf("failed to batch-get admin oauth tokens: %w", err)
+	}
+	result := make(map[string]*tables.TableMCPOauthToken, len(tokens))
+	for i := range tokens {
+		result[tokens[i].OauthConfigID] = &tokens[i]
+	}
+	return result, nil
+}
+
+// PromoteSharedOauthTokenToAdmin transactionally installs the shared-mode
+// bootstrap token for oauthConfigID as the retained admin-mode discovery
+// credential of mcpClientID. Two shapes, both leaving exactly one admin row
+// and zero shared rows for the config:
+//   - an admin row already exists (a repair flow replacing a dead
+//     credential): the fresh shared row's credential fields are copied onto
+//     the existing admin row (preserving its ID and CreatedAt, since the row
+//     represents the binding) and the shared row is deleted;
+//   - no admin row exists (first-time bootstrap): the shared row itself is
+//     retagged to auth_mode='admin' with MCPClientID set.
+//
+// Errors if the shared row is missing or not status='active', since the caller
+// must have just completed a successful admin flow, which always leaves an
+// active shared row behind (CompleteOAuthFlow's default write). On a per-user
+// client that 'shared' row is only ever this transient staging state, never a
+// production credential; this promotion (or a revoke on verification failure)
+// is what resolves it, so outside that window per-user clients hold no
+// shared rows.
+func (s *RDBConfigStore) PromoteSharedOauthTokenToAdmin(ctx context.Context, oauthConfigID, mcpClientID string) error {
+	if oauthConfigID == "" || mcpClientID == "" {
+		return fmt.Errorf("promote shared oauth token to admin: oauthConfigID and mcpClientID are required")
+	}
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var shared tables.TableMCPOauthToken
+		// Same active-first, most-recently-updated ordering as
+		// GetSharedOauthTokenByConfigID: nothing guarantees at most one
+		// auth_mode='shared' row per oauth_config_id, and a bare First()
+		// without ORDER BY can select a stale row, fail the active-status
+		// check below, and reject a repair whose fresh token is actually
+		// present.
+		if err := dbForUpdate(tx).
+			Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "shared").
+			Order("CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC, id DESC").
+			First(&shared).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("no shared oauth token found for config %s to promote", oauthConfigID)
+			}
+			return fmt.Errorf("failed to load shared oauth token for config %s: %w", oauthConfigID, err)
+		}
+		if shared.Status != "active" {
+			return fmt.Errorf("shared oauth token for config %s has status %q, expected 'active'", oauthConfigID, shared.Status)
+		}
+
+		var admin tables.TableMCPOauthToken
+		adminErr := dbForUpdate(tx).
+			Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "admin").
+			First(&admin).Error
+		now := time.Now()
+		if adminErr == nil {
+			// Replace the existing admin row's credential in place, keeping
+			// its identity (ID + CreatedAt: the row represents the binding,
+			// not the individual credential), then drop the now-redundant
+			// shared row.
+			admin.MCPClientID = mcpClientID
+			admin.AccessToken = shared.AccessToken
+			admin.RefreshToken = shared.RefreshToken
+			admin.TokenType = shared.TokenType
+			admin.ExpiresAt = shared.ExpiresAt
+			admin.Scopes = shared.Scopes
+			admin.EncryptionStatus = shared.EncryptionStatus
+			admin.Status = "active"
+			admin.LastRefreshedAt = &now
+			if err := tx.Save(&admin).Error; err != nil {
+				return fmt.Errorf("failed to update admin oauth token for config %s: %w", oauthConfigID, err)
+			}
+			// Delete every remaining shared row for this config, not just
+			// the one selected above: any other shared row left behind
+			// (e.g. by a stale/orphaned row predating this promotion) would
+			// let GetSharedOauthTokenByConfigID keep returning a shared
+			// row, making completeMCPClientOAuth's replay guard read this
+			// as a new repair flow instead of a completed one.
+			if err := tx.Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "shared").
+				Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
+				return fmt.Errorf("failed to delete promoted shared oauth token for config %s: %w", oauthConfigID, err)
+			}
+			return nil
+		}
+		if !errors.Is(adminErr, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("failed to load admin oauth token for config %s: %w", oauthConfigID, adminErr)
+		}
+
+		// First-time promotion: retag the shared row itself.
+		shared.AuthMode = "admin"
+		shared.MCPClientID = mcpClientID
+		if err := tx.Save(&shared).Error; err != nil {
+			return fmt.Errorf("failed to retag shared oauth token to admin for config %s: %w", oauthConfigID, err)
+		}
+		// Same reasoning as the replace-admin-row branch above: clear any
+		// other leftover shared row for this config so the replay guard
+		// sees the promotion as complete.
+		if err := tx.Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "shared").
+			Delete(&tables.TableMCPOauthToken{}).Error; err != nil {
+			return fmt.Errorf("failed to delete leftover shared oauth tokens for config %s: %w", oauthConfigID, err)
+		}
+		return nil
+	})
 }
 
 // CreateOauthConfig creates a new OAuth config
@@ -7427,6 +7530,31 @@ func (s *RDBConfigStore) GetMCPPerUserHeaderCredentialByID(ctx context.Context, 
 	return &cred, nil
 }
 
+// GetAdminMCPPerUserHeaderCredentialsByClientIDs is the batch counterpart of
+// GetMCPPerUserHeaderCredentialByMode's admin branch, styled after
+// GetOauthConfigsByIDs: one query resolving the retained admin-mode header
+// credential for each of the given MCP client IDs, keyed by MCPClientID.
+// Not filtered by status: callers inspect cred.Status themselves (the
+// registry list projects 'needs_update' rows into a response-only state).
+// Clients with no admin row are simply absent from the map. Empty input
+// returns an empty map without querying.
+func (s *RDBConfigStore) GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPPerUserHeaderCredential, error) {
+	if len(mcpClientIDs) == 0 {
+		return map[string]*tables.TableMCPPerUserHeaderCredential{}, nil
+	}
+	var creds []tables.TableMCPPerUserHeaderCredential
+	if err := s.DB().WithContext(ctx).
+		Where("mcp_client_id IN ? AND auth_mode = ?", mcpClientIDs, "admin").
+		Find(&creds).Error; err != nil {
+		return nil, fmt.Errorf("failed to batch-get admin mcp per-user header credentials: %w", err)
+	}
+	result := make(map[string]*tables.TableMCPPerUserHeaderCredential, len(creds))
+	for i := range creds {
+		result[creds[i].MCPClientID] = &creds[i]
+	}
+	return result, nil
+}
+
 // UpsertMCPPerUserHeaderCredential atomically inserts or updates a credential
 // row keyed by (auth_mode, identity, mcp_client_id) — or, for auth_mode='admin',
 // by mcp_client_id alone, since the retained bootstrap-verification credential
@@ -7495,7 +7623,11 @@ func (s *RDBConfigStore) DeleteMCPPerUserHeaderCredential(ctx context.Context, i
 // lookups apply their own status='active' filter and don't go through
 // this method.
 func (s *RDBConfigStore) ListMCPPerUserHeaderCredentials(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderCredential, error) {
-	query := s.ScopedDB(ctx).Model(&tables.TableMCPPerUserHeaderCredential{})
+	// Always excludes auth_mode='admin' so the retained admin discovery
+	// credential never leaks into the per-identity sessions UI, mirroring
+	// ListOauthUserTokens' auth_mode scoping.
+	query := s.ScopedDB(ctx).Model(&tables.TableMCPPerUserHeaderCredential{}).
+		Where("mcp_per_user_header_credentials.auth_mode IN ?", perUserOauthAuthModes)
 	query = applyMCPSessionFilters(query, params, mcpSessionFilterTable{
 		table:          "mcp_per_user_header_credentials",
 		authModeColumn: "auth_mode",

--- a/framework/configstore/rdb_mcp_admin_auth_mode_test.go
+++ b/framework/configstore/rdb_mcp_admin_auth_mode_test.go
@@ -46,6 +46,276 @@ func TestGetAdminOauthTokenByConfigID(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+// TestGetAdminOauthTokensByConfigIDs pins the batch counterpart of
+// GetAdminOauthTokenByConfigID: one query keyed by oauth_config_id, admin
+// rows only, no status filter (needs_reauth rows must come back so the
+// registry list can project them), and empty input short-circuits.
+func TestGetAdminOauthTokensByConfigIDs(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	rows := []*tables.TableMCPOauthToken{
+		{ID: "tok-a-active", AuthMode: "admin", OauthConfigID: "cfg-a", Status: "active",
+			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
+		{ID: "tok-b-reauth", AuthMode: "admin", OauthConfigID: "cfg-b", Status: "needs_reauth",
+			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
+		// Non-admin rows on the same configs must be excluded.
+		{ID: "tok-a-shared", AuthMode: "shared", OauthConfigID: "cfg-a", Status: "active",
+			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
+		{ID: "tok-b-user", AuthMode: "user", OauthConfigID: "cfg-b", Status: "needs_reauth",
+			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
+		// A config with only a shared row must be absent from the result.
+		{ID: "tok-c-shared", AuthMode: "shared", OauthConfigID: "cfg-c", Status: "active",
+			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, r := range rows {
+		require.NoError(t, s.DB().Create(r).Error)
+	}
+
+	got, err := s.GetAdminOauthTokensByConfigIDs(ctx, []string{"cfg-a", "cfg-b", "cfg-c", "cfg-missing"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.NotNil(t, got["cfg-a"])
+	assert.Equal(t, "tok-a-active", got["cfg-a"].ID)
+	assert.Equal(t, "active", got["cfg-a"].Status)
+	require.NotNil(t, got["cfg-b"], "needs_reauth admin rows must be returned, not filtered by status")
+	assert.Equal(t, "tok-b-reauth", got["cfg-b"].ID)
+	assert.Equal(t, "needs_reauth", got["cfg-b"].Status)
+	assert.NotContains(t, got, "cfg-c", "a config with only non-admin rows must be absent")
+	assert.NotContains(t, got, "cfg-missing")
+
+	// Empty input returns an empty map without querying.
+	got, err = s.GetAdminOauthTokensByConfigIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestGetAdminMCPPerUserHeaderCredentialsByClientIDs pins the batch
+// counterpart of GetMCPPerUserHeaderCredentialByMode's admin branch: one
+// query keyed by mcp_client_id, admin rows only, no status filter
+// (needs_update rows must come back so the registry list can project them),
+// and empty input short-circuits.
+func TestGetAdminMCPPerUserHeaderCredentialsByClientIDs(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+	uid := "user-1"
+
+	rows := []*tables.TableMCPPerUserHeaderCredential{
+		{ID: "cred-a-active", MCPClientID: "client-a", AuthMode: "admin", Status: "active",
+			HeadersJSON: "{}", CreatedAt: now, UpdatedAt: now},
+		{ID: "cred-b-update", MCPClientID: "client-b", AuthMode: "admin", Status: "needs_update",
+			HeadersJSON: "{}", CreatedAt: now, UpdatedAt: now},
+		// Non-admin rows on the same clients must be excluded.
+		{ID: "cred-a-user", MCPClientID: "client-a", AuthMode: "user", UserID: &uid, Status: "active",
+			HeadersJSON: "{}", CreatedAt: now, UpdatedAt: now},
+		// A client with only a per-identity row must be absent from the result.
+		{ID: "cred-c-user", MCPClientID: "client-c", AuthMode: "user", UserID: &uid, Status: "needs_update",
+			HeadersJSON: "{}", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, r := range rows {
+		require.NoError(t, s.DB().Create(r).Error)
+	}
+
+	got, err := s.GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx, []string{"client-a", "client-b", "client-c", "client-missing"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	require.NotNil(t, got["client-a"])
+	assert.Equal(t, "cred-a-active", got["client-a"].ID)
+	require.NotNil(t, got["client-b"], "needs_update admin rows must be returned, not filtered by status")
+	assert.Equal(t, "cred-b-update", got["client-b"].ID)
+	assert.Equal(t, "needs_update", got["client-b"].Status)
+	assert.NotContains(t, got, "client-c", "a client with only non-admin rows must be absent")
+	assert.NotContains(t, got, "client-missing")
+
+	// Empty input returns an empty map without querying.
+	got, err = s.GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestPromoteSharedOauthTokenToAdmin_ReplacesExistingAdminRow pins the
+// repair shape: a fresh active shared row's credential fields are copied
+// onto the existing admin row (which keeps its ID and CreatedAt, since the
+// row represents the binding), the admin row returns to 'active', and the
+// shared row is deleted so exactly one row remains for the config.
+func TestPromoteSharedOauthTokenToAdmin_ReplacesExistingAdminRow(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	adminCreated := time.Now().Add(-24 * time.Hour)
+
+	sharedExpiresAt := time.Now().Add(2 * time.Hour)
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-admin", AuthMode: "admin", OauthConfigID: "cfg-1", MCPClientID: "client-1",
+		Status: "needs_reauth", AccessToken: "at-dead", RefreshToken: "rt-dead",
+		TokenType: "MAC", Scopes: `["dead"]`, EncryptionStatus: tables.EncryptionStatusPlainText,
+		CreatedAt: adminCreated, UpdatedAt: adminCreated,
+	}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+		AccessToken: "at-fresh", RefreshToken: "rt-fresh", TokenType: "Bearer",
+		ExpiresAt: &sharedExpiresAt, Scopes: `["read","write"]`,
+		EncryptionStatus: tables.EncryptionStatusEncrypted,
+	}).Error)
+
+	require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
+
+	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+	assert.Equal(t, "tok-admin", admin.ID, "existing admin row's ID must be preserved")
+	assert.True(t, adminCreated.Equal(admin.CreatedAt), "existing admin row's CreatedAt must be preserved: got %v, want %v", admin.CreatedAt, adminCreated)
+	assert.Equal(t, "active", admin.Status)
+	assert.Equal(t, "at-fresh", admin.AccessToken)
+	assert.Equal(t, "rt-fresh", admin.RefreshToken)
+	assert.Equal(t, "client-1", admin.MCPClientID)
+	assert.Equal(t, "Bearer", admin.TokenType, "TokenType must be transferred from the shared row")
+	require.NotNil(t, admin.ExpiresAt, "ExpiresAt must be transferred from the shared row")
+	assert.True(t, sharedExpiresAt.Equal(*admin.ExpiresAt), "ExpiresAt must be transferred from the shared row: got %v, want %v", admin.ExpiresAt, sharedExpiresAt)
+	assert.Equal(t, `["read","write"]`, admin.Scopes, "Scopes must be transferred from the shared row")
+	assert.Equal(t, tables.EncryptionStatusEncrypted, admin.EncryptionStatus, "EncryptionStatus must be transferred from the shared row")
+	assert.NotNil(t, admin.LastRefreshedAt, "repair must stamp LastRefreshedAt")
+
+	shared, err := s.GetSharedOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	assert.Nil(t, shared, "the promoted shared row must be deleted")
+
+	var count int64
+	require.NoError(t, s.DB().Model(&tables.TableMCPOauthToken{}).
+		Where("oauth_config_id = ?", "cfg-1").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "exactly one row must remain for the config")
+}
+
+// TestPromoteSharedOauthTokenToAdmin_RetagsWhenNoAdminRow pins the
+// first-time-bootstrap shape: with no admin row present the shared row
+// itself is retagged to auth_mode='admin' with MCPClientID set.
+func TestPromoteSharedOauthTokenToAdmin_RetagsWhenNoAdminRow(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+		AccessToken: "at-fresh", TokenType: "Bearer",
+	}).Error)
+
+	require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
+
+	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+	assert.Equal(t, "tok-shared", admin.ID, "the shared row itself must be retagged, keeping its ID")
+	assert.Equal(t, "client-1", admin.MCPClientID)
+	assert.Equal(t, "active", admin.Status)
+
+	shared, err := s.GetSharedOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	assert.Nil(t, shared, "no shared row must remain after promotion")
+}
+
+// TestPromoteSharedOauthTokenToAdmin_ClearsStrayShareRows pins the fix for a
+// stale/orphaned extra shared row: nothing in the schema guarantees at most
+// one auth_mode='shared' row per oauth_config_id, so promotion must select
+// the active row (not an arbitrary one) and delete every remaining shared
+// row for the config, not just the one it promoted — otherwise
+// GetSharedOauthTokenByConfigID keeps returning a shared row after a
+// "completed" promotion, which the OAuth-callback replay guard would read as
+// a new repair flow instead of a finished one. Covers both the
+// replace-existing-admin-row and first-time-retag branches.
+func TestPromoteSharedOauthTokenToAdmin_ClearsStrayShareRows(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	t.Run("replace-admin-row branch", func(t *testing.T) {
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: "tok-admin-1", AuthMode: "admin", OauthConfigID: "cfg-1", MCPClientID: "client-1",
+			Status: "needs_reauth", AccessToken: "at-dead", TokenType: "Bearer",
+		}).Error)
+		// A stale shared row (older, non-active) that a bare First() with no
+		// ORDER BY could select instead of the active one below.
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: "tok-shared-stale", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "needs_reauth",
+			AccessToken: "at-stale", TokenType: "Bearer",
+		}).Error)
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: "tok-shared-active", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+			AccessToken: "at-fresh", TokenType: "Bearer",
+		}).Error)
+
+		require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
+
+		admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+		require.NoError(t, err)
+		require.NotNil(t, admin)
+		assert.Equal(t, "at-fresh", admin.AccessToken, "the active shared row must be the one promoted, not the stale one")
+
+		shared, err := s.GetSharedOauthTokenByConfigID(ctx, "cfg-1")
+		require.NoError(t, err)
+		assert.Nil(t, shared, "every shared row for the config must be cleared, including the stray stale one")
+
+		var sharedCount int64
+		require.NoError(t, s.DB().Model(&tables.TableMCPOauthToken{}).
+			Where("oauth_config_id = ? AND auth_mode = ?", "cfg-1", "shared").Count(&sharedCount).Error)
+		assert.Equal(t, int64(0), sharedCount)
+	})
+
+	t.Run("first-time-retag branch", func(t *testing.T) {
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: "tok-shared-stale-2", AuthMode: "shared", OauthConfigID: "cfg-2", Status: "needs_reauth",
+			AccessToken: "at-stale-2", TokenType: "Bearer",
+		}).Error)
+		require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+			ID: "tok-shared-active-2", AuthMode: "shared", OauthConfigID: "cfg-2", Status: "active",
+			AccessToken: "at-fresh-2", TokenType: "Bearer",
+		}).Error)
+
+		require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-2", "client-2"))
+
+		admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-2")
+		require.NoError(t, err)
+		require.NotNil(t, admin)
+		assert.Equal(t, "tok-shared-active-2", admin.ID, "the active shared row must be retagged in place")
+
+		shared, err := s.GetSharedOauthTokenByConfigID(ctx, "cfg-2")
+		require.NoError(t, err)
+		assert.Nil(t, shared, "the stray stale shared row must also be cleared")
+	})
+}
+
+// TestPromoteSharedOauthTokenToAdmin_Errors pins the guard rails: an empty
+// oauthConfigID or mcpClientID, a missing shared row, and a non-active shared
+// row all error without touching an existing admin row.
+func TestPromoteSharedOauthTokenToAdmin_Errors(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.Error(t, s.PromoteSharedOauthTokenToAdmin(ctx, "", "client-1"), "empty oauthConfigID must error before starting the transaction")
+	require.Error(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", ""), "empty mcpClientID must error before starting the transaction")
+
+	var count int64
+	require.NoError(t, s.DB().Model(&tables.TableMCPOauthToken{}).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "the empty-argument guard must reject before any row is touched")
+
+	require.Error(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-none", "client-1"), "missing shared row must error")
+
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-admin", AuthMode: "admin", OauthConfigID: "cfg-1", MCPClientID: "client-1",
+		Status: "needs_reauth", AccessToken: "at-dead", TokenType: "Bearer",
+	}).Error)
+	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
+		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "needs_reauth",
+		AccessToken: "at-stale", TokenType: "Bearer",
+	}).Error)
+
+	require.Error(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"), "non-active shared row must error")
+
+	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	require.NoError(t, err)
+	require.NotNil(t, admin)
+	assert.Equal(t, "needs_reauth", admin.Status, "a failed promotion must leave the admin row untouched")
+	assert.Equal(t, "at-dead", admin.AccessToken)
+}
+
 // TestGetMCPPerUserHeaderCredentialByMode_AdminMode pins the new admin
 // branch: an admin-mode row is scoped by mcp_client_id alone (identity is
 // allowed empty), while every other mode is unaffected by the widening and

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -414,6 +414,24 @@ func TestListMCPPerUserHeaderCredentials_NoFilters(t *testing.T) {
 	require.Equal(t, "cred-1", got[0].ID)
 }
 
+// TestListMCPPerUserHeaderCredentials_ExcludesAdminMode pins that the
+// retained admin discovery credential (auth_mode='admin') never leaks into
+// the per-identity sessions list, mirroring ListOauthUserTokens'
+// auth_mode='shared' exclusion on the token table.
+func TestListMCPPerUserHeaderCredentials_ExcludesAdminMode(t *testing.T) {
+	store := setupMCPSessionsTestStore(t)
+	seedMCPSessionsFixture(t, store)
+	require.NoError(t, store.DB().Create(&tables.TableMCPPerUserHeaderCredential{
+		ID: "cred-admin", MCPClientID: "github-prod", AuthMode: "admin",
+		Status: "active", HeadersJSON: "{}",
+	}).Error)
+
+	got, err := store.ListMCPPerUserHeaderCredentials(context.Background(), MCPSessionsFilterParams{})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "cred-1", got[0].ID, "only the per-identity row must be listed; the admin row must be excluded")
+}
+
 func TestListPendingMCPPerUserHeaderFlows_NoFilters(t *testing.T) {
 	store := setupMCPSessionsTestStore(t)
 	seedMCPSessionsFixture(t, store)

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -516,6 +516,18 @@ type ConfigStore interface {
 	// admin-mode counterpart — resolves the retained bootstrap-verification
 	// token for a per_user_oauth client's periodic tool-discovery refresh.
 	GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
+	// GetAdminOauthTokensByConfigIDs is GetAdminOauthTokenByConfigID's batch
+	// counterpart: resolves the retained admin-mode token row for each of the
+	// given oauth_config_ids in one query, keyed by OauthConfigID. Not
+	// filtered by status; configs with no admin row are absent from the map.
+	GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error)
+	// PromoteSharedOauthTokenToAdmin transactionally installs the config's
+	// fresh shared-mode token as the retained admin-mode discovery credential
+	// for mcpClientID: if an admin row already exists its credential fields
+	// are replaced in place (preserving ID and CreatedAt) and the shared row
+	// is deleted; otherwise the shared row is retagged to auth_mode='admin'.
+	// Errors if the shared row is missing or not status='active'.
+	PromoteSharedOauthTokenToAdmin(ctx context.Context, oauthConfigID, mcpClientID string) error
 	// GetExpiringOauthTokens is filtered to authModes via `auth_mode IN
 	// (...)`. Backs TokenRefreshWorker, whose AuthModes field decides which
 	// holder types get proactive background refresh (defaults to shared +
@@ -554,11 +566,6 @@ type ConfigStore interface {
 	// leave a duplicate row behind (see GetSharedOauthTokenByConfigID's doc
 	// comment for why more than one can otherwise exist).
 	DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
-	// DeleteAdminOauthTokenByMCPClientID deletes the retained admin-mode
-	// token row for mcpClientID, if one exists — must run before retagging a
-	// fresh bootstrap-verification row to 'admin' for a client that already
-	// has one, so the retag can't collide with idx_mcp_oauth_tokens_admin_mcp.
-	DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error
 
 	// Flow-row CRUD (mcp_oauth_flows / TableMCPOauthFlow). Method names keep
 	// their historical "OauthUserSession" naming even though the backing
@@ -693,13 +700,20 @@ type ConfigStore interface {
 	// mcp_client_id).
 	GetMCPPerUserHeaderCredentialByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (*tables.TableMCPPerUserHeaderCredential, error)
 	GetMCPPerUserHeaderCredentialByID(ctx context.Context, id string) (*tables.TableMCPPerUserHeaderCredential, error)
+	// GetAdminMCPPerUserHeaderCredentialsByClientIDs resolves the retained
+	// admin-mode header credential for each of the given MCP client IDs in
+	// one query, keyed by MCPClientID. Not filtered by status; clients with
+	// no admin row are absent from the map.
+	GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPPerUserHeaderCredential, error)
 	UpsertMCPPerUserHeaderCredential(ctx context.Context, cred *tables.TableMCPPerUserHeaderCredential) error
 	DeleteMCPPerUserHeaderCredential(ctx context.Context, id string) error
 	// ListMCPPerUserHeaderCredentials returns credential rows matching the
 	// supplied filters, regardless of status. Mirrors ListOauthUserTokens —
 	// the sessions UI surfaces non-active states (needs_update / orphaned)
 	// with distinct affordances, so status filtering is the caller's
-	// responsibility via params.Statuses.
+	// responsibility via params.Statuses. Always excludes auth_mode='admin'
+	// so the retained admin discovery credential never leaks into the
+	// per-identity sessions UI.
 	ListMCPPerUserHeaderCredentials(ctx context.Context, params MCPSessionsFilterParams) ([]tables.TableMCPPerUserHeaderCredential, error)
 	// MarkMCPPerUserHeaderCredentialsNeedsUpdate flips status to 'needs_update'
 	// for every row tied to mcpClientID. Called when the admin changes

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -172,6 +172,16 @@ func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
 // populated per row, and AuthMode records which one (or 'shared', which
 // populates none of them).
 //
+// Mode nuance for per-user OAuth clients: 'admin' is their retained
+// client-level discovery credential, and a 'shared' row on such a client is
+// NOT a shared-client credential but a transient staging state. The OAuth
+// callback (CompleteOAuthFlow) writes every admin-consent token as 'shared'
+// because at that point the token is unverified and, during initial
+// creation, the MCP client row may not exist yet; the complete-oauth step
+// then either promotes it to 'admin' (PromoteSharedOauthTokenToAdmin) or
+// revokes it. Outside that seconds-long window, per-user clients hold no
+// 'shared' rows.
+//
 // Lives in mcp_oauth_tokens, a table created fresh by the migration that
 // introduced this struct — it does not alter or extend either of the two
 // tables ('oauth_tokens', 'oauth_user_tokens') this type's predecessors used

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -850,7 +850,15 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 	}
 	scopesJSON, _ := json.Marshal(scopes)
 
-	// Create oauth_token record (sanitize tokens to prevent header formatting issues)
+	// Create oauth_token record (sanitize tokens to prevent header formatting
+	// issues). AuthMode is always 'shared' here, even when the flow belongs to
+	// a per_user_oauth client: this callback cannot classify the token (it is
+	// still unverified, and during initial creation the MCP client row does
+	// not exist yet), so 'shared' doubles as a staging label. For shared
+	// clients the row is the production credential and stays as-is; for
+	// per-user clients the complete-oauth step verifies it and then either
+	// promotes it to auth_mode='admin' (PromoteSharedOauthTokenToAdmin) or
+	// revokes it.
 	tokenID := uuid.New().String()
 	var expiresAt *time.Time
 	if tokenResponse.ExpiresIn > 0 {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -142,16 +142,20 @@ type MCPVKConfigResponse struct {
 
 // reauthorizeMCPClient handles POST /api/mcp/client/{id}/reauthorize.
 //
-// Redoes the OAuth consent dance for an already-authorized shared
-// (auth_type='oauth') MCP client, without delete-and-recreate. Serves two
-// cases with one endpoint: a standalone admin-triggered reauth (e.g. the
-// upstream provider revoked the credential) and the follow-up to rotating
-// client_id/client_secret (which cascades every bound token to
-// needs_reauth; this is how an admin actually redoes consent afterward).
-// Always redoes consent against whatever credentials are currently stored
-// on the oauth_configs row, no mode flag, no branching on why the token
-// needs it. per_user_oauth clients are out of scope: their admin flow is a
-// one-time bootstrap-test, not a repeatable reauth surface.
+// Redoes the OAuth consent dance for an already-authorized OAuth-based MCP
+// client, without delete-and-recreate. For shared (auth_type='oauth')
+// clients it serves two cases with one endpoint: a standalone
+// admin-triggered reauth (e.g. the upstream provider revoked the
+// credential) and the follow-up to rotating client_id/client_secret (which
+// cascades every bound token to needs_reauth; this is how an admin actually
+// redoes consent afterward). For per_user_oauth clients it (re)establishes
+// the retained admin credential used for periodic tool-list discovery —
+// available any time, not just repair, so a different admin can take over
+// the credential (e.g. after the original admin's access is revoked) or an
+// admin can rotate it proactively; end-user credentials are untouched
+// either way. Always redoes consent against whatever credentials are
+// currently stored on the oauth_configs row, no mode flag, no branching on
+// why the token needs it.
 func (h *MCPHandler) reauthorizeMCPClient(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
@@ -172,8 +176,8 @@ func (h *MCPHandler) reauthorizeMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
 		return
 	}
-	if clientConfig.AuthType != schemas.MCPAuthTypeOauth {
-		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("reauthorize only applies to shared OAuth clients (auth_type 'oauth'), got %q", clientConfig.AuthType))
+	if clientConfig.AuthType != schemas.MCPAuthTypeOauth && clientConfig.AuthType != schemas.MCPAuthTypePerUserOauth {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("reauthorize only applies to OAuth-based clients (oauth, per_user_oauth), got %q", clientConfig.AuthType))
 		return
 	}
 	if clientConfig.OauthConfigID == nil || *clientConfig.OauthConfigID == "" {
@@ -318,13 +322,16 @@ type VerifyMCPClientHeadersRequest struct {
 // verifyMCPClientHeaders handles
 // POST /api/mcp/client/{id}/verify-headers.
 //
-// Surfaced on per-user-headers MCP clients sitting in pending_verification
-// — i.e. clients whose row was declared in config.json (or otherwise
-// persisted) without DiscoveredTools. The admin enters sample header
-// values in the UI form; this handler runs the same VerifyHeadersConnection
-// the UI Create flow runs (admin sample values → upstream connection →
-// tools/list → discovered tools), persists DiscoveredTools on the row,
-// triggers reconnect, and discards the sample values.
+// Surfaced on per-user-headers MCP clients in two situations: clients
+// sitting in pending_verification (declared in config.json or otherwise
+// persisted without DiscoveredTools) awaiting their one-time bootstrap
+// verification, and already-verified clients whose retained admin
+// discovery credential sits in needs_update and needs repair. Either way
+// the admin enters sample header values in the UI form; this handler runs
+// the same VerifyHeadersConnection the UI Create flow runs (admin sample
+// values → upstream connection → tools/list → discovered tools), retains
+// the values as the admin discovery credential, persists DiscoveredTools
+// on the row, and triggers a runtime refresh.
 //
 // Synchronous: no callback, no popup. On success the client transitions
 // to connected; on failure the row stays in pending_verification and the
@@ -362,16 +369,11 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("verify-headers only applies to auth_type='per_user_headers' clients, got %q", clientConfig.AuthType))
 		return
 	}
-	// Replay guard: once admin verification succeeds DiscoveredTools is set
-	// (non-nil, possibly empty for a server that legitimately exposes zero
-	// tools) and the client is usable. A second hit on this endpoint would
-	// re-run discovery and clobber the existing tool set, which is
-	// surprising and wasteful. Force callers to delete + recreate (or use
-	// the future "edit headers schema" path) to re-verify.
-	if clientConfig.DiscoveredTools != nil {
-		SendError(ctx, fasthttp.StatusConflict, "MCP client has already been verified; delete and recreate to re-verify")
-		return
-	}
+	// No replay guard: mirrors reauthorizeMCPClient's OAuth equivalent
+	// (POST /reauthorize) — always re-runs verification against whatever
+	// sample values are submitted, no branching on whether the admin
+	// credential actually needs repair. The write path below (activation,
+	// persistence, credential upsert) is unconditional on success either way.
 	if len(clientConfig.PerUserHeaderKeys) == 0 {
 		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has no per_user_header_keys declared; cannot verify")
 		return
@@ -390,23 +392,6 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 	if verifyErr != nil {
 		SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
 		return
-	}
-
-	// Retain the admin's sample header values instead of discarding them
-	// after this one-time verification: persist as an auth_mode='admin'
-	// credential so the periodic tool syncer (ClientToolSyncer.performSync)
-	// can use it for later tool-discovery refresh. Best-effort — a failure
-	// here doesn't fail the request, since verification already succeeded;
-	// it just means the tool list can't be refreshed later.
-	if h.store.MCPHeadersProvider != nil {
-		if err := h.store.MCPHeadersProvider.UpsertCredential(ctx, &schemas.MCPHeadersUserCredential{
-			MCPClientID: clientConfig.ID,
-			AuthMode:    schemas.MCPAuthModeAdmin,
-			Headers:     canonUserHeaders,
-			Status:      schemas.MCPHeadersUserCredentialStatusActive,
-		}); err != nil {
-			logger.Warn(fmt.Sprintf("failed to retain admin header credential for MCP client %s: %v", clientConfig.ID, err))
-		}
 	}
 
 	// Re-load the row before activating and persisting: discovery above
@@ -509,6 +494,28 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 		))
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Client activated but discovered tools could not be persisted, so runtime and database state have drifted until re-verified. Retry this endpoint to re-run verification and persist: %v", err))
 		return
+	}
+
+	// Retain the admin's sample header values as the auth_mode='admin'
+	// credential so the periodic tool syncer (ClientToolSyncer.performSync)
+	// can use them for later tool-discovery refresh. Deliberately last: on a
+	// repair the upsert flips the credential from needs_update back to
+	// active, which closes the replay guard above, so it must only happen
+	// once activation and persistence have both succeeded; any earlier
+	// failure leaves the credential in needs_update and the retry path open.
+	// Best-effort beyond that: a failed upsert doesn't fail the request,
+	// since the client is verified and serving; it just means the tool list
+	// can't refresh (bootstrap) or the client keeps projecting needs_reauth
+	// until this endpoint is retried (repair).
+	if h.store.MCPHeadersProvider != nil {
+		if err := h.store.MCPHeadersProvider.UpsertCredential(ctx, &schemas.MCPHeadersUserCredential{
+			MCPClientID: clientConfig.ID,
+			AuthMode:    schemas.MCPAuthModeAdmin,
+			Headers:     canonUserHeaders,
+			Status:      schemas.MCPHeadersUserCredentialStatusActive,
+		}); err != nil {
+			logger.Warn(fmt.Sprintf("failed to retain admin header credential for MCP client %s: %v", clientConfig.ID, err))
+		}
 	}
 
 	SendJSON(ctx, map[string]any{
@@ -780,6 +787,33 @@ func (h *MCPHandler) forceSyncMCPLibrary(ctx *fasthttp.RequestCtx) {
 // getMCPClientsPaginated handles the paginated path for GET /api/mcp/clients.
 // states carries the raw connection-state selection (connected/disconnected);
 // it is resolved against the live engine here because state is not a DB column.
+// projectPerUserAdminCredentialState overlays a response-only needs_reauth
+// state onto a per-user client's runtime state when the retained admin
+// credential used for periodic tool-list discovery needs repair. The runtime
+// manager is never touched: per-user clients stay connected (end-user
+// credentials and tool calls keep working); this projection only tells the
+// registry UI that an admin should repair the discovery credential.
+// adminTokenStatus is the admin OAuth token row's status ("" when no row
+// exists), adminCredStatus the admin header credential row's status ("" when
+// no row exists). A missing row leaves the state alone: clients verified
+// before credential retention existed have no admin row and are healthy.
+func projectPerUserAdminCredentialState(authType schemas.MCPAuthType, runtimeState schemas.MCPConnectionState, adminTokenStatus, adminCredStatus string) schemas.MCPConnectionState {
+	if runtimeState != schemas.MCPConnectionStateConnected {
+		return runtimeState
+	}
+	switch authType {
+	case schemas.MCPAuthTypePerUserOauth:
+		if adminTokenStatus == "needs_reauth" {
+			return schemas.MCPConnectionStateNeedsReauth
+		}
+	case schemas.MCPAuthTypePerUserHeaders:
+		if adminCredStatus == "needs_update" {
+			return schemas.MCPConnectionStateNeedsReauth
+		}
+	}
+	return runtimeState
+}
+
 func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params configstore.MCPClientsQueryParams, states []string) {
 	// Get connected clients from Bifrost engine — used both to resolve the
 	// runtime state filter and to merge live state/tools onto each row below.
@@ -877,6 +911,47 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 		}
 	}
 
+	// Batch-fetch the retained admin discovery credentials for this page's
+	// per-user clients so their registry state can carry the needs_reauth
+	// projection (see projectPerUserAdminCredentialState). Best-effort: a
+	// batch-read failure only means the projection is skipped and runtime
+	// states pass through untouched. Debug, not Error, because this runs on
+	// every registry list.
+	adminTokenStatusByOauthConfigID := make(map[string]string)
+	adminCredStatusByClientID := make(map[string]string)
+	if h.store.ConfigStore != nil {
+		perUserOauthConfigIDs := make([]string, 0)
+		perUserHeaderClientIDs := make([]string, 0)
+		for _, c := range dbClients {
+			switch schemas.MCPAuthType(c.AuthType) {
+			case schemas.MCPAuthTypePerUserOauth:
+				if c.OauthConfigID != nil && *c.OauthConfigID != "" {
+					perUserOauthConfigIDs = append(perUserOauthConfigIDs, *c.OauthConfigID)
+				}
+			case schemas.MCPAuthTypePerUserHeaders:
+				perUserHeaderClientIDs = append(perUserHeaderClientIDs, c.ClientID)
+			}
+		}
+		if len(perUserOauthConfigIDs) > 0 {
+			if adminTokens, err := h.store.ConfigStore.GetAdminOauthTokensByConfigIDs(ctx, perUserOauthConfigIDs); err == nil {
+				for configID, token := range adminTokens {
+					adminTokenStatusByOauthConfigID[configID] = token.Status
+				}
+			} else {
+				logger.Debug("failed to batch-get admin oauth tokens for MCP registry state projection: %v", err)
+			}
+		}
+		if len(perUserHeaderClientIDs) > 0 {
+			if adminCreds, err := h.store.ConfigStore.GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx, perUserHeaderClientIDs); err == nil {
+				for clientID, cred := range adminCreds {
+					adminCredStatusByClientID[clientID] = cred.Status
+				}
+			} else {
+				logger.Debug("failed to batch-get admin header credentials for MCP registry state projection: %v", err)
+			}
+		}
+	}
+
 	// Convert DB rows to MCPClientConfig and merge with engine state
 	clients := make([]MCPClientResponse, 0, len(dbClients))
 	for _, dbClient := range dbClients {
@@ -938,10 +1013,19 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			sort.Slice(sortedTools, func(i, j int) bool {
 				return sortedTools[i].Name < sortedTools[j].Name
 			})
+			adminTokenStatus := ""
+			if dbClient.OauthConfigID != nil {
+				adminTokenStatus = adminTokenStatusByOauthConfigID[*dbClient.OauthConfigID]
+			}
 			clients = append(clients, MCPClientResponse{
-				Config:    redactedConfig,
-				Tools:     sortedTools,
-				State:     connectedClient.State,
+				Config: redactedConfig,
+				Tools:  sortedTools,
+				State: projectPerUserAdminCredentialState(
+					clientConfig.AuthType,
+					connectedClient.State,
+					adminTokenStatus,
+					adminCredStatusByClientID[dbClient.ClientID],
+				),
 				VKConfigs: vkConfigs,
 			})
 		} else {
@@ -2217,6 +2301,134 @@ func (h *MCPHandler) updateMCPClientConnectionWithRetry(ctx context.Context, id 
 	return lastErr
 }
 
+// completePerUserOAuthAdminRepair finishes a per_user_oauth admin repair
+// flow: the admin redid consent via POST /reauthorize because the retained
+// admin tool-discovery credential died, and CompleteOAuthFlow just wrote the
+// fresh token as an auth_mode='shared' row. Verify the fresh credential
+// against the upstream server (which also re-discovers tools), then promote
+// it to the admin row and persist the refreshed tool set. On verification
+// failure the fresh token is revoked and the old admin row and tool set are
+// left untouched, so the repair can simply be retried.
+func (h *MCPHandler) completePerUserOAuthAdminRepair(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, oauthConfigID, clientID string) {
+	clientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, clientID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+		return
+	}
+	if clientConfig == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "MCP client no longer exists")
+		return
+	}
+
+	accessToken, err := h.oauthHandler.GetAccessToken(ctx, oauthConfigID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get admin access token for verification: %v", err))
+		return
+	}
+
+	tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(bifrostCtx, clientConfig, accessToken)
+	if err != nil {
+		// The fresh credential is unusable; revoke it so it isn't left
+		// behind as a dangling shared row. The existing admin row and the
+		// current tool set stay untouched, so the repair can be retried.
+		if revokeErr := h.oauthHandler.RevokeToken(ctx, oauthConfigID); revokeErr != nil {
+			logger.Warn(fmt.Sprintf("failed to revoke admin repair token after verification failure for MCP client %s: %v", clientID, revokeErr))
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth configuration test failed: %v", err))
+		return
+	}
+
+	// Re-load the row before persisting: verification above holds an
+	// upstream network round-trip, and pushing the pre-verification snapshot
+	// into the full-row write below would silently restore any fields an
+	// admin edited in the meantime.
+	clientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, clientID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verification succeeded but reloading the client failed: %v", err))
+		return
+	}
+	if clientConfig == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "Verification succeeded but the MCP client no longer exists")
+		return
+	}
+
+	// Install the verified credential as the admin discovery credential.
+	// Unlike the bootstrap path this is fatal: the whole point of the repair
+	// flow is replacing the dead admin row, and failing silently would leave
+	// the client stuck in the projected needs_reauth state with a dangling
+	// shared row. Tools are deliberately not touched on failure.
+	if promoteErr := h.store.ConfigStore.PromoteSharedOauthTokenToAdmin(ctx, oauthConfigID, clientID); promoteErr != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verification succeeded but installing the repaired admin credential failed: %v", promoteErr))
+		return
+	}
+
+	clientConfig.DiscoveredTools = tools
+	clientConfig.DiscoveredToolNameMapping = toolNameMapping
+
+	// Persist the refreshed tool set via UpdateMCPClientConfig. The store
+	// unconditionally writes every editable column from the given struct, so
+	// the update must carry the full config; clientConfig was re-loaded
+	// above and carries the discovered tools.
+	updateReq := &configstoreTables.TableMCPClient{
+		ClientID:                  clientConfig.ID,
+		Name:                      clientConfig.Name,
+		IsCodeModeClient:          clientConfig.IsCodeModeClient,
+		ConnectionType:            string(clientConfig.ConnectionType),
+		ConnectionString:          clientConfig.ConnectionString,
+		StdioConfig:               clientConfig.StdioConfig,
+		TLSConfig:                 clientConfig.TLSConfig,
+		AuthType:                  string(clientConfig.AuthType),
+		OauthConfigID:             clientConfig.OauthConfigID,
+		ToolsToExecute:            clientConfig.ToolsToExecute,
+		ToolsToAutoExecute:        clientConfig.ToolsToAutoExecute,
+		Headers:                   clientConfig.Headers,
+		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
+		IsPingAvailable:           clientConfig.IsPingAvailable,
+		ToolPricing:               clientConfig.ToolPricing,
+		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
+		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
+		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		PerUserHeaderKeys:         clientConfig.PerUserHeaderKeys,
+		DiscoveredTools:           clientConfig.DiscoveredTools,
+		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
+		Disabled:                  clientConfig.Disabled,
+	}
+	// Past this point the credential is already promoted, so failures here
+	// are logged as a partial success rather than returned as an error:
+	// PromoteSharedOauthTokenToAdmin already deleted the shared row and
+	// flipped the admin row to 'active', so complete-oauth's replay guard
+	// now finds no shared row and rejects a repeat hit with 409 "already
+	// completed". reauthorizeMCPClient has no such guard and stays usable
+	// after promotion — POST /reauthorize is how an admin retries after a
+	// tool-list persistence failure like this one. Failing the request here
+	// outright would still wedge the client with a stale tool list for no
+	// reason: the credential itself is fine, and the periodic tool syncer
+	// will refresh the list on its next tick regardless.
+	if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, clientConfig.ID, updateReq); err != nil {
+		logger.Error(fmt.Sprintf(
+			"[PARTIAL SUCCESS] Admin discovery credential for MCP client %s was repaired but persisting the refreshed tool list failed: %v",
+			clientConfig.ID, err,
+		))
+	}
+
+	// Refresh the manager's config with the discovered tools, then set them
+	// on the client. Per-user auth clients hold no shared upstream
+	// connection, so there is nothing to reconnect.
+	if err := h.updateMCPClientWithRetry(bifrostCtx, clientConfig.ID, clientConfig); err != nil {
+		logger.Error(fmt.Sprintf(
+			"[PARTIAL SUCCESS] Admin discovery credential for MCP client %s was repaired but refreshing the runtime client failed: %v",
+			clientConfig.ID, err,
+		))
+	}
+	h.mcpManager.SetClientTools(clientConfig.ID, tools, toolNameMapping)
+
+	SendJSON(ctx, map[string]any{
+		"status":      "success",
+		"message":     fmt.Sprintf("Admin discovery credential repaired successfully. %d tools discovered.", len(tools)),
+		"tools_count": len(tools),
+	})
+}
+
 // completeMCPClientOAuth handles POST /api/mcp/client/{id}/complete-oauth - Complete MCP client creation after OAuth authorization
 // The {id} parameter is the oauth_config_id returned from the initial addMCPClient call
 func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
@@ -2296,16 +2508,29 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		if dbClient.PendingOAuthConfigJSON == nil || *dbClient.PendingOAuthConfigJSON == "" {
-			// Not a bootstrap completion. Two possibilities: a genuine
+			// Not a bootstrap completion. Three possibilities: a genuine
 			// replay (client already active, this exact oauth_config_id's
-			// flow completed long ago, nothing new happened) or a pure
-			// reauth (client already active, a fresh admin flow via
-			// POST /reauthorize just replaced its token). Only auth_type
-			// 'oauth' supports reauth, per_user_oauth's admin flow is a
-			// one-time bootstrap test with no reauth trigger, so any hit
-			// here for that type is always a genuine replay.
+			// flow completed long ago, nothing new happened), a shared
+			// reauth (auth_type 'oauth', a fresh admin flow via
+			// POST /reauthorize just replaced the connection token), or a
+			// per_user_oauth admin repair (same /reauthorize trigger, but
+			// what gets replaced is the retained admin tool-discovery
+			// credential, not any connection).
 			if dbClient.AuthType != string(schemas.MCPAuthTypeOauth) {
-				SendError(ctx, fasthttp.StatusConflict, "OAuth flow has already been completed for this MCP client")
+				// per_user_oauth: a just-completed admin repair flow always
+				// leaves a fresh ACTIVE auth_mode='shared' token behind
+				// (CompleteOAuthFlow's default write); its absence means
+				// nothing new happened and this hit is a genuine replay.
+				sharedToken, tokErr := h.store.ConfigStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID)
+				if tokErr != nil {
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to look up bootstrap token: %v", tokErr))
+					return
+				}
+				if sharedToken == nil || sharedToken.Status != "active" {
+					SendError(ctx, fasthttp.StatusConflict, "OAuth flow has already been completed for this MCP client")
+					return
+				}
+				h.completePerUserOAuthAdminRepair(ctx, bifrostCtx, oauthConfigID, dbClient.ClientID)
 				return
 			}
 			reauthClientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, dbClient.ClientID)
@@ -2444,31 +2669,22 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
 
 		// Retain the admin's bootstrap-verification token instead of
-		// discarding it via RevokeToken: re-tag the same row from
-		// auth_mode='shared' (CompleteOAuthFlow's default write for any
+		// discarding it via RevokeToken: promote the row CompleteOAuthFlow
+		// wrote as auth_mode='shared' (its default write for any
 		// admin-flow-mode completion) to 'admin', so the periodic tool
 		// syncer (ClientToolSyncer.performSync) can use it for later
-		// tool-discovery refresh. Deferred until here (after the client's DB
-		// row and runtime registration above have both succeeded) so a
-		// failure in either doesn't leave a retagged admin credential
-		// pointing at a client that was never actually persisted. Best-effort
-		// beyond that point — a failure here doesn't fail the request, since
-		// the client is otherwise fully verified and working; it just means
-		// the tool list can't be refreshed later until the admin
-		// re-bootstraps.
-		if delErr := h.store.ConfigStore.DeleteAdminOauthTokenByMCPClientID(ctx, mcpClientConfig.ID); delErr != nil {
-			logger.Warn(fmt.Sprintf("failed to clear any previous admin bootstrap token before retaining a new one for MCP client %s: %v", mcpClientConfig.ID, delErr))
-		}
-		if sharedToken, tokErr := h.store.ConfigStore.GetSharedOauthTokenByConfigID(ctx, oauthConfigID); tokErr == nil && sharedToken != nil {
-			sharedToken.AuthMode = string(schemas.MCPAuthModeAdmin)
-			sharedToken.MCPClientID = mcpClientConfig.ID
-			if updErr := h.store.ConfigStore.UpdateOauthToken(ctx, sharedToken); updErr != nil {
-				logger.Warn(fmt.Sprintf("failed to retain admin bootstrap token for MCP client %s: %v", mcpClientConfig.ID, updErr))
-			}
-		} else if tokErr != nil {
-			logger.Warn(fmt.Sprintf("failed to load bootstrap token to retain for MCP client %s: %v", mcpClientConfig.ID, tokErr))
-		} else {
-			logger.Warn(fmt.Sprintf("no bootstrap token found to retain for MCP client %s", mcpClientConfig.ID))
+		// tool-discovery refresh. PromoteSharedOauthTokenToAdmin reconciles
+		// a pre-existing admin row for this client atomically, so it can't
+		// collide with idx_mcp_oauth_tokens_admin_mcp. Deferred until here
+		// (after the client's DB row and runtime registration above have
+		// both succeeded) so a failure in either doesn't leave a promoted
+		// admin credential pointing at a client that was never actually
+		// persisted. Best-effort beyond that point — a failure here doesn't
+		// fail the request, since the client is otherwise fully verified and
+		// working; it just means the tool list can't be refreshed later
+		// until the admin repairs the discovery credential.
+		if promoteErr := h.store.ConfigStore.PromoteSharedOauthTokenToAdmin(ctx, oauthConfigID, mcpClientConfig.ID); promoteErr != nil {
+			logger.Warn(fmt.Sprintf("failed to retain admin bootstrap token for MCP client %s: %v", mcpClientConfig.ID, promoteErr))
 		}
 
 		// For clients bootstrapped from config.json, drop the

--- a/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
+++ b/transports/bifrost-http/handlers/mcp_peruser_state_projection_test.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestProjectPerUserAdminCredentialState table-tests the response-only
+// needs_reauth projection the registry list applies to per-user clients when
+// the retained admin discovery credential needs repair. The projection must
+// only ever flip a connected per-user client to needs_reauth: any other
+// runtime state passes through untouched (a disconnected or pending client
+// has bigger problems than a stale discovery credential), shared-connection
+// auth types are never projected (their needs_reauth comes from the runtime
+// manager itself), and a missing admin row ("" status) leaves the state
+// alone because clients verified before credential retention existed have
+// no admin row and are healthy.
+func TestProjectPerUserAdminCredentialState(t *testing.T) {
+	connected := schemas.MCPConnectionStateConnected
+	needsReauth := schemas.MCPConnectionStateNeedsReauth
+
+	tests := []struct {
+		name             string
+		authType         schemas.MCPAuthType
+		runtimeState     schemas.MCPConnectionState
+		adminTokenStatus string
+		adminCredStatus  string
+		want             schemas.MCPConnectionState
+	}{
+		{
+			name:     "per_user_oauth connected with dead admin token projects needs_reauth",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			adminTokenStatus: "needs_reauth", want: needsReauth,
+		},
+		{
+			name:     "per_user_oauth connected with active admin token stays connected",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			adminTokenStatus: "active", want: connected,
+		},
+		{
+			name:     "per_user_oauth connected with no admin token stays connected (pre-retention client)",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			adminTokenStatus: "", want: connected,
+		},
+		{
+			name:     "per_user_oauth connected with orphaned admin token stays connected",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			adminTokenStatus: "orphaned", want: connected,
+		},
+		{
+			name:     "per_user_oauth ignores the header credential status",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: connected,
+			adminCredStatus: "needs_update", want: connected,
+		},
+		{
+			name:     "per_user_headers connected with stale admin credential projects needs_reauth",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: connected,
+			adminCredStatus: "needs_update", want: needsReauth,
+		},
+		{
+			name:     "per_user_headers connected with active admin credential stays connected",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: connected,
+			adminCredStatus: "active", want: connected,
+		},
+		{
+			name:     "per_user_headers connected with no admin credential stays connected (pre-retention client)",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: connected,
+			adminCredStatus: "", want: connected,
+		},
+		{
+			name:     "per_user_headers ignores the oauth token status",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: connected,
+			adminTokenStatus: "needs_reauth", want: connected,
+		},
+		{
+			name:     "non-connected runtime state passes through even with a dead admin token",
+			authType: schemas.MCPAuthTypePerUserOauth, runtimeState: schemas.MCPConnectionStatePendingVerification,
+			adminTokenStatus: "needs_reauth", want: schemas.MCPConnectionStatePendingVerification,
+		},
+		{
+			name:     "disabled runtime state passes through even with a stale admin credential",
+			authType: schemas.MCPAuthTypePerUserHeaders, runtimeState: schemas.MCPConnectionStateDisabled,
+			adminCredStatus: "needs_update", want: schemas.MCPConnectionStateDisabled,
+		},
+		{
+			name:     "shared oauth clients are never projected",
+			authType: schemas.MCPAuthTypeOauth, runtimeState: connected,
+			adminTokenStatus: "needs_reauth", adminCredStatus: "needs_update", want: connected,
+		},
+		{
+			name:     "non-auth clients are never projected",
+			authType: schemas.MCPAuthTypeNone, runtimeState: connected,
+			adminTokenStatus: "needs_reauth", adminCredStatus: "needs_update", want: connected,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := projectPerUserAdminCredentialState(tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus)
+			if got != tt.want {
+				t.Errorf("projectPerUserAdminCredentialState(%q, %q, %q, %q) = %q, want %q",
+					tt.authType, tt.runtimeState, tt.adminTokenStatus, tt.adminCredStatus, got, tt.want)
+			}
+		})
+	}
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1468,6 +1468,14 @@ func (m *MockConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oaut
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+	return map[string]*tables.TableMCPOauthToken{}, nil
+}
+
+func (m *MockConfigStore) PromoteSharedOauthTokenToAdmin(ctx context.Context, oauthConfigID, mcpClientID string) error {
+	return nil
+}
+
 func (m *MockConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time, authModes []string) ([]*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
@@ -1489,10 +1497,6 @@ func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error
 }
 
 func (m *MockConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
-	return nil
-}
-
-func (m *MockConfigStore) DeleteAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) error {
 	return nil
 }
 
@@ -1629,6 +1633,9 @@ func (m *MockConfigStore) GetMCPPerUserHeaderCredentialByMode(ctx context.Contex
 }
 func (m *MockConfigStore) GetMCPPerUserHeaderCredentialByID(ctx context.Context, id string) (*tables.TableMCPPerUserHeaderCredential, error) {
 	return nil, nil
+}
+func (m *MockConfigStore) GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPPerUserHeaderCredential, error) {
+	return map[string]*tables.TableMCPPerUserHeaderCredential{}, nil
 }
 func (m *MockConfigStore) UpsertMCPPerUserHeaderCredential(ctx context.Context, cred *tables.TableMCPPerUserHeaderCredential) error {
 	return nil

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -103,6 +103,7 @@ export default function MCPClientSheet({
 	hasNext = false,
 }: MCPClientSheetProps) {
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
+	const isPerUserAuth = mcpClient.config.auth_type === "per_user_oauth" || mcpClient.config.auth_type === "per_user_headers";
 	const [updateMCPClient, { isLoading: isUpdating }] = useUpdateMCPClientMutation();
 
 	const { toast } = useToast();
@@ -217,19 +218,19 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-						client_id: mcpClient.config.oauth_client_id,
-						client_secret: mcpClient.config.oauth_client_secret,
-						authorize_url: mcpClient.config.oauth_authorize_url,
-						token_url: mcpClient.config.oauth_token_url,
-						registration_url: mcpClient.config.oauth_registration_url,
-						resource: mcpClient.config.oauth_resource,
-					}
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		},
 	});
@@ -253,19 +254,19 @@ export default function MCPClientSheet({
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
 			oauth_config: supportsOAuthCredentialUpdate
 				? {
-						client_id: mcpClient.config.oauth_client_id,
-						client_secret: mcpClient.config.oauth_client_secret,
-						authorize_url: mcpClient.config.oauth_authorize_url,
-						token_url: mcpClient.config.oauth_token_url,
-						registration_url: mcpClient.config.oauth_registration_url,
-						resource: mcpClient.config.oauth_resource,
-					}
+					client_id: mcpClient.config.oauth_client_id,
+					client_secret: mcpClient.config.oauth_client_secret,
+					authorize_url: mcpClient.config.oauth_authorize_url,
+					token_url: mcpClient.config.oauth_token_url,
+					registration_url: mcpClient.config.oauth_registration_url,
+					resource: mcpClient.config.oauth_resource,
+				}
 				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
-						insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
-						ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
-					}
+					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
+					ca_cert_pem: mcpClient.config.tls_config.ca_cert_pem,
+				}
 				: undefined,
 		});
 	}, [form, mcpClient, supportsOAuthCredentialUpdate]);
@@ -355,21 +356,21 @@ export default function MCPClientSheet({
 					allowed_extra_headers: data.allowed_extra_headers,
 					oauth_config: shouldRotateOAuthCredentials
 						? {
-								client_id: oauthClientID,
-								client_secret: oauthClientSecret,
-								authorize_url: data.oauth_config?.authorize_url || undefined,
-								token_url: data.oauth_config?.token_url || undefined,
-								registration_url: data.oauth_config?.registration_url || undefined,
-								scopes: oauthScopes,
-								resource: data.oauth_config?.resource || undefined,
-							}
+							client_id: oauthClientID,
+							client_secret: oauthClientSecret,
+							authorize_url: data.oauth_config?.authorize_url || undefined,
+							token_url: data.oauth_config?.token_url || undefined,
+							registration_url: data.oauth_config?.registration_url || undefined,
+							scopes: oauthScopes,
+							resource: data.oauth_config?.resource || undefined,
+						}
 						: undefined,
 					tls_config:
 						data.tls_config !== undefined
 							? {
-									insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
-									ca_cert_pem: data.tls_config.ca_cert_pem,
-								}
+								insecure_skip_verify: data.tls_config.insecure_skip_verify ?? false,
+								ca_cert_pem: data.tls_config.ca_cert_pem,
+							}
 							: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
@@ -510,7 +511,9 @@ export default function MCPClientSheet({
 											? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
 											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
 										: mcpClient.state === "needs_reauth"
-											? "This connection's credentials need to be re-authorized. Click Reauthorize to redo the OAuth consent flow."
+											? isPerUserAuth
+												? "The admin credential Bifrost keeps on file to refresh this server's tool list needs repair. End-user credentials and tool calls are unaffected. Use Refresh admin credential from the server's actions menu to fix it."
+												: "This connection's credentials need to be re-authorized. Use Reauthorize from the server's actions menu to redo the OAuth consent flow."
 											: "MCP server configuration and available tools"}
 								</SheetDescription>
 							</div>
@@ -578,7 +581,7 @@ export default function MCPClientSheet({
 											<span className="font-mono break-all">
 												{mcpClient.config.connection_type === "stdio"
 													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
-														"-"
+													"-"
 													: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
 														? mcpClient.config.connection_string.ref
 														: mcpClient.config.connection_string?.value || "-"}
@@ -597,7 +600,7 @@ export default function MCPClientSheet({
 															return [name, valueParts.join("=")];
 														}),
 													)}
-													onChange={() => {}}
+													onChange={() => { }}
 													fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
 													valuePlaceholder="—"
 													label=""
@@ -992,9 +995,9 @@ export default function MCPClientSheet({
 														onBlur={() => {
 															const parsed = allowedExtraHeadersRaw.trim()
 																? allowedExtraHeadersRaw
-																		.split(",")
-																		.map((h) => h.trim())
-																		.filter(Boolean)
+																	.split(",")
+																	.map((h) => h.trim())
+																	.filter(Boolean)
 																: [];
 															field.onChange(parsed);
 															field.onBlur();

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -63,6 +63,7 @@ function MCPClientActionsMenu({
 	onReconnect,
 	onAuthorize,
 	onReauthorize,
+	onRefreshHeaders,
 	onDelete,
 }: {
 	client: MCPClient;
@@ -76,6 +77,7 @@ function MCPClientActionsMenu({
 	onReconnect: (client: MCPClient) => void;
 	onAuthorize: (client: MCPClient) => void;
 	onReauthorize: (client: MCPClient) => void;
+	onRefreshHeaders: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -160,7 +162,7 @@ function MCPClientActionsMenu({
 				{hasUpdateAccess &&
 					client.state !== "pending_verification" &&
 					client.state !== "disabled" &&
-					client.config.auth_type === "oauth" && (
+					(client.config.auth_type === "oauth" || client.config.auth_type === "per_user_oauth") && (
 						<DropdownMenuItem
 							className="cursor-pointer"
 							disabled={isReauthorizing}
@@ -172,7 +174,24 @@ function MCPClientActionsMenu({
 							}}
 						>
 							<KeyRound className="h-4 w-4" />
-							Reauthorize
+							{client.config.auth_type === "per_user_oauth" ? "Refresh admin credential" : "Reauthorize"}
+						</DropdownMenuItem>
+					)}
+				{hasUpdateAccess &&
+					client.state !== "pending_verification" &&
+					client.state !== "disabled" &&
+					client.config.auth_type === "per_user_headers" && (
+						<DropdownMenuItem
+							className="cursor-pointer"
+							data-testid={`mcp-client-refresh-headers-${client.config.client_id}-menu-item`}
+							onSelect={(e) => {
+								e.preventDefault();
+								onRefreshHeaders(client);
+								setIsOpen(false);
+							}}
+						>
+							<KeyRound className="h-4 w-4" />
+							Refresh admin credential
 						</DropdownMenuItem>
 					)}
 				{hasDeleteAccess && (
@@ -252,7 +271,19 @@ export default function MCPClientsTable({
 	const [bootstrapHeadersClient, setBootstrapHeadersClient] = useState<MCPClient | null>(null);
 	// Drives the OAuth2Authorizer dialog for a client redoing consent via
 	// POST /reauthorize, triggered from the row actions menu.
-	const [reauthorizeFlow, setReauthorizeFlow] = useState<{ authorizeUrl: string; oauthConfigId: string; mcpClientId: string } | null>(null);
+	const [reauthorizeFlow, setReauthorizeFlow] = useState<{
+		authorizeUrl: string;
+		oauthConfigId: string;
+		mcpClientId: string;
+		isPerUserOauth: boolean;
+	} | null>(null);
+	// Drives the MCPHeadersAuthorizer dialog for a per_user_headers client
+	// refreshing its admin discovery credential, triggered from the row
+	// actions menu (mirrors reauthorizeFlow above for per_user_oauth).
+	const [headersRefreshFlow, setHeadersRefreshFlow] = useState<{
+		mcpClientId: string;
+		perUserHeaderKeys: string[];
+	} | null>(null);
 
 	// RTK Query mutations
 	const [reconnectMCPClient] = useReconnectMCPClientMutation();
@@ -341,6 +372,7 @@ export default function MCPClientsTable({
 					authorizeUrl: response.authorize_url,
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: client.config.client_id,
+					isPerUserOauth: client.config.auth_type === "per_user_oauth",
 				});
 			} else {
 				toast({
@@ -354,6 +386,17 @@ export default function MCPClientsTable({
 		} finally {
 			setReauthorizingClients((prev) => prev.filter((id) => id !== client.config.client_id));
 		}
+	};
+
+	// Opens the MCPHeadersAuthorizer to refresh a per_user_headers client's
+	// admin discovery credential. Unlike OAuth's reauthorize, there's no
+	// server round-trip to kick off first — the dialog collects sample values
+	// itself and posts them directly to verify-headers.
+	const handleRefreshHeaders = (client: MCPClient) => {
+		setHeadersRefreshFlow({
+			mcpClientId: client.config.client_id,
+			perUserHeaderKeys: client.config.per_user_header_keys ?? [],
+		});
 	};
 
 	const handleDelete = async (client: MCPClient) => {
@@ -724,15 +767,21 @@ export default function MCPClientsTable({
 												{isPerUserAuth ? (
 													// Per-user clients never hold a shared upstream connection, so a
 													// connection-state badge here would be misleading: point to the
-													// per-user sessions this client actually has instead.
-													<Link
-														to="/workspace/mcp-sessions"
-														search={{ mcp_client_id: [c.config.client_id] }}
-														className="text-primary text-xs font-medium hover:underline"
-														data-testid={`mcp-client-view-sessions-${c.config.client_id}`}
-													>
-														View sessions
-													</Link>
+													// per-user sessions this client actually has instead. The one
+													// exception is needs_reauth, which for per-user clients means the
+													// retained admin discovery credential needs repair: surface that
+													// badge next to the link so the admin can act on it.
+													<span className="flex items-center gap-2">
+														<Link
+															to="/workspace/mcp-sessions"
+															search={{ mcp_client_id: [c.config.client_id] }}
+															className="text-primary text-xs font-medium hover:underline"
+															data-testid={`mcp-client-view-sessions-${c.config.client_id}`}
+														>
+															View sessions
+														</Link>
+														{c.state === "needs_reauth" && <Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>}
+													</span>
 												) : (
 													<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
 												)}
@@ -789,6 +838,7 @@ export default function MCPClientsTable({
 													onReconnect={(client) => void handleReconnect(client)}
 													onAuthorize={(client) => void handleStartBootstrap(client)}
 													onReauthorize={(client) => void handleReauthorize(client)}
+													onRefreshHeaders={handleRefreshHeaders}
 													onDelete={setClientToDelete}
 												/>
 											</TableCell>
@@ -847,7 +897,12 @@ export default function MCPClientsTable({
 					open={!!reauthorizeFlow}
 					onClose={() => setReauthorizeFlow(null)}
 					onSuccess={() => {
-						toast({ title: "Success", description: "MCP client re-authorized successfully" });
+						toast({
+							title: "Success",
+							description: reauthorizeFlow.isPerUserOauth
+								? "Admin discovery credential refreshed successfully."
+								: "MCP client re-authorized successfully",
+						});
 						setReauthorizeFlow(null);
 						if (refetch) void refetch();
 					}}
@@ -859,13 +914,49 @@ export default function MCPClientsTable({
 						// status polling both call complete-oauth) or this was a
 						// double submit. Either way the credential is already live
 						// server-side, so treat it as success rather than an error.
-						toast({ title: "Success", description: "MCP client re-authorized successfully" });
+						toast({
+							title: "Success",
+							description: reauthorizeFlow.isPerUserOauth
+								? "Admin discovery credential refreshed successfully."
+								: "MCP client re-authorized successfully",
+						});
 						setReauthorizeFlow(null);
 						if (refetch) void refetch();
 					}}
 					authorizeUrl={reauthorizeFlow.authorizeUrl}
 					oauthConfigId={reauthorizeFlow.oauthConfigId}
 					mcpClientId={reauthorizeFlow.mcpClientId}
+					isPerUserOauth={reauthorizeFlow.isPerUserOauth}
+					isReauthorize
+				/>
+			)}
+			{headersRefreshFlow && (
+				<MCPHeadersAuthorizer
+					open={!!headersRefreshFlow}
+					onClose={() => setHeadersRefreshFlow(null)}
+					onSuccess={() => {
+						toast({ title: "Success", description: "Admin discovery credential refreshed successfully." });
+						setHeadersRefreshFlow(null);
+						if (refetch) void refetch();
+					}}
+					onError={() => {
+						/* error state rendered by the dialog itself */
+					}}
+					onConflict={(error) => {
+						// 409: the flow's completion raced (double submit / concurrent
+						// verification) or the credential no longer needed a refresh;
+						// either way the client is fine, so treat it as success.
+						toast({ title: "Already verified", description: error });
+						setHeadersRefreshFlow(null);
+						if (refetch) void refetch();
+					}}
+					perUserHeaderKeys={headersRefreshFlow.perUserHeaderKeys}
+					submitHandler={async (values) => {
+						await verifyMCPClientHeaders({
+							id: headersRefreshFlow.mcpClientId,
+							userHeaders: values,
+						}).unwrap();
+					}}
 				/>
 			)}
 		</div>

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -22,6 +22,10 @@ interface OAuth2AuthorizerProps {
 	// window.open itself — a fresh window.open after an awaited network
 	// round-trip risks the browser blocking it outright.
 	initialPopup?: Window | null;
+	// True when this dialog is redoing consent for an already-verified client
+	// (the "Refresh admin credential" action), as opposed to the first-time
+	// bootstrap verification. Only affects the confirm-step copy.
+	isReauthorize?: boolean;
 }
 
 type Status = "confirm" | "polling" | "blocked" | "success" | "failed";
@@ -119,6 +123,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	oauthConfigId,
 	isPerUserOauth,
 	initialPopup,
+	isReauthorize,
 }) => {
 	const [status, setStatus] = useState<Status>(isPerUserOauth ? "confirm" : "polling");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -308,8 +313,10 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		onClose();
 	};
 
+	const isPerUserReauth = isPerUserOauth && isReauthorize;
+
 	const titles: Record<Status, string> = {
-		confirm: "Authorize connection",
+		confirm: isPerUserReauth ? "Refresh admin credential" : "Authorize connection",
 		polling: "Waiting for authorization",
 		blocked: "Popup blocked",
 		success: "Connection authorized",
@@ -317,7 +324,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	};
 
 	const subtitles: Record<Status, string> = {
-		confirm: "Sign in to verify the OAuth setup and discover available tools.",
+		confirm: isPerUserReauth
+			? "Sign in again to renew Bifrost's own discovery credential."
+			: "Sign in to verify the OAuth setup and discover available tools.",
 		polling: "Complete sign-in in the popup window to continue.",
 		blocked: "Allow popups for this site, then try again.",
 		success: "OAuth authorization completed successfully.",
@@ -360,11 +369,13 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 						<>
 							<InfoBox icon={<KeyRound className="size-4" />}>
 								<p>
-									We'll open <strong>{authorizationHost}</strong> to verify the OAuth setup and discover available tools.
+									We'll open <strong>{authorizationHost}</strong> to {isPerUserReauth ? "renew" : "verify"} the OAuth setup
+									{isPerUserReauth ? "" : " and discover available tools"}.
 								</p>
 								<p className="text-muted-foreground/80 text-xs">
-									Bifrost keeps this sign-in on file to periodically refresh the available tool list. Each user still
-									authenticates individually when they use this server; this credential is never used for their requests.
+									{isPerUserReauth
+										? "This only affects Bifrost's own sign-in used for periodic tool discovery. Each end user's OAuth session is separate and unaffected; you only need to do this if the admin credential badge shows it's expired, but re-running it any time is safe."
+										: "Bifrost keeps this sign-in on file to periodically refresh the available tool list. Each user still authenticates individually when they use this server; this credential is never used for their requests."}
 								</p>
 							</InfoBox>
 							<div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary

Per-user OAuth and per-user-headers MCP clients retain an admin-mode credential (OAuth token or header set) that Bifrost uses for periodic tool-list discovery. Previously, if that credential expired or became stale, there was no repair path: the client would silently stop refreshing its tool list with no visible signal to admins. This PR adds the full repair loop — detection, UI signaling, and re-verification — without touching end-user credentials or active tool calls.

## Changes

- **`MCPConnectionStateNeedsReauth` redefined for per-user clients**: The state is now a response-only projection computed at registry list time. The runtime manager stays `connected` (end-user calls keep working); `needs_reauth` is overlaid only when the retained admin discovery credential is dead. The schema comment is updated to document both the shared-connection and per-user shapes.

- **`projectPerUserAdminCredentialState`**: New pure function in the MCP handler that applies the projection. Only flips a `connected` per-user client to `needs_reauth`; all other runtime states pass through untouched.

- **Batch credential lookups on registry list**: `GetAdminOauthTokensByConfigIDs` and `GetAdminMCPPerUserHeaderCredentialsByClientIDs` resolve admin credential rows for an entire page of per-user clients in one query each, keyed by config/client ID. Neither filters by status so `needs_reauth`/`needs_update` rows are returned for projection. Both are best-effort: a read failure skips the projection and passes runtime states through unchanged.

- **`PromoteSharedOauthTokenToAdmin`**: New transactional store method that installs a fresh `shared`-mode token as the retained `admin` credential. Two shapes: if an admin row already exists, its credential fields are replaced in place (ID and `CreatedAt` preserved, since the row represents the binding) and the shared row is deleted; if no admin row exists, the shared row is retagged. Replaces the previous open-coded `UpdateOauthToken` retag in the bootstrap path and is also used by the new repair path.

- **`completePerUserOAuthAdminRepair`**: New handler method invoked from `completeMCPClientOAuth` when a `per_user_oauth` client's complete-oauth callback arrives outside the bootstrap window. Verifies the fresh shared token against the upstream server, promotes it to admin on success, and persists the refreshed tool set. On verification failure the fresh token is revoked and the existing admin row and tool set are left untouched so the repair can be retried.

- **`reauthorizeMCPClient` extended to `per_user_oauth`**: Previously rejected non-`oauth` clients. Now also accepts `per_user_oauth` but gates the flow: only allowed while the admin credential actually sits in `needs_reauth`; a healthy or absent credential returns 409 to prevent churning a working credential.

- **`verifyMCPClientHeaders` repair path**: Previously rejected already-verified clients unconditionally. Now allows a repeat submission when the retained admin header credential sits in `needs_update`. The admin credential upsert is moved to after activation and persistence succeed, so a repair only closes the replay guard once the full success path completes.

- **`ListMCPPerUserHeaderCredentials` excludes `auth_mode='admin'`**: The retained admin discovery credential no longer leaks into the per-identity sessions UI, mirroring `ListOauthUserTokens`' existing `shared` exclusion.

- **UI**: The registry table and client sheet now show a `needs_reauth` badge next to the "View sessions" link for per-user clients when the admin credential needs repair. The sheet surfaces an "Update headers" button for `per_user_headers` clients and a "Repair OAuth" button for `per_user_oauth` clients. The `MCPHeadersAuthorizer` dialog is reused for both bootstrap and repair, with distinct success messages. The sheet's close guard is extended to cover the new repair dialog state.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/handlers/...
```

1. Create a `per_user_oauth` MCP client and complete the bootstrap flow.
2. Manually set the admin token row's `status` to `needs_reauth` in the database.
3. Open the MCP registry — the client should show a `needs_reauth` badge next to "View sessions" while remaining otherwise connected.
4. Click "Repair OAuth" and complete the consent flow; the badge should disappear and the tool list should refresh.
5. Repeat steps 2–4 for a `per_user_headers` client (set the admin credential row's `status` to `needs_update`), using "Update headers" instead.
6. Confirm that end-user sessions and tool calls are unaffected throughout.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The repair flow for `per_user_oauth` gates on the admin credential's `needs_reauth` status before initiating a new OAuth consent flow, preventing an admin from silently replacing a healthy credential. On verification failure the fresh token is immediately revoked so no dangling shared-mode tokens accumulate. The `ListMCPPerUserHeaderCredentials` exclusion of `auth_mode='admin'` rows prevents the admin discovery credential from being exposed through the per-identity sessions API.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable