### PR TITLE
adds first time setup token to avoid opening new setup to the world

### DIFF
--- a/docs/deployment-guides/how-to/security-best-practices.mdx
+++ b/docs/deployment-guides/how-to/security-best-practices.mdx
@@ -16,6 +16,10 @@ Most of these controls live on the **Security Settings** page in the dashboard a
 
 The dashboard can be protected with **Password protect the dashboard** on the Security Settings page (an admin username + password). Anyone who reaches the dashboard URL without credentials can read configuration, virtual keys, and logs, so this is the first thing to turn on for a public host.
 
+<Warning>
+**Set the admin password before exposing the port, not after.** Until an admin account exists, `PUT /api/config` is itself reachable without credentials - this is intentional, zero-config UX for a fresh local instance, but it means anyone who reaches an exposed, not-yet-configured instance first can create the admin account before you do. Starting in **Bifrost 2.0.0-prerelease3**, creating the *first* admin account additionally requires a **setup token** that you configure ahead of time via `setup_token` in `config.json` (or the `BIFROST_SETUP_TOKEN` environment variable) - paste that same value into the **Setup token** field shown alongside the username/password fields the first time you enable auth. If you haven't configured one, first-admin creation is rejected until you do. See [Setting up auth](/quickstart/gateway/setting-up-auth) for the full flow. This token requirement only applies once, when no admin account exists yet.
+</Warning>
+
 <Note>
 **Password policy is enforced starting OSS v1.6.0 and Enterprise v1.5.0.** On these versions Bifrost validates the password both in the UI and on the server before saving, and rejects weak values with HTTP 400. On **earlier versions there was no strength check at all**. If you are running an older build, choose a strong password manually (and upgrade as soon as you can).
 </Note>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -61077,6 +61077,28 @@
                             "additionalProperties": true,
                             "description": "Custom metadata captured from request headers (configured via logging_headers or x-bf-lh-* prefix)"
                           },
+                          "plugin_logs": {
+                            "type": "string",
+                            "description": "JSON-serialized plugin log entries grouped by plugin name"
+                          },
+                          "redaction_mapping": {
+                            "type": "object",
+                            "properties": {
+                              "input": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "output": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "description": "Phase-scoped placeholder-to-original-value mappings for reversible MCP redactions. Present only on log detail responses when the caller has `Logs:Reveal`."
+                          },
                           "created_at": {
                             "type": "string",
                             "format": "date-time",
@@ -61311,6 +61333,28 @@
                       "type": "object",
                       "additionalProperties": true,
                       "description": "Custom metadata captured from request headers (configured via logging_headers or x-bf-lh-* prefix)"
+                    },
+                    "plugin_logs": {
+                      "type": "string",
+                      "description": "JSON-serialized plugin log entries grouped by plugin name"
+                    },
+                    "redaction_mapping": {
+                      "type": "object",
+                      "properties": {
+                        "input": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "output": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "description": "Phase-scoped placeholder-to-original-value mappings for reversible MCP redactions. Present only on log detail responses when the caller has `Logs:Reveal`."
                     },
                     "created_at": {
                       "type": "string",
@@ -78891,7 +78935,7 @@
           },
           "auth_config": {
             "type": "object",
-            "description": "Authentication configuration",
+            "description": "Absent when no admin account has been configured yet (first-time setup). Once an admin account exists, this is always present. Available starting in Bifrost 2.0.0-prerelease3; earlier versions always returned this field.",
             "properties": {
               "admin_username": {
                 "type": "string"
@@ -79216,25 +79260,46 @@
             }
           },
           "auth_config": {
-            "type": "object",
-            "description": "Authentication configuration",
-            "properties": {
-              "admin_username": {
-                "type": "string"
+            "allOf": [
+              {
+                "type": "object",
+                "description": "Authentication configuration",
+                "properties": {
+                  "admin_username": {
+                    "type": "string"
+                  },
+                  "admin_password": {
+                    "type": "string",
+                    "description": "Password (redacted as <redacted> in responses)"
+                  },
+                  "is_enabled": {
+                    "type": "boolean"
+                  },
+                  "disable_auth_on_inference": {
+                    "type": "boolean",
+                    "deprecated": true,
+                    "description": "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
+                  }
+                }
               },
-              "admin_password": {
-                "type": "string",
-                "description": "Password (redacted as <redacted> in responses)"
-              },
-              "is_enabled": {
-                "type": "boolean"
-              },
-              "disable_auth_on_inference": {
-                "type": "boolean",
-                "deprecated": true,
-                "description": "Deprecated and ignored. Use client_config.enforce_auth_on_inference instead."
+              {
+                "type": "object",
+                "properties": {
+                  "setup_token": {
+                    "type": "string",
+                    "description": "Available starting in Bifrost 2.0.0-prerelease3. Bootstrap token, required only when this request creates the very first admin account (i.e. no admin account exists yet). Must match the setup token configured by the operator via setup_token in config.json (or the BIFROST_SETUP_TOKEN environment variable); never persisted or returned by GET /api/config. If the operator hasn't configured a setup token, requests that would create the first admin account are rejected until they do. Once an admin account exists, this field is ignored."
+                  }
+                }
               }
-            }
+            ]
+          }
+        },
+        "example": {
+          "auth_config": {
+            "admin_username": "admin",
+            "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+            "is_enabled": true,
+            "setup_token": "<your-setup-token>"
           }
         }
       },

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -253,6 +253,10 @@ GetConfigResponse:
       $ref: '#/FrameworkConfig'
     auth_config:
       $ref: '#/AuthConfig'
+      description: >-
+        Absent when no admin account has been configured yet (first-time setup).
+        Once an admin account exists, this is always present. Available starting
+        in Bifrost 2.0.0-prerelease3; earlier versions always returned this field.
     is_db_connected:
       type: boolean
     is_cache_connected:
@@ -273,4 +277,25 @@ UpdateConfigRequest:
     framework_config:
       $ref: '#/FrameworkConfig'
     auth_config:
-      $ref: '#/AuthConfig'
+      allOf:
+        - $ref: '#/AuthConfig'
+        - type: object
+          properties:
+            setup_token:
+              type: string
+              description: >-
+                Available starting in Bifrost 2.0.0-prerelease3. Bootstrap token,
+                required only when this request creates the very first admin
+                account (i.e. no admin account exists yet). Must match the setup
+                token configured by the operator via setup_token in config.json
+                (or the BIFROST_SETUP_TOKEN environment variable); never
+                persisted or returned by GET /api/config. If the operator hasn't
+                configured a setup token, requests that would create the first
+                admin account are rejected until they do. Once an admin account
+                exists, this field is ignored.
+  example:
+    auth_config:
+      admin_username: admin
+      admin_password: env.BIFROST_ADMIN_PASSWORD
+      is_enabled: true
+      setup_token: <your-setup-token>

--- a/docs/quickstart/gateway/setting-up-auth.mdx
+++ b/docs/quickstart/gateway/setting-up-auth.mdx
@@ -29,6 +29,22 @@ Bifrost provides built-in authentication to protect your dashboard and admin API
   strong password for security.
 </Note>
 
+<Note>
+  **Creating the first admin account:** until an admin account exists, Bifrost's dashboard/admin API is reachable
+  without a password from anyone who can route to it. To close that window, the first time you enable authentication
+  on an instance you must also supply a **Setup token**. Your operator configures this value ahead of time via
+  `setup_token` in `config.json` (accepts a literal value or an `env.VAR_NAME` / `vault.path` reference, same as
+  `admin_username`/`admin_password`) or the `BIFROST_SETUP_TOKEN` environment variable. Paste that same value into
+  the **Setup token** field that appears below the password field. The setup token is never persisted and is never
+  printed to logs. If no setup token is configured, creating the first admin account is rejected until you set one
+  - and because every node in a multi-node deployment reads the same configured value, there's no need to target a
+  specific node.
+</Note>
+
+<Note>
+  Setup token is required for version 2.0.0-prerelease3 and above.
+</Note>
+
 ### Step 3: Configure Inference Call Authentication (Optional)
 
 By default, when authentication is enabled, all API calls (including inference calls) require authentication. You can optionally disable authentication for inference calls while keeping it enabled for the dashboard and admin API:

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -86,6 +86,9 @@ func getPasswordPolicyFailures(password string) []string {
 // ConfigManager is the interface for the config manager
 type ConfigManager interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
+	// ValidateSetupToken checks the one-time bootstrap token required to create the
+	// first admin account. Returns true once an admin account already exists.
+	ValidateSetupToken(token string) bool
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
 	UpdateSyncConfig(ctx context.Context) error
 	ForceReloadPricing(ctx context.Context) error
@@ -193,14 +196,12 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 				"admin_password": passwordSecretVar,
 				"is_enabled":     authConfig.IsEnabled,
 			}
-		} else {
-			// No auth config exists yet, return default empty SecretVar values
-			mapConfig["auth_config"] = map[string]any{
-				"admin_username": &schemas.SecretVar{},
-				"admin_password": &schemas.SecretVar{},
-				"is_enabled":     false,
-			}
 		}
+		// When authConfig is nil, no admin account has been created yet: leave
+		// auth_config unset (rather than a placeholder object) so the UI's
+		// isFirstTimeSetup check (!bifrostConfig?.auth_config) can tell "no admin
+		// configured yet" apart from "admin configured with empty fields" and show
+		// the setup-token field / include setup_token in the create request.
 	} else {
 		mapConfig["auth_config"] = map[string]any{
 			"admin_username": &schemas.SecretVar{},
@@ -277,6 +278,21 @@ func (h *ConfigHandler) updateMetadata(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{"success": true})
 }
 
+// authConfigWithSetupToken extends the persisted AuthConfig shape with the
+// one-time bootstrap setup_token field, for the auth_config object in PUT
+// /api/config requests only. setup_token lives here (nested under auth_config
+// on the wire) rather than directly on configstore.AuthConfig because that
+// type is also what gets persisted to and read back from the DB via
+// UpdateAuthConfig/GetAuthConfig; keeping SetupToken off it means there's no
+// risk of it ever being written to storage or echoed back by GET /api/config.
+type authConfigWithSetupToken struct {
+	configstore.AuthConfig
+	// SetupToken is the one-time bootstrap token (see AuthMiddleware.bootstrapToken)
+	// required only when this request is creating the very first admin account.
+	// It is never persisted.
+	SetupToken string `json:"setup_token,omitempty"`
+}
+
 // updateConfig updates the core configuration settings.
 // Currently, it supports hot-reloading of the `drop_excess_requests` setting.
 // Note that settings like `prometheus_labels` cannot be changed at runtime.
@@ -289,7 +305,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	payload := struct {
 		ClientConfig    configstore.ClientConfig               `json:"client_config"`
 		FrameworkConfig configstoreTables.TableFrameworkConfig `json:"framework_config"`
-		AuthConfig      *configstore.AuthConfig                `json:"auth_config"`
+		AuthConfig      *authConfigWithSetupToken              `json:"auth_config"`
 	}{}
 
 	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
@@ -858,6 +874,17 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 				SendError(ctx, fasthttp.StatusBadRequest, "auth username and password must be provided")
 				return
 			}
+
+			// Creating the very first admin account is the one config write this
+			// endpoint allows while genuinely unauthenticated (no admin exists yet to
+			// authenticate as). Require the operator-configured setup token (config.json
+			// setup_token or BIFROST_SETUP_TOKEN env var) so that action can't be taken by
+			// an unauthenticated network caller racing the real operator to a freshly
+			// exposed instance.
+			if authConfig == nil && !h.configManager.ValidateSetupToken(payload.AuthConfig.SetupToken) {
+				SendError(ctx, fasthttp.StatusForbidden, "a valid setup token is required to create the initial admin account; configure setup_token in config.json (or the BIFROST_SETUP_TOKEN env var) and pass it in this request")
+				return
+			}
 			// Fetching current Auth config
 			if payload.AuthConfig.AdminUserName.GetValue() != "" {
 				if payload.AuthConfig.AdminPassword.ShouldPreserveStored() {
@@ -892,7 +919,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 				}
 			}
 			// Save auth config - this handles both first-time creation and updates
-			err = h.configManager.UpdateAuthConfig(ctx, payload.AuthConfig)
+			err = h.configManager.UpdateAuthConfig(ctx, &payload.AuthConfig.AuthConfig)
 			if err != nil {
 				logger.Warn("failed to update auth config: %v", err)
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update auth config: %v", err))
@@ -906,7 +933,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			if payload.AuthConfig.AdminUserName == nil || payload.AuthConfig.AdminUserName.GetValue() == "" {
 				payload.AuthConfig.AdminUserName = authConfig.AdminUserName
 			}
-			err = h.configManager.UpdateAuthConfig(ctx, payload.AuthConfig)
+			err = h.configManager.UpdateAuthConfig(ctx, &payload.AuthConfig.AuthConfig)
 			if err != nil {
 				logger.Warn("failed to update auth config: %v", err)
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update auth config: %v", err))

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -826,12 +827,24 @@ type AuthMiddleware struct {
 	wsTicketStore     *WSTicketStore
 	tempTokensService *temptoken.Service // optional; when nil, temp-token fallback is disabled
 	tempTokensEnabled atomic.Bool
+	// bootstrapToken gates creation of the very first admin account. It is sourced
+	// from operator config (config.json setup_token or the BIFROST_SETUP_TOKEN env
+	// var) — never generated in-memory — so every node in a multi-node deployment
+	// reads the identical value from its own config/env, and cleared permanently
+	// once an admin account is created. When no token is configured, it stays nil
+	// and CheckBootstrapToken fails closed: the very first admin account cannot be
+	// created until the operator sets one. This closes the unauthenticated-PUT-
+	// /api/config-plants-admin-credentials path while a fresh, not-yet-configured
+	// instance is reachable over the network.
+	bootstrapToken atomic.Pointer[string]
 }
 
 // InitAuthMiddleware initializes the auth middleware. The tempTokens service
 // is optional and still gated by client config — when nil or disabled, the
-// temp-token fallback path is skipped.
-func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketStore, tempTokensService *temptoken.Service) (*AuthMiddleware, error) {
+// temp-token fallback path is skipped. configuredSetupToken is the operator-
+// provisioned bootstrap token resolved from config.json/env (see
+// lib.resolveSetupToken); pass "" when the operator hasn't configured one.
+func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketStore, tempTokensService *temptoken.Service, configuredSetupToken string) (*AuthMiddleware, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is not present")
 	}
@@ -847,6 +860,27 @@ func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketSt
 	}
 
 	am.authConfig.Store(authConfig)
+
+	if authConfig == nil {
+		if configuredSetupToken != "" {
+			am.bootstrapToken.Store(&configuredSetupToken)
+			logger.Warn("================================================================")
+			logger.Warn("No admin account is configured for this Bifrost instance yet.")
+			logger.Warn("Until one is created, the dashboard/API is reachable without a")
+			logger.Warn("password from anyone who can route to this port. To finish setup,")
+			logger.Warn("pass the configured setup token as auth_config.setup_token in the")
+			logger.Warn("PUT /api/config call that creates the admin account.")
+			logger.Warn("================================================================")
+		} else {
+			logger.Warn("================================================================")
+			logger.Warn("No admin account is configured for this Bifrost instance yet, and")
+			logger.Warn("no setup token is configured. Set setup_token in config.json (or")
+			logger.Warn("the BIFROST_SETUP_TOKEN environment variable) before creating the")
+			logger.Warn("first admin account — requests to create it will be rejected until")
+			logger.Warn("a setup token is configured.")
+			logger.Warn("================================================================")
+		}
+	}
 
 	// Load whitelisted routes from client config
 	clientConfig, err := store.GetClientConfig(context.Background())
@@ -864,6 +898,28 @@ func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketSt
 
 func (m *AuthMiddleware) UpdateAuthConfig(authConfig *configstore.AuthConfig) {
 	m.authConfig.Store(authConfig)
+}
+
+// CheckBootstrapToken reports whether token matches the configured setup token.
+// It returns true (no token required) once an admin account already exists, so
+// this only ever gates the very first admin account. When no admin exists yet and
+// no setup token was configured at boot, it fails closed — the first admin account
+// cannot be created until the operator configures one.
+func (m *AuthMiddleware) CheckBootstrapToken(token string) bool {
+	if m.authConfig.Load() != nil {
+		return true
+	}
+	current := m.bootstrapToken.Load()
+	if current == nil {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(*current), []byte(token)) == 1
+}
+
+// ClearBootstrapToken permanently invalidates the setup token after the first admin
+// account has been created successfully.
+func (m *AuthMiddleware) ClearBootstrapToken() {
+	m.bootstrapToken.Store(nil)
 }
 
 // UpdateWhitelistedRoutes updates the configured whitelisted routes that bypass auth middleware.

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -979,6 +979,70 @@ func TestAuthMiddleware_UpdateAuthConfig_NilToEnabled(t *testing.T) {
 	}
 }
 
+// TestAuthMiddleware_BootstrapToken_NoAdminNoToken tests that CheckBootstrapToken fails
+// closed when no admin account exists yet and no setup token was configured at boot (e.g.
+// the operator hasn't set setup_token / BIFROST_SETUP_TOKEN) — the very first admin account
+// cannot be created until the operator configures one.
+func TestAuthMiddleware_BootstrapToken_NoAdminNoToken(t *testing.T) {
+	am := &AuthMiddleware{}
+
+	if am.CheckBootstrapToken("") {
+		t.Error("CheckBootstrapToken should reject when no admin exists and no setup token is configured")
+	}
+	if am.CheckBootstrapToken("anything") {
+		t.Error("CheckBootstrapToken should reject when no admin exists and no setup token is configured")
+	}
+}
+
+// TestAuthMiddleware_BootstrapToken_AdminExists tests that CheckBootstrapToken allows any
+// value through once an admin account already exists, regardless of bootstrapToken state.
+func TestAuthMiddleware_BootstrapToken_AdminExists(t *testing.T) {
+	am := &AuthMiddleware{}
+	am.UpdateAuthConfig(&configstore.AuthConfig{
+		AdminUserName: schemas.NewSecretVar("admin"),
+		AdminPassword: schemas.NewSecretVar("password"),
+		IsEnabled:     true,
+	})
+
+	if !am.CheckBootstrapToken("") {
+		t.Error("CheckBootstrapToken should allow through once an admin account exists")
+	}
+	if !am.CheckBootstrapToken("anything") {
+		t.Error("CheckBootstrapToken should allow through once an admin account exists")
+	}
+}
+
+// TestAuthMiddleware_BootstrapToken_ValidatesAndClears tests that once a bootstrap token is
+// set (simulating InitAuthMiddleware booting with a configured setup token and no admin
+// account yet), only the exact token validates, and creating the admin account — which sets
+// authConfig, mirroring BifrostHTTPServer.UpdateAuthConfig — permanently reopens the gate.
+func TestAuthMiddleware_BootstrapToken_ValidatesAndClears(t *testing.T) {
+	am := &AuthMiddleware{}
+	token := "test-bootstrap-token"
+	am.bootstrapToken.Store(&token)
+
+	if am.CheckBootstrapToken("") {
+		t.Error("CheckBootstrapToken should reject an empty token once a bootstrap token is set")
+	}
+	if am.CheckBootstrapToken("wrong-token") {
+		t.Error("CheckBootstrapToken should reject a mismatched token")
+	}
+	if !am.CheckBootstrapToken(token) {
+		t.Error("CheckBootstrapToken should accept the exact bootstrap token")
+	}
+
+	am.UpdateAuthConfig(&configstore.AuthConfig{
+		AdminUserName: schemas.NewSecretVar("admin"),
+		AdminPassword: schemas.NewSecretVar("password"),
+		IsEnabled:     true,
+	})
+	am.ClearBootstrapToken()
+
+	if !am.CheckBootstrapToken("wrong-token") {
+		t.Error("CheckBootstrapToken should allow anything through once an admin account exists")
+	}
+}
+
 // TestAuthMiddleware_UpdateAuthConfig_EnabledToDisabled tests disabling auth after it was enabled
 func TestAuthMiddleware_UpdateAuthConfig_EnabledToDisabled(t *testing.T) {
 	SetLogger(&mockLogger{})

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -166,7 +166,14 @@ type ConfigData struct {
 	Client        *configstore.ClientConfig `json:"client"`
 	EncryptionKey *schemas.SecretVar        `json:"encryption_key"`
 	// Deprecated: Use GovernanceConfig.AuthConfig instead
-	AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
+	AuthConfig *configstore.AuthConfig `json:"auth_config,omitempty"`
+	// SetupToken is the operator-provisioned bootstrap secret required to create the
+	// very first admin account (see AuthMiddleware.bootstrapToken). It is never
+	// persisted to the config store — only read from this file (or, when absent here,
+	// the BIFROST_SETUP_TOKEN env var) — so every node in a multi-node deployment reads
+	// the same value from its own identical config/env rather than relying on a
+	// per-process generated value.
+	SetupToken        *schemas.SecretVar                    `json:"setup_token,omitempty"`
 	Providers         map[string]configstore.ProviderConfig `json:"providers"`
 	FrameworkConfig   *framework.FrameworkConfig            `json:"framework,omitempty"`
 	MCP               *schemas.MCPConfig                    `json:"mcp,omitempty"`
@@ -425,6 +432,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		Client            *configstore.ClientConfig             `json:"client"`
 		EncryptionKey     *schemas.SecretVar                    `json:"encryption_key"`
 		AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
+		SetupToken        *schemas.SecretVar                    `json:"setup_token,omitempty"`
 		Providers         map[string]configstore.ProviderConfig `json:"providers"`
 		MCP               *schemas.MCPConfig                    `json:"mcp,omitempty"`
 		Webhooks          []*WebhookEndpointConfig              `json:"webhooks,omitempty"`
@@ -451,6 +459,7 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	cd.Server = temp.Server
 	cd.EncryptionKey = temp.EncryptionKey
 	cd.AuthConfig = temp.AuthConfig
+	cd.SetupToken = temp.SetupToken
 	cd.Providers = temp.Providers
 	cd.MCP = temp.MCP
 	cd.Webhooks = temp.Webhooks
@@ -556,6 +565,11 @@ type Config struct {
 	GovernanceConfig *configstore.GovernanceConfig
 	FrameworkConfig  *framework.FrameworkConfig
 	ProxyConfig      *configstoreTables.GlobalProxyConfig
+
+	// SetupToken is the resolved operator-provisioned bootstrap secret (see
+	// ConfigData.SetupToken / resolveSetupToken). Empty when the operator hasn't
+	// configured one. Never persisted — read fresh from config/env on every boot.
+	SetupToken string
 
 	// webhookEndpoints serves webhook endpoint config to the request path and
 	// the delivery worker without database reads. Guarded by muWebhooks;
@@ -920,6 +934,8 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 	}
 	// 1a. Vault config acknowledgement (initialization handled by enterprise layer)
 	initVault(&configData)
+	// 1b. Bootstrap setup token (from config file or BIFROST_SETUP_TOKEN env var)
+	config.SetupToken = resolveSetupToken(&configData)
 	// 2. Stores (config, logs, vector) — creates defaults for absent configs
 	if err := initStores(ctx, config, &configData, configDBPath, logsDBPath); err != nil {
 		return nil, err
@@ -4582,6 +4598,23 @@ func initEncryption(configData *ConfigData) error {
 // initVault is a no-op stub at the OSS level.
 // Vault initialization is performed by the enterprise layer via config_store.vault_store.
 func initVault(_ *ConfigData) {}
+
+// resolveSetupToken resolves the bootstrap setup token required to create the very
+// first admin account from config data or the BIFROST_SETUP_TOKEN environment
+// variable. Returns "" when neither is set — callers must then fail closed rather
+// than fall back to generating and logging a token, since a per-process generated
+// value would differ across nodes in a multi-node deployment. Whitespace-only
+// values are treated as unset so an accidental " " doesn't become a guessable token.
+func resolveSetupToken(configData *ConfigData) string {
+	configured := ""
+	if configData.SetupToken != nil {
+		configured = strings.TrimSpace(configData.SetupToken.GetValue())
+	}
+	if configured == "" {
+		return strings.TrimSpace(os.Getenv("BIFROST_SETUP_TOKEN"))
+	}
+	return configured
+}
 
 // syncEncryption encrypts all plaintext rows in the config store if encryption is enabled.
 // Called during bootup after encryption key is initialized and all config data has been loaded.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -20324,3 +20324,31 @@ func TestLoadWebhooksConfigWithoutSection(t *testing.T) {
 	_, ok := config.WebhookEndpointByName("db-only")
 	assert.True(t, ok, "database endpoints load into memory even with no file section")
 }
+
+func TestResolveSetupToken_Unset(t *testing.T) {
+	t.Setenv("BIFROST_SETUP_TOKEN", "")
+	assert.Empty(t, resolveSetupToken(&ConfigData{}))
+}
+
+func TestResolveSetupToken_ConfiguredValue(t *testing.T) {
+	t.Setenv("BIFROST_SETUP_TOKEN", "")
+	configData := &ConfigData{SetupToken: schemas.NewSecretVar("my-token")}
+	assert.Equal(t, "my-token", resolveSetupToken(configData))
+}
+
+func TestResolveSetupToken_ConfiguredWhitespaceOnly_FallsBackToEnv(t *testing.T) {
+	t.Setenv("BIFROST_SETUP_TOKEN", "env-token")
+	configData := &ConfigData{SetupToken: schemas.NewSecretVar("   ")}
+	assert.Equal(t, "env-token", resolveSetupToken(configData), "whitespace-only config value must be treated as unset")
+}
+
+func TestResolveSetupToken_EnvWhitespaceOnly_TreatedAsUnset(t *testing.T) {
+	t.Setenv("BIFROST_SETUP_TOKEN", "\t \n")
+	assert.Empty(t, resolveSetupToken(&ConfigData{}), "whitespace-only env value must be treated as unset")
+}
+
+func TestResolveSetupToken_TrimsSurroundingWhitespace(t *testing.T) {
+	t.Setenv("BIFROST_SETUP_TOKEN", "")
+	configData := &ConfigData{SetupToken: schemas.NewSecretVar("  my-token  ")}
+	assert.Equal(t, "my-token", resolveSetupToken(configData))
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -76,6 +76,7 @@ type ServerCallbacks interface {
 	ExpandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error)
 	// Auth related callbacks
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
+	ValidateSetupToken(token string) bool
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
 	// Pricing related callbacks
 	UpdateSyncConfig(ctx context.Context) error
@@ -1017,8 +1018,21 @@ func (s *BifrostHTTPServer) UpdateAuthConfig(ctx context.Context, authConfig *co
 		} else {
 			s.AuthMiddleware.UpdateAuthConfig(updatedAuthConfig)
 		}
+		// The first admin account now exists (or already did) — permanently
+		// invalidate the bootstrap setup token. No-op if already cleared.
+		s.AuthMiddleware.ClearBootstrapToken()
 	}
 	return nil
+}
+
+// ValidateSetupToken reports whether token is a valid one-time bootstrap setup token,
+// as required to create the very first admin account (see AuthMiddleware.bootstrapToken).
+// Once an admin account exists, this always returns true — the gate closes permanently.
+func (s *BifrostHTTPServer) ValidateSetupToken(token string) bool {
+	if s.AuthMiddleware == nil {
+		return true
+	}
+	return s.AuthMiddleware.CheckBootstrapToken(token)
 }
 
 // UpdateDropExcessRequests updates excess requests config
@@ -2253,7 +2267,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		if s.Config.MCPHeadersProvider != nil {
 			s.Config.MCPHeadersProvider.SetTempTokenService(s.TempTokens)
 		}
-		s.AuthMiddleware, err = handlers.InitAuthMiddleware(s.Config.ConfigStore, s.WSTicketStore, s.TempTokens)
+		s.AuthMiddleware, err = handlers.InitAuthMiddleware(s.Config.ConfigStore, s.WSTicketStore, s.TempTokens, s.Config.SetupToken)
 		if err != nil {
 			s.WSTicketStore.Stop()
 			s.WSTicketStore = nil

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -45,6 +45,11 @@
     "auth_config": {
       "$ref": "#/$defs/auth_config"
     },
+    "setup_token": {
+      "type": "string",
+      "pattern": "\\S",
+      "description": "Operator-provisioned bootstrap secret required to create the very first admin account when no admin account is configured yet. You can set the value as env.<ENV_VAR_NAME> to use an environment variable, or as vault.<path> to use a Vault secret reference. We also read the setup token from the BIFROST_SETUP_TOKEN environment variable. Identical across every node in a multi-node deployment (unlike a randomly generated value), so any node can authorize first-admin creation. Never persisted and never logged; if left unset, creating the first admin account is rejected until this is configured. Whitespace-only values are rejected."
+    },
     "client": {
       "type": "object",
       "description": "Client configuration settings",

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -1,6 +1,8 @@
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -59,6 +61,13 @@ export default function SecurityView() {
 		is_enabled: false,
 	});
 	const [passwordError, setPasswordError] = useState("");
+	const [setupToken, setSetupToken] = useState("");
+	const [setupTokenErrorMessage, setSetupTokenErrorMessage] = useState<string | null>(null);
+	// No admin account has ever been created on this instance yet. The very first
+	// PUT /api/config that creates one must include the setup token the operator
+	// configured via setup_token in config.json (or BIFROST_SETUP_TOKEN), so this
+	// field only needs to show up that once.
+	const isFirstTimeSetup = !bifrostConfig?.auth_config;
 
 	useEffect(() => {
 		if (bifrostConfig && config) {
@@ -197,6 +206,12 @@ export default function SecurityView() {
 				passwordInputRef.current?.focus({ preventScroll: true });
 				return;
 			}
+			if (isFirstTimeSetup && authConfig.is_enabled && !setupToken.trim()) {
+				setSetupTokenErrorMessage(
+					"Enter the setup token configured by your operator to create the first admin account. It's set via setup_token in config.json or the BIFROST_SETUP_TOKEN environment variable.",
+				);
+				return;
+			}
 			setPasswordError("");
 
 			await updateCoreConfig({
@@ -204,15 +219,24 @@ export default function SecurityView() {
 				client_config: localConfig,
 				...(showPasswordSection
 					? {
-						auth_config: authConfig.is_enabled && hasUsername && hasPassword ? authConfig : { ...authConfig, is_enabled: false },
+						auth_config: {
+							...(authConfig.is_enabled && hasUsername && hasPassword ? authConfig : { ...authConfig, is_enabled: false }),
+							...(isFirstTimeSetup ? { setup_token: setupToken.trim() } : {}),
+						},
 					}
 					: {}),
 			}).unwrap();
+			setSetupToken("");
 			toast.success("Security settings updated successfully.");
 		} catch (error) {
-			toast.error(getErrorMessage(error));
+			const message = getErrorMessage(error);
+			if (isFirstTimeSetup && message.toLowerCase().includes("setup token")) {
+				setSetupTokenErrorMessage(message);
+			} else {
+				toast.error(message);
+			}
 		}
-	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig]);
+	}, [bifrostConfig, localConfig, authConfig, showPasswordSection, updateCoreConfig, isFirstTimeSetup, setupToken]);
 
 	return (
 		<div className="mx-auto w-full max-w-4xl space-y-4">
@@ -287,6 +311,25 @@ export default function SecurityView() {
 										</p>
 									) : null}
 								</div>
+								{isFirstTimeSetup && authConfig.is_enabled ? (
+									<div className="space-y-2">
+										<Label htmlFor="setup-token">Setup token</Label>
+										<Input
+											id="setup-token"
+											data-testid="security-setup-token-input"
+											type="password"
+											autoComplete="off"
+											placeholder="Paste the setup token configured by your operator"
+											value={setupToken}
+											onChange={(e) => setSetupToken(e.target.value)}
+										/>
+										<p className="text-muted-foreground text-xs">
+											No admin account exists yet, so this instance is reachable without a password. To finish setup, ask your
+											operator for the setup token configured via <code>setup_token</code> in <code>config.json</code> (or the{" "}
+											<code>BIFROST_SETUP_TOKEN</code> environment variable) and paste it here.
+										</p>
+									</div>
+								) : null}
 							</div>
 						</div>
 					</div>
@@ -462,6 +505,24 @@ export default function SecurityView() {
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>
 			</div>
+			<Dialog open={!!setupTokenErrorMessage} onOpenChange={(open) => !open && setSetupTokenErrorMessage(null)}>
+				<DialogContent data-testid="setup-token-error-dialog">
+					<DialogHeader>
+						<DialogTitle>Setup token required</DialogTitle>
+						<DialogDescription>{setupTokenErrorMessage}</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setSetupTokenErrorMessage(null)} data-testid="setup-token-error-close">
+							Close
+						</Button>
+						<Button asChild data-testid="setup-token-error-view-docs">
+							<a href="https://docs.getbifrost.ai/quickstart/gateway/setting-up-auth" target="_blank" rel="noopener noreferrer">
+								View docs
+							</a>
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -494,6 +494,10 @@ export interface AuthConfig {
 	admin_username: SecretVar;
 	admin_password: SecretVar;
 	is_enabled: boolean;
+	/** Write-only: required only when this PUT request creates the very first admin account
+	 *  (no admin account exists yet). Provided by the operator via setup_token in config.json
+	 *  or the BIFROST_SETUP_TOKEN env var. Never persisted or returned by GET /api/config. */
+	setup_token?: string;
 }
 
 // Global proxy type (for global proxy configuration, not per-provider)


### PR DESCRIPTION
## Summary

Closes a race-condition security gap where an unauthenticated network caller could reach a freshly deployed, not-yet-configured Bifrost instance and create the first admin account before the real operator does. Previously, `PUT /api/config` was intentionally open when no admin account existed (zero-config UX), but this left a window of exposure on any publicly reachable host.

The fix introduces a one-time **setup token** — generated in-memory at startup when no admin account is configured, printed to the server's startup logs, and required alongside the username/password when creating the first admin account. The token is never persisted, is regenerated on every restart until an admin account exists, and is permanently invalidated once the first admin account is created.

## Changes

- **Bootstrap token generation (`middlewares.go`):** `InitAuthMiddleware` generates a UUID setup token via `atomic.Pointer[string]` when no admin account is configured, logs it prominently to stdout, and exposes `CheckBootstrapToken` (constant-time comparison) and `ClearBootstrapToken` methods.
- **Token validation in the config handler (`config.go`):** `updateConfig` now calls `ValidateSetupToken` before allowing the first admin account to be created. Returns HTTP 403 if the token is missing or wrong.
- **Token cleared on first admin account creation (`server.go`):** `UpdateAuthConfig` calls `ClearBootstrapToken` after successfully persisting the first admin account, permanently closing the gate.
- **`setup_token`** **field added to** **`UpdateConfigRequest`:** The field is accepted in the request body but never persisted or returned by `GET /api/config`.
- **UI (`securityView.tsx`):** When no `auth_config` exists server-side (`isFirstTimeSetup`), a **Setup token** input field is shown below the password field. The token is validated client-side before submission and cleared from state after a successful save.
- **TypeScript types (`config.ts`):** `setup_token?: string` added to `BifrostConfig`.
- **OpenAPI schema (`config.yaml`):** `setup_token` documented on `UpdateConfigRequest`.
- **Docs:** A `<Warning>` block added to `security-best-practices.mdx` and a `<Note>` added to `setting-up-auth.mdx` explaining the setup token flow, where to find it, and that it only applies once.
- **Tests (`middlewares_test.go`):** Two new test cases cover the no-token-generated (pass-through) case and the validate-then-clear lifecycle.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

**Manual flow:**

1. Start a fresh Bifrost instance with no existing admin account.
2. Check startup logs for the block beginning `No admin account is configured for this Bifrost instance yet.` and copy the setup token.
3. Open the dashboard → Security Settings. Confirm the **Setup token** field appears below the password field.
4. Attempt to save with auth enabled but without the setup token — expect a toast error.
5. Paste the correct token and save — expect success and the Setup token field to disappear on reload.
6. Confirm that `PUT /api/config` without the token returns HTTP 403 while no admin account exists.
7. Restart the server before completing setup and confirm a new token is printed.

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

Any automation or scripts that call `PUT /api/config` to create the first admin account on a fresh instance must now include `setup_token` in the request body. The token is available in the server's startup logs. Instances that already have an admin account configured are unaffected — the field is ignored once an admin account exists.

## Security considerations

- The setup token is generated with `uuid.NewString()` (crypto-random UUID), stored only in process memory, and compared with `crypto/subtle.ConstantTimeCompare` to prevent timing attacks.
- The token is never written to disk, never returned by any API endpoint, and is permanently invalidated after first use.
- Operators must have access to the process's stdout/log stream (`docker logs`, `kubectl logs`, or terminal) to retrieve the token, which is the same access level required to operate the host — this is the intended trust boundary.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicablecg