### PR TITLE
feat: add `token_exchange` MCP auth type with delegated identity-provider token exchange

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -456,6 +456,24 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 		return nil
 	}
 
+	// Token-exchange clients with no DiscoveredTools have not had their
+	// one-time admin verification run yet (which also retains the admin
+	// discovery credential). Park in pending_verification like
+	// per-user-headers; the per-call path takes over once verified.
+	if config.AuthType == schemas.MCPAuthTypeTokenExchange && len(config.DiscoveredTools) == 0 {
+		m.mu.Lock()
+		if client, exists := m.clientMap[config.ID]; exists {
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				client.ConnectionInfo.ConnectionURL = &url
+			}
+			client.State = schemas.MCPConnectionStatePendingVerification
+		}
+		m.mu.Unlock()
+		m.logger.Debug("%s Token-exchange MCP client '%s' registered in pending_verification (awaiting admin verification)", MCPLogPrefix, config.Name)
+		return nil
+	}
+
 	// Per-user auth types: skip persistent connection. Auth is per-request at
 	// runtime. The admin verifies the configuration via a sample login before
 	// this is called, and tools are populated separately via SetClientTools().
@@ -807,7 +825,10 @@ func (m *MCPManager) performAdminToolDiscovery(ctx context.Context, config *sche
 		return nil, nil, fmt.Errorf("failed to resolve admin credential: %w", err)
 	}
 	switch config.AuthType {
-	case schemas.MCPAuthTypePerUserOauth:
+	case schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange:
+		// Both resolve to a bearer credential (the retained bootstrap token,
+		// or a client-credentials token for token exchange), so they share
+		// the bearer-based one-shot verification path.
 		accessToken := strings.TrimPrefix(headers.Get("Authorization"), "Bearer ")
 		if accessToken == "" {
 			return nil, nil, fmt.Errorf("admin credential resolved no access token")
@@ -1140,6 +1161,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		TLSConfig:             updatedConfig.TLSConfig,
 		PerUserHeaderKeys:     slices.Clone(updatedConfig.PerUserHeaderKeys),
 		PendingOAuthConfig:    updatedConfig.PendingOAuthConfig,
+		TokenExchange:         updatedConfig.TokenExchange,
 	}
 
 	// Atomically replace the config pointer

--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -51,6 +51,7 @@ func NewCredStore(oauth2Provider schemas.OAuth2Provider, headersProvider schemas
 			schemas.MCPAuthTypeOauth:          &sharedOAuthResolver{provider: oauth2Provider},
 			schemas.MCPAuthTypePerUserOauth:   &perUserOAuthResolver{provider: oauth2Provider},
 			schemas.MCPAuthTypePerUserHeaders: &perUserHeadersResolver{provider: headersProvider},
+			schemas.MCPAuthTypeTokenExchange:  &tokenExchangeResolver{provider: oauth2Provider},
 		},
 		logger: logger,
 	}

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -116,7 +116,7 @@ func (r *perUserOAuthResolver) AdminConnectionHeaders(ctx context.Context, confi
 	if config.OauthConfigID == nil || *config.OauthConfigID == "" {
 		return nil, fmt.Errorf("per-user OAuth client %q has no linked oauth config", config.Name)
 	}
-	accessToken, err := r.provider.GetAdminAccessToken(ctx, *config.OauthConfigID)
+	accessToken, err := r.provider.GetAdminAccessToken(ctx, config.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get admin access token for MCP server %s: %w", config.Name, err)
 	}

--- a/core/mcp/credstore/per_user_oauth_test.go
+++ b/core/mcp/credstore/per_user_oauth_test.go
@@ -66,6 +66,12 @@ func (f *fakeOAuth2Provider) ForceRefreshAccessToken(ctx *schemas.BifrostContext
 	return errors.New("not implemented")
 }
 
+func (f *fakeOAuth2Provider) TokenExchangeAvailable() bool { return false }
+
+func (f *fakeOAuth2Provider) GetExchangedAccessToken(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (string, error) {
+	return "", errors.New("not implemented")
+}
+
 func newTestOAuthContext() *schemas.BifrostContext {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	ctx.SetValue(schemas.BifrostContextKeyMCPSessionID, "sess-1")

--- a/core/mcp/credstore/token_exchange.go
+++ b/core/mcp/credstore/token_exchange.go
@@ -1,0 +1,96 @@
+package credstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// tokenExchangeResolver handles MCPAuthTypeTokenExchange — the caller's
+// identity-provider token is exchanged for a short-lived upstream token
+// scoped to the client's configured audience. Strictly delegated: every
+// tool call presents the caller's own identity upstream, and there is no
+// interactive flow — on a missing or rejected caller token the raised
+// *MCPAuthRequiredError (Kind "exchange") tells the caller to fix the
+// request credential and retry.
+//
+// ConnectionHeaders returns only the Authorization header — static config
+// headers are layered separately by AcquireClientConn / clientmanager via
+// utils.StaticConfigHeaders so the connect-plugin gate never observes the
+// bearer token.
+//
+// RequiresPerCallConnection is true: exchanged tokens are caller-scoped, so
+// clients never hold a persistent upstream connection; AcquireClientConn
+// opens a fresh ephemeral HTTP transport per call.
+type tokenExchangeResolver struct {
+	provider schemas.OAuth2Provider
+}
+
+func (r *tokenExchangeResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	if r.provider == nil {
+		return nil, fmt.Errorf("token exchange requires an OAuth2Provider but none is configured")
+	}
+
+	accessToken, err := r.provider.GetExchangedAccessToken(ctx, config)
+	if err != nil {
+		if errors.Is(err, schemas.ErrExchangeSubjectTokenMissing) {
+			return nil, &schemas.MCPAuthRequiredError{
+				Kind:                schemas.MCPAuthRequiredKindExchange,
+				MCPClientID:         config.ID,
+				MCPClientName:       config.Name,
+				SubjectTokenMissing: true,
+				Message:             fmt.Sprintf("Authentication required for %s: this server uses your identity token, so the request must be authenticated with one. Retry with your identity-provider credential.", config.Name),
+			}
+		}
+		var rejected *schemas.TokenExchangeRejectedError
+		if errors.As(err, &rejected) {
+			return nil, &schemas.MCPAuthRequiredError{
+				Kind:          schemas.MCPAuthRequiredKindExchange,
+				MCPClientID:   config.ID,
+				MCPClientName: config.Name,
+				ExchangeError: rejected.Detail,
+				Message:       fmt.Sprintf("The identity provider declined to issue a token for %s on your behalf. Re-authenticate and retry; if the problem persists, ask an administrator to check your access to this server.", config.Name),
+			}
+		}
+		return nil, fmt.Errorf("failed to get exchanged access token for MCP server %s: %w", config.Name, err)
+	}
+
+	return bearerHeader(accessToken), nil
+}
+
+func (r *tokenExchangeResolver) RequiresPerCallConnection() bool { return true }
+
+// ForceRefresh evicts the caller's cached exchanged token and performs a
+// fresh exchange. Resolution (mode/identity from ctx, fallback selection)
+// happens inside the provider — see
+// schemas.OAuth2Provider.ForceRefreshAccessToken.
+func (r *tokenExchangeResolver) ForceRefresh(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) error {
+	if r.provider == nil {
+		return fmt.Errorf("token exchange requires an OAuth2Provider but none is configured")
+	}
+	return r.provider.ForceRefreshAccessToken(ctx, config)
+}
+
+// AdminConnectionHeaders resolves the retained admin bootstrap token (see
+// GetAdminAccessToken's doc comment) for periodic tool-discovery refresh,
+// exactly like the per-user OAuth resolver: the credential persisted at
+// verification, lazily renewed through the provider's unified refresh path.
+func (r *tokenExchangeResolver) AdminConnectionHeaders(ctx context.Context, config *schemas.MCPClientConfig) (http.Header, error) {
+	if r.provider == nil {
+		return nil, fmt.Errorf("token exchange requires an OAuth2Provider but none is configured")
+	}
+	accessToken, err := r.provider.GetAdminAccessToken(ctx, config.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get admin access token for MCP server %s: %w", config.Name, err)
+	}
+	return bearerHeader(accessToken), nil
+}
+
+func bearerHeader(token string) http.Header {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+token)
+	return headers
+}

--- a/core/mcp/credstore/token_exchange_test.go
+++ b/core/mcp/credstore/token_exchange_test.go
@@ -1,0 +1,151 @@
+package credstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// fakeExchangeProvider narrows fakeOAuth2Provider for the token-exchange
+// resolver: only the exchange methods carry configurable behavior.
+type fakeExchangeProvider struct {
+	fakeOAuth2Provider
+
+	exchangedToken    string
+	exchangedTokenErr error
+	forceRefreshErr   error
+
+	forceRefreshCalls int
+}
+
+func (f *fakeExchangeProvider) GetExchangedAccessToken(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (string, error) {
+	if f.exchangedTokenErr != nil {
+		return "", f.exchangedTokenErr
+	}
+	return f.exchangedToken, nil
+}
+
+func (f *fakeExchangeProvider) ForceRefreshAccessToken(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) error {
+	f.forceRefreshCalls++
+	return f.forceRefreshErr
+}
+
+func exchangeClientConfig() *schemas.MCPClientConfig {
+	return &schemas.MCPClientConfig{
+		ID:       "client-1",
+		Name:     "Exchange Client",
+		AuthType: schemas.MCPAuthTypeTokenExchange,
+		TokenExchange: &schemas.MCPTokenExchangeConfig{
+			Audience: "api://client-1",
+			ClientID: schemas.NewSecretVar("exchange-client"),
+		},
+	}
+}
+
+func newExchangeTestContext() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func TestTokenExchangeConnectionHeadersSuccess(t *testing.T) {
+	r := &tokenExchangeResolver{provider: &fakeExchangeProvider{exchangedToken: "exchanged-token"}}
+	headers, err := r.ConnectionHeaders(newExchangeTestContext(), exchangeClientConfig())
+	if err != nil {
+		t.Fatalf("ConnectionHeaders returned error: %v", err)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer exchanged-token" {
+		t.Fatalf("Authorization = %q, want %q", got, "Bearer exchanged-token")
+	}
+}
+
+func TestTokenExchangeConnectionHeadersMissingSubject(t *testing.T) {
+	r := &tokenExchangeResolver{provider: &fakeExchangeProvider{exchangedTokenErr: schemas.ErrExchangeSubjectTokenMissing}}
+	_, err := r.ConnectionHeaders(newExchangeTestContext(), exchangeClientConfig())
+
+	var authErr *schemas.MCPAuthRequiredError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected *MCPAuthRequiredError, got %T: %v", err, err)
+	}
+	if authErr.Kind != schemas.MCPAuthRequiredKindExchange {
+		t.Fatalf("Kind = %q, want %q", authErr.Kind, schemas.MCPAuthRequiredKindExchange)
+	}
+	if !authErr.SubjectTokenMissing {
+		t.Fatal("SubjectTokenMissing = false, want true")
+	}
+	if authErr.AuthorizeURL != "" || authErr.SubmitURL != "" {
+		t.Fatal("exchange auth-required errors must carry no interactive URLs")
+	}
+}
+
+func TestTokenExchangeConnectionHeadersRejected(t *testing.T) {
+	provider := &fakeExchangeProvider{
+		exchangedTokenErr: &schemas.TokenExchangeRejectedError{Detail: `{"error":"invalid_grant"}`},
+	}
+	r := &tokenExchangeResolver{provider: provider}
+	_, err := r.ConnectionHeaders(newExchangeTestContext(), exchangeClientConfig())
+
+	var authErr *schemas.MCPAuthRequiredError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected *MCPAuthRequiredError, got %T: %v", err, err)
+	}
+	if authErr.SubjectTokenMissing {
+		t.Fatal("SubjectTokenMissing = true, want false for a rejection")
+	}
+	if authErr.ExchangeError != `{"error":"invalid_grant"}` {
+		t.Fatalf("ExchangeError = %q, want provider detail", authErr.ExchangeError)
+	}
+}
+
+func TestTokenExchangeRequiresPerCallConnection(t *testing.T) {
+	r := &tokenExchangeResolver{}
+	if !r.RequiresPerCallConnection() {
+		t.Fatal("token exchange must require per-call connections")
+	}
+}
+
+func TestTokenExchangeForceRefreshDelegates(t *testing.T) {
+	provider := &fakeExchangeProvider{}
+	r := &tokenExchangeResolver{provider: provider}
+	if err := r.ForceRefresh(newExchangeTestContext(), exchangeClientConfig()); err != nil {
+		t.Fatalf("ForceRefresh returned error: %v", err)
+	}
+	if provider.forceRefreshCalls != 1 {
+		t.Fatalf("ForceRefreshAccessToken calls = %d, want 1", provider.forceRefreshCalls)
+	}
+}
+
+func TestTokenExchangeAdminConnectionHeaders(t *testing.T) {
+	// The retained admin credential resolves via GetAdminAccessToken, the
+	// same path the per-user OAuth resolver uses.
+	provider := &fakeExchangeProvider{fakeOAuth2Provider: fakeOAuth2Provider{adminAccessToken: "admin-token"}}
+	r := &tokenExchangeResolver{provider: provider}
+
+	headers, err := r.AdminConnectionHeaders(context.Background(), exchangeClientConfig())
+	if err != nil {
+		t.Fatalf("AdminConnectionHeaders returned error: %v", err)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer admin-token" {
+		t.Fatalf("Authorization = %q, want admin bearer", got)
+	}
+
+	// A dead/missing retained credential surfaces as a plain error the tool
+	// syncer logs and retries.
+	dead := &tokenExchangeResolver{provider: &fakeExchangeProvider{fakeOAuth2Provider: fakeOAuth2Provider{adminAccessTokenErr: errors.New("needs reauth")}}}
+	if _, err := dead.AdminConnectionHeaders(context.Background(), exchangeClientConfig()); err == nil {
+		t.Fatal("expected error when the retained admin credential is unavailable")
+	}
+}
+
+func TestTokenExchangeNilProvider(t *testing.T) {
+	r := &tokenExchangeResolver{}
+	if _, err := r.ConnectionHeaders(newExchangeTestContext(), exchangeClientConfig()); err == nil {
+		t.Fatal("expected error with nil provider")
+	}
+	if err := r.ForceRefresh(newExchangeTestContext(), exchangeClientConfig()); err == nil {
+		t.Fatal("expected error with nil provider")
+	}
+	if _, err := r.AdminConnectionHeaders(context.Background(), exchangeClientConfig()); err == nil {
+		t.Fatal("expected error with nil provider")
+	}
+}

--- a/core/mcp/toolsync.go
+++ b/core/mcp/toolsync.go
@@ -132,9 +132,11 @@ func (cts *ClientToolSyncer) performSync() {
 	case conn != nil:
 		// Shared-connection path (unchanged): reuse the live conn.
 		newTools, newMapping, err = cts.manager.runListToolsWithHooks(ctx, conn, clientName)
-	case config.AuthType == schemas.MCPAuthTypePerUserOauth || config.AuthType == schemas.MCPAuthTypePerUserHeaders:
+	case config.AuthType == schemas.MCPAuthTypePerUserOauth ||
+		config.AuthType == schemas.MCPAuthTypePerUserHeaders ||
+		config.AuthType == schemas.MCPAuthTypeTokenExchange:
 		// Per-user auth types never hold a persistent conn (RequiresPerCallConnection
-		// is true for both). Resolve the retained admin bootstrap credential and
+		// is true for them). Resolve the retained admin bootstrap credential and
 		// run a one-shot ephemeral connect-discover-close cycle instead.
 		newTools, newMapping, err = cts.manager.performAdminToolDiscovery(ctx, config)
 	default:

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -746,6 +746,17 @@ func validateMCPClientConfig(config *schemas.MCPClientConfig) error {
 			return fmt.Errorf("oauth_config_id must not be set for per_user_headers auth type in client '%s'", config.Name)
 		}
 	}
+	if config.AuthType == schemas.MCPAuthTypeTokenExchange {
+		if config.TokenExchange == nil || strings.TrimSpace(config.TokenExchange.Audience) == "" {
+			return fmt.Errorf("token_exchange.audience is required (non-empty) for token_exchange auth type in client '%s'", config.Name)
+		}
+		if strings.TrimSpace(config.TokenExchange.ClientID.GetValue()) == "" && !config.TokenExchange.ClientID.IsFromSecret() {
+			return fmt.Errorf("token_exchange.client_id is required (non-empty) for token_exchange auth type in client '%s'", config.Name)
+		}
+		if config.OauthConfigID != nil && *config.OauthConfigID != "" {
+			return fmt.Errorf("oauth_config_id must not be set for token_exchange auth type in client '%s'", config.Name)
+		}
+	}
 	return nil
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -352,6 +352,7 @@ const (
 	BifrostContextKeyUserID                              BifrostContextKey = "bifrost-user-id"                    // string (to store the user ID (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyUserName                            BifrostContextKey = "bifrost-user-name"                  // string (to store the user name (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyUserEmail                           BifrostContextKey = "bifrost-user-email"                 // string (to store the user email (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyMCPInboundBearer                    BifrostContextKey = "bifrost-mcp-inbound-bearer"         // string (the caller's validated identity-provider token, used as the subject of delegated token exchange; set by the upstream auth layer - DO NOT SET THIS MANUALLY. SECURITY: live credential - never log its value)
 	BifrostContextKeyQueryScope                          BifrostContextKey = "bifrost-query-scope"                // configstore.QueryScope (func that mutates a query; set by upstream wrapper - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyVisibilityFilterProvider            BifrostContextKey = "bifrost-visibility-filter-provider" // DEPRECATED: replaced by BifrostContextKeyQueryScope. Will be removed once all callers migrate.
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -32,6 +32,7 @@ var reservedKeys = []any{
 	BifrostContextKeyMCPHealthCheckRequest,
 	BifrostContextKeyUpstreamLatency,
 	BifrostContextKeyRoutingInfo,
+	BifrostContextKeyMCPInboundBearer,
 }
 
 // pluginLogStore holds plugin log entries accumulated during request processing.

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -32,6 +33,13 @@ var (
 	ErrOAuth2TokenNotFound        = errors.New("per-user oauth token not found for this identity and mcp server")
 	ErrOAuth2FlowNotPending       = errors.New("oauth flow is not in pending state")
 	ErrOAuth2FlowExpired          = errors.New("oauth flow has expired")
+	// ErrTokenExchangeUnavailable means delegated token exchange cannot run:
+	// no identity-provider integration with an exchange client is configured
+	// (nil TokenExchangeIdPResolver, or Available() == false).
+	ErrTokenExchangeUnavailable = errors.New("delegated token exchange is not available: identity-provider integration with an exchange client is not configured")
+	// ErrExchangeSubjectTokenMissing means the request carried no caller
+	// identity-provider token to use as the exchange subject.
+	ErrExchangeSubjectTokenMissing = errors.New("no caller identity-provider token available to exchange")
 	// ErrMCPReconnectNotApplicable signals that the reconnect operation is not
 	// meaningful for this client type — e.g. per-user OAuth clients, where
 	// each user manages their own auth and there is no shared upstream
@@ -43,8 +51,9 @@ var (
 // to the caller. The value lands in MCPAuthRequiredError.Kind and on the wire
 // under extra_fields.mcp_auth_required.kind.
 const (
-	MCPAuthRequiredKindOAuth   = "oauth"
-	MCPAuthRequiredKindHeaders = "headers"
+	MCPAuthRequiredKindOAuth    = "oauth"
+	MCPAuthRequiredKindHeaders  = "headers"
+	MCPAuthRequiredKindExchange = "exchange"
 )
 
 // MCPAuthRequiredError is returned when a per-user MCP credential is missing
@@ -52,8 +61,11 @@ const (
 // submission) before tool execution can proceed.
 //
 // Kind discriminates which set of fields is populated:
-//   - "oauth":   AuthorizeURL, SessionID
-//   - "headers": SubmitURL, SessionID, RequiredHeaderKeys, AdminHeaderKeys
+//   - "oauth":    AuthorizeURL, SessionID
+//   - "headers":  SubmitURL, SessionID, RequiredHeaderKeys, AdminHeaderKeys
+//   - "exchange": SubjectTokenMissing, ExchangeError (no interactive flow:
+//     the caller fixes the request credential and retries; there is no URL
+//     to visit and no flow row to track)
 //
 // SessionID is shared by both Kinds: for "oauth" it is the
 // mcp_per_user_oauth_flows row ID, for "headers" the
@@ -79,6 +91,14 @@ type MCPAuthRequiredError struct {
 	SubmitURL          string   `json:"submit_url,omitempty"`
 	RequiredHeaderKeys []string `json:"required_header_keys,omitempty"`
 	AdminHeaderKeys    []string `json:"admin_header_keys,omitempty"`
+
+	// Exchange-specific fields (populated when Kind == "exchange").
+	// SubjectTokenMissing is true when the request carried no caller token to
+	// exchange; false means a token was present but the identity provider
+	// rejected the exchange, with ExchangeError carrying the provider's
+	// error/error_description for display.
+	SubjectTokenMissing bool   `json:"subject_token_missing,omitempty"`
+	ExchangeError       string `json:"exchange_error,omitempty"`
 }
 
 func (e *MCPAuthRequiredError) Error() string {
@@ -316,7 +336,83 @@ const (
 	MCPAuthTypeOauth          MCPAuthType = "oauth"            // OAuth 2.0 authentication (server-level, admin authenticates once)
 	MCPAuthTypePerUserOauth   MCPAuthType = "per_user_oauth"   // Per-user OAuth 2.0 authentication (each user authenticates individually)
 	MCPAuthTypePerUserHeaders MCPAuthType = "per_user_headers" // Per-user header authentication (each user submits API keys / signed tokens; admin declares the required key names via PerUserHeaderKeys)
+	MCPAuthTypeTokenExchange  MCPAuthType = "token_exchange"   // Delegated token exchange: the caller's identity-provider token is exchanged for a short-lived upstream token scoped to this server's audience; requires user-identity authentication to be available
 )
+
+// MCPTokenExchangeConfig configures delegated token exchange for one MCP
+// client (AuthType == token_exchange): which resource the exchanged token
+// must be scoped to, and the identity-provider application authorized to
+// perform the exchange for that resource. The endpoint and grant shape are
+// not configured here — they come from the deployment's identity-provider
+// integration at exchange time.
+type MCPTokenExchangeConfig struct {
+	// Audience is the resource identifier the identity provider scopes the
+	// exchanged token to (e.g. "api://jira-mcp"). Required.
+	Audience string `json:"audience"`
+	// ClientID identifies the identity-provider application authorized to
+	// perform exchanges for this audience — a dedicated registration
+	// carrying the token-exchange (or on-behalf-of) grant, not the SSO
+	// login application. Required. Supports env./vault. references.
+	ClientID *SecretVar `json:"client_id"`
+	// ClientSecret authenticates the exchange application. Omit for public
+	// clients. Supports env./vault. references.
+	ClientSecret *SecretVar `json:"client_secret,omitempty"`
+	// Scopes optionally narrows the exchanged token; joined into the OAuth
+	// scope parameter. Include "offline_access" (where the identity provider
+	// supports it) to have exchanges issue refresh tokens, which keeps the
+	// retained admin discovery credential self-renewing instead of flipping
+	// to needs_reauth when it expires.
+	Scopes []string `json:"scopes,omitempty"`
+	// AuthorizationServerURL optionally overrides where the exchange request
+	// is sent, for identity providers that bind an audience to a specific
+	// authorization server distinct from the one used for SSO login (e.g.
+	// Okta's per-resource Custom Authorization Servers). When empty, the
+	// exchange is sent to the deployment's SSO login issuer, which is
+	// correct for providers with a single tenant-wide token endpoint (Entra,
+	// Auth0).
+	AuthorizationServerURL *string `json:"authorization_server_url,omitempty"`
+}
+
+// DiffersFrom reports whether resolved's fields differ from c's, comparing
+// audience, client_id, client_secret, authorization_server_url, and scopes
+// (order-insensitive). Callers pass a fully-resolved value for resolved —
+// e.g. the update-MCP-client API's redacted-value-preserve merge, or a
+// config.json sync's "file value if declared, else keep stored" merge —
+// not a raw partial declaration. A nil receiver always differs from a
+// non-nil resolved value (first token_exchange config ever set on this
+// client); resolved == nil never differs (nothing to compare against).
+func (c *MCPTokenExchangeConfig) DiffersFrom(resolved *MCPTokenExchangeConfig) bool {
+	if resolved == nil {
+		return false
+	}
+	if c == nil {
+		return true
+	}
+	if c.Audience != resolved.Audience {
+		return true
+	}
+	if !c.ClientID.Equals(resolved.ClientID) {
+		return true
+	}
+	if !c.ClientSecret.Equals(resolved.ClientSecret) {
+		return true
+	}
+	existingURL, resolvedURL := "", ""
+	if c.AuthorizationServerURL != nil {
+		existingURL = *c.AuthorizationServerURL
+	}
+	if resolved.AuthorizationServerURL != nil {
+		resolvedURL = *resolved.AuthorizationServerURL
+	}
+	if existingURL != resolvedURL {
+		return true
+	}
+	existingScopes := slices.Clone(c.Scopes)
+	resolvedScopes := slices.Clone(resolved.Scopes)
+	slices.Sort(existingScopes)
+	slices.Sort(resolvedScopes)
+	return !slices.Equal(existingScopes, resolvedScopes)
+}
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
@@ -348,10 +444,13 @@ type MCPClientConfig struct {
 	// utils.StaticConfigHeaders so admin-set values in `Headers` with the
 	// same name cannot leak through the plugin gate. Required (non-empty)
 	// when AuthType == per_user_headers; ignored otherwise.
-	PerUserHeaderKeys   []string          `json:"per_user_header_keys,omitempty"`
-	AllowedExtraHeaders WhiteList         `json:"allowed_extra_headers,omitempty"` // Allowlist of request-level headers that callers may forward to this MCP server at execution time
-	InProcessServer     *server.MCPServer `json:"-"`                               // MCP server instance for in-process connections (Go package only)
-	ToolsToExecute      WhiteList         `json:"tools_to_execute,omitempty"`      // Include-only list.
+	PerUserHeaderKeys []string `json:"per_user_header_keys,omitempty"`
+	// TokenExchange scopes delegated token exchange. Required (with a
+	// non-empty Audience) when AuthType == token_exchange; ignored otherwise.
+	TokenExchange       *MCPTokenExchangeConfig `json:"token_exchange,omitempty"`
+	AllowedExtraHeaders WhiteList               `json:"allowed_extra_headers,omitempty"` // Allowlist of request-level headers that callers may forward to this MCP server at execution time
+	InProcessServer     *server.MCPServer       `json:"-"`                               // MCP server instance for in-process connections (Go package only)
+	ToolsToExecute      WhiteList               `json:"tools_to_execute,omitempty"`      // Include-only list.
 	// ToolsToExecute semantics:
 	// - ["*"] => all tools are included
 	// - []    => no tools are included (deny-by-default)

--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -12,10 +12,11 @@ type OAuth2Provider interface {
 
 	// GetAdminAccessToken is GetAccessToken's admin-mode counterpart:
 	// resolves the retained bootstrap-verification credential for a
-	// per_user_oauth client's periodic tool-discovery refresh (see
+	// per-user client's periodic tool-discovery refresh (see
 	// ClientToolSyncer.performSync's per-user branch), rather than the
-	// shared-mode production credential.
-	GetAdminAccessToken(ctx context.Context, oauthConfigID string) (string, error)
+	// shared-mode production credential. Keyed by the MCP client ID, which
+	// every retained admin credential carries.
+	GetAdminAccessToken(ctx context.Context, mcpClientID string) (string, error)
 
 	// ValidateToken checks if the token is still valid
 	ValidateToken(ctx context.Context, oauthConfigID string) (bool, error)
@@ -74,6 +75,83 @@ type OAuth2Provider interface {
 	// token row is resolved — the one refresh path for every kind of MCP
 	// OAuth credential.
 	ForceRefreshAccessToken(ctx *BifrostContext, config *MCPClientConfig) error
+
+	// Delegated token exchange methods (MCPAuthTypeTokenExchange)
+
+	// TokenExchangeAvailable reports whether delegated token exchange can
+	// run (a TokenExchangeIdPResolver is installed and Available). Consulted
+	// by the create/update path to reject token_exchange clients that could
+	// never resolve.
+	TokenExchangeAvailable() bool
+
+	// GetExchangedAccessToken returns an upstream access token for config
+	// (AuthType == token_exchange), exchanging the caller's identity-provider
+	// token (BifrostContextKeyMCPInboundBearer) for one scoped to
+	// config.TokenExchange.Audience. Results are cached in memory per
+	// (auth mode, identity, mcp client) until shortly before expiry.
+	// Returns ErrExchangeSubjectTokenMissing when the request carried no
+	// caller token, ErrTokenExchangeUnavailable when no identity-provider
+	// integration is configured, and *TokenExchangeRejectedError when the
+	// provider refused the exchange.
+	GetExchangedAccessToken(ctx *BifrostContext, config *MCPClientConfig) (string, error)
+}
+
+// TokenExchangeRejectedError reports that the identity provider refused a
+// delegated token exchange: the subject token was invalid or revoked, the
+// exchange client lacks permission for the audience, or the grant is
+// disabled. Detail carries the provider's error/error_description body for
+// display; it never contains tokens.
+type TokenExchangeRejectedError struct {
+	Detail string
+}
+
+func (e *TokenExchangeRejectedError) Error() string {
+	return "identity provider rejected the token exchange: " + e.Detail
+}
+
+// TokenExchangeGrantShape selects the wire form of a delegated token
+// exchange request; identity providers differ on the grant they expose.
+type TokenExchangeGrantShape string
+
+const (
+	// TokenExchangeGrantRFC8693 is the standard token-exchange grant
+	// (grant_type=urn:ietf:params:oauth:grant-type:token-exchange, RFC 8693).
+	TokenExchangeGrantRFC8693 TokenExchangeGrantShape = "rfc8693"
+	// TokenExchangeGrantJWTBearerOBO is the jwt-bearer on-behalf-of variant
+	// (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer with
+	// requested_token_use=on_behalf_of) used by identity providers that do
+	// not expose the RFC 8693 grant.
+	TokenExchangeGrantJWTBearerOBO TokenExchangeGrantShape = "jwt_bearer_obo"
+)
+
+// TokenExchangeIdP is the identity-provider side of one delegated token
+// exchange call: where to send it and which grant shape to use. The client
+// credentials authorized to perform the exchange live on each MCP client's
+// own token_exchange block, not here.
+type TokenExchangeIdP struct {
+	TokenEndpoint string
+	GrantShape    TokenExchangeGrantShape
+}
+
+// TokenExchangeIdPResolver supplies the identity-provider details for
+// delegated token exchange (MCPAuthTypeTokenExchange). Implementations
+// derive the token endpoint and grant shape from the deployment's
+// identity-provider integration. A nil resolver, or Available() == false,
+// means the auth type is unavailable: creation of token_exchange clients is
+// rejected and existing ones fail resolution.
+type TokenExchangeIdPResolver interface {
+	// Available reports whether delegated token exchange can run: an
+	// identity-provider integration is configured.
+	Available() bool
+
+	// Resolve returns the endpoint and grant shape for exchanges made on
+	// behalf of the given MCP client — implementations should honor a
+	// client-level authorization-server override (config.TokenExchange)
+	// where the provider supports one, falling back to the deployment's
+	// default identity-provider integration otherwise. Called per exchange
+	// (implementations should cache discovery internally) so provider
+	// reconfiguration takes effect without restarts.
+	Resolve(ctx context.Context, config *MCPClientConfig) (*TokenExchangeIdP, error)
 }
 
 // OauthConfig represents OAuth client configuration

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1547,6 +1547,19 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 		hash.Write(data)
 	}
 
+	// Hash the token_exchange scoping block so edits to it in config.json
+	// drift the hash and trigger reconciliation. Same JSON-column-first
+	// fallback shape as PendingOAuthConfig above, for the same reason.
+	if m.TokenExchangeJSON != nil && *m.TokenExchangeJSON != "" {
+		hash.Write([]byte(*m.TokenExchangeJSON))
+	} else if m.TokenExchange != nil {
+		data, err := json.Marshal(m.TokenExchange)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
 	// will enable it in the future with a migration
 	// hash.Write([]byte("disabled:" + strconv.FormatBool(m.Disabled)))
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -463,6 +463,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"drop_oauth_config_pkce_columns"}, run: migrationDropOauthConfigPKCEColumns},
 	{IDs: []string{"drop_oauth_config_token_id_column"}, run: migrationDropOauthConfigTokenIDColumn},
 	{IDs: []string{"add_mcp_admin_auth_mode_indexes"}, run: migrationAddMCPAdminAuthModeIndexes},
+	{IDs: []string{"add_mcp_client_token_exchange_json_column"}, run: migrationAddMCPClientTokenExchangeJSONColumn},
 }
 
 // quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
@@ -10010,6 +10011,43 @@ func migrationAddMCPClientPendingOAuthConfigJSONColumn(ctx context.Context, db *
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_client_pending_oauth_config_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientTokenExchangeJSONColumn adds the token_exchange_json
+// column to config_mcp_clients: the audience/scopes/fallback scoping block
+// for auth_type='token_exchange' clients. NULL for all other auth types; the
+// block carries no credentials.
+func migrationAddMCPClientTokenExchangeJSONColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_client_token_exchange_json_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if !mig.HasColumn(&tables.TableMCPClient{}, "token_exchange_json") {
+				if err := mig.AddColumn(&tables.TableMCPClient{}, "token_exchange_json"); err != nil {
+					return fmt.Errorf("failed to add token_exchange_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableMCPClient{}, "token_exchange_json") {
+				if err := mig.DropColumn(&tables.TableMCPClient{}, "token_exchange_json"); err != nil {
+					return fmt.Errorf("failed to drop token_exchange_json column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_token_exchange_json_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1563,6 +1563,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					DiscoveredTools:           dbClient.DiscoveredTools,
 					DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 					PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+					TokenExchange:             dbClient.TokenExchange,
 					PendingOAuthConfig:        dbClient.PendingOAuthConfig,
 					// ConfigHash must round-trip so config-file reconciliation
 					// can compare the stored hash against the file hash; an
@@ -1612,6 +1613,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			DiscoveredTools:           dbClient.DiscoveredTools,
 			DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 			PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+			TokenExchange:             dbClient.TokenExchange,
 			PendingOAuthConfig:        dbClient.PendingOAuthConfig,
 			// ConfigHash must round-trip so config-file reconciliation can
 			// compare the stored hash against the file hash; an empty hash
@@ -2042,6 +2044,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		DiscoveredTools:           dbClient.DiscoveredTools,
 		DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 		PerUserHeaderKeys:         dbClient.PerUserHeaderKeys,
+		TokenExchange:             dbClient.TokenExchange,
 		PendingOAuthConfig:        dbClient.PendingOAuthConfig,
 	}, nil
 }
@@ -2160,6 +2163,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			// validation rejects the row (empty PerUserHeaderKeys is
 			// invalid for per_user_headers), leaving the client orphaned.
 			PerUserHeaderKeys:  clientConfigCopy.PerUserHeaderKeys,
+			TokenExchange:      clientConfigCopy.TokenExchange,
 			PendingOAuthConfig: clientConfigCopy.PendingOAuthConfig,
 			Disabled:           clientConfigCopy.Disabled,
 			// ConfigHash has json:"-" so deepCopy loses it; use original
@@ -2173,6 +2177,29 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		}
 		return nil
 	})
+}
+
+// marshalTokenExchangeJSON serialises the token_exchange block the way
+// TableMCPClient.BeforeSave does (nil -> NULL, encrypted at rest when
+// enabled — the block carries the exchange application's client_secret),
+// for the map-based update path that bypasses GORM hooks.
+func marshalTokenExchangeJSON(cfg *schemas.MCPTokenExchangeConfig) (*string, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal token_exchange: %w", err)
+	}
+	s := string(data)
+	if encrypt.IsEnabled() && s != "" {
+		encrypted, err := encrypt.Encrypt(s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encrypt mcp token exchange config: %w", err)
+		}
+		s = encrypted
+	}
+	return &s, nil
 }
 
 // UpdateMCPClientConfig updates an existing MCP client configuration in the database.
@@ -2334,6 +2361,15 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if clientConfig.PerUserHeaderKeys != nil {
 			updates["per_user_header_keys_json"] = perUserHeaderKeysJSON
 		}
+		// Mirror BeforeSave for the token_exchange block: nil means
+		// "preserve" on API updates (same convention as PerUserHeaderKeys).
+		tokenExchangeJSON, tokenExchangeErr := marshalTokenExchangeJSON(clientConfig.TokenExchange)
+		if tokenExchangeErr != nil {
+			return tokenExchangeErr
+		}
+		if tokenExchangeJSON != nil {
+			updates["token_exchange_json"] = tokenExchangeJSON
+		}
 		// Config-file driven reconciliation passes ConfigHash. In this mode we should
 		// also sync connection/auth metadata from config.json and persist the hash.
 		if clientConfigCopy.ConfigHash != "" {
@@ -2358,6 +2394,9 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			updates["auth_type"] = clientConfigCopy.AuthType
 			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 			updates["per_user_header_keys_json"] = perUserHeaderKeysJSON
+			// Config-file mode syncs the full auth metadata, so nil here
+			// means "clear", not "preserve".
+			updates["token_exchange_json"] = tokenExchangeJSON
 			// Mirror BeforeSave: nil → NULL; non-nil → serialised JSON,
 			// encrypted at rest (the stash can carry an inline OAuth
 			// client_secret).
@@ -6500,47 +6539,50 @@ func (s *RDBConfigStore) DeleteSharedOauthTokensByConfigID(ctx context.Context, 
 	return nil
 }
 
-// GetAdminOauthTokenByConfigID resolves the single retained admin-mode token
-// row for a config — the bootstrap-verification credential kept alive for a
-// per_user_oauth client's periodic tool-discovery refresh (see
+// GetAdminOauthTokenByMCPClientID resolves the single retained admin-mode
+// token row for an MCP client — the bootstrap-verification credential kept
+// alive for a per-user client's periodic tool-discovery refresh (see
 // GetSharedOauthTokenByConfigID's doc comment for the parallel shared-mode
-// case; this mirrors it exactly, just auth_mode='admin' instead of 'shared').
-// Returns (nil, nil) when no admin token exists for this config.
-func (s *RDBConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
-	if oauthConfigID == "" {
+// case). Keyed by mcp_client_id because every admin row carries it — set at
+// promotion for per_user_oauth, at bootstrap for token_exchange (whose rows
+// have no oauth_configs template at all). Not filtered by status: callers
+// inspect token.Status themselves. Returns (nil, nil) when no admin token
+// exists for this client.
+func (s *RDBConfigStore) GetAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) (*tables.TableMCPOauthToken, error) {
+	if mcpClientID == "" {
 		return nil, nil
 	}
 	var token tables.TableMCPOauthToken
-	result := s.DB().WithContext(ctx).Where("oauth_config_id = ? AND auth_mode = ?", oauthConfigID, "admin").First(&token)
+	result := s.DB().WithContext(ctx).Where("mcp_client_id = ? AND auth_mode = ?", mcpClientID, "admin").First(&token)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to get admin oauth token by config id: %w", result.Error)
+		return nil, fmt.Errorf("failed to get admin oauth token by mcp client id: %w", result.Error)
 	}
 	return &token, nil
 }
 
-// GetAdminOauthTokensByConfigIDs is GetAdminOauthTokenByConfigID's batch
-// counterpart, styled after GetOauthConfigsByIDs: one query resolving the
-// retained admin-mode token row for each of the given oauth_config_ids,
-// keyed by OauthConfigID. Not filtered by status: callers inspect
-// token.Status themselves (the registry list projects 'needs_reauth' rows
-// into a response-only state). Configs with no admin row are simply absent
-// from the map. Empty input returns an empty map without querying.
-func (s *RDBConfigStore) GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
-	if len(oauthConfigIDs) == 0 {
+// GetAdminOauthTokensByMCPClientIDs is GetAdminOauthTokenByMCPClientID's
+// batch counterpart, styled after GetOauthConfigsByIDs: one query resolving
+// the retained admin-mode token row for each of the given MCP client IDs,
+// keyed by MCPClientID. Not filtered by status: callers inspect token.Status
+// themselves (the registry list projects 'needs_reauth' rows into a
+// response-only state). Clients with no admin row are simply absent from the
+// map. Empty input returns an empty map without querying.
+func (s *RDBConfigStore) GetAdminOauthTokensByMCPClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+	if len(mcpClientIDs) == 0 {
 		return map[string]*tables.TableMCPOauthToken{}, nil
 	}
 	var tokens []tables.TableMCPOauthToken
 	if err := s.DB().WithContext(ctx).
-		Where("oauth_config_id IN ? AND auth_mode = ?", oauthConfigIDs, "admin").
+		Where("mcp_client_id IN ? AND auth_mode = ?", mcpClientIDs, "admin").
 		Find(&tokens).Error; err != nil {
 		return nil, fmt.Errorf("failed to batch-get admin oauth tokens: %w", err)
 	}
 	result := make(map[string]*tables.TableMCPOauthToken, len(tokens))
 	for i := range tokens {
-		result[tokens[i].OauthConfigID] = &tokens[i]
+		result[tokens[i].MCPClientID] = &tokens[i]
 	}
 	return result, nil
 }
@@ -6691,11 +6733,12 @@ func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.Tab
 			Where("auth_mode = ? AND mcp_client_id = ?", "shared", token.MCPClientID).
 			First(&existing).Error
 	case token.AuthMode == "admin" && token.MCPClientID != "":
-		// Mirrors the shared-mode branch above: exactly one admin-mode
-		// row per mcp_client_id (idx_mcp_oauth_tokens_admin_mcp), so a
-		// second admin verification for the same client must reuse this
-		// row rather than falling through to Create and violating that
-		// unique index.
+		// Admin rows written directly (token_exchange bootstrap; the
+		// per_user_oauth admin row is installed via
+		// PromoteSharedOauthTokenToAdmin instead): one per MCP client
+		// (idx_mcp_oauth_tokens_admin_mcp), so a second admin write for
+		// the same client must reuse this row rather than falling
+		// through to Create and violating that unique index.
 		lookupErr = dbForUpdate(txDB).
 			Where("auth_mode = ? AND mcp_client_id = ?", "admin", token.MCPClientID).
 			First(&existing).Error
@@ -6846,11 +6889,18 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 		Where("auth_mode IN ?", authModes).
 		Where("status = ?", "active").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).
-		Where("EXISTS (?)",
+		// Two liveness shapes: rows linked through an oauth_configs template
+		// (shared / per_user_oauth), and rows bound directly to an MCP
+		// client with no template (token_exchange admin credentials, whose
+		// oauth_config_id is empty).
+		Where("EXISTS (?) OR (mcp_oauth_tokens.oauth_config_id = '' AND EXISTS (?))",
 			s.DB().Model(&tables.TableMCPClient{}).
 				Select("1").
 				Joins("JOIN oauth_configs ON oauth_configs.id = config_mcp_clients.oauth_config_id").
-				Where("oauth_configs.id = mcp_oauth_tokens.oauth_config_id AND config_mcp_clients.disabled = ?", false)).
+				Where("oauth_configs.id = mcp_oauth_tokens.oauth_config_id AND config_mcp_clients.disabled = ?", false),
+			s.DB().Model(&tables.TableMCPClient{}).
+				Select("1").
+				Where("config_mcp_clients.client_id = mcp_oauth_tokens.mcp_client_id AND config_mcp_clients.disabled = ?", false)).
 		Find(&tokens)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get expiring tokens: %w", result.Error)
@@ -7216,6 +7266,28 @@ func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oa
 		Update("status", "needs_reauth")
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark tokens needs_reauth for oauth config %s: %w", oauthConfigID, result.Error)
+	}
+	return nil
+}
+
+// MarkAdminExchangeTokenNeedsReauthByMCPClientID flips status to
+// 'needs_reauth' on a single row: the token_exchange client's retained admin
+// bootstrap credential (auth_mode='admin', mcp_client_id=<id>,
+// oauth_config_id='' — see isExchangeBackedTokenRow in framework/oauth2 for
+// the same row shape). The oauth_config_id='' filter excludes a
+// per_user_oauth client's admin row, which is keyed by mcp_client_id too but
+// carries a real oauth_config_id and is already covered by
+// MarkTokensNeedsReauthByConfigID.
+func (s *RDBConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error {
+	if mcpClientID == "" {
+		return nil
+	}
+	result := s.DB().WithContext(ctx).
+		Model(&tables.TableMCPOauthToken{}).
+		Where("mcp_client_id = ? AND auth_mode = ? AND oauth_config_id = ?", mcpClientID, "admin", "").
+		Update("status", "needs_reauth")
+	if result.Error != nil {
+		return fmt.Errorf("failed to mark admin exchange token needs_reauth for mcp client %s: %w", mcpClientID, result.Error)
 	}
 	return nil
 }

--- a/framework/configstore/rdb_mcp_admin_auth_mode_test.go
+++ b/framework/configstore/rdb_mcp_admin_auth_mode_test.go
@@ -11,82 +11,81 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestGetAdminOauthTokenByConfigID pins the admin-mode counterpart of
+// TestGetAdminOauthTokenByMCPClientID pins the admin-mode counterpart of
 // GetSharedOauthTokenByConfigID: it must resolve the auth_mode='admin' row
-// for a config and must not cross-match a 'shared'-mode row on the same
-// oauth_config_id, since the two modes back entirely different callers
+// for an MCP client and must not cross-match a 'shared'-mode row on the same
+// mcp_client_id, since the two modes back entirely different callers
 // (GetAdminAccessToken vs GetAccessToken).
-func TestGetAdminOauthTokenByConfigID(t *testing.T) {
+func TestGetAdminOauthTokenByMCPClientID(t *testing.T) {
 	s := setupRDBTestStore(t)
 	ctx := context.Background()
 	now := time.Now()
 
 	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
-		ID: "tok-admin", AuthMode: "admin", OauthConfigID: "cfg-1", Status: "active",
+		ID: "tok-admin", AuthMode: "admin", OauthConfigID: "cfg-1", MCPClientID: "client-1", Status: "active",
 		AccessToken: "at-admin", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now,
 	}).Error)
 	require.NoError(t, s.DB().Create(&tables.TableMCPOauthToken{
-		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", Status: "active",
+		ID: "tok-shared", AuthMode: "shared", OauthConfigID: "cfg-1", MCPClientID: "client-1", Status: "active",
 		AccessToken: "at-shared", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now,
 	}).Error)
 
-	got, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	got, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-1")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, "tok-admin", got.ID, "must resolve the admin-mode row, not the shared-mode row for the same config")
+	assert.Equal(t, "tok-admin", got.ID, "must resolve the admin-mode row, not the shared-mode row for the same client")
 
-	// A config with no admin-mode row at all resolves to (nil, nil).
-	got, err = s.GetAdminOauthTokenByConfigID(ctx, "cfg-no-admin")
+	// A client with no admin-mode row at all resolves to (nil, nil).
+	got, err = s.GetAdminOauthTokenByMCPClientID(ctx, "client-no-admin")
 	require.NoError(t, err)
 	assert.Nil(t, got)
 
-	// Empty oauthConfigID short-circuits to (nil, nil) without querying.
-	got, err = s.GetAdminOauthTokenByConfigID(ctx, "")
+	// Empty mcpClientID short-circuits to (nil, nil) without querying.
+	got, err = s.GetAdminOauthTokenByMCPClientID(ctx, "")
 	require.NoError(t, err)
 	assert.Nil(t, got)
 }
 
-// TestGetAdminOauthTokensByConfigIDs pins the batch counterpart of
-// GetAdminOauthTokenByConfigID: one query keyed by oauth_config_id, admin
+// TestGetAdminOauthTokensByMCPClientIDs pins the batch counterpart of
+// GetAdminOauthTokenByMCPClientID: one query keyed by mcp_client_id, admin
 // rows only, no status filter (needs_reauth rows must come back so the
 // registry list can project them), and empty input short-circuits.
-func TestGetAdminOauthTokensByConfigIDs(t *testing.T) {
+func TestGetAdminOauthTokensByMCPClientIDs(t *testing.T) {
 	s := setupRDBTestStore(t)
 	ctx := context.Background()
 	now := time.Now()
 
 	rows := []*tables.TableMCPOauthToken{
-		{ID: "tok-a-active", AuthMode: "admin", OauthConfigID: "cfg-a", Status: "active",
+		{ID: "tok-a-active", AuthMode: "admin", MCPClientID: "client-a", Status: "active",
 			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
-		{ID: "tok-b-reauth", AuthMode: "admin", OauthConfigID: "cfg-b", Status: "needs_reauth",
+		// token_exchange-shaped admin row: no oauth_config_id at all.
+		{ID: "tok-b-reauth", AuthMode: "admin", MCPClientID: "client-b", Status: "needs_reauth",
 			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
-		// Non-admin rows on the same configs must be excluded.
-		{ID: "tok-a-shared", AuthMode: "shared", OauthConfigID: "cfg-a", Status: "active",
+		// Non-admin rows on the same clients must be excluded.
+		{ID: "tok-a-shared", AuthMode: "shared", MCPClientID: "client-a", Status: "active",
 			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
-		{ID: "tok-b-user", AuthMode: "user", OauthConfigID: "cfg-b", Status: "needs_reauth",
-			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
-		// A config with only a shared row must be absent from the result.
-		{ID: "tok-c-shared", AuthMode: "shared", OauthConfigID: "cfg-c", Status: "active",
+		// A client with only a shared row must be absent from the result.
+		{ID: "tok-c-shared", AuthMode: "shared", MCPClientID: "client-c", Status: "active",
 			AccessToken: "x", TokenType: "Bearer", CreatedAt: now, UpdatedAt: now},
 	}
 	for _, r := range rows {
 		require.NoError(t, s.DB().Create(r).Error)
 	}
 
-	got, err := s.GetAdminOauthTokensByConfigIDs(ctx, []string{"cfg-a", "cfg-b", "cfg-c", "cfg-missing"})
+	got, err := s.GetAdminOauthTokensByMCPClientIDs(ctx, []string{"client-a", "client-b", "client-c", "client-missing"})
 	require.NoError(t, err)
 	require.Len(t, got, 2)
-	require.NotNil(t, got["cfg-a"])
-	assert.Equal(t, "tok-a-active", got["cfg-a"].ID)
-	assert.Equal(t, "active", got["cfg-a"].Status)
-	require.NotNil(t, got["cfg-b"], "needs_reauth admin rows must be returned, not filtered by status")
-	assert.Equal(t, "tok-b-reauth", got["cfg-b"].ID)
-	assert.Equal(t, "needs_reauth", got["cfg-b"].Status)
-	assert.NotContains(t, got, "cfg-c", "a config with only non-admin rows must be absent")
-	assert.NotContains(t, got, "cfg-missing")
+	require.NotNil(t, got["client-a"])
+	assert.Equal(t, "tok-a-active", got["client-a"].ID)
+	assert.Equal(t, "active", got["client-a"].Status)
+	require.NotNil(t, got["client-b"], "needs_reauth admin rows must be returned, not filtered by status")
+	assert.Equal(t, "tok-b-reauth", got["client-b"].ID)
+	assert.Equal(t, "needs_reauth", got["client-b"].Status)
+	assert.NotContains(t, got, "client-c", "a client with only non-admin rows must be absent")
+	assert.NotContains(t, got, "client-missing")
 
 	// Empty input returns an empty map without querying.
-	got, err = s.GetAdminOauthTokensByConfigIDs(ctx, nil)
+	got, err = s.GetAdminOauthTokensByMCPClientIDs(ctx, nil)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -161,7 +160,7 @@ func TestPromoteSharedOauthTokenToAdmin_ReplacesExistingAdminRow(t *testing.T) {
 
 	require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
 
-	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	admin, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-1")
 	require.NoError(t, err)
 	require.NotNil(t, admin)
 	assert.Equal(t, "tok-admin", admin.ID, "existing admin row's ID must be preserved")
@@ -201,7 +200,7 @@ func TestPromoteSharedOauthTokenToAdmin_RetagsWhenNoAdminRow(t *testing.T) {
 
 	require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
 
-	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	admin, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-1")
 	require.NoError(t, err)
 	require.NotNil(t, admin)
 	assert.Equal(t, "tok-shared", admin.ID, "the shared row itself must be retagged, keeping its ID")
@@ -244,7 +243,7 @@ func TestPromoteSharedOauthTokenToAdmin_ClearsStrayShareRows(t *testing.T) {
 
 		require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"))
 
-		admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+		admin, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-1")
 		require.NoError(t, err)
 		require.NotNil(t, admin)
 		assert.Equal(t, "at-fresh", admin.AccessToken, "the active shared row must be the one promoted, not the stale one")
@@ -271,7 +270,7 @@ func TestPromoteSharedOauthTokenToAdmin_ClearsStrayShareRows(t *testing.T) {
 
 		require.NoError(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-2", "client-2"))
 
-		admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-2")
+		admin, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-2")
 		require.NoError(t, err)
 		require.NotNil(t, admin)
 		assert.Equal(t, "tok-shared-active-2", admin.ID, "the active shared row must be retagged in place")
@@ -309,7 +308,7 @@ func TestPromoteSharedOauthTokenToAdmin_Errors(t *testing.T) {
 
 	require.Error(t, s.PromoteSharedOauthTokenToAdmin(ctx, "cfg-1", "client-1"), "non-active shared row must error")
 
-	admin, err := s.GetAdminOauthTokenByConfigID(ctx, "cfg-1")
+	admin, err := s.GetAdminOauthTokenByMCPClientID(ctx, "client-1")
 	require.NoError(t, err)
 	require.NotNil(t, admin)
 	assert.Equal(t, "needs_reauth", admin.Status, "a failed promotion must leave the admin row untouched")

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -512,15 +512,18 @@ type ConfigStore interface {
 	// needs to reach the row regardless of status to delete it. Returns
 	// (nil, nil) when no shared token exists for this config.
 	GetSharedOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
-	// GetAdminOauthTokenByConfigID is GetSharedOauthTokenByConfigID's
+	// GetAdminOauthTokenByMCPClientID is GetSharedOauthTokenByConfigID's
 	// admin-mode counterpart — resolves the retained bootstrap-verification
-	// token for a per_user_oauth client's periodic tool-discovery refresh.
-	GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error)
-	// GetAdminOauthTokensByConfigIDs is GetAdminOauthTokenByConfigID's batch
-	// counterpart: resolves the retained admin-mode token row for each of the
-	// given oauth_config_ids in one query, keyed by OauthConfigID. Not
-	// filtered by status; configs with no admin row are absent from the map.
-	GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error)
+	// token for a per-user client's periodic tool-discovery refresh. Keyed
+	// by mcp_client_id because every admin row carries it, whether or not
+	// the credential has an oauth_configs template behind it. Not filtered
+	// by status. Returns (nil, nil) when no admin row exists.
+	GetAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) (*tables.TableMCPOauthToken, error)
+	// GetAdminOauthTokensByMCPClientIDs is GetAdminOauthTokenByMCPClientID's
+	// batch counterpart: resolves the retained admin-mode token row for each
+	// of the given MCP client IDs in one query, keyed by MCPClientID. Not
+	// filtered by status; clients with no admin row are absent from the map.
+	GetAdminOauthTokensByMCPClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPOauthToken, error)
 	// PromoteSharedOauthTokenToAdmin transactionally installs the config's
 	// fresh shared-mode token as the retained admin-mode discovery credential
 	// for mcpClientID: if an admin row already exists its credential fields
@@ -642,6 +645,19 @@ type ConfigStore interface {
 	// invalidates every existing holder's cached credential (shared, per-user,
 	// vk, session, admin alike), not just the shared one.
 	MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
+	// MarkAdminExchangeTokenNeedsReauthByMCPClientID flips status to
+	// 'needs_reauth' on a token_exchange client's retained admin bootstrap
+	// credential (auth_mode='admin', mcp_client_id=<id>, oauth_config_id='' —
+	// token_exchange rows have no oauth_configs template, unlike
+	// per_user_oauth's admin row, so this is keyed by MCP client rather than
+	// oauth_config_id the way MarkTokensNeedsReauthByConfigID is). Called
+	// when an admin edits a token_exchange client's audience/client_id/
+	// client_secret/scopes/authorization_server_url. Unlike OAuth rotation,
+	// there is no per-user row to cascade to: end-user exchanged tokens are
+	// cached in-memory only, never persisted (see GetExchangedAccessToken's
+	// doc comment) — the admin row is the only persisted state a
+	// token_exchange config edit can invalidate.
+	MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error
 	// RotateMCPOAuthConfig updates every field of an oauth_configs row in
 	// place when ANY of them differs from what's stored (client_id,
 	// client_secret, authorize_url, token_url, registration_url, resource,

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -35,7 +35,7 @@ type TableMCPClient struct {
 	ToolNameMappingJSON string `gorm:"type:text" json:"-"` // JSON serialized map[string]string
 
 	// OAuth authentication fields
-	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth", "per_user_oauth", "per_user_headers"
+	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth", "per_user_oauth", "per_user_headers", "token_exchange"
 	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID with CASCADE delete
 	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID;constraint:OnDelete:CASCADE" json:"-"` // Gorm relationship
 
@@ -44,6 +44,14 @@ type TableMCPClient struct {
 	// the resolver (intersect with persisted user values) and by
 	// utils.StaticConfigHeaders (strip from plugin-visible static headers).
 	PerUserHeaderKeysJSON string `gorm:"type:text" json:"-"` // JSON serialized []string
+
+	// Token-exchange configuration (audience/scopes + the exchange
+	// application's client credentials) for auth_type='token_exchange'. NULL
+	// for all other auth types. Carries a client secret, so it is encrypted
+	// at rest like the other credential-bearing columns; the exchange
+	// endpoint and grant shape come from the deployment's identity-provider
+	// integration at exchange time.
+	TokenExchangeJSON *string `gorm:"type:text" json:"-"` // JSON serialized schemas.MCPTokenExchangeConfig
 
 	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
 	Disabled              bool `gorm:"default:false" json:"disabled"`                  // Whether the client is intentionally disabled
@@ -73,17 +81,18 @@ type TableMCPClient struct {
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	StdioConfig               *schemas.MCPStdioConfig      `gorm:"-" json:"stdio_config,omitempty"`
-	TLSConfig                 *schemas.MCPTLSConfig        `gorm:"-" json:"tls_config,omitempty"`
-	ToolsToExecute            schemas.WhiteList            `gorm:"-" json:"tools_to_execute"`
-	ToolsToAutoExecute        schemas.WhiteList            `gorm:"-" json:"tools_to_auto_execute"`
-	Headers                   map[string]schemas.SecretVar `gorm:"-" json:"headers"`
-	AllowedExtraHeaders       schemas.WhiteList            `gorm:"-" json:"allowed_extra_headers"`
-	ToolPricing               map[string]float64           `gorm:"-" json:"tool_pricing"`
-	DiscoveredTools           map[string]schemas.ChatTool  `gorm:"-" json:"-"`
-	DiscoveredToolNameMapping map[string]string            `gorm:"-" json:"-"`
-	PerUserHeaderKeys         []string                     `gorm:"-" json:"per_user_header_keys"`
-	PendingOAuthConfig        *schemas.OAuth2Config        `gorm:"-" json:"oauth_config,omitempty"` // Runtime mirror of PendingOAuthConfigJSON
+	StdioConfig               *schemas.MCPStdioConfig         `gorm:"-" json:"stdio_config,omitempty"`
+	TLSConfig                 *schemas.MCPTLSConfig           `gorm:"-" json:"tls_config,omitempty"`
+	ToolsToExecute            schemas.WhiteList               `gorm:"-" json:"tools_to_execute"`
+	ToolsToAutoExecute        schemas.WhiteList               `gorm:"-" json:"tools_to_auto_execute"`
+	Headers                   map[string]schemas.SecretVar    `gorm:"-" json:"headers"`
+	AllowedExtraHeaders       schemas.WhiteList               `gorm:"-" json:"allowed_extra_headers"`
+	ToolPricing               map[string]float64              `gorm:"-" json:"tool_pricing"`
+	DiscoveredTools           map[string]schemas.ChatTool     `gorm:"-" json:"-"`
+	DiscoveredToolNameMapping map[string]string               `gorm:"-" json:"-"`
+	PerUserHeaderKeys         []string                        `gorm:"-" json:"per_user_header_keys"`
+	TokenExchange             *schemas.MCPTokenExchangeConfig `gorm:"-" json:"token_exchange,omitempty"` // Runtime mirror of TokenExchangeJSON
+	PendingOAuthConfig        *schemas.OAuth2Config           `gorm:"-" json:"oauth_config,omitempty"`   // Runtime mirror of PendingOAuthConfigJSON
 }
 
 // TableName sets the table name for each model
@@ -208,6 +217,17 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.PerUserHeaderKeysJSON = ""
 	}
 
+	if c.TokenExchange != nil {
+		data, err := json.Marshal(c.TokenExchange)
+		if err != nil {
+			return err
+		}
+		s := string(data)
+		c.TokenExchangeJSON = &s
+	} else {
+		c.TokenExchangeJSON = nil
+	}
+
 	// Persist the inline `oauth_config` block. Rehydrated by AfterFind so
 	// the initiate-verification endpoint can feed it to InitiateOAuthFlow
 	// the same way the UI Create handler does.
@@ -252,6 +272,15 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 			}
 			c.PendingOAuthConfigJSON = &enc
 		}
+		// The token-exchange block carries the exchange application's
+		// client_secret — same treatment.
+		if c.TokenExchangeJSON != nil && *c.TokenExchangeJSON != "" {
+			enc, err := encrypt.Encrypt(*c.TokenExchangeJSON)
+			if err != nil {
+				return fmt.Errorf("failed to encrypt mcp token exchange config: %w", err)
+			}
+			c.TokenExchangeJSON = &enc
+		}
 		c.EncryptionStatus = EncryptionStatusEncrypted
 	}
 
@@ -275,6 +304,13 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 				return fmt.Errorf("failed to decrypt mcp connection string: %w", err)
 			}
 			c.ConnectionString.Val = decrypted
+		}
+		if c.TokenExchangeJSON != nil && *c.TokenExchangeJSON != "" {
+			decrypted, err := encrypt.Decrypt(*c.TokenExchangeJSON)
+			if err != nil {
+				return fmt.Errorf("failed to decrypt mcp token exchange config: %w", err)
+			}
+			c.TokenExchangeJSON = &decrypted
 		}
 		if c.PendingOAuthConfigJSON != nil && *c.PendingOAuthConfigJSON != "" {
 			decrypted, err := encrypt.Decrypt(*c.PendingOAuthConfigJSON)
@@ -337,6 +373,13 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 		if err := sonic.Unmarshal([]byte(c.PerUserHeaderKeysJSON), &c.PerUserHeaderKeys); err != nil {
 			return err
 		}
+	}
+	if c.TokenExchangeJSON != nil && *c.TokenExchangeJSON != "" {
+		var cfg schemas.MCPTokenExchangeConfig
+		if err := sonic.Unmarshal([]byte(*c.TokenExchangeJSON), &cfg); err != nil {
+			return err
+		}
+		c.TokenExchange = &cfg
 	}
 	if c.PendingOAuthConfigJSON != nil && *c.PendingOAuthConfigJSON != "" {
 		var cfg schemas.OAuth2Config

--- a/framework/oauth2/access_token_test.go
+++ b/framework/oauth2/access_token_test.go
@@ -39,7 +39,10 @@ func seedAccessToken(store *testConfigStore, oauthConfigID, authMode, tokenID, a
 		ID:            tokenID,
 		AuthMode:      authMode,
 		OauthConfigID: oauthConfigID,
-		Status:        "active",
+		// Admin rows are looked up by mcp_client_id (the key every admin row
+		// carries); the tests reuse the same identifier for both lookups.
+		MCPClientID: oauthConfigID,
+		Status:      "active",
 		AccessToken:   accessToken,
 		RefreshToken:  refreshToken,
 		TokenType:     "Bearer",
@@ -182,7 +185,7 @@ func TestAccessToken_MissingToken_ReturnsError(t *testing.T) {
 			token, err := g.get(provider, context.Background(), oauthConfigID)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "no")
-			assert.Contains(t, err.Error(), "token linked to oauth config")
+			assert.Contains(t, err.Error(), "token", "a missing row must surface as a plain no-token error")
 			assert.Empty(t, token)
 		})
 	}

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -38,6 +38,13 @@ const (
 	// terminalStatusUpdateTimeout bounds the detached needs_reauth status
 	// write after a permanent OAuth rejection (see refreshAccessTokenLocked).
 	terminalStatusUpdateTimeout = 10 * time.Second
+
+	// maxTokenEndpointResponseBytes caps how much of an OAuth token endpoint
+	// response callTokenEndpoint reads. A legitimate response is a small
+	// JSON object; this only guards against an unbounded/misbehaving
+	// endpoint, mirroring the cap core/providers/utils/largeresponse.go uses
+	// for provider error bodies.
+	maxTokenEndpointResponseBytes = 512 * 1024
 )
 
 // OAuth2Provider implements the schemas.OAuth2Provider interface
@@ -76,7 +83,15 @@ type OAuth2Provider struct {
 	// read that had to wait on it would lose the entire point of the cache.
 	// Write paths in this file evict inline; handler-level database writes
 	// that bypass the provider evict through the exported eviction methods.
+	// Exchanged tokens (token_exchange auth) share this cache: same key
+	// scheme, same expiry-as-miss validator, same lifecycle evictions —
+	// they just carry no token row ID because nothing is persisted for them.
 	userTokens *userTokenCache
+
+	// exchangeIdP holds the identity-provider resolver backing delegated
+	// token exchange. Same atomic-pointer rationale as tempTokens: written
+	// once at startup, read on the request path, and never guarded by p.mu.
+	exchangeIdP atomic.Pointer[schemas.TokenExchangeIdPResolver]
 }
 
 // NewOAuth2Provider creates a new OAuth provider instance
@@ -180,8 +195,11 @@ func (p *OAuth2Provider) resolveAccessToken(ctx context.Context, token *tables.T
 		return "", fmt.Errorf("oauth token is not active, status: %s: %w", token.Status, schemas.ErrOAuth2TokenExpired)
 	}
 
-	// Refresh only when the token has known expiry and a refresh token is available.
-	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
+	// Refresh only when the token has known expiry and a renewal path: a
+	// refresh token, or the identity-provider integration for
+	// token-exchange admin rows (which can re-mint without one).
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) &&
+		(strings.TrimSpace(token.RefreshToken) != "" || isExchangeBackedTokenRow(token)) {
 		// Attempt automatic refresh
 		if err := p.RefreshAccessToken(ctx, token.ID); err != nil {
 			return "", fmt.Errorf("token expired and refresh failed: %w", err)
@@ -206,16 +224,18 @@ func (p *OAuth2Provider) resolveAccessToken(ctx context.Context, token *tables.T
 }
 
 // GetAdminAccessToken is GetAccessToken's admin-mode counterpart: resolves
-// the retained bootstrap-verification credential for a per_user_oauth
-// client's periodic tool-discovery refresh (ClientToolSyncer.performSync),
-// rather than the shared-mode production credential.
-func (p *OAuth2Provider) GetAdminAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
-	token, err := p.configStore.GetAdminOauthTokenByConfigID(ctx, oauthConfigID)
+// the retained bootstrap-verification credential for a per-user client's
+// periodic tool-discovery refresh (ClientToolSyncer.performSync), rather
+// than the shared-mode production credential. Keyed by the MCP client ID,
+// which every admin row carries regardless of whether an oauth_configs
+// template sits behind the credential.
+func (p *OAuth2Provider) GetAdminAccessToken(ctx context.Context, mcpClientID string) (string, error) {
+	token, err := p.configStore.GetAdminOauthTokenByMCPClientID(ctx, mcpClientID)
 	if err != nil {
 		return "", fmt.Errorf("failed to load admin oauth token: %w", err)
 	}
 	if token == nil {
-		return "", fmt.Errorf("no admin token linked to oauth config")
+		return "", fmt.Errorf("no admin token retained for this MCP client")
 	}
 	return p.resolveAccessToken(ctx, token)
 }
@@ -267,6 +287,14 @@ func (p *OAuth2Provider) refreshAccessTokenLocked(ctx context.Context, tokenID s
 	}
 	if token == nil {
 		return fmt.Errorf("oauth token not found: %s", tokenID)
+	}
+
+	// Token-exchange admin rows have no oauth_configs template; renewal runs
+	// through the identity-provider integration instead of the template's
+	// token endpoint (and may not need a refresh token at all — the
+	// client-credentials fallback re-mints).
+	if isExchangeBackedTokenRow(token) {
+		return p.refreshExchangeAdminToken(ctx, token)
 	}
 
 	if strings.TrimSpace(token.RefreshToken) == "" {
@@ -418,6 +446,19 @@ func (p *OAuth2Provider) ForceRefreshAccessToken(ctx *schemas.BifrostContext, co
 		// call itself fails.
 		p.EvictUserToken(mode, identity, config.ID)
 		return p.RefreshAccessToken(ctx, token.ID)
+	case schemas.MCPAuthTypeTokenExchange:
+		// Nothing is persisted for callers' exchanged tokens, so
+		// force-refresh is evict + re-exchange: drop the cached copy for
+		// this binding and perform a fresh exchange so the retry that
+		// follows sends a token the identity provider just minted.
+		mode := ctx.MCPAuthMode()
+		identity := ctx.MCPIdentity(mode)
+		if identity == "" {
+			return schemas.ErrExchangeSubjectTokenMissing
+		}
+		p.EvictExchangedToken(mode, identity, config.ID)
+		_, err := p.GetExchangedAccessToken(ctx, config)
+		return err
 	default:
 		return fmt.Errorf("force-refresh is not supported for MCP auth type %q", config.AuthType)
 	}
@@ -1181,7 +1222,11 @@ func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string,
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		// Capped read: an OAuth token endpoint response is normally a small
+		// JSON object, but nothing stops a misconfigured or malicious
+		// endpoint from streaming an unbounded body — matching the 512KB cap
+		// core/providers/utils/largeresponse.go uses for error bodies.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenEndpointResponseBytes))
 		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)
@@ -1583,7 +1628,7 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 // lookups are never cached, so a caller completing OAuth (or a token being
 // reactivated) becomes visible on the very next call.
 func (p *OAuth2Provider) GetUserAccessTokenByMode(ctx context.Context, mode schemas.MCPAuthMode, identity, mcpClientID string) (string, error) {
-	key := userTokenCacheKey(mode, identity, mcpClientID)
+	key := userTokenCacheKey(mode, identity, mcpClientID, "")
 	if cached, ok := p.userTokens.Get(key); ok {
 		return cached.accessToken, nil
 	}
@@ -1636,7 +1681,7 @@ func (p *OAuth2Provider) EvictUserToken(mode schemas.MCPAuthMode, identity, mcpC
 	if p == nil {
 		return
 	}
-	p.userTokens.Evict(userTokenCacheKey(mode, identity, mcpClientID))
+	p.userTokens.Evict(userTokenCacheKey(mode, identity, mcpClientID, ""))
 }
 
 // EvictUserTokenByID drops the cached access token backed by the given token

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -31,6 +31,7 @@ type testConfigStore struct {
 	oauthTokens  map[string]*tables.TableMCPOauthToken
 	oauthFlows   map[string]*tables.TableMCPOauthFlow
 	clientConfig *configstore.ClientConfig
+	mcpClients   map[string]*schemas.MCPClientConfig
 }
 
 func newTestConfigStore() *testConfigStore {
@@ -83,14 +84,14 @@ func (s *testConfigStore) GetSharedOauthTokenByConfigID(_ context.Context, oauth
 	return nil, nil
 }
 
-// GetAdminOauthTokenByConfigID is GetSharedOauthTokenByConfigID's admin-mode
-// counterpart — the test-double equivalent of the real store's
-// (oauth_config_id, auth_mode='admin') lookup, used by GetAdminAccessToken.
-func (s *testConfigStore) GetAdminOauthTokenByConfigID(_ context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+// GetAdminOauthTokenByMCPClientID is GetSharedOauthTokenByConfigID's
+// admin-mode counterpart — the test-double equivalent of the real store's
+// (mcp_client_id, auth_mode='admin') lookup, used by GetAdminAccessToken.
+func (s *testConfigStore) GetAdminOauthTokenByMCPClientID(_ context.Context, mcpClientID string) (*tables.TableMCPOauthToken, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, token := range s.oauthTokens {
-		if token.OauthConfigID == oauthConfigID && token.AuthMode == "admin" {
+		if token.MCPClientID == mcpClientID && token.AuthMode == "admin" {
 			return bifrost.Ptr(*token), nil
 		}
 	}

--- a/framework/oauth2/tokenexchange.go
+++ b/framework/oauth2/tokenexchange.go
@@ -1,0 +1,404 @@
+package oauth2
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+const (
+	grantTypeTokenExchange      = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeJWTBearer          = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	subjectTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
+
+	// exchangeExpirySafetyMargin is subtracted from an exchanged token's
+	// expires_in before caching, so a token about to lapse mid-call is
+	// treated as a miss and re-exchanged rather than sent upstream.
+	exchangeExpirySafetyMargin = 30 * time.Second
+
+	// defaultExchangedTokenTTL caches exchanged tokens whose response omitted
+	// expires_in. Deliberately short: with no declared lifetime the only safe
+	// assumption is a brief one, and re-exchanging is cheap.
+	defaultExchangedTokenTTL = 5 * time.Minute
+)
+
+// SetTokenExchangeIdPResolver installs the identity-provider resolver that
+// backs delegated token exchange. Called once at server startup after the
+// identity integration is constructed; nil (never installed) leaves the
+// token_exchange auth type unavailable.
+func (p *OAuth2Provider) SetTokenExchangeIdPResolver(r schemas.TokenExchangeIdPResolver) {
+	p.exchangeIdP.Store(&r)
+}
+
+// tokenExchangeIdPResolver returns the installed resolver, or nil. Lock-free
+// for the same reason tempTokens is: p.mu is write-locked across token
+// refresh network I/O and request-path reads must not wait on that.
+func (p *OAuth2Provider) tokenExchangeIdPResolver() schemas.TokenExchangeIdPResolver {
+	if ptr := p.exchangeIdP.Load(); ptr != nil {
+		return *ptr
+	}
+	return nil
+}
+
+// TokenExchangeAvailable reports whether delegated token exchange can run.
+func (p *OAuth2Provider) TokenExchangeAvailable() bool {
+	r := p.tokenExchangeIdPResolver()
+	return r != nil && r.Available()
+}
+
+// GetExchangedAccessToken returns an upstream access token for a
+// token_exchange client, exchanging the caller's identity-provider token for
+// one scoped to the client's audience. Cached per (auth mode, identity, mcp
+// client) binding in the same in-memory cache as per-user OAuth lookups —
+// exchanged tokens have no database row, so the cached entry (with the
+// expiry-as-miss validator) is the only local state, and a miss simply
+// performs a fresh exchange.
+func (p *OAuth2Provider) GetExchangedAccessToken(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (string, error) {
+	if err := validateExchangeConfig(config); err != nil {
+		return "", err
+	}
+	mode := ctx.MCPAuthMode()
+	// Session identities are caller-asserted opaque strings with no
+	// verification, so they can never anchor a delegated exchange; the
+	// subject token requirement below would fail anyway (nothing stamps a
+	// caller token without verifying it), but reject explicitly for a
+	// clearer error.
+	if mode != schemas.MCPAuthModeUser && mode != schemas.MCPAuthModeVK {
+		return "", schemas.ErrExchangeSubjectTokenMissing
+	}
+	identity := ctx.MCPIdentity(mode)
+	if identity == "" {
+		return "", schemas.ErrExchangeSubjectTokenMissing
+	}
+	subjectToken, _ := ctx.Value(schemas.BifrostContextKeyMCPInboundBearer).(string)
+	if subjectToken == "" {
+		return "", schemas.ErrExchangeSubjectTokenMissing
+	}
+
+	// subjectTokenFingerprint binds the cache entry to the actual bearer
+	// credential validated on this request, not just the (mode, identity)
+	// binding — see userTokenCacheKey's doc comment on subjectDiscriminator
+	// for why MCPAuthModeVK's identity alone isn't enough here.
+	key := userTokenCacheKey(mode, identity, config.ID, subjectTokenFingerprint(subjectToken))
+	if cached, ok := p.userTokens.Get(key); ok {
+		return cached.accessToken, nil
+	}
+	filled, err := p.userTokens.Fill(ctx, key, func() (cachedUserToken, error) {
+		return p.performExchange(ctx, config, func(idp *schemas.TokenExchangeIdP) url.Values {
+			return buildSubjectExchangeForm(idp, config.TokenExchange, subjectToken)
+		})
+	})
+	if err != nil {
+		return "", err
+	}
+	return filled.accessToken, nil
+}
+
+// ExchangeAdminCredential performs a single uncached exchange of the admin's
+// own token (a sample caller token, never associated with any identity
+// binding), producing the admin bootstrap credential used for verification +
+// tool discovery. The full token response is returned so the caller can
+// retain it via RetainExchangeAdminCredential once verification succeeds.
+func (p *OAuth2Provider) ExchangeAdminCredential(ctx context.Context, config *schemas.MCPClientConfig, subjectToken string) (*schemas.OAuth2TokenExchangeResponse, error) {
+	if err := validateExchangeConfig(config); err != nil {
+		return nil, err
+	}
+	subjectToken = strings.TrimSpace(subjectToken)
+	if subjectToken == "" {
+		return nil, schemas.ErrExchangeSubjectTokenMissing
+	}
+	return p.rawExchange(ctx, config, func(idp *schemas.TokenExchangeIdP) url.Values {
+		return buildSubjectExchangeForm(idp, config.TokenExchange, subjectToken)
+	})
+}
+
+// RetainExchangeAdminCredential persists the outcome of a successful admin
+// verification as the retained auth_mode='admin' token row for config — the
+// discovery credential the tool syncer and TokenRefreshWorker keep alive,
+// mirroring what PromoteSharedOauthTokenToAdmin does for per-user OAuth
+// bootstrap. Upserts: a repair replaces the existing row's credential.
+func (p *OAuth2Provider) RetainExchangeAdminCredential(ctx context.Context, config *schemas.MCPClientConfig, response *schemas.OAuth2TokenExchangeResponse) error {
+	if p.configStore == nil {
+		return fmt.Errorf("config store is not available")
+	}
+	token := &tables.TableMCPOauthToken{
+		ID:          uuid.NewString(),
+		AuthMode:    "admin",
+		MCPClientID: config.ID,
+		AccessToken: strings.TrimSpace(response.AccessToken),
+		TokenType:   response.TokenType,
+		Status:      "active",
+	}
+	if response.RefreshToken != "" {
+		token.RefreshToken = strings.TrimSpace(response.RefreshToken)
+	}
+	if response.ExpiresIn > 0 {
+		exp := time.Now().Add(time.Duration(response.ExpiresIn) * time.Second)
+		token.ExpiresAt = &exp
+	}
+	if err := p.configStore.CreateOauthToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to retain admin exchange credential: %w", err)
+	}
+	return nil
+}
+
+// isExchangeBackedTokenRow reports whether a token row is a token_exchange
+// admin credential: bound directly to an MCP client with no oauth_configs
+// template behind it. Such rows refresh through the identity-provider
+// integration (refreshExchangeAdminToken) rather than a template config.
+func isExchangeBackedTokenRow(token *tables.TableMCPOauthToken) bool {
+	return token != nil && token.AuthMode == "admin" && token.MCPClientID != "" && token.OauthConfigID == ""
+}
+
+// refreshExchangeAdminToken is RefreshAccessToken's branch for
+// token_exchange admin rows. Renewal runs on the refresh token the identity
+// provider issued with the admin's exchange (typically requires
+// "offline_access" in the configured scopes); without one the credential is
+// unrenewable — the row flips to needs_reauth and an admin must re-verify
+// with a fresh sample token (the same repair contract per-user OAuth's dead
+// refresh tokens have).
+func (p *OAuth2Provider) refreshExchangeAdminToken(ctx context.Context, token *tables.TableMCPOauthToken) error {
+	clientConfig, err := p.configStore.GetMCPClientConfigByID(ctx, token.MCPClientID)
+	if err != nil {
+		return fmt.Errorf("failed to load MCP client for admin exchange refresh: %w", err)
+	}
+	if clientConfig == nil || clientConfig.AuthType != schemas.MCPAuthTypeTokenExchange {
+		return fmt.Errorf("admin token row %s is not backed by a token_exchange client", token.ID)
+	}
+	if err := validateExchangeConfig(clientConfig); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(token.RefreshToken) == "" {
+		return p.markExchangeAdminNeedsReauth(token, fmt.Errorf("admin exchange credential has no refresh token to renew with"))
+	}
+	form := func(_ *schemas.TokenExchangeIdP) url.Values {
+		clientID, clientSecret := exchangeClientCredentials(clientConfig.TokenExchange)
+		data := url.Values{}
+		data.Set("grant_type", "refresh_token")
+		data.Set("refresh_token", token.RefreshToken)
+		data.Set("client_id", clientID)
+		if clientSecret != "" {
+			data.Set("client_secret", clientSecret)
+		}
+		return data
+	}
+
+	response, err := p.rawExchange(ctx, clientConfig, form)
+	if err != nil {
+		var rejected *schemas.TokenExchangeRejectedError
+		if errors.As(err, &rejected) {
+			return p.markExchangeAdminNeedsReauth(token, err)
+		}
+		// Transient failure — keep the row so the next attempt retries.
+		return fmt.Errorf("admin exchange credential renewal failed: %w", err)
+	}
+
+	now := time.Now()
+	token.AccessToken = strings.TrimSpace(response.AccessToken)
+	if response.RefreshToken != "" {
+		token.RefreshToken = strings.TrimSpace(response.RefreshToken)
+	}
+	token.ExpiresAt = nil
+	if response.ExpiresIn > 0 {
+		exp := now.Add(time.Duration(response.ExpiresIn) * time.Second)
+		token.ExpiresAt = &exp
+	}
+	token.LastRefreshedAt = &now
+	if err := p.configStore.UpdateOauthToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to update admin exchange credential: %w", err)
+	}
+	p.EvictUserTokenByID(token.ID)
+	logger.Debug("admin exchange credential renewed: token_id=%s mcp_client=%s", token.ID, token.MCPClientID)
+	return nil
+}
+
+// markExchangeAdminNeedsReauth flips the admin row to needs_reauth (on a
+// background context so a caller cancellation cannot leave a confirmed-dead
+// credential looking active, mirroring RefreshAccessToken's permanent-error
+// path) and signals re-verification via the ErrOAuth2TokenExpired sentinel.
+func (p *OAuth2Provider) markExchangeAdminNeedsReauth(token *tables.TableMCPOauthToken, cause error) error {
+	if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(context.Background(), token.ID); markErr != nil {
+		return fmt.Errorf("admin exchange credential is dead but status update failed (mcp_client=%s): %w", token.MCPClientID, markErr)
+	}
+	p.EvictUserTokenByID(token.ID)
+	logger.Debug("admin exchange credential marked needs_reauth: mcp_client=%s cause=%v", token.MCPClientID, cause)
+	return fmt.Errorf("admin exchange credential requires re-verification: %v: %w", cause, schemas.ErrOAuth2TokenExpired)
+}
+
+// EvictExchangedToken removes every cached exchanged token for one binding,
+// regardless of which subject bearer token each entry was cached under (see
+// userTokenCacheKey's doc comment on subjectDiscriminator) — the caller here
+// (ForceRefreshAccessToken) knows the binding but not a specific token's
+// fingerprint.
+func (p *OAuth2Provider) EvictExchangedToken(mode schemas.MCPAuthMode, identity, mcpClientID string) {
+	p.userTokens.EvictByBinding(mode, identity, mcpClientID)
+}
+
+// subjectTokenFingerprint derives a stable, non-reversible cache-key
+// component from a caller's bearer token: a truncated SHA-256 hex digest.
+// Never store or log the raw token; the fingerprint is only used to keep
+// distinct subject tokens sharing a (mode, identity, mcpClientID) binding
+// from colliding onto the same cache entry (see userTokenCacheKey's doc
+// comment). Truncated to 16 hex chars (64 bits) — this only needs to avoid
+// accidental collisions within one binding's small entry set, not resist a
+// deliberate second-preimage search.
+func subjectTokenFingerprint(subjectToken string) string {
+	sum := sha256.Sum256([]byte(subjectToken))
+	return hex.EncodeToString(sum[:8])
+}
+
+// performExchange adapts performExchangeCtx to the BifrostContext request path.
+func (p *OAuth2Provider) performExchange(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig, form func(*schemas.TokenExchangeIdP) url.Values) (cachedUserToken, error) {
+	return p.performExchangeCtx(ctx, config, form)
+}
+
+// rawExchange resolves the identity provider and posts the grant built by
+// form. Provider rejections (PermanentOAuthError) surface as
+// *schemas.TokenExchangeRejectedError so callers can distinguish "fix the
+// credential" from transient failures.
+func (p *OAuth2Provider) rawExchange(ctx context.Context, config *schemas.MCPClientConfig, form func(*schemas.TokenExchangeIdP) url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
+	resolver := p.tokenExchangeIdPResolver()
+	if resolver == nil || !resolver.Available() {
+		return nil, schemas.ErrTokenExchangeUnavailable
+	}
+	idp, err := resolver.Resolve(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve identity provider for token exchange: %w", err)
+	}
+	if idp == nil || idp.TokenEndpoint == "" {
+		return nil, schemas.ErrTokenExchangeUnavailable
+	}
+
+	response, err := p.callTokenEndpoint(ctx, idp.TokenEndpoint, form(idp))
+	if err != nil {
+		var permanent *PermanentOAuthError
+		if errors.As(err, &permanent) {
+			return nil, &schemas.TokenExchangeRejectedError{Detail: sanitizeTokenExchangeRejection(permanent.Body)}
+		}
+		return nil, fmt.Errorf("token exchange for MCP client %s failed: %w", config.Name, err)
+	}
+	return response, nil
+}
+
+// sanitizeTokenExchangeRejection extracts only the standard OAuth
+// error/error_description fields (RFC 6749 §5.2) from a raw identity
+// provider response body. The raw body is never returned as-is: it reaches
+// TokenExchangeRejectedError.Detail, which is surfaced both in an
+// externally-serialized API error (MCPAuthRequiredError.ExchangeError) and
+// in a debug log, so anything beyond the standard error fields — stack
+// traces, internal error pages, unrelated response content some identity
+// providers include — must not pass through verbatim.
+func sanitizeTokenExchangeRejection(rawBody string) string {
+	var oauthErr struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal([]byte(rawBody), &oauthErr); err != nil || oauthErr.Error == "" {
+		return "identity provider rejected the request"
+	}
+	if oauthErr.ErrorDescription == "" {
+		return oauthErr.Error
+	}
+	return oauthErr.Error + ": " + oauthErr.ErrorDescription
+}
+
+// performExchangeCtx shapes a rawExchange result into a cache entry, with the
+// expiry safety margin applied so a token about to lapse mid-call reads as a
+// miss.
+func (p *OAuth2Provider) performExchangeCtx(ctx context.Context, config *schemas.MCPClientConfig, form func(*schemas.TokenExchangeIdP) url.Values) (cachedUserToken, error) {
+	response, err := p.rawExchange(ctx, config, form)
+	if err != nil {
+		return cachedUserToken{}, err
+	}
+	ttl := defaultExchangedTokenTTL
+	if response.ExpiresIn > 0 {
+		ttl = time.Duration(response.ExpiresIn) * time.Second
+	}
+	if margined := ttl - exchangeExpirySafetyMargin; margined > 0 {
+		ttl = margined
+	}
+	expiresAt := time.Now().Add(ttl)
+	return cachedUserToken{accessToken: response.AccessToken, expiresAt: &expiresAt}, nil
+}
+
+// validateExchangeConfig guards the invariants the create/update path
+// enforces, so a stale or hand-built config fails cleanly here too.
+func validateExchangeConfig(config *schemas.MCPClientConfig) error {
+	if config.AuthType != schemas.MCPAuthTypeTokenExchange {
+		return fmt.Errorf("MCP client %s does not use token exchange auth", config.Name)
+	}
+	if config.TokenExchange == nil || config.TokenExchange.Audience == "" {
+		return fmt.Errorf("MCP client %s is missing its token_exchange audience", config.Name)
+	}
+	if strings.TrimSpace(config.TokenExchange.ClientID.GetValue()) == "" {
+		return fmt.Errorf("MCP client %s is missing its token_exchange client_id", config.Name)
+	}
+	return nil
+}
+
+// exchangeClientCredentials resolves the exchange application's credentials
+// from the client's token_exchange block (validateExchangeConfig guarantees
+// a client ID is present).
+func exchangeClientCredentials(cfg *schemas.MCPTokenExchangeConfig) (clientID, clientSecret string) {
+	clientID = strings.TrimSpace(cfg.ClientID.GetValue())
+	if cfg.ClientSecret != nil {
+		clientSecret = strings.TrimSpace(cfg.ClientSecret.GetValue())
+	}
+	return clientID, clientSecret
+}
+
+// buildSubjectExchangeForm builds the delegated-exchange request body for the
+// identity provider's grant shape.
+func buildSubjectExchangeForm(idp *schemas.TokenExchangeIdP, cfg *schemas.MCPTokenExchangeConfig, subjectToken string) url.Values {
+	clientID, clientSecret := exchangeClientCredentials(cfg)
+	data := url.Values{}
+	data.Set("client_id", clientID)
+	if clientSecret != "" {
+		data.Set("client_secret", clientSecret)
+	}
+	switch idp.GrantShape {
+	case schemas.TokenExchangeGrantJWTBearerOBO:
+		data.Set("grant_type", grantTypeJWTBearer)
+		data.Set("assertion", subjectToken)
+		data.Set("requested_token_use", "on_behalf_of")
+		// This grant shape addresses the resource through scope alone: the
+		// conventional "<audience>/.default" form requests every permission
+		// the exchange client holds on the resource when no explicit scopes
+		// are configured.
+		data.Set("scope", scopeParam(cfg, true))
+	default:
+		data.Set("grant_type", grantTypeTokenExchange)
+		data.Set("subject_token", subjectToken)
+		data.Set("subject_token_type", subjectTokenTypeAccessToken)
+		data.Set("audience", cfg.Audience)
+		if scope := scopeParam(cfg, false); scope != "" {
+			data.Set("scope", scope)
+		}
+	}
+	return data
+}
+
+// scopeParam joins the configured scopes for the OAuth scope parameter.
+// When defaultToAudience is set and no scopes are configured, it falls back
+// to "<audience>/.default" (the resource-wide form used by grant shapes that
+// have no separate audience parameter).
+func scopeParam(cfg *schemas.MCPTokenExchangeConfig, defaultToAudience bool) string {
+	if len(cfg.Scopes) > 0 {
+		return strings.Join(cfg.Scopes, " ")
+	}
+	if defaultToAudience {
+		return strings.TrimSuffix(cfg.Audience, "/") + "/.default"
+	}
+	return ""
+}

--- a/framework/oauth2/tokenexchange_test.go
+++ b/framework/oauth2/tokenexchange_test.go
@@ -1,0 +1,538 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"gorm.io/gorm"
+)
+
+// fakeIdPResolver implements schemas.TokenExchangeIdPResolver against a test
+// server.
+type fakeIdPResolver struct {
+	idp       *schemas.TokenExchangeIdP
+	available bool
+	err       error
+}
+
+func (f *fakeIdPResolver) Available() bool { return f.available }
+
+func (f *fakeIdPResolver) Resolve(ctx context.Context, config *schemas.MCPClientConfig) (*schemas.TokenExchangeIdP, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.idp, nil
+}
+
+func exchangeTestClientConfig() *schemas.MCPClientConfig {
+	return &schemas.MCPClientConfig{
+		ID:       "client-1",
+		Name:     "Exchange Client",
+		AuthType: schemas.MCPAuthTypeTokenExchange,
+		TokenExchange: &schemas.MCPTokenExchangeConfig{
+			Audience:     "api://client-1",
+			ClientID:     schemas.NewSecretVar("exchange-client"),
+			ClientSecret: schemas.NewSecretVar("exchange-secret"),
+			Scopes:       []string{"read", "write"},
+		},
+	}
+}
+
+// newExchangeProvider builds a provider wired to a resolver pointing at
+// tokenURL, with fast retries so failure tests stay quick.
+func newExchangeProvider(t *testing.T, tokenURL string, shape schemas.TokenExchangeGrantShape) *OAuth2Provider {
+	t.Helper()
+	p := NewOAuth2Provider(nil, nil)
+	p.retryBaseDelay = time.Millisecond
+	p.SetTokenExchangeIdPResolver(&fakeIdPResolver{
+		available: true,
+		idp: &schemas.TokenExchangeIdP{
+			TokenEndpoint: tokenURL,
+			GrantShape:    shape,
+		},
+	})
+	return p
+}
+
+func userExchangeContext(subjectToken string) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+	if subjectToken != "" {
+		ctx.SetValue(schemas.BifrostContextKeyMCPInboundBearer, subjectToken)
+	}
+	return ctx
+}
+
+func tokenEndpointStub(t *testing.T, hits *atomic.Int64, capture *url.Values, accessToken string, expiresIn int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("failed to parse form: %v", err)
+		}
+		if capture != nil {
+			*capture = r.PostForm
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": accessToken,
+			"token_type":   "Bearer",
+			"expires_in":   expiresIn,
+		})
+	}))
+}
+
+func TestGetExchangedAccessTokenRFC8693Form(t *testing.T) {
+	var hits atomic.Int64
+	var form url.Values
+	server := tokenEndpointStub(t, &hits, &form, "exchanged-1", 3600)
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	token, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), exchangeTestClientConfig())
+	if err != nil {
+		t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+	}
+	if token != "exchanged-1" {
+		t.Fatalf("token = %q, want exchanged-1", token)
+	}
+
+	want := map[string]string{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      "subject-jwt",
+		"subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+		"audience":           "api://client-1",
+		"scope":              "read write",
+		"client_id":          "exchange-client",
+		"client_secret":      "exchange-secret",
+	}
+	for key, wantVal := range want {
+		if got := form.Get(key); got != wantVal {
+			t.Errorf("form[%s] = %q, want %q", key, got, wantVal)
+		}
+	}
+}
+
+func TestGetExchangedAccessTokenJWTBearerOBOForm(t *testing.T) {
+	var hits atomic.Int64
+	var form url.Values
+	server := tokenEndpointStub(t, &hits, &form, "exchanged-2", 3600)
+	defer server.Close()
+
+	config := exchangeTestClientConfig()
+	config.TokenExchange.Scopes = nil // exercise the audience/.default fallback
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantJWTBearerOBO)
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); err != nil {
+		t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+	}
+
+	want := map[string]string{
+		"grant_type":          "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"assertion":           "subject-jwt",
+		"requested_token_use": "on_behalf_of",
+		"scope":               "api://client-1/.default",
+	}
+	for key, wantVal := range want {
+		if got := form.Get(key); got != wantVal {
+			t.Errorf("form[%s] = %q, want %q", key, got, wantVal)
+		}
+	}
+	if form.Has("audience") {
+		t.Error("jwt-bearer grant shape must not send an audience parameter")
+	}
+}
+
+func TestGetExchangedAccessTokenCachesUntilExpiry(t *testing.T) {
+	var hits atomic.Int64
+	server := tokenEndpointStub(t, &hits, nil, "exchanged-3", 3600)
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+	for range 3 {
+		if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); err != nil {
+			t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+		}
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("token endpoint hits = %d, want 1 (cached)", got)
+	}
+
+	// A distinct identity misses the cache and exchanges again.
+	otherCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	otherCtx.SetValue(schemas.BifrostContextKeyUserID, "user-2")
+	otherCtx.SetValue(schemas.BifrostContextKeyMCPInboundBearer, "subject-jwt-2")
+	if _, err := p.GetExchangedAccessToken(otherCtx, config); err != nil {
+		t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("token endpoint hits = %d, want 2 (per-identity keying)", got)
+	}
+}
+
+func TestGetExchangedAccessTokenShortExpiryIsMiss(t *testing.T) {
+	var hits atomic.Int64
+	// expires_in below the safety margin: the margined TTL would be
+	// non-positive, so the raw TTL is kept, but the entry still expires
+	// almost immediately and the next call re-exchanges.
+	server := tokenEndpointStub(t, &hits, nil, "exchanged-4", 1)
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); err != nil {
+		t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); err != nil {
+		t.Fatalf("GetExchangedAccessToken returned error: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("token endpoint hits = %d, want 2 (expired entry is a miss)", got)
+	}
+}
+
+func TestGetExchangedAccessTokenMissingSubject(t *testing.T) {
+	p := newExchangeProvider(t, "http://unused.invalid", schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+
+	if _, err := p.GetExchangedAccessToken(userExchangeContext(""), config); !errors.Is(err, schemas.ErrExchangeSubjectTokenMissing) {
+		t.Fatalf("err = %v, want ErrExchangeSubjectTokenMissing (no bearer)", err)
+	}
+
+	// Session-mode identity never anchors an exchange.
+	sessionCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	sessionCtx.SetValue(schemas.BifrostContextKeyMCPSessionID, "sess-1")
+	sessionCtx.SetValue(schemas.BifrostContextKeyMCPInboundBearer, "subject-jwt")
+	if _, err := p.GetExchangedAccessToken(sessionCtx, config); !errors.Is(err, schemas.ErrExchangeSubjectTokenMissing) {
+		t.Fatalf("err = %v, want ErrExchangeSubjectTokenMissing (session mode)", err)
+	}
+}
+
+func TestGetExchangedAccessTokenUnavailable(t *testing.T) {
+	p := NewOAuth2Provider(nil, nil)
+	config := exchangeTestClientConfig()
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); !errors.Is(err, schemas.ErrTokenExchangeUnavailable) {
+		t.Fatalf("err = %v, want ErrTokenExchangeUnavailable (no resolver)", err)
+	}
+	if p.TokenExchangeAvailable() {
+		t.Fatal("TokenExchangeAvailable = true with no resolver")
+	}
+
+	p.SetTokenExchangeIdPResolver(&fakeIdPResolver{available: false})
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), config); !errors.Is(err, schemas.ErrTokenExchangeUnavailable) {
+		t.Fatalf("err = %v, want ErrTokenExchangeUnavailable (unavailable resolver)", err)
+	}
+}
+
+// vkExchangeContext builds a VK-mode context: a shared virtual key plus a
+// caller-specific inbound bearer token, mirroring an on-behalf-of deployment
+// where a Virtual Key routes/bills a team or service while each request
+// still carries its own caller's identity-provider token to exchange.
+func vkExchangeContext(vkID, subjectToken string) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyID, vkID)
+	ctx.SetValue(schemas.BifrostContextKeyMCPInboundBearer, subjectToken)
+	return ctx
+}
+
+// TestGetExchangedAccessToken_VKMode_DifferentSubjectsDoNotCollide pins the
+// security-relevant behavior: two callers sharing the same virtual key but
+// presenting different bearer tokens must each get their own exchanged
+// upstream token, never one caller's token served to the other. Before
+// binding the cache key to a subject-token fingerprint, both calls resolved
+// to the identical (mode, identity, mcpClientID) key and the second caller
+// would have received the first caller's cached token.
+func TestGetExchangedAccessToken_VKMode_DifferentSubjectsDoNotCollide(t *testing.T) {
+	var hits atomic.Int64
+	var lastSubjectToken atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		_ = r.ParseForm()
+		subjectToken := r.PostForm.Get("subject_token")
+		lastSubjectToken.Store(subjectToken)
+		w.Header().Set("Content-Type", "application/json")
+		// Echo the subject token's identity into the minted access token so
+		// the test can assert which caller's token exchange actually ran.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "exchanged-for:" + subjectToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+
+	aliceToken, err := p.GetExchangedAccessToken(vkExchangeContext("vk-shared-123", "alice-jwt"), config)
+	if err != nil {
+		t.Fatalf("alice exchange failed: %v", err)
+	}
+	bobToken, err := p.GetExchangedAccessToken(vkExchangeContext("vk-shared-123", "bob-jwt"), config)
+	if err != nil {
+		t.Fatalf("bob exchange failed: %v", err)
+	}
+
+	if aliceToken == bobToken {
+		t.Fatalf("alice and bob received the same exchanged token %q for the same shared VK with different bearer tokens", aliceToken)
+	}
+	if aliceToken != "exchanged-for:alice-jwt" {
+		t.Errorf("alice's cached token = %q, want exchanged-for:alice-jwt", aliceToken)
+	}
+	if bobToken != "exchanged-for:bob-jwt" {
+		t.Errorf("bob's cached token = %q, want exchanged-for:bob-jwt", bobToken)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("token endpoint hits = %d, want 2 (each distinct subject token must exchange, not hit the other's cache entry)", got)
+	}
+
+	// A repeat call with alice's own token must still hit her cached entry.
+	aliceAgain, err := p.GetExchangedAccessToken(vkExchangeContext("vk-shared-123", "alice-jwt"), config)
+	if err != nil {
+		t.Fatalf("alice repeat exchange failed: %v", err)
+	}
+	if aliceAgain != aliceToken {
+		t.Errorf("alice's repeat call = %q, want cached %q", aliceAgain, aliceToken)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("token endpoint hits = %d after alice's repeat call, want still 2 (cache hit)", got)
+	}
+}
+
+func TestGetExchangedAccessTokenRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"subject token revoked"}`))
+	}))
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	_, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), exchangeTestClientConfig())
+
+	var rejected *schemas.TokenExchangeRejectedError
+	if !errors.As(err, &rejected) {
+		t.Fatalf("expected *TokenExchangeRejectedError, got %T: %v", err, err)
+	}
+	if want := "invalid_grant: subject token revoked"; rejected.Detail != want {
+		t.Fatalf("expected sanitized Detail %q, got %q", want, rejected.Detail)
+	}
+
+	// Rejections are never cached: a subsequent call re-attempts.
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), exchangeTestClientConfig()); err == nil {
+		t.Fatal("expected the retry to hit the endpoint and fail again")
+	}
+}
+
+// TestGetExchangedAccessTokenRejected_NonStandardBodyNotLeaked pins the
+// security-relevant behavior: TokenExchangeRejectedError.Detail is
+// externally serialized (MCPAuthRequiredError.ExchangeError) and appears in
+// a debug log, so a raw identity-provider response that isn't the standard
+// {error, error_description} shape must never pass through verbatim.
+func TestGetExchangedAccessTokenRejected_NonStandardBodyNotLeaked(t *testing.T) {
+	const sensitiveBody = "<html><body>Internal Server Error: db password is hunter2</body></html>"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(sensitiveBody))
+	}))
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	_, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), exchangeTestClientConfig())
+
+	var rejected *schemas.TokenExchangeRejectedError
+	if !errors.As(err, &rejected) {
+		t.Fatalf("expected *TokenExchangeRejectedError, got %T: %v", err, err)
+	}
+	if strings.Contains(rejected.Detail, "hunter2") || strings.Contains(rejected.Detail, sensitiveBody) {
+		t.Fatalf("raw response body leaked into Detail: %q", rejected.Detail)
+	}
+}
+
+func TestForceRefreshEvictsAndReExchanges(t *testing.T) {
+	var hits atomic.Int64
+	server := tokenEndpointStub(t, &hits, nil, "exchanged-5", 3600)
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+	ctx := userExchangeContext("subject-jwt")
+
+	if _, err := p.GetExchangedAccessToken(ctx, config); err != nil {
+		t.Fatalf("initial exchange failed: %v", err)
+	}
+	if err := p.ForceRefreshAccessToken(ctx, config); err != nil {
+		t.Fatalf("ForceRefreshAccessToken returned error: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("token endpoint hits = %d, want 2 (evict + re-exchange)", got)
+	}
+}
+
+func TestExchangeAdminCredentialUncached(t *testing.T) {
+	var hits atomic.Int64
+	var form url.Values
+	server := tokenEndpointStub(t, &hits, &form, "verify-token", 3600)
+	defer server.Close()
+
+	p := newExchangeProvider(t, server.URL, schemas.TokenExchangeGrantRFC8693)
+	config := exchangeTestClientConfig()
+
+	for range 2 {
+		response, err := p.ExchangeAdminCredential(context.Background(), config, "sample-jwt")
+		if err != nil {
+			t.Fatalf("ExchangeAdminCredential returned error: %v", err)
+		}
+		if response.AccessToken != "verify-token" {
+			t.Fatalf("token = %q, want verify-token", response.AccessToken)
+		}
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("token endpoint hits = %d, want 2 (never cached)", got)
+	}
+	if got := form.Get("grant_type"); got != "urn:ietf:params:oauth:grant-type:token-exchange" {
+		t.Fatalf("grant_type = %q, want token-exchange for a subject-token verification", got)
+	}
+
+	// No subject token: nothing to exchange — the admin bootstrap is itself
+	// a delegated exchange, always.
+	if _, err := p.ExchangeAdminCredential(context.Background(), config, "  "); !errors.Is(err, schemas.ErrExchangeSubjectTokenMissing) {
+		t.Fatalf("err = %v, want ErrExchangeSubjectTokenMissing for blank subject", err)
+	}
+}
+
+// exchangeAdminStoreDoubles: the retained-admin-credential lifecycle needs a
+// store; reuse testConfigStore with the two extra methods the exchange
+// refresh path touches.
+
+func (s *testConfigStore) CreateOauthToken(_ context.Context, token *tables.TableMCPOauthToken, _ ...*gorm.DB) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Mirror the real upsert: one admin row per MCP client.
+	for _, existing := range s.oauthTokens {
+		if existing.AuthMode == "admin" && token.AuthMode == "admin" && existing.MCPClientID == token.MCPClientID {
+			token.ID = existing.ID
+			break
+		}
+	}
+	s.oauthTokens[token.ID] = bifrost.Ptr(*token)
+	return nil
+}
+
+func (s *testConfigStore) GetMCPClientConfigByID(_ context.Context, id string) (*schemas.MCPClientConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mcpClients == nil {
+		return nil, nil
+	}
+	cfg := s.mcpClients[id]
+	if cfg == nil {
+		return nil, nil
+	}
+	return cfg, nil
+}
+
+func TestRetainAndRefreshExchangeAdminCredential(t *testing.T) {
+	var hits atomic.Int64
+	var form url.Values
+	server := tokenEndpointStub(t, &hits, &form, "minted-1", 3600)
+	defer server.Close()
+
+	store := newTestConfigStore()
+	config := exchangeTestClientConfig()
+	store.mcpClients = map[string]*schemas.MCPClientConfig{config.ID: config}
+
+	p := NewOAuth2Provider(store, nil)
+	p.retryBaseDelay = time.Millisecond
+	p.SetTokenExchangeIdPResolver(&fakeIdPResolver{
+		available: true,
+		idp: &schemas.TokenExchangeIdP{
+			TokenEndpoint: server.URL,
+			GrantShape:    schemas.TokenExchangeGrantRFC8693,
+		},
+	})
+
+	// Retain an already-expired credential that carries a refresh token, as
+	// if verification just ran and time passed: the next admin lookup must
+	// renew via the refresh-token grant.
+	if err := p.RetainExchangeAdminCredential(context.Background(), config, &schemas.OAuth2TokenExchangeResponse{
+		AccessToken:  "retained-1",
+		RefreshToken: "refresh-1",
+		TokenType:    "Bearer",
+		ExpiresIn:    1,
+	}); err != nil {
+		t.Fatalf("RetainExchangeAdminCredential returned error: %v", err)
+	}
+	row, err := store.GetAdminOauthTokenByMCPClientID(context.Background(), config.ID)
+	if err != nil || row == nil {
+		t.Fatalf("expected a retained admin row, got %v / %v", row, err)
+	}
+	if row.Status != "active" || row.AccessToken != "retained-1" {
+		t.Fatalf("retained row = %+v, want active retained-1", row)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+	token, err := p.GetAdminAccessToken(context.Background(), config.ID)
+	if err != nil {
+		t.Fatalf("GetAdminAccessToken returned error: %v", err)
+	}
+	if token != "minted-1" {
+		t.Fatalf("token = %q, want the renewed token", token)
+	}
+	if got := form.Get("grant_type"); got != "refresh_token" {
+		t.Fatalf("grant_type = %q, want refresh_token renewal", got)
+	}
+	if got := form.Get("refresh_token"); got != "refresh-1" {
+		t.Fatalf("refresh_token = %q, want the retained refresh token", got)
+	}
+
+	// Without a renewal path (no refresh token), an expired credential flips
+	// to needs_reauth and surfaces the expiry sentinel.
+	expired := time.Now().Add(-time.Minute)
+	row.ExpiresAt = &expired
+	row.RefreshToken = ""
+	row.AccessToken = "dead"
+	store.oauthTokens[row.ID] = row
+	if _, err := p.GetAdminAccessToken(context.Background(), config.ID); !errors.Is(err, schemas.ErrOAuth2TokenExpired) {
+		t.Fatalf("err = %v, want ErrOAuth2TokenExpired for an unrenewable credential", err)
+	}
+	reloaded, _ := store.GetAdminOauthTokenByMCPClientID(context.Background(), config.ID)
+	if reloaded == nil || reloaded.Status != "needs_reauth" {
+		t.Fatalf("row status = %+v, want needs_reauth", reloaded)
+	}
+}
+
+func TestValidateExchangeConfig(t *testing.T) {
+	p := newExchangeProvider(t, "http://unused.invalid", schemas.TokenExchangeGrantRFC8693)
+
+	wrongType := exchangeTestClientConfig()
+	wrongType.AuthType = schemas.MCPAuthTypePerUserOauth
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), wrongType); err == nil {
+		t.Fatal("expected error for non-token_exchange auth type")
+	}
+
+	noAudience := exchangeTestClientConfig()
+	noAudience.TokenExchange = &schemas.MCPTokenExchangeConfig{ClientID: schemas.NewSecretVar("exchange-client")}
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), noAudience); err == nil {
+		t.Fatal("expected error for missing audience")
+	}
+
+	noClientID := exchangeTestClientConfig()
+	noClientID.TokenExchange.ClientID = nil
+	if _, err := p.GetExchangedAccessToken(userExchangeContext("subject-jwt"), noClientID); err == nil {
+		t.Fatal("expected error for missing client_id")
+	}
+}

--- a/framework/oauth2/usertokencache.go
+++ b/framework/oauth2/usertokencache.go
@@ -41,23 +41,35 @@ type userTokenCache struct {
 }
 
 // userTokenCacheKey builds the cache key for a (mode, identity, mcp client)
-// binding. identity is a caller-asserted string (see the doc comment
-// above) with no charset restriction, so this goes through
-// lrucache.EncodeKey rather than a plain separator join — see its doc
-// comment for why a naive join lets an identity value forge a component
-// boundary and alias two distinct bindings onto one cache entry.
-func userTokenCacheKey(mode schemas.MCPAuthMode, identity, mcpClientID string) string {
-	return lrucache.EncodeKey(string(mode), identity, mcpClientID)
+// binding, plus an optional subject discriminator. identity is a
+// caller-asserted string (see the doc comment above) with no charset
+// restriction, so this goes through lrucache.EncodeKey rather than a plain
+// separator join — see its doc comment for why a naive join lets an
+// identity value forge a component boundary and alias two distinct
+// bindings onto one cache entry.
+//
+// subjectDiscriminator exists for token_exchange: MCPAuthModeVK's identity
+// is the shared, stable virtual-key row ID, not the actual bearer credential
+// validated on this request — without a discriminator, two callers
+// presenting the same virtual key but different (e.g. different end users')
+// bearer tokens would collide on one cache entry and one caller's exchanged
+// upstream token would be served to the other. Callers outside token
+// exchange pass "" here; every existing (mode, identity, mcpClientID)
+// binding keeps its exact same key, and the scoped eviction predicates
+// below ignore this component so VK-/user-level bulk eviction still matches
+// every subject sharing that identity.
+func userTokenCacheKey(mode schemas.MCPAuthMode, identity, mcpClientID, subjectDiscriminator string) string {
+	return lrucache.EncodeKey(string(mode), identity, mcpClientID, subjectDiscriminator)
 }
 
 // splitUserTokenCacheKey is userTokenCacheKey's inverse, for the scoped
 // eviction predicates.
-func splitUserTokenCacheKey(key string) (mode, identity, clientID string, ok bool) {
-	parts, ok := lrucache.DecodeKey(key, 3)
+func splitUserTokenCacheKey(key string) (mode, identity, clientID, subjectDiscriminator string, ok bool) {
+	parts, ok := lrucache.DecodeKey(key, 4)
 	if !ok {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
-	return parts[0], parts[1], parts[2], true
+	return parts[0], parts[1], parts[2], parts[3], true
 }
 
 func newUserTokenCache(capacity int) *userTokenCache {
@@ -125,8 +137,24 @@ func (c *userTokenCache) EvictByMCPClient(mcpClientID string) {
 		return
 	}
 	c.cache.EvictWhere(func(key string) bool {
-		_, _, clientID, ok := splitUserTokenCacheKey(key)
+		_, _, clientID, _, ok := splitUserTokenCacheKey(key)
 		return ok && clientID == mcpClientID
+	})
+}
+
+// EvictByBinding removes every cached entry for a (mode, identity,
+// mcpClientID) binding, across every subjectDiscriminator. Used for
+// token_exchange's force-refresh, which knows the binding but not the
+// specific bearer token's fingerprint (and, for auth_type token_exchange,
+// several distinct subject tokens can be cached under the same binding —
+// see userTokenCacheKey's doc comment).
+func (c *userTokenCache) EvictByBinding(mode schemas.MCPAuthMode, identity, mcpClientID string) {
+	if c == nil || identity == "" || mcpClientID == "" {
+		return
+	}
+	c.cache.EvictWhere(func(key string) bool {
+		keyMode, keyIdentity, keyClientID, _, ok := splitUserTokenCacheKey(key)
+		return ok && keyMode == string(mode) && keyIdentity == identity && keyClientID == mcpClientID
 	})
 }
 
@@ -138,7 +166,7 @@ func (c *userTokenCache) EvictByVirtualKey(virtualKeyID string) {
 		return
 	}
 	c.cache.EvictWhere(func(key string) bool {
-		mode, identity, _, ok := splitUserTokenCacheKey(key)
+		mode, identity, _, _, ok := splitUserTokenCacheKey(key)
 		return ok && mode == string(schemas.MCPAuthModeVK) && identity == virtualKeyID
 	})
 }
@@ -151,7 +179,7 @@ func (c *userTokenCache) EvictByUser(userID string) {
 		return
 	}
 	c.cache.EvictWhere(func(key string) bool {
-		mode, identity, _, ok := splitUserTokenCacheKey(key)
+		mode, identity, _, _, ok := splitUserTokenCacheKey(key)
 		return ok && mode == string(schemas.MCPAuthModeUser) && identity == userID
 	})
 }

--- a/framework/oauth2/usertokencache_test.go
+++ b/framework/oauth2/usertokencache_test.go
@@ -119,9 +119,9 @@ func TestUserTokenCache_EvictByTokenID(t *testing.T) {
 
 func TestUserTokenCache_EvictByMCPClient(t *testing.T) {
 	c := newUserTokenCache(8)
-	keyA1 := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-a")
-	keyA2 := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-a")
-	keyB := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-b")
+	keyA1 := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-a", "")
+	keyA2 := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-a", "")
+	keyB := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-b", "")
 	for i, k := range []string{keyA1, keyA2, keyB} {
 		_, err := c.Fill(context.Background(), k, fillWith(testToken(fmt.Sprintf("t%d", i), "access", nil)))
 		require.NoError(t, err)
@@ -144,12 +144,12 @@ func TestUserTokenCache_EvictByMCPClient(t *testing.T) {
 
 func TestUserTokenCache_EvictByVirtualKey(t *testing.T) {
 	c := newUserTokenCache(8)
-	keyVK1A := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-a")
-	keyVK1B := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-b")
-	keyVK2 := userTokenCacheKey(schemas.MCPAuthModeVK, "vk2", "client-a")
+	keyVK1A := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-a", "")
+	keyVK1B := userTokenCacheKey(schemas.MCPAuthModeVK, "vk1", "client-b", "")
+	keyVK2 := userTokenCacheKey(schemas.MCPAuthModeVK, "vk2", "client-a", "")
 	// A user-mode identity that happens to equal the VK ID must survive:
 	// the eviction is scoped to vk-mode entries only.
-	keyUser := userTokenCacheKey(schemas.MCPAuthModeUser, "vk1", "client-a")
+	keyUser := userTokenCacheKey(schemas.MCPAuthModeUser, "vk1", "client-a", "")
 	for i, k := range []string{keyVK1A, keyVK1B, keyVK2, keyUser} {
 		_, err := c.Fill(context.Background(), k, fillWith(testToken(fmt.Sprintf("vt%d", i), "access", nil)))
 		require.NoError(t, err)
@@ -173,12 +173,12 @@ func TestUserTokenCache_EvictByVirtualKey(t *testing.T) {
 
 func TestUserTokenCache_EvictByUser(t *testing.T) {
 	c := newUserTokenCache(8)
-	keyU1A := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-a")
-	keyU1B := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-b")
-	keyU2 := userTokenCacheKey(schemas.MCPAuthModeUser, "u2", "client-a")
+	keyU1A := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-a", "")
+	keyU1B := userTokenCacheKey(schemas.MCPAuthModeUser, "u1", "client-b", "")
+	keyU2 := userTokenCacheKey(schemas.MCPAuthModeUser, "u2", "client-a", "")
 	// A vk-mode identity that happens to equal the user ID must survive:
 	// the eviction is scoped to user-mode entries only.
-	keyVK := userTokenCacheKey(schemas.MCPAuthModeVK, "u1", "client-a")
+	keyVK := userTokenCacheKey(schemas.MCPAuthModeVK, "u1", "client-a", "")
 	for i, k := range []string{keyU1A, keyU1B, keyU2, keyVK} {
 		_, err := c.Fill(context.Background(), k, fillWith(testToken(fmt.Sprintf("ut%d", i), "access", nil)))
 		require.NoError(t, err)

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -431,6 +431,24 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// The 'error' behavior rejects exactly the requests token_exchange
+	// clients rely on (an identity token alongside a virtual key), so the
+	// two settings are mutually exclusive — mirrored by the MCP client
+	// create path rejecting token_exchange while it is 'error'. Checked up
+	// front, alongside the other validations above: everything below this
+	// point applies live in-memory mutations before the DB write at the end
+	// of this handler, so a rejection here must happen before any of that
+	// runs — otherwise a 400 would leave runtime state changed with nothing
+	// persisted.
+	if payload.ClientConfig.DualCredentialConflictBehavior == configstoreTables.DualCredentialConflictBehaviorError && h.store.MCPConfig != nil {
+		for _, mcpClient := range h.store.MCPConfig.ClientConfigs {
+			if mcpClient.AuthType == schemas.MCPAuthTypeTokenExchange {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("dual_credential_conflict_behavior cannot be set to 'error' while MCP client %q uses auth_type 'token_exchange'; delete that client first or choose 'prefer_idp'/'prefer_vk'", mcpClient.Name))
+				return
+			}
+		}
+	}
+
 	var restartReasons []string
 
 	if payload.ClientConfig.DropExcessRequests != currentConfig.DropExcessRequests {
@@ -543,7 +561,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	updatedConfig.EnforceGovernanceHeader = payload.ClientConfig.EnforceAuthOnInference
 	updatedConfig.EnforceSCIMAuth = payload.ClientConfig.EnforceAuthOnInference
 
-	// Only update when explicitly provided to avoid clearing the stored default (prefer_idp)
+	// Only update when explicitly provided to avoid clearing the stored default (prefer_idp).
+	// The conflict-vs-token_exchange validation already ran up front, before
+	// any live mutation.
 	if payload.ClientConfig.DualCredentialConflictBehavior != "" {
 		updatedConfig.DualCredentialConflictBehavior = payload.ClientConfig.DualCredentialConflictBehavior
 	}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -103,6 +103,7 @@ func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.Bif
 	r.POST("/api/mcp/client/{id}/initiate-verification", lib.ChainMiddlewares(h.initiateMCPClientVerification, middlewares...))
 	r.POST("/api/mcp/client/{id}/reauthorize", lib.ChainMiddlewares(h.reauthorizeMCPClient, middlewares...))
 	r.POST("/api/mcp/client/{id}/verify-headers", lib.ChainMiddlewares(h.verifyMCPClientHeaders, middlewares...))
+	r.POST("/api/mcp/client/{id}/verify-exchange", lib.ChainMiddlewares(h.verifyMCPClientExchange, middlewares...))
 }
 
 // runOAuthBootstrap kicks off the shared-OAuth flow for an MCP client and
@@ -539,6 +540,159 @@ func (h *MCPHandler) verifyMCPClientHeaders(ctx *fasthttp.RequestCtx) {
 	})
 }
 
+// verifyMCPClientExchange handles
+// POST /api/mcp/client/{id}/verify-exchange. No request body: the subject of
+// the verification exchange is always the signed-in admin's own
+// identity-provider token, stamped on the request context by the auth layer.
+//
+// Surfaced on token_exchange MCP clients in two situations, mirroring
+// verify-headers: clients sitting in pending_verification (declared in
+// config.json, or created from a session with no identity token) awaiting
+// their one-time bootstrap verification, and a voluntary refresh of an
+// already-verified client's retained admin discovery credential —
+// resubmitting always re-runs verification and retains a fresh credential,
+// whether or not the current one needs repair. Synchronous: the admin's
+// token is exchanged exactly like a real caller's would be, the upstream
+// connection is verified, tools are discovered and persisted, the fresh
+// credential is retained for the tool syncer, and the runtime client
+// transitions to connected. On failure the stored state is untouched and
+// the admin can retry.
+func (h *MCPHandler) verifyMCPClientExchange(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
+		return
+	}
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.store)
+	defer cancel()
+
+	id, err := getIDFromCtx(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid mcp client id: %v", err))
+		return
+	}
+
+	clientConfig, err := h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("MCP client '%s' not found", id))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load MCP client: %v", err))
+		return
+	}
+	if clientConfig.AuthType != schemas.MCPAuthTypeTokenExchange {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("verify-exchange only applies to auth_type='token_exchange' clients, got %q", clientConfig.AuthType))
+		return
+	}
+	// No replay guard: mirrors reauthorizeMCPClient's OAuth equivalent and
+	// verify-headers — always re-runs verification with a fresh exchange of
+	// the admin's own identity-provider token, no branching on whether the
+	// retained admin credential actually needs repair. The write path below
+	// (activation, persistence, credential retention) is unconditional on
+	// success either way.
+	if h.store.OAuthProvider == nil || !h.store.OAuthProvider.TokenExchangeAvailable() {
+		SendError(ctx, fasthttp.StatusBadRequest, "token exchange is unavailable: user-identity authentication with an exchange client must be configured")
+		return
+	}
+	// The verification subject is always the signed-in admin's own
+	// identity-provider token ("verify as yourself"); an API-key-authenticated
+	// request has none and must be retried from an identity-authenticated
+	// session.
+	subjectToken := bifrost.GetStringFromContext(bifrostCtx, schemas.BifrostContextKeyMCPInboundBearer)
+	if subjectToken == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "verification exchanges your own identity-provider token, but this request carries none: sign in with your identity provider and retry")
+		return
+	}
+
+	adminResponse, err := h.store.OAuthProvider.ExchangeAdminCredential(bifrostCtx, clientConfig, subjectToken)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Admin credential exchange failed: %v", err))
+		return
+	}
+
+	tools, toolNameMapping, verifyErr := h.mcpManager.VerifyPerUserOAuthConnection(bifrostCtx, clientConfig, adminResponse.AccessToken)
+	if verifyErr != nil {
+		SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
+		return
+	}
+
+	// Same reload-activate-persist ordering as verify-headers, for the same
+	// reasons: the reload narrows the concurrent-edit window opened by the
+	// upstream round-trip, and activating before persisting keeps every
+	// partial failure retryable through this endpoint (the replay guard
+	// reads DiscoveredTools from the DB).
+	clientConfig, err = h.store.ConfigStore.GetMCPClientConfigByID(ctx, id)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verification succeeded but reloading the client for activation failed: %v", err))
+		return
+	}
+	clientConfig.DiscoveredTools = tools
+	clientConfig.DiscoveredToolNameMapping = toolNameMapping
+
+	if err := h.updateMCPClientWithRetry(bifrostCtx, clientConfig.ID, clientConfig); err != nil {
+		logger.Error(fmt.Sprintf("Failed to update MCP client after exchange verification for client %s: %v", clientConfig.ID, err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Verified successfully but failed to activate the client: %v", err))
+		return
+	}
+	h.mcpManager.SetClientTools(clientConfig.ID, tools, toolNameMapping)
+
+	// Persist the discovered tools. Full struct for the same reason as
+	// verify-headers: the store writes every editable column from the given
+	// struct, so a sparse one would zero the other editable fields.
+	updateReq := &configstoreTables.TableMCPClient{
+		ClientID:                  clientConfig.ID,
+		Name:                      clientConfig.Name,
+		IsCodeModeClient:          clientConfig.IsCodeModeClient,
+		ConnectionType:            string(clientConfig.ConnectionType),
+		ConnectionString:          clientConfig.ConnectionString,
+		StdioConfig:               clientConfig.StdioConfig,
+		TLSConfig:                 clientConfig.TLSConfig,
+		AuthType:                  string(clientConfig.AuthType),
+		OauthConfigID:             clientConfig.OauthConfigID,
+		ToolsToExecute:            clientConfig.ToolsToExecute,
+		ToolsToAutoExecute:        clientConfig.ToolsToAutoExecute,
+		Headers:                   clientConfig.Headers,
+		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
+		IsPingAvailable:           clientConfig.IsPingAvailable,
+		ToolPricing:               clientConfig.ToolPricing,
+		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
+		ToolExecutionTimeout:      int(clientConfig.ToolExecutionTimeout / time.Second),
+		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		TokenExchange:             clientConfig.TokenExchange,
+		DiscoveredTools:           clientConfig.DiscoveredTools,
+		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
+		Disabled:                  clientConfig.Disabled,
+	}
+	if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, clientConfig.ID, updateReq); err != nil {
+		logger.Error(fmt.Sprintf(
+			"[PARTIAL SUCCESS] MCP client %s was activated after exchange verification but persisting discovered tools failed: %v. "+
+				"Runtime and database state have drifted: the client is connected now but will return to pending_verification on restart. "+
+				"Retry this endpoint to re-verify and persist.",
+			clientConfig.ID, err,
+		))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Client activated but discovered tools could not be persisted, so runtime and database state have drifted until re-verified. Retry this endpoint to re-run verification and persist: %v", err))
+		return
+	}
+
+	// Retain the admin credential for the periodic tool syncer and the
+	// refresh worker. Deliberately last, mirroring verify-headers: on a
+	// repair the upsert flips the credential back to active, which closes
+	// the replay guard above, so it must only happen once activation and
+	// persistence have both succeeded. Best-effort beyond that: the client
+	// is verified and serving either way; a failed retention just means
+	// tool-list refresh stays unavailable (bootstrap) or the client keeps
+	// projecting needs_reauth (repair) until this endpoint is retried.
+	if retainErr := h.store.OAuthProvider.RetainExchangeAdminCredential(ctx, clientConfig, adminResponse); retainErr != nil {
+		logger.Warn(fmt.Sprintf("failed to retain admin exchange credential for MCP client %s: %v", clientConfig.ID, retainErr))
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":      "success",
+		"message":     fmt.Sprintf("MCP client verified. %d tools discovered. Callers' identity tokens are exchanged automatically on each tool use.", len(tools)),
+		"tools_count": len(tools),
+	})
+}
+
 // pendingOAuthConfigToRequest converts the persisted shared-OAuth bootstrap
 // shape into the request shape consumed by runOAuthBootstrap /
 // InitiateOAuthFlow. Credentials are *SecretVar on both sides, so env./vault.
@@ -815,7 +969,7 @@ func projectPerUserAdminCredentialState(authType schemas.MCPAuthType, runtimeSta
 		return runtimeState
 	}
 	switch authType {
-	case schemas.MCPAuthTypePerUserOauth:
+	case schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange:
 		if adminTokenStatus == "needs_reauth" {
 			return schemas.MCPConnectionStateNeedsReauth
 		}
@@ -930,25 +1084,23 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 	// batch-read failure only means the projection is skipped and runtime
 	// states pass through untouched. Debug, not Error, because this runs on
 	// every registry list.
-	adminTokenStatusByOauthConfigID := make(map[string]string)
+	adminTokenStatusByClientID := make(map[string]string)
 	adminCredStatusByClientID := make(map[string]string)
 	if h.store.ConfigStore != nil {
-		perUserOauthConfigIDs := make([]string, 0)
+		adminTokenClientIDs := make([]string, 0)
 		perUserHeaderClientIDs := make([]string, 0)
 		for _, c := range dbClients {
 			switch schemas.MCPAuthType(c.AuthType) {
-			case schemas.MCPAuthTypePerUserOauth:
-				if c.OauthConfigID != nil && *c.OauthConfigID != "" {
-					perUserOauthConfigIDs = append(perUserOauthConfigIDs, *c.OauthConfigID)
-				}
+			case schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange:
+				adminTokenClientIDs = append(adminTokenClientIDs, c.ClientID)
 			case schemas.MCPAuthTypePerUserHeaders:
 				perUserHeaderClientIDs = append(perUserHeaderClientIDs, c.ClientID)
 			}
 		}
-		if len(perUserOauthConfigIDs) > 0 {
-			if adminTokens, err := h.store.ConfigStore.GetAdminOauthTokensByConfigIDs(ctx, perUserOauthConfigIDs); err == nil {
-				for configID, token := range adminTokens {
-					adminTokenStatusByOauthConfigID[configID] = token.Status
+		if len(adminTokenClientIDs) > 0 {
+			if adminTokens, err := h.store.ConfigStore.GetAdminOauthTokensByMCPClientIDs(ctx, adminTokenClientIDs); err == nil {
+				for clientID, token := range adminTokens {
+					adminTokenStatusByClientID[clientID] = token.Status
 				}
 			} else {
 				logger.Debug("failed to batch-get admin oauth tokens for MCP registry state projection: %v", err)
@@ -993,6 +1145,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
 			Disabled:              dbClient.Disabled,
 			PerUserHeaderKeys:     dbClient.PerUserHeaderKeys,
+			TokenExchange:         dbClient.TokenExchange,
 		}
 		// Populate oauth client credentials from pre-fetched batch
 		if dbClient.OauthConfigID != nil {
@@ -1026,17 +1179,13 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			sort.Slice(sortedTools, func(i, j int) bool {
 				return sortedTools[i].Name < sortedTools[j].Name
 			})
-			adminTokenStatus := ""
-			if dbClient.OauthConfigID != nil {
-				adminTokenStatus = adminTokenStatusByOauthConfigID[*dbClient.OauthConfigID]
-			}
 			clients = append(clients, MCPClientResponse{
 				Config: redactedConfig,
 				Tools:  sortedTools,
 				State: projectPerUserAdminCredentialState(
 					clientConfig.AuthType,
 					connectedClient.State,
-					adminTokenStatus,
+					adminTokenStatusByClientID[dbClient.ClientID],
 					adminCredStatusByClientID[dbClient.ClientID],
 				),
 				VKConfigs: vkConfigs,
@@ -1145,22 +1294,23 @@ const (
 // Immutable fields (connection_type, auth_type, connection_string, stdio_config) are not
 // accepted here; they cannot be changed after creation.
 type MCPClientUpdateRequest struct {
-	Name                  *string                      `json:"name,omitempty"`
-	Disabled              *bool                        `json:"disabled,omitempty"`
-	AllowOnAllVirtualKeys *bool                        `json:"allow_on_all_virtual_keys,omitempty"`
-	IsCodeModeClient      *bool                        `json:"is_code_mode_client,omitempty"`
-	IsPingAvailable       *bool                        `json:"is_ping_available,omitempty"`
-	ToolSyncInterval      *int                         `json:"tool_sync_interval,omitempty"`
-	ToolExecutionTimeout  *int                         `json:"tool_execution_timeout,omitempty"`
-	Headers               map[string]schemas.SecretVar `json:"headers,omitempty"`
-	AllowedExtraHeaders   *schemas.WhiteList           `json:"allowed_extra_headers,omitempty"`
-	ToolPricing           map[string]float64           `json:"tool_pricing,omitempty"`
-	ToolsToExecute        *schemas.WhiteList           `json:"tools_to_execute,omitempty"`
-	ToolsToAutoExecute    *schemas.WhiteList           `json:"tools_to_auto_execute,omitempty"`
-	PerUserHeaderKeys     *[]string                    `json:"per_user_header_keys,omitempty"`
-	TLSConfig             *schemas.MCPTLSConfig        `json:"tls_config,omitempty"`
-	VKConfigs             *[]MCPVKConfigRequest        `json:"vk_configs,omitempty"`
-	OauthConfig           *OAuthConfigRequest          `json:"oauth_config,omitempty"`
+	Name                  *string                         `json:"name,omitempty"`
+	Disabled              *bool                           `json:"disabled,omitempty"`
+	AllowOnAllVirtualKeys *bool                           `json:"allow_on_all_virtual_keys,omitempty"`
+	IsCodeModeClient      *bool                           `json:"is_code_mode_client,omitempty"`
+	IsPingAvailable       *bool                           `json:"is_ping_available,omitempty"`
+	ToolSyncInterval      *int                            `json:"tool_sync_interval,omitempty"`
+	ToolExecutionTimeout  *int                            `json:"tool_execution_timeout,omitempty"`
+	Headers               map[string]schemas.SecretVar    `json:"headers,omitempty"`
+	AllowedExtraHeaders   *schemas.WhiteList              `json:"allowed_extra_headers,omitempty"`
+	ToolPricing           map[string]float64              `json:"tool_pricing,omitempty"`
+	ToolsToExecute        *schemas.WhiteList              `json:"tools_to_execute,omitempty"`
+	ToolsToAutoExecute    *schemas.WhiteList              `json:"tools_to_auto_execute,omitempty"`
+	PerUserHeaderKeys     *[]string                       `json:"per_user_header_keys,omitempty"`
+	TokenExchange         *schemas.MCPTokenExchangeConfig `json:"token_exchange,omitempty"`
+	TLSConfig             *schemas.MCPTLSConfig           `json:"tls_config,omitempty"`
+	VKConfigs             *[]MCPVKConfigRequest           `json:"vk_configs,omitempty"`
+	OauthConfig           *OAuthConfigRequest             `json:"oauth_config,omitempty"`
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
@@ -1327,6 +1477,151 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		SendJSON(ctx, map[string]any{
 			"status":  "success",
 			"message": fmt.Sprintf("MCP client registered. %d tools discovered. Each user will submit their own headers on first tool use.", len(tools)),
+		})
+		return
+	}
+
+	// Handle token exchange: the caller's identity-provider token is exchanged
+	// per request at runtime, so nothing interactive happens at create.
+	// Verification + tool discovery run synchronously when an admin credential
+	// is available (the client-credentials fallback, or a one-time sample
+	// caller token); without either the client is parked in
+	// pending_verification for the verify-exchange endpoint.
+	if req.AuthType == string(schemas.MCPAuthTypeTokenExchange) {
+		if isEnterprise, _ := bifrostCtx.Value(schemas.BifrostContextKeyIsEnterprise).(bool); !isEnterprise {
+			SendError(ctx, fasthttp.StatusBadRequest, "auth_type 'token_exchange' is not supported")
+			return
+		}
+		if h.store.OAuthProvider == nil || !h.store.OAuthProvider.TokenExchangeAvailable() {
+			SendError(ctx, fasthttp.StatusBadRequest, "auth_type 'token_exchange' requires user-identity authentication with an exchange client to be configured")
+			return
+		}
+		if req.TokenExchange == nil || strings.TrimSpace(req.TokenExchange.Audience) == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "token_exchange.audience is required when auth_type is 'token_exchange'")
+			return
+		}
+		if strings.TrimSpace(req.TokenExchange.ClientID.GetValue()) == "" && !req.TokenExchange.ClientID.IsFromSecret() {
+			SendError(ctx, fasthttp.StatusBadRequest, "token_exchange.client_id is required when auth_type is 'token_exchange'")
+			return
+		}
+		// Token-exchange clients rely on requests that may carry both an
+		// identity token and a virtual key; the 'error' conflict behavior
+		// would reject exactly those requests, so the two settings are
+		// mutually exclusive (enforced in both directions — see the
+		// client-config update path).
+		clientConfig, cfgErr := h.store.ConfigStore.GetClientConfig(ctx)
+		if cfgErr != nil {
+			// Fail closed: silently skipping this check on a read error
+			// would let a token_exchange client be created while
+			// dual_credential_conflict_behavior is still 'error', the exact
+			// pairing this validation exists to prevent.
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to load client config to validate dual_credential_conflict_behavior: %v", cfgErr))
+			return
+		}
+		if clientConfig != nil && clientConfig.DualCredentialConflictBehavior == configstoreTables.DualCredentialConflictBehaviorError {
+			SendError(ctx, fasthttp.StatusBadRequest, "auth_type 'token_exchange' cannot be used while dual_credential_conflict_behavior is 'error': change it to 'prefer_idp' or 'prefer_vk' first")
+			return
+		}
+
+		toolSyncInterval := mcp.DefaultToolSyncInterval
+		if req.ToolSyncInterval != 0 {
+			toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
+		} else {
+			config, cfgErr := h.store.ConfigStore.GetClientConfig(ctx)
+			if cfgErr == nil && config != nil {
+				toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
+			}
+		}
+
+		isPingAvailable := true
+		if req.IsPingAvailable != nil {
+			isPingAvailable = *req.IsPingAvailable
+		}
+
+		schemasConfig := &schemas.MCPClientConfig{
+			ID:                    req.ClientID,
+			Name:                  req.Name,
+			IsCodeModeClient:      req.IsCodeModeClient,
+			IsPingAvailable:       &isPingAvailable,
+			ToolSyncInterval:      toolSyncInterval,
+			ToolExecutionTimeout:  resolvedToolExecutionTimeout,
+			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:      req.ConnectionString,
+			StdioConfig:           req.StdioConfig,
+			TLSConfig:             req.TLSConfig,
+			AuthType:              schemas.MCPAuthTypeTokenExchange,
+			TokenExchange:         req.TokenExchange,
+			ToolsToExecute:        req.ToolsToExecute,
+			ToolsToAutoExecute:    req.ToolsToAutoExecute,
+			ToolPricing:           req.ToolPricing,
+			Headers:               req.Headers,
+			AllowedExtraHeaders:   req.AllowedExtraHeaders,
+			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+		}
+
+		// Resolve an admin credential for synchronous verification + tool
+		// discovery, mirroring the other per-user branches: the signed-in
+		// admin's own identity-provider token — stamped on the request
+		// context by the auth layer — is exchanged exactly like a real
+		// caller's would be ("verify as yourself"; there is no manual token
+		// input). Without one (e.g. API-key authentication) the client is
+		// created in pending_verification for verify-exchange, which the
+		// admin must hit from an identity-authenticated session. The full
+		// response is retained after activation as the admin discovery
+		// credential (see the retention block below).
+		var adminResponse *schemas.OAuth2TokenExchangeResponse
+		sampleSubjectToken, _ := bifrostCtx.Value(schemas.BifrostContextKeyMCPInboundBearer).(string)
+		if sampleSubjectToken != "" {
+			response, exchangeErr := h.store.OAuthProvider.ExchangeAdminCredential(bifrostCtx, schemasConfig, sampleSubjectToken)
+			if exchangeErr != nil {
+				SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Admin credential exchange failed: %v", exchangeErr))
+				return
+			}
+			adminResponse = response
+			tools, toolNameMapping, verifyErr := h.mcpManager.VerifyPerUserOAuthConnection(bifrostCtx, schemasConfig, response.AccessToken)
+			if verifyErr != nil {
+				SendError(ctx, fasthttp.StatusUnprocessableEntity, fmt.Sprintf("Verification failed: %v", verifyErr))
+				return
+			}
+			schemasConfig.DiscoveredTools = tools
+			schemasConfig.DiscoveredToolNameMapping = toolNameMapping
+		}
+
+		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, schemasConfig); err != nil {
+			if errors.Is(err, configstore.ErrAlreadyExists) {
+				SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
+				return
+			}
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+			return
+		}
+		if err := h.mcpManager.AddMCPClient(bifrostCtx, schemasConfig); err != nil {
+			if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, schemasConfig.ID); delErr != nil {
+				logger.Error(fmt.Sprintf("Failed to roll back MCP client config after AddMCPClient failure: %v", delErr))
+			}
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register MCP client: %v", err))
+			return
+		}
+
+		// Retain the admin credential for the periodic tool syncer and the
+		// refresh worker, mirroring the per-user OAuth promotion and the
+		// per-user-headers admin upsert. Deliberately after activation and
+		// persistence, and best-effort: a failed retention doesn't fail the
+		// create — the client is verified and serving, tool-list refresh just
+		// stays unavailable until verify-exchange retains a fresh credential.
+		if adminResponse != nil {
+			if retainErr := h.store.OAuthProvider.RetainExchangeAdminCredential(ctx, schemasConfig, adminResponse); retainErr != nil {
+				logger.Warn(fmt.Sprintf("failed to retain admin exchange credential for MCP client %s: %v", schemasConfig.ID, retainErr))
+			}
+		}
+
+		message := fmt.Sprintf("MCP client registered. %d tools discovered. Callers' identity tokens are exchanged automatically on each tool use.", len(schemasConfig.DiscoveredTools))
+		if adminResponse == nil {
+			message = "MCP client registered in pending verification. Verify it from an identity-authenticated session to discover tools."
+		}
+		SendJSON(ctx, map[string]any{
+			"status":  "success",
+			"message": message,
 		})
 		return
 	}
@@ -1764,6 +2059,49 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	// Validate token_exchange updates. AuthType is immutable on update, so
+	// existingConfig.AuthType is the reliable gate here too; the block is
+	// meaningless on any other auth type.
+	if req.TokenExchange != nil {
+		if existingConfig.AuthType != schemas.MCPAuthTypeTokenExchange {
+			SendError(ctx, fasthttp.StatusBadRequest, "token_exchange can only be set for token_exchange clients")
+			return
+		}
+		if strings.TrimSpace(req.TokenExchange.Audience) == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "token_exchange.audience must be non-empty")
+			return
+		}
+		// The GET response redacts the exchange credentials; a round-tripped
+		// redacted value means "keep the stored one", mirroring the header
+		// and TLS redacted-merge behavior above.
+		if existingConfig.TokenExchange != nil {
+			if req.TokenExchange.ClientID.IsRedacted() {
+				req.TokenExchange.ClientID = existingConfig.TokenExchange.ClientID
+			}
+			if req.TokenExchange.ClientSecret.IsRedacted() {
+				req.TokenExchange.ClientSecret = existingConfig.TokenExchange.ClientSecret
+			}
+		}
+		if strings.TrimSpace(req.TokenExchange.ClientID.GetValue()) == "" && !req.TokenExchange.ClientID.IsFromSecret() {
+			SendError(ctx, fasthttp.StatusBadRequest, "token_exchange.client_id must be non-empty")
+			return
+		}
+	}
+	// A real change to the token_exchange scoping block invalidates the
+	// retained admin bootstrap credential the same way rotating oauth_config
+	// invalidates per_user_oauth's (see shouldRotateOAuthConfig's comment
+	// below for the parallel) — new client_id/client_secret/audience/scopes
+	// mean the old admin credential was minted under permissions or an
+	// identity-provider registration that no longer applies. Diffed against
+	// the resolved (post-redaction-preserve) value above so a caller that
+	// round-trips the block unchanged doesn't force a needless
+	// "Re-verify as me". Unlike OAuth there's no per-user row to cascade —
+	// end-user exchanged tokens are cache-only and simply re-exchange fresh
+	// on the next call once evicted below.
+	shouldMarkExchangeNeedsReauth := req.TokenExchange != nil &&
+		existingConfig.AuthType == schemas.MCPAuthTypeTokenExchange &&
+		existingConfig.TokenExchange.DiffersFrom(req.TokenExchange)
+
 	// OAuth config rotation: update every oauth_configs field in place (no new
 	// row, no re-discovery/re-registration triggered here) when ANY of them
 	// differs from what's stored, then cascade every token bound to that
@@ -1898,6 +2236,14 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 
 	perUserHeaderKeys := resolvePerUserHeaderKeys(existingConfig, req)
 
+	// PATCH semantics for the token_exchange scoping block: omitted preserves
+	// the stored block (validated above to only apply to token_exchange
+	// clients).
+	tokenExchange := existingConfig.TokenExchange
+	if req.TokenExchange != nil {
+		tokenExchange = req.TokenExchange
+	}
+
 	// Build the DB update record from all resolved values.
 	dbUpdateRecord := configstoreTables.TableMCPClient{
 		ClientID:              id,
@@ -1919,6 +2265,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		AllowOnAllVirtualKeys: allowOnAllVKs,
 		Disabled:              disabled,
 		PerUserHeaderKeys:     perUserHeaderKeys,
+		TokenExchange:         tokenExchange,
 		TLSConfig:             tlsConfig,
 	}
 	// Rebind persisted discovered tool keys (and inner Function.Name) to the current
@@ -1982,6 +2329,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		AllowOnAllVirtualKeys: allowOnAllVKs,
 		Disabled:              disabled,
 		PerUserHeaderKeys:     perUserHeaderKeys,
+		TokenExchange:         tokenExchange,
 	}
 
 	// Update MCP client config in memory (always — applies name/tools/header changes,
@@ -2027,6 +2375,31 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 				logger.Error(fmt.Sprintf("Failed to close MCP client %s's connection after OAuth credential rotation: %v", id, err))
 			}
 		}
+	}
+
+	// Mark the retained admin exchange credential needs_reauth only now that
+	// the DB row and the in-memory client above have both succeeded — same
+	// ordering rationale as shouldRotateOAuthConfig's cascade above: a
+	// failure between marking and now would lock the admin out over a
+	// client update that itself never went through. Unlike OAuth rotation,
+	// there's no per-user row to cascade (see shouldMarkExchangeNeedsReauth's
+	// comment) and no separate config table to update in the same
+	// transaction — the client row was already persisted above.
+	if shouldMarkExchangeNeedsReauth {
+		if err := h.store.ConfigStore.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, id); err != nil {
+			// Mirrors shouldRotateOAuthConfig's [PARTIAL SUCCESS] handling
+			// above: the rest of the update already committed, only the
+			// reauth marking failed.
+			logger.Error(fmt.Sprintf("[PARTIAL SUCCESS] MCP client %s was updated but marking its admin exchange credential needs_reauth failed: %v", id, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("MCP client updated but marking its admin exchange credential needs_reauth failed: %v", err))
+			return
+		}
+		// No CloseAndMarkNeedsReauth call here (unlike the OAuth rotation
+		// block above): token_exchange always requires a per-call connection
+		// (RequiresPerCallConnection), so the call would unconditionally hit
+		// its early-return no-op — there's no shared connection to close and
+		// no clientState.State that anything reads for this auth type.
+		h.mcpCredentialCacheManager.EvictOauthTokenCacheByMCPClient(ctx, existingConfig.ID)
 	}
 
 	// If the per-user-headers schema now requires additional keys, flip every
@@ -2879,6 +3252,7 @@ func resolvePerUserHeaderKeys(existing *schemas.MCPClientConfig, req MCPClientUp
 	return nil
 }
 
+
 // perUserHeaderKeysAdded reports whether the new schema introduces any key
 // absent from the old schema (order-insensitive). Used by updateMCPClient to
 // decide whether existing user credentials must be marked 'needs_update'.
@@ -2964,7 +3338,8 @@ func (h *MCPHandler) createMCPLibraryEntry(ctx *fasthttp.RequestCtx) {
 	}
 	switch req.AuthType {
 	case schemas.MCPAuthTypeNone, schemas.MCPAuthTypeHeaders, schemas.MCPAuthTypeOauth,
-		schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypePerUserHeaders:
+		schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypePerUserHeaders,
+		schemas.MCPAuthTypeTokenExchange:
 	default:
 		SendError(ctx, fasthttp.StatusBadRequest, "invalid auth_type")
 		return

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1724,6 +1724,12 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 				logger.Warn("skipping MCP client config %q from config file: %v", c.Name, err)
 				continue
 			}
+			if c.AuthType == schemas.MCPAuthTypeTokenExchange {
+				if isEnterprise, _ := ctx.Value(schemas.BifrostContextKeyIsEnterprise).(bool); !isEnterprise {
+					logger.Error("skipping MCP client config %q from config file: auth_type 'token_exchange' is not supported", c.Name)
+					continue
+				}
+			}
 			// oauth_config_id is server-managed state — a credentials-row
 			// reference produced by admin authorization — not a declarative
 			// input. A file-supplied value is at best redundant (the sync
@@ -1861,6 +1867,16 @@ func pinMCPClientImmutableFields(fileClient, existing *schemas.MCPClientConfig) 
 		fileClient.PerUserHeaderKeys = existing.PerUserHeaderKeys
 	}
 
+	// Same rule for the token_exchange scoping block: audience/scopes edits
+	// apply (the update API accepts them too), but a token_exchange client
+	// must keep a block with a non-empty audience.
+	if fileClient.AuthType == schemas.MCPAuthTypeTokenExchange &&
+		(fileClient.TokenExchange == nil || strings.TrimSpace(fileClient.TokenExchange.Audience) == "") &&
+		existing.TokenExchange != nil {
+		logger.Warn("token_exchange cannot be emptied for MCP client %q (auth_type 'token_exchange'); keeping the stored block", existing.Name)
+		fileClient.TokenExchange = existing.TokenExchange
+	}
+
 	fileClient.OauthConfigID = existing.OauthConfigID
 	if len(fileClient.DiscoveredTools) == 0 {
 		fileClient.DiscoveredTools = existing.DiscoveredTools
@@ -1970,6 +1986,64 @@ func rotateMCPOauthConfigFromFile(ctx context.Context, store configstore.ConfigS
 	return incomplete
 }
 
+// rotateMCPTokenExchangeConfigFromFile cascades needs_reauth on the retained
+// admin exchange credential when a config.json edit changes the
+// token_exchange scoping block (audience/client_id/client_secret/
+// authorization_server_url/scopes), mirroring the update-MCP-client API's
+// shouldMarkExchangeNeedsReauth path. Unlike oauth_config there is no
+// separate table row to rotate — the block lives directly on the MCP
+// client row and is already applied via
+// mcpClientConfigToTable/applyMCPClientPinnedStateToRow; this only handles
+// the reauth cascade side effect. No-op when the file doesn't declare a
+// token_exchange block or nothing actually changed.
+//
+// Only fields the file explicitly sets participate in the diff — an
+// absent/empty client_id or client_secret means "not declared" (e.g. still
+// resolving from a secret ref), not a request to clear it, mirroring
+// rotateMCPOauthConfigFromFile's treatment of oauth_config.client_id/
+// client_secret. The resolved value (file-declared fields layered onto the
+// stored ones) is what's diffed via MCPTokenExchangeConfig.DiffersFrom, the
+// same method the update-MCP-client API uses against its own
+// redaction-resolved request value.
+func rotateMCPTokenExchangeConfigFromFile(ctx context.Context, store configstore.ConfigStore, clientID, clientName string, fileBlock, existing *schemas.MCPTokenExchangeConfig) {
+	if store == nil || fileBlock == nil || existing == nil {
+		return
+	}
+	resolved := *existing
+	if fileBlock.Audience != "" {
+		resolved.Audience = fileBlock.Audience
+	}
+	if fileBlock.ClientID.IsSet() {
+		if fileBlock.ClientID.GetValue() != "" {
+			resolved.ClientID = fileBlock.ClientID
+		} else {
+			logger.Warn("token_exchange.client_id declared for MCP client %q resolves to an empty value; keeping the stored value", clientName)
+		}
+	}
+	if fileBlock.ClientSecret.IsSet() {
+		if fileBlock.ClientSecret.GetValue() != "" {
+			resolved.ClientSecret = fileBlock.ClientSecret
+		} else {
+			logger.Warn("token_exchange.client_secret declared for MCP client %q resolves to an empty value; keeping the stored value", clientName)
+		}
+	}
+	if fileBlock.AuthorizationServerURL != nil && *fileBlock.AuthorizationServerURL != "" {
+		resolved.AuthorizationServerURL = fileBlock.AuthorizationServerURL
+	}
+	if len(fileBlock.Scopes) > 0 {
+		resolved.Scopes = fileBlock.Scopes
+	}
+
+	if !existing.DiffersFrom(&resolved) {
+		return
+	}
+	if err := store.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, clientID); err != nil {
+		logger.Warn("failed to mark admin exchange credential needs_reauth for MCP client %q from config file: %v", clientName, err)
+		return
+	}
+	logger.Warn("rotated token_exchange config for MCP client %q from config file; admin exchange credential must be re-verified", clientName)
+}
+
 // authorizedOauthRowForComparison loads the oauth_configs row backing an
 // already-authorized client so an edited file oauth_config block can be
 // detected by pinMCPClientImmutableFields. Returns nil whenever there is
@@ -2020,6 +2094,7 @@ func applyMCPClientPinnedStateToRow(row *configstoreTables.TableMCPClient, clien
 	row.ConnectionString = clientConfig.ConnectionString
 	row.StdioConfig = clientConfig.StdioConfig
 	row.PerUserHeaderKeys = mcputils.CanonicalizeHeaderKeys(clientConfig.PerUserHeaderKeys)
+	row.TokenExchange = clientConfig.TokenExchange
 	row.OauthConfigID = clientConfig.OauthConfigID
 	row.DiscoveredTools = clientConfig.DiscoveredTools
 	row.DiscoveredToolNameMapping = clientConfig.DiscoveredToolNameMapping
@@ -2074,6 +2149,7 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 					// edit does not reset a verified client.
 					authorizedOauth := authorizedOauthRowForComparison(ctx, config.ConfigStore, newClientConfig, existingClientConfig)
 					incompleteRotation := rotateMCPOauthConfigFromFile(ctx, config.ConfigStore, existingClientConfig.Name, newClientConfig.PendingOAuthConfig, authorizedOauth)
+					rotateMCPTokenExchangeConfigFromFile(ctx, config.ConfigStore, existingClientConfig.ID, existingClientConfig.Name, newClientConfig.TokenExchange, existingClientConfig.TokenExchange)
 					warnIgnoredImmutableMCPFields(existingClientConfig.Name, pinMCPClientImmutableFields(newClientConfig, existingClientConfig))
 					applyMCPClientPinnedStateToRow(&fileClientRow, newClientConfig)
 					fileClientRow.ClientID = existingClientConfig.ID
@@ -2212,6 +2288,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
 		PerUserHeaderKeys:         mcputils.CanonicalizeHeaderKeys(clientConfig.PerUserHeaderKeys),
+		TokenExchange:             clientConfig.TokenExchange,
 		PendingOAuthConfig:        clientConfig.PendingOAuthConfig,
 		ConfigHash:                clientConfig.ConfigHash,
 	}, nil
@@ -2300,6 +2377,7 @@ func syncMCPConfigFromFile(ctx context.Context, config *Config, configData *Conf
 					fileClient.ConfigHash = existing.ConfigHash
 					fileRow.ConfigHash = existing.ConfigHash
 				}
+				rotateMCPTokenExchangeConfigFromFile(ctx, config.ConfigStore, existing.ID, existing.Name, fileClient.TokenExchange, existing.TokenExchange)
 			}
 			changedImmutable := pinMCPClientImmutableFields(fileClient, existing)
 			if fileEdited {
@@ -6569,6 +6647,7 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys
 	c.MCPConfig.ClientConfigs[configIndex].Disabled = updatedConfig.Disabled
 	c.MCPConfig.ClientConfigs[configIndex].PerUserHeaderKeys = updatedConfig.PerUserHeaderKeys
+	c.MCPConfig.ClientConfigs[configIndex].TokenExchange = updatedConfig.TokenExchange
 
 	// Handle disable/enable lifecycle when the Disabled flag toggles and the client
 	// is registered at runtime. We call the core bifrost methods directly (not the
@@ -6787,6 +6866,17 @@ func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas
 	}
 	if config.OauthClientSecret != nil {
 		configCopy.OauthClientSecret = config.OauthClientSecret.Redacted()
+	}
+
+	// Redact the token-exchange application credentials. Copy the struct
+	// first — configCopy shares the pointer with the live config, and
+	// Redacted() returns a fresh SecretVar so the live block is never
+	// mutated.
+	if config.TokenExchange != nil {
+		exchangeCopy := *config.TokenExchange
+		exchangeCopy.ClientID = exchangeCopy.ClientID.Redacted()
+		exchangeCopy.ClientSecret = exchangeCopy.ClientSecret.Redacted()
+		configCopy.TokenExchange = &exchangeCopy
 	}
 
 	// Redact credentials inside the inline `oauth_config` bootstrap block.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1464,11 +1464,11 @@ func (m *MockConfigStore) GetSharedOauthTokenByConfigID(ctx context.Context, oau
 	return nil, nil
 }
 
-func (m *MockConfigStore) GetAdminOauthTokenByConfigID(ctx context.Context, oauthConfigID string) (*tables.TableMCPOauthToken, error) {
+func (m *MockConfigStore) GetAdminOauthTokenByMCPClientID(ctx context.Context, mcpClientID string) (*tables.TableMCPOauthToken, error) {
 	return nil, nil
 }
 
-func (m *MockConfigStore) GetAdminOauthTokensByConfigIDs(ctx context.Context, oauthConfigIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
+func (m *MockConfigStore) GetAdminOauthTokensByMCPClientIDs(ctx context.Context, mcpClientIDs []string) (map[string]*tables.TableMCPOauthToken, error) {
 	return map[string]*tables.TableMCPOauthToken{}, nil
 }
 
@@ -1563,6 +1563,10 @@ func (m *MockConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, o
 	for _, tok := range m.oauthTokensByConfigID[oauthConfigID] {
 		tok.Status = "needs_reauth"
 	}
+	return nil
+}
+
+func (m *MockConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error {
 	return nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4838,9 +4838,39 @@
             "headers",
             "oauth",
             "per_user_oauth",
-            "per_user_headers"
+            "per_user_headers",
+            "token_exchange"
           ],
           "description": "Authentication type for MCP connection"
+        },
+        "token_exchange": {
+          "type": "object",
+          "description": "Delegated token-exchange configuration for auth_type 'token_exchange': each caller's identity-provider token is exchanged at runtime for a short-lived token scoped to this server's audience. The exchange endpoint and grant shape come from the deployment's identity-provider integration; the application performing the exchange is configured here. Requires user-identity authentication to be available. The MCP client lands in `pending_verification` state at boot; an admin verifies it once from the UI (as themselves).",
+          "properties": {
+            "audience": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Resource identifier the exchanged token is scoped to at the identity provider (e.g. 'api://jira-mcp')"
+            },
+            "client_id": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Identity-provider application authorized to perform exchanges for this audience — a dedicated registration carrying the token-exchange (or on-behalf-of) grant, not the SSO login application. Can use env. or vault. prefix."
+            },
+            "client_secret": {
+              "type": "string",
+              "description": "Secret for the exchange application; omit for public clients. Can use env. or vault. prefix."
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Optional scopes to request on the exchanged token. Include 'offline_access' (where the identity provider supports it) so exchanges issue refresh tokens, keeping the retained admin discovery credential self-renewing."
+            }
+          },
+          "required": ["audience", "client_id"],
+          "additionalProperties": false
         },
         "oauth_config": {
           "type": "object",
@@ -5052,6 +5082,25 @@
           "then": {
             "not": {
               "required": ["per_user_header_keys"]
+            }
+          }
+        },
+        {
+          "$comment": "token_exchange requires its scoping block (audience), and the block only applies to that auth type; forbid it elsewhere so a misplaced declaration fails validation instead of being silently ignored.",
+          "if": {
+            "properties": {
+              "auth_type": {
+                "const": "token_exchange"
+              }
+            },
+            "required": ["auth_type"]
+          },
+          "then": {
+            "required": ["token_exchange"]
+          },
+          "else": {
+            "not": {
+              "required": ["token_exchange"]
             }
           }
         }


### PR DESCRIPTION
## Summary

Adds `token_exchange` as a new MCP authentication type. With this auth type, each caller's identity-provider token is exchanged at runtime for a short-lived upstream token scoped to a configured audience, using either the RFC 8693 standard token-exchange grant or the JWT-bearer on-behalf-of variant. No interactive OAuth flow is required — callers present their own identity token and the exchange happens transparently per tool call.

## Changes

- **New `MCPAuthTypeTokenExchange` auth type**: Callers' identity-provider tokens are exchanged per request via a configurable exchange application (`client_id`, `client_secret`, `audience`, `scopes`). The exchange endpoint and grant shape come from a deployment-level `TokenExchangeIdPResolver`.

- **`tokenExchangeResolver` in credstore**: Implements `ConnectionHeaders` (returns a bearer header from the exchanged token), `RequiresPerCallConnection` (always true — no persistent upstream connection), `ForceRefresh` (evicts cached token and re-exchanges), and `AdminConnectionHeaders` (uses the retained admin bootstrap credential keyed by MCP client ID).

- **`tokenexchange.go` in the OAuth2 provider**: Implements `GetExchangedAccessToken` (cached per auth-mode/identity/client binding), `ExchangeAdminCredential` (uncached, for admin verification), `RetainExchangeAdminCredential` (persists the admin bootstrap token row), and `refreshExchangeAdminToken` (renews via refresh token or flips to `needs_reauth`).

- **Admin verification endpoint** `POST /api/mcp/client/{id}/verify-exchange`: The signed-in admin exchanges their own identity token as a sample caller, verifies the upstream connection, discovers tools, persists them, and retains the admin discovery credential. Mirrors `verify-headers` in structure and replay-guard logic.

- **`pending_verification` parking**: Token-exchange clients with no discovered tools (declared in `config.json` or created without an identity token) are parked in `pending_verification` until the admin runs `verify-exchange`.

- **Admin token lookup re-keyed by MCP client ID**: `GetAdminOauthTokenByConfigID` / `GetAdminOauthTokensByConfigIDs` renamed to `GetAdminOauthTokenByMCPClientID` / `GetAdminOauthTokensByMCPClientIDs`. Token-exchange admin rows have no `oauth_configs` template, so the lookup key is now always the MCP client ID, which every admin row carries.

- **Tool syncer extended**: `ClientToolSyncer.performSync` now routes `token_exchange` clients through the admin tool discovery path alongside `per_user_oauth` and `per_user_headers`.

- **`GetExpiringOauthTokens` extended**: The expiry query now also picks up token-exchange admin rows (which have no `oauth_config_id`) so the refresh worker keeps them alive.

- **`dual_credential_conflict_behavior` guard**: Setting the conflict behavior to `error` is blocked while any `token_exchange` client exists (and vice versa), since that behavior would reject the dual-credential requests those clients depend on.

- **Config hash and DB migration**: A new `token_exchange_json` column is added to `config_mcp_clients`, encrypted at rest. The config hash includes the token-exchange block so edits in `config.json` trigger reconciliation.

- **Schema and JSON schema**: `MCPTokenExchangeConfig` struct added. `config.schema.json` updated with the `token_exchange` object definition and a conditional requiring it when `auth_type` is `token_exchange`.

- **Redaction**: The exchange application's `client_id` and `client_secret` are redacted in GET responses, with round-tripped redacted values on update meaning "keep stored".

- **`BifrostContextKeyMCPInboundBearer`**: New reserved context key carrying the caller's validated identity-provider token as the exchange subject. Marked as a live credential — never logged.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/credstore/... ./framework/oauth2/... ./framework/configstore/... ./transports/bifrost-http/...
```

1. Configure a `token_exchange` MCP client in `config.json` with a valid `audience` and `client_id`.
2. Start the server — the client should appear in `pending_verification`.
3. Sign in with an identity provider and call `POST /api/mcp/client/{id}/verify-exchange`. Expect a `200` with a `tools_count` in the response and the client transitioning to `connected`.
4. Make a tool call as a user with a valid identity token. Confirm the upstream receives a bearer token scoped to the configured audience.
5. Attempt to set `dual_credential_conflict_behavior` to `error` while the client exists — expect a `400`.
6. Attempt to create a `token_exchange` client while `dual_credential_conflict_behavior` is `error` — expect a `400`.

## Breaking changes

- [x] Yes
- [ ] No

`GetAdminOauthTokenByConfigID` and `GetAdminOauthTokensByConfigIDs` on the `ConfigStore` interface are renamed to `GetAdminOauthTokenByMCPClientID` and `GetAdminOauthTokensByMCPClientIDs`. Any external implementations of the `ConfigStore` interface must be updated. The lookup semantics change from `oauth_config_id` to `mcp_client_id` — existing `per_user_oauth` admin rows must have `mcp_client_id` populated (which the existing promotion path already ensures).

## Security considerations

- `BifrostContextKeyMCPInboundBearer` carries a live caller credential. It is explicitly marked as never-log in the constant's doc comment and is reserved so plugins cannot overwrite it.
- The `token_exchange_json` column (carrying the exchange application's `client_secret`) is encrypted at rest using the same path as other credential-bearing columns.
- Exchange results are cached in memory only — no exchanged caller token is ever written to the database.
- Session-mode identities are explicitly rejected as exchange subjects; only `user` and `vk` auth modes can anchor a delegated exchange.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable