### PR TITLE
feat(complexity): harness-aware complexity input extraction for cc and codex

### DIFF
--- a/plugins/governance/complexityextract.go
+++ b/plugins/governance/complexityextract.go
@@ -1,18 +1,84 @@
 package governance
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/plugins/governance/complexity"
 )
 
+type complexityHarness uint8
+
+const (
+	complexityHarnessUnknown complexityHarness = iota
+	complexityHarnessClaudeCode
+	complexityHarnessCodex
+)
+
+type complexityTextKind uint8
+
+const (
+	complexityTextInvalid complexityTextKind = iota
+	complexityTextHuman
+	// Context-only text can be ignored while an earlier human turn remains the
+	// routing subject for the current request.
+	complexityTextContextOnly
+	// Housekeeping text drives an internal request. When it is the newest
+	// relevant user turn, complexity routing must not inherit an older prompt.
+	complexityTextHousekeeping
+)
+
+type complexityTagPair struct {
+	open  string
+	close string
+}
+
+var (
+	// Claude Code emits these protocol wrappers as user-role text. Keep this
+	// list client-gated and explicit: arbitrary XML-like user text is valid.
+	claudeContextTags = [...]complexityTagPair{
+		{open: "<system-reminder>", close: "</system-reminder>"},
+	}
+	claudeHousekeepingTags = [...]complexityTagPair{
+		{open: "<local-command-caveat>", close: "</local-command-caveat>"},
+		{open: "<local-command-stdout>", close: "</local-command-stdout>"},
+		{open: "<local-command-stderr>", close: "</local-command-stderr>"},
+		{open: "<command-name>", close: "</command-name>"},
+		{open: "<command-message>", close: "</command-message>"},
+		{open: "<command-args>", close: "</command-args>"},
+	}
+	// These fixed pairs mirror Codex contextual user fragments. Dynamic
+	// <external_*> fragments are intentionally excluded to avoid stripping
+	// arbitrary caller-owned XML.
+	codexContextTags = [...]complexityTagPair{
+		{open: "# AGENTS.md instructions", close: "</INSTRUCTIONS>"},
+		{open: "<environment_context>", close: "</environment_context>"},
+		{open: "<skill>", close: "</skill>"},
+		{open: "<turn_aborted>", close: "</turn_aborted>"},
+		{open: "<subagent_notification>", close: "</subagent_notification>"},
+		{open: "<codex_internal_context", close: "</codex_internal_context>"},
+		{open: "<goal_context>", close: "</goal_context>"},
+		{open: "<recommended_plugins>", close: "</recommended_plugins>"},
+	}
+	codexHousekeepingTags = [...]complexityTagPair{
+		{open: "<user_shell_command>", close: "</user_shell_command>"},
+	}
+)
+
+const codexTurnMetadataHeader = "x-codex-turn-metadata"
+
 // buildComplexityInput extracts text from normalized BifrostRequest values for
 // complexity_tier routing. It intentionally runs after the transport converters
 // have produced Bifrost's typed request shape, so governance does not duplicate
 // provider-specific raw payload parsing.
-func buildComplexityInput(req *schemas.BifrostRequest) (complexity.ComplexityInput, bool) {
+func buildComplexityInput(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (complexity.ComplexityInput, bool) {
 	if req == nil {
+		return complexity.ComplexityInput{}, false
+	}
+
+	harness := detectComplexityHarness(ctx)
+	if harness == complexityHarnessCodex && isCodexBackgroundRequest(ctx) {
 		return complexity.ComplexityInput{}, false
 	}
 
@@ -21,7 +87,7 @@ func buildComplexityInput(req *schemas.BifrostRequest) (complexity.ComplexityInp
 		if req.ChatRequest == nil {
 			return complexity.ComplexityInput{}, false
 		}
-		return extractFromChatMessages(req.ChatRequest.Input)
+		return extractFromChatMessages(req.ChatRequest.Input, harness)
 	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
 		if req.TextCompletionRequest == nil {
 			return complexity.ComplexityInput{}, false
@@ -31,7 +97,7 @@ func buildComplexityInput(req *schemas.BifrostRequest) (complexity.ComplexityInp
 		if req.ResponsesRequest == nil {
 			return complexity.ComplexityInput{}, false
 		}
-		return extractFromResponsesRequest(req.ResponsesRequest)
+		return extractFromResponsesRequest(req.ResponsesRequest, harness)
 	default:
 		return complexity.ComplexityInput{}, false
 	}
@@ -39,28 +105,40 @@ func buildComplexityInput(req *schemas.BifrostRequest) (complexity.ComplexityInp
 
 // extractFromChatMessages builds a complexity input from chat messages by
 // preserving system/developer context and tracking only text-only user turns.
-func extractFromChatMessages(messages []schemas.ChatMessage) (complexity.ComplexityInput, bool) {
+func extractFromChatMessages(messages []schemas.ChatMessage, harness complexityHarness) (complexity.ComplexityInput, bool) {
 	if len(messages) == 0 {
 		return complexity.ComplexityInput{}, false
 	}
 
 	var input complexity.ComplexityInput
 	var userTexts []string
+	lastRelevantUserKind := complexityTextInvalid
 
 	for _, msg := range messages {
 		switch msg.Role {
 		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
-			input.SystemText = appendText(input.SystemText, extractChatText(msg.Content))
+			input.SystemText = appendText(input.SystemText, sanitizeSystemText(extractChatText(msg.Content), harness))
 		case schemas.ChatMessageRoleUser:
 			text, ok := extractChatTextOnly(msg.Content)
-			if !ok || strings.TrimSpace(text) == "" {
+			if !ok {
 				return complexity.ComplexityInput{}, false
 			}
-			userTexts = append(userTexts, text)
+			text, kind := sanitizeUserText(text, harness)
+			switch kind {
+			case complexityTextHuman:
+				userTexts = append(userTexts, text)
+				lastRelevantUserKind = kind
+			case complexityTextContextOnly:
+				continue
+			case complexityTextHousekeeping:
+				lastRelevantUserKind = kind
+			default:
+				return complexity.ComplexityInput{}, false
+			}
 		}
 	}
 
-	if len(userTexts) == 0 {
+	if lastRelevantUserKind == complexityTextHousekeeping || len(userTexts) == 0 {
 		return complexity.ComplexityInput{}, false
 	}
 
@@ -85,17 +163,18 @@ func extractFromTextCompletionRequest(req *schemas.BifrostTextCompletionRequest)
 
 // extractFromResponsesRequest builds a complexity input from Responses API
 // messages while combining instructions with system/developer message text.
-func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest) (complexity.ComplexityInput, bool) {
+func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest, harness complexityHarness) (complexity.ComplexityInput, bool) {
 	if req == nil || len(req.Input) == 0 {
 		return complexity.ComplexityInput{}, false
 	}
 
 	var input complexity.ComplexityInput
 	if req.Params != nil && req.Params.Instructions != nil {
-		input.SystemText = *req.Params.Instructions
+		input.SystemText = sanitizeSystemText(*req.Params.Instructions, harness)
 	}
 
 	var userTexts []string
+	lastRelevantUserKind := complexityTextInvalid
 	for _, msg := range req.Input {
 		if msg.Role == nil {
 			continue
@@ -103,17 +182,28 @@ func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest) (complexi
 
 		switch *msg.Role {
 		case schemas.ResponsesInputMessageRoleSystem, schemas.ResponsesInputMessageRoleDeveloper:
-			input.SystemText = appendText(input.SystemText, extractResponsesText(msg.Content))
+			input.SystemText = appendText(input.SystemText, sanitizeSystemText(extractResponsesText(msg.Content), harness))
 		case schemas.ResponsesInputMessageRoleUser:
 			text, ok := extractResponsesTextOnly(msg.Content)
-			if !ok || strings.TrimSpace(text) == "" {
+			if !ok {
 				return complexity.ComplexityInput{}, false
 			}
-			userTexts = append(userTexts, text)
+			text, kind := sanitizeUserText(text, harness)
+			switch kind {
+			case complexityTextHuman:
+				userTexts = append(userTexts, text)
+				lastRelevantUserKind = kind
+			case complexityTextContextOnly:
+				continue
+			case complexityTextHousekeeping:
+				lastRelevantUserKind = kind
+			default:
+				return complexity.ComplexityInput{}, false
+			}
 		}
 	}
 
-	if len(userTexts) == 0 {
+	if lastRelevantUserKind == complexityTextHousekeeping || len(userTexts) == 0 {
 		return complexity.ComplexityInput{}, false
 	}
 
@@ -224,6 +314,139 @@ func isResponsesInputTextBlock(block schemas.ResponsesMessageContentBlock) bool 
 	return block.Type == "" ||
 		block.Type == schemas.ResponsesInputMessageContentBlockTypeText ||
 		block.Type == schemas.ResponsesOutputMessageContentTypeText
+}
+
+func detectComplexityHarness(ctx *schemas.BifrostContext) complexityHarness {
+	if ctx == nil {
+		return complexityHarnessUnknown
+	}
+
+	userAgent, _ := ctx.Value(schemas.BifrostContextKeyUserAgent).(string)
+	if strings.TrimSpace(userAgent) == "" {
+		headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+		userAgent = headers["user-agent"]
+	}
+
+	switch {
+	case schemas.ClaudeCLI.Matches(userAgent):
+		return complexityHarnessClaudeCode
+	case schemas.CodexCLI.Matches(userAgent), schemas.CodexDesktop.Matches(userAgent):
+		return complexityHarnessCodex
+	default:
+		return complexityHarnessUnknown
+	}
+}
+
+func isCodexBackgroundRequest(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
+		return false
+	}
+	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
+	rawMetadata := strings.TrimSpace(headers[codexTurnMetadataHeader])
+	if rawMetadata == "" {
+		return false
+	}
+
+	var metadata struct {
+		RequestKind string `json:"request_kind"`
+	}
+	if err := json.Unmarshal([]byte(rawMetadata), &metadata); err != nil {
+		return false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(metadata.RequestKind)) {
+	case "prewarm", "compaction", "memory":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeUserText(text string, harness complexityHarness) (string, complexityTextKind) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", complexityTextInvalid
+	}
+
+	switch harness {
+	case complexityHarnessClaudeCode:
+		cleaned, removedContext := stripComplexityTags(text, claudeContextTags[:])
+		cleaned, removedHousekeeping := stripComplexityTags(cleaned, claudeHousekeepingTags[:])
+		return classifySanitizedText(cleaned, removedContext, removedHousekeeping)
+	case complexityHarnessCodex:
+		cleaned, removedContext := stripComplexityTags(text, codexContextTags[:])
+		cleaned, removedHousekeeping := stripComplexityTags(cleaned, codexHousekeepingTags[:])
+		return classifySanitizedText(cleaned, removedContext, removedHousekeeping)
+	default:
+		return text, complexityTextHuman
+	}
+}
+
+func sanitizeSystemText(text string, harness complexityHarness) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+
+	switch harness {
+	case complexityHarnessClaudeCode:
+		text, _ = stripComplexityTags(text, claudeContextTags[:])
+		text, _ = stripComplexityTags(text, claudeHousekeepingTags[:])
+	case complexityHarnessCodex:
+		text, _ = stripComplexityTags(text, codexContextTags[:])
+		text, _ = stripComplexityTags(text, codexHousekeepingTags[:])
+	}
+	return strings.TrimSpace(text)
+}
+
+func classifySanitizedText(text string, removedContext, removedHousekeeping bool) (string, complexityTextKind) {
+	text = strings.TrimSpace(text)
+	if text != "" {
+		return text, complexityTextHuman
+	}
+	if removedHousekeeping {
+		return "", complexityTextHousekeeping
+	}
+	if removedContext {
+		return "", complexityTextContextOnly
+	}
+	return "", complexityTextInvalid
+}
+
+func stripComplexityTags(text string, tags []complexityTagPair) (string, bool) {
+	removedAny := false
+	for _, tag := range tags {
+		var cleaned strings.Builder
+		remaining := text
+		removedTag := false
+
+		for {
+			start := strings.Index(remaining, tag.open)
+			if start < 0 {
+				cleaned.WriteString(remaining)
+				break
+			}
+
+			afterOpen := remaining[start+len(tag.open):]
+			closeOffset := strings.Index(afterOpen, tag.close)
+			if closeOffset < 0 {
+				// Preserve malformed/unclosed input instead of guessing where a
+				// client-owned fragment ends.
+				cleaned.WriteString(remaining)
+				break
+			}
+
+			cleaned.WriteString(remaining[:start])
+			remaining = afterOpen[closeOffset+len(tag.close):]
+			removedTag = true
+		}
+
+		if removedTag {
+			text = cleaned.String()
+			removedAny = true
+		}
+	}
+	return strings.TrimSpace(text), removedAny
 }
 
 // appendText joins adjacent text fragments with one separating space while

--- a/plugins/governance/complexityextract_test.go
+++ b/plugins/governance/complexityextract_test.go
@@ -1,7 +1,9 @@
 package governance
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +38,7 @@ func TestBuildComplexityInput_ChatTextMessages(t *testing.T) {
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Compare them to Lamport clocks", input.LastUserText)
 	assert.Equal(t, []string{"Explain vector clocks"}, input.PriorUserTexts)
@@ -52,7 +54,7 @@ func TestBuildComplexityInput_TextCompletionPrompt(t *testing.T) {
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, prompt, input.LastUserText)
 }
@@ -70,7 +72,7 @@ func TestBuildComplexityInput_TextCompletionPromptArraySkipped(t *testing.T) {
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.False(t, ok)
 	assert.Empty(t, input.LastUserText)
 }
@@ -112,7 +114,7 @@ func TestBuildComplexityInput_ResponsesInputTextBlocks(t *testing.T) {
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Can you explain the changes?", input.LastUserText)
 	assert.Equal(t, []string{"I changed the retry policy and circuit breaker thresholds."}, input.PriorUserTexts)
@@ -177,7 +179,7 @@ func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input, ok := buildComplexityInput(tt.req)
+			input, ok := buildComplexityInput(nil, tt.req)
 			require.True(t, ok)
 			assert.Equal(t, tt.wantLastUser, input.LastUserText)
 			assert.Equal(t, tt.wantSystem, input.SystemText)
@@ -210,7 +212,7 @@ func TestBuildComplexityInput_ResponsesOutputTextTypedUserBlocks(t *testing.T) {
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.True(t, ok)
 	assert.Equal(t, "Explain encryption", input.LastUserText)
 	assert.Equal(t, "You are a coding agent", input.SystemText)
@@ -232,7 +234,7 @@ func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(
 		},
 	}
 
-	input, ok := buildComplexityInput(req)
+	input, ok := buildComplexityInput(nil, req)
 	require.False(t, ok)
 	assert.Empty(t, input.LastUserText)
 }
@@ -282,11 +284,260 @@ func TestBuildComplexityInput_SkipsMixedModalityUserContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			input, ok := buildComplexityInput(tt.req)
+			input, ok := buildComplexityInput(nil, tt.req)
 			require.False(t, ok)
 			assert.Empty(t, input.LastUserText)
 		})
 	}
+}
+
+func TestSanitizeUserText_ClaudeCodeWrappers(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		wantText string
+		wantKind complexityTextKind
+	}{
+		{
+			name:     "system_reminder",
+			text:     "<system-reminder>Internal context</system-reminder>",
+			wantKind: complexityTextContextOnly,
+		},
+		{
+			name:     "local_command_caveat",
+			text:     "<local-command-caveat>Ignore local command messages</local-command-caveat>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "local_command_stdout",
+			text:     "<local-command-stdout>Compacted</local-command-stdout>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "local_command_stderr",
+			text:     "<local-command-stderr>command failed</local-command-stderr>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_name",
+			text:     "<command-name>/compact</command-name>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_message",
+			text:     "<command-message>compact</command-message>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "command_args",
+			text:     "<command-args>focus on routing</command-args>",
+			wantKind: complexityTextHousekeeping,
+		},
+		{
+			name:     "wrapper_with_human_text",
+			text:     "<local-command-stdout>build failed</local-command-stdout>\nWhy did the build fail?",
+			wantText: "Why did the build fail?",
+			wantKind: complexityTextHuman,
+		},
+		{
+			name:     "malformed_wrapper_is_preserved",
+			text:     "<local-command-stdout>build failed",
+			wantText: "<local-command-stdout>build failed",
+			wantKind: complexityTextHuman,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotText, gotKind := sanitizeUserText(tt.text, complexityHarnessClaudeCode)
+			assert.Equal(t, tt.wantText, gotText)
+			assert.Equal(t, tt.wantKind, gotKind)
+		})
+	}
+}
+
+func TestBuildComplexityInput_ClaudeCodeContextAndHousekeeping(t *testing.T) {
+	claudeCtx := complexityHarnessContext(schemas.ClaudeCLI.String(), nil)
+
+	tests := []struct {
+		name       string
+		messages   []schemas.ChatMessage
+		wantOK     bool
+		wantLast   string
+		wantPriors []string
+	}{
+		{
+			name: "trailing_context_reveals_previous_human_turn",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<system-reminder>Use the repository instructions</system-reminder>")},
+			},
+			wantOK:   true,
+			wantLast: "Explain vector clocks",
+		},
+		{
+			name: "historical_command_is_not_conversation_context",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<command-name>/plugin</command-name>")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Compare them to Lamport clocks")},
+			},
+			wantOK:     true,
+			wantLast:   "Compare them to Lamport clocks",
+			wantPriors: []string{"Explain vector clocks"},
+		},
+		{
+			name: "newest_local_command_skips_request",
+			messages: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("<local-command-stdout>Compacted</local-command-stdout>")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := buildComplexityInput(claudeCtx, &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Input: tt.messages,
+				},
+			})
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantLast, input.LastUserText)
+			assert.Equal(t, tt.wantPriors, input.PriorUserTexts)
+		})
+	}
+}
+
+func TestBuildComplexityInput_CodexContextAndSystemText(t *testing.T) {
+	codexCtx := complexityHarnessContext(schemas.CodexDesktop.String(), nil)
+	userRole := schemas.ResponsesInputMessageRoleUser
+	systemRole := schemas.ResponsesInputMessageRoleSystem
+	systemText := "Keep answers concise. <recommended_plugins>Plugin inventory</recommended_plugins>"
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{Role: &systemRole, Content: complexityResponsesString(systemText)},
+				{Role: &userRole, Content: complexityResponsesString("<environment_context><cwd>/tmp/repo</cwd></environment_context>")},
+				{Role: &userRole, Content: complexityResponsesString("Fix the latest-message extractor")},
+			},
+		},
+	}
+
+	input, ok := buildComplexityInput(codexCtx, req)
+	require.True(t, ok)
+	assert.Equal(t, "Fix the latest-message extractor", input.LastUserText)
+	assert.Empty(t, input.PriorUserTexts)
+	assert.Equal(t, "Keep answers concise.", input.SystemText)
+	assert.Equal(t, systemText, *req.ResponsesRequest.Input[0].Content.ContentStr, "classifier sanitization must not mutate the request")
+}
+
+func TestBuildComplexityInput_CodexNewestHousekeepingSkipsRequest(t *testing.T) {
+	codexCtx := complexityHarnessContext(schemas.CodexCLI.String(), nil)
+	userRole := schemas.ResponsesInputMessageRoleUser
+
+	tests := []struct {
+		name       string
+		latestText string
+	}{
+		{
+			name:       "local_shell_command",
+			latestText: "<user_shell_command><command>pwd</command><result>/tmp/repo</result></user_shell_command>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, ok := buildComplexityInput(codexCtx, &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{
+					Input: []schemas.ResponsesMessage{
+						{Role: &userRole, Content: complexityResponsesString("Explain vector clocks")},
+						{Role: &userRole, Content: complexityResponsesString(tt.latestText)},
+					},
+				},
+			})
+			require.False(t, ok)
+			assert.Empty(t, input.LastUserText)
+		})
+	}
+}
+
+func TestBuildComplexityInput_CodexRequestKinds(t *testing.T) {
+	userRole := schemas.ResponsesInputMessageRoleUser
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{Role: &userRole, Content: complexityResponsesString("Explain vector clocks")},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		userAgent   string
+		requestKind string
+		rawMetadata string
+		wantOK      bool
+	}{
+		{name: "turn", userAgent: schemas.CodexCLI.String(), requestKind: "turn", wantOK: true},
+		{name: "prewarm", userAgent: schemas.CodexCLI.String(), requestKind: "prewarm"},
+		{name: "compaction", userAgent: schemas.CodexCLI.String(), requestKind: "compaction"},
+		{name: "memory", userAgent: schemas.CodexDesktop.String(), requestKind: "memory"},
+		{name: "unknown_kind_preserves_behavior", userAgent: schemas.CodexCLI.String(), requestKind: "future_kind", wantOK: true},
+		{name: "malformed_metadata_preserves_behavior", userAgent: schemas.CodexCLI.String(), rawMetadata: "{", wantOK: true},
+		{name: "non_codex_cannot_skip", userAgent: "generic-client/1.0", requestKind: "compaction", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rawMetadata := tt.rawMetadata
+			if rawMetadata == "" {
+				rawMetadata = `{"request_kind":"` + tt.requestKind + `"}`
+			}
+			ctx := complexityHarnessContext("", map[string]string{
+				"user-agent":            tt.userAgent,
+				codexTurnMetadataHeader: rawMetadata,
+			})
+
+			input, ok := buildComplexityInput(ctx, req)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, "Explain vector clocks", input.LastUserText)
+			}
+		})
+	}
+}
+
+func TestBuildComplexityInput_HarnessMarkersRequireMatchingUserAgent(t *testing.T) {
+	markerText := "<local-command-stdout>Compacted</local-command-stdout>"
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{Role: schemas.ChatMessageRoleUser, Content: complexityChatString(markerText)},
+			},
+		},
+	}
+
+	input, ok := buildComplexityInput(complexityHarnessContext("generic-client/1.0", nil), req)
+	require.True(t, ok)
+	assert.Equal(t, markerText, input.LastUserText)
+}
+
+func complexityHarnessContext(userAgent string, headers map[string]string) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	if userAgent != "" {
+		ctx.SetValue(schemas.BifrostContextKeyUserAgent, userAgent)
+	}
+	if headers != nil {
+		ctx.SetValue(schemas.BifrostContextKeyRequestHeaders, headers)
+	}
+	return ctx
 }
 
 func complexityChatString(text string) *schemas.ChatMessageContent {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -733,13 +733,13 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 	var computeComplexity func() *complexity.ComplexityResult
 	if analyzer := p.complexityAnalyzer.Load(); analyzer != nil {
 		computeComplexity = func() *complexity.ComplexityResult {
-			input, ok := buildComplexityInput(req)
+			input, ok := buildComplexityInput(ctx, req)
 			if !ok {
 				if p.logger != nil {
-					p.logger.Debug("[Governance] Complexity analysis skipped: unsupported request type")
+					p.logger.Debug("[Governance] Complexity analysis skipped: no routable human-authored text detected")
 				}
 				ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, complexity.MechanismSkipped)
-				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo, "Complexity analysis skipped: no supported text-bearing input detected")
+				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelInfo, "Complexity analysis skipped: no routable human-authored text detected")
 				return nil
 			}
 


### PR DESCRIPTION
## Summary

Complexity routing for Claude Code and Codex clients currently treats all user-role messages as human-authored prompts. Both clients inject protocol-level fragments (context injections, housekeeping commands, shell output) into user turns that should not be routed as real user intent. This PR teaches the complexity extractor to detect which harness is making the request and strip or classify those fragments before routing decisions are made.

## Changes

- Added a `complexityHarness` type and detection logic that identifies Claude Code and Codex clients via `User-Agent` headers.
- Introduced `complexityTextKind` to classify sanitized user turns as `human`, `context-only`, or `housekeeping`, allowing the extractor to skip context injections while still surfacing the most recent real human prompt.
- Added `sanitizeUserText` and `sanitizeSystemText` helpers that strip known protocol tag pairs (e.g. `<system-reminder>`, `<local-command-stdout>`, `<environment_context>`, `<user_shell_command>`) from user and system text before complexity scoring. Malformed/unclosed tags are preserved rather than silently dropped.
- When the newest relevant user turn is a housekeeping fragment (e.g. a `/compact` command or shell result), the request is skipped entirely rather than inheriting an older human prompt as the routing subject.
- Added `isCodexBackgroundRequest` which reads the `x-codex-turn-metadata` header and skips complexity routing for `prewarm`, `compaction`, and `memory` request kinds.
- Sanitization is non-mutating: the original request payload is never modified.
- Updated the skip log message from "unsupported request type" to "no routable human-authored text detected" to better reflect the actual reason for skipping.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

New test cases cover:
- Each Claude Code and Codex protocol tag being stripped and classified correctly
- Trailing context-only turns revealing the previous human turn as the routing subject
- Housekeeping turns as the newest relevant message causing the request to be skipped
- Codex background request kinds (`prewarm`, `compaction`, `memory`) being skipped; unknown kinds and malformed metadata preserving normal behavior
- Non-Codex clients being unaffected by Codex-specific metadata headers
- Harness-specific tag stripping requiring a matching `User-Agent` (generic clients see raw text)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Tag stripping is gated strictly on known harness `User-Agent` values. Arbitrary XML-like content in user messages from unrecognized clients is never stripped, preventing accidental removal of caller-owned content. Dynamic tag patterns (e.g. `<external_*>`) are explicitly excluded from Codex stripping for the same reason.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable