### PR TITLE
server: export ObserveWarmupRoutingEmbedding for enterprise

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1985,7 +1985,7 @@ func (s *BifrostHTTPServer) ReloadPlugin(ctx context.Context, name string, path 
 		governanceEmbeddingPlugin.SetEmbeddingRequestExecutor(s.Client.EmbeddingRequest)
 	}
 	if governanceWarmupObserverPlugin, ok := plugin.(governance.WarmupEmbedUsageObserverSetter); ok {
-		governanceWarmupObserverPlugin.SetWarmupEmbedUsageObserver(s.observeWarmupRoutingEmbedding)
+		governanceWarmupObserverPlugin.SetWarmupEmbedUsageObserver(s.ObserveWarmupRoutingEmbedding)
 	}
 	return s.SyncLoadedPlugin(ctx, name, plugin, placement, order)
 }
@@ -2246,12 +2246,18 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	return nil
 }
 
-// observeWarmupRoutingEmbedding forwards semantic-routing warmup embedding
+// ObserveWarmupRoutingEmbedding forwards semantic-routing warmup embedding
 // usage from the governance plugin to the telemetry plugin's routing overhead
 // counters. The telemetry plugin is resolved per call (warmup is rare — boot
 // and config changes only) so a reloaded telemetry instance, with its fresh
 // registry, is picked up without re-wiring governance.
-func (s *BifrostHTTPServer) observeWarmupRoutingEmbedding(provider, model string, inputTokens int) {
+//
+// Exported because embedders that reimplement Bootstrap rather than calling it
+// must repeat this wiring themselves, and an unexported method is unreachable
+// from their package even through the embedded server. Warmup embeds carry no
+// request or response, so an embedder that misses this observer loses the usage
+// entirely — it cannot be recovered from the RoutingDebug path.
+func (s *BifrostHTTPServer) ObserveWarmupRoutingEmbedding(provider, model string, inputTokens int) {
 	plugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
 	if err != nil || plugin == nil {
 		return
@@ -2625,7 +2631,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// RoutingDebug stamp path that per-request classification embeds use.
 	governanceWarmupObserverPlugin, err := lib.FindPluginAs[governance.WarmupEmbedUsageObserverSetter](s.Config, s.getGovernancePluginName())
 	if err == nil && governanceWarmupObserverPlugin != nil {
-		governanceWarmupObserverPlugin.SetWarmupEmbedUsageObserver(s.observeWarmupRoutingEmbedding)
+		governanceWarmupObserverPlugin.SetWarmupEmbedUsageObserver(s.ObserveWarmupRoutingEmbedding)
 	}
 
 	// Initialize Sidekiq runner for background jobs


### PR DESCRIPTION
## Summary

`observeWarmupRoutingEmbedding` was unexported, making it unreachable from embedder packages that reimplement `Bootstrap` rather than delegating to it. Those embedders could not wire the warmup embedding usage observer, causing warmup embed token usage to be silently dropped with no recovery path.

## Changes

- Exported `observeWarmupRoutingEmbedding` → `ObserveWarmupRoutingEmbedding` so embedders in external packages can reference it directly through the embedded server when setting up their own `Bootstrap` logic.
- Updated both call sites (`Bootstrap` and `ReloadPlugin`) to reference the exported name.
- Expanded the method comment to explain why it is exported and the consequence of missing this wiring.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that an embedder package that embeds `BifrostHTTPServer` and calls `SetWarmupEmbedUsageObserver` with `s.ObserveWarmupRoutingEmbedding` compiles successfully, and that warmup embedding token usage is recorded in Prometheus routing overhead counters after a governance plugin reload or server bootstrap.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This is a visibility change on an internal telemetry observer; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable