### PR TITLE
[fix]: transcription - preserve the client's multipart filename so non-WAV containers are not relabelled audio.mp3

### DIFF
--- a/core/providers/openai/transcription.go
+++ b/core/providers/openai/transcription.go
@@ -17,7 +17,8 @@ func (request *OpenAITranscriptionRequest) ToBifrostTranscriptionRequest(ctx *sc
 		Provider: provider,
 		Model:    model,
 		Input: &schemas.TranscriptionInput{
-			File: request.File,
+			File:     request.File,
+			Filename: request.Filename,
 		},
 		Params:    &request.TranscriptionParameters,
 		Fallbacks: schemas.ParseFallbacks(request.Fallbacks),

--- a/core/providers/openai/transcription_test.go
+++ b/core/providers/openai/transcription_test.go
@@ -344,6 +344,67 @@ func multipartFieldValue(t *testing.T, contentType string, body []byte, name str
 	return ""
 }
 
+// TestTranscriptionRequest_PreservesFilenameEndToEnd covers issue #5670: the
+// ingress conversion must carry the client's filename into the Bifrost request
+// so the outbound multipart form labels the audio with its real container.
+// M4A/MP4/webm bytes are not magic-byte sniffable, so a dropped filename hits
+// the audio.mp3 fallback and OpenAI rejects the mislabelled upload.
+func TestTranscriptionRequest_PreservesFilenameEndToEnd(t *testing.T) {
+	ingress := &OpenAITranscriptionRequest{
+		Model:    "whisper-1",
+		File:     []byte("\x00\x00\x00\x20ftypM4A fake-m4a-bytes"),
+		Filename: "recording.m4a",
+	}
+
+	bifrostReq := ingress.ToBifrostTranscriptionRequest(nil)
+	if bifrostReq.Input.Filename != "recording.m4a" {
+		t.Fatalf("ingress conversion dropped filename: %q", bifrostReq.Input.Filename)
+	}
+
+	egress := ToOpenAITranscriptionRequest(bifrostReq)
+	if egress == nil {
+		t.Fatal("egress request is nil")
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if bifrostErr := ParseTranscriptionFormDataBodyFromRequest(writer, egress, schemas.OpenAI); bifrostErr != nil {
+		t.Fatalf("unexpected bifrost error: %v", bifrostErr.Error.Message)
+	}
+
+	if got := multipartFilePartName(t, writer.FormDataContentType(), body.Bytes()); got != "recording.m4a" {
+		t.Errorf("wire multipart file part named %q, want %q (sniffing fallback engaged)", got, "recording.m4a")
+	}
+}
+
+// multipartFilePartName returns the filename of the first "file" part in the
+// multipart body, or "" if absent.
+func multipartFilePartName(t *testing.T, contentType string, body []byte) string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", contentType, err)
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart(): %v", err)
+		}
+		name := part.FormName()
+		filename := part.FileName()
+		_, _ = io.Copy(io.Discard, part)
+		_ = part.Close()
+		if name == "file" {
+			return filename
+		}
+	}
+	return ""
+}
+
 func TestParseTranscriptionFormDataBodyFromRequest_ChunkingStrategyString(t *testing.T) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -3329,6 +3329,10 @@ func parseTranscriptionMultipartRequest(ctx *fasthttp.RequestCtx, req interface{
 		return err
 	}
 	transcriptionReq.File = fileData
+	// Carry the part's filename so the outbound request preserves the container
+	// format; without it the provider falls back to magic-byte sniffing, which
+	// mislabels non-sniffable containers (e.g. m4a/mp4) as audio.mp3.
+	transcriptionReq.Filename = fileHeader.Filename
 
 	// Extract optional parameters
 	if languageValues := form.Value["language"]; len(languageValues) > 0 && languageValues[0] != "" {

--- a/transports/bifrost-http/integrations/openai_test.go
+++ b/transports/bifrost-http/integrations/openai_test.go
@@ -221,3 +221,20 @@ func TestParseTranscriptionMultipartRequest_TypedFieldsNotShadowedByExtraParams(
 		t.Errorf("timestamp_granularities[] leaked into ExtraParams: %#v", req.ExtraParams["timestamp_granularities[]"])
 	}
 }
+
+// TestParseTranscriptionMultipartRequest_PreservesFilename covers issue #5670:
+// the multipart part's filename must reach the parsed request, otherwise the
+// provider re-derives it from magic bytes and mislabels non-sniffable
+// containers (m4a/mp4/webm) as audio.mp3, which OpenAI rejects.
+func TestParseTranscriptionMultipartRequest_PreservesFilename(t *testing.T) {
+	ctx := buildTranscriptionMultipartCtx(t, nil)
+
+	req := &openai.OpenAITranscriptionRequest{}
+	if err := parseTranscriptionMultipartRequest(ctx, req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if req.Filename != "sample.mp3" {
+		t.Errorf("Filename = %q, want %q (multipart part filename dropped)", req.Filename, "sample.mp3")
+	}
+}


### PR DESCRIPTION
## Summary

The `/v1/audio/transcriptions` transport parsed the multipart upload but never carried the part's filename, and the OpenAI ingress converter dropped it again when building the Bifrost request. The provider then fell back to magic-byte sniffing, which has no ftyp check, so MP4-family containers (m4a, mp4, webm) were relabelled `audio.mp3` and rejected upstream with 400 "Audio file might be corrupted or unsupported".

## Changes

- `transports/bifrost-http/integrations/openai.go`: `parseTranscriptionMultipartRequest` now sets `transcriptionReq.Filename` from `fileHeader.Filename` (matching the sibling file-upload parser)
- `core/providers/openai/transcription.go`: `ToBifrostTranscriptionRequest` now carries `Filename` into `schemas.TranscriptionInput`.
- Tests: transport-level filename propagation test, plus a core round-trip test (ingress → egress → multipart form) asserting the wire form file part keeps its real name; the round-trip test fails on current dev

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

`cd core && go test ./providers/openai/ -run Transcription -v`
`cd transports && go test ./bifrost-http/integrations/ -run ParseTranscriptionMultipartRequest -v`

## Breaking changes

- [x] No


## Related issues

Closes #5670

## Security considerations

Filename is passed through as a multipart form filename only, not used for any filesystem access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


