### PR TITLE
docs: add OAuth reauthorization, admin discovery credentials, auth failure recovery, and credential rotation docs

### DIFF
--- a/docs/mcp/auth/headers.mdx
+++ b/docs/mcp/auth/headers.mdx
@@ -22,7 +22,7 @@ This auth type is only valid for **HTTP** and **SSE** connections.
 - Custom header-based schemes (`X-Tenant-ID`, `X-Region`, etc.)
 - Anything where you'd add headers to a `curl` command
 
-For per-user OAuth see [OAuth 2.0](./oauth) (admin authenticates once) or [Per-User OAuth](./per-user-oauth) (each user authenticates).
+If the upstream service speaks OAuth instead, see [OAuth 2.0](./oauth) (admin authenticates once) or [Per-User OAuth](./per-user-oauth) (each user authenticates themselves). For per-user header values, see [Per-User Headers](./per-user-headers).
 
 ---
 

--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -159,7 +159,7 @@ The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (
 
 Once authorized, the OAuth credentials live in the encrypted `oauth_configs` table and the `pending_oauth_config_json` stash is cleared from the row; see [Token management](#token-management).
 
-**Lifecycle across restarts and config edits:** the authorized state is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config`, and the `oauth_config` block — cannot be changed after creation: file edits to them are **ignored**, matching the update API (which does not accept them), and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the file entry, and restart (see [Rotation](#token-management)).
+**Lifecycle across restarts and config edits:** the authorized state is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`) cannot be changed after creation: file edits to them are **ignored**, matching the update API (which does not accept them), and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the file entry, and restart. The `oauth_config` block is different: editing it on an already-authorized client **rotates** the stored OAuth credentials in place (see [Rotation](#rotation)), with a boot warning that existing sessions must re-authenticate. Only fields present in the file participate; absent fields keep their stored values.
 
 </Tab>
 </Tabs>
@@ -206,7 +206,7 @@ Bifrost will:
 4. Continue with the standard authorize / token exchange flow
 
 <Warning>
-The `redirect_uri` Bifrost registers with the upstream provider is locked to Bifrost's current public URL (`mcp_external_client_url`, or the request `Host` header if unset). If you change Bifrost's public URL later, the upstream provider will reject the next authorize call with **"Invalid redirect URI"**. To recover, clear the stored client credentials for the affected MCP server so Bifrost re-runs DCR with the new URL.
+The `redirect_uri` Bifrost registers with the upstream provider is locked to Bifrost's current public URL (`mcp_external_client_url`, or the request `Host` header if unset). If you change Bifrost's public URL later, the upstream provider will reject the next authorize call with **"Invalid redirect URI"**. Reauthorization reuses the registered client, so it cannot fix the mismatch on its own: delete the client and recreate it so Bifrost re-runs DCR against the new URL. (For manually registered credentials, add the new redirect URI in the provider's dashboard instead, then [reauthorize](#reauthorization).)
 </Warning>
 
 ---
@@ -257,6 +257,8 @@ Status values:
 - `failed` — authorization failed or token is invalid
 - `revoked` — the token was revoked (via DELETE); the config row is retained with no live token
 
+When a stored token permanently dies later (refresh rejected, provider-side revocation), the status flips on the **token row**, not on the OAuth config: the token moves to `needs_reauth` and the MCP client's connection state shows [`needs_reauth`](#reauthorization). The OAuth config itself stays `authorized`.
+
 ### Automatic refresh
 
 Bifrost refreshes access tokens automatically using the stored refresh token, in two layers:
@@ -264,11 +266,63 @@ Bifrost refreshes access tokens automatically using the stored refresh token, in
 - **In the background** — a worker periodically refreshes tokens that are about to expire, so active clients always have a valid token ready.
 - **On use** — if a token is already expired when a request needs it, Bifrost refreshes it inline before forwarding the request.
 
-Background refresh only runs while the MCP client is enabled. Disabling a client pauses it; on re-enable, the token is refreshed on first use. If a client stays disabled long enough for the provider to expire the idle refresh token, re-authorization is required.
+Background refresh only runs while the MCP client is enabled. Disabling a client pauses it; on re-enable, the token is refreshed on first use. If a client stays disabled long enough for the provider to expire the idle refresh token, [reauthorization](#reauthorization) is required.
+
+Transient refresh failures (network blips, provider hiccups) keep retrying silently. Only a permanent rejection (the provider refuses the refresh token outright) flips the token to `needs_reauth`.
+
+<Warning>
+**Some providers only issue a refresh token when you explicitly ask for one.** Google is the canonical case: without `access_type=offline&prompt=consent` on the authorize URL, the grant contains only an access token, and the client lands in `needs_reauth` at every token expiry (roughly hourly for Google). Bifrost preserves any query parameters already present on the configured `authorize_url`, so append the provider's offline-access parameters there, e.g. `"authorize_url": "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"`.
+</Warning>
 
 ### Rotation
 
-Editing `oauth_config` after setup is not currently supported — the edit flow rejects it (`connection_type`, `auth_type`, and `connection_string` are likewise immutable after creation). To change OAuth credentials, scopes, or endpoints: delete the client and recreate it (UI or API). For a config.json-declared client, delete it from the dashboard, update the `oauth_config` block in the file, and restart — the client re-enters `pending_verification` and can be authorized with the new options.
+`PUT /api/mcp/client/{id}` accepts an `oauth_config` block for clients with `auth_type` `oauth` or `per_user_oauth` (400 for any other auth type). Any field can be rotated: `client_id`, `client_secret`, `authorize_url`, `token_url`, `registration_url`, `resource`, `scopes`. Rotation applies the changed fields **in place** on the same OAuth config row; it does not create a new row and does not re-run discovery or client registration.
+
+```bash
+curl -X PUT http://localhost:8080/api/mcp/client/mcp_client_abc123 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "oauth_config": {
+      "client_id": "new-client-id",
+      "client_secret": "new-client-secret"
+    }
+  }'
+```
+
+Semantics:
+
+- **Unset fields preserve stored values.** `client_id` / `client_secret` follow the SecretVar masked-placeholder convention (sending back the redacted value from a GET means "keep"); the other fields treat empty as "not provided".
+- **Any actual change cascades.** Every token bound to that OAuth config flips to `needs_reauth`, regardless of auth mode: the shared connection token, every per-user token, and the retained admin discovery credential alike. Shared clients surface it on the next reconnect; per-user callers get the standard reauth URL on their next tool call.
+- **A no-op round-trip is safe.** Re-sending the stored values does not cascade anything.
+- **Cannot run while the client is (or is being) disabled** (400; enable the client first, or send the enable and rotation as separate requests).
+
+The same rotation applies to config.json-declared clients: editing the `oauth_config` block of an already-authorized client rotates the stored config at the next boot and cascades `needs_reauth`, with a boot warning that existing sessions must re-authenticate.
+
+<Warning>
+Rotating `client_id` or `client_secret` immediately signs out every current session on the MCP client, shared and per-user alike. Everyone re-authenticates against the new credentials; for the shared connection itself, that means clicking **Reauthorize** (below).
+</Warning>
+
+### Reauthorization
+
+A shared OAuth client whose credential permanently dies lands in the **`needs_reauth`** connection state: the client was authorized and connected at least once, but the token can no longer be refreshed (provider-side revocation, expired refresh token, or a credential rotation). This is distinct from `pending_verification`, which means initial setup never completed.
+
+`needs_reauth` is sticky: the health monitor and enable/disable toggles will not flip the client back to `connected` or `disconnected`, and the **Reconnect** action is disabled for it (reconnecting cannot help when the credential itself is dead). Only a human redoing consent clears it.
+
+From the dashboard, open the client and click **Reauthorize**: Bifrost redoes the OAuth consent flow in a popup against the currently stored credentials, and on completion reconnects the client.
+
+<Frame>
+  <img src="/media/ui-mcp-needs-reauth-reauthorize.png" alt="MCP client sheet showing the red needs_reauth badge and the Reauthorize button" />
+</Frame>
+
+The same flow is scriptable via `POST /api/mcp/client/{id}/reauthorize` (`{id}` = MCP client ID):
+
+```bash
+curl -X POST http://localhost:8080/api/mcp/client/mcp_client_abc123/reauthorize
+```
+
+The response is the same `pending_oauth` payload the create flow returns (`oauth_config_id`, `authorize_url`, `expires_at`, `complete_url`, `status_url`, `next_steps`): open `authorize_url` in a browser, poll `status_url` until `authorized`, then POST `complete_url`. On completion the client reconnects and the response reads `"MCP client re-authorized and reconnected successfully"`.
+
+Error cases: 400 if the client's `auth_type` is not OAuth-based, or if it never completed initial authorization (use `initiate-verification` instead); 404 for an unknown ID; 503 when no OAuth provider is configured. For `per_user_oauth` clients the endpoint repairs the retained admin discovery credential instead, and is gated accordingly; see [Per-User OAuth](./per-user-oauth#admin-discovery-credential).
 
 ### Revoke
 
@@ -351,7 +405,7 @@ The `redirect_uri` Bifrost registers and the consent URLs it builds are derived 
 See [Reverse Proxy configuration →](../../deployment-guides/config-json/client#reverse-proxy) for the full reference.
 
 <Warning>
-**Changing `mcp_external_client_url` after an upstream provider has been registered breaks already-authorized clients.** Upstream providers lock the `redirect_uri` to whatever was registered during DCR. To recover, clear the stored OAuth client credentials so Bifrost re-registers with the new URL.
+**Changing `mcp_external_client_url` after an upstream provider has been registered breaks already-authorized clients.** Upstream providers lock the `redirect_uri` to whatever was registered during DCR. To recover, delete and recreate the affected client so Bifrost re-registers with the new URL (reauthorization alone reuses the registered client and cannot fix the mismatch). For manually registered credentials, add the new redirect URI at the provider's dashboard, then [reauthorize](#reauthorization).
 </Warning>
 
 ---
@@ -370,8 +424,9 @@ See [Reverse Proxy configuration →](../../deployment-guides/config-json/client
 
 - Check that the refresh token is still valid (some providers expire refresh tokens after long idle)
 - If the client was disabled for a long stretch, background refresh was paused for it — the refresh token may have expired at the provider in the meantime
+- If the provider never issued a refresh token at all, the client will hit this at every access-token expiry; append the provider's offline-access parameters to `authorize_url` (see the warning under [Automatic refresh](#automatic-refresh))
 - Verify scopes are still sufficient
-- Re-authorize: `DELETE /api/oauth/config/{id}` then create a new client
+- Re-authorize: click **Reauthorize** on the client (or `POST /api/mcp/client/{id}/reauthorize`); see [Reauthorization](#reauthorization)
 </Accordion>
 
 <Accordion title="Callback hangs at `/api/oauth/callback`">
@@ -383,7 +438,7 @@ See [Reverse Proxy configuration →](../../deployment-guides/config-json/client
 
 <Accordion title="`Invalid redirect URI` from the upstream provider">
 
-You changed Bifrost's public URL after the upstream client was registered. Clear the stored credentials so Bifrost re-runs DCR with the new URL.
+You changed Bifrost's public URL after the upstream client was registered. Delete and recreate the client so Bifrost re-runs DCR with the new URL; for manually registered credentials, add the new redirect URI at the provider's dashboard and then [reauthorize](#reauthorization).
 </Accordion>
 </AccordionGroup>
 
@@ -396,6 +451,7 @@ You changed Bifrost's public URL after the upstream client was registered. Clear
 | `/api/mcp/client`                                | POST   | Create MCP client; returns `pending_oauth` + `authorize_url`           |
 | `/api/mcp/client/{id}/initiate-verification`     | POST   | Start authorization for a `pending_verification` client declared in config.json (`{id}` = MCP client ID); returns `authorize_url` + `status_url` + `complete_url` |
 | `/api/mcp/client/{id}/complete-oauth`            | POST   | Finalize after upstream redirect lands on `/api/oauth/callback` (`{id}` = `oauth_config_id`) |
+| `/api/mcp/client/{id}/reauthorize`               | POST   | Redo consent for a `needs_reauth` client without delete-and-recreate (`{id}` = MCP client ID); returns the same `pending_oauth` payload as create |
 | `/api/oauth/callback`                            | GET    | Upstream provider redirects here; handled internally                   |
 | `/api/oauth/config/{oauth_config_id}/status`     | GET    | Current OAuth config status + token metadata                           |
 | `/api/oauth/config/{oauth_config_id}`            | DELETE | Revoke token + remove OAuth config                                     |

--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -53,7 +53,7 @@ Per-user auth requires every request to carry an identity. See [Identity modes](
 Connection-state semantics (`connected`, `disconnected`, `error`, shown on the MCP client list) describe a persistent upstream connection, so they only apply to server-level clients. Per-user clients are stateless by design: each tool call resolves and uses the caller's credential on its own, with nothing held open between calls, so the dashboard links a per-user client to its [MCP Sessions](../sessions) rows instead of showing a connection state for it. Two lifecycle states are the exception and appear for every auth type:
 
 - **`pending_verification`**: all five auth types, including `oauth`, `per_user_oauth`, and `per_user_headers`, can be declared in `config.json`, and the three that need an admin verification step (the two OAuth variants plus `per_user_headers`) land in this state at boot. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row that runs the same verification flow the Web UI Create form uses. See each auth type's page for the `config.json` shape.
-- **`needs_reauth`**: on a server-level client, the connection credential itself died and must be reauthorized. On a per-user client, it means the admin credential Bifrost retains to refresh the server's tool list needs repair; end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it from the client sheet.
+- **`needs_reauth`**: on a server-level client, the connection credential itself died and must be reauthorized via the **Reauthorize** button on the client sheet (or [`POST /api/mcp/client/{id}/reauthorize`](./oauth#reauthorization)). On a per-user client, it means the admin credential Bifrost retains to refresh the server's tool list needs repair; end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it from the client sheet: **Repair OAuth** (the same reauthorize flow) for [`per_user_oauth`](./per-user-oauth#admin-discovery-credential), or **Update headers** (re-running `verify-headers` with fresh sample values) for [`per_user_headers`](./per-user-headers#admin-discovery-credential).
 
 ---
 
@@ -189,7 +189,7 @@ The `mcp_auth_required` payload carries a `kind` discriminator (`"oauth"` or `"h
 
 Every per-user credential — OAuth tokens and submitted headers — shows up on the **MCP Sessions** page. From there callers can:
 
-- See the credential's status (`active`, `orphaned`, `needs_reauth`, `needs_update`)
+- See the credential's status (`active`, `pending`, `orphaned`, `needs_reauth`, `needs_update`)
 - **Re-authenticate** an OAuth row whose upstream token went stale
 - **Edit values** on a header row when their key changes
 - **Revoke** a credential outright

--- a/docs/mcp/auth/per-user-headers.mdx
+++ b/docs/mcp/auth/per-user-headers.mdx
@@ -53,7 +53,7 @@ VK and session-mode URLs may also carry a `#t=<temp-token>` fragment when [`mcp_
 
 ## Setup
 
-The admin configures the MCP client once, declaring the schema (header names) end-users will need to fill in. During setup, Bifrost asks the admin for sample values, runs a one-time upstream verify, and discovers the tool list — same as the per-user OAuth setup pattern, just with a values form instead of an OAuth popup. Sample values are discarded after the test.
+The admin configures the MCP client once, declaring the schema (header names) end-users will need to fill in. During setup, Bifrost asks the admin for sample values, runs a one-time upstream verify, and discovers the tool list — same as the per-user OAuth setup pattern, just with a values form instead of an OAuth popup. When verification runs through the `verify-headers` flow, the sample values are retained as the [admin discovery credential](#admin-discovery-credential) used to keep the tool list fresh; values passed inline on the create call are still used once and discarded.
 
 <Tabs>
 <Tab title="Web UI">
@@ -98,7 +98,7 @@ curl -X POST http://localhost:8080/api/mcp/client \
 | Field                  | Type                          | Purpose                                                                            |
 | ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
 | `per_user_header_keys` | `string[]`                    | Required header names end-users must supply. The schema.                           |
-| `user_headers`         | `map[string]string`           | Admin's sample values for the one-time verify. Discarded after the create call.   |
+| `user_headers`         | `map[string]string`           | Admin's sample values for the one-time verify. Discarded after the create call; only the [`verify-headers` flow](#admin-discovery-credential) retains them as the admin discovery credential. |
 | `headers`              | `map[string]EnvVar`           | Optional static admin headers that accompany every per-user request.              |
 
 On success, Bifrost runs the upstream verify with `user_headers`, attaches the discovered tools, persists the MCP client, and returns:
@@ -137,7 +137,7 @@ Declare the client with `auth_type: "per_user_headers"` and the required header-
 }
 ```
 
-At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost opens the same sample-values dialog the Web UI Create flow uses. Submit values, the upstream verify runs, tools are discovered, the credentials are discarded, and the client transitions to `connected`.
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost opens the same sample-values dialog the Web UI Create flow uses. Submit values, the upstream verify runs, tools are discovered, the values are retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh, and the client transitions to `connected`.
 
 The same step is scriptable — no browser involved:
 
@@ -152,7 +152,7 @@ curl -X POST http://localhost:8080/api/mcp/client/{id}/verify-headers \
   }'
 ```
 
-`user_headers` must cover every declared key. On success the response carries `tools_count` and the client transitions to `connected`; a `422` means the upstream verify failed (retry with different values); a `409` means the client was already verified — delete and recreate it to re-verify.
+`user_headers` must cover every declared key. On success the response carries `tools_count` and the client transitions to `connected`; a `422` means the upstream verify failed (retry with different values). A `409` means the client was already verified and its [admin discovery credential](#admin-discovery-credential) is healthy (or absent), so there is nothing to re-verify. The one legitimate repeat call is a repair: while the admin credential sits in `needs_update`, the endpoint accepts fresh sample values and flips the credential back to `active` on success.
 
 **Lifecycle across restarts and config edits:** the verified state (discovered tools) is server-side and survives restarts and config.json re-syncs, including edits to `per_user_header_keys` — new keys apply to end-user submissions without re-verification. The key list cannot be *emptied*, though: an edit that removes all keys is ignored and the stored keys kept (with a warning at boot). Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config` — cannot be changed after creation: file edits to them are ignored with a boot warning, matching the update API. Delete the client and re-declare it to change them.
 
@@ -178,7 +178,7 @@ There is a strict separation between the two:
 
 ## Editing the schema
 
-If the admin later changes `per_user_header_keys` (adds, removes, or renames a required header), all existing credentials for that MCP server flip to `needs_update`. End-users will see an `mcp_auth_required` payload on the next tool call and be sent back to the submission form to fill in the new schema. Their old values are preserved where the key still matches — the form pre-shows which keys are already on file (names only, never values).
+If the admin later changes `per_user_header_keys` (adds, removes, or renames a required header), all existing credentials for that MCP server flip to `needs_update`. End-users will see an `mcp_auth_required` payload on the next tool call and be sent back to the submission form to fill in the new schema. Their old values are preserved where the key still matches — the form pre-shows which keys are already on file (names only, never values). The retained [admin discovery credential](#admin-discovery-credential) flips to `needs_update` too, which surfaces as a `needs_reauth` badge on the client until the admin re-runs verification with values for the new schema.
 
 <Tabs>
 <Tab title="Web UI">
@@ -254,6 +254,35 @@ Every per-user header credential shows up on the **MCP Sessions** page with one 
 
 From the sessions table the user can **Edit values** (mints a fresh submission flow against the same MCP/identity) or **Revoke** outright. See [MCP Sessions](../sessions) for the full lifecycle and the orphan/reactivate behavior on VK changes.
 
+The client-level [admin discovery credential](#admin-discovery-credential) is deliberately excluded from this page: it is not an end-user credential, and it is managed from the client sheet instead.
+
+---
+
+## Admin discovery credential
+
+When admin verification runs through the `verify-headers` flow (the **Verify** dialog on a `pending_verification` client, or the endpoint directly), the sample values are retained as a client-level **admin discovery credential** (auth mode `admin`). Its role is deliberately narrow:
+
+- **Tool-list refresh only.** The periodic tool syncer uses it for a one-shot connect, `tools/list`, disconnect cycle on the client's [tool sync interval](#periodic-tool-sync). It is **never** used for end-user tool calls; those always run under the caller's own submitted values.
+- **Invisible on the sessions page.** Admin credentials are excluded from [MCP Sessions](../sessions); they are managed from the client sheet instead.
+
+If the credential falls into `needs_update` (typically because `per_user_header_keys` changed), the client list projects a **`needs_reauth`** badge next to the client's **View sessions** link. This is a display-level state: end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it. Clients created with inline `user_headers` before running `verify-headers` have no admin row and simply stay healthy (their tool list just cannot refresh periodically).
+
+To repair it, open the client sheet and click **Update headers**: the same sample-values dialog re-runs the upstream verify, re-discovers tools, and flips the credential back to `active`. The scriptable equivalent is a repeat `POST /api/mcp/client/{id}/verify-headers` call, which is accepted while the admin credential sits in `needs_update` (any other repeat returns `409`).
+
+<Frame>
+  <img src="/media/ui-mcp-per-user-headers-admin-repair.png" alt="Per-user headers client sheet showing the needs_reauth badge next to View sessions and the Update headers button" />
+</Frame>
+
+### Periodic tool sync
+
+Per-user clients hold no persistent upstream connection, but their tool list still refreshes on a schedule using the admin discovery credential. The cadence follows the per-client `tool_sync_interval` (minutes, on the create/update API):
+
+- **Positive**: sync every N minutes for this client
+- **`0` / unset**: inherit the global `mcp_tool_sync_interval` client setting (minutes, default 10)
+- **Negative**: disable periodic sync for this client
+
+A failed sync keeps the existing tool set and retries on the next cycle. In `config.json`, the field also accepts duration strings such as `"10m"` (recommended); a bare number there is a legacy nanosecond value, unlike the API which takes minutes.
+
 ---
 
 ## Configuration reference
@@ -277,7 +306,7 @@ From the sessions table the user can **Edit values** (mints a fresh submission f
 | `auth_type`            | string                | `"per_user_headers"`                                                             |
 | `per_user_header_keys` | `string[]`            | Required header names. Must be non-empty.                                        |
 | `headers`              | `map[string]EnvVar`   | Optional static admin headers.                                                   |
-| `user_headers`         | `map[string]string`   | **Create-only**: admin sample values for the upstream verify; not persisted.    |
+| `user_headers`         | `map[string]string`   | **Create-only**: admin sample values for the upstream verify; not persisted on the create path. The [`verify-headers` flow](#admin-discovery-credential) retains its values as the admin discovery credential. |
 
 <Note>
 MCP client names cannot contain hyphens — Bifrost prefixes tools as `<client>-<tool>` and uses the hyphen to split the two halves at execution time.

--- a/docs/mcp/auth/per-user-oauth.mdx
+++ b/docs/mcp/auth/per-user-oauth.mdx
@@ -30,7 +30,7 @@ This is separate from Bifrost acting as an OAuth 2.1 Authorization Server *for i
 
 ## Setup
 
-Per-user OAuth needs a one-time admin test login so Bifrost can verify the OAuth configuration and discover the tool list from the upstream service. The admin's temp token is discarded after verification; per-user tokens are minted lazily by end-users at runtime.
+Per-user OAuth needs a one-time admin test login so Bifrost can verify the OAuth configuration and discover the tool list from the upstream service. The admin's bootstrap token is retained after verification as the [admin discovery credential](#admin-discovery-credential), used only to keep the tool list fresh; per-user tokens are minted lazily by end-users at runtime, and end-user traffic never uses the admin token.
 
 You can run the admin verification either from the **Web UI** during create, or from a `config.json`-declared client by clicking **Verify** in the UI after Bifrost boots.
 
@@ -86,11 +86,11 @@ The `oauth_config` block itself is optional, and every inner field is optional. 
 `client_id` and `client_secret` support `env.VAR_NAME` and `vault.path` references — `"client_secret": "env.GITHUB_SECRET"` resolves from the environment at runtime, and the reference (not the resolved secret) is what gets stored. Plain values also work (encrypted at rest, redacted in API responses). The other fields (`authorize_url`, `token_url`, `registration_url`, `scopes`) take literal values only.
 </Note>
 
-At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `connected` with the tool list discovered, and the admin's temp token is discarded.
+At boot the client lands in **`pending_verification`** state. From the MCP Gateway UI, open the client and click **Verify** — Bifrost runs the same admin test login popup the Web UI flow uses. On success the client transitions to `connected` with the tool list discovered, and the admin's bootstrap token is retained as the [admin discovery credential](#admin-discovery-credential) for later tool-list refresh.
 
 The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (`{id}` = MCP client ID) returns `authorize_url` plus `status_url` / `complete_url` hints — open `authorize_url` in a browser for the one-time admin login, poll `status_url` until `authorized`, then POST `complete_url` to run verification and tool discovery.
 
-**Lifecycle across restarts and config edits:** the verified state (`oauth_config_id` + discovered tools) is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields — `auth_type`, `connection_type`, `connection_string`, `stdio_config`, and the `oauth_config` block — cannot be changed after creation: file edits to them are **ignored**, matching the update API, and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the block, and restart (the recreated client re-enters `pending_verification`).
+**Lifecycle across restarts and config edits:** the verified state (`oauth_config_id` + discovered tools) is server-side and survives restarts and config.json re-syncs. Mutable fields (tool lists, headers, pricing, etc.) can be edited freely in config.json. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`) cannot be changed after creation: file edits to them are **ignored**, matching the update API, and Bifrost logs a warning naming the ignored fields at the next boot. To change any of them, delete the client, update the block, and restart (the recreated client re-enters `pending_verification`). The `oauth_config` block is different: editing it on an already-verified client **rotates** the stored OAuth credentials in place and flips every bound token (end-user tokens and the admin discovery credential alike) to `needs_reauth`, with a boot warning that existing sessions must re-authenticate. The same rotation is available over the API via `PUT /api/mcp/client/{id}` with an `oauth_config` body; see [Rotation on the OAuth 2.0 page](./oauth#rotation) for the full field-preservation semantics.
 
 </Tab>
 </Tabs>
@@ -98,6 +98,10 @@ The same flow is scriptable: `POST /api/mcp/client/{id}/initiate-verification` (
 <Info>
 If the upstream server supports OAuth Discovery (RFC 8414), you can leave the authorize and token URLs blank and provide only the **Connection URL** plus client ID. Bifrost discovers the endpoints automatically.
 </Info>
+
+<Tip>
+Providers that only issue refresh tokens on explicit request (Google needs `access_type=offline&prompt=consent`) will otherwise hand out access-token-only grants that expire within about an hour and flip to `needs_reauth`. Append the provider's offline-access parameters to `authorize_url`; Bifrost preserves query parameters already present on it. See the [refresh-token warning on the OAuth 2.0 page](./oauth#automatic-refresh).
+</Tip>
 
 ---
 
@@ -208,6 +212,36 @@ MCP client names cannot contain hyphens — Bifrost prefixes tools as `<client>-
 Every per-user OAuth token shows up on the **MCP Sessions** page. From there callers can re-authenticate stale tokens, revoke rows outright, and see status (`active`, `orphaned`, `needs_reauth`).
 
 See [MCP Sessions](../sessions) for the full lifecycle, the difference between `orphaned` and `needs_reauth`, and the auto-orphan-on-VK-change behavior.
+
+---
+
+## Admin discovery credential
+
+The admin's one-time bootstrap token is not thrown away after verification: Bifrost retains it as a client-level **admin discovery credential** (auth mode `admin`). Its role is deliberately narrow:
+
+- **Tool-list refresh only.** The periodic tool syncer uses it for a one-shot connect, `tools/list`, disconnect cycle on the client's [tool sync interval](#periodic-tool-sync). It is **never** used for end-user tool calls; those always run under the caller's own token.
+- **Proactively refreshed.** The background token refresh worker keeps it alive alongside shared-client tokens, so tool discovery keeps working without anyone logging in again.
+- **Invisible on the sessions page.** Admin credentials are excluded from [MCP Sessions](../sessions); they are managed from the client sheet instead.
+
+If the admin credential permanently dies (refresh rejected, provider-side revocation, or a credential rotation), the client list projects a **`needs_reauth`** badge next to the client's **View sessions** link. This is a display-level state: end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it. Clients verified before Bifrost retained admin credentials have no admin row and simply stay healthy.
+
+To repair it, open the client sheet and click **Repair OAuth**: Bifrost redoes the admin consent flow, verifies the fresh token upstream, re-discovers tools, and installs the token as the new admin credential. If verification fails, the fresh token is revoked and the previous credential and tool set are left untouched, so the repair is safely retryable.
+
+<Frame>
+  <img src="/media/ui-mcp-per-user-oauth-admin-repair.png" alt="Per-user OAuth client sheet showing the needs_reauth badge next to View sessions and the Repair OAuth button" />
+</Frame>
+
+The same repair is scriptable via `POST /api/mcp/client/{id}/reauthorize` (`{id}` = MCP client ID). For `per_user_oauth` clients the endpoint is strictly a repair surface: it returns **409** ("does not need repair or does not exist") unless the admin credential actually sits in `needs_reauth`, so it can never churn a healthy credential. The response is the standard `pending_oauth` payload (`authorize_url`, `status_url`, `complete_url`); complete it the same way as the [scriptable verification flow](#setup).
+
+### Periodic tool sync
+
+Per-user clients hold no persistent upstream connection, but their tool list still refreshes on a schedule using the admin discovery credential. The cadence follows the per-client `tool_sync_interval` (minutes, on the create/update API):
+
+- **Positive**: sync every N minutes for this client
+- **`0` / unset**: inherit the global `mcp_tool_sync_interval` client setting (minutes, default 10)
+- **Negative**: disable periodic sync for this client
+
+A failed sync keeps the existing tool set and retries on the next cycle. In `config.json`, the field also accepts duration strings such as `"10m"` (recommended); a bare number there is a legacy nanosecond value, unlike the API which takes minutes.
 
 ---
 

--- a/docs/mcp/gateway-auth.mdx
+++ b/docs/mcp/gateway-auth.mdx
@@ -132,11 +132,12 @@ curl -X PUT http://localhost:8080/api/config \
 ```json
 {
   "client": {
-    "mcp_server_auth_mode": "both",
+    "mcp_server_auth_mode": "oauth",
     "oauth2_server_config": {
       "issuer_url": "https://bifrost.example.com",
       "auth_code_ttl": 300,
-      "access_token_ttl": 600
+      "access_token_ttl": 600,
+      "disable_vk_identity": false
     }
   }
 }
@@ -148,6 +149,7 @@ curl -X PUT http://localhost:8080/api/config \
 | `oauth2_server_config.issuer_url` | string | No | Stable public URL advertised as the issuer in discovery docs and the JWT `iss` claim. Required for multi-host deployments; single-host can omit it (falls back to the request `Host`). Supports `env.MY_VAR` syntax. |
 | `oauth2_server_config.auth_code_ttl` | integer | No | Authorization code lifetime in seconds (default `300`, max `900` = 15 minutes). |
 | `oauth2_server_config.access_token_ttl` | integer | No | Issued JWT lifetime in seconds (default `600`). |
+| `oauth2_server_config.disable_vk_identity` | boolean | No | Require identity-provider login: removes the virtual-key option from consent and cuts off existing vk-mode grants (see [Token Lifetime & Revocation](#token-lifetime--revocation)). Only honored when an identity provider is configured, and only valid when `mcp_server_auth_mode` is `oauth` (400 otherwise). |
 
 </Tab>
 </Tabs>
@@ -178,6 +180,8 @@ Each completed OAuth connection is a **grant** — a refresh-token lineage Bifro
 ![OAuth Grants table with revoke action](/media/ui-oauth-grants.png)
 
 Revoking a grant stops its refresh token from rotating immediately, so the client can no longer renew access.
+
+The page is backed by `GET /api/oauth2/sessions` (list active grants, filtered and paginated) and `DELETE /api/oauth2/sessions/{id}` (revoke a grant), so the same operations are scriptable.
 
 <Note>
 A revoked grant's current access token is a short-lived JWT that keeps working on `/mcp` until it expires (up to `access_token_ttl`, default `600` seconds). After that the client is fully cut off and must reconnect through the consent flow.

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -257,7 +257,8 @@ Bifrost automatically monitors the health of connected MCP clients:
 - **Check Timeout:** Each ping has a 5-second timeout
 - **Failure Threshold:** After 5 consecutive failed pings, client is marked as `disconnected`
 - **State Tracking:** Real-time state updates (connected ↔ disconnected)
-- **Manual Reconnection:** Once disconnected, requires manual reconnect via API or UI
+- **Manual Reconnection:** Once disconnected by failed health checks, requires manual reconnect via API or UI. One exception: when a live tool call hits a clean upstream auth rejection, Bifrost force-refreshes the credential and reconnects in the background on its own (see [Auth failure recovery](./tool-execution#auth-failure-recovery))
+- **`needs_reauth` is sticky:** clients whose OAuth credential permanently died are parked in `needs_reauth`, health checks won't flip them back, and Reconnect is disabled for them; an admin must [reauthorize](./auth/oauth#reauthorization) instead
 
 **Configuration:**
 ```json
@@ -313,6 +314,8 @@ Tools are discovered from MCP servers during:
 
 The MCP Server dynamically updates its tool registry from the tool manager.
 
+Runtime updates run on a periodic tool sync per client. The cadence is the per-client `tool_sync_interval` (minutes on the API; `0` or unset inherits the global `mcp_tool_sync_interval` client setting, default 10 minutes; negative disables sync for that client). Server-level clients sync over their live connection; per-user clients (`per_user_oauth`, `per_user_headers`) hold no persistent connection, so the syncer uses the retained admin discovery credential for a one-shot connect, `tools/list`, disconnect cycle (see [Per-User OAuth](./auth/per-user-oauth#admin-discovery-credential) and [Per-User Headers](./auth/per-user-headers#admin-discovery-credential)). A failed sync keeps the existing tool set and retries on the next cycle.
+
 ---
 
 ## Per-User Auth on the Gateway
@@ -354,7 +357,7 @@ The URLs Bifrost surfaces (consent pages, header-submission pages, and the `redi
 See [Reverse Proxy configuration →](../deployment-guides/config-json/client#reverse-proxy) for the full reference and examples.
 
 <Warning>
-**Changing `mcp_external_client_url` breaks already-connected per-user OAuth clients.** Upstream OAuth providers lock the `redirect_uri` to whatever was registered during Dynamic Client Registration (RFC 7591). If you change this URL afterwards, existing clients fail with **"Invalid redirect URI"** at the authorize step. To recover, clear the stored OAuth client credentials for the affected MCP server and re-authorize so Bifrost re-registers with the new URL.
+**Changing `mcp_external_client_url` breaks already-connected per-user OAuth clients.** Upstream OAuth providers lock the `redirect_uri` to whatever was registered during Dynamic Client Registration (RFC 7591). If you change this URL afterwards, existing clients fail with **"Invalid redirect URI"** at the authorize step. To recover, delete and recreate the affected MCP client so Bifrost re-runs DCR against the new URL (the [reauthorize flow](./auth/oauth#reauthorization) reuses the registered client, so it cannot fix the mismatch on its own). For manually registered credentials, add the new redirect URI at the provider's dashboard instead, then reauthorize.
 </Warning>
 
 ---

--- a/docs/mcp/sessions.mdx
+++ b/docs/mcp/sessions.mdx
@@ -9,7 +9,7 @@ icon: "table"
 
 <Info>The MCP Sessions UI is available in **Bifrost v1.5.0-prerelease2 and above** (initial release), with per-user-headers support added in **v1.5.4**.</Info>
 
-The **MCP Sessions** page is scoped to **per-user MCP authentications** — both **per-user OAuth tokens** and **per-user submitted headers**. Server-level [`headers`](./auth/headers) and [`oauth`](./auth/oauth) clients don't surface here; their credentials live on the MCP client config itself, not as per-caller rows.
+The **MCP Sessions** page is scoped to **per-user MCP authentications** — both **per-user OAuth tokens** and **per-user submitted headers**. Server-level [`headers`](./auth/headers) and [`oauth`](./auth/oauth) clients don't surface here; their credentials live on the MCP client config itself, not as per-caller rows. Per-user clients also hold one client-level **admin discovery credential** (used only to refresh the server's tool list) that deliberately never appears on this page; it is surfaced and repaired from the client sheet instead (see [Per-User OAuth](./auth/per-user-oauth#admin-discovery-credential) and [Per-User Headers](./auth/per-user-headers#admin-discovery-credential)).
 
 Each row represents one of:
 
@@ -155,7 +155,7 @@ When a credential and a pending flow exist for the same `(identity, MCP)` bindin
 
 Check the row status on the Sessions page:
 
-- **Active** but tool still failing → look at the access-token expiry. If it's past, Bifrost will refresh on the next call automatically; if the refresh itself is failing, the row flips to `needs_reauth` after a couple of retries.
+- **Active** but tool still failing → look at the access-token expiry. If it's past, Bifrost will refresh on the next call automatically (and, when the upstream cleanly rejects a call, force-refreshes and retries that call once inline). Transient refresh failures keep retrying silently; the row flips to `needs_reauth` only when the provider permanently rejects the refresh.
 - **Orphaned** → the caller's identity has lost access to this MCP client. Restore the VK assignment / toggle `AllowOnAllVirtualKeys` back on / fix the access profile; the row reactivates on next reconcile.
 - **Needs re-auth** → click **Re-authenticate** and complete the upstream flow.
 - **Needs update** (header rows) → click **Edit values** and resubmit on the form.

--- a/docs/mcp/tool-execution.mdx
+++ b/docs/mcp/tool-execution.mdx
@@ -381,6 +381,16 @@ if err != nil {
 }
 ```
 
+### Auth failure recovery
+
+When a tool call reaches the upstream MCP server but comes back with a clean auth rejection (401/403), Bifrost reacts on the spot instead of waiting for the health monitor:
+
+- **Per-user clients** (`per_user_oauth`, `per_user_headers`): Bifrost force-refreshes the caller's credential, re-acquires a connection, and retries the same call inline, exactly once. If the retry succeeds, the caller just sees a normal success.
+- **Shared clients** (`oauth`, `headers`): the failing call still fails (there is no way to swap credentials on an open connection mid-call), but Bifrost immediately force-refreshes the credential and reconnects in the background, so the next call succeeds.
+- **Safety opt-out**: tools annotated as destructive and not idempotent are never auto-retried; the original error surfaces so a side effect cannot run twice.
+
+This applies to `POST /v1/mcp/tool/execute`, [Agent Mode](./agent-mode) tool calls, and tool calls over the [MCP Gateway](./gateway) alike.
+
 ---
 
 ## Copy-Pastable Responses


### PR DESCRIPTION
## Summary

Documents the new OAuth reauthorization flow, credential rotation API, admin discovery credentials for per-user clients, auth failure recovery behavior, and several clarifications around token lifecycle, `needs_reauth` semantics, and recovery paths for broken redirect URIs.

## Changes

- **Reauthorization**: Added a full `Reauthorization` section to `oauth.mdx` documenting the `needs_reauth` state, the **Reauthorize** button in the dashboard, and the `POST /api/mcp/client/{id}/reauthorize` endpoint. Clarified that `needs_reauth` is sticky and that Reconnect is disabled for it — only a human redoing consent clears it.

- **Credential rotation**: Replaced the previous "rotation is not supported" note with a full `Rotation` section covering `PUT /api/mcp/client/{id}` with an `oauth_config` body, field-preservation semantics, cascade behavior (all bound tokens flip to `needs_reauth`), no-op safety, and the equivalent config.json path.

- **Admin discovery credentials**: Documented that the admin bootstrap token for `per_user_oauth` and `per_user_headers` clients is retained after verification (not discarded) and used exclusively for periodic tool-list refresh. Added dedicated `Admin discovery credential` sections to both pages covering the `needs_reauth` badge, repair flows (**Repair OAuth** / **Update headers**), and the `verify-headers` repeat-call semantics while in `needs_update`.

- **Periodic tool sync**: Added `Periodic tool sync` subsections to both per-user auth pages documenting `tool_sync_interval` (positive/zero/negative semantics, API vs. config.json units), and added a corresponding note in `gateway.mdx`.

- **Auth failure recovery**: Added an `Auth failure recovery` section to `tool-execution.mdx` describing inline force-refresh-and-retry for per-user clients on 401/403, background reconnect for shared clients, and the safety opt-out for destructive non-idempotent tools.

- **Token lifecycle clarifications**: Distinguished token-row status from OAuth-config status when a refresh token permanently dies. Added a warning about providers (e.g. Google) that only issue refresh tokens when explicitly requested, with the `authorize_url` workaround. Clarified that transient refresh failures retry silently and only permanent rejections flip to `needs_reauth`.

- **Immutability clarifications**: Removed `oauth_config` from the list of immutable fields for both `oauth` and `per_user_oauth` clients, since editing it now rotates credentials in place rather than being ignored.

- **Redirect URI / DCR recovery**: Updated all instances of "clear stored credentials" to "delete and recreate the client" with a note that reauthorization alone reuses the registered client and cannot fix a redirect URI mismatch. Added the alternative path for manually registered credentials (add the new URI at the provider's dashboard, then reauthorize).

- **`disable_vk_identity` config field**: Added documentation for the new `oauth2_server_config.disable_vk_identity` boolean in `gateway-auth.mdx`.

- **OAuth2 sessions API**: Noted that the grants page is backed by `GET /api/oauth2/sessions` and `DELETE /api/oauth2/sessions/{id}` for scriptable revocation.

- **Sessions page**: Clarified that the admin discovery credential is intentionally excluded from MCP Sessions and is managed from the client sheet. Added `pending` to the documented credential status values.

- **API reference table**: Added the `POST /api/mcp/client/{id}/reauthorize` endpoint to the OAuth endpoint summary table.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered docs for the following pages and verify accuracy against the running Bifrost build:

- `docs/mcp/auth/oauth.mdx` — Rotation and Reauthorization sections, updated token lifecycle notes, DCR recovery instructions
- `docs/mcp/auth/per-user-oauth.mdx` — Admin discovery credential section, lifecycle immutability note, offline-access tip
- `docs/mcp/auth/per-user-headers.mdx` — Admin discovery credential section, `verify-headers` repeat-call semantics, schema-edit cascade note
- `docs/mcp/auth/overview.mdx` — `needs_reauth` description, `pending` session status
- `docs/mcp/auth/headers.mdx` — Updated cross-reference line
- `docs/mcp/gateway.mdx` — `needs_reauth` sticky note, tool sync paragraph, DCR recovery warning
- `docs/mcp/gateway-auth.mdx` — `disable_vk_identity` field, sessions API note
- `docs/mcp/sessions.mdx` — Admin credential exclusion note, active-but-failing clarification
- `docs/mcp/tool-execution.mdx` — Auth failure recovery section

## Screenshots/Recordings

UI screenshots referenced in the docs (`ui-mcp-needs-reauth-reauthorize.png`, `ui-mcp-per-user-oauth-admin-repair.png`, `ui-mcp-per-user-headers-admin-repair.png`) should be present in `/media/`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The rotation section documents that rotating `client_id` or `client_secret` immediately invalidates all active sessions for the affected MCP client. The `disable_vk_identity` flag cuts off existing virtual-key-mode grants when enabled. Both behaviors are called out explicitly in the docs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable