### PR TITLE
feat: add `SetShouldRefreshGate` to gate OAuth token sweep ticks

### DIFF
--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -41,6 +41,11 @@ type OAuthTokenRefreshWorker struct {
 	// an atomic pointer because the worker goroutine reads it while the
 	// serving layer installs it after the worker has already started.
 	onTokenRefreshed atomic.Pointer[func(mcpClientID, authMode string)]
+
+	// shouldRefresh, when set, gates whether a sweep tick actually queries and
+	// refreshes tokens (see SetShouldRefreshGate's doc comment). Stored as an
+	// atomic pointer for the same reason as onTokenRefreshed.
+	shouldRefresh atomic.Pointer[func(ctx context.Context) bool]
 }
 
 // NewOAuthTokenRefreshWorker creates a new token refresh worker
@@ -78,6 +83,23 @@ func (w *OAuthTokenRefreshWorker) SetOnTokenRefreshed(cb func(mcpClientID, authM
 		return
 	}
 	w.onTokenRefreshed.Store(&cb)
+}
+
+// SetShouldRefreshGate installs a predicate consulted at the start of every
+// sweep tick; a tick proceeds only when the gate is unset or returns true.
+// Lets a deployment with multiple workers sharing the same token store
+// restrict sweeps to one at a time, avoiding concurrent refreshes of the
+// same token. Safe to call at any time, including while the worker is
+// running; passing nil restores the default (always run).
+func (w *OAuthTokenRefreshWorker) SetShouldRefreshGate(gate func(ctx context.Context) bool) {
+	if w == nil {
+		return
+	}
+	if gate == nil {
+		w.shouldRefresh.Store(nil)
+		return
+	}
+	w.shouldRefresh.Store(&gate)
 }
 
 // Start begins the token refresh worker in a background goroutine
@@ -125,6 +147,9 @@ func (w *OAuthTokenRefreshWorker) run(ctx context.Context) {
 
 // refreshExpiredTokens queries and refreshes tokens that are expiring soon
 func (w *OAuthTokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
+	if gate := w.shouldRefresh.Load(); gate != nil && !(*gate)(ctx) {
+		return
+	}
 	expiryThreshold := time.Now().Add(w.lookAheadWindow)
 
 	// Get tokens expiring before the threshold, restricted to the configured


### PR DESCRIPTION
## Summary

Adds a configurable gate to `OAuthTokenRefreshWorker` that controls whether a sweep tick proceeds. This allows deployments running multiple workers against a shared token store to prevent concurrent token refreshes of the same token.

## Changes

- Added a `shouldRefresh` atomic pointer field to `OAuthTokenRefreshWorker` that holds an optional predicate function
- Added `SetShouldRefreshGate` method to install or clear the gate at any time, including while the worker is running
- At the start of each `refreshExpiredTokens` call, the gate (if set) is evaluated and the sweep is skipped if it returns false
- When no gate is set, behavior is unchanged (sweeps always run)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/oauth2/...
```

Verify that:
- When no gate is set, token refresh sweeps proceed as normal
- When a gate returning `false` is installed, `refreshExpiredTokens` returns early without querying or refreshing tokens
- When a gate returning `true` is installed, sweeps proceed normally
- Calling `SetShouldRefreshGate(nil)` restores default behavior

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The gate function receives a `context.Context`, which may carry request-scoped values. Care should be taken that any gate implementation does not inadvertently expose or leak sensitive context values.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable