### PR TITLE
docs: add `reauth` endpoint for MCP client OAuth re-authentication

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -43745,6 +43745,68 @@
         }
       }
     },
+    "/api/mcp/client/{id}/reauth": {
+      "post": {
+        "operationId": "reauthMCPClient",
+        "summary": "Re-authenticate MCP client",
+        "description": "Opens a fresh OAuth consent flow for an existing MCP client whose stored token\nhas expired or been revoked upstream. Reconnect re-dials with the same dead\ncredentials, so re-authentication is the only way to recover without editing\nthe client.\n\nThe client's existing OAuth configuration (client credentials, endpoints,\nscopes, resource) is reused, so nothing has to be resupplied — including a\nclient_id that originally came from dynamic client registration (RFC 7591).\n\nThe client keeps running on its current credentials until the flow completes:\nfollow `authorize_url` to the provider, poll `/api/oauth/config/{oauth_config_id}/status`,\nthen POST `/api/mcp/client/{oauth_config_id}/complete-oauth` to swap in the new\ntoken and reconnect. The superseded OAuth config and token are revoked at that\npoint.\n\nOnly clients with `auth_type: oauth` are supported. Per-user OAuth tokens belong\nto individual users and are re-authorized via `/api/mcp/sessions/{id}/reauth`.\n",
+        "tags": [
+          "MCP",
+          "OAuth"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "MCP client ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth re-authorization flow initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthFlowInitiation"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Client is not OAuth-authenticated, is disabled, or has no OAuth configuration.\n"
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp/client/{id}/complete-oauth": {
       "post": {
         "operationId": "completeMCPClientOAuth",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -793,6 +793,8 @@ paths:
     $ref: './paths/management/mcp.yaml#/client-by-id'
   /api/mcp/client/{id}/reconnect:
     $ref: './paths/management/mcp.yaml#/client-reconnect'
+  /api/mcp/client/{id}/reauth:
+    $ref: './paths/management/mcp.yaml#/client-reauth'
   /api/mcp/client/{id}/complete-oauth:
     $ref: './paths/management/mcp.yaml#/client-complete-oauth'
 

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -285,6 +285,55 @@ client-reconnect:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
+client-reauth:
+  post:
+    operationId: reauthMCPClient
+    summary: Re-authenticate MCP client
+    description: |
+      Opens a fresh OAuth consent flow for an existing MCP client whose stored token
+      has expired or been revoked upstream. Reconnect re-dials with the same dead
+      credentials, so re-authentication is the only way to recover without editing
+      the client.
+
+      The client's existing OAuth configuration (client credentials, endpoints,
+      scopes, resource) is reused, so nothing has to be resupplied — including a
+      client_id that originally came from dynamic client registration (RFC 7591).
+
+      The client keeps running on its current credentials until the flow completes:
+      follow `authorize_url` to the provider, poll `/api/oauth/config/{oauth_config_id}/status`,
+      then POST `/api/mcp/client/{oauth_config_id}/complete-oauth` to swap in the new
+      token and reconnect. The superseded OAuth config and token are revoked at that
+      point.
+
+      Only clients with `auth_type: oauth` are supported. Per-user OAuth tokens belong
+      to individual users and are re-authorized via `/api/mcp/sessions/{id}/reauth`.
+    tags:
+      - MCP
+      - OAuth
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: MCP client ID
+        schema:
+          type: string
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: OAuth re-authorization flow initiated
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
+      '400':
+        description: |
+          Client is not OAuth-authenticated, is disabled, or has no OAuth configuration.
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
 client-complete-oauth:
   post:
     operationId: completeMCPClientOAuth


### PR DESCRIPTION
## Summary

Adds a new `POST /api/mcp/client/{id}/reauth` endpoint that initiates a fresh OAuth consent flow for an existing MCP client whose stored token has expired or been revoked upstream. Unlike reconnect, which re-dials using the same (potentially dead) credentials, re-authentication starts a new OAuth flow while keeping the client operational on its current credentials until the new token is obtained.

## Changes

- Added the `reauthMCPClient` operation to both `openapi.json` and `openapi.yaml`, routed at `/api/mcp/client/{id}/reauth`
- Defined the `client-reauth` path in `docs/openapi/paths/management/mcp.yaml` with full request/response documentation
- The endpoint reuses the client's existing OAuth configuration (credentials, endpoints, scopes, resource, and any dynamically registered `client_id` per RFC 7591), so nothing needs to be resupplied
- The flow follows the same pattern as initial OAuth setup: follow `authorize_url`, poll `/api/oauth/config/{oauth_config_id}/status`, then POST to `/api/mcp/client/{oauth_config_id}/complete-oauth` to swap in the new token and reconnect; the superseded OAuth config and token are revoked at that point
- Only clients with `auth_type: oauth` are supported; per-user OAuth tokens are handled via `/api/mcp/sessions/{id}/reauth`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Create an MCP client with `auth_type: oauth` and complete the initial OAuth flow.
2. Revoke or expire the stored token upstream.
3. Call `POST /api/mcp/client/{id}/reauth` with a valid `ManagementBearerAuth` token.
4. Expect a `200` response containing an `OAuthFlowInitiation` payload with an `authorize_url`.
5. Complete the OAuth flow via the returned URL, poll the status endpoint, then POST to `complete-oauth`.
6. Verify the client reconnects successfully using the new token and the old OAuth config is revoked.
7. Verify that calling the endpoint on a non-OAuth client returns `400`, and on a nonexistent client returns `404`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The endpoint is protected by `ManagementBearerAuth`. The existing OAuth credentials (including dynamically registered client IDs) are reused server-side and never re-exposed to the caller. The superseded token and OAuth config are explicitly revoked upon completion of the new flow, preventing credential accumulation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable