### PR TITLE
weaviate + redis adapter fixes

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -79,15 +79,12 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 	// Check if index already exists
 	infoResult := s.client.Do(ctx, "FT.INFO", namespace)
 	if infoResult.Err() == nil {
-		ftInfo, ftInfoErr := s.client.FTInfo(ctx, namespace).Result()
-		if ftInfoErr != nil {
-			s.logger.Warn(fmt.Sprintf("could not inspect existing index %q for dimension validation (check skipped): %v", namespace, ftInfoErr))
-		} else {
-			for _, attr := range ftInfo.Attributes {
-				if strings.EqualFold(attr.Type, "VECTOR") && attr.Dim > 0 && attr.Dim != dimension {
-					return fmt.Errorf("namespace %q already exists with dimension %d but config requires %d — update vector_store_namespace to a new name or drop the existing index manually", namespace, attr.Dim, dimension)
-				}
-			}
+		// Read the dimension out of the raw reply rather than the typed FTInfo
+		// helper. That helper refuses to decode while the client speaks RESP3
+		// without UnstableResp3 — which is exactly how this store configures it
+		// — so it always failed and the check below silently never ran.
+		if existing, ok := vectorDimensionFromFTInfo(infoResult.Val()); ok && existing != dimension {
+			return fmt.Errorf("namespace %q already exists with dimension %d but config requires %d — update vector_store_namespace to a new name or drop the existing index manually", namespace, existing, dimension)
 		}
 		s.cacheNamespaceFieldTypes(namespace, properties)
 		return nil // Index already exists with matching dimension
@@ -890,6 +887,67 @@ func attributesToMap(value interface{}) map[string]interface{} {
 	default:
 		return nil
 	}
+}
+
+// vectorDimensionFromFTInfo reads the declared dimension of an index's VECTOR
+// attribute out of a raw FT.INFO reply, returning false when the reply carries
+// no such attribute. Shape depends on the protocol the client negotiated: the
+// top level is a map under RESP3 and a flat key/value sequence under RESP2,
+// and each entry of "attributes" varies the same way.
+func vectorDimensionFromFTInfo(reply interface{}) (int, bool) {
+	attributes, ok := ftInfoField(reply, "attributes")
+	if !ok {
+		return 0, false
+	}
+	entries, ok := attributes.([]interface{})
+	if !ok {
+		return 0, false
+	}
+	for _, entry := range entries {
+		entryType, ok := ftInfoField(entry, "type")
+		if !ok {
+			continue
+		}
+		typeText, ok := toString(entryType)
+		if !ok || !strings.EqualFold(typeText, "VECTOR") {
+			continue
+		}
+		rawDimension, ok := ftInfoField(entry, "dim")
+		if !ok {
+			continue
+		}
+		if value, ok := toFloat64(rawDimension); ok && value > 0 {
+			return int(value), true
+		}
+	}
+	return 0, false
+}
+
+// ftInfoField looks up one field of an FT.INFO reply across both protocol
+// shapes. Used for the top level and for individual attribute entries, which
+// are maps under RESP3 and flat key/value sequences under RESP2.
+func ftInfoField(reply interface{}, name string) (interface{}, bool) {
+	switch typed := reply.(type) {
+	case map[interface{}]interface{}:
+		for key, value := range typed {
+			if keyText, ok := toString(key); ok && strings.EqualFold(keyText, name) {
+				return value, true
+			}
+		}
+	case map[string]interface{}:
+		for key, value := range typed {
+			if strings.EqualFold(key, name) {
+				return value, true
+			}
+		}
+	case []interface{}:
+		for i := 0; i+1 < len(typed); i += 2 {
+			if keyText, ok := toString(typed[i]); ok && strings.EqualFold(keyText, name) {
+				return typed[i+1], true
+			}
+		}
+	}
+	return nil, false
 }
 
 func toString(value interface{}) (string, bool) {

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -628,6 +628,136 @@ func TestRedisStore_ParseSearchResults_EmptyRESP2(t *testing.T) {
 	assert.Empty(t, results)
 }
 
+// TestVectorDimensionFromFTInfo covers both protocol shapes of the FT.INFO
+// reply. The typed FTInfo helper this replaced could not decode under RESP3, so
+// the dimension check it fed silently never ran on a client speaking RESP3.
+func TestVectorDimensionFromFTInfo(t *testing.T) {
+	// What a live RESP3 server returns: each attribute entry is a map.
+	vectorAttributeMap := map[interface{}]interface{}{
+		"identifier":      "embedding",
+		"attribute":       "embedding",
+		"type":            "VECTOR",
+		"algorithm":       "HNSW",
+		"data_type":       "FLOAT32",
+		"dim":             1536,
+		"distance_metric": "COSINE",
+		"flags":           []interface{}{},
+	}
+	// RESP2 renders the same entry as a flat key/value sequence.
+	vectorAttributeFlat := []interface{}{
+		"identifier", "embedding",
+		"attribute", "embedding",
+		"type", "VECTOR",
+		"algorithm", "HNSW",
+		"data_type", "FLOAT32",
+		"dim", int64(1536),
+		"distance_metric", "COSINE",
+	}
+	tagAttribute := []interface{}{
+		"identifier", "tier",
+		"attribute", "tier",
+		"type", "TAG",
+		"SEPARATOR", ",",
+	}
+
+	tests := []struct {
+		name     string
+		reply    interface{}
+		expected int
+		found    bool
+	}{
+		{
+			name: "RESP3 map with map attribute entries",
+			reply: map[interface{}]interface{}{
+				"index_name": "BifrostComplexityRouter",
+				"attributes": []interface{}{vectorAttributeMap},
+			},
+			expected: 1536,
+			found:    true,
+		},
+		{
+			name: "RESP3 map with flat attribute entries",
+			reply: map[interface{}]interface{}{
+				"index_name": "BifrostComplexityRouter",
+				"attributes": []interface{}{tagAttribute, vectorAttributeFlat},
+			},
+			expected: 1536,
+			found:    true,
+		},
+		{
+			name: "RESP3 string-keyed map",
+			reply: map[string]interface{}{
+				"attributes": []interface{}{vectorAttributeMap},
+			},
+			expected: 1536,
+			found:    true,
+		},
+		{
+			name: "RESP2 flat sequence",
+			reply: []interface{}{
+				"index_name", "BifrostComplexityRouter",
+				"attributes", []interface{}{vectorAttributeFlat},
+			},
+			expected: 1536,
+			found:    true,
+		},
+		{
+			// Redis reports numerics as strings under RESP2 and as integers
+			// under RESP3, so both must parse.
+			name:     "dim as string",
+			reply:    map[string]interface{}{"attributes": []interface{}{[]interface{}{"type", "VECTOR", "dim", "768"}}},
+			expected: 768,
+			found:    true,
+		},
+		{
+			name:  "no vector attribute",
+			reply: map[string]interface{}{"attributes": []interface{}{tagAttribute}},
+			found: false,
+		},
+		{
+			name:  "no attributes field",
+			reply: map[string]interface{}{"index_name": "x"},
+			found: false,
+		},
+		{
+			name:  "unexpected shape",
+			reply: "not-a-reply",
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dimension, ok := vectorDimensionFromFTInfo(tt.reply)
+			assert.Equal(t, tt.found, ok)
+			if tt.found {
+				assert.Equal(t, tt.expected, dimension)
+			}
+		})
+	}
+}
+
+// TestRedisStore_CreateNamespaceRejectsDimensionChange proves the guard fires
+// against a live server: recreating an existing index with a different
+// dimension must fail rather than silently reuse the old index.
+func TestRedisStore_CreateNamespaceRejectsDimensionChange(t *testing.T) {
+	setup := NewRedisTestSetup(t)
+	defer setup.Cleanup(t)
+
+	namespace := TestNamespace + "_dimguard"
+	_ = setup.Store.DeleteNamespace(setup.ctx, namespace)
+	t.Cleanup(func() { _ = setup.Store.DeleteNamespace(setup.ctx, namespace) })
+
+	require.NoError(t, setup.Store.CreateNamespace(setup.ctx, namespace, RedisTestDimension, nil))
+
+	// Recreating at the same dimension stays idempotent.
+	require.NoError(t, setup.Store.CreateNamespace(setup.ctx, namespace, RedisTestDimension, nil))
+
+	err := setup.Store.CreateNamespace(setup.ctx, namespace, RedisTestDimension/2, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists with dimension")
+}
+
 func TestRedisStore_ParseSearchResults_ByteScore(t *testing.T) {
 	store := &RedisStore{}
 	// Simulates Valkey RESP2 returning score as []byte

--- a/framework/vectorstore/weaviate.go
+++ b/framework/vectorstore/weaviate.go
@@ -2,13 +2,16 @@ package vectorstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/auth"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/fault"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/filters"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
 	"github.com/weaviate/weaviate-go-client/v5/weaviate/grpc"
@@ -96,10 +99,13 @@ func (s *WeaviateStore) GetChunk(ctx context.Context, className string, id strin
 		WithID(id).
 		Do(ctx)
 	if err != nil {
+		if isWeaviateNotFound(err) {
+			return SearchResult{}, fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
 		return SearchResult{}, err
 	}
 	if len(obj) == 0 {
-		return SearchResult{}, fmt.Errorf("not found: %s", id)
+		return SearchResult{}, fmt.Errorf("%w: %s", ErrNotFound, id)
 	}
 
 	props, ok := obj[0].Properties.(map[string]interface{})
@@ -114,6 +120,14 @@ func (s *WeaviateStore) GetChunk(ctx context.Context, className string, id strin
 	}, nil
 }
 
+// isWeaviateNotFound reports whether err is the client's 404 for an object that
+// does not exist. The client returns this as a normal error, so callers that
+// treat "absent" differently from "failed" must unwrap it themselves.
+func isWeaviateNotFound(err error) bool {
+	var clientErr *fault.WeaviateClientError
+	return errors.As(err, &clientErr) && clientErr.StatusCode == http.StatusNotFound
+}
+
 // GetChunks returns multiple objects by ID
 func (s *WeaviateStore) GetChunks(ctx context.Context, className string, ids []string) ([]SearchResult, error) {
 	out := make([]SearchResult, 0, len(ids))
@@ -123,6 +137,13 @@ func (s *WeaviateStore) GetChunks(ctx context.Context, className string, ids []s
 			WithID(id).
 			Do(ctx)
 		if err != nil {
+			// A missing object is an absent result, not a failure: Weaviate
+			// answers 404 where Qdrant, Pinecone, and Redis simply return
+			// nothing for the id. Surfacing it as an error breaks callers that
+			// probe for an id before writing it.
+			if isWeaviateNotFound(err) {
+				continue
+			}
 			return nil, err
 		}
 		if len(obj) > 0 {


### PR DESCRIPTION
## Summary

The Redis vector store's dimension-mismatch guard was silently never running. The typed `FTInfo` helper used to read the existing index's declared dimension refuses to decode when the client speaks RESP3 without `UnstableResp3`, which is exactly how this store is configured. As a result, creating a namespace with a mismatched dimension would silently reuse the old index instead of returning an error. The fix reads the dimension directly from the raw `FT.INFO` reply, handling both the RESP3 map shape and the RESP2 flat key/value sequence shape.

Additionally, the Weaviate `GetChunk` implementation was returning a raw client error on 404 rather than the sentinel `ErrNotFound` that callers expect, and `GetChunks` was propagating a 404 as a hard failure even though other backends (Qdrant, Pinecone, Redis) simply omit missing IDs from the result set.

## Changes

- Replaced the `FTInfo` typed helper call in `CreateNamespace` with `vectorDimensionFromFTInfo`, which parses the raw `FT.INFO` reply directly and handles both RESP2 and RESP3 wire shapes.
- Added `vectorDimensionFromFTInfo` and `ftInfoField` helpers that walk the raw reply across both protocol shapes to extract the declared vector dimension.
- Added `isWeaviateNotFound` helper that unwraps a `*fault.WeaviateClientError` and checks for HTTP 404.
- `GetChunk` now wraps both the 404 client error and the empty-result case as `fmt.Errorf("%w: %s", ErrNotFound, id)`, making the sentinel checkable via `errors.Is`.
- `GetChunks` now skips missing IDs (404) instead of returning an error, aligning its behaviour with other vector store implementations.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/vectorstore/...
```

- Verify `TestVectorDimensionFromFTInfo` passes across all RESP2 and RESP3 reply shapes.
- Verify `TestRedisStore_CreateNamespaceRejectsDimensionChange` fails when recreating an existing index with a different dimension and succeeds when the dimension matches.
- Call `GetChunk` with a non-existent ID and verify the returned error satisfies `errors.Is(err, ErrNotFound)`.
- Call `GetChunks` with a mix of valid and non-existent IDs and verify only the existing objects are returned without an error.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable