### PR TITLE
feat: add `WithFasthttpBufferSizes` option to `HTTPClientFactory` for configurable SCIM read/write buffers

### DIFF
--- a/core/network/http.go
+++ b/core/network/http.go
@@ -82,18 +82,45 @@ type HTTPClientFactory struct {
 	fasthttpClients map[ClientPurpose]*fasthttp.Client
 	httpClients     map[ClientPurpose]*http.Client
 
+	// Fasthttp read/write buffer sizes. Zero unless a caller opts in via
+	// WithFasthttpBufferSizes; when set, applied to the SCIM client only
+	// (see createFasthttpClient).
+	readBufferSize  int
+	writeBufferSize int
+
 	logger schemas.Logger
+}
+
+// FactoryOption customizes an HTTPClientFactory at construction time.
+type FactoryOption func(*HTTPClientFactory)
+
+// WithFasthttpBufferSizes overrides the fasthttp read/write buffer sizes used for
+// created clients. Non-positive values leave the corresponding field at zero, which
+// selects fasthttp's default buffer size.
+func WithFasthttpBufferSizes(read, write int) FactoryOption {
+	return func(f *HTTPClientFactory) {
+		if read > 0 {
+			f.readBufferSize = read
+		}
+		if write > 0 {
+			f.writeBufferSize = write
+		}
+	}
 }
 
 // NewHTTPClientFactory creates a new HTTP client factory with the given proxy configuration.
 // Pass nil for proxyConfig if proxy is not yet configured.
-func NewHTTPClientFactory(proxyConfig *GlobalProxyConfig, logger schemas.Logger) *HTTPClientFactory {
-	return &HTTPClientFactory{
+func NewHTTPClientFactory(proxyConfig *GlobalProxyConfig, logger schemas.Logger, opts ...FactoryOption) *HTTPClientFactory {
+	f := &HTTPClientFactory{
 		proxyConfig:     proxyConfig,
 		fasthttpClients: make(map[ClientPurpose]*fasthttp.Client, 3),
 		httpClients:     make(map[ClientPurpose]*http.Client, 3),
 		logger:          logger,
 	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
 }
 
 // UpdateProxyConfig updates the proxy configuration and recreates all cached clients.
@@ -222,6 +249,19 @@ func (f *HTTPClientFactory) createFasthttpClient(purpose ClientPurpose) *fasthtt
 		MaxConnWaitTimeout:  DefaultClientConfig.ReadTimeout,
 		ConnPoolStrategy:    fasthttp.FIFO,
 		RetryIfErr:          StaleConnectionRetryIfErr,
+	}
+
+	// Larger header buffers only for SCIM/OAuth, and only when a caller opted in via
+	// WithFasthttpBufferSizes: IdP token endpoints can return response headers
+	// exceeding fasthttp's 4KB default ("small read buffer"). Every other purpose,
+	// and any factory whose caller didn't set a size, keeps fasthttp's default.
+	if purpose == ClientPurposeSCIM {
+		if f.readBufferSize > 0 {
+			client.ReadBufferSize = f.readBufferSize
+		}
+		if f.writeBufferSize > 0 {
+			client.WriteBufferSize = f.writeBufferSize
+		}
 	}
 
 	// Configure proxy if enabled for this purpose


### PR DESCRIPTION
## Summary

IdP token endpoints can return response headers that exceed fasthttp's default 4 KB read buffer, causing failures for SCIM/OAuth clients. This PR introduces an opt-in mechanism to configure larger fasthttp read/write buffer sizes on `HTTPClientFactory`, applying the override exclusively to the SCIM client.

## Changes

- Added `readBufferSize` and `writeBufferSize` fields to `HTTPClientFactory` to store optional buffer size overrides.
- Introduced a `FactoryOption` functional option type and a `WithFasthttpBufferSizes(read, write int)` constructor to allow callers to opt into larger buffers. Non-positive values are ignored, preserving fasthttp's 64 KB default.
- Updated `NewHTTPClientFactory` to accept variadic `FactoryOption` arguments, maintaining backward compatibility with existing callers.
- In `createFasthttpClient`, the buffer size overrides are applied only when `purpose == ClientPurposeSCIM` and the caller explicitly set sizes — all other purposes retain fasthttp's defaults.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that a `HTTPClientFactory` created without `WithFasthttpBufferSizes` produces SCIM clients with fasthttp's default buffer sizes, and that one created with `WithFasthttpBufferSizes(read, write)` applies the override only to the SCIM client while leaving other purpose clients unchanged.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

`NewHTTPClientFactory` accepts variadic options; all existing call sites continue to work without modification.

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing implications. Larger header buffers reduce the risk of dropped responses from IdP token endpoints but do not alter authentication logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable