### PR TITLE
chore: release Bifrost Helm chart v2.1.34 with SCIM `roleResolutionStrategy` support

### DIFF
--- a/docs/changelogs/helm-v2.1.34.mdx
+++ b/docs/changelogs/helm-v2.1.34.mdx
@@ -1,0 +1,12 @@
+---
+title: "v2.1.34"
+description: "Helm v2.1.34 changelog - 2026-08-02"
+---
+
+<Update label="Bifrost Helm" description="v2.1.34">
+
+## Changelog
+
+- Added `bifrost.scim.config.roleResolutionStrategy` (`highestPermissionCount` default, or `order`) to pick a single role when a user matches multiple `attributeRoleMappings` — most-permissioned role vs first match in the list. Passes through into `scim_config.config.roleResolutionStrategy`.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1053,6 +1053,7 @@
             "item": "Helm",
             "icon": "box",
             "pages": [
+              "changelogs/helm-v2.1.34",
               "changelogs/helm-v2.1.33",
               "changelogs/helm-v2.1.32",
               "changelogs/helm-v2.1.31",

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.33
+version: 2.1.34
 appVersion: "1.5.12"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.33
+**Latest Version:** 2.1.34
 
 ## Changelog
+
+### 2.1.34
+
+- Added `bifrost.scim.config.roleResolutionStrategy` (`highestPermissionCount` default, or `order`) to pick a single role when a user matches multiple `attributeRoleMappings` — most-permissioned role vs first match in the list. Passes through into `scim_config.config.roleResolutionStrategy`.
 
 ### 2.1.33
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2367,6 +2367,7 @@
                         "default": "roles"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2440,6 +2441,7 @@
                         "default": "roles"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2507,6 +2509,7 @@
                         "default": "roles"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2572,6 +2575,7 @@
                         "default": "groups"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2647,6 +2651,7 @@
                         "default": "groups"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2744,6 +2749,7 @@
                         "description": "JWT claim field for team IDs"
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -2816,6 +2822,7 @@
                         "items": { "type": "string" }
                       },
                       "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+                      "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
                       "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
                       "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
                       "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -6454,7 +6461,7 @@
     },
     "scim_attribute_role_mappings": {
       "type": "array",
-      "description": "Ordered list of attribute -> role mappings (first match wins).",
+      "description": "List of attribute -> role mappings. When a user resolves to more than one role (from these mappings, the native roles claim, or group/attribute channels), roleResolutionStrategy decides which single role is assigned: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates this mappings list top to bottom and the first matching rule wins.",
       "items": {
         "type": "object",
         "properties": {
@@ -6474,6 +6481,12 @@
         "required": ["attribute", "value", "role"],
         "additionalProperties": false
       }
+    },
+    "scim_role_resolution_strategy": {
+      "type": "string",
+      "enum": ["highestPermissionCount", "order"],
+      "default": "highestPermissionCount",
+      "description": "How a single role is chosen when a user resolves to more than one role: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates the attribute-role mappings top to bottom and the first matching rule wins."
     },
     "scim_attribute_team_mappings": {
       "type": "array",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -952,6 +952,9 @@ bifrost:
       #   - attribute: "groups"
       #     value: "bifrost-admins"
       #     role: "admin"
+      # # Strategy for picking one role when a user resolves to more than one:
+      # # "highestPermissionCount" (default) = role with the most permissions; "order" = evaluate top to bottom, first matching rule wins.
+      # roleResolutionStrategy: "highestPermissionCount"
       # attributeTeamMappings:
       #   - attribute: "groups"
       #     value: "*"            # pass-through: every group becomes a team

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5746,6 +5746,7 @@
           "default": "roles"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -5802,6 +5803,7 @@
           "default": "roles"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -5852,6 +5854,7 @@
           "default": "roles"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"}
@@ -5910,6 +5913,7 @@
           "items": { "type": "string" }
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -5959,6 +5963,7 @@
           "default": "groups"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -6017,6 +6022,7 @@
           "default": "groups"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -6101,6 +6107,7 @@
           "description": "JWT claim field for team IDs"
         },
         "attributeRoleMappings": {"$ref": "#/$defs/scim_attribute_role_mappings"},
+        "roleResolutionStrategy": {"$ref": "#/$defs/scim_role_resolution_strategy"},
         "attributeTeamMappings": {"$ref": "#/$defs/scim_attribute_team_mappings"},
         "attributeBusinessUnitMappings": {"$ref": "#/$defs/scim_attribute_business_unit_mappings"},
         "authProxy": {"$ref": "#/$defs/scim_auth_proxy"},
@@ -7396,7 +7403,7 @@
     },
     "scim_attribute_role_mappings": {
       "type": "array",
-      "description": "Ordered list of attribute -> role mappings (first match wins).",
+      "description": "List of attribute -> role mappings. When a user resolves to more than one role (from these mappings, the native roles claim, or group/attribute channels), roleResolutionStrategy decides which single role is assigned: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates this mappings list top to bottom and the first matching rule wins.",
       "items": {
         "type": "object",
         "properties": {
@@ -7416,6 +7423,12 @@
         "required": ["attribute", "value", "role"],
         "additionalProperties": false
       }
+    },
+    "scim_role_resolution_strategy": {
+      "type": "string",
+      "enum": ["highestPermissionCount", "order"],
+      "default": "highestPermissionCount",
+      "description": "How a single role is chosen when a user resolves to more than one role: 'highestPermissionCount' (default) picks the role with the most permissions; 'order' evaluates the attribute-role mappings top to bottom and the first matching rule wins."
     },
     "scim_attribute_team_mappings": {
       "type": "array",


### PR DESCRIPTION
## Summary

Adds a `roleResolutionStrategy` field to SCIM configuration that controls how a single role is selected when a user matches multiple `attributeRoleMappings`. Previously, there was no defined behavior for multi-match scenarios; this makes the resolution explicit and configurable.

## Changes

- Added `scim_role_resolution_strategy` schema definition to `config.schema.json` with two allowed values: `highestPermissionCount` (default) and `order`. The `highestPermissionCount` strategy selects the role with the most permissions, while `order` selects the first match in the mappings list (top-most wins).
- Added `roleResolutionStrategy` as a `$ref` to the new definition across all SCIM provider config variants in the schema.
- Exposed `bifrost.scim.config.roleResolutionStrategy` in `values.yaml` as a commented-out option with inline documentation.
- Bumped the Bifrost Helm chart to `v2.1.34` and added the corresponding changelog entry.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy the Helm chart with a SCIM configuration where a user matches multiple `attributeRoleMappings` entries.

1. Set `bifrost.scim.config.roleResolutionStrategy: "highestPermissionCount"` and verify the user receives the role with the greatest number of permissions.
2. Set `bifrost.scim.config.roleResolutionStrategy: "order"` and verify the user receives the first matching role in the list.
3. Omit the field entirely and confirm behavior defaults to `highestPermissionCount`.

Validate the generated `scim_config.config.roleResolutionStrategy` value is correctly passed through in the rendered config.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `order` strategy allows operators to explicitly control role precedence in multi-match scenarios, which may be relevant in environments where role assignment has security implications. Operators should review their `attributeRoleMappings` ordering when switching to `order` mode to ensure least-privilege intent is preserved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable