### PR TITLE
docs: add budget override API reference and OpenAPI spec

### DIFF
--- a/docs/features/governance/budget-and-limits.mdx
+++ b/docs/features/governance/budget-and-limits.mdx
@@ -170,6 +170,16 @@ By default, a budget **rolls**: after `reset_duration` elapses since `last_reset
 
 Calendar alignment applies to budgets on **customers**, **teams**, **virtual keys**, and **per–provider-config** budgets. You can set it when creating a budget (`calendar_aligned` on create) or toggle it on update (`calendar_aligned` on the budget in `PUT` requests). Turning calendar alignment **on** for an existing budget resets **current usage to zero** and snaps **`last_reset`** to the current period start.
 
+### Budget overrides
+
+A budget can carry a temporary **override** that adds spending capacity on top of its configured limit without touching the base limit, current usage, or reset schedule. While an override is active, enforcement uses:
+
+```text
+Effective limit = max_limit + override_amount
+```
+
+An override lasts either for a fixed number of reset cycles (the current cycle counts as the first) or until it is explicitly removed. Manage it from the virtual key's **Budget Information** panel, or through `PUT`/`DELETE` on `/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override` — see [Budget Overrides](./virtual-keys#budget-overrides) for the UI walkthrough and API examples.
+
 ---
 
 ## Customer-scoped requests

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -516,11 +516,68 @@ For example, adding a `$100` override to a `$1,000` budget raises its effective 
 
 ![Virtual-key budget with an active override](../../media/vk-override-budget-overriden-budget-view.png)
 
-To change or remove an active override, click **Edit override** on the budget card. For programmatic configuration, see the **Virtual Keys** section of the [API Reference](/api-reference).
+To change or remove an active override, click **Edit override** on the budget card.
 
 <Note>
 Overrides are available after a budget has been created. Budgets inherited from an enterprise [access profile](/enterprise/access-profiles) must be overridden from that access profile instead of from the virtual key.
 </Note>
+
+#### Managing overrides via API
+
+Two endpoints manage the override on a single virtual-key budget. Both take the virtual key ID and the ID of a budget that key owns, and both return the persisted budget alongside its `effective_max_limit`.
+
+Grant extra spend for a fixed number of reset cycles:
+
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 100.0,
+    "mode": "cycles",
+    "cycles": 2
+  }'
+```
+
+The current cycle counts as the first, so `"cycles": 2` covers the rest of this window plus the next one. Use `"mode": "forever"` (with no `cycles`) to keep the override active until it is removed:
+
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 100.0,
+    "mode": "forever"
+  }'
+```
+
+```json Response
+{
+  "budget": {
+    "id": "budget-vk-alpha",
+    "max_limit": 1000.0,
+    "reset_duration": "1M",
+    "current_usage": 240.5,
+    "override_amount": 100.0,
+    "override_mode": "forever",
+    "last_reset": "2025-01-01T00:00:00Z"
+  },
+  "effective_max_limit": 1100.0
+}
+```
+
+A PUT always replaces the existing override rather than adding to it, so re-sending an override with a new amount or mode is the way to change one. Remove it with a DELETE, which restores enforcement against the base `max_limit`:
+
+```bash
+curl -X DELETE http://localhost:8080/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override
+```
+
+Notes on behavior:
+
+- The override never changes `max_limit`, `current_usage`, or the reset schedule — only the limit that usage is enforced against.
+- `amount` must be greater than 0. In `cycles` mode, `cycles` must be greater than 0; in `forever` mode it must be omitted.
+- A finite grant is anchored to the budget's current reset window, so remaining cycles are derived from that grant on every reset. Each node in a cluster computes the same count, and a config reload cannot hand back a cycle that was already spent.
+- A cycles override clears itself once every granted window has closed; `DELETE` clears one at any time and cannot be undone.
+
+For the full request and response schema, see [Set virtual key budget override](/api-reference/governance/set-virtual-key-budget-override) and [Remove virtual key budget override](/api-reference/governance/remove-virtual-key-budget-override) in the API Reference.
 
 ### Making Virtual Keys Mandatory
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -45032,6 +45032,158 @@
         }
       }
     },
+    "/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override": {
+      "put": {
+        "operationId": "updateVirtualKeyBudgetOverride",
+        "summary": "Set virtual key budget override",
+        "description": "Sets or replaces the spending override on one of a virtual key's budgets. The override is additive —\nwhile it is active the budget is enforced against `max_limit + override_amount` — and it leaves the\nbudget's base limit, current usage, and reset schedule untouched.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the budget's current reset window, so every node in a cluster derives the\nsame number of remaining cycles and a config reload cannot resurrect a spent one.\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "vk_id",
+            "in": "path",
+            "required": true,
+            "description": "Virtual key ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "budget_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of a budget owned by the virtual key",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BudgetOverrideRequest"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget override applied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BudgetOverrideResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Virtual key or budget not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteVirtualKeyBudgetOverride",
+        "summary": "Remove virtual key budget override",
+        "description": "Removes any active override from the budget, so it is enforced against its base `max_limit` again.\nThe budget's current usage and reset schedule are unchanged, and the removal is permanent — a cleared\ngrant cannot be re-derived. Safe to call on a budget that has no override.\n",
+        "tags": [
+          "Governance"
+        ],
+        "parameters": [
+          {
+            "name": "vk_id",
+            "in": "path",
+            "required": true,
+            "description": "Virtual key ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "budget_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of a budget owned by the virtual key",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget override removed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BudgetOverrideResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Virtual key or budget not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/governance/teams": {
       "get": {
         "operationId": "listTeams",
@@ -82134,6 +82286,31 @@
           "current_usage": {
             "type": "number"
           },
+          "override_amount": {
+            "type": "number",
+            "description": "Additional spend added on top of `max_limit` while the override is active. Omitted when no override is set."
+          },
+          "override_mode": {
+            "type": "string",
+            "description": "How long the override stays active. `cycles` keeps it active for a finite number of\nreset windows; `forever` keeps it active until it is removed. Omitted when no override is set.\n",
+            "enum": [
+              "cycles",
+              "forever"
+            ]
+          },
+          "override_cycles_remaining": {
+            "type": "integer",
+            "description": "Reset windows the override is still valid for, including the current one. Positive only\nfor `cycles` mode; recomputed from the original grant on every reset, never decremented in place.\n"
+          },
+          "override_cycles_total": {
+            "type": "integer",
+            "description": "Number of reset windows the current `cycles` override was granted for. Immutable for the life of the grant."
+          },
+          "override_anchor_reset": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Reset-window boundary at which the current `cycles` override was granted. Immutable for the life of the grant."
+          },
           "team_id": {
             "type": "string",
             "description": "Team that owns this budget, when the budget is team-scoped"
@@ -82298,6 +82475,50 @@
               "null"
             ],
             "description": "Set to true or false to enable or disable calendar-aligned resets. Only valid with reset durations that use day, week, month, or year suffixes (`d`, `w`, `M`, `Y`); sub-day durations (e.g. `1h`, `30m`) are invalid with calendar alignment and the API rejects that combination. When enabling on an existing budget, current usage is reset to zero and last_reset snaps to the current period start.\n"
+          }
+        }
+      },
+      "BudgetOverrideRequest": {
+        "type": "object",
+        "description": "Replaces the active override on one budget. The override is additive: it does not change the\nbudget's `max_limit`, `current_usage`, or reset schedule. Sending this request against a budget\nthat already has an override replaces that override entirely.\n",
+        "required": [
+          "amount",
+          "mode"
+        ],
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Additional spend in dollars added on top of `max_limit` while the override is active. Must be greater than 0 and finite."
+          },
+          "mode": {
+            "type": "string",
+            "description": "`cycles` keeps the override active for `cycles` reset windows starting with the current one.\n`forever` keeps it active until it is removed with a DELETE.\n",
+            "enum": [
+              "cycles",
+              "forever"
+            ]
+          },
+          "cycles": {
+            "type": "integer",
+            "description": "Number of reset windows the override stays active for, counting the current window as the first.\nRequired and must be greater than 0 when `mode` is `cycles`; must be omitted or 0 when `mode` is `forever`.\n",
+            "minimum": 1
+          }
+        }
+      },
+      "BudgetOverrideResponse": {
+        "type": "object",
+        "description": "The persisted budget and the additive limit now in force.",
+        "required": [
+          "budget",
+          "effective_max_limit"
+        ],
+        "properties": {
+          "budget": {
+            "$ref": "#/components/schemas/Budget"
+          },
+          "effective_max_limit": {
+            "type": "number",
+            "description": "`max_limit` plus `override_amount` while an override is active; equal to `max_limit` otherwise."
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -831,6 +831,8 @@ paths:
     $ref: './paths/management/governance.yaml#/virtual-keys-quota'
   /api/governance/virtual-keys/{vk_id}:
     $ref: './paths/management/governance.yaml#/virtual-keys-by-id'
+  /api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override:
+    $ref: './paths/management/governance.yaml#/virtual-keys-budget-override'
 
   # Governance - Teams
   /api/governance/teams:
@@ -1570,6 +1572,10 @@ components:
       $ref: './schemas/management/governance.yaml#/CreateBudgetRequest'
     UpdateBudgetRequest:
       $ref: './schemas/management/governance.yaml#/UpdateBudgetRequest'
+    BudgetOverrideRequest:
+      $ref: './schemas/management/governance.yaml#/BudgetOverrideRequest'
+    BudgetOverrideResponse:
+      $ref: './schemas/management/governance.yaml#/BudgetOverrideResponse'
     CreateRateLimitRequest:
       $ref: './schemas/management/governance.yaml#/CreateRateLimitRequest'
     UpdateRateLimitRequest:

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -265,6 +265,100 @@ virtual-keys-by-id:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
+virtual-keys-budget-override:
+  put:
+    operationId: updateVirtualKeyBudgetOverride
+    summary: Set virtual key budget override
+    description: |
+      Sets or replaces the spending override on one of a virtual key's budgets. The override is additive —
+      while it is active the budget is enforced against `max_limit + override_amount` — and it leaves the
+      budget's base limit, current usage, and reset schedule untouched.
+
+      Use `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows
+      (the current window counts as the first), or `mode: forever` to keep the override until it is deleted.
+      A finite grant is anchored to the budget's current reset window, so every node in a cluster derives the
+      same number of remaining cycles and a config reload cannot resurrect a spent one.
+    tags:
+      - Governance
+    parameters:
+      - name: vk_id
+        in: path
+        required: true
+        description: Virtual key ID
+        schema:
+          type: string
+      - name: budget_id
+        in: path
+        required: true
+        description: ID of a budget owned by the virtual key
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/BudgetOverrideRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Budget override applied successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BudgetOverrideResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Virtual key or budget not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  delete:
+    operationId: deleteVirtualKeyBudgetOverride
+    summary: Remove virtual key budget override
+    description: |
+      Removes any active override from the budget, so it is enforced against its base `max_limit` again.
+      The budget's current usage and reset schedule are unchanged, and the removal is permanent — a cleared
+      grant cannot be re-derived. Safe to call on a budget that has no override.
+    tags:
+      - Governance
+    parameters:
+      - name: vk_id
+        in: path
+        required: true
+        description: Virtual key ID
+        schema:
+          type: string
+      - name: budget_id
+        in: path
+        required: true
+        description: ID of a budget owned by the virtual key
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Budget override removed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BudgetOverrideResponse'
+      '404':
+        description: Virtual key or budget not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
 # Teams CRUD
 
 teams:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -30,6 +30,29 @@ Budget:
       format: date-time
     current_usage:
       type: number
+    override_amount:
+      type: number
+      description: Additional spend added on top of `max_limit` while the override is active. Omitted when no override is set.
+    override_mode:
+      type: string
+      description: |
+        How long the override stays active. `cycles` keeps it active for a finite number of
+        reset windows; `forever` keeps it active until it is removed. Omitted when no override is set.
+      enum:
+        - cycles
+        - forever
+    override_cycles_remaining:
+      type: integer
+      description: |
+        Reset windows the override is still valid for, including the current one. Positive only
+        for `cycles` mode; recomputed from the original grant on every reset, never decremented in place.
+    override_cycles_total:
+      type: integer
+      description: Number of reset windows the current `cycles` override was granted for. Immutable for the life of the grant.
+    override_anchor_reset:
+      type: string
+      format: date-time
+      description: Reset-window boundary at which the current `cycles` override was granted. Immutable for the life of the grant.
     team_id:
       type: string
       description: Team that owns this budget, when the budget is team-scoped
@@ -130,6 +153,47 @@ UpdateBudgetRequest:
         that use day, week, month, or year suffixes (`d`, `w`, `M`, `Y`); sub-day durations (e.g. `1h`,
         `30m`) are invalid with calendar alignment and the API rejects that combination. When enabling on
         an existing budget, current usage is reset to zero and last_reset snaps to the current period start.
+
+BudgetOverrideRequest:
+  type: object
+  description: |
+    Replaces the active override on one budget. The override is additive: it does not change the
+    budget's `max_limit`, `current_usage`, or reset schedule. Sending this request against a budget
+    that already has an override replaces that override entirely.
+  required:
+    - amount
+    - mode
+  properties:
+    amount:
+      type: number
+      description: Additional spend in dollars added on top of `max_limit` while the override is active. Must be greater than 0 and finite.
+    mode:
+      type: string
+      description: |
+        `cycles` keeps the override active for `cycles` reset windows starting with the current one.
+        `forever` keeps it active until it is removed with a DELETE.
+      enum:
+        - cycles
+        - forever
+    cycles:
+      type: integer
+      description: |
+        Number of reset windows the override stays active for, counting the current window as the first.
+        Required and must be greater than 0 when `mode` is `cycles`; must be omitted or 0 when `mode` is `forever`.
+      minimum: 1
+
+BudgetOverrideResponse:
+  type: object
+  description: The persisted budget and the additive limit now in force.
+  required:
+    - budget
+    - effective_max_limit
+  properties:
+    budget:
+      $ref: '#/Budget'
+    effective_max_limit:
+      type: number
+      description: '`max_limit` plus `override_amount` while an override is active; equal to `max_limit` otherwise.'
 
 CreateRateLimitRequest:
   type: object


### PR DESCRIPTION
## Summary

Adds documentation and OpenAPI specs for budget overrides on virtual-key budgets. An override temporarily raises a budget's effective spending limit by adding an `override_amount` on top of the base `max_limit`, without touching the base limit, current usage, or reset schedule. Overrides can be granted for a finite number of reset cycles or indefinitely, and are managed via `PUT`/`DELETE` on `/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override`.

## Changes

- Added a **Budget overrides** section to `budget-and-limits.mdx` explaining the `effective_max_limit = max_limit + override_amount` enforcement model and linking to the virtual keys walkthrough.
- Expanded the override section in `virtual-keys.mdx` with full API usage examples for `PUT` (both `cycles` and `forever` modes) and `DELETE`, a sample JSON response, and behavioral notes covering immutability of the base limit, cycle anchoring, and cluster consistency.
- Registered `PUT` and `DELETE` endpoints for `/api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override` in the OpenAPI spec (both JSON and YAML), including request/response schemas (`BudgetOverrideRequest`, `BudgetOverrideResponse`) and new override fields on the `Budget` schema (`override_amount`, `override_mode`, `override_cycles_remaining`, `override_cycles_total`, `override_anchor_reset`).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Navigate to the **Budget overrides** section in `budget-and-limits.mdx` and confirm the formula and cross-link render correctly.
2. Navigate to the override API section in `virtual-keys.mdx` and verify all code blocks, the sample response, and the behavioral notes display as expected.
3. Load the OpenAPI spec and confirm the two new endpoints appear under the **Governance** tag with correct request/response schemas and that the `Budget` schema includes the five new override fields.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The new endpoints require `ManagementBearerAuth`, consistent with all other governance management endpoints. No new auth surface is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable