### PR TITLE
fix: inject placeholder text block for document-only messages in Bedrock Converse API

### DIFF
--- a/core/providers/bedrock/document_placeholder_test.go
+++ b/core/providers/bedrock/document_placeholder_test.go
@@ -1,0 +1,124 @@
+package bedrock_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// Bedrock's Converse API rejects a message whose content holds a document block
+// but no accompanying text block ("A text block must be included when using
+// documents"). These tests pin the placeholder-injection fix mirroring the one
+// already in place for the Anthropic-native path.
+
+func TestToBedrockChatCompletionRequest_DocumentOnlyMessageGetsPlaceholderTextBlock(t *testing.T) {
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+					{
+						Type: schemas.ChatContentBlockTypeFile,
+						File: &schemas.ChatInputFile{
+							FileID:   new("file_abc123"),
+							Filename: new("tiny.pdf"),
+							FileType: new("application/pdf"),
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockChatCompletionRequest(ctx, req)
+	require.NoError(t, err)
+
+	blocks := result.Messages[0].Content
+	require.Len(t, blocks, 2, "expected placeholder text block plus document block")
+	require.NotNil(t, blocks[0].Text, "expected leading placeholder text block")
+	require.NotEmpty(t, strings.TrimSpace(*blocks[0].Text))
+	require.NotNil(t, blocks[1].Document, "expected document block after placeholder")
+}
+
+func TestToBedrockChatCompletionRequest_DocumentWithTextDoesNotGetPlaceholder(t *testing.T) {
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+					{
+						Type: schemas.ChatContentBlockTypeText,
+						Text: new("Read the attached PDF."),
+					},
+					{
+						Type: schemas.ChatContentBlockTypeFile,
+						File: &schemas.ChatInputFile{
+							FileID:   new("file_abc123"),
+							Filename: new("tiny.pdf"),
+							FileType: new("application/pdf"),
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockChatCompletionRequest(ctx, req)
+	require.NoError(t, err)
+
+	blocks := result.Messages[0].Content
+	require.Len(t, blocks, 2, "expected no placeholder inserted")
+	require.NotNil(t, blocks[0].Text)
+	require.Equal(t, "Read the attached PDF.", *blocks[0].Text)
+	require.NotNil(t, blocks[1].Document)
+}
+
+func TestToBedrockChatCompletionRequest_UserDocumentWithWhitespaceTextGetsPlaceholder(t *testing.T) {
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+					{
+						Type: schemas.ChatContentBlockTypeText,
+						Text: new("   "),
+					},
+					{
+						Type: schemas.ChatContentBlockTypeFile,
+						File: &schemas.ChatInputFile{
+							FileID:   new("file_abc123"),
+							Filename: new("tiny.pdf"),
+							FileType: new("application/pdf"),
+						},
+					},
+				}},
+			},
+			{
+				Role:    schemas.ChatMessageRoleAssistant,
+				Content: &schemas.ChatMessageContent{ContentStr: new("Understood.")},
+			},
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	result, err := bedrock.ToBedrockChatCompletionRequest(ctx, req)
+	require.NoError(t, err)
+
+	blocks := result.Messages[0].Content
+	require.Len(t, blocks, 2)
+	require.NotNil(t, blocks[0].Text)
+	require.NotEmpty(t, strings.TrimSpace(*blocks[0].Text))
+	require.NotNil(t, blocks[1].Document)
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3803,6 +3803,41 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 	}
 	bedrockMessages = mergedMessages
 
+	// Merging rescues a document block that has a text sibling elsewhere in the
+	// same role's turn, but a message that never had one (or whose only text
+	// block was empty) is still document-only at this point. Insert a
+	// placeholder so it still validates ("A text block must be included when
+	// using documents").
+	for i := range bedrockMessages {
+		if !hasBedrockDocumentBlock(bedrockMessages[i].Content) {
+			continue
+		}
+		content := bedrockMessages[i].Content
+		filtered := content[:0]
+		hasUsableText := false
+		for _, b := range content {
+			if b.Text != nil {
+				if strings.TrimSpace(*b.Text) == "" {
+					continue
+				}
+				hasUsableText = true
+			}
+			filtered = append(filtered, b)
+		}
+		content = filtered
+		if !hasUsableText {
+			at := leadingBedrockReasoningBlockCount(content)
+			withPlaceholder := make([]BedrockContentBlock, 0, len(content)+1)
+			withPlaceholder = append(withPlaceholder, content[:at]...)
+			withPlaceholder = append(withPlaceholder, BedrockContentBlock{
+				Text: schemas.Ptr(bedrockDocumentPlaceholderText),
+			})
+			withPlaceholder = append(withPlaceholder, content[at:]...)
+			content = withPlaceholder
+		}
+		bedrockMessages[i].Content = content
+	}
+
 	return bedrockMessages, systemMessages, nil
 }
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -869,6 +869,38 @@ func convertSystemMessages(msg schemas.ChatMessage) ([]BedrockSystemMessage, err
 	return systemMsgs, nil
 }
 
+// bedrockDocumentPlaceholderText is inserted into a message whose content holds
+// document blocks but no text block. Bedrock's Converse API requires a text block
+// alongside documents ("A text block must be included when using documents"), and
+// convertContentBlock separately strips empty/whitespace-only text blocks, so the
+// placeholder has to be non-whitespace to survive both.
+const bedrockDocumentPlaceholderText = "."
+
+// hasBedrockDocumentBlock reports whether any of the content blocks is a document
+// block, i.e. whether the message needs an accompanying text block.
+func hasBedrockDocumentBlock(blocks []BedrockContentBlock) bool {
+	for _, b := range blocks {
+		if b.Document != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// leadingBedrockReasoningBlockCount returns the number of reasoning content blocks
+// at the head of the content slice, so an injected placeholder can be placed after
+// them rather than before.
+func leadingBedrockReasoningBlockCount(blocks []BedrockContentBlock) int {
+	count := 0
+	for _, b := range blocks {
+		if b.ReasoningContent == nil {
+			break
+		}
+		count++
+	}
+	return count
+}
+
 // convertMessage converts a Bifrost message to Bedrock format.
 // The ctx is propagated to URL fetches inside content blocks.
 func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessage, error) {
@@ -907,6 +939,34 @@ func convertMessage(ctx context.Context, msg schemas.ChatMessage) (BedrockMessag
 	if msg.ChatAssistantMessage != nil && msg.ChatAssistantMessage.ToolCalls != nil {
 		for _, toolCall := range msg.ChatAssistantMessage.ToolCalls {
 			contentBlocks = append(contentBlocks, convertToolCallToContentBlock(ctx, toolCall))
+		}
+	}
+
+	// Bedrock rejects a message whose content contains a document block with no
+	// accompanying text block ("A text block must be included when using
+	// documents"). Insert a placeholder so document-only messages still validate.
+	if hasBedrockDocumentBlock(contentBlocks) {
+		filtered := contentBlocks[:0]
+		hasUsableText := false
+		for _, b := range contentBlocks {
+			if b.Text != nil {
+				if strings.TrimSpace(*b.Text) == "" {
+					continue
+				}
+				hasUsableText = true
+			}
+			filtered = append(filtered, b)
+		}
+		contentBlocks = filtered
+		if !hasUsableText {
+			at := leadingBedrockReasoningBlockCount(contentBlocks)
+			withPlaceholder := make([]BedrockContentBlock, 0, len(contentBlocks)+1)
+			withPlaceholder = append(withPlaceholder, contentBlocks[:at]...)
+			withPlaceholder = append(withPlaceholder, BedrockContentBlock{
+				Text: schemas.Ptr(bedrockDocumentPlaceholderText),
+			})
+			withPlaceholder = append(withPlaceholder, contentBlocks[at:]...)
+			contentBlocks = withPlaceholder
 		}
 	}
 


### PR DESCRIPTION
## Summary

Bedrock's Converse API rejects messages that contain a document block without an accompanying text block, returning the error "A text block must be included when using documents." This PR fixes that by injecting a minimal placeholder text block (`.`) into any message that contains a document block but lacks a non-whitespace text block.

## Changes

- Added `bedrockDocumentPlaceholderText` constant (`"."`) used as the injected placeholder, chosen to be non-whitespace so it survives the existing empty-text-block stripping logic.
- Added `hasBedrockDocumentBlock` helper to detect whether a message's content requires an accompanying text block.
- Added `leadingBedrockReasoningBlockCount` helper to ensure the placeholder is inserted after any leading reasoning blocks rather than before them.
- Applied the placeholder injection in both `convertMessage` (single-message conversion) and `ConvertBifrostMessagesToBedrockMessages` (post-merge pass), so document-only messages are handled correctly regardless of whether they arrive standalone or are produced by the role-merging step.
- Whitespace-only text blocks are stripped before the placeholder check, so a message with only blank text alongside a document is treated the same as a document-only message.
- Added three tests covering: a document-only message receiving a placeholder, a document+text message not receiving a placeholder, and a document with a whitespace-only text block receiving a placeholder.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

The three new tests in `document_placeholder_test.go` directly validate the fix:
- `TestToBedrockChatCompletionRequest_DocumentOnlyMessageGetsPlaceholderTextBlock` — expects a placeholder text block prepended before the document block.
- `TestToBedrockChatCompletionRequest_DocumentWithTextDoesNotGetPlaceholder` — expects no placeholder when a real text block is already present.
- `TestToBedrockChatCompletionRequest_UserDocumentWithWhitespaceTextGetsPlaceholder` — expects a placeholder when the only text block is whitespace.

## Breaking changes

- [x] No

## Security considerations

None. The placeholder is a single period inserted only into the Bedrock request payload and is never stored or surfaced to callers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable