### PR TITLE
`feat: make-before-break reconnect for HTTP/SSE MCP clients with generation-guarded stale write protection`

### DIFF
--- a/core/mcp/auth_retry_test.go
+++ b/core/mcp/auth_retry_test.go
@@ -217,21 +217,24 @@ func (m *authRetryClientManager) AcquireClientConn(_ *schemas.BifrostContext, _ 
 	return m.acquireConn, func() {}, nil
 }
 
+// ReconnectClient mirrors the real MCPManager.beginExclusiveClientOp
+// contract: a completed op is left in m.inflight rather than cleared, so a
+// caller that lost the race and calls AwaitReconnect afterward still finds
+// the (by-then-finished) op instead of racing a delete. A new call only
+// starts a fresh op when none is present or the previous one has finished.
 func (m *authRetryClientManager) ReconnectClient(_ string) error {
+	op := &inflightClientOp{done: make(chan struct{})}
 	m.inflightMu.Lock()
 	if m.inflight != nil {
 		select {
 		case <-m.inflight.done:
-			// Previous op already finished; fall through and replace it, the
-			// same CompareAndSwap-on-a-done-op behavior beginExclusiveClientOp
-			// uses in clientmanager.go.
+			// Previous op finished; replace it and proceed as the new winner.
 		default:
 			m.inflightMu.Unlock()
 			m.reconnectRejected.Add(1)
 			return errors.New("reconnect already in progress for this client")
 		}
 	}
-	op := &inflightClientOp{done: make(chan struct{})}
 	m.inflight = op
 	m.inflightMu.Unlock()
 
@@ -247,19 +250,8 @@ func (m *authRetryClientManager) ReconnectClient(_ string) error {
 	}
 	err := m.reconnectErr
 
-	m.inflightMu.Lock()
 	op.err = err
 	close(op.done)
-	// Deliberately not cleared to nil here: a caller that lost the race and
-	// got "already in progress" above must still be able to observe this
-	// op's outcome via AwaitReconnect after it completes — clearing
-	// immediately would let that caller poll AwaitReconnect a moment too
-	// late, see inflight == nil, and wrongly conclude nothing is (or ever
-	// was) in flight. Mirrors beginExclusiveClientOp's real behavior: the
-	// completed op is only replaced by the next ReconnectClient call, not
-	// deleted on finish. Use resetInflight for tests that need a clean
-	// no-op starting state instead.
-	m.inflightMu.Unlock()
 	return err
 }
 

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -237,23 +237,53 @@ type inflightClientOp struct {
 // slot, preserving the second-caller-errors contract every guarded entry point
 // relies on. On success the caller must invoke finish exactly once with the
 // operation's final error so waiters parked in AwaitReconnect get the outcome.
+//
+// A completed op is deliberately left in the map instead of being deleted on
+// finish: deleting immediately would let a caller who was just rejected with
+// "already in progress" lose the race a second time, observing no entry in
+// AwaitReconnect and silently missing a reconnect that in fact just
+// succeeded. The completed entry is instead lazily replaced the next time
+// this function is called for the same ID, via CompareAndSwap so a fresh
+// concurrent begin can't be shadowed by another late reader observing the
+// old (already-done) op.
 func (m *MCPManager) beginExclusiveClientOp(id string) (finish func(error), ok bool) {
 	op := &inflightClientOp{done: make(chan struct{})}
-	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, op); alreadyInFlight {
-		return nil, false
+	for {
+		existing, loaded := m.reconnectingClients.LoadOrStore(id, op)
+		if !loaded {
+			return m.finishExclusiveClientOp(op), true
+		}
+		existingOp := existing.(*inflightClientOp)
+		select {
+		case <-existingOp.done:
+			// Previous op already finished; replace it with ours so a fresh
+			// operation can start. Any caller still holding a reference to
+			// existingOp (from a Load that raced this one) keeps observing
+			// its correct, already-final result.
+			if m.reconnectingClients.CompareAndSwap(id, existing, op) {
+				return m.finishExclusiveClientOp(op), true
+			}
+			// Lost the race to install ours; retry from the top.
+		default:
+			return nil, false
+		}
 	}
+}
+
+func (m *MCPManager) finishExclusiveClientOp(op *inflightClientOp) func(error) {
 	return func(err error) {
 		op.err = err
 		close(op.done)
-		m.reconnectingClients.Delete(id)
-	}, true
+	}
 }
 
 // AwaitReconnect waits up to budget for the in-flight exclusive operation on
 // the given client (typically a reconnect) to complete. Returns (true, finalErr)
-// when the operation finished within the budget, and (false, nil) when nothing
-// is in flight or the wait timed out. A timed-out wait never cancels the
-// underlying operation; it keeps running to completion in the background.
+// when the operation finished within the budget (including one that had
+// already finished the instant this was called), and (false, nil) when
+// nothing has ever been registered for this client or the wait timed out. A
+// timed-out wait never cancels the underlying operation; it keeps running to
+// completion in the background.
 func (m *MCPManager) AwaitReconnect(clientID string, budget time.Duration) (bool, error) {
 	v, ok := m.reconnectingClients.Load(clientID)
 	if !ok {
@@ -388,7 +418,7 @@ func (m *MCPManager) ReconnectClient(id string) (retErr error) {
 // AddClient adds a new MCP client using the provided context for
 // request-scoped connect hooks. Existing transport lifetimes still use the
 // manager context so persistent MCP connections are not tied to the caller.
-func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPClientConfig) error {
+func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPClientConfig) (retErr error) {
 	if requestCtx == nil {
 		requestCtx = m.ctx
 	}
@@ -448,6 +478,22 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 			Type: config.ConnectionType,
 		},
 	}
+
+	// Claim the per-client exclusive-op slot before the placeholder becomes
+	// visible below (m.mu.Unlock): every other entry point that dials this
+	// client (ReconnectClient, EnableClient, UpdateClient, ...) already
+	// guards itself the same way, and without this guard here one of them
+	// could start a concurrent dial for this ID the instant the placeholder
+	// is published, racing this function's own connect below. config.ID was
+	// just confirmed absent from clientMap under the same lock, so no
+	// exclusive op can already be tracking it — !ok is not expected.
+	finish, ok := m.beginExclusiveClientOp(config.ID)
+	if !ok {
+		delete(m.clientMap, config.ID)
+		m.mu.Unlock()
+		return fmt.Errorf("client %s: conflicting operation already in progress", config.Name)
+	}
+	defer func() { finish(retErr) }()
 
 	// Temporarily unlock for the connection attempt
 	// This is to avoid deadlocks when the connection attempt is made
@@ -1306,7 +1352,8 @@ func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPCli
 	mergedConfig.PendingOAuthConfig = newConfig.PendingOAuthConfig
 	m.mu.RUnlock()
 
-	// connectToMCPClient will close the current connection and create a new clientMap entry.
+	// connectToMCPClient dials with the merged credentials and swaps them into the
+	// existing clientMap entry, replacing the current connection on success.
 	if err := m.connectToMCPClient(m.ctx, &mergedConfig); err != nil {
 		m.mu.Lock()
 		if cs, exists := m.clientMap[id]; exists {
@@ -1445,45 +1492,102 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	if requestCtx == nil {
 		requestCtx = m.ctx
 	}
-	// First lock: Initialize or validate client entry
-	m.mu.Lock()
+	// First lock: initialize or validate the client entry.
+	//
+	// Two strategies, chosen by connection type and current liveness:
+	//   - Make-before-break (HTTP/SSE with a live connection): the entry keeps
+	//     serving tool calls on its current connection for the whole dial
+	//     window. The old handles are captured here and torn down only after
+	//     the new connection has been swapped in (or on a failed dial).
+	//   - Close-first (STDIO, in-process, or no live connection): the old
+	//     handles are captured here, the entry is reset in place, and the
+	//     handles are closed right after unlocking, before the dial starts.
+	//     Two subprocesses coexisting during the dial would double resource
+	//     use and break servers holding exclusive resources (port binds,
+	//     lockfiles), so STDIO stays close-first.
+	//
+	// In both cases the existing *MCPClientState is mutated in place, never
+	// replaced with a new pointer: concurrent readers holding the pointer must
+	// keep observing the live entry rather than a detached copy.
+	var oldConn *client.Client
+	var oldCancel context.CancelFunc
+	makeBeforeBreak := false
+	// Captured below and compared by pointer identity at commit/failure time.
+	// A RemoveClient + AddClient cycle for the same ID during this dial
+	// deletes this entry and stores a fresh *MCPClientState under the same
+	// key; without this check a stale attempt would resolve the new pointer
+	// by ID alone and clobber the freshly re-added client's connection and
+	// tools while leaving its ExecutionConfig untouched.
+	var entry *schemas.MCPClientState
 
-	// Initialize or validate client entry
+	m.mu.Lock()
 	if existingClient, exists := m.clientMap[config.ID]; exists {
 		// If the client is disabled and the caller is not explicitly re-enabling it
 		// (EnableClient sets config.Disabled = false before calling here; ReconnectClient
-		// and the health-monitor path leave it as-is), bail out now — before we overwrite
-		// the Disabled entry — so the Disabled state is preserved.
+		// and the health-monitor path leave it as-is), bail out now, before we touch
+		// the Disabled entry, so the Disabled state is preserved.
 		if existingClient.State == schemas.MCPConnectionStateDisabled && config.Disabled {
 			m.mu.Unlock()
 			return fmt.Errorf("client %s is disabled", config.Name)
 		}
 
-		// Client entry exists from config, check for existing connection, if it does then close
-		if existingClient.CancelFunc != nil {
-			existingClient.CancelFunc()
-			existingClient.CancelFunc = nil
+		entry = existingClient
+
+		oldConn = existingClient.Conn
+		oldCancel = existingClient.CancelFunc
+		existingClient.CancelFunc = nil
+		existingClient.Name = config.Name
+		existingClient.ExecutionConfig = config
+
+		makeBeforeBreak = oldConn != nil &&
+			(config.ConnectionType == schemas.MCPConnectionTypeHTTP || config.ConnectionType == schemas.MCPConnectionTypeSSE)
+		if makeBeforeBreak {
+			// Leave State, Conn, and the tool maps untouched: the client keeps
+			// serving on the old connection until the new one is swapped in.
+			if existingClient.ConnectionInfo == nil {
+				existingClient.ConnectionInfo = &schemas.MCPClientConnectionInfo{}
+			}
+			existingClient.ConnectionInfo.Type = config.ConnectionType
+		} else {
+			// Reset to Disconnected so the API never returns an empty state
+			// during connection attempts; it transitions to Connected only on
+			// success. The generation bump invalidates any late writer that
+			// captured the detached connection (tool syncer, SSE loss callback).
+			existingClient.State = schemas.MCPConnectionStateDisconnected
+			existingClient.Conn = nil
+			existingClient.ToolMap = make(map[string]schemas.ChatTool)
+			existingClient.ToolNameMapping = make(map[string]string)
+			existingClient.ConnectionInfo = &schemas.MCPClientConnectionInfo{
+				Type: config.ConnectionType,
+			}
+			existingClient.ConnGeneration++
 		}
-		if existingClient.Conn != nil {
-			existingClient.Conn.Close()
+	} else {
+		// Create new client entry with configuration.
+		// Initialize State to Disconnected so the API never returns an empty state
+		// during connection attempts; it transitions to Connected only on success.
+		entry = &schemas.MCPClientState{
+			Name:            config.Name,
+			ExecutionConfig: config,
+			State:           schemas.MCPConnectionStateDisconnected,
+			ToolMap:         make(map[string]schemas.ChatTool),
+			ToolNameMapping: make(map[string]string),
+			ConnectionInfo: &schemas.MCPClientConnectionInfo{
+				Type: config.ConnectionType,
+			},
 		}
-		// Update connection type for this connection attempt
-		existingClient.ConnectionInfo.Type = config.ConnectionType
-	}
-	// Create new client entry with configuration.
-	// Initialize State to Disconnected so the API never returns an empty state
-	// during connection attempts; it transitions to Connected only on success.
-	m.clientMap[config.ID] = &schemas.MCPClientState{
-		Name:            config.Name,
-		ExecutionConfig: config,
-		State:           schemas.MCPConnectionStateDisconnected,
-		ToolMap:         make(map[string]schemas.ChatTool),
-		ToolNameMapping: make(map[string]string),
-		ConnectionInfo: &schemas.MCPClientConnectionInfo{
-			Type: config.ConnectionType,
-		},
+		m.clientMap[config.ID] = entry
 	}
 	m.mu.Unlock()
+
+	// Close-first path: tear down the captured handles now, outside the manager
+	// lock (a STDIO Close blocks on the subprocess exiting), before the new
+	// dial begins.
+	if !makeBeforeBreak {
+		m.closeConnHandles(oldCancel, oldConn, config.Name)
+		oldConn = nil
+		oldCancel = nil
+	}
 
 	// Heavy operations performed outside lock
 	var externalClient *client.Client
@@ -1686,31 +1790,15 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	})
 
 	if gateErr != nil {
-		if config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO {
-			cancel()
-		}
-		if externalClient != nil {
-			if closeErr := externalClient.Close(); closeErr != nil {
-				m.logger.Warn("%s Failed to close external client during cleanup: %v", MCPLogPrefix, closeErr)
-			}
-		}
-
 		// A dead OAuth2 credential (refresh permanently rejected/expired) is not a
-		// transient connectivity problem — the entry above was already reset to
-		// Disconnected at the top of this function, but that's misleading here: no
-		// amount of automatic reconnecting will fix it, only a human reauthorizing
-		// the client will. Flip to NeedsReauth instead so the state itself carries
-		// that signal, mirroring how the success path below sets Connected under
-		// the same lock. Never clobber Disabled — DisableClient is authoritative,
-		// same invariant the health monitor's updateClientState guard preserves.
-		if isOAuth2TokenExpiredErrorText(gateErr.GetErrorString()) {
-			m.mu.Lock()
-			if client, exists := m.clientMap[config.ID]; exists && client.State != schemas.MCPConnectionStateDisabled {
-				client.State = schemas.MCPConnectionStateNeedsReauth
-			}
-			m.mu.Unlock()
-		}
-
+		// transient connectivity problem: no amount of automatic reconnecting will
+		// fix it, only a human reauthorizing the client will. Land the entry in
+		// NeedsReauth instead of the generic Disconnected so the state itself
+		// carries that signal. Never clobber Disabled (DisableClient is
+		// authoritative, same invariant the health monitor's updateClientState
+		// guard preserves).
+		needsReauth := isOAuth2TokenExpiredErrorText(gateErr.GetErrorString())
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, needsReauth)
 		return fmt.Errorf("failed to connect MCP client %s: %s", config.Name, gateErr.GetErrorString())
 	}
 
@@ -1753,73 +1841,64 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	// connect+list. A server that legitimately exposes zero tools returns success with
 	// an empty list (listToolsErr == nil) and is still marked Connected.
 	if listToolsErr != nil {
-		if (config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO) && cancel != nil {
-			cancel()
-		}
-		if closeErr := externalClient.Close(); closeErr != nil {
-			m.logger.Warn("%s Failed to close external client after tool retrieval failure: %v", MCPLogPrefix, closeErr)
-		}
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
 		return fmt.Errorf("failed to retrieve tools from MCP client %s: %w", config.Name, listToolsErr)
 	}
 
-	// Second lock: Update client with final connection details and tools
+	// Second lock: atomically swap the new connection details and tools into
+	// the client entry.
 	m.mu.Lock()
 
-	// Verify client still exists (could have been cleaned up during heavy operations)
-	if client, exists := m.clientMap[config.ID]; exists {
-		// If the client was disabled while we were doing the whole connection process
-		// roll back the newly established connection and abort — do not overwrite the Disabled state.
-		// This is a rare edge case where the client was disabled while we were doing the whole connection process
-		if client.State == schemas.MCPConnectionStateDisabled {
-			m.mu.Unlock()
-			if (config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO) && cancel != nil {
-				cancel()
-			}
-			if externalClient != nil {
-				if closeErr := externalClient.Close(); closeErr != nil {
-					m.logger.Warn("%s Failed to close external client during disable rollback: %v", MCPLogPrefix, closeErr)
-				}
-			}
-			m.logger.Debug("%s [%s] Client was disabled during connection setup; rolling back", MCPLogPrefix, config.Name)
-			return fmt.Errorf("client %s was disabled during connection setup", config.Name)
-		}
-
-		// Store the external client connection and details
-		client.Conn = externalClient
-		client.ConnectionInfo = connectionInfo
-		client.State = schemas.MCPConnectionStateConnected
-
-		// Store cancel function for SSE and STDIO connections to enable proper cleanup
-		if config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO {
-			client.CancelFunc = cancel
-		}
-
-		// Store discovered tools
-		for toolName, tool := range tools {
-			client.ToolMap[toolName] = tool
-		}
-
-		// Store tool name mapping for execution (sanitized_name -> original_mcp_name)
-		client.ToolNameMapping = toolNameMapping
-
-		m.logger.Debug("%s [%s] Registering %d tools. Client config - ID: %s, Name: %s, IsCodeModeClient: %v", MCPLogPrefix, config.Name, len(tools), config.ID, config.Name, config.IsCodeModeClient)
-		m.logger.Info("%s Connected to MCP server '%s'", MCPLogPrefix, config.Name)
-	} else {
-		// Release lock before cleanup and return
+	// Verify the entry is still the same one this attempt started with:
+	// resolving by ID alone isn't enough, since a RemoveClient + AddClient
+	// cycle for this ID during the dial deletes this entry and installs a
+	// new pointer under the same key.
+	client, exists := m.clientMap[config.ID]
+	if !exists || client != entry {
 		m.mu.Unlock()
-		// Clean up resources before returning error: client was removed during connection setup
-		// Cancel long-lived context if it was created
-		if (config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO) && cancel != nil {
-			cancel()
-		}
-		// Close external client connection to prevent transport/goroutine leaks
-		if externalClient != nil {
-			if err := externalClient.Close(); err != nil {
-				m.logger.Warn("%s Failed to close external client during cleanup: %v", MCPLogPrefix, err)
-			}
-		}
+		// Client was removed (or removed and re-added) during connection
+		// setup: release both the new handles and any captured old ones to
+		// prevent transport/goroutine leaks, without touching the
+		// replacement entry.
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
 		return fmt.Errorf("client %s was removed during connection setup", config.Name)
 	}
+
+	// If the client was disabled while we were doing the whole connection process
+	// roll back the newly established connection and abort, without overwriting
+	// the Disabled state. This is a rare edge case.
+	if client.State == schemas.MCPConnectionStateDisabled {
+		m.mu.Unlock()
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
+		m.logger.Debug("%s [%s] Client was disabled during connection setup; rolling back", MCPLogPrefix, config.Name)
+		return fmt.Errorf("client %s was disabled during connection setup", config.Name)
+	}
+
+	// Store the external client connection and details
+	client.Conn = externalClient
+	client.ConnectionInfo = connectionInfo
+	client.State = schemas.MCPConnectionStateConnected
+
+	// Store cancel function for SSE and STDIO connections to enable proper cleanup
+	if config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO {
+		client.CancelFunc = cancel
+	}
+
+	// Replace the tool set wholesale (the entry may still hold the previous
+	// connection's tools on the make-before-break path) and store the tool
+	// name mapping for execution (sanitized_name -> original_mcp_name).
+	client.ToolMap = tools
+	client.ToolNameMapping = toolNameMapping
+
+	// Bump the connection generation: anything still bound to the previous
+	// connection (a tool-sync tick that snapshotted it, the old SSE
+	// OnConnectionLost callback) compares its recorded generation against the
+	// entry's and becomes a no-op instead of clobbering the fresh connection.
+	client.ConnGeneration++
+	swapGeneration := client.ConnGeneration
+
+	m.logger.Debug("%s [%s] Registering %d tools. Client config - ID: %s, Name: %s, IsCodeModeClient: %v", MCPLogPrefix, config.Name, len(tools), config.ID, config.Name, config.IsCodeModeClient)
+	m.logger.Info("%s Connected to MCP server '%s'", MCPLogPrefix, config.Name)
 
 	// Release lock BEFORE starting monitors to prevent deadlock
 	// (StartMonitoring -> Start() tries to acquire RLock on the same mutex)
@@ -1828,25 +1907,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	// Register OnConnectionLost hook for SSE connections to detect idle timeouts
 	if config.ConnectionType == schemas.MCPConnectionTypeSSE && externalClient != nil {
 		externalClient.OnConnectionLost(func(err error) {
-			m.logger.Warn("%s SSE connection lost for MCP server '%s': %v", MCPLogPrefix, config.Name, err)
-			// Update state to disconnected, but never overwrite a disabled or
-			// needs-reauth state. DisableClient calls Conn.Close() while holding
-			// m.mu; the SSE library fires OnConnectionLost after the lock is
-			// released, by which point State is already Disabled — do not clobber
-			// it. Also gate on client.Conn == externalClient: a reconnect can
-			// replace this entry's Conn (and its State, e.g. to NeedsReauth on a
-			// dead OAuth2 credential) before this closed connection's own
-			// OnConnectionLost callback gets a chance to fire, so an identity
-			// check is required — a plain State-value check can't tell a stale
-			// callback from a live one.
-			m.mu.Lock()
-			if client, exists := m.clientMap[config.ID]; exists &&
-				client.Conn == externalClient &&
-				client.State != schemas.MCPConnectionStateDisabled &&
-				client.State != schemas.MCPConnectionStateNeedsReauth {
-				client.State = schemas.MCPConnectionStateDisconnected
-			}
-			m.mu.Unlock()
+			m.handleSSEConnectionLost(config.ID, config.Name, swapGeneration, err)
 		})
 	}
 
@@ -1867,7 +1928,105 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		}
 	}
 
+	// Make-before-break: the swap is committed and the workers re-registered,
+	// so the previous connection can now be torn down. In-flight calls that
+	// snapshotted the old connection get close-time errors at this instant
+	// only, instead of failing for the whole dial window.
+	m.closeConnHandles(oldCancel, oldConn, config.Name)
+
 	return nil
+}
+
+// handleSSEConnectionLost is the OnConnectionLost callback body for SSE
+// clients, registered with the connection generation that was current when
+// its connection was swapped in. A callback whose generation no longer
+// matches the entry's belongs to an already-replaced connection (its close
+// during a reconnect swap can fire the SSE library's loss handler) and must
+// not flip the freshly connected client to Disconnected. The Disabled guard
+// is unchanged: DisableClient calls Conn.Close() while holding m.mu, the SSE
+// library fires OnConnectionLost after the lock is released, by which point
+// State is already Disabled and must not be clobbered.
+func (m *MCPManager) handleSSEConnectionLost(clientID, clientName string, generation uint64, err error) {
+	m.mu.Lock()
+	// Never overwrite Disabled (DisableClient is authoritative) or
+	// NeedsReauth: the connection can still be the one this generation was
+	// swapped in for (ConnGeneration unchanged) at the moment a separate
+	// dead-credential detection (e.g. a failed refresh) flips it to
+	// NeedsReauth — clobbering that back to the generic Disconnected would
+	// hide the "a human needs to reauthorize this" signal.
+	client, exists := m.clientMap[clientID]
+	if !exists || client.ConnGeneration != generation ||
+		client.State == schemas.MCPConnectionStateDisabled ||
+		client.State == schemas.MCPConnectionStateNeedsReauth {
+		m.mu.Unlock()
+		m.logger.Debug("%s Ignoring stale SSE connection-lost callback for MCP server '%s': %v", MCPLogPrefix, clientName, err)
+		return
+	}
+	client.State = schemas.MCPConnectionStateDisconnected
+	m.mu.Unlock()
+	m.logger.Warn("%s SSE connection lost for MCP server '%s': %v", MCPLogPrefix, clientName, err)
+}
+
+// closeConnHandles cancels and closes one connection handle pair. Both may be
+// nil. Close errors are logged and swallowed since every caller is on a
+// teardown path.
+func (m *MCPManager) closeConnHandles(cancel context.CancelFunc, conn *client.Client, clientName string) {
+	if cancel != nil {
+		cancel()
+	}
+	if conn != nil {
+		if err := conn.Close(); err != nil {
+			m.logger.Warn("%s Failed to close connection for MCP client '%s': %v", MCPLogPrefix, clientName, err)
+		}
+	}
+}
+
+// failConnectAttempt is the shared teardown for every failure exit of
+// connectToMCPClient after the client entry has been prepared. It first
+// writes the standard post-failure entry state under m.mu: no connection,
+// cleared tool maps, connection info reduced to the bare type, a generation
+// bump, and State Disconnected (or NeedsReauth when the failure was
+// classified as a dead OAuth2 credential). Only then are the half-built new
+// connection handles and the previous connection captured for
+// make-before-break closed, outside the lock.
+//
+// The order is load-bearing: during a make-before-break dial the map entry
+// still references the old connection, and other closers (RemoveClient)
+// close whatever the entry references under m.mu. Detaching under the lock
+// before closing gives any residual double-close a happens-before edge, so
+// the transport's own idempotence check suffices; closing first would race
+// it. The generation bump invalidates late writers that captured the old
+// connection: a tool-sync tick whose list_tools succeeded on the old
+// connection mid-dial must not repopulate the cleared tool map of a
+// Disconnected or NeedsReauth entry, and a late SSE loss callback from the
+// torn-down connection must not overwrite the failure state.
+//
+// Disabled entries keep the state DisableClient wrote, and an entry removed
+// mid-dial leaves the map untouched. entry is the *MCPClientState this
+// attempt started with; a RemoveClient + AddClient cycle for the same ID
+// during the dial installs a different pointer under the same key, and this
+// attempt must not mutate that replacement.
+func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *schemas.MCPClientConfig, newCancel context.CancelFunc, newConn *client.Client, oldCancel context.CancelFunc, oldConn *client.Client, needsReauth bool) {
+	m.mu.Lock()
+	if clientState, exists := m.clientMap[config.ID]; exists && clientState == entry && clientState.State != schemas.MCPConnectionStateDisabled {
+		clientState.Conn = nil
+		clientState.CancelFunc = nil
+		clientState.ToolMap = make(map[string]schemas.ChatTool)
+		clientState.ToolNameMapping = make(map[string]string)
+		clientState.ConnectionInfo = &schemas.MCPClientConnectionInfo{
+			Type: config.ConnectionType,
+		}
+		clientState.ConnGeneration++
+		if needsReauth {
+			clientState.State = schemas.MCPConnectionStateNeedsReauth
+		} else {
+			clientState.State = schemas.MCPConnectionStateDisconnected
+		}
+	}
+	m.mu.Unlock()
+
+	m.closeConnHandles(newCancel, newConn, config.Name)
+	m.closeConnHandles(oldCancel, oldConn, config.Name)
 }
 
 // buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived

--- a/core/mcp/makebeforebreak_test.go
+++ b/core/mcp/makebeforebreak_test.go
@@ -1,0 +1,494 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// Test doubles and helpers for the make-before-break connectToMCPClient tests.
+// =============================================================================
+
+// dialGate lets a test stall the dial of a NEW connection to a fake upstream
+// MCP server while requests on ALREADY-ESTABLISHED sessions keep flowing.
+// New-connection traffic is identified by the absence of the Mcp-Session-Id
+// header (the streamable-HTTP initialize request has no session yet); every
+// request of a live session carries the header and passes through untouched.
+type dialGate struct {
+	mu       sync.Mutex
+	enabled  bool
+	arrived  chan struct{}
+	release  chan struct{}
+	signaled bool
+}
+
+func newDialGate() *dialGate {
+	return &dialGate{
+		arrived: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+// enable arms the gate for the next sessionless request.
+func (g *dialGate) enable() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.enabled = true
+}
+
+// maybeBlock is called by the server handler. It signals arrival (once) and
+// parks the request until the test releases the gate.
+func (g *dialGate) maybeBlock(r *http.Request) {
+	if r.Header.Get("Mcp-Session-Id") != "" {
+		return
+	}
+	g.mu.Lock()
+	if !g.enabled {
+		g.mu.Unlock()
+		return
+	}
+	if !g.signaled {
+		g.signaled = true
+		close(g.arrived)
+	}
+	g.mu.Unlock()
+	<-g.release
+}
+
+// releaseAll lets every parked request through and disarms the gate.
+func (g *dialGate) releaseAll() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.enabled {
+		g.enabled = false
+		close(g.release)
+	}
+}
+
+// buildGatedMCPServer starts a streamable-HTTP MCP server (one "echo" tool)
+// whose middleware routes new-connection requests through the given dialGate.
+func buildGatedMCPServer(t *testing.T, gate *dialGate) *httptest.Server {
+	t.Helper()
+
+	s := server.NewMCPServer("test-make-before-break", "1.0.0", server.WithToolCapabilities(true))
+	echoTool := mcpgo.NewTool("echo",
+		mcpgo.WithDescription("Echo tool"),
+		mcpgo.WithString("message", mcpgo.Required(), mcpgo.Description("message")),
+	)
+	s.AddTool(echoTool, func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		msg, _ := req.GetArguments()["message"].(string)
+		return mcpgo.NewToolResultText(msg), nil
+	})
+
+	streamable := server.NewStreamableHTTPServer(s)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gate != nil {
+			gate.maybeBlock(r)
+		}
+		streamable.ServeHTTP(w, r)
+	})
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// newMakeBeforeBreakConfig builds a shared-connection (auth_type defaulting to
+// headers) HTTP client config pointed at the fake upstream.
+func newMakeBeforeBreakConfig(id, serverURL string) *schemas.MCPClientConfig {
+	return &schemas.MCPClientConfig{
+		ID:               id,
+		Name:             "mbb-" + id,
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar(serverURL),
+		ToolsToExecute:   []string{"*"},
+	}
+}
+
+// callEchoTool executes the client's echo tool through the same seam real
+// tool execution uses (GetClientForTool + AcquireClientConn + CallTool) and
+// returns any error along the way.
+func callEchoTool(m *MCPManager, toolName string) error {
+	state := m.GetClientForTool(toolName)
+	if state == nil {
+		return fmt.Errorf("tool '%s' is not available or not permitted", toolName)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+	conn, release, err := m.AcquireClientConn(bfCtx, state)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	_, callErr := conn.CallTool(ctx, mcpgo.CallToolRequest{
+		Request: mcpgo.Request{Method: string(mcpgo.MethodToolsCall)},
+		Params: mcpgo.CallToolParams{
+			Name:      "echo",
+			Arguments: map[string]interface{}{"message": "ping"},
+		},
+	})
+	return callErr
+}
+
+// snapshotClientState copies the fields the assertions below care about while
+// holding the manager lock.
+func snapshotClientState(m *MCPManager, id string) (state schemas.MCPClientState, exists bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cs, ok := m.clientMap[id]
+	if !ok {
+		return schemas.MCPClientState{}, false
+	}
+	return *cs, true
+}
+
+// =============================================================================
+// Success path: the old connection keeps serving during the dial, the swap is
+// atomic, and the old connection is closed only after the swap.
+// =============================================================================
+
+func TestConnectToMCPClient_MakeBeforeBreak_ServesDuringDialAndClosesOldConn(t *testing.T) {
+	gate := newDialGate()
+	ts := buildGatedMCPServer(t, gate)
+
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := newMakeBeforeBreakConfig("serves-during-dial", ts.URL)
+	toolName := config.Name + "-echo"
+
+	require.NoError(t, m.connectToMCPClient(context.Background(), config))
+
+	before, ok := snapshotClientState(m, config.ID)
+	require.True(t, ok)
+	require.NotNil(t, before.Conn)
+	require.Equal(t, schemas.MCPConnectionStateConnected, before.State)
+	oldConn := before.Conn
+
+	// Kick off the reconnect with the new dial parked behind the gate.
+	gate.enable()
+	reconnectDone := make(chan error, 1)
+	go func() {
+		reconnectDone <- m.connectToMCPClient(context.Background(), config)
+	}()
+
+	select {
+	case <-gate.arrived:
+	case <-time.After(10 * time.Second):
+		t.Fatal("new dial never reached the gated server")
+	}
+
+	// Mid-dial: the entry must still be Connected on the OLD connection with
+	// its tool map intact, and a tool call through it must succeed.
+	mid, ok := snapshotClientState(m, config.ID)
+	require.True(t, ok)
+	assert.Equal(t, schemas.MCPConnectionStateConnected, mid.State, "client must stay Connected for the whole dial window")
+	assert.Same(t, oldConn, mid.Conn, "the old connection must keep serving during the dial")
+	assert.Contains(t, mid.ToolMap, toolName, "the tool map must stay populated during the dial")
+	require.NoError(t, callEchoTool(m, toolName), "a tool call through the old connection must succeed mid-dial")
+
+	gate.releaseAll()
+	require.NoError(t, <-reconnectDone)
+
+	after, ok := snapshotClientState(m, config.ID)
+	require.True(t, ok)
+	assert.Equal(t, schemas.MCPConnectionStateConnected, after.State)
+	require.NotNil(t, after.Conn)
+	assert.NotSame(t, oldConn, after.Conn, "the swap must install a fresh connection")
+	assert.Contains(t, after.ToolMap, toolName)
+	assert.Equal(t, before.ConnGeneration+1, after.ConnGeneration, "the swap must bump the connection generation exactly once")
+
+	// The old connection must be closed after the swap: a call on the
+	// captured handle fails, while the swapped-in client keeps serving.
+	callCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, oldErr := oldConn.CallTool(callCtx, mcpgo.CallToolRequest{
+		Request: mcpgo.Request{Method: string(mcpgo.MethodToolsCall)},
+		Params:  mcpgo.CallToolParams{Name: "echo", Arguments: map[string]interface{}{"message": "ping"}},
+	})
+	require.Error(t, oldErr, "the pre-swap connection must be closed once the swap completes")
+	require.NoError(t, callEchoTool(m, toolName))
+}
+
+func TestConnectToMCPClient_MakeBeforeBreak_ConcurrentCallsAcrossSwap(t *testing.T) {
+	ts := buildGatedMCPServer(t, nil)
+
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := newMakeBeforeBreakConfig("concurrent-swap", ts.URL)
+	toolName := config.Name + "-echo"
+
+	require.NoError(t, m.connectToMCPClient(context.Background(), config))
+
+	// Hammer the tool from many goroutines while several reconnect swaps run.
+	// Calls racing the instant the old connection closes may see close-time
+	// transport errors; what must NEVER appear are the dial-window failures
+	// this change eliminates: a wiped tool map ("not available or not
+	// permitted") or a nil Conn ("has no active connection").
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var windowErrs []error
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if err := callEchoTool(m, toolName); err != nil {
+					msg := err.Error()
+					if strings.Contains(msg, "no active connection") || strings.Contains(msg, "not available or not permitted") {
+						mu.Lock()
+						windowErrs = append(windowErrs, err)
+						mu.Unlock()
+					}
+				}
+			}
+		}()
+	}
+
+	for range 3 {
+		require.NoError(t, m.connectToMCPClient(context.Background(), config))
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, windowErrs, "no call spanning a swap may observe a wiped tool map or a nil connection")
+}
+
+// =============================================================================
+// Failure paths: a failed re-dial must land in exactly today's post-failure
+// state (Disconnected or NeedsReauth, nil Conn, empty tool maps) with the old
+// connection closed.
+// =============================================================================
+
+// flipCredStore succeeds on the first ConnectionHeaders resolution (the
+// initial connect) and fails every one after it (the reconnect), letting the
+// tests below drive a live client into the connect-gate failure path.
+type flipCredStore struct {
+	mu       sync.Mutex
+	calls    int
+	failWith error
+}
+
+func (f *flipCredStore) ConnectionHeaders(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) (http.Header, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.calls > 1 {
+		return nil, f.failWith
+	}
+	return http.Header{}, nil
+}
+
+func (f *flipCredStore) RequestHeaders(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return http.Header{}, nil
+}
+
+func (f *flipCredStore) RequiresPerCallConnection(_ *schemas.MCPClientConfig) bool {
+	return false
+}
+
+func (f *flipCredStore) ForceRefresh(_ *schemas.BifrostContext, _ *schemas.MCPClientConfig) error {
+	return nil
+}
+
+func (f *flipCredStore) AdminConnectionHeaders(_ context.Context, _ *schemas.MCPClientConfig) (http.Header, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func TestConnectToMCPClient_MakeBeforeBreak_DialFailure_ResetsStateAndClosesOldConn(t *testing.T) {
+	tests := []struct {
+		name      string
+		failWith  error
+		wantState schemas.MCPConnectionState
+	}{
+		{
+			name:      "generic failure lands in Disconnected",
+			failWith:  fmt.Errorf("connection refused"),
+			wantState: schemas.MCPConnectionStateDisconnected,
+		},
+		{
+			name:      "dead OAuth2 credential lands in NeedsReauth",
+			failWith:  fmt.Errorf("refresh token rejected by upstream OAuth server, re-authentication required: %w", schemas.ErrOAuth2TokenExpired),
+			wantState: schemas.MCPConnectionStateNeedsReauth,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := buildGatedMCPServer(t, nil)
+
+			m := NewMCPManager(context.Background(), schemas.MCPConfig{}, &flipCredStore{failWith: tc.failWith}, nil, nil)
+			config := newMakeBeforeBreakConfig("dial-failure", ts.URL)
+
+			require.NoError(t, m.connectToMCPClient(context.Background(), config))
+
+			before, ok := snapshotClientState(m, config.ID)
+			require.True(t, ok)
+			require.NotNil(t, before.Conn)
+			oldConn := before.Conn
+
+			require.Error(t, m.connectToMCPClient(context.Background(), config))
+
+			after, ok := snapshotClientState(m, config.ID)
+			require.True(t, ok, "the entry must survive a failed re-dial")
+			assert.Equal(t, tc.wantState, after.State)
+			assert.Nil(t, after.Conn, "a failed re-dial must leave no connection on the entry")
+			assert.Nil(t, after.CancelFunc)
+			assert.Empty(t, after.ToolMap, "a failed re-dial must leave the tool map empty")
+			assert.Empty(t, after.ToolNameMapping)
+
+			// The captured old connection must have been torn down too.
+			callCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_, oldErr := oldConn.CallTool(callCtx, mcpgo.CallToolRequest{
+				Request: mcpgo.Request{Method: string(mcpgo.MethodToolsCall)},
+				Params:  mcpgo.CallToolParams{Name: "echo", Arguments: map[string]interface{}{"message": "ping"}},
+			})
+			require.Error(t, oldErr, "the old connection must be closed on a failed re-dial")
+		})
+	}
+}
+
+// =============================================================================
+// Generation guards: stale tool-sync write-backs and stale OnConnectionLost
+// callbacks must be no-ops.
+// =============================================================================
+
+func TestClientToolSyncer_PerformSync_StaleGenerationWriteDropped(t *testing.T) {
+	// Server whose tools/list handling can be parked, so a connection swap can
+	// be interleaved between performSync's snapshot and its write-back. The
+	// gate is armed only after the initial connect, so the connect's own
+	// tools/list passes through untouched and exactly the syncer's request
+	// parks.
+	var gateMu sync.Mutex
+	gateArmed := false
+	gateSignaled := false
+	listArrived := make(chan struct{})
+	listRelease := make(chan struct{})
+
+	s := server.NewMCPServer("test-stale-sync", "1.0.0", server.WithToolCapabilities(true))
+	echoTool := mcpgo.NewTool("echo",
+		mcpgo.WithDescription("Echo tool"),
+		mcpgo.WithString("message", mcpgo.Required(), mcpgo.Description("message")),
+	)
+	s.AddTool(echoTool, func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		return mcpgo.NewToolResultText("ok"), nil
+	})
+	streamable := server.NewStreamableHTTPServer(s)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		if bytes.Contains(body, []byte(`"tools/list"`)) {
+			gateMu.Lock()
+			blocked := gateArmed
+			if blocked && !gateSignaled {
+				gateSignaled = true
+				close(listArrived)
+			}
+			gateMu.Unlock()
+			if blocked {
+				<-listRelease
+			}
+		}
+		streamable.ServeHTTP(w, r)
+	})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, nil, nil, nil)
+	config := newMakeBeforeBreakConfig("stale-sync", ts.URL)
+
+	require.NoError(t, m.connectToMCPClient(context.Background(), config))
+
+	// Arm the gate for the syncer's tools/list.
+	gateMu.Lock()
+	gateArmed = true
+	gateMu.Unlock()
+
+	syncer := NewClientToolSyncer(m, config.ID, config.Name, time.Minute, &MockLogger{})
+	syncDone := make(chan struct{})
+	go func() {
+		syncer.performSync()
+		close(syncDone)
+	}()
+
+	select {
+	case <-listArrived:
+	case <-time.After(10 * time.Second):
+		t.Fatal("syncer's tools/list never reached the server")
+	}
+
+	// While the sync is parked, simulate a completed reconnect swap: bump the
+	// generation and install a marker tool map.
+	markerTools := map[string]schemas.ChatTool{"marker-tool": {}}
+	m.mu.Lock()
+	m.clientMap[config.ID].ConnGeneration++
+	m.clientMap[config.ID].ToolMap = markerTools
+	m.mu.Unlock()
+
+	close(listRelease)
+	select {
+	case <-syncDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("performSync never finished")
+	}
+
+	after, ok := snapshotClientState(m, config.ID)
+	require.True(t, ok)
+	assert.Contains(t, after.ToolMap, "marker-tool", "a sync that spanned a connection swap must not clobber the post-swap tool map")
+	assert.Len(t, after.ToolMap, 1)
+}
+
+func TestHandleSSEConnectionLost_StaleGenerationNoOp(t *testing.T) {
+	m := &MCPManager{
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+	config := &schemas.MCPClientConfig{ID: "sse-client", Name: "sse-client"}
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateConnected,
+		ConnGeneration:  2,
+	}
+
+	// A callback registered against the replaced connection (generation 1)
+	// must not flip the freshly connected client to Disconnected.
+	m.handleSSEConnectionLost(config.ID, config.Name, 1, fmt.Errorf("idle timeout"))
+	assert.Equal(t, schemas.MCPConnectionStateConnected, m.clientMap[config.ID].State)
+
+	// An unknown client is a no-op.
+	m.handleSSEConnectionLost("missing-client", "missing-client", 2, fmt.Errorf("idle timeout"))
+
+	// The current generation's callback performs today's transition.
+	m.handleSSEConnectionLost(config.ID, config.Name, 2, fmt.Errorf("idle timeout"))
+	assert.Equal(t, schemas.MCPConnectionStateDisconnected, m.clientMap[config.ID].State)
+
+	// The Disabled guard is preserved even for a current-generation callback.
+	m.clientMap[config.ID].State = schemas.MCPConnectionStateDisabled
+	m.handleSSEConnectionLost(config.ID, config.Name, 2, fmt.Errorf("idle timeout"))
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, m.clientMap[config.ID].State)
+}

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -947,7 +947,9 @@ func (m *ToolsManager) recoverSharedConnection(
 	// ExecutionConfig.ID doesn't match the client this recovery is actually
 	// for, or if the tool it was reconnected for is no longer on it —
 	// letting the original auth failure surface is strictly safer than
-	// guessing.
+	// guessing. GetClientByName returns a snapshot copy of the client state,
+	// so it must be re-resolved after the reconnect to pick up the fresh
+	// connection.
 	state := m.clientManager.GetClientByName(executionConfig.Name)
 	if state == nil || state.ExecutionConfig == nil || state.ExecutionConfig.ID != executionConfig.ID {
 		return nil, false

--- a/core/mcp/toolsync.go
+++ b/core/mcp/toolsync.go
@@ -116,6 +116,11 @@ func (cts *ClientToolSyncer) performSync() {
 	}
 
 	conn := clientState.Conn
+	// Record the connection generation alongside the conn snapshot: if a
+	// reconnect swaps in a fresh connection while this sync is in flight, the
+	// write-back below must not clobber the fresh tool set with results from
+	// the replaced connection.
+	connGeneration := clientState.ConnGeneration
 	config := clientState.ExecutionConfig
 	clientName := config.Name
 	cts.manager.mu.RUnlock()
@@ -155,6 +160,14 @@ func (cts *ClientToolSyncer) performSync() {
 	clientState, exists = cts.manager.clientMap[cts.clientID]
 	if !exists {
 		cts.manager.mu.Unlock()
+		return
+	}
+
+	// The connection this sync ran against has been replaced mid-flight;
+	// drop the stale results and let the next tick sync the new connection.
+	if clientState.ConnGeneration != connGeneration {
+		cts.manager.mu.Unlock()
+		cts.logger.Debug("%s Skipping tool sync write-back for %s: connection was replaced during sync", MCPLogPrefix, cts.clientID)
 		return
 	}
 

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -761,6 +761,7 @@ type MCPClientState struct {
 	ConnectionInfo  *MCPClientConnectionInfo `json:"connection_info"` // Connection metadata for management
 	CancelFunc      context.CancelFunc       `json:"-"`               // Cancel function for SSE connections (not serialized)
 	State           MCPConnectionState       // Connection state (connected, disconnected, error)
+	ConnGeneration  uint64                   `json:"-"` // Counts connection swaps; late writers bound to an older Conn compare against it to detect staleness (not serialized)
 }
 
 // MCPClientConnectionInfo stores metadata about how a client is connected.


### PR DESCRIPTION
## Summary

HTTP and SSE MCP clients previously tore down their existing connection before dialing a new one, leaving a window during reconnects where the client entry had a nil `Conn`, an empty tool map, and a `Disconnected` state. Any tool call or state read during that window would fail or return misleading results. This PR introduces a make-before-break reconnect strategy for HTTP/SSE clients: the old connection keeps serving until the new one is fully established and swapped in atomically, eliminating the dial-window outage entirely.

## Changes

- **Make-before-break for HTTP/SSE reconnects**: `connectToMCPClient` now distinguishes between two strategies based on connection type and current liveness. HTTP and SSE clients with a live connection hold the old `Conn` and tool maps in place for the entire dial window; the swap happens atomically under the manager lock only after the new connection is established and tools are listed. STDIO and in-process clients retain the existing close-first behavior to avoid double subprocess spawning and exclusive resource conflicts.

- **`failConnectAttempt` helper**: All failure exits from `connectToMCPClient` now funnel through a single method that writes the post-failure entry state (nil `Conn`, cleared tool maps, `Disconnected` or `NeedsReauth`) under the lock before closing both the half-built new connection and the captured old connection outside it. This ordering prevents races with other closers (e.g., `RemoveClient`) that close whatever the entry references under the lock.

- **`ConnGeneration` field on `MCPClientState`**: A monotonically increasing counter that is bumped on every successful connection swap and on every failure reset. Late writers that captured a connection before a swap compare their recorded generation against the entry's current value to detect staleness and become no-ops instead of clobbering fresh state.

- **Stale tool-sync write-back guard**: `ClientToolSyncer.performSync` records the connection generation alongside its `Conn` snapshot. If a reconnect swap completes while a sync is in flight, the write-back is dropped and the next tick re-syncs the new connection.

- **Generation-aware `handleSSEConnectionLost`**: The `OnConnectionLost` callback is now registered with the generation that was current at swap time. A callback whose generation no longer matches the entry's (e.g., fired by the old connection being closed during a make-before-break swap) is silently ignored rather than flipping a freshly connected client to `Disconnected`.

- **`beginExclusiveClientOp` / `finishExclusiveClientOp` refactor**: Completed ops are left in the map instead of being deleted on finish. A caller that lost the "already in progress" race and subsequently calls `AwaitReconnect` still finds the finished op and gets its result. A new call lazily replaces a finished entry via `CompareAndSwap`. The test double in `auth_retry_test.go` is updated to mirror this contract.

- **`closeConnHandles` helper**: Extracted repeated cancel+close teardown into a single method that logs and swallows close errors, since all callers are on teardown paths.

- **New test file `makebeforebreak_test.go`**: Covers the success path (old connection serves during dial, swap is atomic, old connection is closed after swap), concurrent tool calls across multiple swaps, dial failure state resets for both `Disconnected` and `NeedsReauth` outcomes, stale tool-sync write-back suppression, and stale `OnConnectionLost` callback suppression.

## Type of change

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
go test ./core/mcp/...
```

The new `makebeforebreak_test.go` file exercises all paths introduced by this change. Key scenarios to validate manually:

- Reconnecting an HTTP MCP client while tool calls are in flight should not produce "no active connection" or "not available or not permitted" errors during the dial window.
- A failed reconnect (credential error or network failure) should leave the client in `Disconnected` (or `NeedsReauth` for expired OAuth2 tokens) with a nil `Conn` and empty tool maps, and the previous connection must be closed.
- An SSE client that loses its connection after a successful swap must transition to `Disconnected`; a loss event from the replaced connection must be a no-op.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No auth, secrets, or PII changes. The `ConnGeneration` field is explicitly excluded from JSON serialization.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
