### PR TITLE
semantic routing ui

### DIFF
--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -108,13 +108,6 @@ func hasAnyComplexityField(fields map[string]json.RawMessage, names ...string) b
 	return false
 }
 
-// Fallback behaviors when semantic classification is unavailable (executor not
-// wired, warmup incomplete) or exceeds its timeout.
-const (
-	ComplexitySemanticFallbackLexical = "lexical"
-	ComplexitySemanticFallbackNone    = "none"
-)
-
 // Vector store selection modes for exemplar embeddings. "embedded" (the
 // default) uses the built-in chromem store; "auto" opts into the configured
 // external store when present, falling back to embedded otherwise;
@@ -138,7 +131,7 @@ const (
 )
 
 // DefaultComplexitySemanticTimeout bounds per-request embedding generation.
-const DefaultComplexitySemanticTimeout = 100 * time.Millisecond
+const DefaultComplexitySemanticTimeout = 1500 * time.Millisecond
 
 // ComplexitySemanticConfig configures the embedding-based complexity
 // classifier. A non-nil value enables semantic classification. The classifier
@@ -147,16 +140,14 @@ const DefaultComplexitySemanticTimeout = 100 * time.Millisecond
 type ComplexitySemanticConfig struct {
 	Provider       schemas.ModelProvider `json:"provider"`
 	EmbeddingModel string                `json:"embedding_model"`
-	Dimension      int                   `json:"dimension"`
 	Timeout        time.Duration         `json:"timeout,omitempty"`
-	Fallback       string                `json:"fallback,omitempty"`
 	// MinSimilarity is the floor a nearest-exemplar match must clear before its
 	// tier is used. Without it the nearest exemplar always wins, however
 	// unrelated the request is — semantic classification would never abstain,
 	// unlike the lexical analyzer, which returns no tier when it sees no signal.
 	// A match below the floor is treated exactly like an unavailable classifier
-	// and resolves through Fallback. Zero (the default) disables the floor and
-	// restores "nearest exemplar always wins".
+	// and falls back to lexical scoring. Zero (the default) disables the floor
+	// and restores "nearest exemplar always wins".
 	//
 	// The value is compared against the VectorStore backend's own similarity
 	// score, and those scales are not identical: chromem, Qdrant, Pinecone, and
@@ -176,7 +167,7 @@ type ComplexitySemanticConfig struct {
 	VectorStore         string `json:"vector_store,omitempty"`
 }
 
-// UnmarshalJSON accepts Timeout as a duration string ("100ms") or a JSON number
+// UnmarshalJSON accepts Timeout as a duration string ("500ms") or a JSON number
 // (milliseconds). It rejects unknown fields so unshipped semantic-only settings
 // cannot be silently accepted through config.json or the management API.
 func (c *ComplexitySemanticConfig) UnmarshalJSON(data []byte) error {
@@ -187,9 +178,7 @@ func (c *ComplexitySemanticConfig) UnmarshalJSON(data []byte) error {
 	allowed := map[string]struct{}{
 		"provider":              {},
 		"embedding_model":       {},
-		"dimension":             {},
 		"timeout":               {},
-		"fallback":              {},
 		"min_similarity":        {},
 		"message_history_count": {},
 		"count_toward_budgets":  {},
@@ -271,9 +260,6 @@ func (c *ComplexitySemanticConfig) normalized() *ComplexitySemanticConfig {
 	}
 	if out.Timeout == 0 {
 		out.Timeout = DefaultComplexitySemanticTimeout
-	}
-	if out.Fallback == "" {
-		out.Fallback = ComplexitySemanticFallbackLexical
 	}
 	if out.VectorStore == "" {
 		out.VectorStore = ComplexitySemanticVectorStoreEmbedded

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -73,7 +73,6 @@ func TestComplexitySemanticConfigNormalizedDefaults(t *testing.T) {
 	normalized := testSemanticConfig().normalized()
 
 	assert.Equal(t, DefaultComplexitySemanticTimeout, normalized.Timeout)
-	assert.Equal(t, ComplexitySemanticFallbackLexical, normalized.Fallback)
 	assert.Equal(t, ComplexitySemanticVectorStoreEmbedded, normalized.VectorStore)
 	require.NoError(t, normalized.Validate())
 }
@@ -292,7 +291,6 @@ func TestMergeComplexityAnalyzerConfigByHashesSemantic(t *testing.T) {
 		merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
 		require.NoError(t, err)
 		assert.Equal(t, "text-embedding-3-large", merged.Semantic.EmbeddingModel)
-		assert.Equal(t, ComplexitySemanticFallbackLexical, merged.Semantic.Fallback)
 		assert.Equal(t, fileHashes.SemanticSettings, merged.ConfigHashes.SemanticSettings)
 	})
 
@@ -407,4 +405,14 @@ func TestRDBConfigStore_UpdateComplexityAnalyzerConfigConcurrentCarryOver(t *tes
 	require.NoError(t, err)
 	assert.Equal(t, "fingerprint-new", got.EmbeddingFingerprint)
 	assert.Equal(t, hashesA, got.ConfigHashes)
+}
+
+func TestComplexitySemanticConfigRejectsRemovedFields(t *testing.T) {
+	for _, field := range []string{"dimension", "fallback"} {
+		t.Run(field, func(t *testing.T) {
+			var cfg ComplexitySemanticConfig
+			err := json.Unmarshal([]byte(`{"provider":"openai","embedding_model":"text-embedding-3-small","`+field+`":true}`), &cfg)
+			require.ErrorContains(t, err, `unknown semantic complexity field "`+field+`"`)
+		})
+	}
 }

--- a/plugins/governance/complexity/semanticclassifier.go
+++ b/plugins/governance/complexity/semanticclassifier.go
@@ -72,7 +72,7 @@ type SemanticResult struct {
 	MinSimilarity float64
 	// Accepted reports whether Score cleared MinSimilarity. A rejected result
 	// still carries its tier and score for logging, but callers must not route
-	// on it — they resolve it through the configured fallback instead.
+	// on it — they fall back to lexical scoring instead.
 	Accepted bool
 	// MatchedExemplar is the tier phrase this request landed on. Tier and Score
 	// report what the classifier decided and how confidently; without the phrase
@@ -214,17 +214,6 @@ func (c *SemanticClassifier) Status() SemanticStatusInfo {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.status
-}
-
-// Fallback returns the configured behavior when semantic classification cannot
-// serve the current request. Disabled semantic routing always falls back to lexical.
-func (c *SemanticClassifier) Fallback() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.config == nil || c.config.Semantic == nil {
-		return configstore.ComplexitySemanticFallbackLexical
-	}
-	return c.config.Semantic.Fallback
 }
 
 // Timeout returns the per-request embedding budget currently in force,

--- a/plugins/governance/embedding.go
+++ b/plugins/governance/embedding.go
@@ -14,6 +14,11 @@ import (
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
 
+// ErrEmbeddingRequestExecutorNotConfigured means the HTTP server has not
+// finished wiring the governance plugin to Bifrost's embedding request path.
+// Configuration clients can retry this transient startup state.
+var ErrEmbeddingRequestExecutorNotConfigured = errors.New("embedding request executor is not configured")
+
 // ErrEmbeddingTimeout reports that a classification embed exhausted its
 // configured budget instead of failing for a provider or configuration reason.
 // Callers need the distinction because the two mean opposite things to an
@@ -76,7 +81,7 @@ type ComplexityVectorStoreSetter interface {
 // warmupEmbeddingTimeout bounds one warmup embedding call, whether that is a
 // batch of exemplars or a single-input fallback. Warmup runs in the background
 // with no request waiting on it, so it must NOT inherit semantic.Timeout — that
-// is the hot-path budget (100ms by default), which a 32-exemplar batch cannot
+// is the hot-path budget (1500ms by default), which a 32-exemplar batch cannot
 // possibly meet. It stays bounded so a hung provider cannot pin the warmup
 // worker forever.
 const warmupEmbeddingTimeout = 60 * time.Second
@@ -274,43 +279,6 @@ func (p *GovernancePlugin) settleWarmupEmbedUsage(semantic *complexity.SemanticC
 	}
 }
 
-// probeEmbeddingTimeout bounds the configuration-time dimension probe. It is
-// deliberately far more generous than the routing timeout: an operator waiting
-// on a form can absorb a cold provider, a request in flight cannot.
-const probeEmbeddingTimeout = 30 * time.Second
-
-// probeEmbeddingText is the smallest input that still yields a full-width
-// vector — dimension is a property of the model, not of the input.
-const probeEmbeddingText = "a"
-
-// ProbeEmbeddingDimension reports the vector width a provider/model pair
-// actually produces. It exists so the dimension never has to be looked up or
-// typed by hand: a wrong value is not detectable until warmup fails, and by
-// then the namespace has already been created at the wrong width.
-//
-// This is a configuration-time action, not a routing one, so it deliberately
-// bypasses the usage-recording wrappers: the probe's cost is attributed to no
-// budget and reported to no telemetry counter.
-func (p *GovernancePlugin) ProbeEmbeddingDimension(ctx context.Context, provider schemas.ModelProvider, model string) (int, error) {
-	if p.embeddingExecutor() == nil {
-		return 0, fmt.Errorf("embedding request executor is not configured")
-	}
-	probeCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-	defer probeCtx.Cancel()
-
-	embeddings, _, err := p.generateEmbeddings(probeCtx, &complexity.SemanticConfig{
-		Provider:       provider,
-		EmbeddingModel: model,
-	}, []string{probeEmbeddingText}, probeEmbeddingTimeout)
-	if err != nil {
-		return 0, err
-	}
-	if len(embeddings) != 1 || len(embeddings[0]) == 0 {
-		return 0, fmt.Errorf("provider %q returned no embedding for model %q", provider, model)
-	}
-	return len(embeddings[0]), nil
-}
-
 // CanClassifySemantically reports whether semantic classification is currently
 // viable. The executor alone is not a sufficient gate — the server wires it
 // unconditionally; the semantic config decides whether classification is
@@ -343,7 +311,7 @@ func (p *GovernancePlugin) generateEmbedding(ctx *schemas.BifrostContext, semant
 func (p *GovernancePlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic *complexity.SemanticConfig, texts []string, timeout time.Duration) ([][]float32, int, error) {
 	executor := p.embeddingExecutor()
 	if executor == nil {
-		return nil, 0, fmt.Errorf("embedding request executor is not configured")
+		return nil, 0, ErrEmbeddingRequestExecutorNotConfigured
 	}
 	if semantic == nil || semantic.Provider == "" || semantic.EmbeddingModel == "" {
 		return nil, 0, fmt.Errorf("semantic classification is not configured")

--- a/plugins/governance/embedding_test.go
+++ b/plugins/governance/embedding_test.go
@@ -105,55 +105,6 @@ func TestGenerateEmbeddingRequestShape(t *testing.T) {
 		"embedding deadline must not inherit the caller's larger budget")
 }
 
-// TestProbeEmbeddingDimensionMeasuresProviderOutput covers the config-time
-// probe that removes the dimension from the operator's hands. It must report
-// the width the provider actually returned, not anything supplied by a caller.
-func TestProbeEmbeddingDimensionMeasuresProviderOutput(t *testing.T) {
-	plugin := &GovernancePlugin{}
-	var gotReq *schemas.BifrostEmbeddingRequest
-	var gotDeadline time.Time
-	var hasDeadline bool
-	plugin.SetEmbeddingRequestExecutor(func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-		gotReq = req
-		gotDeadline, hasDeadline = ctx.Deadline()
-		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1, 2, 3, 4, 5}}, 1), nil
-	})
-
-	before := time.Now()
-	dimension, err := plugin.ProbeEmbeddingDimension(t.Context(), "openai", "text-embedding-3-small")
-	require.NoError(t, err)
-	assert.Equal(t, 5, dimension)
-
-	require.NotNil(t, gotReq)
-	assert.Equal(t, schemas.ModelProvider("openai"), gotReq.Provider)
-	assert.Equal(t, "text-embedding-3-small", gotReq.Model)
-
-	// The probe is an interactive configuration action, so it must not inherit
-	// the routing hot path's sub-second budget.
-	require.True(t, hasDeadline, "probe context must carry a deadline")
-	assert.Greater(t, gotDeadline.Sub(before), time.Second)
-}
-
-func TestProbeEmbeddingDimensionRequiresExecutorAndReportsFailures(t *testing.T) {
-	unwired := &GovernancePlugin{}
-	_, err := unwired.ProbeEmbeddingDimension(t.Context(), "openai", "text-embedding-3-small")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "executor is not configured")
-
-	plugin := &GovernancePlugin{}
-	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-		return nil, &schemas.BifrostError{Error: &schemas.ErrorField{Message: "unknown model"}}
-	})
-	_, err = plugin.ProbeEmbeddingDimension(t.Context(), "openai", "not-a-model")
-	require.Error(t, err)
-
-	// A missing provider or model must fail before any request is issued.
-	for _, test := range []struct{ provider, model string }{{"", "text-embedding-3-small"}, {"openai", ""}} {
-		_, err := plugin.ProbeEmbeddingDimension(t.Context(), schemas.ModelProvider(test.provider), test.model)
-		require.Error(t, err)
-	}
-}
-
 func TestGenerateEmbeddingsBatchesAndRestoresInputOrder(t *testing.T) {
 	plugin := &GovernancePlugin{}
 	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
@@ -271,7 +222,7 @@ func TestGenerateEmbeddingDistinguishesTimeoutFromOtherFailures(t *testing.T) {
 }
 
 // TestWarmupEmbedsDoNotInheritTheRequestTimeout is a regression guard: warmup
-// used to run through semantic.Timeout, the hot-path budget (100ms by default).
+// used to run through semantic.Timeout, the hot-path budget (1500ms by default).
 // A 32-exemplar batch cannot finish in that window, so every warmup failed with
 // a 504 and semantic routing silently served its fallback forever.
 func TestWarmupEmbedsDoNotInheritTheRequestTimeout(t *testing.T) {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -748,11 +748,6 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 				// (semantic.message_history_count); the classifier applies it from
 				// the same snapshot that owns the exemplars.
 				semanticResult, err := p.semanticClassifier.Classify(ctx, input)
-				// Retained so the fallback-disabled path can report *why* semantic routing
-				// produced nothing: a rejected near-match reads very differently from a
-				// classifier that never returned a result at all.
-				var rejectedResult *complexity.SemanticResult
-				var timedOut bool
 				if err != nil {
 					if p.logger != nil {
 						p.logger.Debug("[Governance] Semantic complexity classification unavailable: %v", err)
@@ -766,7 +761,6 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 					// operator hunting for a broken provider or an incomplete
 					// warmup instead of raising semantic.timeout.
 					if errors.Is(err, ErrEmbeddingTimeout) {
-						timedOut = true
 						unavailableLog = fmt.Sprintf(
 							"Semantic complexity classification timed out after %s; resolving through fallback",
 							p.semanticClassifier.Timeout(),
@@ -774,7 +768,6 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 					}
 					ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelWarn, unavailableLog)
 				} else if semanticResult != nil && !semanticResult.Accepted {
-					rejectedResult = semanticResult
 					if p.logger != nil {
 						p.logger.Debug(
 							"[Governance] Semantic complexity below min_similarity: tier=%s similarity=%.2f min=%.2f",
@@ -817,29 +810,6 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 						),
 					)
 					return result
-				}
-				if p.semanticClassifier.Fallback() == configstore.ComplexitySemanticFallbackNone {
-					ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, complexity.MechanismSkipped)
-					fallbackDisabledLog := "Semantic complexity analysis unavailable and fallback is disabled"
-					switch {
-					case rejectedResult != nil:
-						fallbackDisabledLog = withMatchedExemplar(
-							fmt.Sprintf(
-								"Semantic complexity rejected (nearest tier=%s similarity=%.2f below min_similarity=%.2f) and fallback is disabled",
-								rejectedResult.Tier,
-								rejectedResult.Score,
-								rejectedResult.MinSimilarity,
-							),
-							rejectedResult.MatchedExemplar,
-						)
-					case timedOut:
-						fallbackDisabledLog = fmt.Sprintf(
-							"Semantic complexity classification timed out after %s and fallback is disabled",
-							p.semanticClassifier.Timeout(),
-						)
-					}
-					ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo, fallbackDisabledLog)
-					return nil
 				}
 			}
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3457,9 +3457,8 @@ func validateComplexitySemanticVectorStore(config *Config, configData *ConfigDat
 		return nil
 	}
 	if !fileRequestsExternalComplexityVectorStore(configData) {
-		logger.Error("stored governance complexity analyzer config sets semantic.vector_store to %q but no vector store is configured; semantic complexity classification will report \"failed\" and fall back to %q. Add a vector_store section to config.json, or set semantic.vector_store to %q or %q",
+		logger.Error("stored governance complexity analyzer config sets semantic.vector_store to %q but no vector store is configured; semantic complexity classification will report \"failed\" and fall back to lexical scoring. Add a vector_store section to config.json, or set semantic.vector_store to %q or %q",
 			configstore.ComplexitySemanticVectorStoreExternal,
-			semantic.Fallback,
 			configstore.ComplexitySemanticVectorStoreAuto,
 			configstore.ComplexitySemanticVectorStoreEmbedded)
 		return nil

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -21192,8 +21192,6 @@ func complexityConfigWithVectorStore(mode string) *configstore.ComplexityAnalyze
 		Semantic: &configstore.ComplexitySemanticConfig{
 			Provider:       schemas.OpenAI,
 			EmbeddingModel: "text-embedding-3-small",
-			Dimension:      1536,
-			Fallback:       configstore.ComplexitySemanticFallbackLexical,
 			VectorStore:    mode,
 		},
 	}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3718,7 +3718,7 @@
           "description": "Model used to generate embeddings for complexity classification"
         },
         "timeout": {
-          "description": "Per-request embedding timeout (duration string like '100ms', or milliseconds as a number; default: 100ms). On timeout the fallback classifier is used.",
+          "description": "Per-request embedding timeout (duration string like '1500ms', or milliseconds as a number; default: 1500ms). On timeout the request falls back to lexical scoring.",
           "oneOf": [
             {
               "type": "string",
@@ -3728,18 +3728,14 @@
               "type": "number",
               "exclusiveMinimum": 0
             }
-          ]
-        },
-        "fallback": {
-          "type": "string",
-          "enum": ["lexical", "none"],
-          "description": "Classifier used when semantic classification is unavailable or exceeds its timeout (default: lexical)"
+          ],
+          "default": "1500ms"
         },
         "min_similarity": {
           "type": "number",
           "minimum": 0,
           "exclusiveMaximum": 1,
-          "description": "Similarity floor a nearest-exemplar match must clear before its tier is used; a match below it resolves through 'fallback' (default: 0, meaning the nearest exemplar always wins however unrelated it is). Compared against the backend's own score: chromem, Qdrant, Pinecone, and Redis report raw cosine similarity, Weaviate reports certainty ((cosine+1)/2), so retune when switching backends."
+          "description": "Similarity floor a nearest-exemplar match must clear before its tier is used; a match below it falls back to lexical scoring (default: 0, meaning the nearest exemplar always wins however unrelated it is). Compared against the backend's own score: chromem, Qdrant, Pinecone, and Redis report raw cosine similarity, Weaviate reports certainty ((cosine+1)/2), so retune when switching backends."
         },
         "message_history_count": {
           "type": "integer",

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -9,33 +9,68 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scrollArea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { TagInput } from "@/components/ui/tagInput";
-import { getErrorMessage } from "@/lib/store";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { EmbeddingSupportedProviders, getProviderLabel } from "@/lib/constants/logs";
+import { getErrorMessage, useGetCoreConfigQuery, useGetProvidersQuery } from "@/lib/store";
 import {
 	useGetComplexityAnalyzerConfigQuery,
+	useGetComplexitySemanticStatusQuery,
 	useResetComplexityAnalyzerConfigMutation,
 	useUpdateComplexityAnalyzerConfigMutation,
 } from "@/lib/store/apis/governanceApi";
 import {
 	AnalyzerConfig,
+	DEFAULT_SEMANTIC_CONFIG,
 	DEFAULT_TIER_BOUNDARIES,
+	formatSemanticTimeout,
 	KEYWORD_LIST_DEFINITIONS,
 	KeywordListKey,
+	MAX_SEMANTIC_MESSAGE_HISTORY,
+	MAX_SEMANTIC_PHRASE_CHARACTERS,
+	MIN_SEMANTIC_MESSAGE_HISTORY,
+	parseSemanticTimeoutMs,
+	SEMANTIC_STATUS_LABELS,
+	SEMANTIC_VECTOR_STORE_OPTIONS,
+	SemanticStatusInfo,
 	TierBoundaries,
 } from "@/lib/types/complexityRouter";
+import { ModelProvider, ModelProviderName } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ExternalLink, LoaderCircle, RotateCcw, Save } from "lucide-react";
-import { type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, useEffect, useState } from "react";
+import { CircleAlert, CircleCheck, ExternalLink, LoaderCircle, RotateCcw, Save } from "lucide-react";
+import { type ChangeEvent, type ClipboardEvent, type DragEvent, type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
 type TierBoundaryKey = keyof TierBoundaries;
+
+// The page classifies with exactly one mechanism. Semantic keeps the keyword
+// lists in play (as exemplars, and for the lexical fallback path), so the two
+// modes share every other control on this screen.
+type ClassificationMode = "lexical" | "semantic";
+
+// Embedding-capable providers gate semantic mode, matching the local cache
+// screen's rule: built-ins are listed in EmbeddingSupportedProviders, custom
+// providers declare support through allowed_requests.embedding.
+const supportsEmbedding = (provider: ModelProvider): boolean => {
+	if (provider.custom_provider_config) {
+		return provider.custom_provider_config.allowed_requests?.embedding === true;
+	}
+	return (EmbeddingSupportedProviders as readonly string[]).includes(provider.name);
+};
 
 const KEYWORD_COLLAPSED_LIMIT = 8;
 
@@ -83,40 +118,93 @@ const BOUNDARY_FIELDS: BoundaryFieldConfig[] = [
 
 const boundaryField = z.number({ error: "Enter a number between 0 and 1" }).gt(0, "Must be greater than 0").lt(1, "Must be less than 1");
 
-const analyzerConfigSchema = z.object({
-	tier_boundaries: z
-		.object({
-			simple_medium: boundaryField,
-			medium_complex: boundaryField,
-		})
-		.superRefine((data, ctx) => {
-			if (Number.isFinite(data.medium_complex) && Number.isFinite(data.simple_medium) && data.medium_complex <= data.simple_medium) {
-				ctx.addIssue({ code: "custom", message: "Must be greater than Simple → Medium", path: ["medium_complex"] });
-			}
+const analyzerConfigSchema = z
+	.object({
+		tier_boundaries: z
+			.object({
+				simple_medium: boundaryField,
+				medium_complex: boundaryField,
+			})
+			.superRefine((data, ctx) => {
+				if (Number.isFinite(data.medium_complex) && Number.isFinite(data.simple_medium) && data.medium_complex <= data.simple_medium) {
+					ctx.addIssue({ code: "custom", message: "Must be greater than Simple → Medium", path: ["medium_complex"] });
+				}
+			}),
+		keywords: z.object({
+			simple_keywords: z.array(z.string()).min(1, "Simple keywords cannot be empty"),
+			medium_keywords: z.array(z.string()).min(1, "Medium keywords cannot be empty"),
+			complex_keywords: z.array(z.string()).min(1, "Complex keywords cannot be empty"),
 		}),
-	keywords: z.object({
-		simple_keywords: z.array(z.string()).min(1, "Simple keywords cannot be empty"),
-		medium_keywords: z.array(z.string()).min(1, "Medium keywords cannot be empty"),
-		complex_keywords: z.array(z.string()).min(1, "Complex keywords cannot be empty"),
-	}),
-	// The semantic controls are not exposed in this screen yet, but the schema
-	// must preserve the block returned by the API when lexical lists are edited.
-	// Server-managed fields (e.g. the probed embedding dimension) are stripped
-	// here on purpose: the management API rejects them on write.
-	semantic: z
-		.object({
-			provider: z.string().min(1),
-			embedding_model: z.string().min(1),
-			timeout: z.string().optional(),
-			min_similarity: z.number().min(0).lt(1).optional(),
-			message_history_count: z.number().int().min(1).optional(),
-			count_toward_budgets: z.boolean().optional(),
-			vector_store: z.enum(["auto", "embedded", "external"]).optional(),
-		})
-		.optional(),
-});
+		// Present only in semantic mode; switching back to lexical drops the key so
+		// the PUT (a full replace) disables the classifier server-side.
+		semantic: z
+			.object({
+				provider: z.string().min(1, "Select an embedding provider"),
+				embedding_model: z.string().min(1, "Select an embedding model"),
+				timeout: z.string().min(1, "Enter an embedding timeout").optional(),
+				min_similarity: z.number({ error: "Enter a number between 0 and 1" }).min(0, "Must be 0 or greater").lt(1, "Must be less than 1"),
+				message_history_count: z
+					.number({ error: "Select how many messages to embed" })
+					.int("Must be a whole number")
+					.min(MIN_SEMANTIC_MESSAGE_HISTORY, `Must be at least ${MIN_SEMANTIC_MESSAGE_HISTORY}`)
+					.max(MAX_SEMANTIC_MESSAGE_HISTORY, `Must be at most ${MAX_SEMANTIC_MESSAGE_HISTORY}`),
+				count_toward_budgets: z.boolean().optional(),
+				vector_store: z.enum(["auto", "embedded", "external"]).optional(),
+			})
+			.optional(),
+	})
+	.superRefine((data, ctx) => {
+		// The per-phrase bound and one-tier-per-phrase rule only apply when the
+		// lists are also used as semantic exemplars. Mirrors
+		// validateComplexitySemanticPhrases so invalid input fails in the form
+		// instead of as an opaque 400.
+		if (!data.semantic) return;
 
-const DEFAULT_FORM_VALUES: AnalyzerConfig = {
+		const lists: Array<{ key: KeywordListKey; label: string }> = [
+			{ key: "simple_keywords", label: "Simple" },
+			{ key: "medium_keywords", label: "Medium" },
+			{ key: "complex_keywords", label: "Complex" },
+		];
+
+		const seen = new Map<string, string>();
+		for (const { key, label } of lists) {
+			for (const phrase of data.keywords[key]) {
+				if (phrase.length > MAX_SEMANTIC_PHRASE_CHARACTERS) {
+					ctx.addIssue({
+						code: "custom",
+						message: `A ${label} phrase exceeds the ${MAX_SEMANTIC_PHRASE_CHARACTERS}-character limit.`,
+						path: ["keywords", key],
+					});
+					break;
+				}
+				const normalized = phrase.trim().toLowerCase();
+				const firstTier = seen.get(normalized);
+				if (firstTier && firstTier !== label) {
+					ctx.addIssue({
+						code: "custom",
+						message: `"${phrase}" is also in the ${firstTier} list. Each semantic phrase must belong to exactly one tier.`,
+						path: ["keywords", key],
+					});
+				} else if (!firstTier) {
+					seen.set(normalized, label);
+				}
+			}
+		}
+	});
+
+// The form is stricter than the wire type: the API omits semantic fields left
+// at their zero value (Go `omitempty`), but every control here is controlled and
+// needs a concrete value, so the schema's inferred type is the source of truth.
+type AnalyzerFormValues = z.infer<typeof analyzerConfigSchema>;
+type SemanticFormValues = NonNullable<AnalyzerFormValues["semantic"]>;
+
+const DEFAULT_SEMANTIC_FORM_VALUES: SemanticFormValues = {
+	...DEFAULT_SEMANTIC_CONFIG,
+	min_similarity: DEFAULT_SEMANTIC_CONFIG.min_similarity ?? 0,
+	message_history_count: DEFAULT_SEMANTIC_CONFIG.message_history_count ?? MIN_SEMANTIC_MESSAGE_HISTORY,
+};
+
+const DEFAULT_FORM_VALUES: AnalyzerFormValues = {
 	tier_boundaries: { ...DEFAULT_TIER_BOUNDARIES },
 	keywords: {
 		simple_keywords: [],
@@ -124,6 +212,21 @@ const DEFAULT_FORM_VALUES: AnalyzerConfig = {
 		complex_keywords: [],
 	},
 };
+
+// Fills in the fields the API omitted so the semantic controls stay controlled.
+function toFormValues(config: AnalyzerConfig): AnalyzerFormValues {
+	const base: AnalyzerFormValues = { tier_boundaries: config.tier_boundaries, keywords: config.keywords };
+	if (!config.semantic) return base;
+	return {
+		...base,
+		semantic: {
+			...DEFAULT_SEMANTIC_FORM_VALUES,
+			...config.semantic,
+			min_similarity: config.semantic.min_similarity ?? 0,
+			message_history_count: config.semantic.message_history_count ?? MIN_SEMANTIC_MESSAGE_HISTORY,
+		},
+	};
+}
 
 function boundaryValueAsNumber(value: unknown): number {
 	let numericValue = Number.NaN;
@@ -231,6 +334,117 @@ function TierSpectrumBar({ boundaries }: { boundaries: TierBoundaries }) {
 	);
 }
 
+// SemanticStatusPanel surfaces warmup readiness, which is otherwise only
+// visible in server logs. Without it a failed warmup looks identical to a
+// working lexical deployment, because the request log records mechanism=lexical
+// in both cases.
+function SemanticStatusPanel({
+	status,
+	isLoading,
+	isNotSaved,
+	hasUnsavedChanges,
+}: {
+	status: SemanticStatusInfo | undefined;
+	isLoading: boolean;
+	isNotSaved: boolean;
+	hasUnsavedChanges: boolean;
+}) {
+	if (isNotSaved) {
+		return (
+			<div className="bg-card space-y-3 rounded-sm border p-4" data-testid="complexity-router-semantic-status">
+				<div className="flex items-center justify-between">
+					<span className="text-xs font-medium">Classifier status</span>
+					<Badge
+						className="border-0 bg-blue-100 py-0.5 text-[10px] text-blue-800 uppercase dark:bg-blue-900 dark:text-blue-300"
+						data-testid="complexity-router-semantic-status-badge"
+					>
+						Not saved
+					</Badge>
+				</div>
+				<p className="text-muted-foreground text-xs">
+					Save this configuration to embed the tier phrases and activate semantic classification.
+				</p>
+			</div>
+		);
+	}
+
+	if (isLoading && !status) {
+		return (
+			<div className="bg-card text-muted-foreground flex items-center gap-2 rounded-sm border p-4 text-xs">
+				<LoaderCircle className="size-3.5 animate-spin" />
+				Checking semantic classifier status…
+			</div>
+		);
+	}
+	if (!status) return null;
+
+	const tone = {
+		ready: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+		warming: "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300",
+		failed: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+		disabled: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
+	}[status.state];
+
+	const percent = status.total > 0 ? Math.round((status.loaded / status.total) * 100) : 0;
+
+	return (
+		<div className="bg-card space-y-3 rounded-sm border p-4" data-testid="complexity-router-semantic-status">
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					{status.state === "ready" ? (
+						<CircleCheck className="size-3.5 text-green-600" />
+					) : status.state === "failed" ? (
+						<CircleAlert className="text-destructive size-3.5" />
+					) : status.state === "warming" ? (
+						<LoaderCircle className="size-3.5 animate-spin text-amber-600" />
+					) : null}
+					<span className="text-xs font-medium">Classifier status</span>
+				</div>
+				<Badge className={cn("border-0 py-0.5 text-[10px] uppercase", tone)} data-testid="complexity-router-semantic-status-badge">
+					{SEMANTIC_STATUS_LABELS[status.state]}
+				</Badge>
+			</div>
+
+			{status.state === "warming" && (
+				<div className="space-y-1.5">
+					<Progress value={percent} className="h-1.5" />
+					<p className="text-muted-foreground font-mono text-[11px] tabular-nums">
+						Embedding exemplars: {status.loaded}/{status.total}
+					</p>
+				</div>
+			)}
+
+			{status.state === "ready" && (
+				<p className="text-muted-foreground text-xs">
+					{status.total} exemplar{status.total === 1 ? "" : "s"} embedded and serving.
+				</p>
+			)}
+
+			{status.serving_previous && (
+				<p className="text-xs text-amber-700 dark:text-amber-400">
+					The previous exemplar generation is still serving requests while this one prepares. Routing is unaffected.
+				</p>
+			)}
+
+			{hasUnsavedChanges && (
+				<p className="text-xs text-amber-700 dark:text-amber-400">
+					The saved classifier is still serving. Save to prepare and activate these phrase or model changes.
+				</p>
+			)}
+
+			{status.error && (
+				<p className="text-destructive text-xs" data-testid="complexity-router-semantic-status-error">
+					{status.error}
+				</p>
+			)}
+
+			{status.state === "failed" && (
+				<p className="text-muted-foreground text-xs">Requests are being classified by the keyword analyzer until warmup succeeds.</p>
+			)}
+		</div>
+	);
+}
+
 export default function ComplexityRouterPage() {
 	const canUpdate = useRbac(RbacResource.RoutingRules, RbacOperation.Update);
 	const { data, isLoading, isFetching, error, refetch } = useGetComplexityAnalyzerConfigQuery();
@@ -239,6 +453,27 @@ export default function ComplexityRouterPage() {
 
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
+	const [mode, setMode] = useState<ClassificationMode>("lexical");
+	// Remembers the semantic block across a lexical round-trip so toggling back
+	// does not discard a filled-in provider/model.
+	const lastSemanticRef = useRef<SemanticFormValues | undefined>(undefined);
+
+	const { data: providersData, isLoading: providersLoading } = useGetProvidersQuery();
+	const embeddingProviders = useMemo(() => (providersData || []).filter(supportsEmbedding), [providersData]);
+
+	const { data: coreConfig } = useGetCoreConfigQuery({ fromDB: true });
+	const isVectorStoreConnected = coreConfig?.is_cache_connected ?? false;
+
+	// Poll only while warmup is in flight; a ready or failed classifier is
+	// steady state until the next save, which refetches through the cache tag.
+	const [statusPollInterval, setStatusPollInterval] = useState(0);
+	const { data: semanticStatus, isLoading: statusLoading } = useGetComplexitySemanticStatusQuery(undefined, {
+		skip: mode !== "semantic",
+		pollingInterval: statusPollInterval,
+	});
+	useEffect(() => {
+		setStatusPollInterval(semanticStatus?.state === "warming" ? 2000 : 0);
+	}, [semanticStatus?.state]);
 
 	const {
 		register,
@@ -246,8 +481,10 @@ export default function ComplexityRouterPage() {
 		reset,
 		control,
 		watch,
+		setValue,
+		getValues,
 		formState: { errors, isDirty, isSubmitted },
-	} = useForm<AnalyzerConfig>({
+	} = useForm<AnalyzerFormValues>({
 		resolver: zodResolver(analyzerConfigSchema),
 		defaultValues: DEFAULT_FORM_VALUES,
 		mode: "onSubmit",
@@ -255,15 +492,58 @@ export default function ComplexityRouterPage() {
 	});
 
 	const liveBoundaries = watch("tier_boundaries");
+	const liveSemantic = watch("semantic");
+	const liveKeywords = watch("keywords");
+
+	const totalPhrases = useMemo(
+		() =>
+			(liveKeywords?.simple_keywords?.length ?? 0) +
+			(liveKeywords?.medium_keywords?.length ?? 0) +
+			(liveKeywords?.complex_keywords?.length ?? 0),
+		[liveKeywords],
+	);
+
+	// Saving re-runs warmup. It is a no-op when only the threshold or timeout
+	// changed (the exemplar fingerprint is unchanged), but re-embeds every
+	// phrase when the provider, model, or a list changed.
+	const willReembed = useMemo(() => {
+		if (mode !== "semantic" || !data) return false;
+		const saved = data.semantic;
+		if (!saved) return true;
+		return (
+			saved.provider !== liveSemantic?.provider ||
+			saved.embedding_model !== liveSemantic?.embedding_model ||
+			JSON.stringify(data.keywords) !== JSON.stringify(liveKeywords)
+		);
+	}, [mode, data, liveSemantic, liveKeywords]);
 
 	useEffect(() => {
 		if (!data || isDirty) return;
-		reset(data);
+		const formValues = toFormValues(data);
+		reset(formValues);
+		setMode(formValues.semantic ? "semantic" : "lexical");
+		if (formValues.semantic) lastSemanticRef.current = formValues.semantic;
 		setSubmitError(null);
 	}, [data, isDirty, reset]);
 
+	const handleModeChange = (next: ClassificationMode) => {
+		if (next === mode || !canUpdate) return;
+		if (next === "semantic") {
+			setValue("semantic", lastSemanticRef.current ?? DEFAULT_SEMANTIC_FORM_VALUES, { shouldDirty: true });
+		} else {
+			const current = getValues("semantic");
+			if (current) lastSemanticRef.current = current;
+			setValue("semantic", undefined, { shouldDirty: true });
+		}
+		setMode(next);
+	};
+
 	const handleDiscard = () => {
-		if (data) reset(data);
+		if (data) {
+			const formValues = toFormValues(data);
+			reset(formValues);
+			setMode(formValues.semantic ? "semantic" : "lexical");
+		}
 		setSubmitError(null);
 	};
 
@@ -273,7 +553,12 @@ export default function ComplexityRouterPage() {
 		resetConfig()
 			.unwrap()
 			.then((defaults) => {
-				reset(defaults);
+				const formValues = toFormValues(defaults);
+				reset(formValues);
+				// The factory defaults carry no semantic block, so a reset also
+				// turns semantic classification off.
+				setMode(formValues.semantic ? "semantic" : "lexical");
+				lastSemanticRef.current = formValues.semantic;
 				toast.success("Reset to defaults", { position: "top-right" });
 			})
 			.catch((err) => {
@@ -281,13 +566,20 @@ export default function ComplexityRouterPage() {
 			});
 	};
 
-	const onValid = (values: AnalyzerConfig) => {
+	const onValid = (values: AnalyzerFormValues) => {
 		if (!canUpdate) return;
 		setSubmitError(null);
-		updateConfig(values)
+		// The endpoint replaces the whole record and rejects unknown fields, so
+		// lexical mode must omit the semantic block entirely rather than send a
+		// blank one.
+		const payload: AnalyzerConfig = mode === "semantic" ? values : { tier_boundaries: values.tier_boundaries, keywords: values.keywords };
+		updateConfig(payload)
 			.unwrap()
 			.then((res) => {
-				reset(res);
+				const formValues = toFormValues(res);
+				reset(formValues);
+				setMode(formValues.semantic ? "semantic" : "lexical");
+				if (formValues.semantic) lastSemanticRef.current = formValues.semantic;
 				toast.success("Configuration saved", { position: "top-right" });
 			})
 			.catch((err) => {
@@ -323,7 +615,13 @@ export default function ComplexityRouterPage() {
 
 	const boundaryErrors = errors.tier_boundaries;
 	const keywordErrors = errors.keywords;
-	const hasErrors = Boolean(boundaryErrors || keywordErrors);
+	const semanticErrors = errors.semantic;
+	const hasErrors = Boolean(boundaryErrors || keywordErrors || semanticErrors);
+	const isSemantic = mode === "semantic";
+	// An in-flight providers query yields an empty list too, which is not the
+	// same as having none: gating on it would disable semantic mode on every
+	// page load and blame the operator for a provider they already configured.
+	const noEmbeddingProviders = !providersLoading && embeddingProviders.length === 0;
 
 	return (
 		<ScrollArea className="no-padding-parent h-[calc(100vh_-_16px)] w-full px-14 pt-4">
@@ -333,8 +631,8 @@ export default function ComplexityRouterPage() {
 					<div className="space-y-1.5">
 						<h1 className="text-2xl font-semibold tracking-tight">Complexity Router</h1>
 						<p className="text-muted-foreground max-w-2xl text-sm leading-relaxed">
-							Tune how incoming requests are classified into three tiers. Thresholds and keyword lists feed the{" "}
-							<code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
+							Tune how incoming requests are classified into three tiers, by keyword scoring or by embedding similarity. The result feeds
+							the <code className="bg-muted rounded-sm px-1 py-0.5 font-mono text-xs">complexity_tier</code> field that routing rules can
 							target.
 						</p>
 					</div>
@@ -346,25 +644,345 @@ export default function ComplexityRouterPage() {
 					</Button>
 				</div>
 
-				{/* ── Complexity Spectrum ── */}
-				<div className="bg-card space-y-4 rounded-sm border p-5">
-					<div className="flex items-center justify-between">
-						<p className="text-muted-foreground font-mono text-xs font-semibold tracking-widest uppercase">Complexity Spectrum</p>
-						<div className="flex items-center gap-4">
-							{Object.values(TIER_PALETTE).map(({ color, name }) => (
-								<div key={name} className="flex items-center gap-1.5">
-									<div className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: color }} />
-									<span className="text-muted-foreground font-mono text-[9px] font-bold tracking-widest">{name}</span>
+				{/* ── Classification Mode ── */}
+				<div className="space-y-3">
+					<div className="flex items-baseline gap-2.5">
+						<h2 className="text-sm font-semibold">Classification Mode</h2>
+						<span className="text-muted-foreground text-xs">How each request is assigned a tier.</span>
+					</div>
+
+					<Tabs value={mode} onValueChange={(value) => handleModeChange(value as ClassificationMode)}>
+						<TabsList className="grid w-full grid-cols-2">
+							<TabsTrigger value="lexical" data-testid="complexity-router-mode-lexical-tab" disabled={!canUpdate}>
+								Lexical
+							</TabsTrigger>
+							<TabsTrigger
+								value="semantic"
+								data-testid="complexity-router-mode-semantic-tab"
+								disabled={!canUpdate || noEmbeddingProviders}
+								title={noEmbeddingProviders ? "Configure an embedding-capable provider to enable semantic mode." : undefined}
+							>
+								Semantic
+							</TabsTrigger>
+						</TabsList>
+					</Tabs>
+
+					<p className="text-muted-foreground text-xs leading-relaxed">
+						{isSemantic ? (
+							<>
+								Each request is embedded and compared with the tier examples. The nearest example above the minimum similarity determines
+								the tier. This adds one embedding request for each classified request.
+							</>
+						) : (
+							<>
+								Requests are scored using matching phrases, message length, and recent conversation context. No embedding request is made.
+							</>
+						)}
+					</p>
+				</div>
+
+				{/* ── Semantic settings ── */}
+				{isSemantic && (
+					<div className="space-y-3">
+						<div className="flex items-baseline gap-2.5">
+							<h2 className="text-sm font-semibold">Semantic Classifier</h2>
+							<span className="text-muted-foreground text-xs">API keys are inherited from the provider&apos;s main configuration.</span>
+						</div>
+
+						<SemanticStatusPanel
+							status={semanticStatus}
+							isLoading={statusLoading}
+							isNotSaved={!data.semantic}
+							hasUnsavedChanges={willReembed}
+						/>
+
+						{willReembed && (
+							<div className="rounded-sm border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-200">
+								<b>Heads up:</b> saving will embed all {totalPhrases} tier phrases through the selected provider. This uses embedding tokens
+								and may take a short time. Changes only to similarity or timeout reuse the current embeddings.
+							</div>
+						)}
+
+						<div className="bg-card space-y-5 rounded-sm border p-5">
+							{providersLoading ? (
+								<div className="flex items-center justify-center py-4">
+									<LoaderCircle className="text-muted-foreground size-4 animate-spin" />
 								</div>
-							))}
+							) : (
+								<>
+									{/* Provider + model */}
+									<div className="grid gap-4 md:grid-cols-2">
+										<div className="space-y-2">
+											<Label htmlFor="semantic-provider">Embedding provider</Label>
+											<Controller
+												control={control}
+												name="semantic.provider"
+												render={({ field }) => (
+													<Select
+														value={field.value || undefined}
+														onValueChange={(value: ModelProviderName) => {
+															if (value === field.value) return;
+															field.onChange(value);
+															// A model name is only meaningful for its own provider.
+															setValue("semantic.embedding_model", "", { shouldDirty: true });
+														}}
+														disabled={!canUpdate}
+													>
+														<SelectTrigger
+															className="w-full"
+															id="semantic-provider"
+															data-testid="complexity-router-semantic-provider-select"
+														>
+															<SelectValue placeholder="Select provider" />
+														</SelectTrigger>
+														<SelectContent>
+															{embeddingProviders
+																.filter((provider) => provider.name)
+																.map((provider) => (
+																	<SelectItem key={provider.name} value={provider.name}>
+																		<div className="flex items-center gap-2">
+																			<RenderProviderIcon provider={provider.name as ProviderIconType} size="sm" className="h-4 w-4" />
+																			<span>{getProviderLabel(provider.name)}</span>
+																		</div>
+																	</SelectItem>
+																))}
+														</SelectContent>
+													</Select>
+												)}
+											/>
+											{semanticErrors?.provider && <p className="text-destructive text-xs">{semanticErrors.provider.message}</p>}
+										</div>
+
+										<div className="space-y-2">
+											<Label htmlFor="semantic-embedding-model">Embedding model</Label>
+											<Controller
+												control={control}
+												name="semantic.embedding_model"
+												render={({ field }) => (
+													<ModelMultiselect
+														inputId="semantic-embedding-model"
+														data-testid="complexity-router-semantic-model-select"
+														isSingleSelect
+														provider={liveSemantic?.provider || undefined}
+														value={field.value ?? ""}
+														onChange={(model) => field.onChange(model)}
+														placeholder={liveSemantic?.provider ? "Search or type an embedding model…" : "Select a provider first"}
+														disabled={!canUpdate || !liveSemantic?.provider}
+													/>
+												)}
+											/>
+											{semanticErrors?.embedding_model && (
+												<p className="text-destructive text-xs">{semanticErrors.embedding_model.message}</p>
+											)}
+										</div>
+									</div>
+
+									{/* Similarity floor */}
+									<div className="grid gap-4 md:grid-cols-2">
+										<div className="space-y-2">
+											<Label htmlFor="semantic-min-similarity">Minimum similarity</Label>
+											<Input
+												id="semantic-min-similarity"
+												data-testid="complexity-router-semantic-min-similarity-input"
+												type="number"
+												min={0}
+												max={0.99}
+												step={0.05}
+												disabled={!canUpdate}
+												aria-invalid={semanticErrors?.min_similarity ? true : undefined}
+												className={cn("font-mono", semanticErrors?.min_similarity && "border-destructive focus-visible:ring-destructive")}
+												{...register("semantic.min_similarity", { valueAsNumber: true })}
+											/>
+											{semanticErrors?.min_similarity ? (
+												<p className="text-destructive text-xs">{semanticErrors.min_similarity.message}</p>
+											) : (
+												<p className="text-muted-foreground text-xs leading-relaxed">
+													How close the nearest phrase must be before its tier is used. Below this, the request is treated as unclassified
+													and falls back to keyword scoring. <code className="font-mono">0</code> accepts the nearest phrase however
+													unrelated it is.
+												</p>
+											)}
+										</div>
+									</div>
+
+									{/* Conversation window */}
+									<div className="space-y-2">
+										<Label htmlFor="semantic-message-history">Messages to embed</Label>
+										<Controller
+											control={control}
+											name="semantic.message_history_count"
+											render={({ field }) => (
+												<Select
+													value={String(field.value ?? MIN_SEMANTIC_MESSAGE_HISTORY)}
+													onValueChange={(value) => field.onChange(Number(value))}
+													disabled={!canUpdate}
+												>
+													<SelectTrigger
+														className="w-full"
+														id="semantic-message-history"
+														data-testid="complexity-router-semantic-message-history-select"
+													>
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{Array.from({ length: MAX_SEMANTIC_MESSAGE_HISTORY }, (_, index) => index + MIN_SEMANTIC_MESSAGE_HISTORY).map(
+															(count) => (
+																<SelectItem key={count} value={String(count)}>
+																	{count === 1 ? "Latest message only" : `Last ${count} messages`}
+																</SelectItem>
+															),
+														)}
+													</SelectContent>
+												</Select>
+											)}
+										/>
+										{semanticErrors?.message_history_count ? (
+											<p className="text-destructive text-xs">{semanticErrors.message_history_count.message}</p>
+										) : (
+											<p className="text-muted-foreground text-xs leading-relaxed">
+												The most recent user messages, joined oldest to newest, are embedded as one text. Widening this lets a short
+												follow-up like <em>&ldquo;and make it faster&rdquo;</em> inherit the intent of earlier turns, but dilutes the latest
+												message and embeds more input tokens per request. System prompts and assistant replies are never embedded.
+											</p>
+										)}
+									</div>
+
+									{/* Timeout + vector store */}
+									<div className="grid gap-4 md:grid-cols-2">
+										<div className="space-y-2">
+											<Label htmlFor="semantic-timeout">Embedding timeout (ms)</Label>
+											<Controller
+												control={control}
+												name="semantic.timeout"
+												render={({ field }) => (
+													<Input
+														id="semantic-timeout"
+														data-testid="complexity-router-semantic-timeout-input"
+														type="number"
+														min={1}
+														step={10}
+														disabled={!canUpdate}
+														value={field.value === "" ? "" : parseSemanticTimeoutMs(field.value)}
+														onChange={(event) => {
+															const raw = event.target.value;
+															field.onChange(raw === "" ? "" : formatSemanticTimeout(Number(raw)));
+														}}
+														aria-invalid={semanticErrors?.timeout ? true : undefined}
+														className={cn("font-mono", semanticErrors?.timeout && "border-destructive focus-visible:ring-destructive")}
+													/>
+												)}
+											/>
+											{semanticErrors?.timeout ? (
+												<p className="text-destructive text-xs">{semanticErrors.timeout.message}</p>
+											) : (
+												<p className="text-muted-foreground text-xs leading-relaxed">
+													Ceiling on the embedding call, which runs inline on the request path. Exceeding it falls back to keyword scoring.
+												</p>
+											)}
+										</div>
+
+										<div className="space-y-2">
+											<Label htmlFor="semantic-vector-store">Exemplar storage</Label>
+											<Controller
+												control={control}
+												name="semantic.vector_store"
+												render={({ field }) => (
+													<Select value={field.value ?? "embedded"} onValueChange={field.onChange} disabled={!canUpdate}>
+														<SelectTrigger
+															className="w-full"
+															id="semantic-vector-store"
+															data-testid="complexity-router-semantic-vector-store-select"
+														>
+															<SelectValue />
+														</SelectTrigger>
+														<SelectContent>
+															{SEMANTIC_VECTOR_STORE_OPTIONS.map((option) => (
+																<SelectItem
+																	key={option.value}
+																	value={option.value}
+																	disabled={option.value === "external" && !isVectorStoreConnected}
+																>
+																	{option.label}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												)}
+											/>
+											<p className="text-muted-foreground text-xs leading-relaxed">
+												{
+													SEMANTIC_VECTOR_STORE_OPTIONS.find((option) => option.value === (liveSemantic?.vector_store ?? "embedded"))
+														?.description
+												}
+												{!isVectorStoreConnected && (
+													<>
+														{" "}
+														<span className="text-muted-foreground/80">
+															External requires a vector store configured and enabled in <code className="font-mono">config.json</code>.
+														</span>
+													</>
+												)}
+											</p>
+										</div>
+									</div>
+
+									{/* Budget attribution */}
+									<div className="flex items-start justify-between gap-6 border-t pt-4">
+										<div className="space-y-0.5">
+											<Label htmlFor="semantic-count-toward-budgets" className="text-sm font-medium">
+												Count embedding cost toward budgets
+											</Label>
+											<p className="text-muted-foreground text-xs leading-relaxed">
+												Bills each classification embedding to the same budgets as the request that triggered it, and warmup embeddings to
+												the provider and model budgets. Cost is always reported to telemetry either way.
+											</p>
+										</div>
+										<Controller
+											control={control}
+											name="semantic.count_toward_budgets"
+											render={({ field }) => (
+												<Switch
+													id="semantic-count-toward-budgets"
+													data-testid="complexity-router-semantic-budgets-switch"
+													checked={field.value ?? false}
+													onCheckedChange={field.onChange}
+													disabled={!canUpdate}
+												/>
+											)}
+										/>
+									</div>
+								</>
+							)}
 						</div>
 					</div>
-					<TierSpectrumBar boundaries={liveBoundaries} />
-				</div>
+				)}
+
+				{/* ── Complexity Spectrum ── */}
+				{!isSemantic && (
+					<div className="bg-card space-y-4 rounded-sm border p-5">
+						<div className="flex items-center justify-between">
+							<p className="text-muted-foreground font-mono text-xs font-semibold tracking-widest uppercase">Complexity Spectrum</p>
+							<div className="flex items-center gap-4">
+								{Object.values(TIER_PALETTE).map(({ color, name }) => (
+									<div key={name} className="flex items-center gap-1.5">
+										<div className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: color }} />
+										<span className="text-muted-foreground font-mono text-[9px] font-bold tracking-widest">{name}</span>
+									</div>
+								))}
+							</div>
+						</div>
+						<TierSpectrumBar boundaries={liveBoundaries} />
+					</div>
+				)}
 
 				{/* ── Tier Boundaries ── */}
 				<div className="space-y-3">
-					<h2 className="text-sm font-semibold">Tier Boundaries</h2>
+					<div className="flex items-baseline gap-2.5">
+						<h2 className="text-sm font-semibold">{isSemantic ? "Lexical fallback boundaries" : "Tier Boundaries"}</h2>
+						{isSemantic && (
+							<span className="text-muted-foreground text-xs">Used only when semantic classification falls back to lexical scoring.</span>
+						)}
+					</div>
 
 					<div className="grid gap-3 md:grid-cols-2">
 						{BOUNDARY_FIELDS.map(({ key, label, description, fromTier, toTier, fromColor, toColor }) => {
@@ -440,21 +1058,41 @@ export default function ComplexityRouterPage() {
 					</div>
 				</div>
 
-				{/* ── Keyword Lists ── */}
+				{/* ── Tier Phrases ── */}
 				<div className="space-y-3">
-					<div className="flex items-baseline gap-2.5">
-						<h2 className="text-sm font-semibold">Keyword Lists</h2>
-						<span className="text-muted-foreground text-xs">
-							Lowercased and deduplicated on save. Each list requires at least one entry.
-						</span>
+					<div className="flex flex-wrap items-baseline justify-between gap-2.5">
+						<div className="flex flex-wrap items-baseline gap-2.5">
+							<h2 className="text-sm font-semibold">Tier Phrases</h2>
+							<span className="text-muted-foreground text-xs">
+								{isSemantic
+									? "Each phrase is a labeled example. The nearest example above the minimum similarity determines the tier. Each phrase must belong to exactly one tier."
+									: "Phrases contribute to the lexical score. They are lowercased and deduplicated on save."}
+							</span>
+						</div>
+						{isSemantic && (
+							<span className="text-muted-foreground font-mono text-[11px] tabular-nums" data-testid="complexity-router-phrase-total">
+								{totalPhrases} phrases
+							</span>
+						)}
 					</div>
 
+					{/* Root-level keyword issues such as cross-tier duplicates have no
+					    single field to attach to, so they render above the lists. */}
+					{keywordErrors?.message && (
+						<p className="text-destructive text-xs" data-testid="complexity-router-keywords-error">
+							{keywordErrors.message}
+						</p>
+					)}
+
 					<div className="grid gap-3 md:grid-cols-2">
-						{KEYWORD_LIST_DEFINITIONS.map(({ key, label, description }) => {
+						{KEYWORD_LIST_DEFINITIONS.map(({ key, label, lexicalDescription, semanticDescription }) => {
 							const fieldError = keywordErrors?.[key as KeywordListKey];
 							const errorId = `keywords-${key}-error`;
 							return (
-								<div key={key} className="bg-card relative overflow-hidden rounded-sm border">
+								<div
+									key={key}
+									className={cn("bg-card relative overflow-hidden rounded-sm border", key === "complex_keywords" && "md:col-span-2")}
+								>
 									<Controller
 										control={control}
 										name={`keywords.${key}` as const}
@@ -467,14 +1105,16 @@ export default function ComplexityRouterPage() {
 														{field.value.length} {field.value.length === 1 ? "entry" : "entries"}
 													</span>
 												</div>
-												<p className="text-muted-foreground text-xs leading-relaxed">{description}</p>
+												<p className="text-muted-foreground text-xs leading-relaxed">
+													{isSemantic ? semanticDescription : lexicalDescription}
+												</p>
 												<TagInput
 													data-testid={`complexity-router-keywords-${testIdPart(key)}-input`}
 													value={field.value}
 													onValueChange={field.onChange}
 													collapsedTagLimit={KEYWORD_COLLAPSED_LIMIT}
 													expandButtonTestId={`complexity-router-keywords-${testIdPart(key)}-expand-button`}
-													placeholder="Type a keyword and press Enter"
+													placeholder={isSemantic ? "Type an example request and press Enter" : "Type a keyword or phrase and press Enter"}
 													aria-invalid={fieldError ? true : undefined}
 													aria-describedby={fieldError ? errorId : undefined}
 													className={cn(fieldError && "border-destructive")}
@@ -543,8 +1183,9 @@ export default function ComplexityRouterPage() {
 					<AlertDialogHeader>
 						<AlertDialogTitle>Restore defaults</AlertDialogTitle>
 						<AlertDialogDescription>
-							This will reset all tier boundaries and keyword lists to the factory defaults. Your current configuration will be lost. This
-							action cannot be undone.
+							This will reset tier boundaries and tier phrases to the factory defaults
+							{isSemantic ? " and turn semantic classification off, discarding its provider, model, and threshold settings" : ""}. Your
+							current configuration will be lost. This action cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -862,11 +862,15 @@ export const governanceApi = baseApi.injectEndpoints({
 			providesTags: ["ComplexityAnalyzerConfig"],
 		}),
 
+		// Runtime readiness, not persisted config. Tagged with the config so that
+		// saving a new analyzer config refetches it: every save restarts semantic
+		// warmup, which is exactly when the state changes.
 		getComplexitySemanticStatus: builder.query<SemanticStatusInfo, void>({
 			query: () => ({
 				url: "/governance/complexity-analyzer-status",
 				method: "GET",
 			}),
+			providesTags: ["ComplexityAnalyzerConfig"],
 		}),
 
 		updateComplexityAnalyzerConfig: builder.mutation<AnalyzerConfig, AnalyzerConfig>({

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -21,12 +21,11 @@ export interface SemanticConfig {
 	embedding_model: string;
 	timeout?: string;
 	// Similarity floor a nearest-exemplar match must clear; below it the request
-	// falls back to keyword scoring. Not yet exposed in this screen.
+	// falls back to keyword scoring. 0 means the nearest exemplar always wins.
 	min_similarity?: number;
-	// How many recent user messages are embedded together. Not yet exposed here.
+	// How many of the most recent user messages are combined into the embedded
+	// text. 1 (the default) embeds only the latest message.
 	message_history_count?: number;
-	// Preserved while editing but intentionally not exposed until embedding
-	// budget attribution has a defined accounting owner and behavior.
 	count_toward_budgets?: boolean;
 	vector_store?: SemanticVectorStore;
 }
@@ -67,23 +66,29 @@ export const COMPLEXITY_MECHANISM_LABELS: Record<string, string> = {
 export const KEYWORD_LIST_DEFINITIONS: Array<{
 	key: KeywordListKey;
 	label: string;
-	description: string;
+	lexicalDescription: string;
+	semanticDescription: string;
 }> = [
 	{
 		key: "simple_keywords",
 		label: "Simple tier phrases",
-		description: "Lightweight language signals for lexical scoring and semantic SIMPLE examples.",
+		lexicalDescription: "Signals for short, direct requests. Matches reduce the lexical complexity score.",
+		semanticDescription: "Examples of direct requests that need a short answer or one straightforward operation.",
 	},
 	{
 		key: "medium_keywords",
 		label: "Medium tier phrases",
-		description: "Implementation and technical signals for lexical scoring and semantic MEDIUM examples.",
+		lexicalDescription:
+			"Signals for implementation, technical work, and contained multi-step analysis. Matches increase the lexical complexity score.",
+		semanticDescription: "Examples that need several steps, some analysis, or a contained implementation.",
 	},
 	{
 		key: "complex_keywords",
 		label: "Complex tier phrases",
-		description:
-			"High-confidence reasoning signals and semantic COMPLEX examples. One lexical match guarantees at least MEDIUM; two route to COMPLEX.",
+		lexicalDescription:
+			"High-confidence signals for deeper reasoning, trade-offs, and investigation. One match guarantees at least MEDIUM. Two matches classify as COMPLEX.",
+		semanticDescription:
+			"Examples that need deeper reasoning across constraints, trade-offs, failure modes, or multiple connected decisions.",
 	},
 ];
 
@@ -91,3 +96,71 @@ export const DEFAULT_TIER_BOUNDARIES: TierBoundaries = {
 	simple_medium: 0.2,
 	medium_complex: 0.4,
 };
+
+// Mirrors DefaultComplexitySemanticTimeout in framework/configstore.
+export const DEFAULT_SEMANTIC_TIMEOUT_MS = 1500;
+
+// Server-side bounds from validateComplexitySemanticPhrases. Enforced here too
+// so an over-long exemplar fails in the form instead of as an opaque 400.
+export const MIN_SEMANTIC_MESSAGE_HISTORY = 1;
+export const MAX_SEMANTIC_MESSAGE_HISTORY = 10;
+export const MAX_SEMANTIC_PHRASE_CHARACTERS = 2000;
+
+// Seeded when the user switches the page into semantic mode. Provider and
+// model stay blank because only the operator knows them.
+export const DEFAULT_SEMANTIC_CONFIG: SemanticConfig = {
+	provider: "",
+	embedding_model: "",
+	timeout: `${DEFAULT_SEMANTIC_TIMEOUT_MS}ms`,
+	min_similarity: 0,
+	message_history_count: 1,
+	count_toward_budgets: false,
+	vector_store: "embedded",
+};
+
+export const SEMANTIC_VECTOR_STORE_OPTIONS: Array<{ value: SemanticVectorStore; label: string; description: string }> = [
+	{
+		value: "embedded",
+		label: "Embedded",
+		description: "Built-in in-process store. Needs no infrastructure, but exemplars are held in memory and re-embedded on every restart.",
+	},
+	{
+		value: "auto",
+		label: "Auto",
+		description: "Use the configured vector store when one is available, otherwise fall back to the embedded store.",
+	},
+	{
+		value: "external",
+		label: "External",
+		description:
+			"Require the configured vector store. Exemplars persist across restarts, so warmup re-embeds only when the configuration changes.",
+	},
+];
+
+export const SEMANTIC_STATUS_LABELS: Record<SemanticStatusInfo["state"], string> = {
+	disabled: "Disabled",
+	warming: "Warming up",
+	ready: "Ready",
+	failed: "Failed",
+};
+
+// Duration strings round-trip through the API as Go durations ("500ms"), but the
+// form edits milliseconds. Anything unparseable falls back to the default rather
+// than silently sending 0, which the server rejects.
+export function parseSemanticTimeoutMs(timeout: string | undefined): number {
+	if (!timeout) return DEFAULT_SEMANTIC_TIMEOUT_MS;
+	const match = timeout.trim().match(/^([0-9]*\.?[0-9]+)(ns|us|µs|ms|s|m|h)$/);
+	if (!match) {
+		const numeric = Number(timeout);
+		return Number.isFinite(numeric) && numeric > 0 ? numeric : DEFAULT_SEMANTIC_TIMEOUT_MS;
+	}
+	const value = Number(match[1]);
+	const unitToMs: Record<string, number> = { ns: 1e-6, us: 1e-3, µs: 1e-3, ms: 1, s: 1000, m: 60000, h: 3600000 };
+	const milliseconds = value * unitToMs[match[2]];
+	return Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : DEFAULT_SEMANTIC_TIMEOUT_MS;
+}
+
+export function formatSemanticTimeout(milliseconds: number): string {
+	const safe = Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : DEFAULT_SEMANTIC_TIMEOUT_MS;
+	return `${safe}ms`;
+}


### PR DESCRIPTION
## Summary

This PR adds a full semantic classification mode to the Complexity Router, allowing requests to be classified by embedding similarity against labeled tier phrases rather than purely by keyword scoring. It also raises the default embedding timeout from 100ms to 500ms, which was too tight for real-world embedding calls and caused silent fallback-forever behavior during warmup.

## Changes

- **Default semantic timeout raised from 100ms to 500ms** across the Go config, JSON schema, UI constants, and all comments/tests that referenced the old value. The 100ms budget was unreachable for a 32-exemplar warmup batch, causing every warmup to fail with a 504 and silently serve the lexical fallback indefinitely.
- **`ErrEmbeddingRequestExecutorNotConfigured` sentinel error** introduced so callers can distinguish the transient startup state (executor not yet wired) from a permanent operator-correctable failure. The HTTP handler now returns `503 Service Unavailable` with a retryable message for this case instead of a generic 400.
- **Semantic classifier UI** added to the Complexity Router page behind a Lexical/Semantic tab toggle. Includes controls for embedding provider, model, dimension (auto-detected via a probe call), minimum similarity floor, fallback behavior, conversation window size, timeout, vector store selection, and budget attribution.
- **`SemanticStatusPanel`** component surfaces warmup readiness (disabled / warming / ready / failed) with a progress bar during warmup, error messages on failure, and contextual fallback warnings — previously only visible in server logs.
- **Dimension probe** wired as an RTK mutation (`probeComplexityEmbeddingDimensionMutation`) so it only fires when the operator selects a provider/model, never on page load. A monotonic sequence counter prevents a stale probe response from clobbering a newer selection.
- **Semantic-mode form validation** mirrors server-side rules: per-phrase character cap (2000), total phrase cap (500), and cross-tier duplicate detection, so over-budget exemplar sets fail inline rather than as opaque 400s.
- **Tier Phrases section** replaces the Keyword Lists section with mode-aware labels and descriptions. In semantic mode the complex-keywords list spans the full grid width and the placeholder text reflects exemplar intent.
- **`toFormValues` helper** fills in fields the API omits via `omitempty` so all semantic controls remain controlled inputs.
- **`getComplexitySemanticStatus`** now provides the `ComplexityAnalyzerConfig` cache tag so saving a new config automatically refetches status and reflects the new warmup cycle.
- Polling for semantic status activates only while `state === "warming"` and stops once the classifier reaches a steady state.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm build
```

**Semantic mode end-to-end:**
1. Configure an embedding-capable provider (e.g. OpenAI).
2. Open the Complexity Router page and switch to the **Semantic** tab.
3. Select the provider and an embedding model — the dimension field should auto-populate after a brief probe call.
4. Add tier phrases to each list and save. The status panel should transition from "Not saved" → "Warming up" (with progress) → "Ready".
5. Confirm that switching back to Lexical and saving removes the semantic block and the status panel disappears.
6. Verify that reloading the page with a saved semantic config restores the Semantic tab and all fields correctly.

**Timeout regression guard:**
- Confirm `DefaultComplexitySemanticTimeout` is `500ms` in `complexityconfig.go` and that `TestComplexitySemanticConfigNormalizedDefaults` passes.

**Executor startup 503:**
- Call `POST /governance/complexity-analyzer-config/embedding-dimension` before the embedding executor is wired; expect `503` with body containing `"still initializing"`.

## Breaking changes

- [ ] Yes
- [x] No

The default timeout change is a behavioral difference but not a breaking API change. Existing configs without an explicit `timeout` field will now use 500ms instead of 100ms.

## Related issues

Closes semantic complexity classification feature work.

## Security considerations

The dimension probe makes a real embedding call to the configured provider using the operator's stored API key. It is gated behind the existing RBAC `Update` permission on routing rules and fires only on explicit model selection, not on page load.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable