### PR TITLE
docs: document make-before-break reconnection and shared-client retry behavior

### DIFF
--- a/docs/mcp/auth/oauth.mdx
+++ b/docs/mcp/auth/oauth.mdx
@@ -270,6 +270,8 @@ Background refresh only runs while the MCP client is enabled. Disabling a client
 
 Transient refresh failures (network blips, provider hiccups) keep retrying silently. Only a permanent rejection (the provider refuses the refresh token outright) flips the token to `needs_reauth`.
 
+A successful background refresh doesn't just update the stored token: for shared clients it immediately recycles the live connection so it starts using the fresh credential. The recycle is [make-before-break](../gateway#reconnection-behavior) for HTTP and SSE clients, so the connection keeps serving tool calls throughout, and token expiry normally passes with zero failed calls. In a multi-node deployment, only the node that performed the refresh recycles its own connection; the other nodes' connections heal on their next auth failure via the retry described in [Auth failure recovery](../tool-execution#auth-failure-recovery).
+
 <Warning>
 **Some providers only issue a refresh token when you explicitly ask for one.** Google is the canonical case: without `access_type=offline&prompt=consent` on the authorize URL, the grant contains only an access token, and the client lands in `needs_reauth` at every token expiry (roughly hourly for Google). Bifrost preserves any query parameters already present on the configured `authorize_url`, so append the provider's offline-access parameters there, e.g. `"authorize_url": "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"`.
 </Warning>

--- a/docs/mcp/auth/overview.mdx
+++ b/docs/mcp/auth/overview.mdx
@@ -55,6 +55,8 @@ Connection-state semantics (`connected`, `disconnected`, `error`, shown on the M
 - **`pending_verification`**: all five auth types, including `oauth`, `per_user_oauth`, and `per_user_headers`, can be declared in `config.json`, and the three that need an admin verification step (the two OAuth variants plus `per_user_headers`) land in this state at boot. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row that runs the same verification flow the Web UI Create form uses. See each auth type's page for the `config.json` shape.
 - **`needs_reauth`**: on a server-level client, the connection credential itself died and must be reauthorized via the **Reauthorize** button on the client sheet (or [`POST /api/mcp/client/{id}/reauthorize`](./oauth#reauthorization)). On a per-user client, it means the admin credential Bifrost retains to refresh the server's tool list needs repair; end-user credentials and tool calls keep working, only tool-list refresh pauses until an admin repairs it from the client sheet: **Repair OAuth** (the same reauthorize flow) for [`per_user_oauth`](./per-user-oauth#admin-discovery-credential), or **Update headers** (re-running `verify-headers` with fresh sample values) for [`per_user_headers`](./per-user-headers#admin-discovery-credential).
 
+Short of that permanent case, token rotation and reauthorization never require downtime for HTTP/SSE server-level clients: reconnection is [make-before-break](../gateway#reconnection-behavior), so the existing connection keeps serving tool calls until the new one is ready.
+
 ---
 
 ## Pick your auth type

--- a/docs/mcp/gateway.mdx
+++ b/docs/mcp/gateway.mdx
@@ -290,6 +290,15 @@ if err != nil {
 }
 ```
 
+### Reconnection behavior
+
+How a client reconnects, and whether tool calls are affected while it does, depends on its connection type:
+
+- **HTTP and SSE clients reconnect make-before-break.** Bifrost dials the new connection first; the existing connection keeps serving tool calls for the whole dial. Once the new connection is ready, the swap is atomic, and only then is the old connection closed. In practice this means credential rotation, reauthorization, and the automatic-refresh recycle described in [Automatic refresh](./auth/oauth#automatic-refresh) don't cause downtime for these clients.
+- **STDIO and in-process clients reconnect close-first.** The existing connection (and, for STDIO, its subprocess) is closed before the new one is dialed, so there's a brief window where the client has no connection. This is deliberate: a STDIO reconnect spawns a new subprocess, and many STDIO servers hold exclusive resources (lockfiles, bound ports, singleton sockets) that a second instance can't acquire while the first is still running. STDIO reconnects are also almost always crash recovery, where the existing connection is already dead and there's nothing to keep serving.
+
+Either way, a tool call that lands during a reconnect window is covered by [Auth failure recovery](./tool-execution#auth-failure-recovery) when the failure is auth-shaped; other failures during a close-first window surface as a normal connection error and are retried by the caller.
+
 ### Request ID Tracking
 
 For Agent Mode operations, Bifrost can track intermediate tool executions:

--- a/docs/mcp/tool-execution.mdx
+++ b/docs/mcp/tool-execution.mdx
@@ -386,8 +386,8 @@ if err != nil {
 When a tool call reaches the upstream MCP server but comes back with a clean auth rejection (401/403), Bifrost reacts on the spot instead of waiting for the health monitor:
 
 - **Per-user clients** (`per_user_oauth`, `per_user_headers`): Bifrost force-refreshes the caller's credential, re-acquires a connection, and retries the same call inline, exactly once. If the retry succeeds, the caller just sees a normal success.
-- **Shared clients** (`oauth`, `headers`): the failing call still fails (there is no way to swap credentials on an open connection mid-call), but Bifrost immediately force-refreshes the credential and reconnects in the background, so the next call succeeds.
-- **Safety opt-out**: tools annotated as destructive and not idempotent are never auto-retried; the original error surfaces so a side effect cannot run twice.
+- **Shared clients** (`oauth`, `headers`): Bifrost immediately force-refreshes the credential and starts reconnecting in the background. The failing call waits briefly for that reconnect (capped by its own deadline) and retries once on the healed connection; the caller usually sees a normal success. If the reconnect doesn't finish in time, the original error surfaces and later calls succeed once the background reconnect completes.
+- **Safety opt-out**: tools annotated as destructive and not idempotent are never retried; the reconnect still happens, but the original error always surfaces so a side effect cannot run twice.
 
 This applies to `POST /v1/mcp/tool/execute`, [Agent Mode](./agent-mode) tool calls, and tool calls over the [MCP Gateway](./gateway) alike.
 


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


