### PR TITLE
fix: strip provider_specific_fields from Anthropic count_tokens

### DIFF
--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -389,6 +389,12 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 		if err != nil {
 			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
 		}
+		// Claude Code history includes provider_specific_fields on tool_use blocks;
+		// strict count_tokens validators (e.g. vLLM) reject unknown content fields.
+		jsonBody, err = StripProviderSpecificFieldsFromContentBlocks(jsonBody)
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+		}
 	}
 
 	if defaults.DeleteStreamField {

--- a/core/providers/anthropic/serversidefallback_test.go
+++ b/core/providers/anthropic/serversidefallback_test.go
@@ -1321,6 +1321,47 @@ func TestBuildAnthropicResponsesRequestBody_CountTokensStripsRejectedFields(t *t
 	}
 }
 
+// Regression: Claude Code serializes tool_use blocks with provider_specific_fields:null.
+// Strict Anthropic-compatible count_tokens validators (vLLM) reject that unknown field.
+func TestBuildAnthropicResponsesRequestBody_CountTokensStripsProviderSpecificFields(t *testing.T) {
+	t.Parallel()
+
+	rawBody := []byte(`{
+		"model":"vllm/GLM-5.2-NVFP4-MTP",
+		"messages":[
+			{"role":"user","content":"hi"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"test","input":{},"provider_specific_fields":null}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"done"}]}
+		]
+	}`)
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+	result, bifrostErr := BuildAnthropicResponsesRequestBody(ctx,
+		&schemas.BifrostResponsesRequest{
+			Provider:       schemas.VLLM,
+			Model:          "GLM-5.2-NVFP4-MTP",
+			RawRequestBody: rawBody,
+		},
+		AnthropicRequestBuildConfig{
+			Provider:      schemas.VLLM,
+			Model:         "GLM-5.2-NVFP4-MTP",
+			IsCountTokens: true,
+		})
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+	if gjson.GetBytes(result, "messages.1.content.0.provider_specific_fields").Exists() {
+		t.Fatalf("expected provider_specific_fields stripped from tool_use, got: %s", result)
+	}
+	if got := gjson.GetBytes(result, "messages.1.content.0.type").String(); got != "tool_use" {
+		t.Fatalf("tool_use block damaged: type=%q body=%s", got, result)
+	}
+	if got := gjson.GetBytes(result, "messages.1.content.0.id").String(); got != "toolu_01" {
+		t.Fatalf("tool_use id lost: %q body=%s", got, result)
+	}
+}
+
 // A fallback entry's speed override needs the fast-mode beta just as a top-level
 // speed does; without it the parameter is rejected as unrecognised.
 func TestFallbackEntrySpeed_InjectsFastModeBetaHeader(t *testing.T) {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1594,6 +1594,35 @@ func StripEmptyThinkingBlocks(jsonBody []byte) ([]byte, error) {
 	return jsonBody, nil
 }
 
+// StripProviderSpecificFieldsFromContentBlocks removes provider_specific_fields
+// from message content blocks. Claude Code serializes tool_use history with
+// "provider_specific_fields": null; Anthropic-compatible count_tokens endpoints
+// (notably vLLM) reject that unknown field with "Extra inputs are not permitted".
+func StripProviderSpecificFieldsFromContentBlocks(jsonBody []byte) ([]byte, error) {
+	messagesResult := providerUtils.GetJSONField(jsonBody, "messages")
+	if !messagesResult.Exists() || !messagesResult.IsArray() {
+		return jsonBody, nil
+	}
+	var err error
+	for mi, msg := range messagesResult.Array() {
+		contentResult := msg.Get("content")
+		if !contentResult.Exists() || !contentResult.IsArray() {
+			continue
+		}
+		for ci, block := range contentResult.Array() {
+			if !block.Get("provider_specific_fields").Exists() {
+				continue
+			}
+			path := fmt.Sprintf("messages.%d.content.%d.provider_specific_fields", mi, ci)
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to strip provider_specific_fields at %s: %w", path, err)
+			}
+		}
+	}
+	return jsonBody, nil
+}
+
 // StripAutoInjectableTools removes code_execution tools from the raw JSON body's tools array
 // when web_search or web_fetch tools are also present. The Anthropic API auto-injects
 // code_execution when web_search_20260209 or web_fetch_20260209 is included in the request,

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -901,6 +901,8 @@ func (provider *VLLMProvider) CountTokens(ctx *schemas.BifrostContext, key schem
 		request,
 		anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.VLLM,
+			Model:                     request.Model,
+			IsCountTokens:             true,
 			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 			ShouldSendBackRawResponse: provider.sendBackRawResponse,
 		},


### PR DESCRIPTION
## Summary

Claude Code CLI serializes `tool_use` history with `"provider_specific_fields": null`. Bifrost's Anthropic `/v1/messages/count_tokens` path was forwarding that non-spec field to strict Anthropic-compatible backends (notably vLLM), which reject it with `Extra inputs are not permitted` and break Claude Code sessions after the first tool use. `/v1/messages` often still succeeded because that path is more lenient or converts the payload differently.

## Changes

- Add `StripProviderSpecificFieldsFromContentBlocks` to remove `provider_specific_fields` from `messages[].content[]`
- Call it from `BuildAnthropicResponsesRequestBody` when `IsCountTokens` is true (alongside existing `fallback_credit_token` stripping)
- Enable `IsCountTokens: true` and pass `Model` in `VLLMProvider.CountTokens` so the count_tokens cleanup path actually runs for vLLM
- Add regression test covering Claude Code-shaped `tool_use` history on the raw-body count_tokens path

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
GOWORK=off go test ./providers/anthropic/ -run 'TestBuildAnthropicResponsesRequestBody_CountTokensStrips' -count=1
GOWORK=off go build ./providers/vllm/
```

Manual curl against Bifrost → vLLM:

```sh
# Should return 200 (not 400 about provider_specific_fields)
curl -s http://localhost:8080/anthropic/v1/messages/count_tokens \
  -H "Content-Type: application/json" \
  -H "x-api-key: $KEY" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "vllm/YOUR_MODEL",
    "messages": [
      {"role": "user", "content": "hi"},
      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "test", "input": {}, "provider_specific_fields": null}]},
      {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "done"}]}
    ]
  }'
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to Claude Code + OpenAI-compatible / vLLM Anthropic compatibility (e.g. maximhq/bifrost#2826).
Closes : #5684 

## Security considerations

None. Only strips a non-spec client field from count_tokens request bodies before upstream forwarding.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

