### PR TITLE
fix: adds context_management param in responses api

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"strings"
 	"sync"
@@ -3720,10 +3721,8 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		}
 
 		if bifrostReq.Params.ExtraParams != nil {
-			anthropicReq.ExtraParams = make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
-			for k, v := range bifrostReq.Params.ExtraParams {
-				anthropicReq.ExtraParams[k] = v
-			}
+			anthropicReq.ExtraParams = make(map[string]any, len(bifrostReq.Params.ExtraParams))
+			maps.Copy(anthropicReq.ExtraParams, bifrostReq.Params.ExtraParams)
 			if cacheControlRaw, exists := anthropicReq.ExtraParams["cache_control"]; exists {
 				parsed := false
 				switch v := cacheControlRaw.(type) {
@@ -3789,18 +3788,6 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				delete(anthropicReq.ExtraParams, "inference_geo")
 				anthropicReq.InferenceGeo = inferenceGeo
 			}
-			if cmVal := bifrostReq.Params.ExtraParams["context_management"]; cmVal != nil {
-				if cm, ok := cmVal.(*ContextManagement); ok && cm != nil {
-					delete(anthropicReq.ExtraParams, "context_management")
-					anthropicReq.ContextManagement = cm
-				} else if data, err := providerUtils.MarshalSorted(cmVal); err == nil {
-					var cm ContextManagement
-					if sonic.Unmarshal(data, &cm) == nil {
-						delete(anthropicReq.ExtraParams, "context_management")
-						anthropicReq.ContextManagement = &cm
-					}
-				}
-			}
 			if tbVal, exists := bifrostReq.Params.ExtraParams["task_budget"]; exists {
 				// Always consume provider-specific key from passthrough extras.
 				delete(anthropicReq.ExtraParams, "task_budget")
@@ -3858,6 +3845,30 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				delete(anthropicReq.ExtraParams, "fallback_credit_token")
 				if token, ok := tokenVal.(string); ok && token != "" {
 					anthropicReq.FallbackCreditToken = &token
+				}
+			}
+		}
+
+		extraContextManagement := bifrostReq.Params.ExtraParams["context_management"]
+		delete(anthropicReq.ExtraParams, "context_management")
+
+		if features, ok := ProviderFeatures[bifrostReq.Provider]; !ok || features.ContextManagementField {
+			if len(bifrostReq.Params.ContextManagement) > 0 {
+				var cm ContextManagement
+				if err := sonic.Unmarshal(bifrostReq.Params.ContextManagement, &cm); err == nil {
+					anthropicReq.ContextManagement = &cm
+				}
+			}
+			// Use the captured extra only when the neutral field didn't already
+			// produce a typed value.
+			if anthropicReq.ContextManagement == nil && extraContextManagement != nil {
+				if cm, ok := extraContextManagement.(*ContextManagement); ok && cm != nil {
+					anthropicReq.ContextManagement = cm
+				} else if data, err := providerUtils.MarshalSorted(extraContextManagement); err == nil {
+					var cm ContextManagement
+					if sonic.Unmarshal(data, &cm) == nil {
+						anthropicReq.ContextManagement = &cm
+					}
 				}
 			}
 		}

--- a/core/providers/anthropic/responses_test.go
+++ b/core/providers/anthropic/responses_test.go
@@ -116,3 +116,279 @@ func TestToAnthropicResponsesRequest_StructuredOutput_NativeOutputConfig_Anthrop
 		}
 	}
 }
+
+// makeContextManagementReq builds a minimal BifrostResponsesRequest for the
+// ContextManagement conversion tests below.
+func makeContextManagementReq(params *schemas.ResponsesParameters) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-6",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("Hello")},
+			},
+		},
+		Params: params,
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_NeutralField covers the
+// /v1/responses ingest path: OpenAIResponsesRequest embeds schemas.ResponsesParameters
+// directly, so an incoming context_management body field lands in the neutral
+// Params.ContextManagement json.RawMessage — not in ExtraParams. Before this fix,
+// ToAnthropicResponsesRequest only read ExtraParams["context_management"], so this
+// value was silently dropped and never reached Anthropic.
+func TestToAnthropicResponsesRequest_ContextManagement_NeutralField(t *testing.T) {
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`{"edits":[{"type":"` + string(ContextManagementEditTypeCompact) + `"}]}`),
+	})
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ContextManagement == nil || len(result.ContextManagement.Edits) != 1 {
+		t.Fatalf("expected ContextManagement to be decoded from the neutral field, got %+v", result.ContextManagement)
+	}
+	if result.ContextManagement.Edits[0].Type != ContextManagementEditTypeCompact {
+		t.Errorf("expected compact edit type, got %q", result.ContextManagement.Edits[0].Type)
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_ExtraParamsFallback covers the
+// /v1/messages ingest path, where AnthropicMessageRequest.ToBifrostResponsesRequest
+// stuffs the already-typed ContextManagement into ExtraParams instead of the neutral
+// field. This must keep working alongside the neutral-field path above.
+func TestToAnthropicResponsesRequest_ContextManagement_ExtraParamsFallback(t *testing.T) {
+	params := &schemas.ResponsesParameters{
+		ExtraParams: map[string]interface{}{
+			"context_management": &ContextManagement{
+				Edits: []ContextManagementEdit{{Type: ContextManagementEditTypeCompact}},
+			},
+		},
+	}
+	req := makeContextManagementReq(params)
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ContextManagement == nil || len(result.ContextManagement.Edits) != 1 {
+		t.Fatalf("expected ContextManagement to be decoded from ExtraParams, got %+v", result.ContextManagement)
+	}
+	if _, exists := result.ExtraParams["context_management"]; exists {
+		t.Errorf("expected context_management to be consumed out of the outgoing request's ExtraParams")
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_OpenAIShapeIsDroppedNotErrored
+// covers the case this fix is actually guarding: /v1/responses is OpenAI's own
+// documented endpoint, and OpenAI's real Responses API defines its own native
+// context_management shape — an array of {type, compact_threshold} objects — which
+// is completely different from Anthropic's {edits:[...]} object shape. A client
+// (or SDK default) may send that OpenAI-shaped value on a request that happens to
+// route to an Anthropic model. This must NOT hard-fail the request — Anthropic
+// simply doesn't support this shape, so it's dropped like any other inapplicable
+// provider-specific param, the same way malformed/incompatible JSON is.
+func TestToAnthropicResponsesRequest_ContextManagement_OpenAIShapeIsDroppedNotErrored(t *testing.T) {
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`[{"type":"compaction","compact_threshold":2000}]`),
+	})
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ContextManagement != nil {
+		t.Errorf("expected ContextManagement to be dropped for an OpenAI-shaped payload, got %+v", result.ContextManagement)
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_MalformedJSONIsDroppedNotErrored
+// mirrors the OpenAI-shape case for plain invalid JSON: it must not fail the request.
+func TestToAnthropicResponsesRequest_ContextManagement_MalformedJSONIsDroppedNotErrored(t *testing.T) {
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`{"edits":`),
+	})
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ContextManagement != nil {
+		t.Errorf("expected ContextManagement to be dropped for malformed JSON, got %+v", result.ContextManagement)
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_FallsBackAfterFailedNeutralDecode
+// covers the case the existing ExtraParamsFallback/OpenAIShape/MalformedJSON tests each
+// only prove half of: ExtraParamsFallback only exercises the fallback when the neutral
+// field is absent entirely, and OpenAIShapeIsDroppedNotErrored/MalformedJSONIsDroppedNotErrored
+// only prove a failed neutral decode is dropped when there's nothing else to fall back to.
+// Neither proves that a neutral field which is PRESENT but fails to decode (wrong shape or
+// malformed) still falls back to a valid Anthropic value sitting in ExtraParams, rather than
+// short-circuiting to nil once the neutral field is non-empty.
+func TestToAnthropicResponsesRequest_ContextManagement_FallsBackAfterFailedNeutralDecode(t *testing.T) {
+	validExtra := &ContextManagement{
+		Edits: []ContextManagementEdit{{Type: ContextManagementEditTypeClearThinking}},
+	}
+
+	cases := []struct {
+		name    string
+		neutral []byte
+	}{
+		{"OpenAI-shaped neutral field", []byte(`[{"type":"compaction","compact_threshold":2000}]`)},
+		{"malformed neutral field", []byte(`{"edits":`)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := makeContextManagementReq(&schemas.ResponsesParameters{
+				ContextManagement: tc.neutral,
+				ExtraParams: map[string]interface{}{
+					"context_management": validExtra,
+				},
+			})
+
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			result, err := ToAnthropicResponsesRequest(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.ContextManagement == nil || len(result.ContextManagement.Edits) != 1 {
+				t.Fatalf("expected fallback to the valid ExtraParams value, got %+v", result.ContextManagement)
+			}
+			if result.ContextManagement.Edits[0].Type != ContextManagementEditTypeClearThinking {
+				t.Errorf("expected the ExtraParams edit type to survive, got %q", result.ContextManagement.Edits[0].Type)
+			}
+			if _, exists := result.ExtraParams["context_management"]; exists {
+				t.Errorf("expected context_management to be removed from the outgoing request's ExtraParams")
+			}
+		})
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_SkippedWhenUnsupportedByProvider
+// verifies the parse is skipped entirely (not attempted-then-discarded) for a
+// provider whose ProviderFeatures entry has ContextManagementField: false — avoids
+// wasted unmarshal work when the post-processing strip pass would throw the result
+// away anyway (see stripUnsupportedAnthropicFields, utils.go:382).
+func TestToAnthropicResponsesRequest_ContextManagement_SkippedWhenUnsupportedByProvider(t *testing.T) {
+	const noContextManagementProvider = schemas.ModelProvider("test-no-context-management")
+	ProviderFeatures[noContextManagementProvider] = ProviderFeatureSupport{ContextManagementField: false}
+	defer delete(ProviderFeatures, noContextManagementProvider)
+
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`{"edits":[{"type":"` + string(ContextManagementEditTypeCompact) + `"}]}`),
+	})
+	req.Provider = noContextManagementProvider
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ContextManagement != nil {
+		t.Errorf("expected ContextManagement to be skipped for a provider with ContextManagementField=false, got %+v", result.ContextManagement)
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_UnknownProviderFailsOpen verifies
+// that a provider absent from ProviderFeatures entirely still gets the parse attempted
+// (fail-open), mirroring stripUnsupportedAnthropicFields's own "unknown provider — safe
+// default: don't strip anything" behavior (utils.go:247).
+func TestToAnthropicResponsesRequest_ContextManagement_UnknownProviderFailsOpen(t *testing.T) {
+	const unknownProvider = schemas.ModelProvider("test-unknown-provider")
+	if _, ok := ProviderFeatures[unknownProvider]; ok {
+		t.Fatalf("test sentinel provider %q unexpectedly already present in ProviderFeatures", unknownProvider)
+	}
+
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`{"edits":[{"type":"` + string(ContextManagementEditTypeCompact) + `"}]}`),
+	})
+	req.Provider = unknownProvider
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ContextManagement == nil || len(result.ContextManagement.Edits) != 1 {
+		t.Fatalf("expected ContextManagement to be decoded (fail-open) for an unknown provider, got %+v", result.ContextManagement)
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_BothInputSources covers
+// both input sources being present at once: Params.ContextManagement (the
+// neutral field) decodes successfully, which used to mean the
+// ExtraParams-consuming branch below it was skipped entirely — leaving a raw
+// duplicate of context_management sitting in the outgoing ExtraParams. The
+// neutral field must win, and the extra must still be removed either way.
+func TestToAnthropicResponsesRequest_ContextManagement_BothInputSources(t *testing.T) {
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ContextManagement: []byte(`{"edits":[{"type":"` + string(ContextManagementEditTypeCompact) + `"}]}`),
+		ExtraParams: map[string]interface{}{
+			"context_management": &ContextManagement{
+				Edits: []ContextManagementEdit{{Type: ContextManagementEditTypeClearThinking}},
+			},
+		},
+	})
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ContextManagement == nil || len(result.ContextManagement.Edits) != 1 {
+		t.Fatalf("expected ContextManagement to be decoded, got %+v", result.ContextManagement)
+	}
+	if result.ContextManagement.Edits[0].Type != ContextManagementEditTypeCompact {
+		t.Errorf("expected the neutral field to win over ExtraParams, got edit type %q", result.ContextManagement.Edits[0].Type)
+	}
+	if _, exists := result.ExtraParams["context_management"]; exists {
+		t.Errorf("expected context_management to be removed from the outgoing request's ExtraParams even though the neutral field won")
+	}
+}
+
+// TestToAnthropicResponsesRequest_ContextManagement_UnsupportedProviderExtraParamsDropped
+// covers a provider with ContextManagementField: false carrying
+// ExtraParams["context_management"] (not the neutral field). The whole
+// feature gate is skipped for such a provider, which used to mean the
+// ExtraParams-consuming delete never ran either — leaving the unsupported
+// value sitting in the outgoing ExtraParams to potentially leak through if
+// passthrough is enabled. It must be removed regardless of the gate.
+func TestToAnthropicResponsesRequest_ContextManagement_UnsupportedProviderExtraParamsDropped(t *testing.T) {
+	const noContextManagementProvider = schemas.ModelProvider("test-no-context-management-extra")
+	ProviderFeatures[noContextManagementProvider] = ProviderFeatureSupport{ContextManagementField: false}
+	defer delete(ProviderFeatures, noContextManagementProvider)
+
+	req := makeContextManagementReq(&schemas.ResponsesParameters{
+		ExtraParams: map[string]interface{}{
+			"context_management": &ContextManagement{
+				Edits: []ContextManagementEdit{{Type: ContextManagementEditTypeCompact}},
+			},
+		},
+	})
+	req.Provider = noContextManagementProvider
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	result, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ContextManagement != nil {
+		t.Errorf("expected ContextManagement to stay unset for a provider with ContextManagementField=false, got %+v", result.ContextManagement)
+	}
+	if _, exists := result.ExtraParams["context_management"]; exists {
+		t.Errorf("expected context_management to be removed from the outgoing request's ExtraParams even though the feature gate is closed")
+	}
+}

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -43,17 +43,21 @@ type ResponsesFeatureSupport struct {
 	// `additional_tools` input items; when false their tools are hoisted into
 	// the top-level tools param instead.
 	AdditionalToolsItem bool
+	// ContextManagement reports whether the backend accepts the context_management
+	// Responses body field.
+	ContextManagement bool
 }
 
 // ProviderFeatures maps each OpenAI-compatible provider to its supported
 // Responses wire extensions. Only providers with a known deviation are listed.
 var ProviderFeatures = map[schemas.ModelProvider]ResponsesFeatureSupport{
-	schemas.OpenAI: {AdditionalToolsItem: true},
+	schemas.OpenAI: {AdditionalToolsItem: true, ContextManagement: true},
 	// Bedrock Mantle validates `input` against the standard union and rejects
 	// additional_tools with "Invalid 'input': value did not match any expected
-	// variant", but accepts the same tools at the top level.
-	schemas.Bedrock:       {AdditionalToolsItem: false},
-	schemas.BedrockMantle: {AdditionalToolsItem: false},
+	// variant", but accepts the same tools at the top level. It also rejects
+	// context_management outright as an unknown parameter.
+	schemas.Bedrock:       {AdditionalToolsItem: false, ContextManagement: false},
+	schemas.BedrockMantle: {AdditionalToolsItem: false, ContextManagement: false},
 }
 
 // supportsAdditionalToolsItem reports whether provider accepts codex
@@ -405,6 +409,12 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 	if bifrostReq.Params != nil {
 		req.ExtraParams = bifrostReq.Params.ExtraParams
 	}
+
+	if features, ok := ProviderFeatures[bifrostReq.Provider]; ok && !features.ContextManagement {
+		req.ContextManagement = nil
+		delete(req.ExtraParams, "context_management")
+	}
+
 	return req
 }
 

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -2377,6 +2377,63 @@ func TestToOpenAIResponsesRequest_FallbackBlockDropped(t *testing.T) {
 	})
 }
 
+// TestToOpenAIResponsesRequest_ContextManagement_ProviderGating covers a real
+// regression: bedrock/openai.gpt-5.4 through /v1/responses forwarded a
+// context_management array straight through to Bedrock Mantle's OpenAI-compatible
+// endpoint, which 400s with "Unknown parameter: 'context_management'" since it
+// doesn't accept the field at all. OpenAI and Azure OpenAI must keep receiving it
+// (default-open, like every other unlisted-provider field here); Bedrock and
+// Bedrock Mantle are the explicit exceptions.
+func TestToOpenAIResponsesRequest_ContextManagement_ProviderGating(t *testing.T) {
+	cm := []byte(`[{"type":"compaction","compact_threshold":2000}]`)
+
+	cases := []struct {
+		name          string
+		provider      schemas.ModelProvider
+		wantForwarded bool
+	}{
+		{"openai forwards it", schemas.OpenAI, true},
+		{"azure forwards it", schemas.Azure, true},
+		{"bedrock drops it", schemas.Bedrock, false},
+		{"bedrock mantle drops it", schemas.BedrockMantle, false},
+		{"unlisted provider forwards it", schemas.ModelProvider("test-unlisted-provider"), true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &schemas.BifrostResponsesRequest{
+				Provider: tc.provider,
+				Model:    "gpt-5.4",
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("Hello")},
+				}},
+				Params: &schemas.ResponsesParameters{
+					ContextManagement: cm,
+					ExtraParams: map[string]interface{}{
+						"context_management": cm,
+					},
+				},
+			}
+
+			result := ToOpenAIResponsesRequest(nil, req)
+			if result == nil {
+				t.Fatal("ToOpenAIResponsesRequest returned nil")
+			}
+
+			gotNeutral := len(result.ContextManagement) > 0
+			_, gotExtra := result.ExtraParams["context_management"]
+
+			if gotNeutral != tc.wantForwarded {
+				t.Errorf("neutral ContextManagement field: got present=%v, want present=%v", gotNeutral, tc.wantForwarded)
+			}
+			if gotExtra != tc.wantForwarded {
+				t.Errorf("ExtraParams[\"context_management\"]: got present=%v, want present=%v", gotExtra, tc.wantForwarded)
+			}
+		})
+	}
+}
+
 func TestBuildResponsesRetrieveQuery_Stream(t *testing.T) {
 	t.Run("emits stream=true and other params when set", func(t *testing.T) {
 		req := &schemas.BifrostResponsesRetrieveRequest{

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -528,6 +528,9 @@ type ResponsesParameters struct {
 	// the combination; providers without the concept ignore it.
 	IncludeServerSideToolInvocations *bool `json:"include_server_side_tool_invocations,omitempty"`
 
+	// ContextManagement configures automatic context window management.
+	ContextManagement json.RawMessage `json:"context_management,omitempty"`
+
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`
@@ -3004,10 +3007,10 @@ type ResponsesToolComputerUsePreview struct {
 // ResponsesToolWebSearch represents a tool web search
 type ResponsesToolWebSearch struct {
 	ExternalWebAccess  *bool                               `json:"external_web_access,omitempty"`
-	Filters            *ResponsesToolWebSearchFilters      `json:"filters,omitempty"` // Filters for the search
+	Filters            *ResponsesToolWebSearchFilters      `json:"filters,omitempty"`              // Filters for the search
 	SearchContentTypes []string                            `json:"search_content_types,omitempty"` // "text" | "image"
-	SearchContextSize  *string                             `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
-	UserLocation       *ResponsesToolWebSearchUserLocation `json:"user_location,omitempty"`       // The approximate location of the user
+	SearchContextSize  *string                             `json:"search_context_size,omitempty"`  // "low" | "medium" | "high"
+	UserLocation       *ResponsesToolWebSearchUserLocation `json:"user_location,omitempty"`        // The approximate location of the user
 
 	// Anthropic only
 	MaxUses *int `json:"max_uses,omitempty"` // Maximum number of uses for the search

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -69206,6 +69206,43 @@
           }
         }
       },
+      "ContextManagement": {
+        "description": "Automatic context window management. The wire shape depends on the target provider: OpenAI-compatible providers accept an array of {type, compact_threshold} entries; Anthropic-compatible providers accept an object with an \"edits\" array (compact_20260112, clear_tool_uses_20250919, clear_thinking_20251015).\n",
+        "oneOf": [
+          {
+            "type": "array",
+            "description": "OpenAI native shape — an array of context-management entries.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Entry type. Currently only \"compaction\" is supported."
+                },
+                "compact_threshold": {
+                  "type": "integer",
+                  "description": "Token threshold at which compaction should be triggered for this entry."
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          {
+            "type": "object",
+            "description": "Anthropic native shape — an object with an \"edits\" array.",
+            "properties": {
+              "edits": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
       "ResponsesRequest": {
         "type": "object",
         "required": [
@@ -69697,6 +69734,9 @@
           },
           "conversation": {
             "type": "string"
+          },
+          "context_management": {
+            "$ref": "#/components/schemas/ContextManagement"
           },
           "include": {
             "type": "array",
@@ -74814,6 +74854,9 @@
           },
           "stream": {
             "type": "boolean"
+          },
+          "context_management": {
+            "$ref": "#/components/schemas/ContextManagement"
           },
           "instructions": {
             "type": "string",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1255,6 +1255,8 @@ components:
       $ref: './schemas/inference/text.yaml#/TextCompletionResponse'
 
     # ==================== Responses API ====================
+    ContextManagement:
+      $ref: './schemas/inference/responses.yaml#/ContextManagement'
     ResponsesRequest:
       $ref: './schemas/inference/responses.yaml#/ResponsesRequest'
     ResponsesResponse:

--- a/docs/openapi/schemas/inference/responses.yaml
+++ b/docs/openapi/schemas/inference/responses.yaml
@@ -1,5 +1,35 @@
 # Responses API schemas
 
+ContextManagement:
+  description: >
+    Automatic context window management. The wire shape depends on the
+    target provider: OpenAI-compatible providers accept an array of
+    {type, compact_threshold} entries; Anthropic-compatible providers accept
+    an object with an "edits" array (compact_20260112, clear_tool_uses_20250919,
+    clear_thinking_20251015).
+  oneOf:
+    - type: array
+      description: OpenAI native shape — an array of context-management entries.
+      items:
+        type: object
+        properties:
+          type:
+            type: string
+            description: Entry type. Currently only "compaction" is supported.
+          compact_threshold:
+            type: integer
+            description: Token threshold at which compaction should be triggered for this entry.
+        additionalProperties: true
+    - type: object
+      description: Anthropic native shape — an object with an "edits" array.
+      properties:
+        edits:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: true
+
 ResponsesRequest:
   type: object
   required:
@@ -10,7 +40,7 @@ ResponsesRequest:
       type: string
       description: Model in provider/model format
     input:
-      $ref: '#/ResponsesRequestInput'
+      $ref: "#/ResponsesRequestInput"
     fallbacks:
       type: array
       items:
@@ -21,6 +51,8 @@ ResponsesRequest:
       type: boolean
     conversation:
       type: string
+    context_management:
+      $ref: "#/ContextManagement"
     include:
       type: array
       items:
@@ -41,29 +73,29 @@ ResponsesRequest:
     prompt_cache_key:
       type: string
     reasoning:
-      $ref: '#/ResponsesParametersReasoning'
+      $ref: "#/ResponsesParametersReasoning"
     safety_identifier:
       type: string
     service_tier:
       type: string
     stream_options:
-      $ref: '#/ResponsesStreamOptions'
+      $ref: "#/ResponsesStreamOptions"
     store:
       type: boolean
     temperature:
       type: number
     text:
-      $ref: '#/ResponsesTextConfig'
+      $ref: "#/ResponsesTextConfig"
     top_logprobs:
       type: integer
     top_p:
       type: number
     tool_choice:
-      $ref: '#/ResponsesToolChoice'
+      $ref: "#/ResponsesToolChoice"
     tools:
       type: array
       items:
-        $ref: '#/ResponsesTool'
+        $ref: "#/ResponsesTool"
     truncation:
       type: string
 
@@ -72,7 +104,7 @@ ResponsesRequestInput:
     - type: string
     - type: array
       items:
-        $ref: '#/ResponsesMessage'
+        $ref: "#/ResponsesMessage"
   description: Input - can be a string or array of messages
 
 ResponsesMessage:
@@ -81,7 +113,7 @@ ResponsesMessage:
     id:
       type: string
     type:
-      $ref: '#/ResponsesMessageType'
+      $ref: "#/ResponsesMessageType"
     status:
       type: string
       enum: [in_progress, completed, incomplete, interpreting, failed]
@@ -89,7 +121,7 @@ ResponsesMessage:
       type: string
       enum: [assistant, user, system, developer]
     content:
-      $ref: '#/ResponsesMessageContent'
+      $ref: "#/ResponsesMessageContent"
     call_id:
       type: string
     name:
@@ -105,7 +137,7 @@ ResponsesMessage:
         - type: string
         - type: array
           items:
-            $ref: '#/ResponsesMessageContentBlock'
+            $ref: "#/ResponsesMessageContentBlock"
         - type: object
           description: Computer tool call output (computer_screenshot).
           properties:
@@ -131,7 +163,7 @@ ResponsesMessage:
     summary:
       type: array
       items:
-        $ref: '#/ResponsesReasoningSummary'
+        $ref: "#/ResponsesReasoningSummary"
     encrypted_content:
       type: string
 
@@ -165,7 +197,7 @@ ResponsesMessageContent:
     - type: string
     - type: array
       items:
-        $ref: '#/ResponsesMessageContentBlock'
+        $ref: "#/ResponsesMessageContentBlock"
 
 ResponsesMessageContentBlock:
   type: object
@@ -174,7 +206,16 @@ ResponsesMessageContentBlock:
   properties:
     type:
       type: string
-      enum: [input_text, input_image, input_file, input_audio, output_text, refusal, reasoning_text]
+      enum:
+        [
+          input_text,
+          input_image,
+          input_file,
+          input_audio,
+          output_text,
+          refusal,
+          reasoning_text,
+        ]
     file_id:
       type: string
     text:
@@ -194,19 +235,19 @@ ResponsesMessageContentBlock:
     file_type:
       type: string
     input_audio:
-      $ref: '#/ResponsesInputMessageContentBlockAudio'
+      $ref: "#/ResponsesInputMessageContentBlockAudio"
     annotations:
       type: array
       items:
-        $ref: '#/ResponsesOutputMessageContentTextAnnotation'
+        $ref: "#/ResponsesOutputMessageContentTextAnnotation"
     logprobs:
       type: array
       items:
-        $ref: '#/ResponsesOutputMessageContentTextLogProb'
+        $ref: "#/ResponsesOutputMessageContentTextLogProb"
     refusal:
       type: string
     cache_control:
-      $ref: './common.yaml#/CacheControl'
+      $ref: "./common.yaml#/CacheControl"
 
 ResponsesInputMessageContentBlockAudio:
   type: object
@@ -259,7 +300,7 @@ ResponsesOutputMessageContentTextLogProb:
     top_logprobs:
       type: array
       items:
-        $ref: './chat.yaml#/LogProb'
+        $ref: "./chat.yaml#/LogProb"
 
 ResponsesParametersReasoning:
   type: object
@@ -286,7 +327,7 @@ ResponsesTextConfig:
   type: object
   properties:
     format:
-      $ref: '#/ResponsesTextConfigFormat'
+      $ref: "#/ResponsesTextConfigFormat"
     verbosity:
       type: string
       enum: [low, medium, high]
@@ -310,7 +351,7 @@ ResponsesToolChoice:
   oneOf:
     - type: string
       enum: [none, auto, required]
-    - $ref: '#/ResponsesToolChoiceStruct'
+    - $ref: "#/ResponsesToolChoiceStruct"
 
 ResponsesToolChoiceStruct:
   type: object
@@ -342,7 +383,7 @@ ResponsesToolChoiceStruct:
     tools:
       type: array
       items:
-        $ref: '#/ResponsesToolChoiceAllowedToolDef'
+        $ref: "#/ResponsesToolChoiceAllowedToolDef"
 
 ResponsesToolChoiceAllowedToolDef:
   type: object
@@ -383,9 +424,9 @@ ResponsesTool:
     description:
       type: string
     cache_control:
-      $ref: './common.yaml#/CacheControl'
+      $ref: "./common.yaml#/CacheControl"
     parameters:
-      $ref: './chat.yaml#/ToolFunctionParameters'
+      $ref: "./chat.yaml#/ToolFunctionParameters"
     strict:
       type: boolean
     vector_store_ids:
@@ -475,13 +516,13 @@ ResponsesResponse:
     created_at:
       type: integer
     error:
-      $ref: '#/ResponsesResponseError'
+      $ref: "#/ResponsesResponseError"
     include:
       type: array
       items:
         type: string
     incomplete_details:
-      $ref: '#/ResponsesResponseIncompleteDetails'
+      $ref: "#/ResponsesResponseIncompleteDetails"
     instructions:
       type: object
     max_output_tokens:
@@ -495,7 +536,7 @@ ResponsesResponse:
     output:
       type: array
       items:
-        $ref: '#/ResponsesMessage'
+        $ref: "#/ResponsesMessage"
     parallel_tool_calls:
       type: boolean
     previous_response_id:
@@ -505,7 +546,7 @@ ResponsesResponse:
     prompt_cache_key:
       type: string
     reasoning:
-      $ref: '#/ResponsesParametersReasoning'
+      $ref: "#/ResponsesParametersReasoning"
     safety_identifier:
       type: string
     service_tier:
@@ -520,31 +561,31 @@ ResponsesResponse:
     temperature:
       type: number
     text:
-      $ref: '#/ResponsesTextConfig'
+      $ref: "#/ResponsesTextConfig"
     top_logprobs:
       type: integer
     top_p:
       type: number
     tool_choice:
-      $ref: '#/ResponsesToolChoice'
+      $ref: "#/ResponsesToolChoice"
     tools:
       type: array
       items:
-        $ref: '#/ResponsesTool'
+        $ref: "#/ResponsesTool"
     truncation:
       type: string
     usage:
-      $ref: '#/ResponsesResponseUsage'
+      $ref: "#/ResponsesResponseUsage"
     extra_fields:
-      $ref: './common.yaml#/BifrostResponseExtraFields'
+      $ref: "./common.yaml#/BifrostResponseExtraFields"
     search_results:
       type: array
       items:
-        $ref: './chat.yaml#/PerplexitySearchResult'
+        $ref: "./chat.yaml#/PerplexitySearchResult"
     videos:
       type: array
       items:
-        $ref: './chat.yaml#/VideoResult'
+        $ref: "./chat.yaml#/VideoResult"
     citations:
       type: array
       items:
@@ -575,15 +616,15 @@ ResponsesResponseUsage:
     input_tokens:
       type: integer
     input_tokens_details:
-      $ref: '#/ResponsesResponseInputTokens'
+      $ref: "#/ResponsesResponseInputTokens"
     output_tokens:
       type: integer
     output_tokens_details:
-      $ref: '#/ResponsesResponseOutputTokens'
+      $ref: "#/ResponsesResponseOutputTokens"
     total_tokens:
       type: integer
     cost:
-      $ref: './usage.yaml#/BifrostCost'
+      $ref: "./usage.yaml#/BifrostCost"
 
 ResponsesResponseInputTokens:
   type: object
@@ -630,21 +671,21 @@ ResponsesStreamResponse:
   description: Streaming responses API response (SSE format)
   properties:
     type:
-      $ref: '#/ResponsesStreamResponseType'
+      $ref: "#/ResponsesStreamResponseType"
     sequence_number:
       type: integer
     response:
-      $ref: '#/ResponsesResponse'
+      $ref: "#/ResponsesResponse"
     output_index:
       type: integer
     item:
-      $ref: '#/ResponsesMessage'
+      $ref: "#/ResponsesMessage"
     content_index:
       type: integer
     item_id:
       type: string
     part:
-      $ref: '#/ResponsesMessageContentBlock'
+      $ref: "#/ResponsesMessageContentBlock"
     delta:
       type: string
     signature:
@@ -652,7 +693,7 @@ ResponsesStreamResponse:
     logprobs:
       type: array
       items:
-        $ref: '#/ResponsesOutputMessageContentTextLogProb'
+        $ref: "#/ResponsesOutputMessageContentTextLogProb"
     text:
       type: string
     refusal:
@@ -664,7 +705,7 @@ ResponsesStreamResponse:
     partial_image_index:
       type: integer
     annotation:
-      $ref: '#/ResponsesOutputMessageContentTextAnnotation'
+      $ref: "#/ResponsesOutputMessageContentTextAnnotation"
     annotation_index:
       type: integer
     code:
@@ -674,7 +715,7 @@ ResponsesStreamResponse:
     param:
       type: string
     extra_fields:
-      $ref: './common.yaml#/BifrostResponseExtraFields'
+      $ref: "./common.yaml#/BifrostResponseExtraFields"
 
 ResponsesStreamResponseType:
   type: string
@@ -746,7 +787,7 @@ BifrostResponsesDeleteResponse:
     deleted:
       type: boolean
     extra_fields:
-      $ref: './common.yaml#/BifrostResponseExtraFields'
+      $ref: "./common.yaml#/BifrostResponseExtraFields"
 
 BifrostResponsesInputItemsResponse:
   type: object
@@ -757,7 +798,7 @@ BifrostResponsesInputItemsResponse:
     data:
       type: array
       items:
-        $ref: '#/ResponsesMessage'
+        $ref: "#/ResponsesMessage"
     has_more:
       type: boolean
     first_id:
@@ -765,4 +806,4 @@ BifrostResponsesInputItemsResponse:
     last_id:
       type: string
     extra_fields:
-      $ref: './common.yaml#/BifrostResponseExtraFields'
+      $ref: "./common.yaml#/BifrostResponseExtraFields"

--- a/docs/openapi/schemas/integrations/openai/responses.yaml
+++ b/docs/openapi/schemas/integrations/openai/responses.yaml
@@ -11,9 +11,11 @@ OpenAIResponsesRequest:
       description: Model identifier
       example: gpt-4
     input:
-      $ref: '#/OpenAIResponsesInput'
+      $ref: "#/OpenAIResponsesInput"
     stream:
       type: boolean
+    context_management:
+      $ref: "../../inference/responses.yaml#/ContextManagement"
     instructions:
       type: string
       description: System instructions for the model
@@ -27,7 +29,7 @@ OpenAIResponsesRequest:
     previous_response_id:
       type: string
     reasoning:
-      $ref: '#/OpenAIResponsesReasoning'
+      $ref: "#/OpenAIResponsesReasoning"
     store:
       type: boolean
     temperature:
@@ -35,13 +37,13 @@ OpenAIResponsesRequest:
       minimum: 0
       maximum: 2
     text:
-      $ref: '#/OpenAIResponsesTextConfig'
+      $ref: "#/OpenAIResponsesTextConfig"
     tool_choice:
-      $ref: '../../inference/responses.yaml#/ResponsesToolChoice'
+      $ref: "../../inference/responses.yaml#/ResponsesToolChoice"
     tools:
       type: array
       items:
-        $ref: '../../inference/responses.yaml#/ResponsesTool'
+        $ref: "../../inference/responses.yaml#/ResponsesTool"
     top_p:
       type: number
     truncation:
@@ -60,7 +62,7 @@ OpenAIResponsesInput:
     - type: string
     - type: array
       items:
-        $ref: '../../inference/responses.yaml#/ResponsesMessage'
+        $ref: "../../inference/responses.yaml#/ResponsesMessage"
   description: Input - can be a string or array of messages
 
 OpenAIResponsesReasoning:
@@ -82,7 +84,7 @@ OpenAIResponsesTextConfig:
   type: object
   properties:
     format:
-      $ref: '#/OpenAIResponsesTextFormat'
+      $ref: "#/OpenAIResponsesTextFormat"
 
 OpenAIResponsesTextFormat:
   type: object
@@ -102,7 +104,7 @@ OpenAIResponsesTextFormat:
 
 # Response reuses inference schema
 OpenAIResponsesResponse:
-  $ref: '../../inference/responses.yaml#/ResponsesResponse'
+  $ref: "../../inference/responses.yaml#/ResponsesResponse"
 
 OpenAIResponsesStreamResponse:
-  $ref: '../../inference/responses.yaml#/ResponsesStreamResponse'
+  $ref: "../../inference/responses.yaml#/ResponsesStreamResponse"


### PR DESCRIPTION
## Summary

Adds support for a `context_management` field in the Responses API, enabling automatic context window management (e.g., compaction) to be configured on requests and returned in responses.

## Changes

- Added `ContextManagement json.RawMessage` field to `ResponsesParameters` in the Go schema, allowing providers that support automatic context window management to receive and pass through this configuration.
- Added `context_management` to the OpenAPI spec for the Responses request, response, and OpenAI integration schemas, documented as supporting automatic context window management such as compaction.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

Send a Responses API request with a `context_management` payload (e.g., an OpenAI compaction config per https://developers.openai.com/api/docs/guides/compaction) and verify it is forwarded to the provider and echoed back in the response.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `context_management` field is stored and forwarded as raw JSON (`json.RawMessage`), so no PII or secrets are introduced beyond what callers explicitly pass. No additional auth or sandboxing concerns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable