### PR TITLE
added plugin logs in mcp logs

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -293,6 +293,7 @@ var logstoreMigrationSteps = []migrationStep{
 	// twice on a fresh DB is harmless.
 	{IDs: []string{"logs_recreate_matviews_with_app_column"}, run: migrationRecreateMatViewsWithUserAgentColumn},
 	{IDs: []string{"mcp_tool_logs_add_endpoint_columns"}, run: migrationAddEndpointColumnsToMCPToolLogs},
+	{IDs: []string{"mcp_tool_logs_add_plugin_logs_column"}, run: migrationAddMCPPluginLogsColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -2849,6 +2850,28 @@ func migrationAddPluginLogsColumn(ctx context.Context, db *gorm.DB, logger schem
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding plugin logs column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPPluginLogsColumn adds the plugin_logs column to MCP tool logs.
+func migrationAddMCPPluginLogsColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "mcp_tool_logs_add_plugin_logs_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &MCPToolLog{}, "plugin_logs")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return dropColumnIfExists(tx.WithContext(ctx), logger, &MCPToolLog{}, "plugin_logs")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding MCP plugin logs column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -32,6 +32,23 @@ func TestMigrationAddMCPRedactionMappingColumn(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+// TestMigrationAddMCPPluginLogsColumn verifies the MCP plugin-log column is additive, idempotent, and preserves existing rows.
+func TestMigrationAddMCPPluginLogsColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "migrations.db")), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE TABLE mcp_tool_logs (id TEXT PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("INSERT INTO mcp_tool_logs (id) VALUES (?)", "mcp-existing").Error)
+
+	ctx := context.Background()
+	require.NoError(t, migrationAddMCPPluginLogsColumn(ctx, db, testLogger{}))
+	require.True(t, db.Migrator().HasColumn(&MCPToolLog{}, "PluginLogs"))
+	require.NoError(t, migrationAddMCPPluginLogsColumn(ctx, db, testLogger{}))
+
+	var count int64
+	require.NoError(t, db.Table("mcp_tool_logs").Where("id = ?", "mcp-existing").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
 // pgTestSchema is this package's dedicated Postgres schema. Test packages
 // (configstore, configstore/tables, logstore) run in parallel against the same
 // database, so each one works in its own schema to avoid clobbering the

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -206,6 +206,7 @@ func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
 		MetadataParsed: map[string]interface{}{
 			"trace": "abc",
 		},
+		PluginLogs: `{"guardrails":[{"plugin_name":"guardrails","level":"info","message":"arguments redacted","timestamp":1}]}`,
 		RedactionData: &schemas.RedactionData{
 			ReversibleMappings: schemas.RedactionMapsByPhase{Input: map[string]string{"EMAIL-1": "private@example.com"}},
 		},
@@ -230,6 +231,7 @@ func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
 	assert.Equal(t, true, dbEntry.ResultParsed.(map[string]interface{})["ok"])
 	assert.Equal(t, "stored for round trip", dbEntry.ErrorDetailsParsed.Error.Message)
 	assert.Equal(t, "abc", dbEntry.MetadataParsed["trace"])
+	assert.Equal(t, entry.PluginLogs, dbEntry.PluginLogs)
 	assert.Equal(t, entry.RedactionMapping, dbEntry.RedactionMapping)
 	assert.Nil(t, dbEntry.RedactionData)
 }
@@ -276,6 +278,7 @@ func TestPrepareMCPToolDBEntry_KeepsOnlyInputPreview(t *testing.T) {
 		MetadataParsed: map[string]interface{}{
 			"trace": "abc",
 		},
+		PluginLogs: `{"guardrails":[{"message":"arguments redacted"}]}`,
 	}
 
 	PrepareMCPToolDBEntry(entry)
@@ -290,6 +293,7 @@ func TestPrepareMCPToolDBEntry_KeepsOnlyInputPreview(t *testing.T) {
 	assert.Nil(t, entry.ErrorDetailsParsed)
 	assert.NotEmpty(t, entry.Arguments)
 	assert.NotEmpty(t, entry.Metadata)
+	assert.Equal(t, `{"guardrails":[{"message":"arguments redacted"}]}`, entry.PluginLogs)
 
 	var preview string
 	require.NoError(t, sonic.Unmarshal([]byte(entry.Arguments), &preview))

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1078,6 +1078,7 @@ type MCPToolLog struct {
 	Cost           *float64  `gorm:"index:idx_mcp_logs_cost" json:"cost,omitempty"`                               // Cost in dollars (per execution cost)
 	Status         string    `gorm:"type:varchar(50);index:idx_mcp_logs_status;not null" json:"status"`           // "processing", "success", or "error"
 	Metadata       string    `gorm:"type:text" json:"-"`                                                          // JSON serialized map[string]interface{}
+	PluginLogs     string    `gorm:"type:text" json:"plugin_logs,omitempty"`                                      // JSON serialized plugin logs grouped by plugin name
 	HasObject      bool      `gorm:"default:false" json:"-"`                                                      // True when payload is stored in object storage
 	CreatedAt      time.Time `gorm:"index;not null" json:"created_at"`
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1629,13 +1629,7 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 		return nil
 	}
 	// Serialize plugin logs once for all entries
-	var pluginLogsJSON string
-	if len(trace.PluginLogs) > 0 {
-		grouped := schemas.GroupPluginLogsByName(trace.PluginLogs)
-		if data, err := sonic.Marshal(grouped); err == nil {
-			pluginLogsJSON = string(data)
-		}
-	}
+	pluginLogsJSON := serializePluginLogs(trace.PluginLogs)
 	p.logger.Debug("Inject: enqueuing %d log entries", len(pending.entries))
 	// Enqueue each log entry (supports multiple attempts per trace)
 	for _, entry := range pending.entries {
@@ -1644,6 +1638,18 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 		p.enqueueLogEntry(entry, p.makePostWriteCallback(nil))
 	}
 	return nil
+}
+
+// serializePluginLogs groups plugin logs by plugin name for persistence and UI rendering.
+func serializePluginLogs(logs []schemas.PluginLogEntry) string {
+	if len(logs) == 0 {
+		return ""
+	}
+	data, err := sonic.Marshal(schemas.GroupPluginLogsByName(logs))
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // MCP Plugin Interface Implementation
@@ -1910,6 +1916,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 	callback := p.mcpToolLogCallback
 	p.mu.Unlock()
 	attachMCPLogRedactionData(ctx, entry, p.contentLoggingEnabled(ctx))
+	entry.PluginLogs = serializePluginLogs(ctx.GetPluginLogs())
 	p.enqueueMCPToolLogEntry(entry, callback)
 
 	return resp, bifrostErr, nil

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -1032,9 +1033,9 @@ func TestBuildLogEntriesOmitEmptyUserAgent(t *testing.T) {
 	}
 }
 
-// TestMCPHooksDeferDBWriteUntilPostHookBatch verifies MCP logs are kept in
-// memory after PreMCPHook and persisted by the batch writer after PostMCPHook.
-func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
+// TestMCPHooksPersistPluginLogs verifies PostMCPHook stores the plugin-log
+// snapshot accumulated before logging's post-hook runs.
+func TestMCPHooksPersistPluginLogs(t *testing.T) {
 	store := newTestStore(t)
 	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
 	if err != nil {
@@ -1085,6 +1086,11 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	}
 
 	result := `{"answer":"done"}`
+	guardrailsName := "guardrails"
+	guardrailsCtx := ctx.WithPluginScope(&guardrailsName)
+	guardrailsCtx.Log(schemas.LogLevelInfo, "MCP tool arguments redacted")
+	guardrailsCtx.ReleasePluginScope()
+
 	_, _, err = plugin.PostMCPHook(ctx, &schemas.BifrostMCPResponse{
 		ChatMessage: &schemas.ChatMessage{
 			Role:    schemas.ChatMessageRoleTool,
@@ -1106,7 +1112,6 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	if got := pendingEntry.RedactionData.ReversibleMappings.Output["EMAIL-2"]; got != "result@example.com" {
 		t.Fatalf("output redaction mapping = %q, want %q", got, "result@example.com")
 	}
-
 	if err := plugin.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
 	}
@@ -1127,6 +1132,13 @@ func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
 	}
 	if logEntry.Latency == nil || *logEntry.Latency != 42 {
 		t.Fatalf("expected latency 42, got %#v", logEntry.Latency)
+	}
+	var pluginLogs map[string][]schemas.PluginLogEntry
+	if err := json.Unmarshal([]byte(logEntry.PluginLogs), &pluginLogs); err != nil {
+		t.Fatalf("expected valid plugin logs JSON, got %q: %v", logEntry.PluginLogs, err)
+	}
+	if got := pluginLogs[guardrailsName]; len(got) != 1 || got[0].Message != "MCP tool arguments redacted" {
+		t.Fatalf("expected guardrails plugin log to be persisted, got %#v", pluginLogs)
 	}
 	assertMCPLogGovernanceFields(t, logEntry, "user-1", "team-1", "customer-1", "bu-1")
 }
@@ -1164,7 +1176,6 @@ func TestPostMCPHookFallbackStampsGovernanceFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostMCPHook() error = %v", err)
 	}
-
 	if err := plugin.Cleanup(); err != nil {
 		t.Fatalf("Cleanup() error = %v", err)
 	}

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -398,7 +398,7 @@ func estimateMCPToolLogEntrySize(log *logstore.MCPToolLog) int {
 	if log == nil {
 		return 0
 	}
-	return len(log.Arguments) + len(log.Result) + len(log.ErrorDetails) + len(log.Metadata) + 512
+	return len(log.Arguments) + len(log.Result) + len(log.ErrorDetails) + len(log.Metadata) + len(log.PluginLogs) + 512
 }
 
 // buildStaleMCPToolLogEntry converts a pending MCP processing row into a

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -715,8 +715,15 @@ export function LogDetailView({
 				<div className="flex items-center gap-3">
 					{revealAvailable && (
 						<div className="flex items-center gap-2">
-							<span className="text-muted-foreground text-[11px] font-medium">Show original values</span>
-							<Switch checked={revealEnabled} onCheckedChange={handleToggleReveal} data-testid="logdetails-reveal-toggle" />
+							<label htmlFor="logdetails-reveal-toggle" className="text-muted-foreground text-[11px] font-medium">
+								Show original values
+							</label>
+							<Switch
+								id="logdetails-reveal-toggle"
+								checked={revealEnabled}
+								onCheckedChange={handleToggleReveal}
+								data-testid="logdetails-reveal-toggle"
+							/>
 						</div>
 					)}
 					{onClose ? (

--- a/ui/app/workspace/logs/views/pluginLogsView.tsx
+++ b/ui/app/workspace/logs/views/pluginLogsView.tsx
@@ -14,6 +14,14 @@ interface PluginLogsViewProps {
 	pluginLogs: string;
 }
 
+function formatPluginName(name: string): string {
+	return name
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
 export default function PluginLogsView({ pluginLogs }: PluginLogsViewProps) {
 	let parsed: Record<string, PluginLogEntry[]>;
 	try {
@@ -58,7 +66,7 @@ function PluginSection({ name, entries }: { name: string; entries: PluginLogEntr
 				className="hover:bg-muted/50 flex w-full items-center gap-2 px-4 py-2 text-left text-sm"
 			>
 				{isOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-				<span className="font-medium">{name}</span>
+				<span className="font-medium">{formatPluginName(name)}</span>
 				<span className="text-muted-foreground text-xs">({entries.length})</span>
 			</button>
 			{isOpen && (

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -21,11 +21,13 @@ import {
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
 import { useGetMCPLogByIdQuery } from "@/lib/store";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { applyRedactionMappingToValue, hasRedactionMappingEntries, mergeRedactionMappings } from "@/lib/utils/redaction";
+import PluginLogsView from "@/app/workspace/logs/views/pluginLogsView";
 import { Link } from "@tanstack/react-router";
 import { addMilliseconds, format, isValid } from "date-fns";
 import { SheetNavigationButtons } from "@/components/sheetNavigationButtons";
@@ -70,6 +72,17 @@ const getValidatedStatus = (status: string): Status => {
 	// Fallback to "processing" for unknown statuses
 	return "processing";
 };
+
+function getPluginLogCount(pluginLogs?: string): number {
+	if (!pluginLogs) return 0;
+	try {
+		const parsed: unknown = JSON.parse(pluginLogs);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return 0;
+		return Object.values(parsed).reduce<number>((count, entries) => count + (Array.isArray(entries) ? entries.length : 0), 0);
+	} catch {
+		return 0;
+	}
+}
 
 export function MCPLogDetailSheet({
 	log,
@@ -131,6 +144,7 @@ export function MCPLogDetailSheet({
 	const displayedArguments = applyRedactionMappingToValue(displayLog.arguments, inputRevealMapping);
 	const displayedResult = applyRedactionMappingToValue(displayLog.result, outputRevealMapping);
 	const displayedErrorDetails = applyRedactionMappingToValue(displayLog.error_details, mixedRevealMapping);
+	const pluginLogCount = getPluginLogCount(displayLog.plugin_logs);
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
@@ -332,68 +346,96 @@ export function MCPLogDetailSheet({
 					</div>
 				</div>
 
-				{/* Arguments */}
-				{displayedArguments && (
-					<div className="w-full rounded-sm border">
-						<div className="border-b px-6 py-2 text-sm font-medium">Arguments</div>
-						<CodeEditor
-							className="z-0 w-full"
-							shouldAdjustInitialHeight={true}
-							maxHeight={250}
-							wrap={true}
-							code={typeof displayedArguments === "string" ? displayedArguments : JSON.stringify(displayedArguments, null, 2)}
-							lang="json"
-							readonly={true}
-							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-						/>
-					</div>
-				)}
+				<Tabs key={displayLog.id} defaultValue="execution" className="gap-2">
+					<TabsList className="bg-muted/60 h-10 w-fit">
+						<TabsTrigger value="execution" className="px-3">
+							Execution
+						</TabsTrigger>
+						<TabsTrigger value="plugins" className="px-3">
+							Plugin Logs
+							{pluginLogCount > 0 ? (
+								<span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
+									{pluginLogCount}
+								</span>
+							) : null}
+						</TabsTrigger>
+					</TabsList>
 
-				{/* Result */}
-				{displayedResult && displayLog.status !== "processing" && (
-					<div className="w-full rounded-sm border">
-						<div className="border-b px-6 py-2 text-sm font-medium">Result</div>
-						<CodeEditor
-							className="z-0 w-full"
-							shouldAdjustInitialHeight={true}
-							maxHeight={350}
-							wrap={true}
-							code={typeof displayedResult === "string" ? displayedResult : JSON.stringify(displayedResult, null, 2)}
-							lang="json"
-							readonly={true}
-							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-						/>
-					</div>
-				)}
+					<TabsContent value="execution" className="space-y-4">
+						{/* Arguments */}
+						{displayedArguments && (
+							<div className="w-full rounded-sm border">
+								<div className="border-b px-6 py-2 text-sm font-medium">Arguments</div>
+								<CodeEditor
+									className="z-0 w-full"
+									shouldAdjustInitialHeight={true}
+									maxHeight={250}
+									wrap={true}
+									code={typeof displayedArguments === "string" ? displayedArguments : JSON.stringify(displayedArguments, null, 2)}
+									lang="json"
+									readonly={true}
+									options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+								/>
+							</div>
+						)}
 
-				{/* Metadata */}
-				{displayLog.metadata && Object.keys(displayLog.metadata).length > 0 && (
-					<div className="space-y-4 rounded-sm border px-6 py-4">
-						<BlockHeader title="Metadata" />
-						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
-							{Object.entries(displayLog.metadata).map(([key, value]) => (
-								<LogEntryDetailsView key={key} className="w-full" label={key} value={String(value)} />
-							))}
-						</div>
-					</div>
-				)}
+						{/* Result */}
+						{displayedResult && displayLog.status !== "processing" && (
+							<div className="w-full rounded-sm border">
+								<div className="border-b px-6 py-2 text-sm font-medium">Result</div>
+								<CodeEditor
+									className="z-0 w-full"
+									shouldAdjustInitialHeight={true}
+									maxHeight={350}
+									wrap={true}
+									code={typeof displayedResult === "string" ? displayedResult : JSON.stringify(displayedResult, null, 2)}
+									lang="json"
+									readonly={true}
+									options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+								/>
+							</div>
+						)}
 
-				{/* Error Details */}
-				{displayedErrorDetails && (
-					<div className="border-destructive/50 w-full rounded-sm border">
-						<div className="border-destructive/50 text-destructive border-b px-6 py-2 text-sm font-medium">Error Details</div>
-						<CodeEditor
-							className="z-0 w-full"
-							shouldAdjustInitialHeight={true}
-							maxHeight={250}
-							wrap={true}
-							code={JSON.stringify(displayedErrorDetails, null, 2)}
-							lang="json"
-							readonly={true}
-							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-						/>
-					</div>
-				)}
+						{/* Metadata */}
+						{displayLog.metadata && Object.keys(displayLog.metadata).length > 0 && (
+							<div className="space-y-4 rounded-sm border px-6 py-4">
+								<BlockHeader title="Metadata" />
+								<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
+									{Object.entries(displayLog.metadata).map(([key, value]) => (
+										<LogEntryDetailsView key={key} className="w-full" label={key} value={String(value)} />
+									))}
+								</div>
+							</div>
+						)}
+
+						{/* Error Details */}
+						{displayedErrorDetails && (
+							<div className="border-destructive/50 w-full rounded-sm border">
+								<div className="border-destructive/50 text-destructive border-b px-6 py-2 text-sm font-medium">Error Details</div>
+								<CodeEditor
+									className="z-0 w-full"
+									shouldAdjustInitialHeight={true}
+									maxHeight={250}
+									wrap={true}
+									code={JSON.stringify(displayedErrorDetails, null, 2)}
+									lang="json"
+									readonly={true}
+									options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+								/>
+							</div>
+						)}
+					</TabsContent>
+
+					<TabsContent value="plugins" className="space-y-3">
+						{displayLog.plugin_logs ? (
+							<PluginLogsView pluginLogs={displayLog.plugin_logs} />
+						) : (
+							<div className="text-muted-foreground rounded-sm border border-dashed p-5 text-center text-sm">
+								No plugin logs for this request.
+							</div>
+						)}
+					</TabsContent>
+				</Tabs>
 			</SheetContent>
 		</Sheet>
 	);

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1143,6 +1143,7 @@ export interface MCPToolLogEntry {
 	cost?: number; // Cost in dollars (per execution cost)
 	status: string; // "processing", "success", or "error"
 	metadata?: Record<string, string>;
+	plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
 	redaction_mapping?: RedactionMapping; // Present on detail responses only when the caller has Logs:Reveal
 	created_at: string; // ISO string format
 	virtual_key?: VirtualKey;


### PR DESCRIPTION
Revives #5489 on the restored MCP guardrails stack. This PR is stacked above #5739; the stack bottom targets `dev`.