### PR TITLE
feat: add generation-guarded LRU cache with single-flight fills and secondary index

### DIFF
--- a/framework/lrucache/lrucache.go
+++ b/framework/lrucache/lrucache.go
@@ -1,0 +1,399 @@
+// Package lrucache provides a bounded, generation-guarded LRU cache with
+// single-flight fills, built for in-memory mirrors of database rows that are
+// kept consistent by explicit eviction rather than TTLs.
+//
+// Design points, all load-bearing for correctness:
+//
+//   - Fills are single-flight: concurrent callers for the same key wait on
+//     one leader and share its result and error. Errors are propagated to
+//     every waiter but never cached, so a failed load is retried by the next
+//     caller. A panicking loader releases its waiters with an error and
+//     re-raises on the leader's own stack.
+//   - A generation counter increments on every explicit eviction or flush.
+//     A fill records the generation before running its loader and its
+//     install is discarded if the generation moved, so a fill racing an
+//     eviction can never re-install the value the eviction just removed.
+//     Capacity (LRU) eviction does not increment it: dropping a still-valid
+//     entry for space is not an invalidation.
+//   - An optional secondary index maps a caller-chosen string (typically a
+//     row's primary key) to the cache key holding it, so write paths that
+//     only know the row identity can evict without recomputing the key.
+//   - An optional validator runs on every hit; an entry it rejects is
+//     removed and reported as a miss, so callers fall through to their full
+//     load path (used, for example, to treat expired credentials as misses
+//     while keeping all expiry policy in the caller).
+//
+// The cache owns its own locking and never holds a lock across a loader
+// call, so loaders are free to perform database reads or network I/O. It
+// must not be guarded by any caller-side lock that is itself held across
+// I/O; give the cache exclusive ownership of its consistency instead.
+//
+// All methods are safe on a nil receiver: reads miss, evictions no-op, and
+// Fill degrades to calling the loader directly. This lets consumers treat
+// an absent cache as "caching disabled" without branching.
+package lrucache
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Loader produces the value for a cache key on a miss. It returns the value,
+// the secondary-index key to register for it (empty for none), and an error.
+// Errors are shared with concurrent waiters but never cached.
+type Loader[V any] func() (value V, indexKey string, err error)
+
+// inflightCall represents one in-progress fill for a cache key. Concurrent
+// callers for the same key wait on done and share result/err.
+type inflightCall[V any] struct {
+	done   chan struct{}
+	result V
+	err    error
+}
+
+type entry[V any] struct {
+	key      string
+	indexKey string
+	value    V
+	// version increments on every in-place value update (setIfGeneration's
+	// existing-entry branch). An update reuses the same *list.Element, so
+	// element identity alone can't distinguish "still the value I read" from
+	// "replaced since I read it" — version closes that gap. See Get's use.
+	version uint64
+}
+
+// Cache is a bounded LRU cache with single-flight fills. Construct with New;
+// the zero value is not usable (but a nil *Cache is, see the package doc).
+type Cache[V any] struct {
+	mu       sync.Mutex
+	capacity int
+	items    map[string]*list.Element
+	order    *list.List // front = most recently used
+	// byIndex maps a secondary-index key to the cache key holding it.
+	byIndex map[string]string
+	// generation increments on every explicit eviction or flush; see the
+	// package doc for the fill-race guarantee it provides.
+	generation uint64
+	// validator, when non-nil, is consulted on every hit; entries it
+	// rejects are removed and reported as misses.
+	validator func(V) bool
+
+	inflightMu sync.Mutex
+	inflight   map[string]*inflightCall[V]
+}
+
+// Option configures a Cache at construction time.
+type Option[V any] func(*Cache[V])
+
+// WithValidator installs a hit-time validity check: entries for which valid
+// returns false are removed and reported as misses.
+func WithValidator[V any](valid func(V) bool) Option[V] {
+	return func(c *Cache[V]) {
+		c.validator = valid
+	}
+}
+
+// New constructs a Cache bounded to capacity entries. A non-positive
+// capacity panics: the bound is part of the type's contract, and silently
+// defaulting it would hide a caller bug.
+func New[V any](capacity int, opts ...Option[V]) *Cache[V] {
+	if capacity <= 0 {
+		panic("lrucache: capacity must be positive")
+	}
+	c := &Cache[V]{
+		capacity: capacity,
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+		byIndex:  make(map[string]string),
+		inflight: make(map[string]*inflightCall[V]),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Get returns the cached value for key. An entry rejected by the validator
+// is removed and reported as a miss.
+func (c *Cache[V]) Get(key string) (V, bool) {
+	var zero V
+	if c == nil {
+		return zero, false
+	}
+	c.mu.Lock()
+	elem, ok := c.items[key]
+	if !ok {
+		c.mu.Unlock()
+		return zero, false
+	}
+	ent := elem.Value.(*entry[V])
+	value := ent.value
+	version := ent.version
+	validator := c.validator
+	c.mu.Unlock()
+
+	// validator runs without c.mu held: it's caller code and may re-enter
+	// the cache (e.g. call Len()), which would deadlock on this
+	// non-reentrant mutex if still held here. Re-check the entry is still
+	// the same one — by *list.Element identity AND version — before acting
+	// on it. Identity alone isn't enough: setIfGeneration's existing-entry
+	// branch updates ent.value in place on the same element, so a
+	// concurrent Fill installing a fresh value between the unlock above and
+	// this re-lock would otherwise look unchanged, and this validator's
+	// verdict on the stale value we already read could wrongly evict it.
+	if validator != nil && !validator(value) {
+		c.mu.Lock()
+		if cur, ok := c.items[key]; ok && cur == elem && cur.Value.(*entry[V]).version == version {
+			c.removeLocked(cur)
+		}
+		c.mu.Unlock()
+		return zero, false
+	}
+
+	c.mu.Lock()
+	if cur, ok := c.items[key]; ok && cur == elem {
+		c.order.MoveToFront(cur)
+	}
+	c.mu.Unlock()
+	return value, true
+}
+
+// Fill runs load for key with single-flight deduplication: concurrent
+// callers for the same key wait for one leader and share its result and
+// error. A successful result is cached unless an eviction or flush landed
+// while the load was in flight; errors are propagated but never cached.
+//
+// A follower waits on its own ctx as well as the leader's completion: if
+// ctx is canceled first, Fill returns ctx.Err() immediately rather than
+// blocking until the (possibly unrelated, possibly slow) leader finishes.
+// The leader itself is unaffected by ctx here — canceling it is load's own
+// responsibility, since load is the one actually doing the I/O.
+func (c *Cache[V]) Fill(ctx context.Context, key string, load Loader[V]) (V, error) {
+	if c == nil {
+		v, _, err := load()
+		return v, err
+	}
+	c.inflightMu.Lock()
+	if call, ok := c.inflight[key]; ok {
+		c.inflightMu.Unlock()
+		select {
+		case <-call.done:
+			return call.result, call.err
+		case <-ctx.Done():
+			var zero V
+			return zero, ctx.Err()
+		}
+	}
+	call := &inflightCall[V]{done: make(chan struct{})}
+	c.inflight[key] = call
+	c.inflightMu.Unlock()
+
+	// Deferred so a panicking loader still releases the waiters and clears
+	// the inflight slot instead of wedging this key for the process
+	// lifetime. Waiters must never mistake a panicked load for success, so
+	// an error is set before the channel closes and the panic is re-raised
+	// for the leader's own stack.
+	defer func() {
+		// Delete before close, not after: a new caller acquiring inflightMu
+		// between the two would otherwise find the stale map entry, see
+		// call.done already closed, and incorrectly reuse this completed
+		// (possibly errored or panic-derived) result instead of starting its
+		// own fresh load. Already-blocked followers are unaffected — they
+		// hold a direct reference to call, not a map lookup.
+		c.inflightMu.Lock()
+		delete(c.inflight, key)
+		c.inflightMu.Unlock()
+		if r := recover(); r != nil {
+			call.err = fmt.Errorf("lrucache: loader panicked: %v", r)
+			close(call.done)
+			panic(r)
+		}
+		close(call.done)
+	}()
+
+	gen := c.currentGeneration()
+	value, indexKey, err := load()
+	call.result, call.err = value, err
+
+	if err == nil {
+		c.setIfGeneration(key, indexKey, value, gen)
+	}
+	return value, err
+}
+
+func (c *Cache[V]) currentGeneration() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.generation
+}
+
+// setIfGeneration installs value under key unless the generation moved since
+// gen was read, meaning an eviction or flush invalidated state while the
+// loader was running.
+func (c *Cache[V]) setIfGeneration(key, indexKey string, value V, gen uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.generation != gen {
+		return
+	}
+	if elem, ok := c.items[key]; ok {
+		ent := elem.Value.(*entry[V])
+		if ent.indexKey != indexKey && ent.indexKey != "" {
+			if mapped, ok := c.byIndex[ent.indexKey]; ok && mapped == key {
+				delete(c.byIndex, ent.indexKey)
+			}
+		}
+		ent.value = value
+		ent.indexKey = indexKey
+		ent.version++
+		if indexKey != "" {
+			c.evictIndexOwnerLocked(indexKey, key)
+			c.byIndex[indexKey] = key
+		}
+		c.order.MoveToFront(elem)
+		return
+	}
+	// Remove any prior owner of indexKey before checking capacity: otherwise
+	// a rebind onto a full cache can remove both the LRU tail (capacity
+	// eviction) and the old owner (index rebind), leaving the cache below
+	// capacity for one insert.
+	if indexKey != "" {
+		c.evictIndexOwnerLocked(indexKey, key)
+	}
+	if c.order.Len() >= c.capacity {
+		if tail := c.order.Back(); tail != nil {
+			c.removeLocked(tail)
+		}
+	}
+	elem := c.order.PushFront(&entry[V]{key: key, indexKey: indexKey, value: value})
+	c.items[key] = elem
+	if indexKey != "" {
+		c.byIndex[indexKey] = key
+	}
+}
+
+// evictIndexOwnerLocked removes the cache entry currently bound to indexKey,
+// if any and if it isn't newKey itself. Rebinding an index key to a
+// different cache key without this would leave the previous owner cached
+// but unreachable through the index, so EvictByIndex could never remove it.
+// Caller holds c.mu.
+func (c *Cache[V]) evictIndexOwnerLocked(indexKey, newKey string) {
+	owner, ok := c.byIndex[indexKey]
+	if !ok || owner == newKey {
+		return
+	}
+	if ownerElem, ok := c.items[owner]; ok {
+		// Removing another key's entry is an invalidation of that key, not a
+		// capacity eviction: bump generation so an in-flight fill for the
+		// former owner cannot re-install it and steal the index binding back.
+		c.generation++
+		c.removeLocked(ownerElem)
+	}
+}
+
+// removeLocked drops an entry from the list, the key map, and the secondary
+// index. Caller holds c.mu.
+func (c *Cache[V]) removeLocked(elem *list.Element) {
+	ent := elem.Value.(*entry[V])
+	c.order.Remove(elem)
+	delete(c.items, ent.key)
+	if ent.indexKey != "" {
+		if mapped, ok := c.byIndex[ent.indexKey]; ok && mapped == ent.key {
+			delete(c.byIndex, ent.indexKey)
+		}
+	}
+}
+
+// Evict removes the entry for an exact key, if present.
+func (c *Cache[V]) Evict(key string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation++
+	if elem, ok := c.items[key]; ok {
+		c.removeLocked(elem)
+	}
+}
+
+// EvictByIndex removes the entry registered under the given secondary-index
+// key, if any.
+func (c *Cache[V]) EvictByIndex(indexKey string) {
+	if c == nil || indexKey == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation++
+	if key, ok := c.byIndex[indexKey]; ok {
+		if elem, ok := c.items[key]; ok {
+			c.removeLocked(elem)
+		}
+	}
+}
+
+// EvictWhere removes every entry whose cache key matches pred. A linear
+// sweep under the lock; intended for rare bulk invalidations, not hot
+// paths.
+func (c *Cache[V]) EvictWhere(pred func(key string) bool) {
+	if c == nil || pred == nil {
+		return
+	}
+	c.mu.Lock()
+	// Bumped here, before pred runs — not after, in the second locked
+	// section below. Evict/EvictByIndex/Flush all bump generation
+	// immediately for the same reason: pred can run arbitrarily long (it's
+	// caller code, possibly re-entering the cache), and any Fill whose
+	// generation check lands in that window must see this invalidation as
+	// already having happened, even for a key that wasn't cached yet when
+	// this call started (and so can never appear in toRemove below).
+	c.generation++
+	keys := make([]string, 0, c.order.Len())
+	for elem := c.order.Front(); elem != nil; elem = elem.Next() {
+		keys = append(keys, elem.Value.(*entry[V]).key)
+	}
+	c.mu.Unlock()
+
+	// pred runs without c.mu held, for the same re-entrancy reason as
+	// Get's validator call above.
+	var toRemove []string
+	for _, key := range keys {
+		if pred(key) {
+			toRemove = append(toRemove, key)
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, key := range toRemove {
+		if elem, ok := c.items[key]; ok {
+			c.removeLocked(elem)
+		}
+	}
+}
+
+// Flush drops every cached entry.
+func (c *Cache[V]) Flush() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation++
+	c.items = make(map[string]*list.Element)
+	c.byIndex = make(map[string]string)
+	c.order.Init()
+}
+
+// Len reports the number of cached entries.
+func (c *Cache[V]) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}

--- a/framework/lrucache/lrucache_test.go
+++ b/framework/lrucache/lrucache_test.go
@@ -1,0 +1,592 @@
+package lrucache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fillWith returns a Loader serving a fixed value and index key.
+func fillWith(value string, indexKey string) Loader[string] {
+	return func() (string, string, error) {
+		return value, indexKey, nil
+	}
+}
+
+func TestCache_HitAndMiss(t *testing.T) {
+	c := New[string](4)
+	_, ok := c.Get("k1")
+	assert.False(t, ok)
+
+	v, err := c.Fill(context.Background(), "k1", fillWith("v1", "id1"))
+	require.NoError(t, err)
+	assert.Equal(t, "v1", v)
+
+	got, ok := c.Get("k1")
+	assert.True(t, ok)
+	assert.Equal(t, "v1", got)
+	assert.Equal(t, 1, c.Len())
+}
+
+func TestCache_CapacityEvictionAndIndexCleanup(t *testing.T) {
+	c := New[string](2)
+	for i := 1; i <= 3; i++ {
+		_, err := c.Fill(context.Background(), fmt.Sprintf("k%d", i), fillWith(fmt.Sprintf("v%d", i), fmt.Sprintf("id%d", i)))
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 2, c.Len())
+
+	// k1 was least recently used and must be gone, along with its index
+	// entry: evicting by its old index key must not disturb survivors.
+	_, ok := c.Get("k1")
+	assert.False(t, ok)
+	c.EvictByIndex("id1")
+	assert.Equal(t, 2, c.Len())
+
+	_, ok = c.Get("k2")
+	assert.True(t, ok)
+	_, ok = c.Get("k3")
+	assert.True(t, ok)
+}
+
+func TestCache_ValidatorRejectionIsMissAndRemoval(t *testing.T) {
+	type timedValue struct {
+		value     string
+		expiresAt time.Time
+	}
+	c := New(4, WithValidator(func(v timedValue) bool {
+		return time.Now().Before(v.expiresAt)
+	}))
+	_, err := c.Fill(context.Background(), "k1", func() (timedValue, string, error) {
+		return timedValue{value: "v1", expiresAt: time.Now().Add(-time.Minute)}, "id1", nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, c.Len())
+
+	_, ok := c.Get("k1")
+	assert.False(t, ok, "rejected entry must be reported as a miss")
+	assert.Equal(t, 0, c.Len(), "rejected entry must be removed")
+}
+
+// TestCache_GetValidatorRejectionDoesNotEvictConcurrentlyUpdatedEntry covers
+// the race the entry.version field exists for: setIfGeneration's
+// existing-entry branch updates a value in place on the same *list.Element,
+// so element identity alone can't tell a Get (mid-validator, evaluating a
+// value it already read) that the entry has since been refreshed. Without
+// the version check, rejecting the stale value would evict the fresh one
+// installed concurrently.
+func TestCache_GetValidatorRejectionDoesNotEvictConcurrentlyUpdatedEntry(t *testing.T) {
+	validatorEntered := make(chan struct{})
+	releaseValidator := make(chan struct{})
+	var pausedOnce atomic.Bool
+	pausedOnce.Store(true)
+
+	c := New(4, WithValidator(func(v string) bool {
+		if pausedOnce.CompareAndSwap(true, false) {
+			close(validatorEntered)
+			<-releaseValidator
+		}
+		return v != "v1" // only the stale first value is rejected
+	}))
+
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", ""))
+	require.NoError(t, err)
+
+	getDone := make(chan struct{})
+	var got string
+	var ok bool
+	go func() {
+		defer close(getDone)
+		got, ok = c.Get("k1")
+	}()
+	<-validatorEntered // Get has read "v1" and is now blocked inside validator.
+
+	// While that validator call is still evaluating the stale "v1" it read,
+	// a concurrent Fill updates the same key in place to "v2".
+	_, err = c.Fill(context.Background(), "k1", fillWith("v2", ""))
+	require.NoError(t, err)
+
+	close(releaseValidator)
+	<-getDone
+
+	assert.False(t, ok, "the original Get call evaluated the stale value and must report a miss")
+	assert.Empty(t, got, "a rejected Get returns the zero value")
+
+	got2, ok2 := c.Get("k1")
+	assert.True(t, ok2, "the concurrently-installed fresh value must not have been collaterally evicted")
+	assert.Equal(t, "v2", got2)
+}
+
+func TestCache_EvictExactKey(t *testing.T) {
+	c := New[string](4)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "id1"))
+	require.NoError(t, err)
+
+	c.Evict("k1")
+	_, ok := c.Get("k1")
+	assert.False(t, ok)
+	assert.Equal(t, 0, c.Len())
+
+	// Evicting an absent key is a no-op, not a panic.
+	c.Evict("never-set")
+}
+
+func TestCache_EvictByIndex(t *testing.T) {
+	c := New[string](4)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "id1"))
+	require.NoError(t, err)
+	_, err = c.Fill(context.Background(), "k2", fillWith("v2", "id2"))
+	require.NoError(t, err)
+
+	c.EvictByIndex("id1")
+	_, ok := c.Get("k1")
+	assert.False(t, ok, "entry holding the evicted index key must be gone")
+	_, ok = c.Get("k2")
+	assert.True(t, ok, "unrelated entry must survive")
+
+	// Unknown and empty index keys are no-ops.
+	c.EvictByIndex("unknown")
+	c.EvictByIndex("")
+	assert.Equal(t, 1, c.Len())
+}
+
+func TestCache_EvictWhere(t *testing.T) {
+	c := New[string](8)
+	for _, k := range []string{"a:1", "a:2", "b:1"} {
+		_, err := c.Fill(context.Background(), k, fillWith("v", ""))
+		require.NoError(t, err)
+	}
+
+	c.EvictWhere(func(key string) bool { return key[0] == 'a' })
+	_, ok := c.Get("a:1")
+	assert.False(t, ok)
+	_, ok = c.Get("a:2")
+	assert.False(t, ok)
+	_, ok = c.Get("b:1")
+	assert.True(t, ok)
+
+	// A nil predicate is a no-op, not a panic.
+	c.EvictWhere(nil)
+	assert.Equal(t, 1, c.Len())
+}
+
+// TestCache_EvictWhereGenerationBumpPrecedesPred exercises the ordering
+// EvictWhere's generation++ move exists for: a concurrent Fill for a key
+// that isn't cached yet (so it can never appear in EvictWhere's keys
+// snapshot or its toRemove list) must still be discarded if its generation
+// was captured before this EvictWhere call, even though EvictWhere's own
+// predicate is still running when the fill completes.
+func TestCache_EvictWhereGenerationBumpPrecedesPred(t *testing.T) {
+	c := New[string](4)
+	// EvictWhere only invokes pred per cached key, so it needs at least one
+	// existing entry to actually run pred (and thus block on it) at all.
+	_, err := c.Fill(context.Background(), "existing-key", fillWith("v", ""))
+	require.NoError(t, err)
+
+	fillStarted := make(chan struct{})
+	releaseFill := make(chan struct{})
+	var fillWg sync.WaitGroup
+	fillWg.Add(1)
+	go func() {
+		defer fillWg.Done()
+		_, _ = c.Fill(context.Background(), "new-key", func() (string, string, error) {
+			close(fillStarted)
+			<-releaseFill
+			return "fresh-value", "", nil
+		})
+	}()
+	<-fillStarted // The fill has captured its generation and is now blocked
+	// inside the loader, before EvictWhere has even started.
+
+	predStarted := make(chan struct{})
+	releasePred := make(chan struct{})
+	var evictWg sync.WaitGroup
+	evictWg.Add(1)
+	go func() {
+		defer evictWg.Done()
+		c.EvictWhere(func(key string) bool {
+			close(predStarted)
+			<-releasePred
+			return false
+		})
+	}()
+	<-predStarted // With the fix, generation is already bumped by this point.
+
+	// Let the fill's loader finish and attempt to install, racing
+	// EvictWhere's still-in-progress predicate.
+	close(releaseFill)
+	fillWg.Wait()
+
+	close(releasePred)
+	evictWg.Wait()
+
+	_, ok := c.Get("new-key")
+	assert.False(t, ok, "a fill whose generation was captured before EvictWhere's bump must not install after it, even though the key wasn't cached yet when EvictWhere snapshotted its keys")
+}
+
+func TestCache_Flush(t *testing.T) {
+	c := New[string](4)
+	for i := 1; i <= 3; i++ {
+		_, err := c.Fill(context.Background(), fmt.Sprintf("k%d", i), fillWith("v", fmt.Sprintf("id%d", i)))
+		require.NoError(t, err)
+	}
+
+	c.Flush()
+	assert.Equal(t, 0, c.Len())
+	for i := 1; i <= 3; i++ {
+		_, ok := c.Get(fmt.Sprintf("k%d", i))
+		assert.False(t, ok)
+	}
+}
+
+func TestCache_InflightDedup(t *testing.T) {
+	c := New[string](4)
+	var calls atomic.Int32
+	release := make(chan struct{})
+	loader := func() (string, string, error) {
+		calls.Add(1)
+		<-release
+		return "v1", "id1", nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]string, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v, err := c.Fill(context.Background(), "k1", loader)
+			// assert, not require: require.NoError calls t.FailNow(), which
+			// per the testing package's own contract must only be called
+			// from the goroutine running the test.
+			assert.NoError(t, err)
+			results[i] = v
+		}()
+	}
+	// Let both goroutines reach the fill before releasing the leader.
+	assert.Eventually(t, func() bool { return calls.Load() == 1 }, time.Second, time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), calls.Load(), "loader must run exactly once")
+	assert.Equal(t, []string{"v1", "v1"}, results)
+}
+
+func TestCache_FillFollowerReturnsOnOwnContextCancellation(t *testing.T) {
+	c := New[string](4)
+	leaderStarted := make(chan struct{})
+	release := make(chan struct{})
+	loader := func() (string, string, error) {
+		close(leaderStarted)
+		<-release
+		return "v1", "id1", nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = c.Fill(context.Background(), "k1", loader)
+	}()
+	<-leaderStarted
+
+	// A follower whose own ctx is canceled must return immediately with
+	// ctx.Err(), not block until the (still in-flight, possibly slow or
+	// unrelated) leader finishes.
+	followerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	followerDone := make(chan struct{})
+	go func() {
+		defer close(followerDone)
+		_, err := c.Fill(followerCtx, "k1", loader)
+		assert.ErrorIs(t, err, context.Canceled)
+	}()
+
+	select {
+	case <-followerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("follower did not return on its own canceled context")
+	}
+
+	// The leader is unaffected by the follower's cancellation and still
+	// completes normally.
+	close(release)
+	wg.Wait()
+	got, ok := c.Get("k1")
+	assert.True(t, ok)
+	assert.Equal(t, "v1", got)
+}
+
+func TestCache_ErrorSharedNotCached(t *testing.T) {
+	c := New[string](4)
+	sentinel := errors.New("load failed")
+	var calls atomic.Int32
+	failing := func() (string, string, error) {
+		calls.Add(1)
+		return "", "", sentinel
+	}
+
+	_, err := c.Fill(context.Background(), "k1", failing)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 0, c.Len(), "errors must not be cached")
+
+	// A second call retries the loader instead of serving the error.
+	_, err = c.Fill(context.Background(), "k1", failing)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestCache_GenerationGuardDiscardsStaleFill(t *testing.T) {
+	c := New[string](4)
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		v, err := c.Fill(context.Background(), "k1", func() (string, string, error) {
+			close(started)
+			<-release
+			return "stale", "id1", nil
+		})
+		// The caller still receives the loaded value; only the install is
+		// discarded. assert, not require: require.NoError calls
+		// t.FailNow(), which per the testing package's own contract must
+		// only be called from the goroutine running the test.
+		assert.NoError(t, err)
+		assert.Equal(t, "stale", v)
+	}()
+
+	<-started
+	c.Evict("k1") // lands while the load is in flight
+	close(release)
+	wg.Wait()
+
+	_, ok := c.Get("k1")
+	assert.False(t, ok, "a fill racing an eviction must not install its result")
+}
+
+func TestCache_UpsertRebindsIndex(t *testing.T) {
+	c := New[string](4)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "id-old"))
+	require.NoError(t, err)
+
+	// Re-fill the same key with a new index key after evicting: the old
+	// index mapping must not linger.
+	c.Evict("k1")
+	_, err = c.Fill(context.Background(), "k1", fillWith("v2", "id-new"))
+	require.NoError(t, err)
+
+	c.EvictByIndex("id-old")
+	got, ok := c.Get("k1")
+	assert.True(t, ok, "stale index key must not evict the rebound entry")
+	assert.Equal(t, "v2", got)
+
+	c.EvictByIndex("id-new")
+	_, ok = c.Get("k1")
+	assert.False(t, ok)
+}
+
+func TestCache_IndexKeyCollisionEvictsPreviousOwner(t *testing.T) {
+	c := New[string](4)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "shared-id"))
+	require.NoError(t, err)
+
+	// A second cache key rebinds the same index key without evicting k1
+	// first. k1 must be evicted as a side effect, or it would be cached but
+	// unreachable through the index forever.
+	_, err = c.Fill(context.Background(), "k2", fillWith("v2", "shared-id"))
+	require.NoError(t, err)
+
+	_, ok := c.Get("k1")
+	assert.False(t, ok, "previous owner of a rebound index key must be evicted")
+	assert.Equal(t, 1, c.Len())
+
+	c.EvictByIndex("shared-id")
+	_, ok = c.Get("k2")
+	assert.False(t, ok, "the new owner must still be reachable through the index before this evict")
+	assert.Equal(t, 0, c.Len())
+}
+
+// TestCache_IndexOwnerEvictionBumpsGeneration pins the gap CodeRabbit flagged
+// in evictIndexOwnerLocked: unlike every other removal path in this file
+// (Evict, EvictByIndex, EvictWhere, Flush, and the LRU-capacity eviction),
+// removing a rebound index key's previous owner did not bump c.generation.
+// That's an implicit invalidation of the owner's key exactly like an
+// explicit Evict, so a stale in-flight Fill for that owner — one that
+// captured its generation before the rebind — must be discarded by
+// setIfGeneration's generation check, not allowed to re-install and steal
+// the index binding back out from under the legitimate new owner.
+//
+// Sequence: k1 is cached under indexKey "id". A refill of k1 starts,
+// captures the current generation, and blocks in its loader. While it's
+// blocked, k2 completes a Fill under the same indexKey "id" — this evicts
+// k1 as the previous owner. k1's stale loader then finishes: its generation
+// check must see the eviction and discard the stale result, leaving k2 as
+// the sole, reachable owner of "id".
+func TestCache_IndexOwnerEvictionBumpsGeneration(t *testing.T) {
+	c := New[string](4)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "id"))
+	require.NoError(t, err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		v, err := c.Fill(context.Background(), "k1", func() (string, string, error) {
+			close(started)
+			<-release
+			return "v1-stale-refill", "id", nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "v1-stale-refill", v)
+	}()
+
+	<-started
+	// k2 rebinds "id" while k1's refill is still blocked in its loader —
+	// this must evict k1 (the current owner) as a side effect AND bump
+	// c.generation, exactly like any other eviction in this file.
+	_, err = c.Fill(context.Background(), "k2", fillWith("v2", "id"))
+	require.NoError(t, err)
+
+	close(release)
+	wg.Wait()
+
+	got, ok := c.Get("k2")
+	assert.True(t, ok, "k2 must still be cached and reachable through the index — a stale racing refill of the evicted previous owner must not steal the index binding back")
+	assert.Equal(t, "v2", got)
+
+	_, ok = c.Get("k1")
+	assert.False(t, ok, "k1's stale refill must be discarded by the generation guard, not reinstalled")
+}
+
+func TestCache_IndexKeyRebindOnFullCachePreservesCapacity(t *testing.T) {
+	c := New[string](2)
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "shared-id"))
+	require.NoError(t, err)
+	_, err = c.Fill(context.Background(), "k2", fillWith("v2", ""))
+	require.NoError(t, err)
+
+	// Move k1 to the front so k2 (not the index-colliding k1) is the LRU tail.
+	_, ok := c.Get("k1")
+	require.True(t, ok)
+
+	// k3 rebinds "shared-id" from k1 (not the LRU tail) while the cache is
+	// already full. This must evict exactly one entry — k1, the rebound
+	// index's prior owner — not two (k1 plus the LRU tail k2).
+	_, err = c.Fill(context.Background(), "k3", fillWith("v3", "shared-id"))
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, c.Len(), "capacity must be preserved: only the rebound index's prior owner should be evicted, not the LRU tail too")
+	_, ok = c.Get("k1")
+	assert.False(t, ok, "k1 (the previous shared-id owner) must be evicted")
+	_, ok = c.Get("k2")
+	assert.True(t, ok, "k2 must survive: it was not involved in the index rebind")
+	_, ok = c.Get("k3")
+	assert.True(t, ok)
+}
+
+func TestCache_CallbacksReenteringCacheDoNotDeadlock(t *testing.T) {
+	var c *Cache[string]
+	c = New(4, WithValidator(func(string) bool {
+		// A validator that calls back into the cache must not deadlock on
+		// c.mu, which Get would still be holding if it weren't released
+		// before this callback runs.
+		c.Len()
+		return true
+	}))
+	_, err := c.Fill(context.Background(), "k1", fillWith("v1", "id1"))
+	require.NoError(t, err)
+	_, err = c.Fill(context.Background(), "k2", fillWith("v2", "id2"))
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.Get("k1")
+
+		c.EvictWhere(func(key string) bool {
+			// Same for an EvictWhere predicate.
+			c.Len()
+			return key == "k2"
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("callback re-entering the cache deadlocked")
+	}
+
+	_, ok := c.Get("k2")
+	assert.False(t, ok, "EvictWhere must still remove the matched entry")
+}
+
+func TestCache_LoaderPanicReleasesWaitersWithError(t *testing.T) {
+	c := New[string](4)
+	started := make(chan struct{})
+
+	var waiterErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-started
+		_, waiterErr = c.Fill(context.Background(), "k1", fillWith("never-used", ""))
+	}()
+
+	func() {
+		defer func() {
+			r := recover()
+			require.NotNil(t, r, "the leader must re-panic")
+		}()
+		_, _ = c.Fill(context.Background(), "k1", func() (string, string, error) {
+			close(started)
+			// Give the waiter a moment to join the inflight call; if it
+			// races past cleanup instead, it just runs its own fresh fill,
+			// which this test also accepts below.
+			time.Sleep(20 * time.Millisecond)
+			panic("boom")
+		})
+	}()
+	wg.Wait()
+
+	if waiterErr != nil {
+		assert.Contains(t, waiterErr.Error(), "panicked")
+	}
+	// Either way the key must not be wedged: a fresh fill succeeds.
+	v, err := c.Fill(context.Background(), "k1", fillWith("v-after", ""))
+	require.NoError(t, err)
+	assert.Equal(t, "v-after", v)
+}
+
+func TestCache_NilSafety(t *testing.T) {
+	var c *Cache[string]
+	_, ok := c.Get("k1")
+	assert.False(t, ok)
+	c.Evict("k1")
+	c.EvictByIndex("id1")
+	c.EvictWhere(func(string) bool { return true })
+	c.Flush()
+	assert.Equal(t, 0, c.Len())
+
+	v, err := c.Fill(context.Background(), "k1", fillWith("v1", "id1"))
+	require.NoError(t, err)
+	assert.Equal(t, "v1", v, "nil cache must degrade to calling the loader directly")
+}
+
+func TestNew_PanicsOnNonPositiveCapacity(t *testing.T) {
+	assert.Panics(t, func() { New[string](0) })
+	assert.Panics(t, func() { New[string](-1) })
+}


### PR DESCRIPTION
## Summary

Introduces a new `lrucache` package providing a bounded, generation-guarded LRU cache with single-flight fills. This is intended for in-memory mirrors of database rows that are kept consistent through explicit eviction rather than TTLs.

## Changes

- Added `framework/lrucache/lrucache.go` implementing a generic `Cache[V]` type with the following capabilities:
  - **Single-flight fills**: concurrent callers for the same key share one loader invocation and its result. Errors are propagated to all waiters but never cached, so failed loads are retried on the next call.
  - **Generation-guarded installs**: a counter increments on every explicit eviction or flush. A fill that completes after an eviction discards its result rather than re-installing the value that was just invalidated. Capacity-driven LRU evictions do not increment the generation since they do not represent invalidation.
  - **Secondary index**: an optional string index key (e.g. a database row's primary key) can be registered per entry, allowing eviction by row identity without recomputing the cache key via `EvictByIndex`.
  - **Hit-time validator**: an optional `WithValidator` option allows callers to treat entries as misses at read time (e.g. expired credentials) without embedding expiry logic in the cache itself.
  - **Nil-safe receiver**: all methods are safe on a nil `*Cache`, degrading gracefully to calling the loader directly or no-oping, so callers can treat a nil cache as "caching disabled" without branching.
  - **Panic-safe loaders**: a panicking loader sets an error on all waiters, clears the inflight slot, and re-raises on the leader's stack, preventing the key from being permanently wedged.
- Added `framework/lrucache/lrucache_test.go` with full coverage of hit/miss behavior, LRU capacity eviction, validator rejection, exact-key and index-key eviction, predicate-based bulk eviction, flush, single-flight deduplication, error propagation, generation guard correctness, index rebinding, panic recovery, nil safety, and invalid capacity construction.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/lrucache/...
```

All tests should pass. The test suite covers concurrency scenarios including single-flight deduplication, generation guard races, and panic recovery.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The cache is designed to hold in-memory mirrors of database rows. Callers using the validator option to gate on credential expiry should ensure the validator is conservative (i.e. rejects on any uncertainty) to avoid serving stale authorization state. The cache itself holds no secrets beyond what callers store in it and does not log values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable