### PR TITLE
bedrock + anthropic patches for adaptive thinking

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -594,7 +594,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 						budgetTokens = MinimumReasoningMaxTokens
 					}
 					if budgetTokens < MinimumReasoningMaxTokens {
-						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
+						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic: %w", MinimumReasoningMaxTokens, ErrReasoningMaxTokensTooLow)
 					}
 					anthropicReq.Thinking = &AnthropicThinking{
 						Type:         "enabled",
@@ -612,7 +612,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					setEffortOnOutputConfig(anthropicReq, effort)
 					budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("%w: %w", ErrReasoningMaxTokensTooLow, err)
 					}
 					anthropicReq.Thinking = &AnthropicThinking{
 						Type:         "enabled",
@@ -622,7 +622,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					// Older models: budget_tokens only
 					budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(*bifrostReq.Params.Reasoning.Effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("%w: %w", ErrReasoningMaxTokensTooLow, err)
 					}
 					anthropicReq.Thinking = &AnthropicThinking{
 						Type:         "enabled",

--- a/core/providers/anthropic/messagestartusage_test.go
+++ b/core/providers/anthropic/messagestartusage_test.go
@@ -1,0 +1,73 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestToAnthropicResponsesStreamResponse_OmitsUsageWhenUnknown is a regression test:
+// Bedrock Converse only reports usage on its terminal event (unlike native Anthropic,
+// which puts input_tokens on message_start too — see the doc comment on
+// bedrock/invoke.go's toAnthropicInvokeStreamBytes). Before the fix, a nil
+// bifrostResp.Response.Usage at message_start time was papered over with a fabricated
+// all-zero AnthropicUsage, which misrepresents cost/usage telemetry to clients that
+// read input_tokens off message_start (as Claude Code does against real Anthropic).
+// Anthropic's own documented streaming contract tolerates usage being entirely absent
+// from message_start (see the "Streaming request with thinking" example at
+// https://platform.claude.com/docs/en/build-with-claude/streaming), and Bifrost's own
+// sibling code path (bedrock/invoke.go toAnthropicInvokeStreamBytes) already omits it
+// for the identical situation — this test brings responses.go in line.
+func TestToAnthropicResponsesStreamResponse_OmitsUsageWhenUnknown(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeCreated,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:    schemas.Ptr("resp_1"),
+			Model: "claude-sonnet-4-6",
+			// Usage intentionally nil — the Bedrock-backed "unknown yet" case.
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, resp)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Message == nil {
+		t.Fatalf("expected a message_start event with a Message, got nil")
+	}
+	if events[0].Message.Usage != nil {
+		t.Errorf("expected Usage to be omitted (nil) when unknown, got %+v", events[0].Message.Usage)
+	}
+}
+
+// TestToAnthropicResponsesStreamResponse_PreservesRealUsage guards against
+// regressing the native-Anthropic case while fixing the above: when usage IS known
+// at message_start time (e.g. real Anthropic, which tokenizes input before it starts
+// streaming), the real values must still pass through unchanged.
+func TestToAnthropicResponsesStreamResponse_PreservesRealUsage(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeCreated,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:    schemas.Ptr("resp_1"),
+			Model: "claude-sonnet-4-6",
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  42,
+				OutputTokens: 1,
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, resp)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Message == nil || events[0].Message.Usage == nil {
+		t.Fatalf("expected a message_start event with real Usage, got %+v", events[0].Message)
+	}
+	if events[0].Message.Usage.InputTokens != 42 {
+		t.Errorf("expected InputTokens=42, got %d", events[0].Message.Usage.InputTokens)
+	}
+}

--- a/core/providers/anthropic/requestbuilder.go
+++ b/core/providers/anthropic/requestbuilder.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"errors"
 	"fmt"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -290,6 +291,16 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 
 		reqBody, convErr := ToAnthropicResponsesRequest(ctx, request)
 		if convErr != nil {
+			if errors.Is(convErr, ErrReasoningMaxTokensTooLow) {
+				return nil, providerUtils.EnrichError(
+					ctx,
+					providerUtils.NewBifrostBadRequestError(convErr.Error()),
+					jsonBody,
+					nil,
+					cfg.ShouldSendBackRawRequest,
+					cfg.ShouldSendBackRawResponse,
+				)
+			}
 			return nil, newErr(schemas.ErrRequestBodyConversion, convErr, jsonBody)
 		}
 		if reqBody == nil {
@@ -531,6 +542,16 @@ func BuildAnthropicChatRequestBody(ctx *schemas.BifrostContext, request *schemas
 	} else {
 		reqBody, convErr := ToAnthropicChatRequest(ctx, request)
 		if convErr != nil {
+			if errors.Is(convErr, ErrReasoningMaxTokensTooLow) {
+				return nil, providerUtils.EnrichError(
+					ctx,
+					providerUtils.NewBifrostBadRequestError(convErr.Error()),
+					jsonBody,
+					nil,
+					cfg.ShouldSendBackRawRequest,
+					cfg.ShouldSendBackRawResponse,
+				)
+			}
 			return nil, newErr(schemas.ErrRequestBodyConversion, convErr, jsonBody)
 		}
 		if reqBody == nil {

--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -539,6 +540,77 @@ func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
 		// The inbound request must not be mutated by the shallow-copy strip.
 		if len(request.Params.Tools) != 2 {
 			t.Errorf("inbound Params.Tools must be untouched, got %d tools", len(request.Params.Tools))
+		}
+	})
+}
+
+// TestBuildAnthropicResponsesRequestBody_ReasoningMaxTokensTooLow is a regression test:
+// a max_tokens too low for the resolved reasoning budget must surface as a clean 400,
+// not an opaque 500. Before the fix, GetBudgetTokensFromReasoningEffort's plain error
+// (and the equivalent explicit MinimumReasoningMaxTokens check) got wrapped by
+// NewBifrostOperationError, which never sets StatusCode, so the HTTP layer defaulted
+// to 500.
+func TestBuildAnthropicResponsesRequestBody_ReasoningMaxTokensTooLow(t *testing.T) {
+	t.Run("adaptive_effort_on_non_adaptive_model", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		// claude-haiku-4-5 supports neither adaptive thinking nor native effort, so
+		// this falls to the budget_tokens-only branch, which 500'd on a too-low
+		// max_tokens before this fix.
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-haiku-4-5",
+			Input:    makeSimpleInput("Hello, world!"),
+			Params: &schemas.ResponsesParameters{
+				MaxOutputTokens: schemas.Ptr(500),
+				Reasoning: &schemas.ResponsesParametersReasoning{
+					Effort: schemas.Ptr("high"),
+				},
+			},
+		}
+
+		_, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err == nil {
+			t.Fatal("expected an error for max_tokens below the reasoning minimum")
+		}
+		if err.StatusCode == nil || *err.StatusCode != 400 {
+			got := "nil"
+			if err.StatusCode != nil {
+				got = fmt.Sprintf("%d", *err.StatusCode)
+			}
+			t.Errorf("expected StatusCode 400, got %s", got)
+		}
+	})
+
+	t.Run("explicit_reasoning_max_tokens_below_minimum", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-haiku-4-5",
+			Input:    makeSimpleInput("Hello, world!"),
+			Params: &schemas.ResponsesParameters{
+				MaxOutputTokens: schemas.Ptr(2000),
+				Reasoning: &schemas.ResponsesParametersReasoning{
+					MaxTokens: schemas.Ptr(100), // below MinimumReasoningMaxTokens (1024)
+				},
+			},
+		}
+
+		_, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err == nil {
+			t.Fatal("expected an error for reasoning.max_tokens below the minimum")
+		}
+		if err.StatusCode == nil || *err.StatusCode != 400 {
+			got := "nil"
+			if err.StatusCode != nil {
+				got = fmt.Sprintf("%d", *err.StatusCode)
+			}
+			t.Errorf("expected StatusCode 400, got %s", got)
 		}
 	})
 }

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2443,22 +2443,15 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		// Only convert response.created back to message_start (not response.in_progress to avoid duplicates)
 		streamResp.Type = AnthropicStreamEventTypeMessageStart
 		if bifrostResp.Response != nil {
-			// Use actual usage if available (forwarded from upstream message_start),
-			// otherwise fall back to zeros for non-Anthropic providers
+			// Use actual usage if available (forwarded from upstream message_start).
+			// When unknown (e.g. Bedrock Converse, which only reports usage on its
+			// terminal event), omit the field entirely rather than fabricating
+			// zeros — Anthropic's own documented streaming contract tolerates usage
+			// being absent from message_start, and reporting zeros would misrepresent
+			// cost/usage telemetry to clients that read input_tokens from here.
 			var messageUsage *AnthropicUsage
 			if bifrostResp.Response.Usage != nil {
 				messageUsage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Response.Usage)
-			} else {
-				messageUsage = &AnthropicUsage{
-					InputTokens:              0,
-					OutputTokens:             0,
-					CacheReadInputTokens:     0,
-					CacheCreationInputTokens: 0,
-					CacheCreation: AnthropicUsageCacheCreation{
-						Ephemeral5mInputTokens: 0,
-						Ephemeral1hInputTokens: 0,
-					},
-				}
 			}
 			streamMessage := &AnthropicMessageResponse{
 				Type:    "message",
@@ -3672,7 +3665,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						budgetTokens = MinimumReasoningMaxTokens
 					}
 					if budgetTokens < MinimumReasoningMaxTokens {
-						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
+						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic: %w", MinimumReasoningMaxTokens, ErrReasoningMaxTokensTooLow)
 					}
 					anthropicReq.Thinking = &AnthropicThinking{
 						Type:         "enabled",
@@ -3693,7 +3686,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 							setEffortOnOutputConfig(anthropicReq, effort)
 							budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
 							if err != nil {
-								return nil, err
+								return nil, fmt.Errorf("%w: %w", ErrReasoningMaxTokensTooLow, err)
 							}
 							anthropicReq.Thinking = &AnthropicThinking{
 								Type:         "enabled",
@@ -3703,7 +3696,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 							// Older models: budget_tokens only
 							budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, MinimumReasoningMaxTokens, anthropicReq.MaxTokens)
 							if err != nil {
-								return nil, err
+								return nil, fmt.Errorf("%w: %w", ErrReasoningMaxTokensTooLow, err)
 							}
 							anthropicReq.Thinking = &AnthropicThinking{
 								Type:         "enabled",

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -26,8 +26,21 @@ const (
 	AnthropicFilesAPIBetaHeader = "files-api-2025-04-14"
 	// AnthropicStructuredOutputsBetaHeader is required for strict tool validation and output_format.
 	AnthropicStructuredOutputsBetaHeader = "structured-outputs-2025-11-13"
-	// AnthropicAdvancedToolUseBetaHeader is required for defer_loading, input_examples, and allowed_callers.
+	// AnthropicAdvancedToolUseBetaHeader now gates only allowed_callers (programmatic
+	// tool calling) — see AnthropicToolSearchBetaHeader below for defer_loading, which
+	// used to be part of this bundle but is gated by its own beta as of current docs.
+	// https://platform.claude.com/docs/en/build-with-claude/overview ("Programmatic tool calling" row)
 	AnthropicAdvancedToolUseBetaHeader = "advanced-tool-use-2025-11-20"
+	// AnthropicToolSearchBetaHeader is required for tool.defer_loading and the
+	// tool_search_tool_* server tool. Available on the Claude API, Vertex AI,
+	// Azure AI Foundry, and Claude in Amazon Bedrock (Mantle) — but NOT on classic
+	// Amazon Bedrock's Converse API, which Bifrost's Bedrock provider always uses
+	// for tool-bearing requests. AWS's own docs restrict this feature to the
+	// InvokeModel/InvokeModelWithResponseStream APIs, never Converse:
+	// https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.html
+	// https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool
+	// Do not gate this on AdvancedToolUse, and do not add a bundle fallback for Bedrock.
+	AnthropicToolSearchBetaHeader = "tool-search-tool-2025-10-19"
 	// AnthropicToolExamplesBetaHeader is required for tool.input_examples as a
 	// standalone feature (Bedrock supports this narrow header without the full
 	// advanced-tool-use-2025-11-20 bundle).
@@ -97,6 +110,7 @@ const (
 	// Use these with strings.HasPrefix when filtering headers per provider,
 	// so that future date bumps (e.g. structured-outputs-2025-12-15) are still matched.
 	AnthropicAdvancedToolUseBetaHeaderPrefix     = "advanced-tool-use-"
+	AnthropicToolSearchBetaHeaderPrefix          = "tool-search-tool-"
 	AnthropicToolExamplesBetaHeaderPrefix        = "tool-examples-"
 	AnthropicStructuredOutputsBetaHeaderPrefix   = "structured-outputs-"
 	AnthropicPromptCachingScopeBetaHeaderPrefix  = "prompt-caching-scope-"
@@ -147,9 +161,9 @@ type ProviderFeatureSupport struct {
 	Bash                   bool // bash client tool (cite: A, B-header)
 	Memory                 bool // memory client tool — on Bedrock bundled under context-management-2025-06-27 (cite: A, B-header)
 	TextEditor             bool // text_editor client tool (cite: A)
-	ToolSearch             bool // tool_search server tool — tool-search-tool-2025-10-19 (cite: A, B-header)
+	ToolSearch             bool // tool_search server tool + tool.defer_loading — tool-search-tool-2025-10-19 (cite: A). NOT supported on classic Amazon Bedrock: AWS restricts this to InvokeModel/InvokeModelWithResponseStream, never Converse, which is the only API Bifrost's Bedrock provider uses for tool-bearing requests.
 	MCP                    bool // MCP connector — explicit "not supported on Bedrock/Vertex" (cite: MCP-excl)
-	AdvancedToolUse        bool // advanced-tool-use-2025-11-20 bundle: defer_loading + input_examples + allowed_callers (cite: A)
+	AdvancedToolUse        bool // advanced-tool-use-2025-11-20 bundle: allowed_callers only as of current docs — defer_loading now has its own beta, see ToolSearch (cite: A)
 	InputExamples          bool // tool.input_examples standalone — tool-examples-2025-10-29. Bedrock supports this independently of the AdvancedToolUse bundle (cite: B-header). On Anthropic / Azure the bundle implicitly covers it.
 	StructuredOutputs      bool // strict tool validation / output_format (cite: A)
 	PromptCachingScope     bool // cache_control.scope — prompt-caching-scope-2026-01-05 (cite: A)
@@ -229,11 +243,15 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	// AWS Bedrock — cite: A + B-header (definitive beta-header list).
 	// Notably NOT supported per docs: MCP, Skills, FilesAPI, WebFetch,
 	// WebSearch, CodeExecution, FastMode, TaskBudgets, AdvisorTool,
-	// InferenceGeo, RedactThinking, AdvancedToolUse (full), PromptCachingScope.
+	// InferenceGeo, RedactThinking, AdvancedToolUse (full), PromptCachingScope,
+	// ToolSearch (tool-search-tool-2025-10-19 is InvokeModel/InvokeModelWithResponseStream
+	// only per AWS's own docs; Bifrost's Bedrock provider always dispatches
+	// tool-bearing requests via Converse, so this can never work end-to-end —
+	// see the ToolSearch field comment above for citations).
 	schemas.Bedrock: {
 		WebSearchNova: true, // nova_grounding — Responses path only
 		CodeExecNova:  true, // nova_code_interpreter — Responses path only
-		ComputerUse:   true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
+		ComputerUse:   true, Bash: true, Memory: true, TextEditor: true,
 		ContainerBasic:         true,
 		StructuredOutputs:      true, // documented on Bedrock per A overview matrix
 		Compaction:             true, // compact-2026-01-12 per B-header

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -27,9 +28,12 @@ import (
 // through without a code change. Exact-match types (currently just
 // "mcp_toolset") are handled separately.
 var anthropicToolTypePrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
-	"web_search_":       func(f ProviderFeatureSupport) bool { return f.WebSearch },
+	// OR in the Nova carve-outs to match ValidateResponsesToolsForProvider —
+	// WebSearch/CodeExecution are false for Bedrock, but WebSearchNova/CodeExecNova
+	// are true (nova_grounding / nova_code_interpreter system tools).
+	"web_search_":       func(f ProviderFeatureSupport) bool { return f.WebSearch || f.WebSearchNova },
 	"web_fetch_":        func(f ProviderFeatureSupport) bool { return f.WebFetch },
-	"code_execution_":   func(f ProviderFeatureSupport) bool { return f.CodeExecution },
+	"code_execution_":   func(f ProviderFeatureSupport) bool { return f.CodeExecution || f.CodeExecNova },
 	"computer_":         func(f ProviderFeatureSupport) bool { return f.ComputerUse },
 	"bash_":             func(f ProviderFeatureSupport) bool { return f.Bash },
 	"memory_":           func(f ProviderFeatureSupport) bool { return f.Memory },
@@ -37,6 +41,13 @@ var anthropicToolTypePrefixToFeature = map[string]func(ProviderFeatureSupport) b
 	"tool_search_tool_": func(f ProviderFeatureSupport) bool { return f.ToolSearch },
 	"advisor_":          func(f ProviderFeatureSupport) bool { return f.AdvisorTool },
 }
+
+// ErrReasoningMaxTokensTooLow marks a reasoning/thinking configuration error caused by
+// a client-supplied max_tokens too low for the resolved reasoning budget — a bad
+// request, not an internal conversion failure. Wrapped (%w) at every reasoning-budget
+// validation site in chat.go/responses.go so requestbuilder.go's newErr closures can
+// distinguish it from genuine internal errors and return 400 instead of a bare 500.
+var ErrReasoningMaxTokensTooLow = errors.New("max_tokens too low for reasoning/thinking configuration")
 
 // isAnthropicServerToolSupported returns whether the given Anthropic server-tool
 // type string is supported by the provider's ProviderFeatureSupport. Unknown
@@ -407,7 +418,10 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 	// Tool-level flags — strip per-tool without dropping the tool itself.
 	for i := range req.Tools {
 		tool := &req.Tools[i]
-		if tool.DeferLoading != nil && !features.AdvancedToolUse {
+		// defer_loading has its own beta (tool-search-tool-2025-10-19) as of
+		// current docs — it's no longer part of the AdvancedToolUse bundle. Gate
+		// on ToolSearch, not AdvancedToolUse (see AnthropicToolSearchBetaHeader).
+		if tool.DeferLoading != nil && !features.ToolSearch {
 			tool.DeferLoading = nil
 		}
 		if len(tool.AllowedCallers) > 0 && !features.AdvancedToolUse {
@@ -698,13 +712,17 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 					}
 				}
 			}
-			if !features.AdvancedToolUse {
+			// defer_loading has its own beta (tool-search-tool-2025-10-19) as of
+			// current docs — gate on ToolSearch, not AdvancedToolUse.
+			if !features.ToolSearch {
 				if providerUtils.JSONFieldExists(jsonBody, base+".defer_loading") {
 					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".defer_loading")
 					if err != nil {
 						return nil, fmt.Errorf("strip raw %s.defer_loading: %w", base, err)
 					}
 				}
+			}
+			if !features.AdvancedToolUse {
 				if providerUtils.JSONFieldExists(jsonBody, base+".allowed_callers") {
 					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".allowed_callers")
 					if err != nil {
@@ -1143,14 +1161,12 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 					headers = appendUniqueHeader(headers, AnthropicStructuredOutputsBetaHeader)
 				}
 			}
-			// Check for advanced-tool-use features. defer_loading and
-			// allowed_callers are only available as part of the bundle
-			// header; input_examples additionally has a standalone header
-			// (tool-examples-2025-10-29) used on Bedrock where the bundle is
-			// not accepted.
+			// defer_loading has its own beta (tool-search-tool-2025-10-19) as of
+			// current docs — it's no longer part of the AdvancedToolUse bundle.
+			// allowed_callers is still bundle-only.
 			if tool.DeferLoading != nil && *tool.DeferLoading {
-				if !hasProvider || features.AdvancedToolUse {
-					headers = appendUniqueHeader(headers, AnthropicAdvancedToolUseBetaHeader)
+				if !hasProvider || features.ToolSearch {
+					headers = appendUniqueHeader(headers, AnthropicToolSearchBetaHeader)
 				}
 			}
 			if len(tool.InputExamples) > 0 {
@@ -1378,6 +1394,7 @@ var betaHeaderPrefixKnown = []string{
 	"context-management-",
 	"files-api-",
 	AnthropicAdvancedToolUseBetaHeaderPrefix,
+	AnthropicToolSearchBetaHeaderPrefix,
 	AnthropicToolExamplesBetaHeaderPrefix,
 	AnthropicInterleavedThinkingBetaHeaderPrefix,
 	AnthropicSkillsBetaHeaderPrefix,
@@ -1770,6 +1787,7 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	"context-management-":                        func(f ProviderFeatureSupport) bool { return f.ContextEditing },
 	"files-api-":                                 func(f ProviderFeatureSupport) bool { return f.FilesAPI },
 	AnthropicAdvancedToolUseBetaHeaderPrefix:     func(f ProviderFeatureSupport) bool { return f.AdvancedToolUse },
+	AnthropicToolSearchBetaHeaderPrefix:          func(f ProviderFeatureSupport) bool { return f.ToolSearch },
 	AnthropicToolExamplesBetaHeaderPrefix:        func(f ProviderFeatureSupport) bool { return f.InputExamples },
 	AnthropicInterleavedThinkingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.InterleavedThinking },
 	AnthropicSkillsBetaHeaderPrefix:              func(f ProviderFeatureSupport) bool { return f.Skills },

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1332,6 +1332,30 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("Vertex/keeps_tool_search_beta_header", func(t *testing.T) {
+		result := FilterBetaHeadersForProvider([]string{AnthropicToolSearchBetaHeader}, schemas.Vertex)
+		if len(result) != 1 || result[0] != AnthropicToolSearchBetaHeader {
+			t.Errorf("expected %q to be kept for Vertex, got %v", AnthropicToolSearchBetaHeader, result)
+		}
+	})
+
+	t.Run("BedrockMantle/keeps_tool_search_beta_header", func(t *testing.T) {
+		result := FilterBetaHeadersForProvider([]string{AnthropicToolSearchBetaHeader}, schemas.BedrockMantle)
+		if len(result) != 1 || result[0] != AnthropicToolSearchBetaHeader {
+			t.Errorf("expected %q to be kept for Bedrock Mantle, got %v", AnthropicToolSearchBetaHeader, result)
+		}
+	})
+
+	t.Run("Bedrock/drops_tool_search_beta_header", func(t *testing.T) {
+		// tool-search-tool-2025-10-19 is InvokeModel/InvokeModelWithResponseStream
+		// only per AWS's docs; classic Bedrock always uses Converse here, so this
+		// must never reach AWS regardless of what the client sends.
+		result := FilterBetaHeadersForProvider([]string{AnthropicToolSearchBetaHeader}, schemas.Bedrock)
+		if len(result) != 0 {
+			t.Errorf("expected %q to be dropped for Bedrock, got %v", AnthropicToolSearchBetaHeader, result)
+		}
+	})
+
 	t.Run("unknown_headers_dropped_for_non_anthropic", func(t *testing.T) {
 		result := FilterBetaHeadersForProvider([]string{"some-future-beta-2025"}, schemas.Vertex)
 		if len(result) != 0 {
@@ -1892,6 +1916,39 @@ func TestStripUnsupportedAnthropicFields_ContainerSkillsGating(t *testing.T) {
 		}
 		if req.Container.ContainerObject.Skills == nil {
 			t.Errorf("expected empty skills preserved on Skills=true provider (not nilled)")
+		}
+	})
+}
+
+// TestStripUnsupportedAnthropicFields_ToolSearchGating covers #5xxx: defer_loading
+// used to be gated on AdvancedToolUse (the advanced-tool-use-2025-11-20 bundle), but
+// per current Anthropic docs defer_loading now has its own beta
+// (tool-search-tool-2025-10-19) and must be gated on ToolSearch instead. Vertex is a
+// real example where the two flags diverge: ToolSearch=true, AdvancedToolUse=false.
+func TestStripUnsupportedAnthropicFields_ToolSearchGating(t *testing.T) {
+	t.Run("vertex_tool_search_true_advanced_tool_use_false_keeps_defer_loading", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-sonnet-4-5",
+			Tools: []AnthropicTool{
+				{Name: "search", DeferLoading: schemas.Ptr(true)},
+			},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Vertex, "claude-sonnet-4-5")
+		if req.Tools[0].DeferLoading == nil || !*req.Tools[0].DeferLoading {
+			t.Errorf("expected defer_loading to survive for Vertex (ToolSearch=true), got %v", req.Tools[0].DeferLoading)
+		}
+	})
+
+	t.Run("bedrock_tool_search_false_strips_defer_loading", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-sonnet-4-5",
+			Tools: []AnthropicTool{
+				{Name: "search", DeferLoading: schemas.Ptr(true)},
+			},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Bedrock, "claude-sonnet-4-5")
+		if req.Tools[0].DeferLoading != nil {
+			t.Errorf("expected defer_loading to be stripped for Bedrock (ToolSearch=false), got %v", *req.Tools[0].DeferLoading)
 		}
 	})
 }

--- a/core/providers/anthropic/validatechattools_test.go
+++ b/core/providers/anthropic/validatechattools_test.go
@@ -19,12 +19,12 @@ func TestValidateChatToolsForProvider(t *testing.T) {
 	}
 
 	cases := []struct {
-		name         string
-		provider     schemas.ModelProvider
-		input        []schemas.ChatTool
-		wantKeep     int
-		wantDropped  []string
-		assertNotes  string
+		name        string
+		provider    schemas.ModelProvider
+		input       []schemas.ChatTool
+		wantKeep    int
+		wantDropped []string
+		assertNotes string
 	}{
 		{
 			name:     "function tools always survive on any provider",
@@ -33,26 +33,32 @@ func TestValidateChatToolsForProvider(t *testing.T) {
 			wantKeep: 2,
 		},
 		{
-			name:        "bedrock drops web_search",
-			provider:    schemas.Bedrock,
-			input:       []schemas.ChatTool{serverTool("web_search_20260209", "web_search")},
-			wantKeep:    0,
-			wantDropped: []string{"web_search_20260209"},
-			assertNotes: "Bedrock has WebSearch=false per Table 20 (AWS user guide beta-header list + Anthropic overview)",
+			name:     "bedrock keeps web_search + code_execution via Nova carve-out, matching the Responses-path validator",
+			provider: schemas.Bedrock,
+			input: []schemas.ChatTool{
+				serverTool("web_search_20260209", "web_search"),
+				serverTool("code_execution_20250825", "code_execution"),
+			},
+			// WebSearch/CodeExecution are false for Bedrock, but WebSearchNova/
+			// CodeExecNova are true — ValidateResponsesToolsForProvider already ORs
+			// these in; the Chat path must match, or a Nova2 request loses the tool
+			// at validation time before it ever reaches the Nova-system-tool
+			// conversion in convertToolConfigFromFiltered.
+			wantKeep:    2,
+			assertNotes: "Bedrock has WebSearch=false, WebSearchNova=true (nova_grounding); CodeExecution=false, CodeExecNova=true (nova_code_interpreter)",
 		},
 		{
-			name:        "bedrock drops web_fetch + code_execution + mcp_toolset",
-			provider:    schemas.Bedrock,
+			name:     "bedrock drops web_fetch + mcp_toolset",
+			provider: schemas.Bedrock,
 			input: []schemas.ChatTool{
 				serverTool("web_fetch_20260309", "web_fetch"),
-				serverTool("code_execution_20250825", "code_execution"),
 				serverTool("mcp_toolset", "notion"),
 			},
 			wantKeep:    0,
-			wantDropped: []string{"web_fetch_20260309", "code_execution_20250825", "mcp_toolset"},
+			wantDropped: []string{"web_fetch_20260309", "mcp_toolset"},
 		},
 		{
-			name:     "bedrock keeps computer/bash/memory/text_editor/tool_search",
+			name:     "bedrock keeps computer/bash/memory/text_editor, drops tool_search",
 			provider: schemas.Bedrock,
 			input: []schemas.ChatTool{
 				serverTool("computer_20251124", "computer"),
@@ -61,18 +67,21 @@ func TestValidateChatToolsForProvider(t *testing.T) {
 				serverTool("text_editor_20250728", "str_replace_based_edit_tool"),
 				serverTool("tool_search_tool_bm25", "tool_search_tool_bm25"),
 			},
-			wantKeep: 5,
+			// tool-search-tool-2025-10-19 is InvokeModel/InvokeModelWithResponseStream
+			// only per AWS's docs; classic Bedrock always dispatches via Converse.
+			wantKeep:    4,
+			wantDropped: []string{"tool_search_tool_bm25"},
 		},
 		{
 			name:     "bedrock partial drop mixes function + server tools",
 			provider: schemas.Bedrock,
 			input: []schemas.ChatTool{
 				fnTool,
-				serverTool("web_search_20260209", "web_search"),
+				serverTool("web_fetch_20260309", "web_fetch"),
 				serverTool("bash_20250124", "bash"),
 			},
 			wantKeep:    2, // fnTool + bash
-			wantDropped: []string{"web_search_20260209"},
+			wantDropped: []string{"web_fetch_20260309"},
 		},
 		{
 			name:        "vertex drops web_fetch",

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1195,6 +1195,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	applyDroppedUnsupportedTools(ctx, &bifrostResponse.ExtraFields, provider.logger)
 
 	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
 		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
@@ -1207,6 +1208,20 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	}
 
 	return bifrostResponse, nil
+}
+
+// applyDroppedUnsupportedTools reads tool-drop info stashed in context during
+// request building (ValidateChatToolsForProvider / ValidateResponsesToolsForProvider,
+// plus the Nova-model gate in convertToolConfigFromFiltered/ToBedrockResponsesRequest)
+// and surfaces it on the response so callers aren't left guessing why a requested
+// tool never showed up — mirrors how ProviderResponseHeaders is threaded via context.
+func applyDroppedUnsupportedTools(ctx *schemas.BifrostContext, extraFields *schemas.BifrostResponseExtraFields, logger schemas.Logger) {
+	dropped, ok := ctx.Value(schemas.BifrostContextKeyDroppedUnsupportedTools).([]string)
+	if !ok || len(dropped) == 0 {
+		return
+	}
+	extraFields.DroppedUnsupportedTools = dropped
+	logger.Warn(fmt.Sprintf("bedrock: dropped unsupported tools from request: %v", dropped))
 }
 
 // normalizeCachedUsage folds the accumulated cached read/write token counts into
@@ -1664,6 +1679,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 	bifrostResponse.ExtraFields.ProviderResponseHeaders = providerResponseHeaders
+	applyDroppedUnsupportedTools(ctx, &bifrostResponse.ExtraFields, provider.logger)
 
 	// Set raw request if enabled
 	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {

--- a/core/providers/bedrock/convert_tool_config_test.go
+++ b/core/providers/bedrock/convert_tool_config_test.go
@@ -99,6 +99,133 @@ func TestConvertToolConfig_KeepsBedrockSupportedServerTools(t *testing.T) {
 	}
 }
 
+// TestConvertToolConfig_NovaGetsWebSearchAndCodeExecution is a regression test:
+// the chat-completions Bedrock builder had no branch converting web_search/
+// code_execution into Bedrock's Nova system-tool shape at all — only the
+// Responses-path builder (ToBedrockResponsesRequest) did — so a Nova2 model could
+// never receive nova_grounding/nova_code_interpreter via chat completions, even
+// though ValidateChatToolsForProvider (once aligned with the Responses-path
+// validator) keeps these tool types for Bedrock via the WebSearchNova/CodeExecNova
+// carve-out.
+func TestConvertToolConfig_NovaGetsWebSearchAndCodeExecution(t *testing.T) {
+	params := &schemas.ChatParameters{
+		Tools: []schemas.ChatTool{
+			{Type: schemas.ChatToolType("web_search_20260209"), Name: "web_search"},
+			{Type: schemas.ChatToolType("code_execution_20250825"), Name: "code_execution"},
+		},
+	}
+
+	cfg := convertToolConfig("amazon.nova-2-lite-v1:0", params)
+	if cfg == nil {
+		t.Fatalf("expected a ToolConfig with Nova system tools, got nil")
+	}
+	if len(cfg.Tools) != 2 {
+		t.Fatalf("expected 2 Nova system tools, got %d: %+v", len(cfg.Tools), cfg.Tools)
+	}
+	var gotGrounding, gotCodeInterpreter bool
+	for _, tool := range cfg.Tools {
+		if tool.SystemTool == nil {
+			t.Errorf("expected a SystemTool entry, got %+v", tool)
+			continue
+		}
+		switch tool.SystemTool.Name {
+		case BedrockSystemToolNovaGrounding:
+			gotGrounding = true
+		case BedrockSystemToolNovaCodeInterpreter:
+			gotCodeInterpreter = true
+		}
+	}
+	if !gotGrounding {
+		t.Error("expected nova_grounding system tool for web_search")
+	}
+	if !gotCodeInterpreter {
+		t.Error("expected nova_code_interpreter system tool for code_execution")
+	}
+}
+
+// TestToBedrockChatCompletionRequest_NovaAliasGetsWebSearch is a regression test for a
+// CodeRabbit finding on PR #5821: convertChatParameters already computes capModel :=
+// ResolveCanonicalModel(ctx, bifrostReq.Model) for capability gating, but the call to
+// convertToolConfigFromFiltered passed the raw bifrostReq.Model instead — so a model
+// alias that resolves to Nova2 but whose raw string doesn't literally contain "nova-2"
+// would fail IsNova2Model's substring check and silently drop web_search/code_execution
+// instead of converting them to nova_grounding/nova_code_interpreter. The Responses-path
+// sibling (ToBedrockResponsesRequest) already passes capModel correctly.
+func TestToBedrockChatCompletionRequest_NovaAliasGetsWebSearch(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, &schemas.ResolvedAlias{
+		Key: "my-nova-alias",
+		Config: &schemas.AliasConfig{
+			ModelID: "amazon.nova-2-lite-v1:0",
+		},
+	})
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "my-nova-alias", // raw string does not contain "nova-2"
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("search the web")}},
+		},
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{
+				{Type: schemas.ChatToolType("web_search_20260209"), Name: "web_search"},
+			},
+		},
+	}
+
+	bedrockReq, err := ToBedrockChatCompletionRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bedrockReq.ToolConfig == nil || len(bedrockReq.ToolConfig.Tools) != 1 {
+		t.Fatalf("expected exactly 1 tool (nova_grounding), got %+v", bedrockReq.ToolConfig)
+	}
+	tool := bedrockReq.ToolConfig.Tools[0]
+	if tool.SystemTool == nil || tool.SystemTool.Name != BedrockSystemToolNovaGrounding {
+		t.Errorf("expected nova_grounding system tool via the aliased canonical model, got %+v", tool)
+	}
+}
+
+// TestToBedrockChatCompletionRequest_DropsUnsupportedToolsSignaled is a regression
+// test: tools silently dropped from a Bedrock-bound request (because the target
+// provider/model doesn't support them) must be surfaced via
+// BifrostContextKeyDroppedUnsupportedTools so ChatCompletion/Responses can populate
+// ExtraFields.DroppedUnsupportedTools instead of leaving the caller uninformed.
+func TestToBedrockChatCompletionRequest_DropsUnsupportedToolsSignaled(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Bedrock,
+		Model:    "global.anthropic.claude-sonnet-4-6", // not Nova2
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}},
+		},
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{
+				{Type: schemas.ChatToolType("web_fetch_20260309"), Name: "web_fetch"},   // provider-level drop (WebFetch=false)
+				{Type: schemas.ChatToolType("web_search_20260209"), Name: "web_search"}, // model-level drop (non-Nova2)
+			},
+		},
+	}
+
+	_, err := ToBedrockChatCompletionRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dropped, ok := ctx.Value(schemas.BifrostContextKeyDroppedUnsupportedTools).([]string)
+	if !ok {
+		t.Fatalf("expected BifrostContextKeyDroppedUnsupportedTools to be set")
+	}
+	wantDropped := map[string]bool{"web_fetch_20260309": true, "web_search_20260209": true}
+	if len(dropped) != len(wantDropped) {
+		t.Fatalf("expected %d dropped tools, got %d: %v", len(wantDropped), len(dropped), dropped)
+	}
+	for _, d := range dropped {
+		if !wantDropped[d] {
+			t.Errorf("unexpected dropped tool %q", d)
+		}
+	}
+}
+
 // TestConvertChatParameters_ServerToolNameFromBody is a diagnostic probe for the
 // Bedrock managed-tool harness failures (`tools.0.<type>.name: Field required`). It
 // reproduces the real inbound seam: the harness body is unmarshaled into
@@ -629,6 +756,37 @@ func TestToBedrockResponsesRequest_OmitsToolChoiceWhenNoTools(t *testing.T) {
 	}
 	if bedrockReq.ToolConfig != nil {
 		t.Fatalf("expected no ToolConfig when all tools are skipped, got %+v", bedrockReq.ToolConfig)
+	}
+}
+
+// TestToBedrockResponsesRequest_WebSearchPreviewGetsNovaGrounding is a regression test
+// for a CodeRabbit finding on PR #5821: ValidateResponsesToolsForProvider keeps both
+// web_search and web_search_preview for Bedrock (case schemas.ResponsesToolTypeWebSearch,
+// schemas.ResponsesToolTypeWebSearchPreview), but the Nova-conversion loop only checked
+// tool.Type == ResponsesToolTypeWebSearch — a kept-but-unconverted web_search_preview
+// tool would silently disappear: no nova_grounding system tool on Nova2, no
+// drop-signal on non-Nova2.
+func TestToBedrockResponsesRequest_WebSearchPreviewGetsNovaGrounding(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostResponsesRequest{
+		Model: "amazon.nova-2-lite-v1:0",
+		Input: []schemas.ResponsesMessage{glmUserMessage("search the web")},
+		Params: &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(2000),
+			Tools:           []schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeWebSearchPreview}},
+		},
+	}
+
+	bedrockReq, err := ToBedrockResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToBedrockResponsesRequest failed: %v", err)
+	}
+	if bedrockReq.ToolConfig == nil || len(bedrockReq.ToolConfig.Tools) != 1 {
+		t.Fatalf("expected exactly 1 tool (nova_grounding), got %+v", bedrockReq.ToolConfig)
+	}
+	tool := bedrockReq.ToolConfig.Tools[0]
+	if tool.SystemTool == nil || tool.SystemTool.Name != BedrockSystemToolNovaGrounding {
+		t.Errorf("expected nova_grounding system tool for web_search_preview, got %+v", tool)
 	}
 }
 

--- a/core/providers/bedrock/invoke.go
+++ b/core/providers/bedrock/invoke.go
@@ -964,6 +964,16 @@ func (r *BedrockInvokeRequest) convertAnthropicTools() *BedrockToolConfig {
 			continue
 		}
 
+		// tool_search_tool_* is a server tool for Anthropic's tool-search-tool beta,
+		// not an invocable function — and classic Bedrock can't support tool search
+		// at all (AWS restricts it to InvokeModel/InvokeModelWithResponseStream,
+		// never Converse; see ProviderFeatures[schemas.Bedrock].ToolSearch in the
+		// anthropic package). Skip it here rather than building a broken,
+		// schema-less "function" tool out of it.
+		if typeStr, ok := toolMap["type"].(string); ok && strings.HasPrefix(typeStr, "tool_search_tool_") {
+			continue
+		}
+
 		spec := &BedrockToolSpec{}
 		if name, ok := toolMap["name"].(string); ok {
 			spec.Name = name
@@ -1217,12 +1227,41 @@ func toBedrockInvokeAnthropicResponse(resp *schemas.BifrostResponsesResponse, mo
 		}
 		// Reasoning content
 		if item.ResponsesReasoning != nil {
-			for _, summary := range item.ResponsesReasoning.Summary {
-				if summary.Text != "" {
-					result.Content = append(result.Content, BedrockInvokeMessagesContentBlock{
-						Type:     "thinking",
-						Thinking: summary.Text,
-					})
+			// Bedrock-origin reasoning lives in Content.ContentBlocks (see
+			// convertSingleBedrockMessageToBifrostMessages) — ResponsesReasoning.Summary
+			// is OpenAI Responses-API shape and is always empty for Bedrock. Fall back
+			// to Summary whenever ContentBlocks yields no usable reasoning block, not
+			// merely when ContentBlocks is empty — a non-empty ContentBlocks containing
+			// no reasoning-type block would otherwise silently lose the Summary data.
+			emittedFromContentBlocks := false
+			if item.Content != nil {
+				for _, block := range item.Content.ContentBlocks {
+					// Only require Text != nil (matching convertBifrostReasoningToBedrockReasoning,
+					// the sibling egress function) — not non-empty. Bedrock can return a
+					// reasoning block with empty text but a real signature; requiring
+					// non-empty text here would drop the whole block, losing the
+					// signature a client needs to replay history on the next turn.
+					if block.Type == schemas.ResponsesOutputMessageContentTypeReasoning && block.Text != nil {
+						blk := BedrockInvokeMessagesContentBlock{
+							Type:     "thinking",
+							Thinking: *block.Text,
+						}
+						if sig := reasoningSignatureForBedrock(block.Signature); sig != nil {
+							blk.Signature = *sig
+						}
+						result.Content = append(result.Content, blk)
+						emittedFromContentBlocks = true
+					}
+				}
+			}
+			if !emittedFromContentBlocks {
+				for _, summary := range item.ResponsesReasoning.Summary {
+					if summary.Text != "" {
+						result.Content = append(result.Content, BedrockInvokeMessagesContentBlock{
+							Type:     "thinking",
+							Thinking: summary.Text,
+						})
+					}
 				}
 			}
 		}
@@ -1498,12 +1537,13 @@ func toAnthropicInvokeStreamBytes(resp *schemas.BifrostResponsesStreamResponse) 
 			idx = *resp.ContentIndex
 		}
 		if resp.Signature != nil {
+			// Anthropic emits the signature as its own event type, not nested inside
+			// thinking_delta — https://platform.claude.com/docs/en/build-with-claude/thinking#streaming-thinking
 			event = map[string]interface{}{
 				"type":  "content_block_delta",
 				"index": idx,
 				"delta": map[string]interface{}{
-					"type":      "thinking_delta",
-					"thinking":  "",
+					"type":      "signature_delta",
 					"signature": *resp.Signature,
 				},
 			}

--- a/core/providers/bedrock/invoke_test.go
+++ b/core/providers/bedrock/invoke_test.go
@@ -47,6 +47,30 @@ func TestConvertAnthropicTools_NoCacheControl_Unaffected(t *testing.T) {
 	}
 }
 
+// TestConvertAnthropicTools_ToolSearchTypeNeverBecomesInvocable is a regression test:
+// classic Bedrock's Converse API has no concept of Anthropic's tool_search_tool_*
+// entries (tool search is InvokeModel/InvokeModelWithResponseStream only per AWS's
+// docs), so an inbound tool_search_tool_regex entry must never be built into an
+// ordinary invocable BedrockToolSpec — that would present a broken, schema-less
+// "function" tool to the model instead of being dropped.
+func TestConvertAnthropicTools_ToolSearchTypeNeverBecomesInvocable(t *testing.T) {
+	req := &BedrockInvokeRequest{
+		Tools: []interface{}{
+			map[string]interface{}{
+				"type": "tool_search_tool_regex_20251119",
+				"name": "tool_search_tool_regex",
+			},
+			anthropicToolMap("keep_me", nil),
+		},
+	}
+
+	toolConfig := req.convertAnthropicTools()
+	require.NotNil(t, toolConfig)
+	require.Len(t, toolConfig.Tools, 1, "the tool_search_tool_* entry must be skipped, only the real tool kept")
+	require.NotNil(t, toolConfig.Tools[0].ToolSpec)
+	assert.Equal(t, "keep_me", toolConfig.Tools[0].ToolSpec.Name)
+}
+
 // TestConvertAnthropicTools_CarriesCacheControl is the regression test for #5629: a
 // cache_control marker on an Anthropic-native tool must survive the invoke->Converse
 // conversion as a positional cachePoint entry appended after the marked tool, the same
@@ -293,6 +317,149 @@ func TestToBedrockInvokeAnthropicResponse_IncludesCacheFields(t *testing.T) {
 	assert.Equal(t, 5, result.Usage.OutputTokens)
 	assert.Equal(t, 8336, result.Usage.CacheCreationInputTokens)
 	assert.Equal(t, 0, result.Usage.CacheReadInputTokens)
+}
+
+// --- Regression tests for #5638: /invoke egress dropped the reasoning signature (and,
+// for Bedrock-originated reasoning, the thinking text itself) because neither the
+// non-streaming response builder nor the streaming signature event carried it. ---
+
+// TestToBedrockInvokeAnthropicResponse_ThinkingSignature covers the non-streaming path:
+// Bedrock-originated reasoning lives in item.Content.ContentBlocks (not
+// item.ResponsesReasoning.Summary, which is always empty for Bedrock — see
+// convertSingleBedrockMessageToBifrostMessages), so the response builder must read
+// ContentBlocks first and carry the signature through to the Anthropic-shaped thinking
+// block, or a client replaying it back to Bedrock will 400 on a missing signature.
+func TestToBedrockInvokeAnthropicResponse_ThinkingSignature(t *testing.T) {
+	model := "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+	thinkingText := "Let me work through this."
+	signature := "EqQBCgIYAhIM...fixture"
+	resp := &schemas.BifrostResponsesResponse{
+		Model: model,
+		Output: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{},
+				},
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
+							Text:      &thinkingText,
+							Signature: &signature,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := toBedrockInvokeAnthropicResponse(resp, model)
+	require.Len(t, result.Content, 1)
+	assert.Equal(t, "thinking", result.Content[0].Type)
+	assert.Equal(t, thinkingText, result.Content[0].Thinking)
+	assert.Equal(t, signature, result.Content[0].Signature)
+}
+
+// TestToBedrockInvokeAnthropicResponse_SummaryFallbackWhenContentBlocksUnusable covers
+// a CodeRabbit finding on PR #5821: the branch decision was "does Content.ContentBlocks
+// have any entries" rather than "did we actually emit a thinking block from it." If
+// ContentBlocks is non-empty but contains no usable reasoning block (e.g. a
+// non-reasoning content type), the ResponsesReasoning.Summary fallback — which may hold
+// real data — was never consulted, silently losing thinking content on /invoke egress.
+func TestToBedrockInvokeAnthropicResponse_SummaryFallbackWhenContentBlocksUnusable(t *testing.T) {
+	model := "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+	resp := &schemas.BifrostResponsesResponse{
+		Model: model,
+		Output: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{
+						{Text: "fallback summary text"},
+					},
+				},
+				Content: &schemas.ResponsesMessageContent{
+					// Non-empty, but no reasoning-type block within it.
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesOutputMessageContentTypeText},
+					},
+				},
+			},
+		},
+	}
+
+	result := toBedrockInvokeAnthropicResponse(resp, model)
+	require.Len(t, result.Content, 1, "expected the Summary fallback to be used when ContentBlocks yields no reasoning block")
+	assert.Equal(t, "thinking", result.Content[0].Type)
+	assert.Equal(t, "fallback summary text", result.Content[0].Thinking)
+}
+
+// TestToBedrockInvokeAnthropicResponse_EmptyTextSignaturePreserved guards against a
+// stricter-than-necessary empty-text filter dropping the signature along with it.
+// The sibling egress function (convertBifrostReasoningToBedrockReasoning, responses.go)
+// only requires block.Text != nil — not non-empty — before carrying a reasoning block
+// through; this response builder must match that, or a Bedrock-returned reasoning block
+// with empty text but a real signature gets silently discarded here, losing the
+// signature a client needs to replay history on the next turn.
+func TestToBedrockInvokeAnthropicResponse_EmptyTextSignaturePreserved(t *testing.T) {
+	model := "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+	emptyText := ""
+	signature := "EqQBCgIYAhIM...fixture"
+	resp := &schemas.BifrostResponsesResponse{
+		Model: model,
+		Output: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+				ResponsesReasoning: &schemas.ResponsesReasoning{
+					Summary: []schemas.ResponsesReasoningSummary{},
+				},
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
+							Text:      &emptyText,
+							Signature: &signature,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := toBedrockInvokeAnthropicResponse(resp, model)
+	require.Len(t, result.Content, 1, "the block must survive even with empty text, so its signature isn't lost")
+	assert.Equal(t, "thinking", result.Content[0].Type)
+	assert.Equal(t, "", result.Content[0].Thinking)
+	assert.Equal(t, signature, result.Content[0].Signature)
+}
+
+// TestToAnthropicInvokeStreamBytes_ReasoningSignatureDelta covers the streaming path:
+// Anthropic-compatible SDKs (including Claude Code) parse a thinking signature only off
+// a dedicated signature_delta event, never nested inside thinking_delta — see
+// https://platform.claude.com/docs/en/build-with-claude/thinking#streaming-thinking.
+func TestToAnthropicInvokeStreamBytes_ReasoningSignatureDelta(t *testing.T) {
+	signature := "EqQBCgIYAhIM...fixture"
+	idx := 0
+	resp := &schemas.BifrostResponsesStreamResponse{
+		Type:         schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
+		ContentIndex: &idx,
+		Signature:    &signature,
+	}
+
+	frames, err := toAnthropicInvokeStreamBytes(resp)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	var event map[string]interface{}
+	require.NoError(t, json.Unmarshal(frames[0], &event))
+
+	delta, ok := event["delta"].(map[string]interface{})
+	require.True(t, ok, "expected a delta object")
+	assert.Equal(t, "signature_delta", delta["type"], "signature must arrive as its own event type, not nested in thinking_delta")
+	assert.Equal(t, signature, delta["signature"])
+	_, hasThinking := delta["thinking"]
+	assert.False(t, hasThinking, "signature_delta must not carry a thinking field")
 }
 
 // --- Regression tests for #5560: InvokeModel silently dropped image / tool_use /

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2234,8 +2234,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	// Converse API genuinely can't consume are dropped. The kept slice is used
 	// locally below — bifrostReq.Params.Tools is never mutated.
 	var keepTools []schemas.ResponsesTool
+	var providerDroppedTools []string
 	if bifrostReq.Params != nil && bifrostReq.Params.Tools != nil {
-		keepTools, _ = anthropic.ValidateResponsesToolsForProvider(bifrostReq.Params.Tools, schemas.Bedrock)
+		keepTools, providerDroppedTools = anthropic.ValidateResponsesToolsForProvider(bifrostReq.Params.Tools, schemas.Bedrock)
 	}
 
 	bedrockReq := &BedrockConverseRequest{
@@ -2508,25 +2509,24 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	}
 
 	// Convert tools (using the provider-filtered keepTools set computed above).
+	var modelDroppedTools []string
 	if len(keepTools) > 0 {
 		var bedrockTools []BedrockTool
 		isNova2 := schemas.IsNova2Model(capModel)
 		for _, tool := range keepTools {
-			if tool.Type == schemas.ResponsesToolTypeWebSearch || tool.Type == schemas.ResponsesToolTypeCodeInterpreter {
-				if !isNova2 {
-					// skip adding this tool
-					continue
-				}
-				var systemToolName BedrockSystemToolType
-				switch tool.Type {
-				case schemas.ResponsesToolTypeWebSearch:
-					systemToolName = BedrockSystemToolNovaGrounding
-				case schemas.ResponsesToolTypeCodeInterpreter:
+			if tool.Type == schemas.ResponsesToolTypeWebSearch || tool.Type == schemas.ResponsesToolTypeWebSearchPreview || tool.Type == schemas.ResponsesToolTypeCodeInterpreter {
+				// web_search and web_search_preview are both kept for Bedrock by
+				// ValidateResponsesToolsForProvider (same case, same WebSearchNova
+				// carve-out) — both must map to nova_grounding here too.
+				systemToolName := BedrockSystemToolNovaGrounding
+				if tool.Type == schemas.ResponsesToolTypeCodeInterpreter {
 					systemToolName = BedrockSystemToolNovaCodeInterpreter
 				}
-				bedrockTools = append(bedrockTools, BedrockTool{
-					SystemTool: &BedrockSystemTool{Name: systemToolName},
-				})
+				if bt := convertToNovaSystemTool(systemToolName, isNova2); bt != nil {
+					bedrockTools = append(bedrockTools, *bt)
+				} else {
+					modelDroppedTools = append(modelDroppedTools, string(tool.Type))
+				}
 				continue
 			}
 			if tool.ResponsesToolFunction != nil {
@@ -2582,6 +2582,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 				Tools: bedrockTools,
 			}
 		}
+	}
+	if dropped := append(append([]string{}, providerDroppedTools...), modelDroppedTools...); len(dropped) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyDroppedUnsupportedTools, dropped)
 	}
 
 	// Convert tool choice

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -292,10 +292,10 @@ type BedrockS3Location struct {
 
 // BedrockToolUse represents a tool use request
 type BedrockToolUse struct {
-	ToolUseID string          `json:"toolUseId"`       // Required: Unique identifier for this tool use
-	Name      string          `json:"name"`            // Required: Name of the tool to use
-	Input     json.RawMessage `json:"input"`           // Required: Input parameters for the tool (json.RawMessage preserves key ordering for prompt caching)
-	Type      string          `json:"type,omitempty"`  // Optional: "server_tool_use" for Nova system tools
+	ToolUseID string          `json:"toolUseId"`      // Required: Unique identifier for this tool use
+	Name      string          `json:"name"`           // Required: Name of the tool to use
+	Input     json.RawMessage `json:"input"`          // Required: Input parameters for the tool (json.RawMessage preserves key ordering for prompt caching)
+	Type      string          `json:"type,omitempty"` // Optional: "server_tool_use" for Nova system tools
 }
 
 // BedrockToolResult represents the result of a tool use
@@ -524,7 +524,7 @@ type BedrockGuardrailTrace struct {
 
 // BedrockGuardrailAssessment represents a guardrail assessment
 type BedrockGuardrailAssessment struct {
-	AppliedGuardrailDetails   *BedrockGuardrailAppliedDetails           `json:"appliedGuardrailDetails,omitempty"`
+	AppliedGuardrailDetails   *BedrockGuardrailAppliedDetails            `json:"appliedGuardrailDetails,omitempty"`
 	AutomatedReasoningPolicy  *BedrockGuardrailAutomatedReasoningPolicy  `json:"automatedReasoningPolicy,omitempty"`
 	ContentPolicy             *BedrockGuardrailContentPolicy             `json:"contentPolicy,omitempty"`
 	ContextualGroundingPolicy *BedrockGuardrailContextualGroundingPolicy `json:"contextualGroundingPolicy,omitempty"`
@@ -693,12 +693,13 @@ type BedrockInvokeMessagesResponse struct {
 
 // BedrockInvokeMessagesContentBlock represents a content block in an Anthropic Messages response.
 type BedrockInvokeMessagesContentBlock struct {
-	Type     string      `json:"type"`
-	Text     string      `json:"text,omitempty"`
-	ID       string      `json:"id,omitempty"`
-	Name     string      `json:"name,omitempty"`
-	Input    interface{} `json:"input,omitempty"`
-	Thinking string      `json:"thinking,omitempty"`
+	Type      string      `json:"type"`
+	Text      string      `json:"text,omitempty"`
+	ID        string      `json:"id,omitempty"`
+	Name      string      `json:"name,omitempty"`
+	Input     interface{} `json:"input,omitempty"`
+	Thinking  string      `json:"thinking,omitempty"`
+	Signature string      `json:"signature,omitempty"`
 }
 
 // BedrockInvokeMessagesUsage represents token usage in an Anthropic Messages response.

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -258,11 +258,20 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	// Filter provider-unsupported server tools once; both convertToolConfig and
 	// collectBedrockServerTools consume the same filtered set, and
 	// buildBedrockServerToolChoice resolves pinned names against it.
-	filteredTools, _ := anthropic.ValidateChatToolsForProvider(bifrostReq.Params.Tools, schemas.Bedrock)
+	filteredTools, providerDropped := anthropic.ValidateChatToolsForProvider(bifrostReq.Params.Tools, schemas.Bedrock)
 
 	// Convert tool config (function/custom tools → Converse toolConfig.tools).
-	if toolConfig := convertToolConfigFromFiltered(ctx, bifrostReq.Model, bifrostReq.Params, filteredTools); toolConfig != nil {
+	// capModel (not bifrostReq.Model) — convertToolConfigFromFiltered's IsNova2Model
+	// check needs the canonical model, or a Nova2 alias whose raw string doesn't
+	// literally contain "nova-2" fails the check and drops web_search/code_execution
+	// instead of converting them. Mirrors ToBedrockResponsesRequest, which already
+	// passes capModel to the same check.
+	toolConfig, modelDropped := convertToolConfigFromFiltered(ctx, capModel, bifrostReq.Params, filteredTools)
+	if toolConfig != nil {
 		bedrockReq.ToolConfig = toolConfig
+	}
+	if dropped := append(append([]string{}, providerDropped...), modelDropped...); len(dropped) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyDroppedUnsupportedTools, dropped)
 	}
 
 	// Tunnel Bedrock-supported Anthropic server tools through Converse's
@@ -1661,6 +1670,15 @@ func collectBedrockServerToolsFromFiltered(filtered []schemas.ChatTool) (serverT
 		if tool.Function != nil || tool.Custom != nil {
 			continue
 		}
+		// web_search_*/code_execution_* survive ValidateChatToolsForProvider via
+		// the WebSearchNova/CodeExecNova carve-out, but they're handled exclusively
+		// by convertToolConfigFromFiltered's Nova system-tool conversion
+		// (toolConfig.tools[].systemTool) — tunneling them here too would send
+		// Bedrock two conflicting representations of the same tool.
+		typeStr := string(tool.Type)
+		if strings.HasPrefix(typeStr, "web_search_") || strings.HasPrefix(typeStr, "code_execution_") {
+			continue
+		}
 		bytes, err := providerUtils.MarshalSorted(tool)
 		if err != nil {
 			continue
@@ -1824,7 +1842,8 @@ func convertToolConfig(model string, params *schemas.ChatParameters) *BedrockToo
 	}
 	// Strip unsupported server tools before the conversion loop.
 	filtered, _ := anthropic.ValidateChatToolsForProvider(params.Tools, schemas.Bedrock)
-	return convertToolConfigFromFiltered(nil, model, params, filtered)
+	toolConfig, _ := convertToolConfigFromFiltered(nil, model, params, filtered)
+	return toolConfig
 }
 
 // convertToolConfigFromFiltered is the inner variant that accepts a
@@ -1836,12 +1855,33 @@ func convertToolConfig(model string, params *schemas.ChatParameters) *BedrockToo
 // this function can consult the resolved alias and honor explicit
 // AliasConfig.ModelFamily overrides. Test paths may pass nil — family
 // detection then falls back to substring matching on model.
-func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, params *schemas.ChatParameters, filtered []schemas.ChatTool) *BedrockToolConfig {
-	if params == nil {
+// convertToNovaSystemTool builds the Bedrock system-tool substitute for an
+// Anthropic web_search/code_execution server tool — the only way either
+// survives on Bedrock, and only for Nova2 models (nova_grounding /
+// nova_code_interpreter). Returns nil when the model isn't Nova2, so the
+// caller drops the tool instead. Shared by the Chat (convertToolConfigFromFiltered)
+// and Responses (ToBedrockResponsesRequest) builders so there is one model-aware
+// rule instead of two independently-maintained ones.
+func convertToNovaSystemTool(systemToolName BedrockSystemToolType, isNova2 bool) *BedrockTool {
+	if !isNova2 {
 		return nil
 	}
+	return &BedrockTool{SystemTool: &BedrockSystemTool{Name: systemToolName}}
+}
 
+// convertToolConfigFromFiltered returns the built ToolConfig plus any tool type
+// strings dropped here because the model isn't Nova2 (web_search/code_execution
+// survive ValidateChatToolsForProvider via the Nova carve-out but only actually
+// work on Nova2 models). Callers combine this with ValidateChatToolsForProvider's
+// own dropped list for a complete picture.
+func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, params *schemas.ChatParameters, filtered []schemas.ChatTool) (*BedrockToolConfig, []string) {
+	if params == nil {
+		return nil, nil
+	}
+
+	isNova2 := schemas.IsNova2Model(model)
 	var bedrockTools []BedrockTool
+	var droppedForModel []string
 	for _, tool := range filtered {
 		if tool.Function != nil {
 			// Serialize the parameters (or a default empty schema) to json.RawMessage
@@ -1881,6 +1921,23 @@ func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, pa
 					CachePoint: newBedrockCachePoint(tool.CacheControl.TTL),
 				})
 			}
+		} else if typeStr := string(tool.Type); strings.HasPrefix(typeStr, "web_search_") || strings.HasPrefix(typeStr, "code_execution_") {
+			// web_search/code_execution survive ValidateChatToolsForProvider only
+			// via the WebSearchNova/CodeExecNova carve-out — the only Bedrock
+			// models that actually support them are Nova2, via the nova_grounding /
+			// nova_code_interpreter system tools. Anything else here (already
+			// filtered by ValidateChatToolsForProvider) falls through and is
+			// silently dropped, matching the pre-existing behavior for
+			// unsupported server tools.
+			systemToolName := BedrockSystemToolNovaGrounding
+			if strings.HasPrefix(typeStr, "code_execution_") {
+				systemToolName = BedrockSystemToolNovaCodeInterpreter
+			}
+			if bt := convertToNovaSystemTool(systemToolName, isNova2); bt != nil {
+				bedrockTools = append(bedrockTools, *bt)
+			} else {
+				droppedForModel = append(droppedForModel, typeStr)
+			}
 		}
 	}
 
@@ -1890,7 +1947,7 @@ func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, pa
 	// doesn't support), omit ToolConfig entirely so the request is valid and
 	// the model simply answers without tool access.
 	if len(bedrockTools) == 0 {
-		return nil
+		return nil, droppedForModel
 	}
 
 	toolConfig := &BedrockToolConfig{
@@ -1940,7 +1997,7 @@ func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, pa
 		}
 	}
 
-	return toolConfig
+	return toolConfig, droppedForModel
 }
 
 // convertToolChoice converts Bifrost tool choice to Bedrock format

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2155,6 +2155,24 @@ func NewBifrostTimeoutError(message string, err error) *schemas.BifrostError {
 	}
 }
 
+// NewBifrostBadRequestError creates a standardized error for client-input validation
+// failures surfaced during request conversion (e.g. an unsatisfiable reasoning/thinking
+// + max_tokens combination). Sets StatusCode to 400, distinguishing these from
+// NewBifrostOperationError's genuinely-internal conversion failures, which the HTTP
+// layer defaults to 500 when StatusCode is unset.
+func NewBifrostBadRequestError(message string) *schemas.BifrostError {
+	statusCode := 400
+	errorType := "invalid_request_error"
+	return &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: message,
+			Type:    &errorType,
+		},
+	}
+}
+
 // NewBifrostUpstreamConnectionError creates a standardized error for upstream
 // connectivity failures where Bifrost successfully dispatched to the provider
 // but the provider failed to return a response body (DNS lookup failure,

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -347,6 +347,7 @@ const (
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
 	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
 	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)
+	BifrostContextKeyDroppedUnsupportedTools             BifrostContextKey = "bifrost-dropped-unsupported-tools"          // []string (set by provider request builders — tool type strings silently dropped because the target provider/model doesn't support them)
 	BifrostContextKeyMCPAddedTools                       BifrostContextKey = "bifrost-mcp-added-tools"                    // []string (set by bifrost - DO NOT SET THIS MANUALLY)) - list of tools added to the request by MCP, all the tool are in the format "clientName-toolName"
 	BifrostContextKeyLargePayloadMode                    BifrostContextKey = "bifrost-large-payload-mode"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large payload streaming mode is active
 	BifrostContextKeyLargePayloadReader                  BifrostContextKey = "bifrost-large-payload-reader"               // io.Reader (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large payloads
@@ -1708,8 +1709,13 @@ type BifrostResponseExtraFields struct {
 	ParseErrors               []BatchError       `json:"parse_errors,omitempty"` // errors encountered while parsing JSONL batch results
 	ConvertedRequestType      RequestType        `json:"converted_request_type,omitempty"`
 	DroppedCompatPluginParams []string           `json:"dropped_compat_plugin_params,omitempty"` // params dropped by the compat plugin based on model catalog
-	ProviderResponseHeaders   map[string]string  `json:"provider_response_headers,omitempty"`    // HTTP response headers from the provider (filtered to exclude transport-level headers)
-	PassthroughPath           string             `json:"passthrough_path,omitempty"`             // Stripped provider path for passthrough requests, e.g. "/v1/chat/completions"
+	// DroppedUnsupportedTools lists tool type strings silently stripped from the
+	// request because the target provider/model doesn't support them (e.g.
+	// web_search requested against a non-Nova Bedrock model). Currently populated
+	// only by the Bedrock provider.
+	DroppedUnsupportedTools []string          `json:"dropped_unsupported_tools,omitempty"`
+	ProviderResponseHeaders map[string]string `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
+	PassthroughPath         string            `json:"passthrough_path,omitempty"`          // Stripped provider path for passthrough requests, e.g. "/v1/chat/completions"
 }
 
 type RoutingInfo struct {


### PR DESCRIPTION
## Summary

This PR fixes several correctness bugs across the Anthropic and Bedrock providers: reasoning/thinking `max_tokens` validation errors now surface as HTTP 400 instead of 500; `tool.defer_loading` is re-gated on its own `tool-search-tool-2025-10-19` beta header rather than the `advanced-tool-use` bundle; Bedrock's classic Converse path no longer claims to support `tool_search_tool_*` (which AWS restricts to InvokeModel only); Nova2 web search and code execution tools are now correctly handled on the chat completions path (not just the Responses path); reasoning signatures are preserved through the `/invoke` egress path; and `message_start` streaming events no longer fabricate all-zero usage when the upstream hasn't reported it yet.

Closes #5638

## Changes

- **Reasoning** **`max_tokens`** **→ 400 not 500**: Introduced `ErrReasoningMaxTokensTooLow` sentinel error, wrapped at every reasoning-budget validation site in `chat.go` and `responses.go`. `requestbuilder.go` now detects it via `errors.Is` and calls `NewBifrostBadRequestError` (new helper, sets `StatusCode=400`) instead of the generic operation error that defaulted to 500.
- **`defer_loading`** **beta header split**: `tool.defer_loading` now requires `tool-search-tool-2025-10-19` (`AnthropicToolSearchBetaHeader`), not the `advanced-tool-use-2025-11-20` bundle. `ProviderFeatureSupport.ToolSearch` gates it; `AdvancedToolUse` is narrowed to `allowed_callers` only. `stripUnsupportedAnthropicFields`, `StripUnsupportedFieldsFromRawBody`, `AddMissingBetaHeadersToContext`, and `betaHeaderPrefixToFeature` are all updated consistently.
- **Bedrock drops** **`ToolSearch`**: `ProviderFeatures[schemas.Bedrock].ToolSearch` is set to `false` because AWS restricts `tool-search-tool-2025-10-19` to InvokeModel/InvokeModelWithResponseStream; Bifrost's Bedrock provider always dispatches tool-bearing requests via Converse. `convertAnthropicTools` in `invoke.go` now explicitly skips `tool_search_tool_*` entries rather than building a broken schema-less function tool.
- **Nova2 web search/code execution on chat completions path**: `ValidateChatToolsForProvider`'s prefix map now ORs in `WebSearchNova`/`CodeExecNova` for `web_search_`/`code_execution_` prefixes, matching the Responses-path validator. `convertToolConfigFromFiltered` gains a new branch that converts these to `nova_grounding`/`nova_code_interpreter` system tools for Nova2 models and records them as model-dropped for non-Nova2 models. A shared `convertToNovaSystemTool` helper is extracted so both the Chat and Responses builders use one rule.
- **Dropped tools surfaced on response**: `BifrostContextKeyDroppedUnsupportedTools` context key and `BifrostResponseExtraFields.DroppedUnsupportedTools` field are added. Both `ChatCompletion` and `Responses` in `bedrock.go` call a new `applyDroppedUnsupportedTools` helper that reads the context value and logs a warning.
- **Reasoning signature through** **`/invoke`**: `toBedrockInvokeAnthropicResponse` now reads `item.Content.ContentBlocks` first (where Bedrock-originated reasoning lives) and carries the `Signature` field through to `BedrockInvokeMessagesContentBlock` (new field). The streaming path emits a `signature_delta` event type instead of nesting the signature inside `thinking_delta`, matching Anthropic's documented streaming contract.
- **`message_start`** **usage omission**: `ToAnthropicResponsesStreamResponse` no longer fabricates an all-zero `AnthropicUsage` when `bifrostResp.Response.Usage` is nil. The field is omitted entirely, which Anthropic's streaming spec permits and which avoids misrepresenting cost telemetry to clients (e.g. Claude Code) that read `input_tokens` from `message_start`.
- **`collectBedrockServerToolsFromFiltered`**: Skips `web_search_`/`code_execution_` prefixes to avoid sending Bedrock two conflicting representations of the same Nova system tool.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/bedrock/... ./core/providers/utils/...
```

Key scenarios to validate:

- Send a request with `reasoning.effort=high` and `max_tokens=500` to an Anthropic model — expect a `400` response, not `500`.
- Send a request with `tool.defer_loading=true` to Vertex — expect `tool-search-tool-2025-10-19` in the beta headers, not `advanced-tool-use-2025-11-20`.
- Send a `tool_search_tool_*` tool to classic Bedrock — expect it to be silently dropped, not forwarded as a broken function tool.
- Send `web_search`/`code_execution` tools to a Nova2 Bedrock model via chat completions — expect `nova_grounding`/`nova_code_interpreter` system tools in the Converse request.
- Verify `ExtraFields.DroppedUnsupportedTools` is populated when tools are dropped on Bedrock.
- Stream a reasoning response through `/invoke` — expect a `signature_delta` event carrying the signature, and the thinking text present in the non-streaming response.

## Breaking changes

- [x] No

`DroppedUnsupportedTools` is a new additive field. The `defer_loading` beta header change is a correctness fix; clients that were relying on `advanced-tool-use` to gate `defer_loading` on Bedrock were already broken (Bedrock doesn't support it). The `message_start` usage omission is spec-compliant and only removes fabricated zeros.

## Security considerations

None. No auth, secrets, PII, or sandboxing changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable