### PR TITLE
feat: add ui for `token_exchange` (On-Behalf-Of) auth type MCP clients

### DIFF
--- a/framework/oauth2/tokenexchange.go
+++ b/framework/oauth2/tokenexchange.go
@@ -17,8 +17,19 @@ import (
 )
 
 const (
-	grantTypeTokenExchange      = "urn:ietf:params:oauth:grant-type:token-exchange"
-	grantTypeJWTBearer          = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	grantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+	grantTypeJWTBearer     = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	// subjectTokenTypeAccessToken is the RFC 8693 subject_token_type declared
+	// for delegated exchanges. The raw bearer stamped as the caller's
+	// identity token (BifrostContextKeyMCPInboundBearer) must be a genuine
+	// OAuth access token, not an ID token: identity-provider token-exchange
+	// endpoints reject an ID token both as a type mismatch when declared
+	// access_token (observed as Okta's "'subject_token' is invalid") and
+	// outright when declared id_token (Okta's "'subject_token_type' is
+	// invalid or not supported" — id_token isn't a supported
+	// subject_token_type at all). Whatever stamps this context key is
+	// responsible for ensuring it is a genuine access token, not merely an
+	// identity-bearing JWT.
 	subjectTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
 
 	// exchangeExpirySafetyMargin is subtracted from an exchanged token's

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibraryInstallSheet.tsx
@@ -113,6 +113,8 @@ function authLabel(authType?: MCPAuthType | string): string {
 			return "Per-user OAuth";
 		case "per_user_headers":
 			return "User headers";
+		case "token_exchange":
+			return "Token exchange";
 		default:
 			return "No auth";
 	}
@@ -128,6 +130,8 @@ function authHelpText(authType?: MCPAuthType | string): string {
 			return "Create the MCP client, then authorize the first user OAuth connection.";
 		case "per_user_headers":
 			return "Declare the header names each caller must supply, then verify a sample set on install.";
+		case "token_exchange":
+			return "Set the identity-provider audience for this server; each caller's identity token is exchanged automatically.";
 		default:
 			return "No credentials are required for this catalog entry.";
 	}

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -14,7 +14,9 @@ import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
 import { CreateMCPClientRequest, SecretVar, MCPAuthType, MCPConnectionType, MCPStdioConfig, MCPTLSConfig } from "@/lib/types/mcp";
 import { parseArrayFromText } from "@/lib/utils/array";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
 import { Info } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -68,12 +70,20 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const { toast } = useToast();
 	const [createMCPClient] = useCreateMCPClientMutation();
 
+	// Token exchange is backed by the deployment's identity-provider
+	// integration, so the option only renders when one is enabled. The exact
+	// exchange-client requirement is enforced server-side at create; a missing
+	// tokenExchangeClient section surfaces as the create error.
+	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !IS_ENTERPRISE });
+	const idpConfigured = !!scimProviders?.some((p) => (p as { enabled?: boolean }).enabled);
+
 	const [isLoading, setIsLoading] = useState(false);
 	const [argsText, setArgsText] = useState("");
 	// STDIO env vars as a name→value map. Empty value = pass the bare name so the
 	// stdio process reads it from Bifrost's host environment.
 	const [envVars, setEnvVars] = useState<Record<string, string>>({});
 	const [scopesText, setScopesText] = useState("");
+	const [tokenExchangeScopesText, setTokenExchangeScopesText] = useState("");
 	const [resourceText, setResourceText] = useState("");
 	const [oauthFlow, setOauthFlow] = useState<{
 		authorizeUrl: string;
@@ -93,11 +103,13 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const [headersFlow, setHeadersFlow] = useState<{ payload: CreateMCPClientRequest } | null>(null);
 
 	// UI splits the canonical `auth_type` into two dropdowns:
-	//   - authKind: none | headers | oauth
-	//   - authScope: shared | per_user (hidden when authKind = none)
+	//   - authKind: none | headers | oauth | token_exchange
+	//   - authScope: shared | per_user (hidden when authKind is none or
+	//     token_exchange — exchange is inherently per-caller, with no shared
+	//     variant to scope)
 	// They recombine into the wire `auth_type` ("oauth", "per_user_oauth",
-	// "headers", "per_user_headers", "none") so the backend contract is
-	// unchanged.
+	// "headers", "per_user_headers", "token_exchange", "none") so the backend
+	// contract is unchanged.
 	const [authScope, setAuthScope] = useState<"shared" | "per_user">("shared");
 
 	const methods = useForm<CreateMCPClientRequest>({ defaultValues: emptyForm });
@@ -107,16 +119,18 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const authType = watch("auth_type");
 	const headers = watch("headers");
 
-	const authKind: "none" | "headers" | "oauth" =
+	const authKind: "none" | "headers" | "oauth" | "token_exchange" =
 		authType === "oauth" || authType === "per_user_oauth"
 			? "oauth"
 			: authType === "headers" || authType === "per_user_headers"
 				? "headers"
-				: "none";
+				: authType === "token_exchange"
+					? "token_exchange"
+					: "none";
 
-	const applyAuthKind = (kind: "none" | "headers" | "oauth") => {
-		if (kind === "none") {
-			setValue("auth_type", "none");
+	const applyAuthKind = (kind: "none" | "headers" | "oauth" | "token_exchange") => {
+		if (kind === "none" || kind === "token_exchange") {
+			setValue("auth_type", kind);
 			return;
 		}
 		if (kind === "oauth") {
@@ -159,6 +173,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			setArgsText("");
 			setEnvVars({});
 			setScopesText("");
+			setTokenExchangeScopesText("");
 			setResourceText("");
 			setOauthFlow(null);
 			setHeadersFlow(null);
@@ -217,6 +232,19 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					description: "OAuth resource must be an absolute URI without a fragment.",
 					variant: "destructive",
 				});
+				hasErrors = true;
+			}
+		}
+
+		if (authType === "token_exchange") {
+			const audience = data.token_exchange?.audience?.trim() || "";
+			if (!audience) {
+				setError("token_exchange.audience", { message: "Audience is required for token exchange" });
+				hasErrors = true;
+			}
+			const exchangeClientId = data.token_exchange?.client_id;
+			if (!exchangeClientId?.value && !exchangeClientId?.ref) {
+				setError("token_exchange.client_id", { message: "Exchange client ID is required for token exchange" });
 				hasErrors = true;
 			}
 		}
@@ -280,6 +308,21 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					? data.headers
 					: undefined,
 			per_user_header_keys: authType === "per_user_headers" ? perUserHeaderKeys : undefined,
+			token_exchange:
+				authType === "token_exchange"
+					? {
+						audience: data.token_exchange?.audience?.trim() || "",
+						client_id: data.token_exchange?.client_id ?? emptySecretVar,
+						client_secret:
+							data.token_exchange?.client_secret?.value ||
+								data.token_exchange?.client_secret?.type === "env" ||
+								data.token_exchange?.client_secret?.type === "vault"
+								? data.token_exchange.client_secret
+								: undefined,
+						scopes: tokenExchangeScopesText.trim() ? parseArrayFromText(tokenExchangeScopesText) : undefined,
+						authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
+					}
+					: undefined,
 			tools_to_execute: ["*"],
 		};
 
@@ -505,12 +548,18 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 												<SelectItem value="oauth" data-testid="auth-type-oauth">
 													OAuth 2.0
 												</SelectItem>
+												{IS_ENTERPRISE && idpConfigured && (
+													<SelectItem value="token_exchange" data-testid="auth-type-token-exchange">
+														Token Exchange (On-Behalf-Of)
+													</SelectItem>
+												)}
 											</SelectContent>
 										</Select>
 									</FormItem>
 
-									{/* Auth Scope — only meaningful when there's an auth flow */}
-									{authKind !== "none" && (
+									{/* Auth Scope — only meaningful when there's an auth flow with a
+									    shared variant; token exchange is inherently per-caller */}
+									{authKind !== "none" && authKind !== "token_exchange" && (
 										<FormItem className="w-full">
 											<FormLabel>Auth Scope</FormLabel>
 											<Select value={authScope} onValueChange={(value: "shared" | "per_user") => applyAuthScope(value)}>
@@ -604,6 +653,155 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											    dialog that opens on Create — mirrors the OAuth flow
 											    where the verification step is also a dialog, not an
 											    inline panel. */}
+										</div>
+									)}
+
+									{authType === "token_exchange" && (
+										<div className="space-y-4" data-testid="token-exchange-fields">
+											<p className="text-muted-foreground text-sm">
+												Each caller's identity token is exchanged automatically for a short-lived token scoped to this server - users never
+												authenticate to it individually, and this server connects per tool call instead of holding a shared connection.
+												Callers must authenticate with their identity provider token; virtual keys alone cannot use this server. Creating
+												the server verifies it as you, using your own signed-in identity.
+											</p>
+											<FormField
+												control={control}
+												name="token_exchange.audience"
+												render={({ field }) => (
+													<FormItem>
+														<div className="flex items-center gap-2">
+															<FormLabel>Audience</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			The resource identifier this server is registered as at your identity provider. Exchanged tokens are
+																			scoped to it.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<FormControl>
+															<Input
+																data-testid="token-exchange-audience-input"
+																placeholder="api://my-mcp-server"
+																value={field.value || ""}
+																onChange={(e) => {
+																	field.onChange(e.target.value);
+																	clearErrors("token_exchange.audience");
+																}}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={control}
+												name="token_exchange.client_id"
+												render={({ field }) => (
+													<FormItem>
+														<div className="flex items-center gap-2">
+															<FormLabel>Exchange Client ID</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			A dedicated application at your identity provider with the token exchange (or on-behalf-of) grant
+																			enabled and permission to request this audience. Not the SSO login application.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<SecretVarInput
+															value={field.value}
+															onChange={(value) => {
+																field.onChange(value);
+																clearErrors("token_exchange.client_id");
+															}}
+															placeholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
+															data-testid="token-exchange-client-id-input"
+														/>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={control}
+												name="token_exchange.client_secret"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Exchange Client Secret (optional)</FormLabel>
+														<SecretVarInput
+															value={field.value}
+															onChange={field.onChange}
+															placeholder="env.EXCHANGE_CLIENT_SECRET"
+															maskNonEnvValue
+															data-testid="token-exchange-client-secret-input"
+														/>
+														<p className="text-muted-foreground text-xs">Omit for public clients.</p>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<FormField
+												control={control}
+												name="token_exchange.authorization_server_url"
+												render={({ field }) => (
+													<FormItem>
+														<div className="flex items-center gap-2">
+															<FormLabel>Authorization Server URL (optional)</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			Only needed when the audience above is registered on a different authorization server than the one
+																			your SSO login uses - for example, Okta&apos;s per-resource Custom Authorization Servers. Leave blank
+																			to use your SSO login&apos;s issuer, which is correct for most providers.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<FormControl>
+															<Input
+																data-testid="token-exchange-authorization-server-url-input"
+																placeholder="https://your-domain.okta.com/oauth2/your-auth-server-id"
+																value={field.value || ""}
+																onChange={(e) => field.onChange(e.target.value)}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											<div className="space-y-1">
+												<div className="space-y-0.5">
+													<div className="text-sm font-medium">Scopes (optional)</div>
+													<p className="text-muted-foreground text-sm">
+														Comma-separated scopes to request on exchanged tokens. Include <code>offline_access</code> (where your identity
+														provider supports it) so the retained discovery credential can renew itself in the background.
+													</p>
+												</div>
+												<Textarea
+													data-testid="token-exchange-scopes-textarea"
+													className="h-20"
+													placeholder="jira.read, jira.write, offline_access"
+													value={tokenExchangeScopesText}
+													onChange={(e) => setTokenExchangeScopesText(e.target.value)}
+												/>
+											</div>
 										</div>
 									)}
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -103,7 +103,10 @@ export default function MCPClientSheet({
 	hasNext = false,
 }: MCPClientSheetProps) {
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
-	const isPerUserAuth = mcpClient.config.auth_type === "per_user_oauth" || mcpClient.config.auth_type === "per_user_headers";
+	const isPerUserAuth =
+		mcpClient.config.auth_type === "per_user_oauth" ||
+		mcpClient.config.auth_type === "per_user_headers" ||
+		mcpClient.config.auth_type === "token_exchange";
 	const [updateMCPClient, { isLoading: isUpdating }] = useUpdateMCPClientMutation();
 
 	const { toast } = useToast();
@@ -128,6 +131,7 @@ export default function MCPClientSheet({
 	const [allowedExtraHeadersRaw, setAllowedExtraHeadersRaw] = useState<string>((mcpClient.config.allowed_extra_headers || []).join(", "));
 	const [perUserHeaderKeysRaw, setPerUserHeaderKeysRaw] = useState<string>((mcpClient.config.per_user_header_keys || []).join(", "));
 	const [oauthScopesRaw, setOauthScopesRaw] = useState<string>((mcpClient.config.oauth_scopes || []).join(", "));
+	const [tokenExchangeScopesRaw, setTokenExchangeScopesRaw] = useState<string>((mcpClient.config.token_exchange?.scopes || []).join(", "));
 	// Persists names for newly added VKs so they survive search result changes
 	const [localVKNames, setLocalVKNames] = useState<Record<string, string>>({});
 
@@ -151,6 +155,10 @@ export default function MCPClientSheet({
 		setOauthScopesRaw((mcpClient.config.oauth_scopes || []).join(", "));
 	}, [mcpClient.config.oauth_scopes]);
 
+	useEffect(() => {
+		setTokenExchangeScopesRaw((mcpClient.config.token_exchange?.scopes || []).join(", "));
+	}, [mcpClient.config.token_exchange?.scopes]);
+
 	// Name lookup: server response names → names captured when a key was picked.
 	// Every row is one or the other, so the selector's results aren't needed here.
 	const vkNameByID = useMemo<Record<string, string>>(() => {
@@ -170,6 +178,7 @@ export default function MCPClientSheet({
 		[allToolNames],
 	);
 	const supportsOAuthCredentialUpdate = mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
+	const supportsTokenExchangeCredentialUpdate = mcpClient.config.auth_type === "token_exchange";
 
 	const addVKConfig = ({ value: vkId, label }: { value: string; label: string }) => {
 		setLocalVKNames((prev) => ({ ...prev, [vkId]: label }));
@@ -226,6 +235,18 @@ export default function MCPClientSheet({
 					resource: mcpClient.config.oauth_resource,
 				}
 				: undefined,
+			// Unlike oauth_config, token_exchange is replaced wholesale server-side
+			// (only client_id/client_secret get redacted-value preservation) — so
+			// every field, not just the ones the user edits, must be pre-populated
+			// with its current stored value rather than left blank.
+			token_exchange: supportsTokenExchangeCredentialUpdate
+				? {
+					audience: mcpClient.config.token_exchange?.audience,
+					client_id: mcpClient.config.token_exchange?.client_id,
+					client_secret: mcpClient.config.token_exchange?.client_secret,
+					authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
+				}
+				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
 					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
@@ -262,6 +283,18 @@ export default function MCPClientSheet({
 					resource: mcpClient.config.oauth_resource,
 				}
 				: undefined,
+			// Unlike oauth_config, token_exchange is replaced wholesale server-side
+			// (only client_id/client_secret get redacted-value preservation) — so
+			// every field, not just the ones the user edits, must be pre-populated
+			// with its current stored value rather than left blank.
+			token_exchange: supportsTokenExchangeCredentialUpdate
+				? {
+					audience: mcpClient.config.token_exchange?.audience,
+					client_id: mcpClient.config.token_exchange?.client_id,
+					client_secret: mcpClient.config.token_exchange?.client_secret,
+					authorization_server_url: mcpClient.config.token_exchange?.authorization_server_url,
+				}
+				: undefined,
 			tls_config: mcpClient.config.tls_config
 				? {
 					insecure_skip_verify: mcpClient.config.tls_config.insecure_skip_verify,
@@ -269,11 +302,13 @@ export default function MCPClientSheet({
 				}
 				: undefined,
 		});
-	}, [form, mcpClient, supportsOAuthCredentialUpdate]);
+	}, [form, mcpClient, supportsOAuthCredentialUpdate, supportsTokenExchangeCredentialUpdate]);
 
 	const initialOauthScopesRaw = (mcpClient.config.oauth_scopes || []).join(", ");
 	const oauthScopesDirty = oauthScopesRaw !== initialOauthScopesRaw;
-	const isDirty = form.formState.isDirty || vkConfigsDirty || oauthScopesDirty;
+	const initialTokenExchangeScopesRaw = (mcpClient.config.token_exchange?.scopes || []).join(", ");
+	const tokenExchangeScopesDirty = tokenExchangeScopesRaw !== initialTokenExchangeScopesRaw;
+	const isDirty = form.formState.isDirty || vkConfigsDirty || oauthScopesDirty || tokenExchangeScopesDirty;
 	// dirtyFields tracks deep changes vs. the pre-populated default values —
 	// used both to gate the rotation warning below and, in onSubmit, to only
 	// rotate when the user actually changed a field. Every oauth_config field
@@ -287,6 +322,17 @@ export default function MCPClientSheet({
 		form.formState.dirtyFields.oauth_config?.registration_url ||
 		form.formState.dirtyFields.oauth_config?.resource ||
 		oauthScopesDirty
+	);
+	// Same rationale as oauthCredentialsDirty: any touched token_exchange
+	// field gates both the cache-eviction warning below and, in onSubmit,
+	// whether the block is sent at all (see the comment there on why it must
+	// be sent whole, not just the changed field).
+	const tokenExchangeCredentialsDirty = !!(
+		form.formState.dirtyFields.token_exchange?.audience ||
+		form.formState.dirtyFields.token_exchange?.client_id ||
+		form.formState.dirtyFields.token_exchange?.client_secret ||
+		form.formState.dirtyFields.token_exchange?.authorization_server_url ||
+		tokenExchangeScopesDirty
 	);
 
 	const handleNavigate = useCallback(
@@ -338,6 +384,18 @@ export default function MCPClientSheet({
 			// form state either way, so re-enabling before a later save still
 			// submits the edited values.
 			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && !data.disabled && oauthCredentialsDirty;
+			// Unlike oauth_config, the backend replaces token_exchange wholesale
+			// (it only preserves client_id/client_secret when they round-trip the
+			// redacted sentinel) — so whenever anything in this block changed, the
+			// full current state (including untouched fields) must be resent, not
+			// just the edited field, or untouched fields would be cleared.
+			const shouldUpdateTokenExchange = supportsTokenExchangeCredentialUpdate && tokenExchangeCredentialsDirty;
+			const tokenExchangeScopes = tokenExchangeScopesRaw.trim()
+				? tokenExchangeScopesRaw
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean)
+				: [];
 			await updateMCPClient({
 				id: mcpClient.config.client_id,
 				data: {
@@ -363,6 +421,15 @@ export default function MCPClientSheet({
 							registration_url: data.oauth_config?.registration_url || undefined,
 							scopes: oauthScopes,
 							resource: data.oauth_config?.resource || undefined,
+						}
+						: undefined,
+					token_exchange: shouldUpdateTokenExchange
+						? {
+							audience: data.token_exchange?.audience?.trim() || "",
+							client_id: data.token_exchange?.client_id ?? { value: "", ref: "" },
+							client_secret: data.token_exchange?.client_secret,
+							authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
+							scopes: tokenExchangeScopes,
 						}
 						: undefined,
 					tls_config:
@@ -507,9 +574,11 @@ export default function MCPClientSheet({
 								</SheetTitle>
 								<SheetDescription>
 									{mcpClient.state === "pending_verification"
-										? mcpClient.config.auth_type === "per_user_oauth"
-											? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
-											: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
+										? mcpClient.config.auth_type === "token_exchange"
+											? "This server needs a one-time verification: Bifrost exchanges your signed-in identity token, tests the connection, and discovers tools. Callers then have their own identity tokens exchanged automatically on every tool call."
+											: mcpClient.config.auth_type === "per_user_oauth"
+												? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
+												: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
 										: mcpClient.state === "needs_reauth"
 											? isPerUserAuth
 												? "The admin credential Bifrost keeps on file to refresh this server's tool list needs repair. End-user credentials and tool calls are unaffected. Use Refresh admin credential from the server's actions menu to fix it."
@@ -1174,6 +1243,128 @@ export default function MCPClientSheet({
 															</FormItem>
 														)}
 													/>
+												</div>
+											</AccordionContent>
+										</AccordionItem>
+									</Accordion>
+								) : null}
+								{supportsTokenExchangeCredentialUpdate ? (
+									<Accordion type="single" collapsible className="w-full">
+										<AccordionItem value="token-exchange-advanced" className="border-b-0">
+											<AccordionTrigger className="py-0" data-testid="token-exchange-advanced-trigger">
+												<span className="text-sm font-medium">Token Exchange Advanced Settings</span>
+											</AccordionTrigger>
+											<AccordionContent className="space-y-4 pt-4 pb-0">
+												<p className="text-muted-foreground text-sm">
+													Connection type and auth type cannot be changed. Every field here is resent on save, so update the ones you mean
+													to change and leave the rest as shown.
+												</p>
+												{tokenExchangeCredentialsDirty && (
+													<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+														<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+														<p>
+															Changing any token exchange field immediately evicts every cached exchanged token for this server. The next
+															tool call for each caller re-exchanges a fresh token.
+														</p>
+													</div>
+												)}
+												<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+													<FormField
+														control={form.control}
+														name="token_exchange.audience"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Audience</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={!hasUpdateMCPClientAccess}
+																		placeholder="api://my-mcp-server"
+																		data-testid="mcpclient-input-token-exchange-audience"
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="token_exchange.client_id"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Exchange Client ID</FormLabel>
+																<FormControl>
+																	<SecretVarInput
+																		data-testid="mcpclient-input-token-exchange-client-id"
+																		placeholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
+																		disabled={!hasUpdateMCPClientAccess}
+																		redactNonEnvValue
+																		value={field.value}
+																		onChange={field.onChange}
+																	/>
+																</FormControl>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="token_exchange.client_secret"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Exchange Client Secret</FormLabel>
+																<FormControl>
+																	<SecretVarInput
+																		data-testid="mcpclient-input-token-exchange-client-secret"
+																		placeholder="env.EXCHANGE_CLIENT_SECRET"
+																		disabled={!hasUpdateMCPClientAccess}
+																		hideValueWhenEnv
+																		redactNonEnvValue
+																		value={field.value}
+																		onChange={field.onChange}
+																	/>
+																</FormControl>
+																<p className="text-muted-foreground text-xs">Omit for public clients.</p>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormField
+														control={form.control}
+														name="token_exchange.authorization_server_url"
+														render={({ field }) => (
+															<FormItem className="flex flex-col gap-2">
+																<FormLabel>Authorization Server URL</FormLabel>
+																<FormControl>
+																	<Input
+																		{...field}
+																		value={field.value ?? ""}
+																		disabled={!hasUpdateMCPClientAccess}
+																		placeholder="https://your-domain.okta.com/oauth2/your-auth-server-id"
+																		data-testid="mcpclient-input-token-exchange-authorization-server-url"
+																	/>
+																</FormControl>
+																<p className="text-muted-foreground text-xs">
+																	Leave blank to use the deployment's SSO login issuer.
+																</p>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+													<FormItem className="flex flex-col gap-2">
+														<FormLabel>Scopes</FormLabel>
+														<FormControl>
+															<Input
+																value={tokenExchangeScopesRaw}
+																disabled={!hasUpdateMCPClientAccess}
+																onChange={(e) => setTokenExchangeScopesRaw(e.target.value)}
+																placeholder="jira.read, jira.write, offline_access"
+																data-testid="mcpclient-input-token-exchange-scopes"
+															/>
+														</FormControl>
+														<p className="text-muted-foreground text-xs">Comma-separated.</p>
+													</FormItem>
 												</div>
 											</AccordionContent>
 										</AccordionItem>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsFilterSidebar.tsx
@@ -58,6 +58,7 @@ const AUTH_TYPE_OPTIONS: FilterOption[] = [
 	{ value: "oauth", label: "OAuth" },
 	{ value: "per_user_oauth", label: "Per-User OAuth" },
 	{ value: "per_user_headers", label: "Per-User Headers" },
+	{ value: "token_exchange", label: "Token Exchange" },
 ];
 
 // Connection state is runtime, not a column — the backend resolves these

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -25,6 +26,7 @@ import {
 	useReauthorizeMCPClientMutation,
 	useReconnectMCPClientMutation,
 	useUpdateMCPClientMutation,
+	useVerifyMCPClientExchangeMutation,
 	useVerifyMCPClientHeadersMutation,
 } from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
@@ -58,12 +60,14 @@ function MCPClientActionsMenu({
 	isReconnecting,
 	isAuthorizing,
 	isReauthorizing,
+	isVerifyingExchange,
 	isPerUserAuth,
 	onEdit,
 	onReconnect,
 	onAuthorize,
 	onReauthorize,
 	onRefreshHeaders,
+	onVerifyExchange,
 	onDelete,
 }: {
 	client: MCPClient;
@@ -72,12 +76,14 @@ function MCPClientActionsMenu({
 	isReconnecting: boolean;
 	isAuthorizing: boolean;
 	isReauthorizing: boolean;
+	isVerifyingExchange: boolean;
 	isPerUserAuth: boolean;
 	onEdit: (client: MCPClient) => void;
 	onReconnect: (client: MCPClient) => void;
 	onAuthorize: (client: MCPClient) => void;
 	onReauthorize: (client: MCPClient) => void;
 	onRefreshHeaders: (client: MCPClient) => void;
+	onVerifyExchange: (client: MCPClient) => void;
 	onDelete: (client: MCPClient) => void;
 }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -194,6 +200,24 @@ function MCPClientActionsMenu({
 							Refresh admin credential
 						</DropdownMenuItem>
 					)}
+				{hasUpdateAccess &&
+					client.state !== "pending_verification" &&
+					client.state !== "disabled" &&
+					client.config.auth_type === "token_exchange" && (
+						<DropdownMenuItem
+							className="cursor-pointer"
+							disabled={isVerifyingExchange}
+							data-testid={`mcp-client-verify-exchange-${client.config.client_id}-menu-item`}
+							onSelect={(e) => {
+								e.preventDefault();
+								onVerifyExchange(client);
+								setIsOpen(false);
+							}}
+						>
+							<KeyRound className="h-4 w-4" />
+							Re-verify as me
+						</DropdownMenuItem>
+					)}
 				{hasDeleteAccess && (
 					<DropdownMenuItem
 						variant="destructive"
@@ -249,12 +273,20 @@ export default function MCPClientsTable({
 	const hasDeleteMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
 	const [selectedMCPClient, setSelectedMCPClient] = useState<MCPClient | null>(null);
 	const [clientToDelete, setClientToDelete] = useState<MCPClient | null>(null);
+	// Drives the token_exchange "Re-verify as me" confirm dialog. Unlike
+	// per_user_oauth/per_user_headers, verify-exchange needs no popup or
+	// sample values — it fires as soon as confirmed — but admins still need
+	// the same "what does this touch, when do I need it" context those flows
+	// get from OAuth2Authorizer/MCPHeadersAuthorizer before we exchange their
+	// identity token.
+	const [exchangeVerifyClient, setExchangeVerifyClient] = useState<MCPClient | null>(null);
 	const [showDetailSheet, setShowDetailSheet] = useState(false);
 	const { toast } = useToast();
 
 	const [reconnectingClients, setReconnectingClients] = useState<string[]>([]);
 	const [authorizingClients, setAuthorizingClients] = useState<string[]>([]);
 	const [reauthorizingClients, setReauthorizingClients] = useState<string[]>([]);
+	const [verifyingExchangeClients, setVerifyingExchangeClients] = useState<string[]>([]);
 	const [togglingClientIds, setTogglingClientIds] = useState<Set<string>>(new Set());
 	// Drives the OAuth2Authorizer dialog for a config.json-bootstrapped client
 	// sitting in pending_verification, triggered from the row actions menu.
@@ -288,6 +320,7 @@ export default function MCPClientsTable({
 	// RTK Query mutations
 	const [reconnectMCPClient] = useReconnectMCPClientMutation();
 	const [reauthorizeMCPClient] = useReauthorizeMCPClientMutation();
+	const [verifyMCPClientExchange] = useVerifyMCPClientExchangeMutation();
 	const [deleteMCPClient] = useDeleteMCPClientMutation();
 	const [updateMCPClient] = useUpdateMCPClientMutation();
 	const [initiateVerification] = useInitiateMCPClientVerificationMutation();
@@ -313,10 +346,16 @@ export default function MCPClientsTable({
 	};
 
 	const handleStartBootstrap = async (client: MCPClient) => {
-		// per_user_headers takes a synchronous form-based path; OAuth-based
-		// types kick off the existing browser flow below.
+		// per_user_headers takes a synchronous form-based path, token_exchange
+		// opens the same "Re-verify as me" confirm dialog used to repair an
+		// already-verified client; OAuth-based types kick off the existing
+		// browser flow below.
 		if (client.config.auth_type === "per_user_headers") {
 			setBootstrapHeadersClient(client);
+			return;
+		}
+		if (client.config.auth_type === "token_exchange") {
+			handleRequestVerifyExchange(client);
 			return;
 		}
 		const isPerUserOauth = client.config.auth_type === "per_user_oauth";
@@ -399,6 +438,31 @@ export default function MCPClientsTable({
 		});
 	};
 
+	// Opens the "Re-verify as me" confirm dialog for a token_exchange client.
+	// The exchange call itself is synchronous and inputless — the backend
+	// exchanges the signed-in admin's own identity token, so there's nothing
+	// to collect — but admins still need the same "what does this touch, when
+	// do I need it" context OAuth2Authorizer/MCPHeadersAuthorizer give before
+	// their identity token gets used.
+	const handleRequestVerifyExchange = (client: MCPClient) => {
+		setExchangeVerifyClient(client);
+	};
+
+	const handleVerifyExchange = async (client: MCPClient) => {
+		try {
+			setVerifyingExchangeClients((prev) => [...prev, client.config.client_id]);
+			const response = await verifyMCPClientExchange(client.config.client_id).unwrap();
+			toast({ title: "Verified", description: response.message });
+			if (refetch) {
+				await refetch();
+			}
+		} catch (error) {
+			toast({ title: "Verification failed", description: getErrorMessage(error), variant: "destructive" });
+		} finally {
+			setVerifyingExchangeClients((prev) => prev.filter((id) => id !== client.config.client_id));
+		}
+	};
+
 	const handleDelete = async (client: MCPClient) => {
 		try {
 			await deleteMCPClient(client.config.client_id).unwrap();
@@ -443,6 +507,8 @@ export default function MCPClientsTable({
 			case "oauth":
 			case "per_user_oauth":
 				return "OAuth";
+			case "token_exchange":
+				return "Token Exchange";
 			default:
 				return type;
 		}
@@ -452,6 +518,7 @@ export default function MCPClientsTable({
 		switch (type) {
 			case "per_user_oauth":
 			case "per_user_headers":
+			case "token_exchange":
 				return "Per-User";
 			case "oauth":
 			case "headers":
@@ -619,6 +686,66 @@ export default function MCPClientsTable({
 				/>
 			)}
 
+			{/* Mirrors OAuth2Authorizer's confirm-step layout (icon header, muted
+			    info box, outline-cancel + default-continue footer) so token_exchange
+			    reverification reads as the same kind of admin-credential action,
+			    not a destructive one. */}
+			<Dialog open={!!exchangeVerifyClient} onOpenChange={(next) => !next && setExchangeVerifyClient(null)}>
+				<DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
+					<DialogHeader className="border-b px-5 py-4 text-left">
+						<div className="flex items-start gap-3">
+							<div className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-md">
+								<KeyRound className="size-4" />
+							</div>
+							<div className="min-w-0 space-y-0.5">
+								<DialogTitle className="text-sm leading-snug font-medium">Re-verify as me</DialogTitle>
+								<DialogDescription className="text-xs leading-relaxed">
+									Renew Bifrost&apos;s own discovery credential using your identity.
+								</DialogDescription>
+							</div>
+						</div>
+					</DialogHeader>
+					<div className="space-y-3 px-5 py-4">
+						<div className="border-border bg-muted/40 text-muted-foreground flex gap-3 rounded-md border p-3.5 text-sm">
+							<span className="mt-0.5 shrink-0">
+								<KeyRound className="size-4" />
+							</span>
+							<div className="space-y-1 leading-relaxed">
+								<p>
+									This exchanges your own signed-in identity to renew Bifrost&apos;s discovery credential for{" "}
+									<strong>{exchangeVerifyClient?.config.name}</strong>.
+								</p>
+								<p className="text-muted-foreground/80 text-xs">
+									That credential is only used to periodically fetch this server&apos;s tool list, not for real user requests,
+									whose tokens are exchanged automatically on every request. You only need this if the credential badge shows
+									it&apos;s expired, but running it any time is safe.
+								</p>
+							</div>
+						</div>
+						<div className="flex justify-end gap-2">
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={() => setExchangeVerifyClient(null)}
+								data-testid="verify-exchange-cancel-btn"
+							>
+								Cancel
+							</Button>
+							<Button
+								size="sm"
+								onClick={() => {
+									if (exchangeVerifyClient) void handleVerifyExchange(exchangeVerifyClient);
+									setExchangeVerifyClient(null);
+								}}
+								data-testid="verify-exchange-confirm-btn"
+							>
+								Continue
+							</Button>
+						</div>
+					</div>
+				</DialogContent>
+			</Dialog>
+
 			<div className="mb-4 flex items-center justify-between gap-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">MCP Server Catalog</h2>
@@ -702,7 +829,15 @@ export default function MCPClientsTable({
 									// Per-user auth types (OAuth + headers) don't hold a shared
 									// upstream connection, so reconnect is a no-op for them — the
 									// backend's ReconnectClient rejects with ErrMCPReconnectNotApplicable.
-									const isPerUserAuth = c.config.auth_type === "per_user_oauth" || c.config.auth_type === "per_user_headers";
+									const isPerUserAuth =
+										c.config.auth_type === "per_user_oauth" ||
+										c.config.auth_type === "per_user_headers" ||
+										c.config.auth_type === "token_exchange";
+									// Token-exchange clients hold no per-user session rows (nothing
+									// to view), unlike per_user_oauth/per_user_headers — mirrors
+									// mcpClientSheet.tsx's hasPerUserSessions.
+									const hasPerUserSessions =
+										c.config.auth_type === "per_user_oauth" || c.config.auth_type === "per_user_headers";
 									const enabledToolsCount =
 										c.state == "connected"
 											? c.config.tools_to_execute?.includes("*")
@@ -764,24 +899,30 @@ export default function MCPClientsTable({
 												)}
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
-												{isPerUserAuth ? (
+												{isPerUserAuth && (c.state === "pending_verification" || c.state === "needs_reauth") ? (
+													// pending_verification and needs_reauth are actionable
+													// admin-facing states (bootstrap / repair the retained admin
+													// credential) rather than a live per-caller connection state —
+													// surface just the badge, not the sessions link, since there's
+													// nothing to view yet (unverified) or the link isn't the fix
+													// (repair via the actions menu is).
+													<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
+												) : isPerUserAuth && hasPerUserSessions ? (
 													// Per-user clients never hold a shared upstream connection, so a
 													// connection-state badge here would be misleading: point to the
-													// per-user sessions this client actually has instead. The one
-													// exception is needs_reauth, which for per-user clients means the
-													// retained admin discovery credential needs repair: surface that
-													// badge next to the link so the admin can act on it.
-													<span className="flex items-center gap-2">
-														<Link
-															to="/workspace/mcp-sessions"
-															search={{ mcp_client_id: [c.config.client_id] }}
-															className="text-primary text-xs font-medium hover:underline"
-															data-testid={`mcp-client-view-sessions-${c.config.client_id}`}
-														>
-															View sessions
-														</Link>
-														{c.state === "needs_reauth" && <Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>}
-													</span>
+													// per-user sessions this client actually has instead.
+													<Link
+														to="/workspace/mcp-sessions"
+														search={{ mcp_client_id: [c.config.client_id] }}
+														className="text-primary text-xs font-medium hover:underline"
+														data-testid={`mcp-client-view-sessions-${c.config.client_id}`}
+													>
+														View sessions
+													</Link>
+												) : isPerUserAuth ? (
+													// Token exchange: no stored sessions to link to, and not in an
+													// actionable state — nothing to surface here.
+													null
 												) : (
 													<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
 												)}
@@ -833,12 +974,14 @@ export default function MCPClientsTable({
 													isReconnecting={reconnectingClients.includes(c.config.client_id)}
 													isAuthorizing={authorizingClients.includes(c.config.client_id)}
 													isReauthorizing={reauthorizingClients.includes(c.config.client_id)}
+													isVerifyingExchange={verifyingExchangeClients.includes(c.config.client_id)}
 													isPerUserAuth={isPerUserAuth}
 													onEdit={handleRowClick}
 													onReconnect={(client) => void handleReconnect(client)}
 													onAuthorize={(client) => void handleStartBootstrap(client)}
 													onReauthorize={(client) => void handleReauthorize(client)}
 													onRefreshHeaders={handleRefreshHeaders}
+													onVerifyExchange={handleRequestVerifyExchange}
 													onDelete={setClientToDelete}
 												/>
 											</TableCell>

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -284,6 +284,18 @@ export const mcpApi = baseApi.injectEndpoints({
 			}),
 			invalidatesTags: ["MCPClients"],
 		}),
+
+		// Verify a token_exchange MCP client (pending_verification bootstrap, or
+		// needs_reauth repair). No body: the backend exchanges the signed-in
+		// admin's own identity-provider token, verifies upstream, discovers
+		// tools, and retains the admin discovery credential.
+		verifyMCPClientExchange: builder.mutation<{ status: string; message: string; tools_count: number }, string>({
+			query: (mcpClientId) => ({
+				url: `/mcp/client/${mcpClientId}/verify-exchange`,
+				method: "POST",
+			}),
+			invalidatesTags: ["MCPClients"],
+		}),
 	}),
 });
 
@@ -304,4 +316,5 @@ export const {
 	useInitiateMCPClientVerificationMutation,
 	useReauthorizeMCPClientMutation,
 	useVerifyMCPClientHeadersMutation,
+	useVerifyMCPClientExchangeMutation,
 } = mcpApi;

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -12,7 +12,7 @@ export type MCPConnectionState =
 	| "disabled"
 	| "needs_reauth";
 
-export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers";
+export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers" | "token_exchange";
 
 // Lifecycle states for a per-user MCP header credential row. Mirrors the
 // status column on mcp_per_user_header_credentials.
@@ -34,6 +34,31 @@ export interface MCPStdioConfig {
 export interface MCPTLSConfig {
 	insecure_skip_verify?: boolean;
 	ca_cert_pem?: SecretVar;
+}
+
+// Delegated token-exchange scoping for auth_type === "token_exchange": each
+// caller's identity-provider token is exchanged at runtime for a short-lived
+// token scoped to this server's audience. Carries no credentials — the
+// exchange endpoint and client come from the deployment's identity-provider
+// integration.
+export interface MCPTokenExchangeConfig {
+	audience: string; // Resource identifier at the identity provider, e.g. "api://jira-mcp"
+	// Identity-provider application authorized to perform exchanges for this
+	// audience — a dedicated registration carrying the token-exchange (or
+	// on-behalf-of) grant, not the SSO login application. Redacted on GET.
+	client_id: SecretVar;
+	client_secret?: SecretVar; // Omit for public clients. Redacted on GET.
+	// Optional scopes on the exchanged token. Include "offline_access" (where
+	// the identity provider supports it) so the retained admin discovery
+	// credential gets a refresh token and stays self-renewing.
+	scopes?: string[];
+	// Overrides where the exchange request is sent, for identity providers
+	// that bind an audience to a specific authorization server distinct from
+	// the one used for SSO login (e.g. Okta's per-resource Custom
+	// Authorization Servers). Leave empty to use the deployment's SSO login
+	// issuer, which is correct for providers with one tenant-wide token
+	// endpoint (Entra, Auth0).
+	authorization_server_url?: string;
 }
 
 export interface OAuthConfig {
@@ -85,6 +110,9 @@ export interface MCPClientConfig {
 	// in the credential store, not on the client config. Required (non-empty)
 	// for per_user_headers auth; ignored for all other auth types.
 	per_user_header_keys?: string[];
+	// token_exchange-only: audience/scopes the exchanged tokens are scoped to.
+	// Required (with a non-empty audience) for token_exchange auth.
+	token_exchange?: MCPTokenExchangeConfig;
 	is_ping_available?: boolean;
 	tool_pricing?: Record<string, number>;
 	// Per-client override (0 = use global, -1 = disabled). API returns NANOSECONDS
@@ -124,6 +152,11 @@ export interface CreateMCPClientRequest {
 	headers?: Record<string, SecretVar>;
 	// per_user_headers-only: admin-declared header schema (names only).
 	per_user_header_keys?: string[];
+	// token_exchange-only: audience/scopes the exchanged tokens are scoped to.
+	// Verification runs automatically as the signed-in admin (their own
+	// identity-provider token is the exchange subject); sessions without one
+	// (e.g. API-key auth) create the client in pending_verification.
+	token_exchange?: MCPTokenExchangeConfig;
 	// per_user_headers-only: a sample set of header values supplied by the
 	// admin so the server can verify upstream + discover tools in the same
 	// create call. Discarded after verification (never persisted). Mirrors
@@ -176,6 +209,7 @@ export interface UpdateMCPClientRequest {
 	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect
 	tls_config?: MCPTLSConfig; // TLS configuration for HTTP/SSE connections
 	oauth_config?: OAuthConfigUpdate; // Only supported for existing oauth/per_user_oauth clients (credential rotation)
+	token_exchange?: MCPTokenExchangeConfig; // Only supported for existing token_exchange clients; omitted = preserve
 	vk_configs?: MCPVKConfig[]; // When provided, replaces all VK assignments for this MCP client
 }
 
@@ -187,7 +221,7 @@ export interface GetMCPClientsParams {
 	server?: string;
 	// Comma-separated exact-match filters (OR semantics), mirroring the library page.
 	connection_type?: string; // http,sse,stdio
-	auth_type?: string; // none,headers,oauth,per_user_oauth,per_user_headers
+	auth_type?: string; // none,headers,oauth,per_user_oauth,per_user_headers,token_exchange
 	state?: string; // connected,disconnected — resolved against live engine state
 	virtual_keys?: string; // comma-separated VK IDs the client is assigned to
 	// Boolean facets — omit for "no filter".

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1196,6 +1196,18 @@ export const mcpClientUpdateSchema = z.object({
 			resource: z.string().optional(),
 		})
 		.optional(),
+	token_exchange: z
+		.object({
+			audience: z.string().trim().min(1, "Audience is required"),
+			client_id: secretVarSchema.optional(),
+			client_secret: secretVarSchema.optional(),
+			authorization_server_url: z
+				.string()
+				.optional()
+				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Authorization Server URL must start with http:// or https://" }),
+			scopes: z.array(z.string()).optional(),
+		})
+		.optional(),
 	tls_config: z
 		.object({
 			insecure_skip_verify: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Adds `token_exchange` as a first-class MCP auth type, enabling OAuth 2.0 Token Exchange (On-Behalf-Of) for MCP clients. When configured, each caller's identity-provider token is automatically exchanged at runtime for a short-lived token scoped to the target server's audience — no per-user login flow, no shared credential, and no persistent session rows. The feature is gated behind `IS_ENTERPRISE` and requires an active SCIM/IdP integration to be visible in the UI.

## Changes

- Added `token_exchange` to the `MCPAuthType` union and introduced `MCPTokenExchangeConfig` (audience, exchange client ID/secret, optional scopes) to the MCP type definitions and request/response interfaces.
- Extended the MCP client creation form with a `token_exchange` auth kind option, including fields for audience, exchange client ID, exchange client secret (optional), and scopes. The option only renders when the deployment has an IdP configured.
- Removed the "Auth Scope" dropdown for `token_exchange` since it is inherently per-caller with no shared variant.
- Added a `verifyMCPClientExchange` API mutation that POSTs to `/mcp/client/:id/verify-exchange` with no body; the backend exchanges the signed-in admin's own identity token to bootstrap and discover tools.
- Wired `token_exchange` into the client sheet: bootstrap uses "Verify as me" instead of an OAuth browser flow, a "Re-verify as me" repair button appears on `needs_reauth`, and the connection-state badge is suppressed (no persistent session to display).
- Classified `token_exchange` as a per-user auth type throughout the table and sheet so reconnect actions and session links are correctly suppressed.
- Added `token_exchange` as a filter option in the clients filter sidebar and as a display label in the clients table.
- Added `token_exchange` label and help text to the MCP library install sheet.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Deploy with an enterprise license and an active SCIM/IdP integration enabled.
2. Navigate to the MCP Clients page and open the "Add Client" form.
3. Confirm "Token Exchange (On-Behalf-Of)" appears in the auth type dropdown only when an IdP is configured.
4. Select it and verify the audience, exchange client ID, exchange client secret, and scopes fields render; confirm the "Auth Scope" dropdown is absent.
5. Create a client — the backend should exchange your signed-in identity token, verify upstream, and discover tools.
6. Confirm the client sheet shows "Verify as me" for `pending_verification` and "Re-verify as me" for `needs_reauth`.
7. Confirm no sessions link or live connection badge appears for `token_exchange` clients.
8. Confirm `token_exchange` appears as a filter option in the sidebar and renders "Token Exchange" / "Per-User" in the table columns.

```sh
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- Exchange client credentials (client ID and secret) are treated as `SecretVar` values and are redacted on GET responses, consistent with existing OAuth credential handling.
- The token exchange verification endpoint uses the signed-in admin's own identity token as the exchange subject; sessions authenticated only via virtual/API keys cannot bootstrap or use `token_exchange` clients, enforced server-side.
- No exchanged tokens are persisted; they are short-lived and scoped per tool call.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable