### PR TITLE
feat: add `ShellRewriter` hook to UI handler for pre-hydration HTML rewriting

### DIFF
--- a/framework/configstore/sidekiq.go
+++ b/framework/configstore/sidekiq.go
@@ -220,6 +220,58 @@ func (s *RDBConfigStore) FailSidekiqJob(ctx context.Context, id, runnerID, metad
 	return nil
 }
 
+// CancelSidekiqJob flips a pending or running job to cancelled and stamps
+// completed_at. It is the durable half of a cancel request: the row immediately
+// stops looking in-flight, so it is never re-claimed by the dispatcher and never
+// reaped as stale, even if the node currently running it dies before noticing.
+//
+// It is deliberately NOT fenced on runner_id — a cancel arrives on whichever node
+// serves the HTTP request, which is often not the one that owns the job. The
+// owning node learns about it either from its in-process cancel func (same node)
+// or from its next heartbeat, which is fenced on status = running and so returns
+// "ownership lost" once the status has moved to cancelled.
+//
+// Returns true when this call was the one that cancelled the job; false means the
+// job did not exist or had already reached a terminal status, which callers treat
+// as a no-op rather than an error.
+func (s *RDBConfigStore) CancelSidekiqJob(ctx context.Context, id string) (bool, error) {
+	now := time.Now()
+	res := s.DB().WithContext(ctx).
+		Model(&tables.TableSidekiqJob{}).
+		Where("id = ? AND status IN ?", id, []string{tables.SidekiqStatusPending, tables.SidekiqStatusRunning}).
+		Updates(map[string]any{
+			"status":       tables.SidekiqStatusCancelled,
+			"updated_at":   now,
+			"completed_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}
+
+// FinalizeCancelledSidekiqJob stores the last metadata snapshot of a job that was
+// cancelled mid-run, so the partial progress counters (and the handler's summary
+// message) survive for the UI. It only touches the metadata: the status,
+// completed_at and last_error written by CancelSidekiqJob stand.
+//
+// Fenced on runner_id and status = cancelled so a stale runner cannot resurrect
+// counters onto a job that has since been re-claimed, and so a handler unwinding
+// for some other reason cannot mistakenly write here. A zero-row result is not an
+// error — the job may have been finalized already.
+func (s *RDBConfigStore) FinalizeCancelledSidekiqJob(ctx context.Context, id, runnerID, metadata string) error {
+	if metadata == "" {
+		return nil
+	}
+	return s.DB().WithContext(ctx).
+		Model(&tables.TableSidekiqJob{}).
+		Where("id = ? AND runner_id = ? AND status = ?", id, runnerID, tables.SidekiqStatusCancelled).
+		Updates(map[string]any{
+			"metadata":   metadata,
+			"updated_at": time.Now(),
+		}).Error
+}
+
 // ListClaimableSidekiqJobs returns jobs eligible to be picked up: those that are
 // pending (never started), or running but stale (heartbeat older than staleBefore,
 // i.e. their owner is presumed dead). Ordered oldest-first. The dispatcher scans

--- a/framework/configstore/sidekiq_test.go
+++ b/framework/configstore/sidekiq_test.go
@@ -258,6 +258,117 @@ func TestFailSidekiqJob(t *testing.T) {
 	require.NotNil(t, got.CompletedAt)
 }
 
+func TestCancelSidekiqJob(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	t.Run("pending job is cancelled before it ever runs", func(t *testing.T) {
+		require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "p1", Kind: "k"}))
+
+		cancelled, err := store.CancelSidekiqJob(ctx, "p1")
+		require.NoError(t, err)
+		assert.True(t, cancelled)
+
+		got := getJob(t, store, "p1")
+		assert.Equal(t, tables.SidekiqStatusCancelled, got.Status)
+		require.NotNil(t, got.CompletedAt)
+	})
+
+	t.Run("running job is cancelled regardless of owner", func(t *testing.T) {
+		require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "r1", Kind: "k"}))
+		_, err := store.ClaimSidekiqJob(ctx, "r1", "owner-A", time.Now().Add(-time.Minute))
+		require.NoError(t, err)
+
+		// The cancel arrives on a node that does not own the job — it must still apply.
+		cancelled, err := store.CancelSidekiqJob(ctx, "r1")
+		require.NoError(t, err)
+		assert.True(t, cancelled)
+		assert.Equal(t, tables.SidekiqStatusCancelled, getJob(t, store, "r1").Status)
+
+		// The owner learns of it through its heartbeat, which is fenced on running.
+		alive, err := store.HeartbeatSidekiqJob(ctx, "r1", "owner-A")
+		require.NoError(t, err)
+		assert.False(t, alive, "heartbeat must report lost ownership so the owner stops")
+	})
+
+	t.Run("cancelled job is neither claimable nor reapable", func(t *testing.T) {
+		require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "c1", Kind: "k"}))
+		_, err := store.ClaimSidekiqJob(ctx, "c1", "owner-A", time.Now().Add(-time.Minute))
+		require.NoError(t, err)
+		_, err = store.CancelSidekiqJob(ctx, "c1")
+		require.NoError(t, err)
+		setUpdatedAt(t, store, "c1", time.Now().Add(-30*time.Minute))
+
+		claimable, err := store.ListClaimableSidekiqJobs(ctx, time.Now().Add(-15*time.Minute))
+		require.NoError(t, err)
+		for _, j := range claimable {
+			assert.NotEqual(t, "c1", j.ID, "a cancelled job must not be re-claimed")
+		}
+
+		reaped, err := store.MarkStaleSidekiqJobsFailed(ctx, time.Now().Add(-15*time.Minute))
+		require.NoError(t, err)
+		assert.Zero(t, reaped, "a cancelled job must not be reaped as stale")
+		assert.Equal(t, tables.SidekiqStatusCancelled, getJob(t, store, "c1").Status)
+
+		inFlight, err := store.GetInFlightSidekiqJobByKind(ctx, "k")
+		require.NoError(t, err)
+		if inFlight != nil {
+			assert.NotEqual(t, "c1", inFlight.ID, "a cancelled job must not count as in-flight")
+		}
+	})
+
+	t.Run("terminal and unknown jobs are no-ops", func(t *testing.T) {
+		require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: "d1", Kind: "k"}))
+		_, err := store.ClaimSidekiqJob(ctx, "d1", "owner-A", time.Now().Add(-time.Minute))
+		require.NoError(t, err)
+		require.NoError(t, store.CompleteSidekiqJob(ctx, "d1", "owner-A", `{"done":true}`))
+
+		cancelled, err := store.CancelSidekiqJob(ctx, "d1")
+		require.NoError(t, err)
+		assert.False(t, cancelled, "completing wins a race against a cancel click")
+		assert.Equal(t, tables.SidekiqStatusCompleted, getJob(t, store, "d1").Status)
+
+		cancelled, err = store.CancelSidekiqJob(ctx, "does-not-exist")
+		require.NoError(t, err)
+		assert.False(t, cancelled)
+	})
+}
+
+func TestFinalizeCancelledSidekiqJob(t *testing.T) {
+	store := setupSidekiqTestStore(t)
+	ctx := context.Background()
+
+	newCancelledJob := func(t *testing.T, id string) {
+		t.Helper()
+		require.NoError(t, store.CreateSidekiqJob(ctx, &tables.TableSidekiqJob{ID: id, Kind: "k", Metadata: `{"processed":3}`}))
+		_, err := store.ClaimSidekiqJob(ctx, id, "owner-A", time.Now().Add(-time.Minute))
+		require.NoError(t, err)
+		_, err = store.CancelSidekiqJob(ctx, id)
+		require.NoError(t, err)
+	}
+
+	t.Run("stores the partial progress without disturbing the status", func(t *testing.T) {
+		newCancelledJob(t, "f1")
+		require.NoError(t, store.FinalizeCancelledSidekiqJob(ctx, "f1", "owner-A", `{"processed":9}`))
+
+		got := getJob(t, store, "f1")
+		assert.Equal(t, `{"processed":9}`, got.Metadata)
+		assert.Equal(t, tables.SidekiqStatusCancelled, got.Status, "finalizing must not change the status")
+	})
+
+	t.Run("empty metadata leaves the last checkpoint alone", func(t *testing.T) {
+		newCancelledJob(t, "f2")
+		require.NoError(t, store.FinalizeCancelledSidekiqJob(ctx, "f2", "owner-A", ""))
+		assert.Equal(t, `{"processed":3}`, getJob(t, store, "f2").Metadata)
+	})
+
+	t.Run("a non-owner cannot write counters", func(t *testing.T) {
+		newCancelledJob(t, "f3")
+		require.NoError(t, store.FinalizeCancelledSidekiqJob(ctx, "f3", "owner-B", `{"processed":99}`))
+		assert.Equal(t, `{"processed":3}`, getJob(t, store, "f3").Metadata, "fenced on runner_id")
+	})
+}
+
 func TestFailSidekiqJobEmptyMetadataPreservesExisting(t *testing.T) {
 	store := setupSidekiqTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -880,6 +880,8 @@ type ConfigStore interface {
 	UpdateSidekiqJobProgress(ctx context.Context, id, runnerID, metadata string) error
 	CompleteSidekiqJob(ctx context.Context, id, runnerID, metadata string) error
 	FailSidekiqJob(ctx context.Context, id, runnerID, metadata, lastErr string) error
+	CancelSidekiqJob(ctx context.Context, id string) (bool, error)
+	FinalizeCancelledSidekiqJob(ctx context.Context, id, runnerID, metadata string) error
 	ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error)
 	GetInFlightSidekiqJobByKind(ctx context.Context, kind string) (*tables.TableSidekiqJob, error)
 	MarkStaleSidekiqJobsFailed(ctx context.Context, staleBefore time.Time) (int64, error)

--- a/framework/configstore/tables/sidekiq.go
+++ b/framework/configstore/tables/sidekiq.go
@@ -12,7 +12,27 @@ const (
 	SidekiqStatusCompleted = "completed"
 	// SidekiqStatusFailed marks a job that errored or was reaped as stale.
 	SidekiqStatusFailed = "failed"
+	// SidekiqStatusCancelled marks a job stopped on request before it finished. It is
+	// terminal and distinct from failed: nothing went wrong, the work was simply cut
+	// short, so whatever the job had already committed stands and the row is never
+	// re-claimed. The metadata still holds the partial progress counters.
+	SidekiqStatusCancelled = "cancelled"
 )
+
+// SidekiqTerminalStatuses lists the statuses a job never leaves. A job in any of
+// these is done being worked on: it is not claimable, not reapable, and not
+// counted as in-flight.
+var SidekiqTerminalStatuses = []string{SidekiqStatusCompleted, SidekiqStatusFailed, SidekiqStatusCancelled}
+
+// IsSidekiqTerminalStatus reports whether a job status is terminal.
+func IsSidekiqTerminalStatus(status string) bool {
+	switch status {
+	case SidekiqStatusCompleted, SidekiqStatusFailed, SidekiqStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
 
 // TableSidekiqJob is a generic, durable background-job record. It is intentionally
 // not tied to any feature: callers store all job-specific data (provider, filters,

--- a/framework/sidekiq/sidekiq.go
+++ b/framework/sidekiq/sidekiq.go
@@ -25,6 +25,12 @@ type Store interface {
 	UpdateSidekiqJobProgress(ctx context.Context, id, runnerID, metadata string) error
 	CompleteSidekiqJob(ctx context.Context, id, runnerID, metadata string) error
 	FailSidekiqJob(ctx context.Context, id, runnerID, metadata, lastErr string) error
+	// CancelSidekiqJob flips a pending or running job to cancelled. Returns true only
+	// when this call performed the transition (false = unknown or already terminal).
+	CancelSidekiqJob(ctx context.Context, id string) (bool, error)
+	// FinalizeCancelledSidekiqJob stores the last metadata snapshot of a cancelled job
+	// so its partial progress survives.
+	FinalizeCancelledSidekiqJob(ctx context.Context, id, runnerID, metadata string) error
 	// ListClaimableSidekiqJobs returns pending jobs and running jobs whose heartbeat is older than staleBefore.
 	ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error)
 }
@@ -63,6 +69,13 @@ type Runner struct {
 	inflightMu sync.Mutex
 	inflight   map[string]struct{}
 
+	// jobCancels maps a claimed job's ID to the cancel func of its handler context.
+	// Cancel uses it to stop a job running on this node the moment the request lands,
+	// instead of waiting up to a heartbeat interval for the status change to be noticed.
+	// Entries exist only between claim and handler return.
+	jobCancelsMu sync.Mutex
+	jobCancels   map[string]context.CancelFunc
+
 	baseCtx context.Context
 	cancel  context.CancelFunc
 	sem     chan struct{}
@@ -84,6 +97,7 @@ func New(store Store, logger schemas.Logger, maxConcurrent int, runnerID string)
 		runnerID:          runnerID,
 		heartbeatInterval: HeartbeatInterval,
 		inflight:          make(map[string]struct{}),
+		jobCancels:        make(map[string]context.CancelFunc),
 		baseCtx:           ctx,
 		cancel:            cancel,
 		sem:               make(chan struct{}, maxConcurrent),
@@ -140,6 +154,61 @@ func (r *Runner) EnqueuePartitioned(ctx context.Context, id, kind, partitioningK
 	}
 	r.spawn(*job)
 	return nil
+}
+
+// Cancel stops a pending or running job. It flips the durable row to cancelled
+// first — so the dispatcher will not re-claim it and the reaper will not fail it,
+// whatever happens next — and then cancels the handler's context if the job
+// happens to be running on this node, which stops the work within one checkpoint
+// instead of one heartbeat.
+//
+// A job owned by another node is stopped by that node's next heartbeat, which is
+// fenced on status = running and therefore reads the cancellation as lost
+// ownership. Cancelling an unknown or already-terminal job is a no-op: it returns
+// false with no error, since the caller's intent ("this job should not be
+// running") already holds.
+func (r *Runner) Cancel(ctx context.Context, id string) (bool, error) {
+	cancelled, err := r.store.CancelSidekiqJob(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	// Signal the local handler even when the row was already terminal: another node
+	// may have cancelled it while this node still runs the goroutine.
+	r.cancelLocal(id)
+	return cancelled, nil
+}
+
+// cancelLocal cancels the handler context of a job running on this node, if any.
+func (r *Runner) cancelLocal(id string) {
+	r.jobCancelsMu.Lock()
+	cancel, ok := r.jobCancels[id]
+	r.jobCancelsMu.Unlock()
+	if ok {
+		cancel()
+	}
+}
+
+func (r *Runner) registerJobCancel(id string, cancel context.CancelFunc) (unregister func()) {
+	r.jobCancelsMu.Lock()
+	r.jobCancels[id] = cancel
+	r.jobCancelsMu.Unlock()
+	return func() {
+		r.jobCancelsMu.Lock()
+		delete(r.jobCancels, id)
+		r.jobCancelsMu.Unlock()
+	}
+}
+
+// isCancelled re-reads the job row to distinguish a cancellation from the other
+// reasons a handler context dies (node shutdown, lost ownership). It is only
+// consulted on the error path of a context-cancelled handler, so the extra read
+// costs nothing in the normal case.
+func (r *Runner) isCancelled(id string) bool {
+	job, err := r.store.GetSidekiqJob(r.baseCtx, id)
+	if err != nil || job == nil {
+		return false
+	}
+	return job.Status == tables.SidekiqStatusCancelled
 }
 
 func (r *Runner) staleBefore() time.Time {
@@ -241,6 +310,17 @@ func (r *Runner) execute(job tables.TableSidekiqJob) {
 		return
 	}
 
+	// Expose the handler's cancel func so an in-process Cancel stops this job at once.
+	// Registered after the claim (only the owner can be asked to stop) and removed as
+	// soon as the handler returns.
+	unregisterCancel := r.registerJobCancel(job.ID, cancel)
+	defer unregisterCancel()
+	// A cancel that landed between the claim and the registration above would have
+	// found no cancel func; re-check the row so the job does not run on regardless.
+	if r.isCancelled(job.ID) {
+		cancel()
+	}
+
 	stopHeartbeat := r.startHeartbeat(jobCtx, cancel, job.ID)
 	defer stopHeartbeat()
 
@@ -250,13 +330,44 @@ func (r *Runner) execute(job tables.TableSidekiqJob) {
 
 	finalMetadata, err := fn(jobCtx, job, progress)
 	if err != nil {
+		// A cancelled job unwinds through this path too: the handler sees its context
+		// die and returns ctx.Err(), or its next checkpoint fails because the row is no
+		// longer running. Neither is a failure — the status is already cancelled, so
+		// only the partial progress needs persisting.
+		if jobCtx.Err() != nil && r.isCancelled(job.ID) {
+			r.logger.Info("sidekiq: job %s (%s) cancelled", job.ID, job.Kind)
+			if cerr := r.store.FinalizeCancelledSidekiqJob(r.baseCtx, job.ID, r.runnerID, finalMetadata); cerr != nil {
+				r.logger.Error("sidekiq: failed to store final progress for cancelled job %s: %v", job.ID, cerr)
+			}
+			return
+		}
 		r.logger.Error("sidekiq: job %s (%s) failed: %v", job.ID, job.Kind, err)
 		if ferr := r.store.FailSidekiqJob(r.baseCtx, job.ID, r.runnerID, finalMetadata, err.Error()); ferr != nil {
+			// Same race as the complete path: a cancel can land while the handler is
+			// returning an unrelated error, in which case the fail is correctly rejected
+			// (the row is no longer running). Honor the cancellation and persist progress.
+			if r.isCancelled(job.ID) {
+				r.logger.Info("sidekiq: job %s (%s) cancelled as it was failing", job.ID, job.Kind)
+				if cerr := r.store.FinalizeCancelledSidekiqJob(r.baseCtx, job.ID, r.runnerID, finalMetadata); cerr != nil {
+					r.logger.Error("sidekiq: failed to store final progress for cancelled job %s: %v", job.ID, cerr)
+				}
+				return
+			}
 			r.logger.Error("sidekiq: failed to mark job %s failed: %v", job.ID, ferr)
 		}
 		return
 	}
 	if cerr := r.store.CompleteSidekiqJob(r.baseCtx, job.ID, r.runnerID, finalMetadata); cerr != nil {
+		// A cancel can land while the handler is finishing its last unit of work, in
+		// which case the complete is correctly rejected (the row is no longer running).
+		// Honor the cancellation rather than reporting a spurious failure.
+		if r.isCancelled(job.ID) {
+			r.logger.Info("sidekiq: job %s (%s) cancelled as it was completing", job.ID, job.Kind)
+			if ferr := r.store.FinalizeCancelledSidekiqJob(r.baseCtx, job.ID, r.runnerID, finalMetadata); ferr != nil {
+				r.logger.Error("sidekiq: failed to store final progress for cancelled job %s: %v", job.ID, ferr)
+			}
+			return
+		}
 		r.logger.Error("sidekiq: failed to mark job %s completed: %v", job.ID, cerr)
 	}
 }

--- a/framework/sidekiq/sidekiq_test.go
+++ b/framework/sidekiq/sidekiq_test.go
@@ -36,18 +36,21 @@ type fakeStore struct {
 	completed  map[string]string
 	failedMeta map[string]string
 	failedErr  map[string]string
-	terminal   chan string
+	// cancelledMeta records the final progress snapshot stored for a cancelled job.
+	cancelledMeta map[string]string
+	terminal      chan string
 }
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		jobs:       map[string]*jobState{},
-		running:    map[string]int{},
-		progress:   map[string]string{},
-		completed:  map[string]string{},
-		failedMeta: map[string]string{},
-		failedErr:  map[string]string{},
-		terminal:   make(chan string, 16),
+		jobs:          map[string]*jobState{},
+		running:       map[string]int{},
+		progress:      map[string]string{},
+		completed:     map[string]string{},
+		failedMeta:    map[string]string{},
+		failedErr:     map[string]string{},
+		cancelledMeta: map[string]string{},
+		terminal:      make(chan string, 16),
 	}
 }
 
@@ -161,6 +164,41 @@ func (f *fakeStore) FailSidekiqJob(_ context.Context, id, runnerID, metadata, la
 	return nil
 }
 
+func (f *fakeStore) CancelSidekiqJob(_ context.Context, id string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	j, ok := f.jobs[id]
+	if !ok || tables.IsSidekiqTerminalStatus(j.status) {
+		return false, nil
+	}
+	j.status = tables.SidekiqStatusCancelled
+	j.updatedAt = time.Now()
+	return true, nil
+}
+
+func (f *fakeStore) FinalizeCancelledSidekiqJob(_ context.Context, id, runnerID, metadata string) error {
+	f.mu.Lock()
+	j, ok := f.jobs[id]
+	if !ok || j.status != tables.SidekiqStatusCancelled {
+		f.mu.Unlock()
+		return errors.New("not owned by caller or not cancelled")
+	}
+	// The real store fences the UPDATE on runner_id and treats a zero-row result
+	// as success, so a stale runner writing to a re-claimed job is a silent no-op
+	// rather than an error. Mirror that here instead of reporting a failure.
+	if j.owner != runnerID {
+		f.mu.Unlock()
+		return nil
+	}
+	if metadata != "" {
+		j.metadata = metadata
+	}
+	f.cancelledMeta[id] = metadata
+	f.mu.Unlock()
+	f.terminal <- id
+	return nil
+}
+
 func (f *fakeStore) ListClaimableSidekiqJobs(_ context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -265,6 +303,91 @@ func TestHandlerPanicRecovered(t *testing.T) {
 	defer store.mu.Unlock()
 	if store.failedErr["job3"] == "" {
 		t.Errorf("expected a failure recorded for a panicking handler")
+	}
+}
+
+// A cancel must stop the handler, land the job on "cancelled" rather than "failed",
+// and keep the progress it had committed.
+func TestCancelStopsRunningJobAndKeepsProgress(t *testing.T) {
+	store := newFakeStore()
+	r := testRunner(store)
+	started := make(chan struct{})
+	r.Register("k", func(ctx context.Context, _ tables.TableSidekiqJob, progress ProgressFunc) (string, error) {
+		_ = progress("checkpoint")
+		close(started)
+		<-ctx.Done()
+		return "partial", ctx.Err()
+	})
+
+	if err := r.Enqueue(context.Background(), "job5", "k", "{}", ""); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	<-started
+
+	cancelled, err := r.Cancel(context.Background(), "job5")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("Cancel reported no transition for a running job")
+	}
+	waitTerminal(t, store)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := store.jobs["job5"].status; got != tables.SidekiqStatusCancelled {
+		t.Errorf("status = %q, want cancelled", got)
+	}
+	if store.cancelledMeta["job5"] != "partial" {
+		t.Errorf("cancelled metadata = %q, want partial", store.cancelledMeta["job5"])
+	}
+	if _, failed := store.failedErr["job5"]; failed {
+		t.Error("a cancelled job must not also be recorded as failed")
+	}
+}
+
+// Cancelling a job that already finished is a no-op, not an error: a click racing
+// the final batch must not rewrite a completed job or surface a failure.
+func TestCancelCompletedJobIsNoop(t *testing.T) {
+	store := newFakeStore()
+	r := testRunner(store)
+	r.Register("k", func(_ context.Context, _ tables.TableSidekiqJob, _ ProgressFunc) (string, error) {
+		return "final", nil
+	})
+
+	if err := r.Enqueue(context.Background(), "job6", "k", "{}", ""); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	waitTerminal(t, store)
+
+	cancelled, err := r.Cancel(context.Background(), "job6")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled {
+		t.Error("Cancel reported a transition for an already-completed job")
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := store.jobs["job6"].status; got != tables.SidekiqStatusCompleted {
+		t.Errorf("status = %q, want completed", got)
+	}
+}
+
+// A cancelled job must never be picked back up by the dispatcher.
+func TestCancelledJobIsNotClaimable(t *testing.T) {
+	store := newFakeStore()
+	store.seed("job7", "k", tables.SidekiqStatusCancelled, time.Hour)
+
+	jobs, err := store.ListClaimableSidekiqJobs(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("ListClaimableSidekiqJobs: %v", err)
+	}
+	for _, j := range jobs {
+		if j.ID == "job7" {
+			t.Fatal("a cancelled job must not be claimable")
+		}
 	}
 }
 

--- a/plugins/logging/costrecalc.go
+++ b/plugins/logging/costrecalc.go
@@ -61,6 +61,17 @@ type CostRecalcJobMeta struct {
 	Message string `json:"message,omitempty"`
 }
 
+// stoppedEarlyMessage summarizes a run that ended before walking the whole window,
+// so a cancelled (or shutdown-interrupted) job still reports what it committed.
+// Costs already written are kept — they are correct, just incomplete in coverage.
+func stoppedEarlyMessage(meta *CostRecalcJobMeta) string {
+	msg := fmt.Sprintf("Stopped early after checking %d log(s): %d cost value(s) recalculated, %d skipped.", meta.Processed, meta.Updated, meta.Skipped)
+	if meta.Total > 0 && int64(meta.Processed) < meta.Total {
+		msg += fmt.Sprintf(" %d log(s) in the selected window were not checked.", meta.Total-int64(meta.Processed))
+	}
+	return msg
+}
+
 // CountRecalcTargets returns how many logs fall in scope for a cost recalculation
 // with the given filters. missingCostOnly narrows to rows that currently have no
 // cost. It counts via the same raw-table SearchLogs path the worker walks (which
@@ -149,7 +160,11 @@ func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, ch
 
 	for {
 		if err := ctx.Err(); err != nil {
-			// Cancelled (shutdown). Persist the cursor so a resume continues here.
+			// Stopped early — either a user cancellation or a node shutdown. Record what
+			// was done and persist the cursor; on shutdown a resume continues from here,
+			// on a cancellation the checkpoint is rejected (the row is no longer running)
+			// and the runner stores this same snapshot against the cancelled job instead.
+			meta.Message = stoppedEarlyMessage(&meta)
 			_ = checkpoint(snapshot())
 			return snapshot(), err
 		}
@@ -248,6 +263,13 @@ func (p *LoggerPlugin) RunCostRecalcJob(ctx context.Context, metaJSON string, ch
 		}
 
 		if err := checkpoint(snapshot()); err != nil {
+			// A cancellation flips the job row out of running, so the checkpoint is
+			// rejected before the loop gets back to its ctx.Err() guard. Report the
+			// cancellation, not the checkpoint write, as the reason the job stopped.
+			if cerr := ctx.Err(); cerr != nil {
+				meta.Message = stoppedEarlyMessage(&meta)
+				return snapshot(), cerr
+			}
 			return snapshot(), fmt.Errorf("failed to checkpoint cost recalc progress: %w", err)
 		}
 

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -400,6 +400,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.DELETE("/api/logs", lib.ChainMiddlewares(h.deleteLogs, middlewares...))
 	r.POST("/api/logs/recalculate-cost", lib.ChainMiddlewares(h.recalculateLogCosts, middlewares...))
 	r.GET("/api/logs/recalculate-cost/status", lib.ChainMiddlewares(h.getRecalculateCostStatus, middlewares...))
+	r.POST("/api/logs/recalculate-cost/cancel", lib.ChainMiddlewares(h.cancelRecalculateCost, middlewares...))
 
 	// MCP Tool Log retrieval with filtering, search, and pagination
 	r.GET("/api/mcp-logs", lib.ChainMiddlewares(h.getMCPLogs, middlewares...))
@@ -2142,6 +2143,66 @@ func (h *LoggingHandler) getRecalculateCostStatus(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	SendJSON(ctx, recalcJobStatusFromRow(job))
+}
+
+// cancelRecalculateCost handles POST /api/logs/recalculate-cost/cancel. With an
+// ?id= it cancels that job; otherwise it cancels the current in-flight one. Costs
+// already recalculated are kept — cancelling stops further work, it does not undo
+// what was committed. It responds with the job's status after the cancellation so
+// the caller can settle its progress UI from the same shape it was polling.
+//
+// Cancelling a job that has already reached a terminal status is not an error: the
+// job is simply returned as-is, which keeps a click racing the last batch from
+// surfacing a spurious failure.
+func (h *LoggingHandler) cancelRecalculateCost(ctx *fasthttp.RequestCtx) {
+	if h.sidekiqRunner == nil || h.sidekiqStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "Background job runner is not available")
+		return
+	}
+
+	var (
+		job *tables.TableSidekiqJob
+		err error
+	)
+	if id := strings.TrimSpace(string(ctx.QueryArgs().Peek("id"))); id != "" {
+		job, err = h.sidekiqStore.GetSidekiqJob(ctx, id)
+	} else {
+		job, err = h.sidekiqStore.GetInFlightSidekiqJobByKind(ctx, logging.CostRecalcJobKind)
+	}
+	if err != nil {
+		logger.Error("failed to look up recalculate-cost job to cancel: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to look up the recalculation job")
+		return
+	}
+	if job == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "No recalculation job to cancel")
+		return
+	}
+	// Guard the id-supplied path: this endpoint must not become a way to cancel
+	// arbitrary background jobs of other kinds.
+	if job.Kind != logging.CostRecalcJobKind {
+		SendError(ctx, fasthttp.StatusBadRequest, "Job is not a cost recalculation")
+		return
+	}
+	if tables.IsSidekiqTerminalStatus(job.Status) {
+		SendJSON(ctx, recalcJobStatusFromRow(job))
+		return
+	}
+
+	if _, err := h.sidekiqRunner.Cancel(ctx, job.ID); err != nil {
+		logger.Error("failed to cancel recalculate-cost job %s: %v", job.ID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to cancel the recalculation")
+		return
+	}
+
+	// Re-read so the response carries the cancelled status and the counters committed
+	// before the stop. The handler may still be unwinding, so its final progress
+	// snapshot can land moments later — the caller's next poll picks that up.
+	if fresh, ferr := h.sidekiqStore.GetSidekiqJob(ctx, job.ID); ferr == nil && fresh != nil {
+		SendJSON(ctx, recalcJobStatusFromRow(fresh))
+		return
+	}
+	SendJSON(ctx, recalcJobStatus{ID: job.ID, Status: tables.SidekiqStatusCancelled})
 }
 
 // recalcJobStatus is the API view of a cost-recalculation job: the durable sidekiq

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -360,6 +360,124 @@ func TestRecalculateLogCostsRejectsDuplicateJob(t *testing.T) {
 	}
 }
 
+func TestCancelRecalculateCost(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	// newHandler wires a handler over a store seeded with one recalculation job.
+	newHandler := func(job *tables.TableSidekiqJob) (*LoggingHandler, *fakeSidekiqStore) {
+		store := newFakeSidekiqStore()
+		if job != nil {
+			store.jobs[job.ID] = job
+			if !tables.IsSidekiqTerminalStatus(job.Status) {
+				store.inFlight = job
+			}
+		}
+		h := &LoggingHandler{logManager: &dashboardLogManager{}}
+		h.SetSidekiqBackend(sidekiq.New(store, &mockLogger{}, 1, ""), store)
+		return h, store
+	}
+
+	call := func(h *LoggingHandler, uri string) *fasthttp.RequestCtx {
+		var req fasthttp.Request
+		req.Header.SetMethod(fasthttp.MethodPost)
+		req.SetRequestURI(uri)
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+		h.cancelRecalculateCost(ctx)
+		return ctx
+	}
+
+	runningJob := func() *tables.TableSidekiqJob {
+		return &tables.TableSidekiqJob{
+			ID:       "job-1",
+			Kind:     loggingplugin.CostRecalcJobKind,
+			Status:   tables.SidekiqStatusRunning,
+			Metadata: `{"total":10,"processed":4,"updated":3,"skipped":1}`,
+		}
+	}
+
+	t.Run("cancels the in-flight job when no id is given", func(t *testing.T) {
+		h, store := newHandler(runningJob())
+		ctx := call(h, "/api/logs/recalculate-cost/cancel")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", got, ctx.Response.Body())
+		}
+		if got := store.jobs["job-1"].Status; got != tables.SidekiqStatusCancelled {
+			t.Fatalf("job status = %q, want cancelled", got)
+		}
+		var body recalcJobStatus
+		if err := json.Unmarshal(ctx.Response.Body(), &body); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if body.Status != tables.SidekiqStatusCancelled {
+			t.Fatalf("response status = %q, want cancelled", body.Status)
+		}
+		// The counters committed before the stop must survive for the UI to report.
+		if body.Updated != 3 || body.Skipped != 1 || body.Processed != 4 {
+			t.Fatalf("partial progress lost: %+v", body)
+		}
+	})
+
+	t.Run("cancels the job named by id", func(t *testing.T) {
+		h, store := newHandler(runningJob())
+		ctx := call(h, "/api/logs/recalculate-cost/cancel?id=job-1")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", got, ctx.Response.Body())
+		}
+		if got := store.jobs["job-1"].Status; got != tables.SidekiqStatusCancelled {
+			t.Fatalf("job status = %q, want cancelled", got)
+		}
+	})
+
+	t.Run("an already-terminal job is returned unchanged", func(t *testing.T) {
+		done := runningJob()
+		done.Status = tables.SidekiqStatusCompleted
+		h, store := newHandler(done)
+		ctx := call(h, "/api/logs/recalculate-cost/cancel?id=job-1")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", got, ctx.Response.Body())
+		}
+		if got := store.jobs["job-1"].Status; got != tables.SidekiqStatusCompleted {
+			t.Fatalf("a completed job must not be rewritten, got %q", got)
+		}
+	})
+
+	t.Run("refuses to cancel a job of another kind", func(t *testing.T) {
+		other := runningJob()
+		other.Kind = "some_other_job"
+		h, store := newHandler(other)
+		ctx := call(h, "/api/logs/recalculate-cost/cancel?id=job-1")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", got, ctx.Response.Body())
+		}
+		if got := store.jobs["job-1"].Status; got != tables.SidekiqStatusRunning {
+			t.Fatalf("unrelated job must be untouched, got %q", got)
+		}
+	})
+
+	t.Run("404 when there is nothing to cancel", func(t *testing.T) {
+		h, _ := newHandler(nil)
+		ctx := call(h, "/api/logs/recalculate-cost/cancel")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", got, ctx.Response.Body())
+		}
+	})
+
+	t.Run("503 when the background runner is not wired", func(t *testing.T) {
+		h := &LoggingHandler{logManager: &dashboardLogManager{}}
+		ctx := call(h, "/api/logs/recalculate-cost/cancel")
+
+		if got := ctx.Response.StatusCode(); got != fasthttp.StatusServiceUnavailable {
+			t.Fatalf("expected 503, got %d: %s", got, ctx.Response.Body())
+		}
+	})
+}
+
 // fakeSidekiqStore implements both sidekiq.Store (for the runner) and
 // handlers.SidekiqJobStore (for the endpoints), backed by an in-memory map.
 type fakeSidekiqStore struct {
@@ -428,6 +546,27 @@ func (s *fakeSidekiqStore) FailSidekiqJob(ctx context.Context, id, runnerID, met
 }
 func (s *fakeSidekiqStore) ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error) {
 	return nil, nil
+}
+func (s *fakeSidekiqStore) CancelSidekiqJob(ctx context.Context, id string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[id]
+	if !ok || tables.IsSidekiqTerminalStatus(job.Status) {
+		return false, nil
+	}
+	job.Status = tables.SidekiqStatusCancelled
+	if s.inFlight != nil && s.inFlight.ID == id {
+		s.inFlight = nil
+	}
+	return true, nil
+}
+func (s *fakeSidekiqStore) FinalizeCancelledSidekiqJob(ctx context.Context, id, runnerID, metadata string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok && job.Status == tables.SidekiqStatusCancelled && metadata != "" {
+		job.Metadata = metadata
+	}
+	return nil
 }
 
 type dashboardLogManager struct {

--- a/transports/bifrost-http/handlers/ui.go
+++ b/transports/bifrost-http/handlers/ui.go
@@ -16,18 +16,34 @@ import (
 
 const uiDevServerAddr = "localhost:3000"
 
+// ShellRewriter may rewrite the pre-hydration HTML shell before it is served.
+//
+// It is the seam the enterprise build uses to point the shell's logo at a
+// custom asset, so a branded deployment does not flash the Bifrost mark
+// for the moment before the bundle boots. OSS leaves it nil and serves the
+// embedded document exactly as bundled.
+//
+// It runs on the request path for every HTML document, so an implementation
+// must be cheap and must return data unchanged when it has nothing to do.
+type ShellRewriter func(ctx *fasthttp.RequestCtx, data []byte) []byte
+
 // UIHandler handles UI routes.
 type UIHandler struct {
 	uiContent embed.FS
 	// uiDevClient proxies dashboard requests to the local Vite dev server.
 	// It is only set when dev mode is enabled (see NewUIHandler); nil otherwise.
 	uiDevClient *fasthttp.HostClient
+	// shellRewriter rewrites the pre-hydration shell. nil disables the rewrite
+	// entirely, which is the OSS path.
+	shellRewriter ShellRewriter
 }
 
-// NewUIHandler creates a new UIHandler instance.
-func NewUIHandler(uiContent embed.FS) *UIHandler {
+// NewUIHandler creates a new UIHandler instance. shellRewriter may be nil, in
+// which case index.html is always served exactly as embedded.
+func NewUIHandler(uiContent embed.FS, shellRewriter ShellRewriter) *UIHandler {
 	h := &UIHandler{
-		uiContent: uiContent,
+		uiContent:     uiContent,
+		shellRewriter: shellRewriter,
 	}
 	// Only wire the dev-server proxy client when running in dev mode. Timeouts
 	// guard against the local Vite server hanging dashboard requests if it is
@@ -133,6 +149,13 @@ func (h *UIHandler) serveDashboard(ctx *fasthttp.RequestCtx) {
 			ctx.SetBodyString("404 - File not found")
 			return
 		}
+	}
+
+	// Give the build a chance to rewrite the static skeleton before it goes out
+	// — see ShellRewriter. nil on OSS, where the embedded bytes are served
+	// untouched.
+	if h.shellRewriter != nil && filepath.Ext(cleanPath) == ".html" {
+		data = h.shellRewriter(ctx, data)
 	}
 
 	// Set content type based on file extension

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1776,6 +1776,14 @@ func (m *MockConfigStore) FailSidekiqJob(ctx context.Context, id, runnerID, meta
 	return nil
 }
 
+func (m *MockConfigStore) CancelSidekiqJob(ctx context.Context, id string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockConfigStore) FinalizeCancelledSidekiqJob(ctx context.Context, id, runnerID, metadata string) error {
+	return nil
+}
+
 func (m *MockConfigStore) ListClaimableSidekiqJobs(ctx context.Context, staleBefore time.Time) ([]tables.TableSidekiqJob, error) {
 	return nil, nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -210,6 +210,13 @@ type BifrostHTTPServer struct {
 	Server *fasthttp.Server
 	Router *router.Router
 
+	// ShellRewriter lets a build rewrite the pre-hydration HTML shell before it
+	// is served — the enterprise build uses it to swap in a custom logo.
+	// nil on OSS, where the embedded document is served exactly as bundled. It
+	// must be assigned before RegisterUIRoutes, which builds the UI handler
+	// from it.
+	ShellRewriter handlers.ShellRewriter
+
 	WebSocketHandler   *handlers.WebSocketHandler
 	MCPServerHandler   *handlers.MCPServerHandler
 	devPprofHandler    *handlers.DevPprofHandler
@@ -2192,7 +2199,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 // RegisterUIRoutes registers the UI handler with the specified router
 func (s *BifrostHTTPServer) RegisterUIRoutes(middlewares ...schemas.BifrostHTTPMiddleware) {
 	// WARNING: This UI handler needs to be registered after all the other handlers
-	handlers.NewUIHandler(s.UIContent).RegisterRoutes(s.Router, middlewares...)
+	handlers.NewUIHandler(s.UIContent, s.ShellRewriter).RegisterRoutes(s.Router, middlewares...)
 }
 
 // GetAllRedactedKeys gets all redacted keys from the config store

--- a/ui/app/_fallbacks/enterprise/components/branding/brandingView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/branding/brandingView.tsx
@@ -1,0 +1,20 @@
+import { Palette } from "lucide-react";
+import ContactUsView from "../views/contactUsView";
+
+// OSS stub. Custom branding is an enterprise capability — the OSS backend
+// exposes no endpoint to store a logo, so this build always renders the
+// Bifrost default and this view only explains the upgrade path.
+export default function BrandingView() {
+	return (
+		<div className="h-full w-full">
+			<ContactUsView
+				className="mx-auto min-h-[80vh]"
+				icon={<Palette className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+				title="Unlock custom branding"
+				description="Replace the Bifrost logo with your own across the dashboard and login screen. This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+				readmeLink="https://docs.getbifrost.ai/enterprise/overview"
+				testIdPrefix="branding"
+			/>
+		</div>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useBranding } from "@/lib/hooks/useBranding";
 import { getErrorMessage, useLoginMutation } from "@/lib/store/apis";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
@@ -57,7 +58,7 @@ export default function LoginView() {
 		}
 	};
 
-	const logoSrc = mounted && resolvedTheme === "dark" ? "/bifrost-logo-dark.webp" : "/bifrost-logo.webp";
+	const { logoSrc, logoAlt } = useBranding(mounted && resolvedTheme === "dark");
 
 	return (
 		<div className="flex min-h-screen items-center justify-center p-4">
@@ -65,7 +66,7 @@ export default function LoginView() {
 				<div className="border-border bg-card w-full space-y-6 rounded-sm border p-8">
 					{/* Logo */}
 					<div className="flex items-center justify-center">
-						<img src={logoSrc} alt="Bifrost" width={160} height={26} className="" />
+						<img src={logoSrc} alt={logoAlt} width={160} height={26} className="max-h-[40px] w-auto max-w-[220px] object-contain" />
 					</div>
 
 					<div className="space-y-2 text-center">

--- a/ui/app/login/layout.tsx
+++ b/ui/app/login/layout.tsx
@@ -1,8 +1,10 @@
 import { ThemeProvider } from "@/components/themeProvider";
+import { useBranding } from "@/lib/hooks/useBranding";
 import { ReduxProvider } from "@/lib/store/provider";
 import { DEFAULT_POST_LOGIN_PATH, getLoginGotoFromSearch } from "@/lib/utils/loginGoto";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useTheme } from "next-themes";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import LoginPage from "./page";
 
@@ -20,21 +22,35 @@ function RouteComponent() {
 	);
 }
 
-function PendingComponent() {
+// Split out so it can call useBranding, which needs the Redux store. The
+// pending state previously rendered without ReduxProvider; it is now wrapped
+// below so this brief screen shows the customer's logo too rather than
+// flashing the Bifrost one on the way to the login form.
+function PendingCard() {
+	const { resolvedTheme } = useTheme();
+	const { logoSrc, logoAlt } = useBranding(resolvedTheme === "dark");
 	return (
-		<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-			<div className="flex min-h-screen items-center justify-center p-4">
-				<div className="w-full max-w-md">
-					<div className="border-border bg-card w-full space-y-6 rounded-sm border p-8">
-						<div className="flex items-center justify-center">
-							<img src="/bifrost-logo.webp" alt="Bifrost" width={160} height={26} />
-						</div>
-						<div className="flex items-center justify-center py-6">
-							<div className="text-muted-foreground text-sm">Checking authentication...</div>
-						</div>
+		<div className="flex min-h-screen items-center justify-center p-4">
+			<div className="w-full max-w-md">
+				<div className="border-border bg-card w-full space-y-6 rounded-sm border p-8">
+					<div className="flex items-center justify-center">
+						<img src={logoSrc} alt={logoAlt} width={160} height={26} className="max-h-[40px] w-auto max-w-[220px] object-contain" />
+					</div>
+					<div className="flex items-center justify-center py-6">
+						<div className="text-muted-foreground text-sm">Checking authentication...</div>
 					</div>
 				</div>
 			</div>
+		</div>
+	);
+}
+
+function PendingComponent() {
+	return (
+		<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+			<ReduxProvider>
+				<PendingCard />
+			</ReduxProvider>
 		</ThemeProvider>
 	);
 }

--- a/ui/app/workspace/config/branding/layout.tsx
+++ b/ui/app/workspace/config/branding/layout.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import BrandingPage from "./page";
+
+export const Route = createFileRoute("/workspace/config/branding")({
+	component: BrandingPage,
+});

--- a/ui/app/workspace/config/branding/page.tsx
+++ b/ui/app/workspace/config/branding/page.tsx
@@ -1,0 +1,26 @@
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import BrandingView from "@enterprise/components/branding/brandingView";
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+export default function BrandingPage() {
+	const navigate = useNavigate();
+
+	// custom branding is enterprise-only: OSS keeps the Bifrost branding, and
+	// the backend exposes no write endpoint there, so the page would be inert.
+	useEffect(() => {
+		if (!IS_ENTERPRISE) {
+			navigate({ to: "/workspace/config/client-settings", replace: true });
+		}
+	}, [navigate]);
+
+	if (!IS_ENTERPRISE) {
+		return null;
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<BrandingView />
+		</div>
+	);
+}

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -20,7 +20,7 @@ import {
 	useGetUserAgentMappingsQuery,
 } from "@/lib/store";
 import { useLazyGetLogByIdQuery, useLazyGetLogsQuery } from "@/lib/store/apis/logsApi";
-import type { LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
+import type { DisplayLogEntry, LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -30,6 +30,10 @@ import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } fro
 import { parseAsSafeArrayOf, parseAsSafeString } from "@/lib/queryParamsParser";
 import { parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// A fallback chain is a handful of attempts, so one page covers every realistic
+// chain. Capped at the list endpoint's own maximum.
+const chainChildrenPageLimit = 1000;
 
 export default function LogsPage() {
 	const [error, setError] = useState<string | null>(null);
@@ -103,6 +107,7 @@ export default function LogsPage() {
 			cache_hit_types: parseAsSafeArrayOf.withDefault([]),
 			metadata_filters: parseAsString.withDefault(""),
 			selected_log: parseAsString.withDefault(""),
+			grouped: parseAsBoolean.withDefault(false),
 		},
 		{
 			history: "push",
@@ -114,6 +119,9 @@ export default function LogsPage() {
 	const selectedLogId = urlState.selected_log || null;
 	const activeLogFetchId = useRef<string | null>(null);
 	const polling = urlState.polling;
+	// Grouped view collapses fallback chains under their root. Disabled while a
+	// session filter is active — that view is already scoped to one chain/session.
+	const grouped = urlState.grouped && !urlState.parent_request_id;
 
 	// Convert URL state to filters and pagination for API calls
 	const filters: LogFilters = useMemo(
@@ -302,6 +310,7 @@ export default function LogsPage() {
 		{
 			filters,
 			pagination,
+			rootsOnly: grouped,
 		},
 		{
 			pollingInterval: showEmptyState || polling ? 10000 : 0,
@@ -359,6 +368,66 @@ export default function LogsPage() {
 			});
 		},
 		[filters, setFilters],
+	);
+
+	// --- Grouped view: chain expansion state -------------------------------
+	// Children of an expanded root, keyed by root log id. Loaded lazily through
+	// the list endpoint with the active filters plus parent_request_id, not the
+	// sessions endpoint — the sessions endpoint ignores filters, which would show
+	// rows the filter bar says are excluded. Filtering here keeps the expansion
+	// consistent with child_count, which the server computes under the same
+	// filters: every row is either a root or a child, and always matches.
+	const [expandedChainIds, setExpandedChainIds] = useState<Set<string>>(new Set());
+	const [chainChildren, setChainChildren] = useState<Record<string, LogEntry[]>>({});
+	const [loadingChainIds, setLoadingChainIds] = useState<Set<string>>(new Set());
+	const [triggerGetChainChildren] = useLazyGetLogsQuery();
+
+	// Collapse everything when the page of roots changes — expanded ids from the
+	// previous page are meaningless and cached children may be stale.
+	useEffect(() => {
+		setExpandedChainIds(new Set());
+		setChainChildren({});
+		setLoadingChainIds(new Set());
+	}, [filters, pagination, grouped]);
+
+	const handleToggleChain = useCallback(
+		(log: LogEntry) => {
+			const isExpanded = expandedChainIds.has(log.id);
+			setExpandedChainIds((prev) => {
+				const next = new Set(prev);
+				if (next.has(log.id)) {
+					next.delete(log.id);
+				} else {
+					next.add(log.id);
+				}
+				return next;
+			});
+			if (isExpanded || chainChildren[log.id] || loadingChainIds.has(log.id)) return;
+
+			setLoadingChainIds((prev) => new Set(prev).add(log.id));
+			triggerGetChainChildren({
+				filters: { ...filters, parent_request_id: log.id },
+				pagination: { ...pagination, limit: chainChildrenPageLimit, offset: 0, sort_by: "timestamp", order: "asc" },
+			}).then((result) => {
+				setLoadingChainIds((prev) => {
+					const next = new Set(prev);
+					next.delete(log.id);
+					return next;
+				});
+				if (result.data) {
+					const children = result.data.logs;
+					setChainChildren((prevCache) => ({ ...prevCache, [log.id]: children }));
+				} else if (result.error) {
+					setExpandedChainIds((prev) => {
+						const next = new Set(prev);
+						next.delete(log.id);
+						return next;
+					});
+					setError(getErrorMessage(result.error));
+				}
+			});
+		},
+		[expandedChainIds, chainChildren, loadingChainIds, triggerGetChainChildren, filters, pagination],
 	);
 
 	const handleDelete = useCallback(
@@ -500,8 +569,8 @@ export default function LogsPage() {
 	}, [userAgentMappingsData?.mappings]);
 
 	const columns = useMemo(
-		() => createColumns(handleDelete, hasDeleteAccess, metadataKeys, customAppIcons),
-		[customAppIcons, handleDelete, hasDeleteAccess, metadataKeys],
+		() => createColumns(handleDelete, hasDeleteAccess, metadataKeys, customAppIcons, grouped),
+		[customAppIcons, handleDelete, hasDeleteAccess, metadataKeys, grouped],
 	);
 
 	const columnIds = useMemo(
@@ -546,12 +615,36 @@ export default function LogsPage() {
 		paramName: "cols",
 		storageKey: "bifrost.logs.cols",
 		defaultHidden: DEFAULT_HIDDEN_COLUMNS,
-		fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
+		fixedColumns: {
+			...(grouped ? { left: ["expand"] } : {}),
+			...(hasDeleteAccess ? { right: ["actions"] } : {}),
+		},
 	});
 
 	// Navigation for log detail sheet
 	const logs = logsData?.logs ?? [];
 	const totalItems = logsData?.stats?.total_requests ?? 0;
+
+	// Grouped view: splice loaded children in below their expanded root. Children
+	// are marked so the table can indent them; they don't affect pagination.
+	const displayLogs: DisplayLogEntry[] = useMemo(() => {
+		if (!grouped || expandedChainIds.size === 0) return logs;
+		const out: DisplayLogEntry[] = [];
+		for (const log of logs) {
+			out.push(log);
+			if (expandedChainIds.has(log.id)) {
+				for (const child of chainChildren[log.id] ?? []) {
+					out.push({ ...child, __chainChild: true });
+				}
+			}
+		}
+		return out;
+	}, [logs, grouped, expandedChainIds, chainChildren]);
+
+	const tableMeta = useMemo(
+		() => ({ expandedChainIds, loadingChainIds, onToggleChain: handleToggleChain }),
+		[expandedChainIds, loadingChainIds, handleToggleChain],
+	);
 	const selectedLogFromData = useMemo(
 		() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null),
 		[selectedLogId, logs],
@@ -595,6 +688,7 @@ export default function LogsPage() {
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
+						rootsOnly: grouped,
 					}).then((result) => {
 						if (result.data?.logs?.length) {
 							const lastLog = result.data.logs[result.data.logs.length - 1];
@@ -620,6 +714,7 @@ export default function LogsPage() {
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
+						rootsOnly: grouped,
 					}).then((result) => {
 						if (result.data?.logs?.length) {
 							const firstLog = result.data.logs[0];
@@ -635,7 +730,7 @@ export default function LogsPage() {
 				}
 			}
 		},
-		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
+		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, grouped, setUrlState, triggerGetLogs],
 	);
 
 	return (
@@ -665,6 +760,8 @@ export default function LogsPage() {
 								loading={logsIsFetching}
 								polling={polling}
 								onPollToggle={handlePollToggle}
+								grouped={grouped}
+								onGroupedToggle={(enabled) => setUrlState({ grouped: enabled, offset: 0 })}
 								period={period}
 								onPeriodChange={handlePeriodChange}
 								totalLogs={totalItems}
@@ -736,7 +833,8 @@ export default function LogsPage() {
 						<div className="min-h-0 flex-1">
 							<LogsDataTable
 								columns={columns}
-								data={logs}
+								data={displayLogs}
+								tableMeta={tableMeta}
 								loading={logsIsFetching}
 								totalItems={totalItems}
 								pagination={pagination}

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -14,13 +14,21 @@ import {
 	Status,
 	StatusBarColors,
 } from "@/lib/constants/logs";
-import { ChatMessageContent, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
+import { ChatMessageContent, DisplayLogEntry, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { ColumnDef } from "@tanstack/react-table";
 import { format, formatDistanceToNow } from "date-fns";
-import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
+import { ArrowUpDown, ChevronRight, CornerDownRight, Loader2, MoreHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
+
+// Passed to useReactTable({ meta }) by the logs page so the expander column can
+// read/toggle chain expansion without threading props through column factories.
+export interface LogsTableMeta {
+	expandedChainIds: Set<string>;
+	loadingChainIds: Set<string>;
+	onToggleChain: (log: LogEntry) => void;
+}
 
 function LogActionsMenu({ log, onDelete }: { log: LogEntry; onDelete: (log: LogEntry) => void }) {
 	const [isOpen, setIsOpen] = useState(false);
@@ -261,7 +269,51 @@ export const createColumns = (
 	hasDeleteAccess = true,
 	metadataKeys: string[] = [],
 	customAppIcons: Record<string, string> = {},
+	groupedView = false,
 ): ColumnDef<LogEntry>[] => {
+	// Chevron that expands a fallback chain in the grouped view. Child rows get a
+	// corner connector instead so the hierarchy stays readable in any column order.
+	const expandColumn: ColumnDef<LogEntry>[] = groupedView
+		? [
+			{
+				id: "expand",
+				header: "",
+				size: 52,
+				cell: ({ row, table }) => {
+					const meta = table.options.meta as LogsTableMeta | undefined;
+					const log = row.original as DisplayLogEntry;
+					if (log.__chainChild) {
+						return <CornerDownRight className="text-muted-foreground/70 mx-auto size-3.5" />;
+					}
+					const childCount = log.child_count ?? 0;
+					if (!childCount || !meta) return null;
+					const isExpanded = meta.expandedChainIds.has(log.id);
+					const isLoading = meta.loadingChainIds.has(log.id);
+					return (
+						<button
+							type="button"
+							data-testid="log-chain-expand-btn"
+							aria-label={isExpanded ? "Collapse fallback chain" : `Expand fallback chain (${childCount} attempts)`}
+							aria-expanded={isExpanded}
+							className="text-muted-foreground hover:text-foreground gap-1 rounded-sm transition-colors absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center cursor-pointer"
+							onClick={(event) => {
+								event.stopPropagation();
+								meta.onToggleChain(log);
+							}}
+						>
+							{isLoading ? (
+								<Loader2 className="size-3.5 animate-spin" />
+							) : (
+								<ChevronRight className={cn("size-3.5 transition-transform", isExpanded && "rotate-90")} />
+							)}
+							<span className="font-mono text-[10.5px] tabular-nums">{childCount}</span>
+						</button>
+					);
+				},
+			},
+		]
+		: [];
+
 	const baseColumns: ColumnDef<LogEntry>[] = [
 		{
 			accessorKey: "status",
@@ -530,5 +582,5 @@ export const createColumns = (
 		]
 		: [];
 
-	return [...baseColumns, ...attributionColumns, ...metadataColumns, ...actionsColumn];
+	return [...expandColumn, ...baseColumns, ...attributionColumns, ...metadataColumns, ...actionsColumn];
 };

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -4,6 +4,7 @@ import { Command, CommandItem, CommandList } from "@/components/ui/command";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage } from "@/lib/store";
 import { useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
@@ -11,7 +12,7 @@ import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
-import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
+import { Calculator, ListTree, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { RecalculateCostDialog, type RecalculateCostMode } from "./recalculateCostDialog";
@@ -25,6 +26,9 @@ interface LogsHeaderViewProps {
 	loading?: boolean;
 	polling: boolean;
 	onPollToggle: (enabled: boolean) => void;
+	/** Grouped view: collapse fallback chains into their root request */
+	grouped: boolean;
+	onGroupedToggle: (enabled: boolean) => void;
 	period: string;
 	onPeriodChange: (period?: string, from?: Date, to?: Date) => void;
 	/** Total logs matching the current filters/time window (stats.total_requests) */
@@ -45,6 +49,8 @@ export function LogsHeaderView({
 	loading = false,
 	polling,
 	onPollToggle,
+	grouped,
+	onGroupedToggle,
 	period,
 	onPeriodChange,
 	totalLogs,
@@ -216,6 +222,25 @@ export function LogsHeaderView({
 				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
 				Live
 			</Button>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						data-testid="logs-group-chains-btn"
+						variant={grouped ? "default" : "outline"}
+						size="sm"
+						className="h-7.5"
+						onClick={() => onGroupedToggle(!grouped)}
+					>
+						<ListTree className="h-4 w-4" />
+						Group
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent sideOffset={6} className="max-w-64">
+					Groups fallback attempts and linked requests under the original root request. Expand any row to view the complete request chain.
+					<br /><br />
+					This grouped view may load more slowly than the flat view for very large log tables.
+				</TooltipContent>
+			</Tooltip>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
 				<Input

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -7,7 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
 import { getErrorMessage } from "@/lib/store";
-import { useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
+import { useCancelRecalculateCostJobMutation, useGetRecalculateCostStatusQuery } from "@/lib/store/apis/logsApi";
 import { getActiveTempToken } from "@/lib/store/apis/tempToken";
 import type { LogFilters as LogFiltersType, RecalcJobStatus } from "@/lib/types/logs";
 import { getApiBaseUrl } from "@/lib/utils/port";
@@ -16,6 +16,15 @@ import { Calculator, ListTree, MoreVertical, Radio, RefreshCw, Search } from "lu
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { RecalculateCostDialog, type RecalculateCostMode } from "./recalculateCostDialog";
+
+// One id for the whole recalculation lifecycle, so the start / progress / cancelling
+// / result updates all land on the same toast instead of stacking.
+const RECALC_TOAST_ID = "logs-recalculate-costs";
+
+// Statuses a recalculation job never leaves. Polling stops at any of them.
+function isTerminalRecalcStatus(status: RecalcJobStatus["status"]): boolean {
+	return status === "completed" || status === "failed" || status === "cancelled";
+}
 
 interface LogsHeaderViewProps {
 	filters: LogFiltersType;
@@ -75,6 +84,11 @@ export function LogsHeaderView({
 			skip: !activeRecalcJobId,
 		},
 	);
+	const [cancelRecalcJob] = useCancelRecalculateCostJobMutation();
+	// True from the moment Cancel is clicked until the job settles. It swaps the
+	// progress toast for a "cancelling" one so the button can't be clicked twice while
+	// the worker finishes the batch it is in the middle of.
+	const [recalcCancelRequested, setRecalcCancelRequested] = useState(false);
 	const isRecalcRunning = !!activeRecalcJobId;
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -108,8 +122,7 @@ export function LogsHeaderView({
 		async (mode: RecalculateCostMode) => {
 			setRecalcDialogOpen(false);
 			const missingCostOnly = mode === "missing";
-			const toastId = "logs-recalculate-costs";
-			toast.loading("Starting cost recalculation...", { id: toastId });
+			toast.loading("Starting cost recalculation...", { id: RECALC_TOAST_ID });
 
 			try {
 				// Recalculation runs as a background job. Enqueue it (or attach to the one
@@ -119,32 +132,62 @@ export function LogsHeaderView({
 					throw new Error("Recalculation job did not start");
 				}
 				if (alreadyRunning) {
-					toast.loading("A cost recalculation is already running...", { id: toastId });
+					toast.loading("A cost recalculation is already running...", { id: RECALC_TOAST_ID });
 				}
+				setRecalcCancelRequested(false);
 				setActiveRecalcJobId(status.id);
 			} catch (err) {
-				toast.error("Cost recalculation failed", { id: toastId, description: getErrorMessage(err) });
+				toast.error("Cost recalculation failed", { id: RECALC_TOAST_ID, description: getErrorMessage(err) });
 			}
 		},
 		[filters],
 	);
+
+	// Stop the tracked job. The worker finishes the batch it is in the middle of and
+	// then settles as "cancelled", which the status effect below reports — so this only
+	// sends the request and switches the toast to its cancelling state; it never clears
+	// the tracked job itself. If the request fails the job keeps running and the next
+	// poll restores the progress toast.
+	const handleCancelRecalculate = useCallback(async () => {
+		const jobId = activeRecalcJobIdRef.current;
+		if (!jobId) return;
+		setRecalcCancelRequested(true);
+		toast.loading("Cancelling cost recalculation…", {
+			id: RECALC_TOAST_ID,
+			description: "Finishing the current batch. Costs already recalculated are kept.",
+		});
+		try {
+			await cancelRecalcJob({ id: jobId }).unwrap();
+		} catch (err) {
+			setRecalcCancelRequested(false);
+			// Same id as the rest of the lifecycle: this replaces the "Cancelling…"
+			// toast rather than stacking a second one on top of it. The next poll
+			// (2s) then restores the progress toast with its Cancel action, which
+			// is the truthful end state — the job is still running.
+			toast.error("Couldn't cancel the recalculation", {
+				id: RECALC_TOAST_ID,
+				description: getErrorMessage(err),
+			});
+		}
+	}, [cancelRecalcJob]);
 
 	// If the status endpoint keeps failing, stop polling and surface the error so the
 	// user isn't left with a loading toast that never resolves.
 	useEffect(() => {
 		if (!activeRecalcJobId || !recalcJobStatusError) return;
 		toast.error("Cost recalculation failed", {
-			id: "logs-recalculate-costs",
+			id: RECALC_TOAST_ID,
 			description: "Lost track of the recalculation job status. Please refresh and try again.",
 		});
 		setActiveRecalcJobId(null);
+		setRecalcCancelRequested(false);
 	}, [activeRecalcJobId, recalcJobStatusError]);
 
 	// If we unmount while a job is still being tracked, polling stops but the global
 	// loading toast would otherwise linger — dismiss it on the way out.
 	useEffect(() => {
 		return () => {
-			if (activeRecalcJobIdRef.current) toast.dismiss("logs-recalculate-costs");
+			if (activeRecalcJobIdRef.current) toast.dismiss(RECALC_TOAST_ID);
 		};
 	}, []);
 
@@ -152,37 +195,60 @@ export function LogsHeaderView({
 	// and on a terminal status show the result, refresh the view, and stop polling.
 	useEffect(() => {
 		if (!activeRecalcJobId || !recalcJobStatus) return;
-		const toastId = "logs-recalculate-costs";
 
-		if (recalcJobStatus.status === "completed" || recalcJobStatus.status === "failed") {
+		if (isTerminalRecalcStatus(recalcJobStatus.status)) {
 			if (recalcJobStatus.status === "failed") {
 				toast.error("Cost recalculation failed", {
-					id: toastId,
+					id: RECALC_TOAST_ID,
 					description: recalcJobStatus.last_error || recalcJobStatus.message || "The job did not complete",
+				});
+			} else if (recalcJobStatus.status === "cancelled") {
+				// Not an error: whatever the job committed before stopping is valid, so
+				// report the partial result rather than framing it as a failure.
+				toast.info("Cost recalculation cancelled", {
+					id: RECALC_TOAST_ID,
+					description: recalcJobStatus.message || `Stopped after ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
+					duration: 5000,
 				});
 			} else {
 				toast.success("Cost recalculation complete", {
-					id: toastId,
+					id: RECALC_TOAST_ID,
 					description: recalcJobStatus.message || `${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
 					duration: 5000,
 				});
 			}
 			setActiveRecalcJobId(null);
+			setRecalcCancelRequested(false);
+			// A cancelled job still wrote costs for the rows it got through, so refresh
+			// on every terminal status, not just completion.
 			void fetchLogs();
 			void fetchStats();
 			return;
 		}
 
+		// A cancel is in flight: keep the "cancelling" toast (and its lack of a Cancel
+		// button) in place rather than overwriting it with a progress update.
+		if (recalcCancelRequested) return;
+
 		const total = recalcJobStatus.total || 0;
 		const processed = total > 0 ? Math.min(recalcJobStatus.processed, total) : recalcJobStatus.processed;
 		toast.loading("Recalculating log costs...", {
-			id: toastId,
+			id: RECALC_TOAST_ID,
 			description:
 				total > 0
 					? `${processed}/${total} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`
 					: `${recalcJobStatus.processed} checked, ${recalcJobStatus.updated} updated, ${recalcJobStatus.skipped} skipped`,
+			action: {
+				label: "Cancel",
+				// preventDefault keeps the toast mounted so it can report the cancellation;
+				// sonner otherwise dismisses a toast as soon as its action fires.
+				onClick: (event) => {
+					event.preventDefault();
+					void handleCancelRecalculate();
+				},
+			},
 		});
-	}, [activeRecalcJobId, recalcJobStatus, fetchLogs, fetchStats]);
+	}, [activeRecalcJobId, recalcJobStatus, recalcCancelRequested, handleCancelRecalculate, fetchLogs, fetchStats]);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
@@ -283,12 +349,18 @@ export function LogsHeaderView({
 				<PopoverContent className="bg-accent w-[250px] p-2" align="end">
 					<Command>
 						<CommandList>
+							{/* While a job runs this doubles as the cancel control, so the run can
+							    still be stopped if the progress toast was dismissed. */}
 							<CommandItem
 								className="hover:bg-accent/50 cursor-pointer"
-								disabled={isRecalcRunning}
+								disabled={recalcCancelRequested}
 								onSelect={() => {
-									if (isRecalcRunning) return;
+									if (recalcCancelRequested) return;
 									setOpenMoreActionsPopover(false);
+									if (isRecalcRunning) {
+										void handleCancelRecalculate();
+										return;
+									}
 									setRecalcDialogOpen(true);
 								}}
 							>
@@ -298,9 +370,15 @@ export function LogsHeaderView({
 									<Calculator className="text-muted-foreground size-4" />
 								)}
 								<div className="flex flex-col">
-									<span className="text-sm">{isRecalcRunning ? "Recalculating costs…" : "Recalculate costs"}</span>
+									<span className="text-sm">
+										{recalcCancelRequested ? "Cancelling…" : isRecalcRunning ? "Cancel recalculation" : "Recalculate costs"}
+									</span>
 									<span className="text-muted-foreground text-xs">
-										{isRecalcRunning ? "A recalculation is already running" : "Recompute cost for logs in this view"}
+										{recalcCancelRequested
+											? "Finishing the current batch"
+											: isRecalcRunning
+												? "Stop the running recalculation; costs already updated are kept"
+												: "Recompute cost for logs in this view"}
 									</span>
 								</div>
 							</CommandItem>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -11,9 +11,9 @@ import { Button } from "@/components/ui/button";
 import { ComboboxSelect, type ComboboxSelectOption } from "@/components/ui/combobox";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { DEFAULT_PAGE_SIZE_OPTIONS, useTablePageSizePreference } from "@/lib/hooks/useTablePageSizePreference";
-import type { LogEntry, Pagination } from "@/lib/types/logs";
+import type { DisplayLogEntry, LogEntry, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import type { ColumnOrderState, ColumnPinningState, VisibilityState } from "@tanstack/react-table";
+import type { ColumnOrderState, ColumnPinningState, TableMeta, VisibilityState } from "@tanstack/react-table";
 import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,6 +36,8 @@ interface DataTableProps {
 	onToggleColumnVisibility: (id: string) => void;
 	onTogglePin: (id: string, side: "left" | "right") => void;
 	onReorderColumns: (entries: ColumnConfigEntry[]) => void;
+	/** Table meta consumed by the expand column in grouped view */
+	tableMeta?: TableMeta<LogEntry>;
 }
 
 export function LogsDataTable({
@@ -55,11 +57,12 @@ export function LogsDataTable({
 	onToggleColumnVisibility,
 	onTogglePin,
 	onReorderColumns,
+	tableMeta,
 }: DataTableProps) {
 	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
 	const [pageSizePref, setPageSizePref, pageSizeHydrated] = useTablePageSizePreference("bifrost.logs.pageSize");
 
-	const fixedColumnIds = useMemo(() => new Set<string>(["actions"]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>(["expand", "actions"]), []);
 
 	// Measure actual header cell widths for pixel-perfect pin offsets
 	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
@@ -147,6 +150,7 @@ export function LogsDataTable({
 			columnPinning,
 		},
 		onSortingChange: handleSortingChange,
+		meta: tableMeta,
 	});
 
 	const hasItems = totalItems > 0;
@@ -224,7 +228,14 @@ export function LogsDataTable({
 						</TableRow>
 						{table.getRowModel().rows.length ? (
 							table.getRowModel().rows.map((row) => (
-								<TableRow key={row.id} className="hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer">
+								<TableRow
+									key={row.id}
+									className={cn(
+										"hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer",
+										(row.original as DisplayLogEntry).__chainChild &&
+										"bg-muted/30 border-l-2 border-l-zinc-300 dark:border-l-zinc-600",
+									)}
+								>
 									{row.getVisibleCells().map((cell) => {
 										const pinned = cell.column.getIsPinned();
 										const size = cell.column.getSize();

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1,5 +1,7 @@
 import {
 	ArrowUpRight,
+	BadgeCheck,
+	BadgeInfo,
 	BookOpenText,
 	BookUser,
 	Boxes,
@@ -9,25 +11,26 @@ import {
 	Building2,
 	ChartColumnBig,
 	ChevronsLeftRightEllipsis,
+	CircuitBoard,
 	Construction,
 	DatabaseZap,
 	Flag,
 	FlaskConical,
 	FolderGit,
 	Gavel,
+	GitCompareArrows,
 	Globe,
+	Hexagon,
 	History,
 	KeyRound,
 	Landmark,
-	Hexagon,
-	BadgeCheck,
-	BadgeInfo,
 	LaptopMinimalCheck,
 	LayoutGrid,
 	LogOut,
 	Logs,
 	Megaphone,
 	Network,
+	Palette,
 	PanelLeftClose,
 	PanelLeftOpen,
 	Plug,
@@ -50,13 +53,10 @@ import {
 	Wallet,
 	WalletCards,
 	Webhook,
-	CircuitBoard,
-	GitCompareArrows,
 } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
 	Sidebar,
 	SidebarContent,
@@ -71,9 +71,11 @@ import {
 	SidebarMenuSubItem,
 	useSidebar,
 } from "@/components/ui/sidebar";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { HIDDEN_UNTIL_NAV_COOKIE, REMIND_LATER_COOKIE, useOnboardingChecklist } from "@/hooks/useOnboardingChecklist";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { useBranding } from "@/lib/hooks/useBranding";
 import { useGetCoreConfigQuery, useGetLatestReleaseQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
@@ -283,15 +285,14 @@ const SidebarItemView = ({
 
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-		isHighlighted
-			? "bg-sidebar-accent text-accent-foreground border-primary/20"
-			: isActive || isAnySubItemActive
-				? "bg-sidebar-accent text-primary border-primary/20"
-				: item.hasAccess
-					? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-					: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-	} `;
+	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
+		? "bg-sidebar-accent text-accent-foreground border-primary/20"
+		: isActive || isAnySubItemActive
+			? "bg-sidebar-accent text-primary border-primary/20"
+			: item.hasAccess
+				? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+				: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+		} `;
 
 	const innerContent = (
 		<div className="flex w-full items-center justify-between">
@@ -442,15 +443,14 @@ const SidebarItemView = ({
 						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : isRouteMatch(subItem.url);
 						const isSubItemHighlighted = highlightedUrl ? subItemHref.startsWith(highlightedUrl) : false;
 						const SubItemIcon = subItem.icon;
-						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-							isSubItemHighlighted
-								? "bg-sidebar-accent text-accent-foreground"
-								: isSubItemActive
-									? "bg-sidebar-accent text-primary font-medium"
-									: subItem.hasAccess === false
-										? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-										: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-						}`;
+						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
+							? "bg-sidebar-accent text-accent-foreground"
+							: isSubItemActive
+								? "bg-sidebar-accent text-primary font-medium"
+								: subItem.hasAccess === false
+									? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+									: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+							}`;
 						const subInner = (
 							<div className="flex w-full items-center gap-2">
 								{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
@@ -994,21 +994,21 @@ export default function AppSidebar() {
 			},
 			...(isDbConnected
 				? [
-						{
-							title: "Prompt Repository",
-							url: "/workspace/prompt-repo",
-							icon: FolderGit,
-							description: "Prompt repository",
-							hasAccess: hasPromptRepositoryAccess,
-						},
-						{
-							title: "Skills Repository",
-							url: "/workspace/skills-repo",
-							icon: BookOpenText,
-							description: "Skills repository",
-							hasAccess: hasSkillsRepositoryAccess,
-						},
-					]
+					{
+						title: "Prompt Repository",
+						url: "/workspace/prompt-repo",
+						icon: FolderGit,
+						description: "Prompt repository",
+						hasAccess: hasPromptRepositoryAccess,
+					},
+					{
+						title: "Skills Repository",
+						url: "/workspace/skills-repo",
+						icon: BookOpenText,
+						description: "Skills repository",
+						hasAccess: hasSkillsRepositoryAccess,
+					},
+				]
 				: []),
 			{
 				title: "Evals",
@@ -1055,14 +1055,14 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "Proxy",
-									url: "/workspace/config/proxy",
-									icon: Globe,
-									description: "Proxy configuration",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Proxy",
+								url: "/workspace/config/proxy",
+								icon: Globe,
+								description: "Proxy configuration",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 					{
 						title: "API Keys",
@@ -1087,14 +1087,21 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "License Info",
-									url: "/workspace/config/license",
-									icon: BadgeInfo,
-									description: "Enterprise license information",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Branding",
+								url: "/workspace/config/branding",
+								icon: Palette,
+								description: "Custom logo and icon",
+								hasAccess: hasSettingsAccess,
+							},
+							{
+								title: "License Info",
+								url: "/workspace/config/license",
+								icon: BadgeInfo,
+								description: "Enterprise license information",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 				],
 			},
@@ -1356,9 +1363,10 @@ export default function AppSidebar() {
 		return false;
 	};
 
-	// Always render the light theme version for SSR to avoid hydration mismatch
-	const logoSrc = mounted && resolvedTheme === "dark" ? "/bifrost-logo-dark.webp" : "/bifrost-logo.webp";
-	const iconSrc = mounted && resolvedTheme === "dark" ? "/bifrost-icon-dark.webp" : "/bifrost-icon.webp";
+	// Always render the light theme version for SSR to avoid hydration mismatch.
+	// On a custom branding deployment useBranding returns the customer's assets
+	// instead, which are theme-agnostic.
+	const { logoSrc, iconSrc, logoAlt } = useBranding(mounted && resolvedTheme === "dark");
 
 	const { isConnected: isWebSocketConnected } = useWebSocket();
 
@@ -1514,7 +1522,16 @@ export default function AppSidebar() {
 				{/* Expanded state: horizontal layout */}
 				<div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
 					<Link to="/workspace/logs" className="group flex items-center gap-2 pl-2">
-						<img className="h-[22px] w-auto" src={logoSrc} alt="Bifrost" width={70} height={70} />
+						{/* max-w caps an unusually wide uploaded logo so it cannot push the
+						    collapse button out of the header; object-contain preserves its
+						    aspect ratio within that box. */}
+						<img
+							className="h-[22px] w-auto max-w-[150px] object-contain"
+							src={logoSrc}
+							alt={logoAlt}
+							width={70}
+							height={70}
+						/>
 					</Link>
 					<button
 						onClick={toggleSidebar}
@@ -1531,7 +1548,14 @@ export default function AppSidebar() {
 					className="hidden w-full cursor-pointer flex-col items-center gap-2 py-2 group-data-[collapsible=icon]:flex"
 					onClick={toggleSidebar}
 				>
-					<img className="h-[22px] w-auto" src={iconSrc} alt="Bifrost" width={22} height={22} style={{ width: 18 }} />
+					<img
+						className="h-[22px] w-auto object-contain"
+						src={iconSrc}
+						alt={logoAlt}
+						width={22}
+						height={22}
+						style={{ width: 18 }}
+					/>
 				</div>
 			</SidebarHeader>
 			{envLabel && (

--- a/ui/lib/hooks/useBranding.ts
+++ b/ui/lib/hooks/useBranding.ts
@@ -1,0 +1,69 @@
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { useGetBrandingQuery } from "@/lib/store/apis/brandingApi";
+import { getApiBaseUrl } from "@/lib/utils/port";
+
+/** Bundled Bifrost assets. These are the OSS values and the fallback for every
+ * slot an enterprise deployment has not overridden. */
+const DEFAULT_LOGO_LIGHT = "/bifrost-logo.webp";
+const DEFAULT_LOGO_DARK = "/bifrost-logo-dark.webp";
+const DEFAULT_ICON_LIGHT = "/bifrost-icon.webp";
+const DEFAULT_ICON_DARK = "/bifrost-icon-dark.webp";
+
+/**
+ * Resolves a branding asset URL returned by the API against the current API
+ * base. The server returns paths rooted at /api; in development the app is
+ * served from a different origin than the API, so those need the resolved base
+ * prepended or the browser would request them from the Vite dev server.
+ */
+export function resolveBrandingAssetUrl(url: string | undefined): string {
+	if (!url) return "";
+	const apiBase = getApiBaseUrl();
+	return url.startsWith("/api/") ? `${apiBase}${url.slice("/api".length)}` : url;
+}
+
+export interface BrandingAssets {
+	/** Wordmark for the expanded sidebar and the login screen. */
+	logoSrc: string;
+	/** Square mark for the collapsed sidebar. */
+	iconSrc: string;
+	/** True when a custom logo or icon is in use. Surfaces that hardcode
+	 * "Bifrost" as alt text or a product name should fall back to a neutral
+	 * label when this is set. */
+	isCustom: boolean;
+	/** Alt text: the customer's logo is not the Bifrost logo, and labelling it
+	 * as such would be wrong on a custom branding deployment. */
+	logoAlt: string;
+}
+
+/**
+ * Resolves which logo and icon to render.
+ *
+ * Each slot falls back independently: a deployment that uploaded only a logo
+ * keeps the default Bifrost icon. Custom assets are theme-agnostic — a single
+ * upload serves both light and dark — so `isDark` only selects between the two
+ * bundled defaults.
+ *
+ * While the query is in flight the defaults are returned rather than nothing,
+ * so the logo never renders as a blank gap. On a branded deployment that means
+ * a brief flash of the Bifrost logo on first paint; the pre-hydration shell is
+ * rewritten server-side to avoid it on the initial document load, and the
+ * response is cached for subsequent navigations.
+ */
+export function useBranding(isDark: boolean): BrandingAssets {
+	// Fires on the login screen too, where no session exists — the endpoint is
+	// public precisely so this works pre-auth. Skipped on OSS, where the whole
+	// branding surface lives in the enterprise build and the route does not
+	// exist: without this every page load would spend a request on a 404 and
+	// then fall back to the defaults it already has.
+	const { data } = useGetBrandingQuery(undefined, { skip: !IS_ENTERPRISE });
+
+	const hasLogo = Boolean(data?.has_logo && data.logo_url);
+	const hasIcon = Boolean(data?.has_icon && data.icon_url);
+
+	return {
+		logoSrc: hasLogo ? resolveBrandingAssetUrl(data!.logo_url) : isDark ? DEFAULT_LOGO_DARK : DEFAULT_LOGO_LIGHT,
+		iconSrc: hasIcon ? resolveBrandingAssetUrl(data!.icon_url) : isDark ? DEFAULT_ICON_DARK : DEFAULT_ICON_LIGHT,
+		isCustom: Boolean(data?.enabled),
+		logoAlt: data?.enabled ? "" : "Bifrost",
+	};
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -196,6 +196,7 @@ export const baseApi = createApi({
 		"Skills",
 		"OAuth2Grants",
 		"UserAgentMappings",
+		"Branding",
 		"Devices",
 		"CircuitBreakerPolicies",
 		"CircuitBreakerState",

--- a/ui/lib/store/apis/brandingApi.ts
+++ b/ui/lib/store/apis/brandingApi.ts
@@ -1,0 +1,72 @@
+import { baseApi } from "./baseApi";
+
+/**
+ * custom branding.
+ *
+ * Enterprise deployments can replace the Bifrost logo and icon. Every endpoint
+ * below lives in the enterprise build — the read is public there (the login
+ * screen renders before any session exists), while the writes carry auth and
+ * RBAC. On OSS none of them exist: callers skip the query (see useBranding) and
+ * every surface keeps the bundled defaults.
+ *
+ * The response carries URLs rather than base64 so the images are fetched and
+ * cached by the browser as ordinary assets instead of riding along in JSON.
+ */
+export interface BrandingState {
+	/** True when at least one slot is overridden. */
+	enabled: boolean;
+	has_logo: boolean;
+	has_icon: boolean;
+	/** Content-versioned; empty when the slot uses the Bifrost default. */
+	logo_url?: string;
+	icon_url?: string;
+	updated_at?: string;
+}
+
+/**
+ * Upload payload, applied as a merge:
+ *
+ *   omitted        -> leave that slot as stored
+ *   ""             -> clear that slot, restoring the Bifrost default
+ *   base64 data    -> replace that slot
+ *
+ * So a caller changing only the icon omits the logo fields rather than
+ * re-uploading the logo to avoid wiping it.
+ */
+export interface BrandingPayload {
+	logo?: string; // base64 image data (a full data: URI is also accepted)
+	logo_mime?: string;
+	icon?: string;
+	icon_mime?: string;
+}
+
+export const brandingApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getBranding: builder.query<BrandingState, void>({
+			query: () => ({
+				url: "/branding",
+			}),
+			providesTags: ["Branding"],
+		}),
+
+		updateBranding: builder.mutation<BrandingState, BrandingPayload>({
+			query: (data) => ({
+				url: "/branding",
+				method: "PUT",
+				body: data,
+			}),
+			invalidatesTags: ["Branding"],
+		}),
+
+		// Clears branding and restores the default Bifrost logo and icon.
+		resetBranding: builder.mutation<BrandingState, void>({
+			query: () => ({
+				url: "/branding",
+				method: "DELETE",
+			}),
+			invalidatesTags: ["Branding"],
+		}),
+	}),
+});
+
+export const { useGetBrandingQuery, useUpdateBrandingMutation, useResetBrandingMutation } = brandingApi;

--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -2,6 +2,7 @@
 export { baseApi, clearAuthStorage, getErrorMessage, setAuthToken } from "./baseApi";
 
 // API slices and hooks
+export * from "./brandingApi";
 export * from "./configApi";
 export * from "./featureFlagsApi";
 export * from "./devApi";

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -431,6 +431,21 @@ export const logsApi = baseApi.injectEndpoints({
 			}),
 		}),
 
+		// Stop a running cost recalculation. Costs already recomputed are kept; the job
+		// simply stops walking the window. Omit id to cancel whichever job is in flight.
+		// Resolves with the job's post-cancel status so the caller can settle its UI.
+		cancelRecalculateCostJob: builder.mutation<RecalcJobStatus, { id?: string } | void>({
+			query: (arg) => ({
+				url: "/logs/recalculate-cost/cancel",
+				method: "POST",
+				params: arg?.id ? { id: arg.id } : {},
+			}),
+			// A cancelled job still committed costs for every row it got through, so
+			// every Logs-tagged query (stats, histograms, filter data) is stale — same
+			// as for the start mutation above.
+			invalidatesTags: ["Logs"],
+		}),
+
 		// Get a single log entry by ID (includes raw_request and raw_response)
 		getLogById: builder.query<LogEntry, string>({
 			query: (id) => `/logs/${encodeURIComponent(id)}`,
@@ -477,6 +492,7 @@ export const {
 	useDeleteLogsMutation,
 	useRecalculateLogCostsMutation,
 	useGetRecalculateCostStatusQuery,
+	useCancelRecalculateCostJobMutation,
 	useLazyGetLogByIdQuery,
 	useGetLogByIdQuery,
 } = logsApi;

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -127,15 +127,18 @@ export const logsApi = baseApi.injectEndpoints({
 			{
 				filters: LogFilters;
 				pagination: Pagination;
+				/** Grouped view: hide fallback-child rows so each chain lists as its root */
+				rootsOnly?: boolean;
 			}
 		>({
-			query: ({ filters, pagination }) => ({
+			query: ({ filters, pagination, rootsOnly }) => ({
 				url: "/logs",
 				params: {
 					limit: pagination.limit,
 					offset: pagination.offset,
 					sort_by: pagination.sort_by,
 					order: pagination.order,
+					...(rootsOnly ? { roots_only: "true" } : {}),
 					...buildFilterParams(filters),
 				},
 			}),

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -882,10 +882,13 @@ export interface RecalculateCostProgress {
 }
 
 // RecalcJobStatus is the status of a background cost-recalculation job, returned by
-// POST /api/logs/recalculate-cost (202/409) and GET /api/logs/recalculate-cost/status.
+// POST /api/logs/recalculate-cost (202/409), POST /api/logs/recalculate-cost/cancel
+// and GET /api/logs/recalculate-cost/status.
 export interface RecalcJobStatus {
 	id?: string;
-	status: "idle" | "pending" | "running" | "completed" | "failed";
+	// "cancelled" is terminal like completed/failed: the job was stopped on request,
+	// and the counters describe the work it committed before stopping.
+	status: "idle" | "pending" | "running" | "completed" | "failed" | "cancelled";
 	total: number;
 	processed: number;
 	updated: number;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -620,7 +620,16 @@ export interface LogEntry {
 	redaction_mapping?: RedactionMapping; // Phase-scoped placeholder-to-original mappings, present only when caller has Logs:Reveal
 	user_agent?: string; // Raw HTTP User-Agent of the calling client
 	app?: string; // Backend-detected client app
+	// Aggregates over this log's fallback children (rows whose parent_request_id
+	// equals this log's id). Present only on roots_only list responses.
+	child_count?: number;
+	children_cost?: number;
+	children_tokens?: number;
 }
+
+// A log row as rendered by the logs table. __chainChild marks rows injected
+// below an expanded parent in the grouped view; it never comes from the API.
+export type DisplayLogEntry = LogEntry & { __chainChild?: boolean };
 
 export interface LogFilters {
 	providers?: string[];


### PR DESCRIPTION
## Summary

Introduces a `ShellRewriter` hook that allows enterprise builds to rewrite the pre-hydration HTML shell before it is served, eliminating the flash of the default Bifrost logo before React hydrates on branded deployments. OSS deployments are unaffected — the rewriter is `nil` by default and the embedded document is served exactly as bundled.

## Changes

- Added the `ShellRewriter` function type to `UIHandler`, providing a seam for the enterprise build to swap logo references in the static HTML skeleton before it reaches the client. The rewriter is only invoked for `.html` files and is skipped entirely when `nil`.
- Exported `ShellRewriter` on `BifrostHTTPServer` so the enterprise build can assign an implementation before `RegisterUIRoutes` is called, which constructs the `UIHandler` from it.
- Updated `NewUIHandler` to accept a `ShellRewriter` parameter (nil-safe) and `RegisterUIRoutes` to forward `s.ShellRewriter` into it.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## Breaking changes

- [x] Yes — `NewUIHandler` now requires a second `ShellRewriter` argument (pass `nil` for OSS/default behaviour)
- [ ] No

## Security considerations

- The rewriter runs on the request path for every HTML document served; implementations must be cheap and must return data unchanged when there is nothing to do.
- OSS builds never execute any rewrite logic, as the `nil` check short-circuits before the function is called.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable