### PR TITLE
feat: retry shared-connection MCP auth failures after bounded reconnect wait with concurrent dedup

### DIFF
--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -79,11 +80,15 @@ func (m *MockClientManager) GetToolPerClient(ctx context.Context) map[string][]s
 }
 
 func (m *MockClientManager) GetPluginPipeline() PluginPipeline             { return nil }
-func (m *MockClientManager) ReleasePluginPipeline(pipeline PluginPipeline)  {}
+func (m *MockClientManager) ReleasePluginPipeline(pipeline PluginPipeline) {}
 func (m *MockClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schemas.MCPClientState) (*client.Client, func(), error) {
 	return nil, func() {}, nil
 }
 func (m *MockClientManager) ReconnectClient(id string) error { return nil }
+
+func (m *MockClientManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
+	return false, nil
+}
 func (m *MockClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
 	resp, err := op(req)
 	if err != nil {
@@ -577,6 +582,10 @@ func (m *MockAutoClientManager) AcquireClientConn(ctx *schemas.BifrostContext, s
 	return nil, func() {}, nil
 }
 func (m *MockAutoClientManager) ReconnectClient(id string) error { return nil }
+
+func (m *MockAutoClientManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
+	return false, nil
+}
 func (m *MockAutoClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
 	resp, err := op(req)
 	if err != nil {

--- a/core/mcp/auth_retry_test.go
+++ b/core/mcp/auth_retry_test.go
@@ -154,9 +154,34 @@ type authRetryClientManager struct {
 	reconnectErr    error
 	reconnectCalls  atomic.Int32
 	reconnectSignal chan struct{}
+
+	// reconnectGate, when non-nil, blocks an in-flight ReconnectClient until
+	// the channel is closed, letting tests hold the reconnect open while the
+	// caller's bounded wait (or a concurrent second caller) races against it.
+	reconnectGate chan struct{}
+	// reconnectRejected counts callers that lost the in-flight race and got
+	// the "already in progress" error, mirroring the real manager's guard.
+	reconnectRejected atomic.Int32
+
+	// rerouteToolState, when non-nil, is what GetClientForTool returns
+	// instead of state — simulating global tool routing having picked a
+	// different client for this tool name by the time a stale lookup runs.
+	rerouteToolState *schemas.MCPClientState
+	// byNameState, when non-nil, is what GetClientByName(state.Name) returns
+	// instead of state itself — simulating the reconnected client having a
+	// different identity (e.g. a different ExecutionConfig.ID, as if it was
+	// deleted and recreated under the same name) by the time the
+	// post-reconnect reacquire runs.
+	byNameState *schemas.MCPClientState
+
+	inflightMu sync.Mutex
+	inflight   *inflightClientOp
 }
 
 func (m *authRetryClientManager) GetClientByName(clientName string) *schemas.MCPClientState {
+	if m.byNameState != nil {
+		return m.byNameState
+	}
 	if m.state != nil && m.state.Name == clientName {
 		return m.state
 	}
@@ -164,6 +189,11 @@ func (m *authRetryClientManager) GetClientByName(clientName string) *schemas.MCP
 }
 
 func (m *authRetryClientManager) GetClientForTool(toolName string) *schemas.MCPClientState {
+	if m.rerouteToolState != nil {
+		if _, ok := m.rerouteToolState.ToolMap[toolName]; ok {
+			return m.rerouteToolState
+		}
+	}
 	if m.state != nil {
 		if _, ok := m.state.ToolMap[toolName]; ok {
 			return m.state
@@ -176,8 +206,8 @@ func (m *authRetryClientManager) GetToolPerClient(_ context.Context) map[string]
 	return nil
 }
 
-func (m *authRetryClientManager) GetPluginPipeline() PluginPipeline            { return nil }
-func (m *authRetryClientManager) ReleasePluginPipeline(_ PluginPipeline)       {}
+func (m *authRetryClientManager) GetPluginPipeline() PluginPipeline      { return nil }
+func (m *authRetryClientManager) ReleasePluginPipeline(_ PluginPipeline) {}
 
 func (m *authRetryClientManager) AcquireClientConn(_ *schemas.BifrostContext, _ *schemas.MCPClientState) (*client.Client, func(), error) {
 	m.acquireCalls.Add(1)
@@ -188,6 +218,23 @@ func (m *authRetryClientManager) AcquireClientConn(_ *schemas.BifrostContext, _ 
 }
 
 func (m *authRetryClientManager) ReconnectClient(_ string) error {
+	m.inflightMu.Lock()
+	if m.inflight != nil {
+		select {
+		case <-m.inflight.done:
+			// Previous op already finished; fall through and replace it, the
+			// same CompareAndSwap-on-a-done-op behavior beginExclusiveClientOp
+			// uses in clientmanager.go.
+		default:
+			m.inflightMu.Unlock()
+			m.reconnectRejected.Add(1)
+			return errors.New("reconnect already in progress for this client")
+		}
+	}
+	op := &inflightClientOp{done: make(chan struct{})}
+	m.inflight = op
+	m.inflightMu.Unlock()
+
 	m.reconnectCalls.Add(1)
 	if m.reconnectSignal != nil {
 		select {
@@ -195,7 +242,54 @@ func (m *authRetryClientManager) ReconnectClient(_ string) error {
 		default:
 		}
 	}
-	return m.reconnectErr
+	if m.reconnectGate != nil {
+		<-m.reconnectGate
+	}
+	err := m.reconnectErr
+
+	m.inflightMu.Lock()
+	op.err = err
+	close(op.done)
+	// Deliberately not cleared to nil here: a caller that lost the race and
+	// got "already in progress" above must still be able to observe this
+	// op's outcome via AwaitReconnect after it completes — clearing
+	// immediately would let that caller poll AwaitReconnect a moment too
+	// late, see inflight == nil, and wrongly conclude nothing is (or ever
+	// was) in flight. Mirrors beginExclusiveClientOp's real behavior: the
+	// completed op is only replaced by the next ReconnectClient call, not
+	// deleted on finish. Use resetInflight for tests that need a clean
+	// no-op starting state instead.
+	m.inflightMu.Unlock()
+	return err
+}
+
+// resetInflight clears any completed inflight record so the next
+// ReconnectClient call starts from a clean no-op state. Only needed by tests
+// that reuse the same authRetryClientManager across multiple reconnect
+// phases and require no stale op to be observable via AwaitReconnect;
+// ReconnectClient's own CompareAndSwap-style replace makes this unnecessary
+// for tests that just call ReconnectClient again.
+func (m *authRetryClientManager) resetInflight() {
+	m.inflightMu.Lock()
+	m.inflight = nil
+	m.inflightMu.Unlock()
+}
+
+func (m *authRetryClientManager) AwaitReconnect(_ string, budget time.Duration) (bool, error) {
+	m.inflightMu.Lock()
+	op := m.inflight
+	m.inflightMu.Unlock()
+	if op == nil {
+		return false, nil
+	}
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-op.done:
+		return true, op.err
+	case <-timer.C:
+		return false, nil
+	}
 }
 
 func (m *authRetryClientManager) RunWithPluginPipeline(_ *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
@@ -417,26 +511,124 @@ func TestExecuteTool_AuthFailureRetry_PerUser_RetryAlsoFails(t *testing.T) {
 	}
 }
 
-// TestExecuteTool_AuthFailureRetry_Shared_FailsFastAndTriggersBackgroundReconnect
-// covers the shared-connection path: the original call fails and returns
-// immediately (no synchronous retry — a full ReconnectClient can take
-// minutes), while a background goroutine forces a refresh and reconnects so
-// the NEXT call succeeds. Asserts the goroutine actually runs, not just that
-// the immediate call failed.
-func TestExecuteTool_AuthFailureRetry_Shared_FailsFastAndTriggersBackgroundReconnect(t *testing.T) {
-	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, nil)
+// TestExecuteTool_AuthFailureRetry_Shared_RetriesAfterReconnectCompletes
+// covers the shared-connection happy path: the original call fails with a
+// 401, a background goroutine forces a refresh and reconnects, and because
+// the reconnect completes within the bounded wait budget the SAME call is
+// retried once on the healed connection and succeeds.
+func TestExecuteTool_AuthFailureRetry_Shared_RetriesAfterReconnectCompletes(t *testing.T) {
+	// Explicit idempotent hint: retry-safety fails closed on missing
+	// annotations (see TestExecuteTool_AuthFailureRetry_NoAnnotations_SkipsRetry),
+	// so this reconnect-mechanics test needs an explicitly-safe tool to reach
+	// the retry path at all.
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, boolPtr(true))
 
 	ft := &fakeCallToolTransport{callErrs: []error{errors.New("tool call failed: 401 Unauthorized")}}
 	conn := client.NewClient(ft, client.WithSession())
 
-	reconnectSignal := make(chan struct{}, 1)
-	forceRefreshSignal := make(chan struct{}, 1)
-
-	cm := &authRetryClientManager{state: state, reconnectSignal: reconnectSignal}
-	cs := &authRetryCredStore{requiresPerCall: false, forceRefreshSignal: forceRefreshSignal}
+	cm := &authRetryClientManager{state: state, acquireConn: conn}
+	cs := &authRetryCredStore{requiresPerCall: false}
 	tm := newAuthRetryToolsManager(cm, cs)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := newAuthRetryToolCallRequest(toolName)
+
+	resp, err := tm.ExecuteTool(ctx, req, conn, state.ExecutionConfig, state.ToolNameMapping)
+	if err != nil {
+		t.Fatalf("expected the retry after a completed reconnect to succeed, got error: %v", err)
+	}
+	if resp == nil || resp.ChatMessage == nil {
+		t.Fatalf("expected a populated chat message response, got %+v", resp)
+	}
+	if got := ft.CallCount(); got != 2 {
+		t.Errorf("expected 2 CallTool invocations (original + exactly 1 retry), got %d", got)
+	}
+	if got := cm.reconnectCalls.Load(); got != 1 {
+		t.Errorf("expected ReconnectClient to run exactly once, got %d", got)
+	}
+	if got := cs.forceRefreshCalls.Load(); got != 1 {
+		t.Errorf("expected the background ForceRefresh to run exactly once, got %d", got)
+	}
+	if got := cm.acquireCalls.Load(); got != 1 {
+		t.Errorf("expected AcquireClientConn to run exactly once for the retry, got %d", got)
+	}
+}
+
+// TestExecuteTool_AuthFailureRetry_Shared_RoutingChangedDuringReconnect_RejectsRetry
+// pins the gap CodeRabbit flagged: recoverSharedConnection re-resolved its
+// retry target via GetClientForTool(toolName) — global tool-name routing
+// across every client — instead of reacquiring the specific client that was
+// just reconnected. If routing picks a different client for this tool name
+// while the reconnect is in flight, the stale lookup would silently retry
+// the ORIGINAL callRequest against an unintended upstream, breaking provider
+// isolation. The retry must reacquire by the reconnected client's own name
+// and refuse to proceed if the resolved state's ExecutionConfig.ID doesn't
+// match, surfacing the original auth failure instead of retrying nowhere.
+func TestExecuteTool_AuthFailureRetry_Shared_RoutingChangedDuringReconnect_RejectsRetry(t *testing.T) {
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, boolPtr(true))
+
+	// What GetClientByName("sharedclient") resolves to by the time the
+	// post-reconnect reacquire runs: same name, but a different
+	// ExecutionConfig.ID — as if the client was deleted and recreated under
+	// the same name while the reconnect was in flight. A stale caller
+	// holding the original executionConfig must not treat this as the same
+	// client it was retrying for.
+	mismatched := &schemas.MCPClientState{
+		Name:            "sharedclient",
+		ExecutionConfig: &schemas.MCPClientConfig{ID: "sharedclient-id-v2", Name: "sharedclient"},
+		ToolMap:         state.ToolMap,
+		ToolNameMapping: map[string]string{},
+	}
+
+	ft := &fakeCallToolTransport{callErrs: []error{errors.New("tool call failed: 401 Unauthorized")}}
+	conn := client.NewClient(ft, client.WithSession())
+
+	cm := &authRetryClientManager{state: state, acquireConn: conn, byNameState: mismatched}
+	cs := &authRetryCredStore{requiresPerCall: false}
+	tm := newAuthRetryToolsManager(cm, cs)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := newAuthRetryToolCallRequest(toolName)
+
+	_, err := tm.ExecuteTool(ctx, req, conn, state.ExecutionConfig, state.ToolNameMapping)
+	if err == nil {
+		t.Fatalf("expected the original auth failure to surface when routing resolves to a different client, got no error")
+	}
+	if got := ft.CallCount(); got != 1 {
+		t.Errorf("must not retry against the rerouted client: expected exactly 1 CallTool invocation (the original), got %d", got)
+	}
+	if got := cm.acquireCalls.Load(); got != 0 {
+		t.Errorf("must not acquire a connection for the mismatched client, got %d AcquireClientConn calls", got)
+	}
+}
+
+// TestExecuteTool_AuthFailureRetry_Shared_FallsBackWhenReconnectExceedsBudget
+// covers the bounded-wait give-up: the reconnect is held open past the
+// caller's remaining deadline (which caps the wait budget), so the original
+// auth failure surfaces with no retry while the reconnect keeps running in
+// the background.
+func TestExecuteTool_AuthFailureRetry_Shared_FallsBackWhenReconnectExceedsBudget(t *testing.T) {
+	// Explicit idempotent hint: retry-safety fails closed on missing
+	// annotations (see TestExecuteTool_AuthFailureRetry_NoAnnotations_SkipsRetry),
+	// so without it this test's "no retry" assertions would pass for the
+	// wrong reason (annotation fail-closed) instead of proving the budget
+	// give-up path this test is named for.
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, boolPtr(true))
+
+	ft := &fakeCallToolTransport{callErrs: []error{errors.New("tool call failed: 401 Unauthorized")}}
+	conn := client.NewClient(ft, client.WithSession())
+
+	reconnectGate := make(chan struct{})
+	defer close(reconnectGate) // let the held reconnect goroutine finish after the test
+
+	reconnectSignal := make(chan struct{}, 1)
+	cm := &authRetryClientManager{state: state, acquireConn: conn, reconnectGate: reconnectGate, reconnectSignal: reconnectSignal}
+	cs := &authRetryCredStore{requiresPerCall: false}
+	tm := newAuthRetryToolsManager(cm, cs)
+
+	// A short caller deadline caps the reconnect wait budget well below the
+	// package const, keeping the test fast.
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(300*time.Millisecond))
 	req := newAuthRetryToolCallRequest(toolName)
 
 	start := time.Now()
@@ -444,38 +636,186 @@ func TestExecuteTool_AuthFailureRetry_Shared_FailsFastAndTriggersBackgroundRecon
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Fatal("expected the original call to fail")
+		t.Fatal("expected the original error to surface when the reconnect exceeds the budget")
 	}
 	if !errors.Is(err, ErrMCPToolCallFailed) {
 		t.Errorf("expected error to wrap ErrMCPToolCallFailed, got: %v", err)
 	}
 	if got := ft.CallCount(); got != 1 {
-		t.Errorf("shared-connection auth failures must not retry synchronously, got %d CallTool invocations", got)
-	}
-	if elapsed > 2*time.Second {
-		t.Errorf("expected the call to fail fast (no synchronous ReconnectClient), took %v", elapsed)
+		t.Errorf("expected no retry when the reconnect exceeds the budget, got %d CallTool invocations", got)
 	}
 	if got := cm.acquireCalls.Load(); got != 0 {
-		t.Errorf("shared-connection path must not call AcquireClientConn, got %d calls", got)
+		t.Errorf("AcquireClientConn must not run when the reconnect exceeds the budget, got %d calls", got)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected the bounded wait to give up quickly under a short caller deadline, took %v", elapsed)
 	}
 
-	// The background goroutine (ForceRefresh, then ReconnectClient) must
-	// actually run — not just the immediate failure.
-	select {
-	case <-forceRefreshSignal:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected the background goroutine to call ForceRefresh, but it never did")
-	}
+	// The reconnect itself must still have been triggered and left running.
 	select {
 	case <-reconnectSignal:
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected the background goroutine to call ReconnectClient, but it never did")
 	}
+}
+
+// TestExecuteTool_AuthFailureRetry_Shared_ReconnectFails_OriginalErrorSurfaces
+// covers the reconnect-failed branch: the reconnect completes within budget
+// but with an error, so no retry runs and the original failure surfaces.
+func TestExecuteTool_AuthFailureRetry_Shared_ReconnectFails_OriginalErrorSurfaces(t *testing.T) {
+	// Explicit idempotent hint: retry-safety fails closed on missing
+	// annotations (see TestExecuteTool_AuthFailureRetry_NoAnnotations_SkipsRetry),
+	// so this reconnect-mechanics test needs an explicitly-safe tool to reach
+	// the retry path at all.
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, boolPtr(true))
+
+	ft := &fakeCallToolTransport{callErrs: []error{errors.New("tool call failed: 401 Unauthorized")}}
+	conn := client.NewClient(ft, client.WithSession())
+
+	cm := &authRetryClientManager{state: state, acquireConn: conn, reconnectErr: errors.New("dial tcp: connection refused")}
+	cs := &authRetryCredStore{requiresPerCall: false}
+	tm := newAuthRetryToolsManager(cm, cs)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := newAuthRetryToolCallRequest(toolName)
+
+	_, err := tm.ExecuteTool(ctx, req, conn, state.ExecutionConfig, state.ToolNameMapping)
+	if err == nil {
+		t.Fatal("expected the original error to surface when the reconnect fails")
+	}
+	if !errors.Is(err, ErrMCPToolCallFailed) {
+		t.Errorf("expected error to wrap ErrMCPToolCallFailed, got: %v", err)
+	}
+	if got := ft.CallCount(); got != 1 {
+		t.Errorf("expected no retry when the reconnect fails, got %d CallTool invocations", got)
+	}
+	if got := cm.reconnectCalls.Load(); got != 1 {
+		t.Errorf("expected ReconnectClient to run exactly once, got %d", got)
+	}
+	if got := cm.acquireCalls.Load(); got != 0 {
+		t.Errorf("AcquireClientConn must not run when the reconnect fails, got %d calls", got)
+	}
+}
+
+// TestExecuteTool_AuthFailureRetry_Shared_DestructiveNonIdempotent_ReconnectsWithoutRetry
+// pins the opt-out ordering on the shared path: a destructive, non-idempotent
+// tool must never be auto-retried, but the connection healing (background
+// force-refresh + reconnect) must still run so subsequent calls succeed.
+func TestExecuteTool_AuthFailureRetry_Shared_DestructiveNonIdempotent_ReconnectsWithoutRetry(t *testing.T) {
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", boolPtr(true), nil)
+
+	ft := &fakeCallToolTransport{callErrs: []error{errors.New("tool call failed: 401 Unauthorized")}}
+	conn := client.NewClient(ft, client.WithSession())
+
+	reconnectSignal := make(chan struct{}, 1)
+	forceRefreshSignal := make(chan struct{}, 1)
+
+	cm := &authRetryClientManager{state: state, acquireConn: conn, reconnectSignal: reconnectSignal}
+	cs := &authRetryCredStore{requiresPerCall: false, forceRefreshSignal: forceRefreshSignal}
+	tm := newAuthRetryToolsManager(cm, cs)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := newAuthRetryToolCallRequest(toolName)
+
+	_, err := tm.ExecuteTool(ctx, req, conn, state.ExecutionConfig, state.ToolNameMapping)
+	if err == nil {
+		t.Fatal("expected the original error to surface for a destructive, non-idempotent tool")
+	}
+	if !errors.Is(err, ErrMCPToolCallFailed) {
+		t.Errorf("expected error to wrap ErrMCPToolCallFailed, got: %v", err)
+	}
+	if got := ft.CallCount(); got != 1 {
+		t.Errorf("destructive, non-idempotent tool must not be retried, got %d CallTool invocations", got)
+	}
+	if got := cm.acquireCalls.Load(); got != 0 {
+		t.Errorf("AcquireClientConn must not run when the retry is opted out, got %d calls", got)
+	}
+
+	// The connection healing must still run despite the retry opt-out.
+	select {
+	case <-forceRefreshSignal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the background goroutine to call ForceRefresh despite the retry opt-out, but it never did")
+	}
+	select {
+	case <-reconnectSignal:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the background goroutine to call ReconnectClient despite the retry opt-out, but it never did")
+	}
 	if got := cm.reconnectCalls.Load(); got != 1 {
 		t.Errorf("expected ReconnectClient to be triggered exactly once, got %d", got)
 	}
-	if got := cs.forceRefreshCalls.Load(); got != 1 {
-		t.Errorf("expected the background ForceRefresh to run exactly once, got %d", got)
+}
+
+// TestExecuteTool_AuthFailureRetry_Shared_Concurrent401sJoinOneReconnect
+// covers the dedup contract: two concurrent 401s on the same shared client
+// trigger only one actual reconnect; the loser of the race joins the
+// winner's in-flight attempt and both calls retry successfully once it
+// completes.
+func TestExecuteTool_AuthFailureRetry_Shared_Concurrent401sJoinOneReconnect(t *testing.T) {
+	// Explicit idempotent hint: retry-safety fails closed on missing
+	// annotations (see TestExecuteTool_AuthFailureRetry_NoAnnotations_SkipsRetry),
+	// so this reconnect-mechanics test needs an explicitly-safe tool to reach
+	// the retry path at all.
+	state, toolName := newAuthRetryClientState("sharedclient", "dotool", nil, boolPtr(true))
+
+	ft := &fakeCallToolTransport{callErrs: []error{
+		errors.New("tool call failed: 401 Unauthorized"),
+		errors.New("tool call failed: 401 Unauthorized"),
+	}}
+	conn := client.NewClient(ft, client.WithSession())
+
+	reconnectGate := make(chan struct{})
+	reconnectSignal := make(chan struct{}, 1)
+	cm := &authRetryClientManager{state: state, acquireConn: conn, reconnectGate: reconnectGate, reconnectSignal: reconnectSignal}
+	cs := &authRetryCredStore{requiresPerCall: false}
+	tm := newAuthRetryToolsManager(cm, cs)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			req := newAuthRetryToolCallRequest(toolName)
+			_, errs[idx] = tm.ExecuteTool(ctx, req, conn, state.ExecutionConfig, state.ToolNameMapping)
+		}(i)
+	}
+
+	// Hold the winner's reconnect open until the loser has demonstrably lost
+	// the race (got the "already in progress" rejection), then release it.
+	select {
+	case <-reconnectSignal:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected a reconnect to start, but none did")
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for cm.reconnectRejected.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("expected the second 401 to lose the reconnect race, but no rejection was observed")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(reconnectGate)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("expected concurrent call %d to succeed after joining the shared reconnect, got: %v", i, err)
+		}
+	}
+	if got := cm.reconnectCalls.Load(); got != 1 {
+		t.Errorf("expected exactly one actual reconnect for concurrent 401s, got %d", got)
+	}
+	if got := cm.reconnectRejected.Load(); got != 1 {
+		t.Errorf("expected exactly one caller to lose the reconnect race, got %d", got)
+	}
+	if got := ft.CallCount(); got != 4 {
+		t.Errorf("expected 4 CallTool invocations (2 originals + 2 retries), got %d", got)
+	}
+	if got := cm.acquireCalls.Load(); got != 2 {
+		t.Errorf("expected each concurrent caller to acquire the healed connection once, got %d", got)
 	}
 }
 

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -223,6 +223,53 @@ func (m *MCPManager) GetClients() []schemas.MCPClientState {
 	return clients
 }
 
+// inflightClientOp tracks one in-flight exclusive operation on a client
+// (reconnect, enable/disable, credential update). Waiters observe completion
+// through the done channel; err carries the operation's final outcome and is
+// only safe to read after done is closed.
+type inflightClientOp struct {
+	done chan struct{}
+	err  error
+}
+
+// beginExclusiveClientOp atomically registers an in-flight exclusive operation
+// for the given client ID. ok is false when another operation already holds the
+// slot, preserving the second-caller-errors contract every guarded entry point
+// relies on. On success the caller must invoke finish exactly once with the
+// operation's final error so waiters parked in AwaitReconnect get the outcome.
+func (m *MCPManager) beginExclusiveClientOp(id string) (finish func(error), ok bool) {
+	op := &inflightClientOp{done: make(chan struct{})}
+	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, op); alreadyInFlight {
+		return nil, false
+	}
+	return func(err error) {
+		op.err = err
+		close(op.done)
+		m.reconnectingClients.Delete(id)
+	}, true
+}
+
+// AwaitReconnect waits up to budget for the in-flight exclusive operation on
+// the given client (typically a reconnect) to complete. Returns (true, finalErr)
+// when the operation finished within the budget, and (false, nil) when nothing
+// is in flight or the wait timed out. A timed-out wait never cancels the
+// underlying operation; it keeps running to completion in the background.
+func (m *MCPManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
+	v, ok := m.reconnectingClients.Load(clientID)
+	if !ok {
+		return false, nil
+	}
+	op := v.(*inflightClientOp)
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case <-op.done:
+		return true, op.err
+	case <-timer.C:
+		return false, nil
+	}
+}
+
 // CloseAndMarkNeedsReauth tears down a shared client's live upstream
 // connection and flips it to NeedsReauth, without attempting a new dial.
 // Used after OAuth credential rotation: RotateMCPOAuthConfig has already
@@ -237,11 +284,12 @@ func (m *MCPManager) GetClients() []schemas.MCPClientState {
 //
 // Returns:
 //   - error: if the client does not exist or has no persistent connection
-func (m *MCPManager) CloseAndMarkNeedsReauth(id string) error {
-	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+func (m *MCPManager) CloseAndMarkNeedsReauth(id string) (retErr error) {
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -284,12 +332,13 @@ func (m *MCPManager) CloseAndMarkNeedsReauth(id string) error {
 //
 // Returns:
 //   - error: Any error that occurred during reconnection
-func (m *MCPManager) ReconnectClient(id string) error {
+func (m *MCPManager) ReconnectClient(id string) (retErr error) {
 	// Acquire per-client reconnect/update guard before reading config snapshot.
-	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect already in progress for this client")
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	m.mu.Lock()
 	client, ok := m.clientMap[id]
@@ -932,16 +981,18 @@ func (m *MCPManager) removeClientUnsafe(id string) error {
 //
 // Returns:
 //   - error: Any error that occurred during disable
-func (m *MCPManager) DisableClient(id string) error {
+func (m *MCPManager) DisableClient(id string) (retErr error) {
 	// The internal in-process client must never be disabled:
 	if id == BifrostMCPClientKey {
 		return fmt.Errorf("cannot disable internal bifrost client")
 	}
-	// Use LoadOrStore (not Load) so the check and the sentinel insertion are atomic.
-	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+	// beginExclusiveClientOp registers atomically, so the check and the
+	// in-flight record insertion cannot race another operation.
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -992,7 +1043,7 @@ func (m *MCPManager) DisableClient(id string) error {
 //
 // Returns:
 //   - error: Any error that occurred during enable or connection
-func (m *MCPManager) EnableClient(id string) error {
+func (m *MCPManager) EnableClient(id string) (retErr error) {
 	m.mu.Lock()
 	clientState, ok := m.clientMap[id]
 	if !ok {
@@ -1028,12 +1079,13 @@ func (m *MCPManager) EnableClient(id string) error {
 	}
 
 	// Guard against concurrent reconnects for the same client from any caller
-	// (health monitor, manual API call, etc.). LoadOrStore is atomic — whichever
+	// (health monitor, manual API call, etc.). Registration is atomic: whichever
 	// caller arrives second gets the "already in progress" error immediately.
-	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect already in progress for this client")
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	if err := m.connectToMCPClient(m.ctx, configCopy); err != nil {
 		// Connection failed — leave the entry as Disconnected so the health monitor can
@@ -1083,11 +1135,12 @@ func (m *MCPManager) EnableClient(id string) error {
 //
 // Returns:
 //   - error: Any error that occurred during client update or tool retrieval
-func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientConfig) error {
-	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientConfig) (retErr error) {
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1208,17 +1261,18 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 //
 // Returns:
 //   - error: Any connection error; nil on success
-func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPClientConfig) error {
+func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPClientConfig) (retErr error) {
 	if newConfig == nil {
 		return fmt.Errorf("newConfig must not be nil")
 	}
 	// Hold the per-client reconnect guard for the entire read + long reconnect so
 	// UpdateClient/DisableClient cannot mutate ExecutionConfig while a failed reconnect
 	// restores the pre-attempt snapshot.
-	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
 		return fmt.Errorf("reconnect already in progress for this client")
 	}
-	defer m.reconnectingClients.Delete(id)
+	defer func() { finish(retErr) }()
 
 	m.mu.RLock()
 	client, ok := m.clientMap[id]

--- a/core/mcp/codemode/starlark/starlark_test.go
+++ b/core/mcp/codemode/starlark/starlark_test.go
@@ -49,6 +49,10 @@ func (m *testClientManager) AcquireClientConn(ctx *schemas.BifrostContext, state
 	return nil, func() {}, nil
 }
 func (m *testClientManager) ReconnectClient(id string) error { return nil }
+
+func (m *testClientManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
+	return false, nil
+}
 func (m *testClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op codemcp.MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
 	resp, err := op(req)
 	if err != nil {

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -22,6 +22,11 @@ const (
 	BifrostMCPClientKey                 = "bifrostInternal" // Key for internal Bifrost client in clientMap
 	MCPLogPrefix                        = "[Bifrost MCP]"   // Consistent logging prefix
 	MCPClientConnectionEstablishTimeout = 30 * time.Second  // Timeout for MCP client connection establishment
+	// MCPSharedAuthRetryReconnectBudget is the longest a failing shared-connection
+	// tool call waits for the reconnect it triggered before surfacing the original
+	// auth failure. The reconnect itself keeps running in the background when the
+	// budget elapses. Also capped by the calling request's own remaining deadline.
+	MCPSharedAuthRetryReconnectBudget = 10 * time.Second
 )
 
 // ============================================================================
@@ -42,7 +47,7 @@ type MCPManager struct {
 	serverRunning        bool                               // Track whether local MCP server is running
 	healthMonitorManager *HealthMonitorManager              // Manager for client health monitors
 	toolSyncManager      *ToolSyncManager                   // Manager for periodic tool synchronization
-	reconnectingClients  sync.Map                           // Tracks in-flight reconnect attempts per client ID (map[string]bool)
+	reconnectingClients  sync.Map                           // Tracks in-flight exclusive client operations per client ID (map[string]*inflightClientOp); waiters join via AwaitReconnect
 	bootClientConfigs    []*schemas.MCPClientConfig         // Client configs supplied at construction, dialed by ConnectConfiguredClients
 	connectOnce          sync.Once                          // Ensures ConnectConfiguredClients dials the boot configs exactly once
 

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,6 +40,14 @@ type ClientManager interface {
 	// per-call-connection (per-user) auth types, matching its existing
 	// contract.
 	ReconnectClient(id string) error
+	// AwaitReconnect waits up to budget for an in-flight exclusive connection
+	// operation on the given client (typically a reconnect) to finish. Returns
+	// (true, finalErr) when one completed within the budget, and (false, nil)
+	// when nothing is in flight or the wait timed out. A timed-out wait never
+	// cancels the operation; it keeps running in the background. Lets a caller
+	// that lost the ReconnectClient race join the winner's outcome instead of
+	// failing outright.
+	AwaitReconnect(clientID string, budget time.Duration) (joined bool, err error)
 	// RunWithPluginPipeline wraps an MCP wire operation in the canonical plugin
 	// gate (PreMCPHooks → op → PostMCPHooks). It owns the tracing span,
 	// MCPRequestType/ClientName/ToolName stamping, plugin log draining, and
@@ -77,15 +84,6 @@ type ToolsManager struct {
 	clientManager         ClientManager
 	logger                schemas.Logger
 	agentModeExecutor     *AgentModeExecutor
-
-	// backgroundReconnectInFlight dedupes triggerBackgroundReconnect per
-	// client ID (map[string]bool via sync.Map). ReconnectClient already
-	// guards concurrent connection replacement, but that guard only covers
-	// the reconnect step itself — without this, a burst of auth failures on
-	// the same shared client would still fire one ForceRefresh (a real
-	// OAuth token-endpoint call) per goroutine before ReconnectClient's own
-	// dedup rejects the redundant reconnects.
-	backgroundReconnectInFlight sync.Map
 
 	// CredentialStore resolves per-call credentials (headers, Bearer tokens)
 	// and signals whether a client needs an ephemeral upstream connection.
@@ -776,17 +774,20 @@ func (m *ToolsManager) executeToolInternal(
 //   - Per-user (RequiresPerCallConnection==true): cheap and ephemeral, no
 //     rate limiter guards it — force a credential refresh, re-acquire a
 //     fresh connection, and retry the SAME call synchronously, exactly once.
-//   - Shared (RequiresPerCallConnection==false): a synchronous ReconnectClient
-//     chains multiple retried connection steps and can itself take minutes —
-//     far longer than this call's own timeout budget — and there is no way
-//     to swap just the bearer header on an already-open transport. Fail this
-//     call immediately and repair the connection out of band instead, so the
+//   - Shared (RequiresPerCallConnection==false): the bearer is baked into the
+//     persistent transport at connect time, so healing requires a full
+//     ReconnectClient, which chains multiple retried connection steps and can
+//     take minutes worst-case. Trigger it in the background unconditionally
+//     (the connection must heal even when the retry below is suppressed),
+//     then wait a bounded budget for it to finish; if it completes in time,
+//     retry the SAME call once on the healed connection. If it does not,
+//     surface the original error while the reconnect keeps running so the
 //     NEXT call succeeds.
 //
 // Returns (response, true) only when a synchronous retry ran and actually
 // succeeded — the only case where the caller should treat this as a success
 // instead of the original failure. Every other outcome (opt-out gate,
-// shared-connection fail-fast, retry-also-failed) is (nil, false).
+// reconnect timeout or failure, retry-also-failed) is (nil, false).
 func (m *ToolsManager) attemptAuthFailureRecovery(
 	ctx *schemas.BifrostContext,
 	toolName string,
@@ -794,30 +795,11 @@ func (m *ToolsManager) attemptAuthFailureRecovery(
 	executionConfig *schemas.MCPClientConfig,
 	toolExecutionTimeout time.Duration,
 ) (*mcp.CallToolResult, bool) {
-	// Shared connections are repaired out of band regardless of the failing
-	// tool's destructive hint: triggerBackgroundReconnect only refreshes
-	// credentials and reconnects, it never re-executes the tool, so the
-	// duplicated-side-effect concern the destructive check below guards
-	// against doesn't apply to this path. Gating this on the destructive
-	// check would leave the entire shared connection broken for every other
-	// tool on it until the health monitor's independent ping cycle notices,
-	// defeating the fast-repair goal of this function.
-	if !m.credStore.RequiresPerCallConnection(executionConfig) {
-		m.triggerBackgroundReconnect(executionConfig)
-		return nil, false
-	}
-
 	state := m.clientManager.GetClientForTool(toolName)
-	if state == nil {
-		// No client state means no connection to re-acquire — nothing to retry.
-		return nil, false
-	}
 
 	// Safety opt-out: a spurious retry against a destructive, non-idempotent
-	// tool could cause a real-world side effect twice. Let the original
-	// error surface normally instead of auto-retrying. Only gates the
-	// synchronous per-user retry below — the shared-connection background
-	// repair above never re-executes the tool, so it's unaffected.
+	// tool could cause a real-world side effect twice. This gates only the
+	// retry; on the shared path the connection is still healed first.
 	//
 	// Fail closed on missing hints, matching the MCP spec's own defaults
 	// (destructiveHint defaults to true, idempotentHint to false, each only
@@ -826,25 +808,41 @@ func (m *ToolsManager) attemptAuthFailureRecovery(
 	// is common (both hints are optional per spec) and treating it as safe
 	// to retry would auto-retry an actually-destructive tool whose server
 	// simply never set the hint.
-	if tool, ok := state.ToolMap[toolName]; ok {
-		readOnly := false
-		destructive := true
-		idempotent := false
-		if tool.Annotations != nil {
-			if tool.Annotations.ReadOnlyHint != nil {
-				readOnly = *tool.Annotations.ReadOnlyHint
+	retryOptedOut := false
+	if state != nil {
+		if tool, ok := state.ToolMap[toolName]; ok {
+			readOnly := false
+			destructive := true
+			idempotent := false
+			if tool.Annotations != nil {
+				if tool.Annotations.ReadOnlyHint != nil {
+					readOnly = *tool.Annotations.ReadOnlyHint
+				}
+				if tool.Annotations.DestructiveHint != nil {
+					destructive = *tool.Annotations.DestructiveHint
+				}
+				if tool.Annotations.IdempotentHint != nil {
+					idempotent = *tool.Annotations.IdempotentHint
+				}
 			}
-			if tool.Annotations.DestructiveHint != nil {
-				destructive = *tool.Annotations.DestructiveHint
-			}
-			if tool.Annotations.IdempotentHint != nil {
-				idempotent = *tool.Annotations.IdempotentHint
+			if !readOnly && destructive && !idempotent {
+				m.logger.Debug("%s Skipping auth-failure auto-retry for destructive, non-idempotent tool %s", MCPLogPrefix, toolName)
+				retryOptedOut = true
 			}
 		}
-		if !readOnly && destructive && !idempotent {
-			m.logger.Debug("%s Skipping auth-failure auto-retry for destructive, non-idempotent tool %s", MCPLogPrefix, toolName)
-			return nil, false
-		}
+	}
+
+	if !m.credStore.RequiresPerCallConnection(executionConfig) {
+		return m.recoverSharedConnection(ctx, toolName, callRequest, executionConfig, toolExecutionTimeout, retryOptedOut)
+	}
+
+	if retryOptedOut {
+		return nil, false
+	}
+
+	if state == nil {
+		// No client state means no connection to re-acquire — nothing to retry.
+		return nil, false
 	}
 
 	if err := m.credStore.ForceRefresh(ctx, executionConfig); err != nil {
@@ -880,6 +878,105 @@ func (m *ToolsManager) attemptAuthFailureRecovery(
 	return retryResponse, true
 }
 
+// recoverSharedConnection handles the shared-connection half of
+// attemptAuthFailureRecovery. It always triggers the background force-refresh
+// + reconnect first, so the connection heals even when retryOptedOut
+// suppresses the retry. It then waits up to MCPSharedAuthRetryReconnectBudget
+// (further capped by the caller's remaining deadline) for the reconnect to
+// finish; a caller that lost the reconnect race to a concurrent 401 joins the
+// winner's in-flight attempt via AwaitReconnect. On an in-budget successful
+// reconnect it re-acquires the healed connection and retries the SAME call
+// exactly once. Any other outcome returns (nil, false) so the original error
+// surfaces, with the reconnect still running in the background on a timeout.
+func (m *ToolsManager) recoverSharedConnection(
+	ctx *schemas.BifrostContext,
+	toolName string,
+	callRequest mcp.CallToolRequest,
+	executionConfig *schemas.MCPClientConfig,
+	toolExecutionTimeout time.Duration,
+	retryOptedOut bool,
+) (*mcp.CallToolResult, bool) {
+	reconnectResult := m.triggerBackgroundReconnect(executionConfig)
+	if retryOptedOut || reconnectResult == nil || executionConfig == nil {
+		return nil, false
+	}
+
+	budget := MCPSharedAuthRetryReconnectBudget
+	if callerDeadline, hasDeadline := ctx.Deadline(); hasDeadline {
+		if remaining := time.Until(callerDeadline); remaining < budget {
+			budget = remaining
+		}
+	}
+	if budget <= 0 {
+		return nil, false
+	}
+	waitDeadline := time.Now().Add(budget)
+
+	timer := time.NewTimer(budget)
+	defer timer.Stop()
+	select {
+	case reconnectErr := <-reconnectResult:
+		if reconnectErr != nil {
+			// The trigger may have lost the race to a concurrent reconnect of
+			// the same client (e.g. another 401 or the health monitor); join
+			// that in-flight attempt for the remaining budget instead of
+			// giving up. When the error was a real reconnect failure there is
+			// no in-flight operation left and this returns immediately.
+			joined, joinErr := m.clientManager.AwaitReconnect(executionConfig.ID, time.Until(waitDeadline))
+			if !joined || joinErr != nil {
+				return nil, false
+			}
+		}
+	case <-ctx.Done():
+		// Caller cancellation, not just deadline: a canceled request must not
+		// park here for the remaining budget. The reconnect keeps running in
+		// the background either way.
+		return nil, false
+	case <-timer.C:
+		m.logger.Debug("%s Reconnect for %s did not finish within the retry budget; surfacing the original auth failure", MCPLogPrefix, executionConfig.Name)
+		return nil, false
+	}
+
+	// The reconnect replaces the client state entry, so re-resolve it to pick
+	// up the fresh connection. Reacquire by the reconnected client's own
+	// name, not GetClientForTool(toolName): that resolves through global
+	// tool-name routing across every client, so if routing changed while the
+	// reconnect was in flight (e.g. another client now also serves this tool
+	// name) it could silently retry the original callRequest against an
+	// unintended upstream. Reject the retry outright if the resolved state's
+	// ExecutionConfig.ID doesn't match the client this recovery is actually
+	// for, or if the tool it was reconnected for is no longer on it —
+	// letting the original auth failure surface is strictly safer than
+	// guessing.
+	state := m.clientManager.GetClientByName(executionConfig.Name)
+	if state == nil || state.ExecutionConfig == nil || state.ExecutionConfig.ID != executionConfig.ID {
+		return nil, false
+	}
+	if _, ok := state.ToolMap[toolName]; !ok {
+		return nil, false
+	}
+	conn, release, err := m.clientManager.AcquireClientConn(ctx, state)
+	if err != nil {
+		m.logger.Debug("%s Auth-failure retry could not acquire the reconnected client for %s: %v", MCPLogPrefix, toolName, err)
+		return nil, false
+	}
+	defer release()
+
+	retryCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
+	defer cancel()
+
+	retryStart := time.Now()
+	retryResponse, retryErr := conn.CallTool(retryCtx, callRequest)
+	schemas.AddUpstreamLatency(ctx, time.Since(retryStart))
+	if retryErr != nil {
+		m.logger.Debug("%s Auth-failure retry after reconnect also failed for %s: %v", MCPLogPrefix, toolName, retryErr)
+		return nil, false
+	}
+
+	m.logger.Debug("%s Auth-failure retry after reconnect succeeded for %s", MCPLogPrefix, toolName)
+	return retryResponse, true
+}
+
 // triggerBackgroundReconnect forces a credential refresh and reconnects a
 // shared-connection MCP client in the background, mirroring the health
 // monitor's own background-reconnect pattern (ClientHealthMonitor.
@@ -890,26 +987,19 @@ func (m *ToolsManager) attemptAuthFailureRecovery(
 // Runs on a fresh background context — the caller's request context ends as
 // soon as attemptAuthFailureRecovery returns the original failure to the
 // tool call's caller.
-func (m *ToolsManager) triggerBackgroundReconnect(config *schemas.MCPClientConfig) {
+//
+// The returned channel (buffered, never blocks the goroutine) receives the
+// ReconnectClient outcome exactly once, letting the caller wait a bounded
+// budget for the connection to heal. nil is returned only for a nil config.
+func (m *ToolsManager) triggerBackgroundReconnect(config *schemas.MCPClientConfig) <-chan error {
 	if config == nil {
-		return
+		return nil
 	}
 	clientID := config.ID
 	clientName := config.Name
 
-	// Dedupe the whole refresh+reconnect sequence, not just the reconnect
-	// step ReconnectClient already guards internally: without this, a burst
-	// of tool calls hitting auth failure on the same shared client at once
-	// would each fire their own ForceRefresh (a real OAuth token-endpoint
-	// call) before ReconnectClient's own guard rejects the redundant
-	// reconnects.
-	if _, alreadyInFlight := m.backgroundReconnectInFlight.LoadOrStore(clientID, true); alreadyInFlight {
-		m.logger.Debug("%s Background reconnect already in flight for %s, skipping duplicate trigger", MCPLogPrefix, clientName)
-		return
-	}
+	result := make(chan error, 1)
 	go func() {
-		defer m.backgroundReconnectInFlight.Delete(clientID)
-
 		refreshCtx, cancel := context.WithTimeout(context.Background(), MCPClientConnectionEstablishTimeout)
 		bgCtx := schemas.NewBifrostContext(refreshCtx, schemas.NoDeadline)
 		if err := m.credStore.ForceRefresh(bgCtx, config); err != nil {
@@ -921,12 +1011,15 @@ func (m *ToolsManager) triggerBackgroundReconnect(config *schemas.MCPClientConfi
 		}
 		cancel()
 
-		if err := m.clientManager.ReconnectClient(clientID); err != nil {
-			m.logger.Debug("%s Background reconnect triggered by an upstream auth rejection did not complete for %s: %v", MCPLogPrefix, clientName, err)
-			return
+		reconnectErr := m.clientManager.ReconnectClient(clientID)
+		if reconnectErr != nil {
+			m.logger.Debug("%s Background reconnect triggered by an upstream auth rejection did not complete for %s: %v", MCPLogPrefix, clientName, reconnectErr)
+		} else {
+			m.logger.Info("%s Background reconnect triggered by an upstream auth rejection succeeded for %s", MCPLogPrefix, clientName)
 		}
-		m.logger.Info("%s Background reconnect triggered by an upstream auth rejection succeeded for %s", MCPLogPrefix, clientName)
+		result <- reconnectErr
 	}()
+	return result
 }
 
 // ExecuteAgentForChatRequest executes agent mode for a chat request, handling

--- a/core/mcp/toolmanager_test.go
+++ b/core/mcp/toolmanager_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -49,6 +50,10 @@ func (m *mockToolClientManager) AcquireClientConn(ctx *schemas.BifrostContext, s
 	return nil, func() {}, nil
 }
 func (m *mockToolClientManager) ReconnectClient(id string) error { return nil }
+
+func (m *mockToolClientManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
+	return false, nil
+}
 func (m *mockToolClientManager) RunWithPluginPipeline(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest, op MCPOpFunc) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
 	resp, err := op(req)
 	if err != nil {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6885,7 +6885,7 @@ func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time
 	result := s.DB().WithContext(ctx).
 		// mcp_oauth_tokens holds both shared and per-user rows; callers
 		// decide which holder types get proactive background refresh via
-		// authModes (TokenRefreshWorker.AuthModes, shared + admin by default).
+		// authModes (OAuthTokenRefreshWorker.AuthModes, shared + admin by default).
 		Where("auth_mode IN ?", authModes).
 		Where("status = ?", "active").
 		Where("expires_at IS NOT NULL AND expires_at < ?", before).

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -532,7 +532,7 @@ type ConfigStore interface {
 	// Errors if the shared row is missing or not status='active'.
 	PromoteSharedOauthTokenToAdmin(ctx context.Context, oauthConfigID, mcpClientID string) error
 	// GetExpiringOauthTokens is filtered to authModes via `auth_mode IN
-	// (...)`. Backs TokenRefreshWorker, whose AuthModes field decides which
+	// (...)`. Backs OAuthTokenRefreshWorker, whose AuthModes field decides which
 	// holder types get proactive background refresh (defaults to shared +
 	// admin — other per-user tokens otherwise refresh lazily/inline on
 	// lookup via GetOauthUserTokenByMode).

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -3,14 +3,15 @@ package oauth2
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// TokenRefreshWorker manages automatic token refresh for expiring OAuth tokens
-type TokenRefreshWorker struct {
+// OAuthTokenRefreshWorker manages automatic token refresh for expiring OAuth tokens
+type OAuthTokenRefreshWorker struct {
 	provider        *OAuth2Provider
 	refreshInterval time.Duration
 	lookAheadWindow time.Duration // How far ahead to look for expiring tokens
@@ -34,10 +35,16 @@ type TokenRefreshWorker struct {
 	stopOnce  sync.Once
 	cancel    context.CancelFunc
 	logger    schemas.Logger
+
+	// onTokenRefreshed, when set, is invoked after each successful proactive
+	// refresh with the token's owning MCP client ID and auth mode. Stored as
+	// an atomic pointer because the worker goroutine reads it while the
+	// serving layer installs it after the worker has already started.
+	onTokenRefreshed atomic.Pointer[func(mcpClientID, authMode string)]
 }
 
-// NewTokenRefreshWorker creates a new token refresh worker
-func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *TokenRefreshWorker {
+// NewOAuthTokenRefreshWorker creates a new token refresh worker
+func NewOAuthTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *OAuthTokenRefreshWorker {
 	if logger == nil {
 		logger = bifrost.NewNoOpLogger()
 	}
@@ -45,7 +52,7 @@ func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *Tok
 		logger.Warn("config store is nil, skipping token refresh worker")
 		return nil
 	}
-	return &TokenRefreshWorker{
+	return &OAuthTokenRefreshWorker{
 		provider:        provider,
 		refreshInterval: 5 * time.Minute,             // Check every 5 minutes
 		lookAheadWindow: 5 * time.Minute,             // Refresh tokens expiring in next 5 minutes
@@ -55,8 +62,26 @@ func NewTokenRefreshWorker(provider *OAuth2Provider, logger schemas.Logger) *Tok
 	}
 }
 
+// SetOnTokenRefreshed registers a callback invoked after each successful
+// proactive token refresh, with the owning MCP client ID and the token's
+// auth mode. It lets the serving layer react to a freshened credential, for
+// example by recycling a connection that captured the old one. Tokens with
+// no MCP client ID (legacy rows) never fire the callback. Safe to call at
+// any time, including while the worker is running; passing nil clears the
+// callback.
+func (w *OAuthTokenRefreshWorker) SetOnTokenRefreshed(cb func(mcpClientID, authMode string)) {
+	if w == nil {
+		return
+	}
+	if cb == nil {
+		w.onTokenRefreshed.Store(nil)
+		return
+	}
+	w.onTokenRefreshed.Store(&cb)
+}
+
 // Start begins the token refresh worker in a background goroutine
-func (w *TokenRefreshWorker) Start(ctx context.Context) {
+func (w *OAuthTokenRefreshWorker) Start(ctx context.Context) {
 	runCtx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
 	go w.run(runCtx)
@@ -66,7 +91,7 @@ func (w *TokenRefreshWorker) Start(ctx context.Context) {
 // Stop gracefully stops the token refresh worker. Safe to call multiple times
 // — guarded by sync.Once so a redundant call from a secondary shutdown path
 // can't panic by re-closing the channel.
-func (w *TokenRefreshWorker) Stop() {
+func (w *OAuthTokenRefreshWorker) Stop() {
 	w.stopOnce.Do(func() {
 		// Cancel any in-flight refresh so a blocked DB call unwinds promptly,
 		// then signal run() to exit its ticker loop.
@@ -79,7 +104,7 @@ func (w *TokenRefreshWorker) Stop() {
 }
 
 // run is the main worker loop
-func (w *TokenRefreshWorker) run(ctx context.Context) {
+func (w *OAuthTokenRefreshWorker) run(ctx context.Context) {
 	ticker := time.NewTicker(w.refreshInterval)
 	defer ticker.Stop()
 
@@ -99,7 +124,7 @@ func (w *TokenRefreshWorker) run(ctx context.Context) {
 }
 
 // refreshExpiredTokens queries and refreshes tokens that are expiring soon
-func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
+func (w *OAuthTokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 	expiryThreshold := time.Now().Add(w.lookAheadWindow)
 
 	// Get tokens expiring before the threshold, restricted to the configured
@@ -128,17 +153,20 @@ func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 			w.logger.Debug("Failed to refresh token: token_id: %s, mcp_client_id: %s, error: %s", token.ID, token.MCPClientID, err.Error())
 		} else {
 			w.logger.Debug("Successfully refreshed token: %s", token.ID)
+			if cb := w.onTokenRefreshed.Load(); cb != nil && token.MCPClientID != "" {
+				(*cb)(token.MCPClientID, token.AuthMode)
+			}
 		}
 	}
 }
 
 // SetRefreshInterval updates the refresh check interval (for testing)
-func (w *TokenRefreshWorker) SetRefreshInterval(interval time.Duration) {
+func (w *OAuthTokenRefreshWorker) SetRefreshInterval(interval time.Duration) {
 	w.refreshInterval = interval
 }
 
 // SetLookAheadWindow updates the look-ahead window for token expiry (for testing)
-func (w *TokenRefreshWorker) SetLookAheadWindow(window time.Duration) {
+func (w *OAuthTokenRefreshWorker) SetLookAheadWindow(window time.Duration) {
 	w.lookAheadWindow = window
 }
 

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -268,6 +268,7 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 	store.oauthTokens[tokenID] = &tables.TableMCPOauthToken{
 		ID:            tokenID,
 		AuthMode:      "shared",
+		MCPClientID:   "test-mcp-client-id",
 		OauthConfigID: oauthConfigID,
 		Status:        "active",
 		AccessToken:   "old-access-token",
@@ -280,11 +281,11 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 	return oauthConfigID, tokenID
 }
 
-func newTestWorker(store *testConfigStore) *TokenRefreshWorker {
+func newTestWorker(store *testConfigStore) *OAuthTokenRefreshWorker {
 	noopLogger := bifrost.NewDefaultLogger(schemas.LogLevelError)
 	provider := NewOAuth2Provider(store, noopLogger)
 	provider.retryBaseDelay = 1 * time.Millisecond // speed up retry backoff in tests
-	return NewTokenRefreshWorker(provider, noopLogger)
+	return NewOAuthTokenRefreshWorker(provider, noopLogger)
 }
 
 func newTestProvider(store *testConfigStore) *OAuth2Provider {
@@ -855,6 +856,139 @@ func TestTokenRefreshWorker_400UnauthorizedClient_MarksNeedsReauth(t *testing.T)
 	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
 	assert.Equal(t, "needs_reauth", token.Status, "400 unauthorized_client must mark token needs_reauth")
+}
+
+// newRecordingRefreshHook returns a hook callback plus an accessor for the
+// (mcpClientID, authMode) pairs it has recorded, safe for concurrent use.
+func newRecordingRefreshHook() (func(string, string), func() [][2]string) {
+	var mu sync.Mutex
+	var calls [][2]string
+	hook := func(mcpClientID, authMode string) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, [2]string{mcpClientID, authMode})
+	}
+	get := func() [][2]string {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(calls)
+	}
+	return hook, get
+}
+
+func TestTokenRefreshWorker_OnTokenRefreshed_FiresOnceOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	hook, calls := newRecordingRefreshHook()
+	worker.SetOnTokenRefreshed(hook)
+	worker.refreshExpiredTokens(context.Background())
+
+	got := calls()
+	require.Len(t, got, 1, "hook must fire exactly once per successful refresh")
+	assert.Equal(t, "test-mcp-client-id", got[0][0])
+	assert.Equal(t, "shared", got[0][1])
+}
+
+func TestTokenRefreshWorker_OnTokenRefreshed_NoFireOnRefreshFailure(t *testing.T) {
+	failures := map[string]http.HandlerFunc{
+		"permanent 401": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "invalid_grant",
+			})
+		},
+		"transient 503": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		},
+	}
+
+	for name, handler := range failures {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			store := newTestConfigStore()
+			seedFixtures(t, store, server.URL+"/token")
+
+			worker := newTestWorker(store)
+			hook, calls := newRecordingRefreshHook()
+			worker.SetOnTokenRefreshed(hook)
+			worker.refreshExpiredTokens(context.Background())
+
+			assert.Empty(t, calls(), "hook must not fire when the refresh fails")
+		})
+	}
+}
+
+func TestTokenRefreshWorker_OnTokenRefreshed_NoFireWhenMCPClientIDEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
+	store.oauthTokens[tokenID].MCPClientID = "" // legacy row with no owning client
+
+	worker := newTestWorker(store)
+	hook, calls := newRecordingRefreshHook()
+	worker.SetOnTokenRefreshed(hook)
+	worker.refreshExpiredTokens(context.Background())
+
+	assert.Empty(t, calls(), "hook must not fire for a token with no MCP client ID")
+
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken, "the refresh itself must still run")
+}
+
+func TestTokenRefreshWorker_SetOnTokenRefreshed_NilSafe(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	_, tokenID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	hook, calls := newRecordingRefreshHook()
+	worker.SetOnTokenRefreshed(hook)
+	worker.SetOnTokenRefreshed(nil) // clearing must be safe and must silence the hook
+
+	var nilWorker *OAuthTokenRefreshWorker
+	nilWorker.SetOnTokenRefreshed(hook) // nil receiver must not panic (constructor can return nil)
+
+	worker.refreshExpiredTokens(context.Background())
+
+	assert.Empty(t, calls(), "a cleared hook must not fire")
+
+	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken)
 }
 
 // seedAdminOauthConfig inserts a minimal authorized oauth_config row —

--- a/framework/oauth2/tokenexchange.go
+++ b/framework/oauth2/tokenexchange.go
@@ -135,7 +135,7 @@ func (p *OAuth2Provider) ExchangeAdminCredential(ctx context.Context, config *sc
 
 // RetainExchangeAdminCredential persists the outcome of a successful admin
 // verification as the retained auth_mode='admin' token row for config — the
-// discovery credential the tool syncer and TokenRefreshWorker keep alive,
+// discovery credential the tool syncer and OAuthTokenRefreshWorker keep alive,
 // mirroring what PromoteSharedOauthTokenToAdmin does for per-user OAuth
 // bootstrap. Upserts: a repair replaces the existing row's credential.
 func (p *OAuth2Provider) RetainExchangeAdminCredential(ctx context.Context, config *schemas.MCPClientConfig, response *schemas.OAuth2TokenExchangeResponse) error {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -606,9 +606,9 @@ type Config struct {
 	pluginStatusMu sync.RWMutex
 	pluginStatus   map[string]schemas.PluginStatus // name -> status
 
-	OAuthProvider      *oauth2.OAuth2Provider
-	TokenRefreshWorker *oauth2.TokenRefreshWorker
-	OAuthSweepWorker   *oauth2.PerUserOAuthSweepWorker
+	OAuthProvider           *oauth2.OAuth2Provider
+	OAuthTokenRefreshWorker *oauth2.OAuthTokenRefreshWorker
+	OAuthSweepWorker        *oauth2.PerUserOAuthSweepWorker
 
 	// MCPHeadersProvider backs MCPAuthTypePerUserHeaders credential storage.
 	// Constructed alongside OAuthProvider and passed into the Bifrost core
@@ -4916,11 +4916,15 @@ func initFrameworkConfig(ctx context.Context, config *Config, configData *Config
 	// OAuthProvider for MCPAuthTypePerUserHeaders clients.
 	config.MCPHeadersProvider = mcp_headers.NewProvider(config.ConfigStore, logger)
 
-	// Start token refresh worker for automatic OAuth token refresh
-	config.TokenRefreshWorker = oauth2.NewTokenRefreshWorker(config.OAuthProvider, logger)
-	if config.TokenRefreshWorker != nil {
-		config.TokenRefreshWorker.Start(ctx)
-	}
+	// Construct the OAuth token refresh worker, but don't start it here: Start
+	// runs an immediate refresh sweep synchronously with launching its
+	// goroutine, and this point in startup is well before any MCP client is
+	// dialed or the server's SetOnTokenRefreshed reconnect callback is wired
+	// up (see its registration in server.go). A refresh landing in that gap
+	// would leave nothing to trigger the affected client's reconnect until
+	// the next scheduled sweep or a call happens to fail — the server starts
+	// the worker itself, right after that callback is installed.
+	config.OAuthTokenRefreshWorker = oauth2.NewOAuthTokenRefreshWorker(config.OAuthProvider, logger)
 
 	// Start per-user OAuth sweep worker: expires stale pending flows and reaps
 	// long-orphaned token rows. Orphan retention defaults to 30 days.
@@ -5404,15 +5408,15 @@ func (c *Config) GetKVStore() *kvstore.Store {
 }
 
 // Close gracefully shuts down all background components associated with the Config.
-// This includes ModelCatalog sync worker, TokenRefreshWorker, KVStore cleanup loop,
+// This includes ModelCatalog sync worker, OAuthTokenRefreshWorker, KVStore cleanup loop,
 // ConfigStore, LogsStore, and VectorStore. It should be called when the Config is
 // no longer needed to prevent goroutine leaks.
 func (c *Config) Close(ctx context.Context) {
 	if c.ModelCatalog != nil {
 		c.ModelCatalog.Cleanup()
 	}
-	if c.TokenRefreshWorker != nil {
-		c.TokenRefreshWorker.Stop()
+	if c.OAuthTokenRefreshWorker != nil {
+		c.OAuthTokenRefreshWorker.Stop()
 	}
 	if c.OAuthSweepWorker != nil {
 		c.OAuthSweepWorker.Stop()

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2483,6 +2483,41 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// enterprise ones — registered after that snapshot, causing the client to fail
 	// and only recover on a later health-monitor reconnect).
 	s.Client.ConnectConfiguredMCPClients(s.Ctx)
+	// A proactively refreshed shared OAuth token leaves the live MCP connection
+	// still holding the old bearer (the credential is baked into the transport
+	// at connect time), so recycle the connection as soon as the refresh worker
+	// lands a fresh token instead of waiting for a call to fail. Installed only
+	// after the boot dial above so the worker's first sweep cannot race client
+	// construction. In-flight calls on the old connection may fail once during
+	// the recycle; the reactive auth-failure retry covers them. Per-user
+	// (non-shared) tokens have no persistent connection, so they are skipped.
+	if s.Config.OAuthTokenRefreshWorker != nil {
+		s.Config.OAuthTokenRefreshWorker.SetOnTokenRefreshed(func(mcpClientID, authMode string) {
+			if authMode != "shared" {
+				return
+			}
+			// Run in a goroutine: a reconnect can take minutes worst-case and
+			// must not block the worker's sequential refresh loop. Expected
+			// no-op outcomes (a reconnect already in progress, or a client
+			// type reconnect does not apply to) surface here as errors and
+			// are deliberately logged at Debug only.
+			go func() {
+				if err := s.ReconnectMCPClient(s.Ctx, mcpClientID); err != nil {
+					logger.Debug("MCP client %s was not reconnected after a proactive token refresh: %v", mcpClientID, err)
+					return
+				}
+				logger.Debug("recycled shared MCP connection for client %s after a proactive token refresh", mcpClientID)
+			}()
+		})
+		// Started here, not at construction (lib/config.go): Start's first
+		// refresh sweep runs immediately, synchronously with launching its
+		// goroutine. Starting any earlier — before the callback above is
+		// wired up and before the boot dial above has run — would let a
+		// refresh land with nothing to trigger the affected client's
+		// reconnect, leaving a live connection on the old bearer until the
+		// next scheduled sweep or a call happens to fail.
+		s.Config.OAuthTokenRefreshWorker.Start(s.Ctx)
+	}
 	// Serve a minimal robots.txt so crawlers/CLI tools (e.g. Claude Code) don't
 	// trigger 404 warnings when probing the host before marketplace fetches.
 	s.Router.GET("/robots.txt", func(ctx *fasthttp.RequestCtx) {


### PR DESCRIPTION
## Summary

On shared MCP connections, a 401 auth failure previously triggered a background reconnect but returned the original error immediately with no retry. This PR upgrades that path to a bounded-wait retry: the caller waits up to `MCPSharedAuthRetryReconnectBudget` (10 s, further capped by the request's own remaining deadline) for the reconnect to finish, then retries the same call once on the healed connection. If the reconnect exceeds the budget it keeps running in the background and the original error surfaces as before. Concurrent 401s on the same client now deduplicate: the loser of the reconnect race joins the winner's in-flight attempt via a new `AwaitReconnect` interface method rather than failing outright.

Additionally, `OAuthTokenRefreshWorker` (renamed from `TokenRefreshWorker`) gains a `SetOnTokenRefreshed` callback. The HTTP server installs this callback after the boot dial to proactively recycle shared MCP connections whenever the background token refresh worker lands a fresh credential, instead of waiting for the next call to fail with a 401.

## Changes

- **`inflightClientOp` struct and `beginExclusiveClientOp`**: Replaced the `sync.Map[string]bool` sentinel in `MCPManager` with a `sync.Map[string]*inflightClientOp` that carries a `done` channel and final error. All exclusive-operation entry points (`ReconnectClient`, `DisableClient`, `EnableClient`, `UpdateClient`, `UpdateClientConnection`) now use `beginExclusiveClientOp` and propagate their return error to waiters via a deferred `finish(retErr)`.

- **`AwaitReconnect`**: New method on `MCPManager` (and `ClientManager` interface) that lets a caller block up to a given budget for an in-flight exclusive operation to complete, returning the operation's final error. A timed-out wait never cancels the underlying operation.

- **`recoverSharedConnection`**: New method extracted from `attemptAuthFailureRecovery` that implements the bounded-wait retry for shared connections. It triggers the background reconnect, waits for the result channel, falls back to `AwaitReconnect` if the trigger lost the race to a concurrent reconnect, then re-acquires the healed connection and retries the call once.

- **`triggerBackgroundReconnect`**: Now returns a `<-chan error` (buffered, capacity 1) so the caller can observe the reconnect outcome without blocking the goroutine.

- **Retry opt-out ordering**: The destructive/non-idempotent tool gate now sets a `retryOptedOut` flag rather than returning early, so connection healing always runs on the shared path even when the retry itself is suppressed.

- **`OAuthTokenRefreshWorker` rename and `SetOnTokenRefreshed` callback**: `TokenRefreshWorker` is renamed to `OAuthTokenRefreshWorker` throughout. A new `SetOnTokenRefreshed(func(mcpClientID, authMode string))` method (backed by an `atomic.Pointer`) lets callers register a hook invoked after each successful proactive refresh. The HTTP server uses this to trigger a background `ReconnectMCPClient` for shared-auth clients immediately after a token is refreshed.

- **Test coverage**: Replaced the single `TestExecuteTool_AuthFailureRetry_Shared_FailsFastAndTriggersBackgroundReconnect` test with four focused tests covering: successful bounded-wait retry, budget-exceeded fallback, reconnect-failed fallback, destructive-tool reconnect-without-retry, and concurrent 401 deduplication. The `authRetryClientManager` mock now implements the full `inflightClientOp` dedup logic to faithfully simulate the real manager. New `OAuthTokenRefreshWorker` tests cover the callback firing, non-firing on failure, non-firing for tokens with no MCP client ID, and nil-safety.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/... ./framework/oauth2/...
```

Key scenarios exercised by the new tests:
- A shared-connection 401 where the reconnect completes within budget: expect 2 `CallTool` invocations and a successful response.
- A shared-connection 401 where the reconnect is held open past the caller deadline: expect 1 `CallTool` invocation, the original error, and the reconnect still running.
- Two concurrent 401s on the same client: expect exactly 1 actual `ReconnectClient` call, 1 rejected duplicate, 4 total `CallTool` invocations, and both callers succeeding.
- A destructive non-idempotent tool: expect no retry but the background reconnect still fires.

## Breaking changes

- [x] Yes
- [ ] No

`TokenRefreshWorker` is renamed to `OAuthTokenRefreshWorker` and the `Config` field `TokenRefreshWorker` is renamed to `OAuthTokenRefreshWorker`. Any code referencing these names directly must be updated. The `ClientManager` interface gains a new required method `AwaitReconnect(clientID string, budget time.Duration) (bool, error)`; all implementations (including mocks) must add this method.

## Security considerations

The bounded-wait retry re-uses the caller's existing request context deadline to cap the reconnect wait, preventing a malicious or slow upstream from holding a request open indefinitely beyond its own timeout. The `SetOnTokenRefreshed` callback is stored as an `atomic.Pointer` to avoid data races between the worker goroutine and the serving layer installing the callback after startup.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable