### PR TITLE
feat: add `roots_only` filter to collapse fallback chains with child aggregates

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -941,6 +941,7 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval, timeout t
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
 		f.ParentRequestID == "" &&
+		!f.RootsOnly &&
 		len(f.MetadataFilters) == 0 &&
 		canUseMatViewStatusFilter(f.Status) &&
 		len(f.RoutingEngineUsed) == 0 &&

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -236,7 +236,12 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		baseQuery = baseQuery.Where("object_type IN ?", filters.Objects)
 	}
 	if filters.ParentRequestID != "" {
-		baseQuery = baseQuery.Where("parent_request_id = ?", filters.ParentRequestID)
+		// A row is never its own child: parent_request_id is client-settable, and
+		// a self-referencing row already lists as a root (see applyRootsOnlyFilter),
+		// so without this it would also appear inside its own expansion.
+		baseQuery = baseQuery.Where("parent_request_id = ? AND id <> parent_request_id", filters.ParentRequestID)
+	} else if filters.RootsOnly {
+		baseQuery = s.applyRootsOnlyFilter(baseQuery, filters)
 	}
 	if len(filters.SelectedKeyIDs) > 0 {
 		baseQuery = baseQuery.Where("selected_key_id IN ?", filters.SelectedKeyIDs)
@@ -436,6 +441,51 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		}
 	}
 	return baseQuery
+}
+
+// applyRootsOnlyFilter hides rows that nest under another row already present in
+// this same result set, so each fallback chain lists as its root request.
+//
+// The parent set is the *filtered, scoped* population, not the whole table: a
+// row is only hidden when the row it points at would itself be listed. This is
+// what keeps a chain from vanishing when a filter matches only part of it —
+// with `status=success` over a chain whose root errored and whose retry
+// succeeded, the root fails the filter, so the retry is not hidden and lists as
+// its own root instead of disappearing. It also means the subquery inherits the
+// caller's QueryScope and time window: a child whose parent is invisible to
+// this caller, or falls outside the range, is promoted rather than dropped.
+//
+// Rows whose parent_request_id is a client/provider session string (baggage,
+// realtime `sess_…`) match no log id and stay top-level, as do self-referencing
+// rows — parent_request_id is client-settable, and a row that points at itself
+// would otherwise be unreachable from any view.
+func (s *RDBLogStore) applyRootsOnlyFilter(baseQuery *gorm.DB, filters SearchFilters) *gorm.DB {
+	ctx := baseQuery.Statement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Same filters, minus the two that describe *this* query's shape rather than
+	// which rows are listable. Clearing RootsOnly also stops the recursion.
+	parentFilters := filters
+	parentFilters.RootsOnly = false
+	parentFilters.ParentRequestID = ""
+
+	if s.db.Dialector.Name() == "clickhouse" {
+		// ClickHouse has no correlated subqueries, so the parent id set is built
+		// once per query. The inherited filters (crucially the time window) bound
+		// it — an unfiltered `SELECT id FROM logs` would materialize every id in
+		// the table on every page load.
+		parents := s.applyFilters(s.ScopedDB(ctx).Model(&Log{}).Select("id"), parentFilters)
+		return baseQuery.Where("(parent_request_id IS NULL OR parent_request_id = id OR parent_request_id NOT IN (?))", parents)
+	}
+
+	// Correlated form elsewhere: the PK lookup on parent.id keeps this an index
+	// probe per candidate row rather than a materialized anti-join. Unqualified
+	// columns in the filter predicates bind to the inner `parent` scope.
+	parents := s.applyFilters(s.ScopedDB(ctx).Table("logs AS parent").Select("1"), parentFilters).
+		Where("parent.id = logs.parent_request_id")
+	return baseQuery.Where("(parent_request_id IS NULL OR parent_request_id = id OR NOT EXISTS (?))", parents)
 }
 
 // Create inserts a new log entry into the database.
@@ -861,6 +911,12 @@ func (s *RDBLogStore) searchLogs(ctx context.Context, filters SearchFilters, pag
 		return nil, err
 	}
 
+	if filters.RootsOnly {
+		if err := s.attachChildAggregates(ctx, logs, filters); err != nil {
+			return nil, err
+		}
+	}
+
 	hasLogs := len(logs) > 0
 	if !hasLogs {
 		var err error
@@ -879,6 +935,65 @@ func (s *RDBLogStore) searchLogs(ctx context.Context, filters SearchFilters, pag
 		},
 		HasLogs: hasLogs,
 	}, nil
+}
+
+// attachChildAggregates populates ChildCount/ChildrenCost/ChildrenTokens on the
+// given page of logs with one grouped query over the page's IDs. The index on
+// parent_request_id keeps this cheap (bounded by the page size), and the
+// rolled-up cost/tokens let the UI summarize a collapsed fallback chain.
+//
+// The same filters that produced the page are applied to the children, so a
+// collapsed chain summarizes exactly the rows that expanding it lists (the
+// expand call re-queries with these filters plus parent_request_id). A root
+// whose children all fail the filters reports ChildCount 0 and offers nothing
+// to expand.
+func (s *RDBLogStore) attachChildAggregates(ctx context.Context, logs []Log, filters SearchFilters) error {
+	if len(logs) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(logs))
+	for _, log := range logs {
+		ids = append(ids, log.ID)
+	}
+
+	var aggs []struct {
+		ParentRequestID string  `gorm:"column:parent_request_id"`
+		ChildCount      int64   `gorm:"column:child_count"`
+		ChildrenCost    float64 `gorm:"column:children_cost"`
+		ChildrenTokens  int64   `gorm:"column:children_tokens"`
+	}
+	// Clear the two filters that describe the shape of the roots query rather
+	// than which rows are listable; the rest carry over verbatim. Clearing
+	// RootsOnly also keeps the parent-existence subquery out of this query — a
+	// child is counted against its own parent, not re-tested for one.
+	childFilters := filters
+	childFilters.RootsOnly = false
+	childFilters.ParentRequestID = ""
+
+	err := s.applyFilters(s.ScopedDB(ctx).Model(&Log{}), childFilters).
+		Select("parent_request_id, COUNT(*) AS child_count, COALESCE(SUM(cost), 0) AS children_cost, COALESCE(SUM(total_tokens), 0) AS children_tokens").
+		Where("parent_request_id IN ? AND id <> parent_request_id", ids).
+		Group("parent_request_id").
+		Scan(&aggs).Error
+	if err != nil {
+		return fmt.Errorf("failed to aggregate child logs: %w", err)
+	}
+	if len(aggs) == 0 {
+		return nil
+	}
+
+	byParent := make(map[string]int, len(aggs))
+	for i, agg := range aggs {
+		byParent[agg.ParentRequestID] = i
+	}
+	for i := range logs {
+		if aggIdx, ok := byParent[logs[i].ID]; ok {
+			logs[i].ChildCount = aggs[aggIdx].ChildCount
+			logs[i].ChildrenCost = aggs[aggIdx].ChildrenCost
+			logs[i].ChildrenTokens = aggs[aggIdx].ChildrenTokens
+		}
+	}
+	return nil
 }
 
 // GetSessionLogs returns paginated logs for a single parent_request_id session.

--- a/framework/logstore/rdb_rootsonly_test.go
+++ b/framework/logstore/rdb_rootsonly_test.go
@@ -1,0 +1,248 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newRootsOnlyStore returns a store over a seeded in-memory DB.
+//
+// Named shared-cache DSN: SearchLogs queries from concurrent goroutines, and a
+// plain :memory: DSN would give each pooled connection its own empty DB. The
+// name is process-global and the DB lives until its last connection closes, so
+// close it on cleanup — otherwise a second run in the same process (-count=2)
+// re-seeds into the surviving DB and fails on duplicate primary keys.
+func newRootsOnlyStore(t *testing.T) (*RDBLogStore, time.Time) {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	require.NoError(t, db.AutoMigrate(&Log{}))
+
+	now := time.Now()
+	strPtr := func(v string) *string { return &v }
+	floatPtr := func(v float64) *float64 { return &v }
+
+	seed := []Log{
+		// Fallback chain: root + two attempts pointing at the root's log ID. The
+		// root errored and the last attempt succeeded — the shape that a status
+		// filter must not make disappear.
+		{ID: "root-a", Timestamp: now, Status: "error", Provider: "openai", FallbackIndex: 0},
+		{ID: "child-a1", Timestamp: now.Add(time.Second), Status: "error", Provider: "openai", FallbackIndex: 1, ParentRequestID: strPtr("root-a"), Cost: floatPtr(0.5), TotalTokens: 100},
+		{ID: "child-a2", Timestamp: now.Add(2 * time.Second), Status: "success", Provider: "anthropic", FallbackIndex: 2, ParentRequestID: strPtr("root-a"), Cost: floatPtr(0.25), TotalTokens: 40},
+		// Plain root with no children.
+		{ID: "root-b", Timestamp: now, Status: "success", Provider: "openai", FallbackIndex: 0},
+		// Baggage-session member: parent is a client session string, not a log ID.
+		{ID: "session-member", Timestamp: now, Status: "success", Provider: "openai", FallbackIndex: 0, ParentRequestID: strPtr("client-session-123")},
+		// Baggage-session member that reuses a real log's ID as its session ID.
+		// parent points at an actual log row, so it nests under root-a like a
+		// fallback attempt — hidden from the roots list, counted in aggregates.
+		{ID: "session-member-on-root", Timestamp: now.Add(3 * time.Second), Status: "success", Provider: "openai", FallbackIndex: 0, ParentRequestID: strPtr("root-a"), Cost: floatPtr(1.5), TotalTokens: 60},
+		// parent_request_id is client-settable (baggage), so a row can point at
+		// itself. It must stay listable rather than hide itself out of every view.
+		{ID: "self-ref", Timestamp: now, Status: "success", Provider: "openai", FallbackIndex: 0, ParentRequestID: strPtr("self-ref")},
+	}
+	for i := range seed {
+		require.NoError(t, db.Create(&seed[i]).Error)
+	}
+
+	return &RDBLogStore{db: db, logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}, now
+}
+
+// RootsOnly hides every row whose parent_request_id references another row in
+// the same filtered result set (fallback attempts and session members keyed on
+// a prior request's ID), so each chain lists as its root request. Rows whose
+// parent is a client session string stay top-level — there is no root row to
+// nest under. Roots carry child aggregates for the expandable chain UI.
+func TestSearchLogsRootsOnly(t *testing.T) {
+	s, _ := newRootsOnlyStore(t)
+	ctx := context.Background()
+
+	t.Run("flat view returns every row", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Len(t, result.Logs, 7)
+		require.EqualValues(t, 7, result.Pagination.TotalCount)
+	})
+
+	t.Run("roots_only hides fallback children and attaches child aggregates", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.EqualValues(t, 4, result.Pagination.TotalCount)
+
+		byID := map[string]Log{}
+		for _, log := range result.Logs {
+			byID[log.ID] = log
+		}
+		require.Len(t, byID, 4)
+		require.NotContains(t, byID, "child-a1")
+		require.NotContains(t, byID, "child-a2")
+		require.NotContains(t, byID, "session-member-on-root")
+
+		rootA := byID["root-a"]
+		require.EqualValues(t, 3, rootA.ChildCount)
+		require.InDelta(t, 2.25, rootA.ChildrenCost, 1e-9)
+		require.EqualValues(t, 200, rootA.ChildrenTokens)
+
+		require.Zero(t, byID["root-b"].ChildCount)
+		require.Zero(t, byID["session-member"].ChildCount)
+	})
+
+	t.Run("self-referencing row stays listable", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Contains(t, logIDs(result.Logs), "self-ref")
+	})
+
+	t.Run("parent filter overrides roots_only so children stay reachable", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true, ParentRequestID: "root-a"}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Len(t, result.Logs, 3)
+		for _, log := range result.Logs {
+			require.Equal(t, "root-a", *log.ParentRequestID)
+		}
+	})
+
+	// The invariant the grouped view rests on: under any filter set, every row
+	// the flat view would list appears exactly once in the grouped view — either
+	// as a root, or under the root it expands from — and ChildCount agrees with
+	// what that expansion returns.
+	t.Run("grouped view partitions the filtered rows exactly once each", func(t *testing.T) {
+		for _, f := range []SearchFilters{
+			{},
+			{Status: []string{"success"}},
+			{Status: []string{"error"}},
+			{Providers: []string{"openai"}},
+			{Providers: []string{"anthropic"}},
+		} {
+			flat, err := s.SearchLogs(ctx, f, PaginationOptions{Limit: 50})
+			require.NoError(t, err)
+
+			rootFilters := f
+			rootFilters.RootsOnly = true
+			roots, err := s.SearchLogs(ctx, rootFilters, PaginationOptions{Limit: 50})
+			require.NoError(t, err)
+
+			seen := logIDs(roots.Logs)
+			for _, root := range roots.Logs {
+				childFilters := f
+				childFilters.ParentRequestID = root.ID
+				children, err := s.SearchLogs(ctx, childFilters, PaginationOptions{Limit: 50})
+				require.NoError(t, err)
+				require.EqualValues(t, root.ChildCount, len(children.Logs), "child_count disagrees with expansion for %s under %+v", root.ID, f)
+				seen = append(seen, logIDs(children.Logs)...)
+			}
+
+			require.ElementsMatch(t, logIDs(flat.Logs), seen, "grouped view lost or duplicated rows under %+v", f)
+		}
+	})
+
+	t.Run("GetSessionLogs serves a chain's children by root ID", func(t *testing.T) {
+		result, err := s.GetSessionLogs(ctx, "root-a", PaginationOptions{Limit: 50, Order: "asc"})
+		require.NoError(t, err)
+		require.Len(t, result.Logs, 3)
+		require.Equal(t, "child-a1", result.Logs[0].ID)
+		require.Equal(t, "child-a2", result.Logs[1].ID)
+		require.Equal(t, "session-member-on-root", result.Logs[2].ID)
+	})
+}
+
+// A child is only hidden when the row it points at is itself listable under the
+// same filters. Otherwise filtering on a column that varies across a fallback
+// chain (status, provider, model, key) would drop the whole chain: the child is
+// hidden because its parent exists, and the parent is dropped by the filter.
+func TestSearchLogsRootsOnlyPromotesChildrenWhenParentIsFilteredOut(t *testing.T) {
+	s, now := newRootsOnlyStore(t)
+	ctx := context.Background()
+
+	t.Run("status filter promotes the successful attempt of a failed chain", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true, Status: []string{"success"}}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+
+		ids := logIDs(result.Logs)
+		// root-a errored, so it is not a listable parent — its successful members
+		// surface in their own right instead of vanishing with it.
+		require.Contains(t, ids, "child-a2")
+		require.Contains(t, ids, "session-member-on-root")
+		require.NotContains(t, ids, "child-a1") // still an error row
+		require.Len(t, ids, 5)
+		require.EqualValues(t, 5, result.Pagination.TotalCount)
+	})
+
+	t.Run("provider filter promotes the attempt that ran on that provider", func(t *testing.T) {
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true, Providers: []string{"anthropic"}}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.Equal(t, []string{"child-a2"}, logIDs(result.Logs))
+	})
+
+	t.Run("child aggregates count only children matching the filters", func(t *testing.T) {
+		// root-a's three children are two openai rows and one anthropic row.
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true, Providers: []string{"openai"}}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+
+		byID := map[string]Log{}
+		for _, log := range result.Logs {
+			byID[log.ID] = log
+		}
+		rootA := byID["root-a"]
+		require.EqualValues(t, 2, rootA.ChildCount) // child-a2 (anthropic) excluded
+		require.InDelta(t, 2.0, rootA.ChildrenCost, 1e-9)
+		require.EqualValues(t, 160, rootA.ChildrenTokens)
+	})
+
+	t.Run("time window promotes children whose parent falls outside it", func(t *testing.T) {
+		start := now.Add(1500 * time.Millisecond)
+		result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true, StartTime: &start}, PaginationOptions{Limit: 50})
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"child-a2", "session-member-on-root"}, logIDs(result.Logs))
+	})
+}
+
+// The parent-existence subquery runs under the caller's QueryScope, like the
+// outer query. A child whose parent is invisible to this caller is promoted to
+// a root rather than hidden behind a row they can never see or expand.
+func TestSearchLogsRootsOnlyRespectsQueryScope(t *testing.T) {
+	s, _ := newRootsOnlyStore(t)
+	ctx := queryscope.WithQueryScope(context.Background(), func(db *gorm.DB) *gorm.DB {
+		return db.Where("id <> ?", "root-a")
+	})
+
+	result, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true}, PaginationOptions{Limit: 50})
+	require.NoError(t, err)
+
+	ids := logIDs(result.Logs)
+	require.NotContains(t, ids, "root-a")
+	require.Contains(t, ids, "child-a1")
+	require.Contains(t, ids, "child-a2")
+	require.Contains(t, ids, "session-member-on-root")
+	require.EqualValues(t, len(ids), result.Pagination.TotalCount)
+}
+
+// RootsOnly needs a per-row predicate the hourly matview cannot express, so the
+// matview count path must fall back to raw.
+func TestCanUseMatViewFiltersExcludesRootsOnly(t *testing.T) {
+	require.True(t, canUseMatViewFilters(SearchFilters{}))
+	require.False(t, canUseMatViewFilters(SearchFilters{RootsOnly: true}))
+}
+
+func logIDs(logs []Log) []string {
+	ids := make([]string, 0, len(logs))
+	for _, log := range logs {
+		ids = append(ids, log.ID)
+	}
+	return ids
+}

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -53,6 +53,7 @@ type SearchFilters struct {
 	StopReasons       []string          `json:"stop_reasons,omitempty"` // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
 	Objects           []string          `json:"objects,omitempty"`      // For filtering by request type (chat.completion, text.completion, embedding)
 	ParentRequestID   string            `json:"parent_request_id,omitempty"`
+	RootsOnly         bool              `json:"roots_only,omitempty"` // Hide rows whose parent_request_id points at another row matching these same filters, so each chain lists as its root request only. Ignored when ParentRequestID is set.
 	SelectedKeyIDs    []string          `json:"selected_key_ids,omitempty"`
 	VirtualKeyIDs     []string          `json:"virtual_key_ids,omitempty"`
 	RoutingRuleIDs    []string          `json:"routing_rule_ids,omitempty"`
@@ -257,6 +258,13 @@ type Log struct {
 	IsLargePayloadResponse  bool      `gorm:"default:false" json:"is_large_payload_response"`
 	HasObject               bool      `gorm:"default:false" json:"-"`              // True when payload is stored in object storage
 	ContentHidden           bool      `gorm:"default:false" json:"content_hidden"` // True when content logging was disabled for the request, so the payload must never be served back through the API/UI (whether it was retained in object storage or dropped entirely)
+
+	// Aggregates over this log's child rows (rows whose parent_request_id equals
+	// this log's ID, i.e. fallback attempts). Populated only on roots_only list
+	// queries so the UI can render an expandable chain row; never stored.
+	ChildCount     int64   `gorm:"-" json:"child_count,omitempty"`
+	ChildrenCost   float64 `gorm:"-" json:"children_cost,omitempty"`
+	ChildrenTokens int64   `gorm:"-" json:"children_tokens,omitempty"`
 
 	RedactionData          *schemas.RedactionData        `gorm:"-" json:"-"`                           // Transient guardrail redaction data consumed by enterprise logstore wrappers
 	RedactionMapping       string                        `gorm:"type:text" json:"-"`                   // Reversible redaction mapping (encrypted when an encryption key is set), written by enterprise logstore wrappers; deleted with the row

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1043,9 +1043,14 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	fallbackRequestID, ok := ctx.Value(schemas.BifrostContextKeyFallbackRequestID).(string)
 	if ok && fallbackRequestID != "" {
 		effectiveRequestID = fallbackRequestID
-		if parentRequestID == "" {
-			parentRequestID = requestID
-		}
+		// A fallback attempt always nests under the primary request, even when the
+		// client supplied a session id via baggage. Leaving the session id here
+		// would point the attempt at a string that is not a log row, so the
+		// grouped log view could not collapse the chain — and if that string
+		// happened to collide with a real request id, the attempt would nest under
+		// an unrelated request. The session id stays on the primary row, which is
+		// what the session view lists.
+		parentRequestID = requestID
 	}
 
 	fallbackIndex := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyFallbackIndex)

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -718,6 +718,11 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
 	}
+	if rootsOnly := string(ctx.QueryArgs().Peek("roots_only")); rootsOnly != "" {
+		if val, err := strconv.ParseBool(rootsOnly); err == nil {
+			filters.RootsOnly = val
+		}
+	}
 	parseMetadataFilters(ctx, filters)
 
 	// Extract pagination parameters


### PR DESCRIPTION
## Summary

Adds a `roots_only` filter to the log search API that collapses fallback chains into a single root row. When enabled, any log whose `parent_request_id` points at an actual log row is hidden from the list view, leaving only the chain's root visible. Each root is annotated with child aggregates (`child_count`, `children_cost`, `children_tokens`) so the UI can render an expandable row summarizing the full chain without additional queries.

## Changes

- Added `RootsOnly bool` to `SearchFilters` and wired it to the `roots_only` query parameter in the HTTP handler via `strconv.ParseBool`.
- In `applyFilters`, when `RootsOnly` is set and no `ParentRequestID` filter is active, a subquery filters out rows whose `parent_request_id` matches an existing log ID. ClickHouse uses an uncorrelated `NOT IN` subquery (correlated subqueries are unsupported); all other dialects use `NOT EXISTS`.
- After a `roots_only` search returns a page, `attachChildAggregates` runs a single grouped query over the page's IDs to populate `ChildCount`, `ChildrenCost`, and `ChildrenTokens` on each root. These fields are transient (`gorm:"-"`) and never stored.
- `ParentRequestID` takes precedence over `RootsOnly` — when a parent filter is active the full child list is returned, matching the expand-on-click behaviour.
- `canUseMatViewFilters` now returns `false` when `RootsOnly` is set, since the per-row existence predicate cannot be expressed in the hourly materialized view count path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestSearchLogsRootsOnly
go test ./framework/logstore/... -run TestCanUseMatViewFiltersExcludesRootsOnly
go test ./...
```

**HTTP:**
```sh
GET /logs?roots_only=true
```
Expected: only root rows returned, each carrying `child_count`, `children_cost`, and `children_tokens` where children exist.

```sh
GET /logs?roots_only=true&parent_request_id=<id>
```
Expected: `roots_only` is ignored; all children of the given parent are returned.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `roots_only` subquery operates only on the `logs` table within the tenant-scoped DB connection. No new data is exposed; child rows remain accessible via `GetSessionLogs` using the root's ID.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable