### PR TITLE
feat: make log recalculation task cancellable

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -20,7 +20,7 @@ import {
 	useGetUserAgentMappingsQuery,
 } from "@/lib/store";
 import { useLazyGetLogByIdQuery, useLazyGetLogsQuery } from "@/lib/store/apis/logsApi";
-import type { LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
+import type { DisplayLogEntry, LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -30,6 +30,10 @@ import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } fro
 import { parseAsSafeArrayOf, parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// A fallback chain is a handful of attempts, so one page covers every realistic
+// chain. Capped at the list endpoint's own maximum.
+const chainChildrenPageLimit = 1000;
 
 export default function LogsPage() {
 	const [error, setError] = useState<string | null>(null);
@@ -103,6 +107,7 @@ export default function LogsPage() {
 			cache_hit_types: parseAsSafeArrayOf.withDefault([]),
 			metadata_filters: parseAsString.withDefault(""),
 			selected_log: parseAsString.withDefault(""),
+			grouped: parseAsBoolean.withDefault(false),
 		},
 		{
 			history: "push",
@@ -114,6 +119,9 @@ export default function LogsPage() {
 	const selectedLogId = urlState.selected_log || null;
 	const activeLogFetchId = useRef<string | null>(null);
 	const polling = urlState.polling;
+	// Grouped view collapses fallback chains under their root. Disabled while a
+	// session filter is active — that view is already scoped to one chain/session.
+	const grouped = urlState.grouped && !urlState.parent_request_id;
 
 	// Convert URL state to filters and pagination for API calls
 	const filters: LogFilters = useMemo(
@@ -302,6 +310,7 @@ export default function LogsPage() {
 		{
 			filters,
 			pagination,
+			rootsOnly: grouped,
 		},
 		{
 			pollingInterval: showEmptyState || polling ? 10000 : 0,
@@ -359,6 +368,66 @@ export default function LogsPage() {
 			});
 		},
 		[filters, setFilters],
+	);
+
+	// --- Grouped view: chain expansion state -------------------------------
+	// Children of an expanded root, keyed by root log id. Loaded lazily through
+	// the list endpoint with the active filters plus parent_request_id, not the
+	// sessions endpoint — the sessions endpoint ignores filters, which would show
+	// rows the filter bar says are excluded. Filtering here keeps the expansion
+	// consistent with child_count, which the server computes under the same
+	// filters: every row is either a root or a child, and always matches.
+	const [expandedChainIds, setExpandedChainIds] = useState<Set<string>>(new Set());
+	const [chainChildren, setChainChildren] = useState<Record<string, LogEntry[]>>({});
+	const [loadingChainIds, setLoadingChainIds] = useState<Set<string>>(new Set());
+	const [triggerGetChainChildren] = useLazyGetLogsQuery();
+
+	// Collapse everything when the page of roots changes — expanded ids from the
+	// previous page are meaningless and cached children may be stale.
+	useEffect(() => {
+		setExpandedChainIds(new Set());
+		setChainChildren({});
+		setLoadingChainIds(new Set());
+	}, [filters, pagination, grouped]);
+
+	const handleToggleChain = useCallback(
+		(log: LogEntry) => {
+			const isExpanded = expandedChainIds.has(log.id);
+			setExpandedChainIds((prev) => {
+				const next = new Set(prev);
+				if (next.has(log.id)) {
+					next.delete(log.id);
+				} else {
+					next.add(log.id);
+				}
+				return next;
+			});
+			if (isExpanded || chainChildren[log.id] || loadingChainIds.has(log.id)) return;
+
+			setLoadingChainIds((prev) => new Set(prev).add(log.id));
+			triggerGetChainChildren({
+				filters: { ...filters, parent_request_id: log.id },
+				pagination: { ...pagination, limit: chainChildrenPageLimit, offset: 0, sort_by: "timestamp", order: "asc" },
+			}).then((result) => {
+				setLoadingChainIds((prev) => {
+					const next = new Set(prev);
+					next.delete(log.id);
+					return next;
+				});
+				if (result.data) {
+					const children = result.data.logs;
+					setChainChildren((prevCache) => ({ ...prevCache, [log.id]: children }));
+				} else if (result.error) {
+					setExpandedChainIds((prev) => {
+						const next = new Set(prev);
+						next.delete(log.id);
+						return next;
+					});
+					setError(getErrorMessage(result.error));
+				}
+			});
+		},
+		[expandedChainIds, chainChildren, loadingChainIds, triggerGetChainChildren, filters, pagination],
 	);
 
 	const handleDelete = useCallback(
@@ -500,8 +569,8 @@ export default function LogsPage() {
 	}, [userAgentMappingsData?.mappings]);
 
 	const columns = useMemo(
-		() => createColumns(handleDelete, hasDeleteAccess, metadataKeys, customAppIcons),
-		[customAppIcons, handleDelete, hasDeleteAccess, metadataKeys],
+		() => createColumns(handleDelete, hasDeleteAccess, metadataKeys, customAppIcons, grouped),
+		[customAppIcons, handleDelete, hasDeleteAccess, metadataKeys, grouped],
 	);
 
 	const columnIds = useMemo(
@@ -546,12 +615,36 @@ export default function LogsPage() {
 		paramName: "cols",
 		storageKey: "bifrost.logs.cols",
 		defaultHidden: DEFAULT_HIDDEN_COLUMNS,
-		fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
+		fixedColumns: {
+			...(grouped ? { left: ["expand"] } : {}),
+			...(hasDeleteAccess ? { right: ["actions"] } : {}),
+		},
 	});
 
 	// Navigation for log detail sheet
 	const logs = logsData?.logs ?? [];
 	const totalItems = logsData?.stats?.total_requests ?? 0;
+
+	// Grouped view: splice loaded children in below their expanded root. Children
+	// are marked so the table can indent them; they don't affect pagination.
+	const displayLogs: DisplayLogEntry[] = useMemo(() => {
+		if (!grouped || expandedChainIds.size === 0) return logs;
+		const out: DisplayLogEntry[] = [];
+		for (const log of logs) {
+			out.push(log);
+			if (expandedChainIds.has(log.id)) {
+				for (const child of chainChildren[log.id] ?? []) {
+					out.push({ ...child, __chainChild: true });
+				}
+			}
+		}
+		return out;
+	}, [logs, grouped, expandedChainIds, chainChildren]);
+
+	const tableMeta = useMemo(
+		() => ({ expandedChainIds, loadingChainIds, onToggleChain: handleToggleChain }),
+		[expandedChainIds, loadingChainIds, handleToggleChain],
+	);
 	const selectedLogFromData = useMemo(
 		() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null),
 		[selectedLogId, logs],
@@ -595,6 +688,7 @@ export default function LogsPage() {
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
+						rootsOnly: grouped,
 					}).then((result) => {
 						if (result.data?.logs?.length) {
 							const lastLog = result.data.logs[result.data.logs.length - 1];
@@ -620,6 +714,7 @@ export default function LogsPage() {
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
+						rootsOnly: grouped,
 					}).then((result) => {
 						if (result.data?.logs?.length) {
 							const firstLog = result.data.logs[0];
@@ -635,7 +730,7 @@ export default function LogsPage() {
 				}
 			}
 		},
-		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
+		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, grouped, setUrlState, triggerGetLogs],
 	);
 
 	return (
@@ -665,6 +760,8 @@ export default function LogsPage() {
 								loading={logsIsFetching}
 								polling={polling}
 								onPollToggle={handlePollToggle}
+								grouped={grouped}
+								onGroupedToggle={(enabled) => setUrlState({ grouped: enabled, offset: 0 })}
 								period={period}
 								onPeriodChange={handlePeriodChange}
 								totalLogs={totalItems}
@@ -736,7 +833,8 @@ export default function LogsPage() {
 						<div className="min-h-0 flex-1">
 							<LogsDataTable
 								columns={columns}
-								data={logs}
+								data={displayLogs}
+								tableMeta={tableMeta}
 								loading={logsIsFetching}
 								totalItems={totalItems}
 								pagination={pagination}

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -14,13 +14,21 @@ import {
 	Status,
 	StatusBarColors,
 } from "@/lib/constants/logs";
-import { ChatMessageContent, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
+import { ChatMessageContent, DisplayLogEntry, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { ColumnDef } from "@tanstack/react-table";
 import { format, formatDistanceToNow } from "date-fns";
-import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
+import { ArrowUpDown, ChevronRight, CornerDownRight, Loader2, MoreHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
+
+// Passed to useReactTable({ meta }) by the logs page so the expander column can
+// read/toggle chain expansion without threading props through column factories.
+export interface LogsTableMeta {
+	expandedChainIds: Set<string>;
+	loadingChainIds: Set<string>;
+	onToggleChain: (log: LogEntry) => void;
+}
 
 function LogActionsMenu({ log, onDelete }: { log: LogEntry; onDelete: (log: LogEntry) => void }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -261,7 +269,51 @@ export const createColumns = (
 	hasDeleteAccess = true,
 	metadataKeys: string[] = [],
 	customAppIcons: Record<string, string> = {},
+	groupedView = false,
 ): ColumnDef<LogEntry>[] => {
+	// Chevron that expands a fallback chain in the grouped view. Child rows get a
+	// corner connector instead so the hierarchy stays readable in any column order.
+	const expandColumn: ColumnDef<LogEntry>[] = groupedView
+		? [
+			{
+				id: "expand",
+				header: "",
+				size: 52,
+				cell: ({ row, table }) => {
+					const meta = table.options.meta as LogsTableMeta | undefined;
+					const log = row.original as DisplayLogEntry;
+					if (log.__chainChild) {
+						return <CornerDownRight className="text-muted-foreground/70 mx-auto size-3.5" />;
+					}
+					const childCount = log.child_count ?? 0;
+					if (!childCount || !meta) return null;
+					const isExpanded = meta.expandedChainIds.has(log.id);
+					const isLoading = meta.loadingChainIds.has(log.id);
+					return (
+						<button
+							type="button"
+							data-testid="log-chain-expand-btn"
+							aria-label={isExpanded ? "Collapse fallback chain" : `Expand fallback chain (${childCount} attempts)`}
+							aria-expanded={isExpanded}
+							className="text-muted-foreground hover:text-foreground gap-1 rounded-sm transition-colors absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer"
+							onClick={(event) => {
+								event.stopPropagation();
+								meta.onToggleChain(log);
+							}}
+						>
+							{isLoading ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : (
+								<ChevronRight className={cn("size-3.5 transition-transform", isExpanded && "rotate-90")} />
+							)}
+							<span className="font-mono text-[10.5px] tabular-nums">{childCount}</span>
+						</button>
+					);
+				},
+			},
+		]
+		: [];
+
 	const baseColumns: ColumnDef<LogEntry>[] = [
 		{
 			accessorKey: "status",
@@ -530,5 +582,5 @@ export const createColumns = (
 		]
 		: [];
 
-	return [...baseColumns, ...attributionColumns, ...metadataColumns, ...actionsColumn];
+	return [...expandColumn, ...baseColumns, ...attributionColumns, ...metadataColumns, ...actionsColumn];
 };

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -4,6 +4,7 @@ import { Command, CommandItem, CommandList } from "@/components/ui/command";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage } from "@/lib/store";
 import { useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
@@ -11,7 +12,7 @@ import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
-import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
+import { Calculator, ListTree, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { RecalculateCostDialog, type RecalculateCostMode } from "./recalculateCostDialog";
@@ -25,6 +26,9 @@ interface LogsHeaderViewProps {
 	loading?: boolean;
 	polling: boolean;
 	onPollToggle: (enabled: boolean) => void;
+	/** Grouped view: collapse fallback chains into their root request */
+	grouped: boolean;
+	onGroupedToggle: (enabled: boolean) => void;
 	period: string;
 	onPeriodChange: (period?: string, from?: Date, to?: Date) => void;
 	/** Total logs matching the current filters/time window (stats.total_requests) */
@@ -45,6 +49,8 @@ export function LogsHeaderView({
 	loading = false,
 	polling,
 	onPollToggle,
+	grouped,
+	onGroupedToggle,
 	period,
 	onPeriodChange,
 	totalLogs,
@@ -216,6 +222,25 @@ export function LogsHeaderView({
 				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
 				Live
 			</Button>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						data-testid="logs-group-chains-btn"
+						variant={grouped ? "default" : "outline"}
+						size="sm"
+						className="h-7.5"
+						onClick={() => onGroupedToggle(!grouped)}
+					>
+						<ListTree className="h-4 w-4" />
+						Group
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent sideOffset={6} className="max-w-64">
+					Groups fallback attempts and linked requests under the original root request. Expand any row to view the complete request chain.
+					<br /><br />
+					This grouped view may load more slowly than the flat view for very large log tables.
+				</TooltipContent>
+			</Tooltip>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
 				<Input

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -7,7 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage } from "@/lib/store";
-import { useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
+import { useCancelRecalculateCostJobMutation, useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
 import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
 import { getApiBaseUrl } from "@/lib/utils/port";
@@ -16,6 +16,15 @@ import { Calculator, ListTree, MoreVertical, Radio, RefreshCw, Search } from "lu
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { RecalculateCostDialog, type RecalculateCostMode } from "./recalculateCostDialog";
+
+// One id for the whole recalculation lifecycle, so the start / progress / cancelling
+// / result updates all land on the same toast instead of stacking.
+const RECALC_TOAST_ID = "logs-recalculate-costs";
+
+// Statuses a recalculation job never leaves. Polling stops at any of them.
+function isTerminalRecalcStatus(status: RecalcJobStatus["status"]): boolean {
+	return status === "completed" || status === "failed" || status === "cancelled";
+}
 
 interface LogsHeaderViewProps {
 	filters: LogFiltersType;
@@ -75,6 +84,11 @@ export function LogsHeaderView({
 			skip: !activeRecalcJobId,
 		},
 	);
+	const [cancelRecalcJob] = useCancelRecalculateCostJobMutation();
+	// True from the moment Cancel is clicked until the job settles. It swaps the
+	// progress toast for a "cancelling" one so the button can't be clicked twice while
+	// the worker finishes the batch it is in the middle of.
+	const [recalcCancelRequested, setRecalcCancelRequested] = useState(false);
 	const isRecalcRunning = !!activeRecalcJobId;
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -108,8 +122,7 @@ export function LogsHeaderView({
 		async (mode: RecalculateCostMode) => {
 			setRecalcDialogOpen(false);
 			const missingCostOnly = mode === "missing";
-			const toastId = "logs-recalculate-costs";
-			toast.loading("Starting cost recalculation...", { id: toastId });
+			toast.loading("Starting cost recalculation...", { id: RECALC_TOAST_ID });
 
 			try {
 				// Recalculation runs as a background job. Enqueue it (or attach to the one
@@ -119,32 +132,62 @@ export function LogsHeaderView({
 					throw new Error("Recalculation job did not start");
 				}
 				if (alreadyRunning) {
-					toast.loading("A cost recalculation is already running...", { id: toastId });
+					toast.loading("A cost recalculation is already running...", { id: RECALC_TOAST_ID });
 				}
+				setRecalcCancelRequested(false);
 				setActiveRecalcJobId(status.id);
 			} catch (err) {
-				toast.error("Cost recalculation failed", { id: toastId, description: getErrorMessage(err) });
+				toast.error("Cost recalculation failed", { id: RECALC_TOAST_ID, description: getErrorMessage(err) });
 			}
 		},
 		[filters],
 	);
+
+	// Stop the tracked job. The worker finishes the batch it is in the middle of and
+	// then settles as "cancelled", which the status effect below reports — so this only
+	// sends the request and switches the toast to its cancelling state; it never clears
+	// the tracked job itself. If the request fails the job keeps running and the next
+	// poll restores the progress toast.
+	const handleCancelRecalculate = useCallback(async () => {
+		const jobId = activeRecalcJobIdRef.current;
+		if (!jobId) return;
+		setRecalcCancelRequested(true);
+		toast.loading("Cancelling cost recalculation…", {
+			id: RECALC_TOAST_ID,
+			description: "Finishing the current batch. Costs already recalculated are kept.",
+		});
+		try {
+			await cancelRecalcJob({ id: jobId }).unwrap();
+		} catch (err) {
+			setRecalcCancelRequested(false);
+			// Same id as the rest of the lifecycle: this replaces the "Cancelling…"
+			// toast rather than stacking a second one on top of it. The next poll
+			// (2s) then restores the progress toast with its Cancel action, which
+			// is the truthful end state — the job is still running.
+			toast.error("Couldn't cancel the recalculation", {
+				id: RECALC_TOAST_ID,
+				description: getErrorMessage(err),
+			});
+		}
+	}, [cancelRecalcJob]);
 
 	// If the status endpoint keeps failing, stop polling and surface the error so the
 	// user isn't left with a loading toast that never resolves.
 	useEffect(() => {
 		if (!activeRecalcJobId || !recalcJobStatusError) return;
 		toast.error("Cost recalculation failed", {
-			id: "logs-recalculate-costs",
+			id: RECALC_TOAST_ID,
 			description: "Lost track of the recalculation job status. Please refresh and try again.",
 		});
 		setActiveRecalcJobId(null);
+		setRecalcCancelRequested(false);
 	}, [activeRecalcJobId, recalcJobStatusError]);
 
 	// If we unmount while a job is still being tracked, polling stops but the global
 	// loading toast would otherwise linger — dismiss it on the way out.
 	useEffect(() => {
 		return () => {
-			if (activeRecalcJobIdRef.current) toast.dismiss("logs-recalculate-costs");
+			if (activeRecalcJobIdRef.current) toast.dismiss(RECALC_TOAST_ID);
 		};
 	}, []);
 
@@ -152,37 +195,60 @@ export function LogsHeaderView({
 	// and on a terminal status show the result, refresh the view, and stop polling.
 	useEffect(() => {
 		if (!activeRecalcJobId || !recalcJobStatus) return;
-		const toastId = "logs-recalculate-costs";
 
-		if (recalcJobStatus.status === "completed" || recalcJobStatus.status === "failed") {
+		if (isTerminalRecalcStatus(recalcJobStatus.status)) {
 			if (recalcJobStatus.status === "failed") {
 				toast.error("Cost recalculation failed", {
-					id: toastId,
+					id: RECALC_TOAST_ID,
 					description: recalcJobStatus.last_error || recalcJobStatus.message || "The job did not complete",
+				});
+			} else if (recalcJobStatus.status === "cancelled") {
+				// Not an error: whatever the job committed before stopping is valid, so
+				// report the partial result rather than framing it as a failure.
+				toast.info("Cost recalculation cancelled", {
+					id: RECALC_TOAST_ID,
+					description: recalcJobStatus.message || `Stopped after ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
+					duration: 5000,
 				});
 			} else {
 				toast.success("Cost recalculation complete", {
-					id: toastId,
+					id: RECALC_TOAST_ID,
 					description: recalcJobStatus.message || `${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
 					duration: 5000,
 				});
 			}
 			setActiveRecalcJobId(null);
+			setRecalcCancelRequested(false);
+			// A cancelled job still wrote costs for the rows it got through, so refresh
+			// on every terminal status, not just completion.
 			void fetchLogs();
 			void fetchStats();
 			return;
 		}
 
+		// A cancel is in flight: keep the "cancelling" toast (and its lack of a Cancel
+		// button) in place rather than overwriting it with a progress update.
+		if (recalcCancelRequested) return;
+
 		const total = recalcJobStatus.total || 0;
 		const processed = total > 0 ? Math.min(recalcJobStatus.processed, total) : recalcJobStatus.processed;
 		toast.loading("Recalculating log costs...", {
-			id: toastId,
+			id: RECALC_TOAST_ID,
 			description:
 				total > 0
 					? `${processed}/${total} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`
 					: `${recalcJobStatus.processed} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
+			action: {
+				label: "Cancel",
+				// preventDefault keeps the toast mounted so it can report the cancellation;
+				// sonner otherwise dismisses a toast as soon as its action fires.
+				onClick: (event) => {
+					event.preventDefault();
+					void handleCancelRecalculate();
+				},
+			},
 		});
-	}, [activeRecalcJobId, recalcJobStatus, fetchLogs, fetchStats]);
+	}, [activeRecalcJobId, recalcJobStatus, recalcCancelRequested, handleCancelRecalculate, fetchLogs, fetchStats]);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
@@ -283,12 +349,18 @@ export function LogsHeaderView({
 				<PopoverContent className="bg-accent w-[250px] p-2" align="end">
 					<Command>
 						<CommandList>
+							{/* While a job runs this doubles as the cancel control, so the run can
+							    still be stopped if the progress toast was dismissed. */}
 							<CommandItem
 								className="hover:bg-accent/50 cursor-pointer"
-								disabled={isRecalcRunning}
+								disabled={recalcCancelRequested}
 								onSelect={() => {
-									if (isRecalcRunning) return;
+									if (recalcCancelRequested) return;
 									setOpenMoreActionsPopover(false);
+									if (isRecalcRunning) {
+										void handleCancelRecalculate();
+										return;
+									}
 									setRecalcDialogOpen(true);
 								}}
 							>
@@ -298,9 +370,15 @@ export function LogsHeaderView({
 									<Calculator className="text-muted-foreground size-4" />
 								)}
 								<div className="flex flex-col">
-									<span className="text-sm">{isRecalcRunning ? "Recalculating costs…" : "Recalculate costs"}</span>
+									<span className="text-sm">
+										{recalcCancelRequested ? "Cancelling…" : isRecalcRunning ? "Cancel recalculation" : "Recalculate costs"}
+									</span>
 									<span className="text-muted-foreground text-xs">
-										{isRecalcRunning ? "A recalculation is already running" : "Recompute cost for logs in this view"}
+										{recalcCancelRequested
+											? "Finishing the current batch"
+											: isRecalcRunning
+												? "Stop the running recalculation; costs already updated are kept"
+												: "Recompute cost for logs in this view"}
 									</span>
 								</div>
 							</CommandItem>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -11,9 +11,9 @@ import { Button } from "@/components/ui/button";
 import { ComboboxSelect, type ComboboxSelectOption } from "@/components/ui/combobox";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { DEFAULT_PAGE_SIZE_OPTIONS, useTablePageSizePreference } from "@/lib/hooks/useTablePageSizePreference";
-import type { LogEntry, Pagination } from "@/lib/types/logs";
+import type { DisplayLogEntry, LogEntry, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import type { ColumnOrderState, ColumnPinningState, VisibilityState } from "@tanstack/react-table";
+import type { ColumnOrderState, ColumnPinningState, TableMeta, VisibilityState } from "@tanstack/react-table";
 import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,6 +36,8 @@ interface DataTableProps {
 	onToggleColumnVisibility: (id: string) => void;
 	onTogglePin: (id: string, side: "left" | "right") => void;
 	onReorderColumns: (entries: ColumnConfigEntry[]) => void;
+	/** Table meta consumed by the expand column in grouped view */
+	tableMeta?: TableMeta<LogEntry>;
 }
 
 export function LogsDataTable({
@@ -55,11 +57,12 @@ export function LogsDataTable({
 	onToggleColumnVisibility,
 	onTogglePin,
 	onReorderColumns,
+	tableMeta,
 }: DataTableProps) {
 	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
 	const [pageSizePref, setPageSizePref, pageSizeHydrated] = useTablePageSizePreference("bifrost.logs.pageSize");
 
-	const fixedColumnIds = useMemo(() => new Set<string>(["actions"]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>(["expand", "actions"]), []);
 
 	// Measure actual header cell widths for pixel-perfect pin offsets
 	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
@@ -147,6 +150,7 @@ export function LogsDataTable({
 			columnPinning,
 		},
 		onSortingChange: handleSortingChange,
+		meta: tableMeta,
 	});
 
 	const hasItems = totalItems > 0;
@@ -224,7 +228,14 @@ export function LogsDataTable({
 						</TableRow>
 						{table.getRowModel().rows.length ? (
 							table.getRowModel().rows.map((row) => (
-								<TableRow key={row.id} className="hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer">
+								<TableRow
+									key={row.id}
+									className={cn(
+										"hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer",
+										(row.original as DisplayLogEntry).__chainChild &&
+										"bg-muted/30 border-l-2 border-l-zinc-300 dark:border-l-zinc-600",
+									)}
+								>
 									{row.getVisibleCells().map((cell) => {
 										const pinned = cell.column.getIsPinned();
 										const size = cell.column.getSize();

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -431,6 +431,21 @@ export const logsApi = baseApi.injectEndpoints({
 			}),
 		}),
 
+		// Stop a running cost recalculation. Costs already recomputed are kept; the job
+		// simply stops walking the window. Omit id to cancel whichever job is in flight.
+		// Resolves with the job's post-cancel status so the caller can settle its UI.
+		cancelRecalculateCostJob: builder.mutation<RecalcJobStatus, { id?: string } | void>({
+			query: (arg) => ({
+				url: "/logs/recalculate-cost/cancel",
+				method: "POST",
+				params: arg?.id ? { id: arg.id } : {},
+			}),
+			// A cancelled job still committed costs for every row it got through, so
+			// every Logs-tagged query (stats, histograms, filter data) is stale — same
+			// as for the start mutation above.
+			invalidatesTags: ["Logs"],
+		}),
+
 		// Get a single log entry by ID (includes raw_request and raw_response)
 		getLogById: builder.query<LogEntry, string>({
 			query: (id) => `/logs/${encodeURIComponent(id)}`,
@@ -477,6 +492,7 @@ export const {
 	useDeleteLogsMutation,
 	useRecalculateLogCostsMutation,
 	useGetRecalculateCostStatusQuery,
+	useCancelRecalculateCostJobMutation,
 	useLazyGetLogByIdQuery,
 	useGetLogByIdQuery,
 } = logsApi;

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -127,15 +127,18 @@ export const logsApi = baseApi.injectEndpoints({
 			{
 				filters: LogFilters;
 				pagination: Pagination;
+				/** Grouped view: hide fallback-child rows so each chain lists as its root */
+				rootsOnly?: boolean;
 			}
 		>({
-			query: ({ filters, pagination }) => ({
+			query: ({ filters, pagination, rootsOnly }) => ({
 				url: "/logs",
 				params: {
 					limit: pagination.limit,
 					offset: pagination.offset,
 					sort_by: pagination.sort_by,
 					order: pagination.order,
+					...(rootsOnly ? { roots_only: "true" } : {}),
 					...buildFilterParams(filters),
 				},
 			}),

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -882,10 +882,13 @@ export interface RecalculateCostProgress {
 }
 
 // RecalcJobStatus is the status of a background cost-recalculation job, returned by
-// POST /api/logs/recalculate-cost (202/409) and GET /api/logs/recalculate-cost/status.
+// POST /api/logs/recalculate-cost (202/409), POST /api/logs/recalculate-cost/cancel
+// and GET /api/logs/recalculate-cost/status.
 export interface RecalcJobStatus {
 	id?: string;
-	status: "idle" | "pending" | "running" | "completed" | "failed";
+	// "cancelled" is terminal like completed/failed: the job was stopped on request,
+	// and the counters describe the work it committed before stopping.
+	status: "idle" | "pending" | "running" | "completed" | "failed" | "cancelled";
 	total: number;
 	processed: number;
 	updated: number;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -620,7 +620,16 @@ export interface LogEntry {
 	redaction_mapping?: RedactionMapping; // Phase-scoped placeholder-to-original mappings, present only when caller has Logs:Reveal
 	user_agent?: string; // Raw HTTP User-Agent of the calling client
 	app?: string; // Backend-detected client app
+	// Aggregates over this log's fallback children (rows whose parent_request_id
+	// equals this log's id). Present only on roots_only list responses.
+	child_count?: number;
+	children_cost?: number;
+	children_tokens?: number;
 }
+
+// A log row as rendered by the logs table. __chainChild marks rows injected
+// below an expanded parent in the grouped view; it never comes from the API.
+export type DisplayLogEntry = LogEntry & { __chainChild?: boolean };
 
 export interface LogFilters {
 	providers?: string[];


### PR DESCRIPTION
## Summary

Adds the ability to cancel a running cost recalculation job from the logs header. Previously, once a recalculation was started it could not be stopped from the UI. This PR wires up a new `POST /logs/recalculate-cost/cancel` API endpoint, adds a `cancelled` terminal status to the job lifecycle, and updates the progress toast and "More actions" menu to expose a cancel control.

## Changes

- Added `cancelRecalculateCostJob` mutation to `logsApi` targeting `POST /logs/recalculate-cost/cancel`, which resolves with the job's post-cancel status.
- Added `"cancelled"` as a terminal `RecalcJobStatus` status alongside `completed` and `failed`, with counters reflecting work committed before stopping.
- Introduced `isTerminalRecalcStatus` helper and a shared `RECALC_TOAST_ID` constant to consolidate all recalculation lifecycle toast updates onto a single toast.
- Added `recalcCancelRequested` state to track the window between the cancel request being sent and the job settling, preventing duplicate cancel clicks and avoiding progress toast overwrites during that window.
- The in-progress toast now includes a **Cancel** action button; `event.preventDefault()` keeps the toast mounted so it can report the cancellation result rather than dismissing immediately.
- The "More actions" menu item transforms into a **Cancel recalculation** control while a job is running, providing a fallback cancel path if the toast was dismissed. It is disabled (not hidden) while cancellation is in flight.
- On a `cancelled` terminal status, an informational (non-error) toast reports the partial result, and logs/stats are refreshed since the job may have committed partial cost updates.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Logs view and open **More actions**.
2. Click **Recalculate costs** to start a recalculation over a large log window.
3. While the progress toast is visible, click the **Cancel** button on the toast. Verify:
   - The toast switches to "Cancelling cost recalculation…" with a description about finishing the current batch.
   - The "More actions" menu item shows "Cancelling…" and is disabled.
   - Once the job settles, an info toast appears reporting the partial result (rows updated/skipped before stopping).
   - The logs and stats views refresh.
4. Repeat and cancel via the **More actions** menu item instead of the toast button.
5. Dismiss the progress toast mid-run, then open **More actions** and verify **Cancel recalculation** is still available and functional.
6. Verify that a completed or failed job still reports correctly and is unaffected by this change.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No new auth surfaces. The cancel endpoint follows the same authentication pattern as the existing recalculate-cost endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable