### PR TITLE
docs: add per-user access-profile budget override API and docs

### DIFF
--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -177,6 +177,28 @@ Access profile budgets apply uniformly to everyone assigned the template. When y
 
 For example, if Alice is on the Engineering profile but you want to add a separate $20/month cap on Claude Opus just for her, you can create a user-scoped model limit for Alice without changing what the Engineering profile gives everyone else. These limits stack independently alongside the profile budget; both must pass for a request to be allowed, and they are not affected by profile propagation. See [Give one user an individual per-model budget](#give-one-user-an-individual-per-model-budget) for steps for the above.
 
+To temporarily raise the profile budget itself for one user, add a **budget override** from the User Detail Sheet instead. An override is additive and leaves the base limit, current usage, and reset schedule untouched:
+
+```text
+Effective limit = Base budget + Override amount
+```
+
+Choose **for a number of reset cycles** (the current cycle counts as the first) or **until removed**. Overrides propagate cluster-wide and survive profile cloning and propagation, and setting one requires the `AccessProfiles.Update` permission. Programmatically:
+
+```bash
+# Add or replace an override
+curl -X PUT "$BIFROST_URL/api/users/$USER_ID/access-profiles/$PROFILE_ID/budgets/$BUDGET_ID/override" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"amount": 100, "mode": "cycles", "cycles": 2}'
+
+# Remove it
+curl -X DELETE "$BIFROST_URL/api/users/$USER_ID/access-profiles/$PROFILE_ID/budgets/$BUDGET_ID/override" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Use `"mode": "forever"` (omitting `cycles`) to keep the override active until it is deleted. The response returns the persisted budget plus its `effective_max_limit`. For the equivalent on a standalone virtual key, see [Budget Overrides](/features/governance/virtual-keys#budget-overrides).
+
 ### Edit, duplicate, delete
 
 Each row action exposes:

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -52960,6 +52960,162 @@
         }
       }
     },
+    "/api/users/{target_user_id}/access-profiles/{profile_id}/budgets/{budget_id}/override": {
+      "put": {
+        "operationId": "updateUserAccessProfileBudgetOverride",
+        "summary": "Set a user's access-profile budget override",
+        "description": "Sets or replaces the spending override on one budget of a single user's copy of an access profile.\nThe override is additive — while it is active the budget is enforced against\n`max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset\nschedule untouched. Only this user is affected; the access profile template and every other user\nassigned to it keep their original limits.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the\ncalendar period start — so every node in a cluster derives the same number of remaining cycles.\nThe change is propagated cluster-wide and survives access-profile cloning and propagation.\n\nRequires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy\nof the profile, not on the shared template.\n",
+        "tags": [
+          "Access Profiles"
+        ],
+        "parameters": [
+          {
+            "name": "target_user_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the user whose access-profile budget is being overridden",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the access profile assigned to the user",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "budget_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of a budget on the user's copy of the access profile",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BudgetOverrideRequest"
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget override applied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BudgetOverrideResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User access profile or budget not found, or the profile is outside the caller's access scope"
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteUserAccessProfileBudgetOverride",
+        "summary": "Remove a user's access-profile budget override",
+        "description": "Removes any active override from the user's budget, so it is enforced against its base `max_limit`\nagain. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a\ncleared grant cannot be re-derived. Safe to call on a budget that has no override.\n\nRequires the `AccessProfiles.Update` permission.\n",
+        "tags": [
+          "Access Profiles"
+        ],
+        "parameters": [
+          {
+            "name": "target_user_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the user whose access-profile budget override is being removed",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of the access profile assigned to the user",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "budget_id",
+            "in": "path",
+            "required": true,
+            "description": "ID of a budget on the user's copy of the access profile",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Budget override removed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BudgetOverrideResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User access profile or budget not found, or the profile is outside the caller's access scope"
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/users/{target_user_id}/access-profiles/{profile_id}/virtual-keys": {
       "post": {
         "operationId": "addUserAccessProfileVirtualKey",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -929,6 +929,8 @@ paths:
     $ref: './paths/management/accessprofiles.yaml#/users-access-profiles'
   /api/users/{target_user_id}/access-profiles/{profile_id}:
     $ref: './paths/management/accessprofiles.yaml#/users-access-profile-by-id'
+  /api/users/{target_user_id}/access-profiles/{profile_id}/budgets/{budget_id}/override:
+    $ref: './paths/management/accessprofiles.yaml#/users-access-profile-budget-override'
   /api/users/{target_user_id}/access-profiles/{profile_id}/virtual-keys:
     $ref: './paths/management/accessprofiles.yaml#/users-access-profile-virtual-keys'
   /api/users/{target_user_id}/access-profiles/virtual-keys/{vk_id}:

--- a/docs/openapi/paths/management/accessprofiles.yaml
+++ b/docs/openapi/paths/management/accessprofiles.yaml
@@ -548,6 +548,112 @@ users-access-profile-by-id:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
+users-access-profile-budget-override:
+  put:
+    operationId: updateUserAccessProfileBudgetOverride
+    summary: Set a user's access-profile budget override
+    description: |
+      Sets or replaces the spending override on one budget of a single user's copy of an access profile.
+      The override is additive — while it is active the budget is enforced against
+      `max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset
+      schedule untouched. Only this user is affected; the access profile template and every other user
+      assigned to it keep their original limits.
+
+      Use `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows
+      (the current window counts as the first), or `mode: forever` to keep the override until it is deleted.
+      A finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the
+      calendar period start — so every node in a cluster derives the same number of remaining cycles.
+      The change is propagated cluster-wide and survives access-profile cloning and propagation.
+
+      Requires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy
+      of the profile, not on the shared template.
+    tags:
+      - Access Profiles
+    parameters:
+      - name: target_user_id
+        in: path
+        required: true
+        description: ID of the user whose access-profile budget is being overridden
+        schema:
+          type: string
+      - name: profile_id
+        in: path
+        required: true
+        description: ID of the access profile assigned to the user
+        schema:
+          type: integer
+      - name: budget_id
+        in: path
+        required: true
+        description: ID of a budget on the user's copy of the access profile
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/governance.yaml#/BudgetOverrideRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Budget override applied successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BudgetOverrideResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: User access profile or budget not found, or the profile is outside the caller's access scope
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  delete:
+    operationId: deleteUserAccessProfileBudgetOverride
+    summary: Remove a user's access-profile budget override
+    description: |
+      Removes any active override from the user's budget, so it is enforced against its base `max_limit`
+      again. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a
+      cleared grant cannot be re-derived. Safe to call on a budget that has no override.
+
+      Requires the `AccessProfiles.Update` permission.
+    tags:
+      - Access Profiles
+    parameters:
+      - name: target_user_id
+        in: path
+        required: true
+        description: ID of the user whose access-profile budget override is being removed
+        schema:
+          type: string
+      - name: profile_id
+        in: path
+        required: true
+        description: ID of the access profile assigned to the user
+        schema:
+          type: integer
+      - name: budget_id
+        in: path
+        required: true
+        description: ID of a budget on the user's copy of the access profile
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Budget override removed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/BudgetOverrideResponse'
+      '404':
+        description: User access profile or budget not found, or the profile is outside the caller's access scope
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
 users-access-profile-virtual-keys:
   post:
     operationId: addUserAccessProfileVirtualKey


### PR DESCRIPTION
## Summary

Adds a per-user budget override mechanism for access-profile budgets, allowing administrators to temporarily raise a single user's spending limit without modifying the shared profile template or affecting other users.

## Changes

- Added `PUT /api/users/{target_user_id}/access-profiles/{profile_id}/budgets/{budget_id}/override` to set or replace a spending override on a user's access-profile budget. The override is additive (`effective_max_limit = base_limit + override_amount`) and leaves the base limit, current usage, and reset schedule untouched.
- Added `DELETE /api/users/{target_user_id}/access-profiles/{profile_id}/budgets/{budget_id}/override` to remove an active override, reverting enforcement to the base `max_limit`.
- Overrides support two modes: `cycles` (active for a finite number of reset windows, with the current window counting as the first) and `forever` (active until explicitly deleted). Overrides propagate cluster-wide and survive profile cloning and propagation.
- Both endpoints require the `AccessProfiles.Update` permission and reference the budget on the user's own copy of the profile, not the shared template.
- Documented the budget override feature in `access-profiles.mdx`, including the additive formula, mode options, curl examples, and a cross-reference to the equivalent virtual key override feature.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Set an override for 2 reset cycles
curl -X PUT "$BIFROST_URL/api/users/$USER_ID/access-profiles/$PROFILE_ID/budgets/$BUDGET_ID/override" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"amount": 100, "mode": "cycles", "cycles": 2}'
# Expect 200 with the persisted budget and effective_max_limit = base + 100

# Set a permanent override
curl -X PUT "$BIFROST_URL/api/users/$USER_ID/access-profiles/$PROFILE_ID/budgets/$BUDGET_ID/override" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"amount": 100, "mode": "forever"}'
# Expect 200

# Remove the override
curl -X DELETE "$BIFROST_URL/api/users/$USER_ID/access-profiles/$PROFILE_ID/budgets/$BUDGET_ID/override" \
  -H "Authorization: Bearer $TOKEN"
# Expect 200 with budget reverted to base max_limit

# Verify other users on the same profile are unaffected
```

## Breaking changes

- [x] No

## Security considerations

Both endpoints require the `AccessProfiles.Update` permission. The `budget_id` must belong to the target user's own copy of the profile, preventing callers from modifying the shared template or budgets belonging to other users. Overrides are scoped to a single user and do not bleed into the profile template or other assigned users.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable