### PR TITLE
fix: tool ordering in extractToolsFromResponsesConversationHistory

### DIFF
--- a/core/providers/bedrock/convert_tool_config_test.go
+++ b/core/providers/bedrock/convert_tool_config_test.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -797,5 +798,65 @@ func glmUserMessage(text string) schemas.ResponsesMessage {
 		Content: &schemas.ResponsesMessageContent{
 			ContentStr: schemas.Ptr(text),
 		},
+	}
+}
+
+// TestExtractToolsFromConversationHistory_StableOrder locks in the fix for the
+// non-deterministic tool ordering that both reconstruction paths had: toolConfig
+// was built by ranging a Go map, so identical requests produced different tool
+// orders. Tools are the first thing in Bedrock's prompt-cache prefix, so every
+// reshuffle was a guaranteed cache miss.
+func TestExtractToolsFromConversationHistory_StableOrder(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	names := []string{"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"}
+
+	t.Run("responses", func(t *testing.T) {
+		input := []schemas.ResponsesMessage{}
+		for i, name := range names {
+			input = append(input, schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr(fmt.Sprintf("call_%d", i)),
+					Name:   schemas.Ptr(name),
+				},
+			})
+		}
+		for i := 0; i < 50; i++ {
+			_, tools := extractToolsFromResponsesConversationHistory(ctx, input, "us.anthropic.claude-opus-5")
+			assertToolOrder(t, tools, names)
+		}
+	})
+
+	t.Run("chat", func(t *testing.T) {
+		toolCalls := []schemas.ChatAssistantMessageToolCall{}
+		for i, name := range names {
+			toolCalls = append(toolCalls, schemas.ChatAssistantMessageToolCall{
+				ID:       schemas.Ptr(fmt.Sprintf("call_%d", i)),
+				Function: schemas.ChatAssistantMessageToolCallFunction{Name: schemas.Ptr(name)},
+			})
+		}
+		input := []schemas.ChatMessage{{
+			Role:                 schemas.ChatMessageRoleAssistant,
+			ChatAssistantMessage: &schemas.ChatAssistantMessage{ToolCalls: toolCalls},
+		}}
+		for i := 0; i < 50; i++ {
+			_, tools := extractToolsFromConversationHistory(ctx, input)
+			assertToolOrder(t, tools, names)
+		}
+	})
+}
+
+func assertToolOrder(t *testing.T, tools []BedrockTool, want []string) {
+	t.Helper()
+	if len(tools) != len(want) {
+		t.Fatalf("got %d tools, want %d", len(tools), len(want))
+	}
+	for i, tool := range tools {
+		if tool.ToolSpec == nil {
+			t.Fatalf("tools[%d] has no ToolSpec", i)
+		}
+		if tool.ToolSpec.Name != want[i] {
+			t.Fatalf("tool order drifted: got %s at index %d, want %s", tool.ToolSpec.Name, i, want[i])
+		}
 	}
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2892,6 +2892,7 @@ func ensureResponsesToolConfigForConversation(ctx context.Context, bifrostReq *s
 func extractToolsFromResponsesConversationHistory(ctx context.Context, messages []schemas.ResponsesMessage, model string) (bool, []BedrockTool) {
 	var hasToolContent bool
 	toolMap := make(map[string]*schemas.ResponsesTool) // Use map to deduplicate by name
+	var toolNames []string                             // Insertion-order tracking for toolMap
 	var hasNovaGrounding, hasNovaCodeInterpreter bool
 
 	for _, msg := range messages {
@@ -2904,6 +2905,7 @@ func extractToolsFromResponsesConversationHistory(ctx context.Context, messages 
 				if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.Name != nil {
 					toolName := *msg.ResponsesToolMessage.Name
 					if _, exists := toolMap[toolName]; !exists {
+						toolNames = append(toolNames, toolName)
 						// Create a minimal tool definition
 						toolMap[toolName] = &schemas.ResponsesTool{
 							Type: "function",
@@ -2929,7 +2931,8 @@ func extractToolsFromResponsesConversationHistory(ctx context.Context, messages 
 
 	// Convert function tool map to BedrockTool slice
 	var tools []BedrockTool
-	for _, tool := range toolMap {
+	for _, toolName := range toolNames {
+		tool := toolMap[toolName]
 		if tool.Name != nil && tool.ResponsesToolFunction != nil {
 			schemaObject := tool.ResponsesToolFunction.Parameters
 			if schemaObject == nil {

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -2045,21 +2045,22 @@ func convertToolChoice(toolChoice schemas.ChatToolChoice) *BedrockToolChoice {
 func extractToolsFromConversationHistory(ctx context.Context, messages []schemas.ChatMessage) (bool, []BedrockTool) {
 	hasToolContent := false
 	toolsMap := make(map[string]BedrockTool)
+	var toolNames []string // Insertion-order tracking for toolsMap
 
 	for _, msg := range messages {
-		hasToolContent = checkMessageForToolContent(ctx, msg, toolsMap) || hasToolContent
+		hasToolContent = checkMessageForToolContent(ctx, msg, toolsMap, &toolNames) || hasToolContent
 	}
 
 	tools := make([]BedrockTool, 0, len(toolsMap))
-	for _, tool := range toolsMap {
-		tools = append(tools, tool)
+	for _, toolName := range toolNames {
+		tools = append(tools, toolsMap[toolName])
 	}
 
 	return hasToolContent, tools
 }
 
 // checkMessageForToolContent checks a single message for tool content and updates the tools map
-func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, toolsMap map[string]BedrockTool) bool {
+func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, toolsMap map[string]BedrockTool, toolNames *[]string) bool {
 	hasContent := false
 
 	// Check assistant tool calls
@@ -2069,6 +2070,7 @@ func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, to
 			if toolCall.Function.Name != nil {
 				toolName := bedrockAliasToolName(ctx, *toolCall.Function.Name)
 				if _, exists := toolsMap[toolName]; !exists {
+					*toolNames = append(*toolNames, toolName)
 					// Create a complete schema object for extracted tools
 					schemaObject := map[string]interface{}{
 						"type":       "object",


### PR DESCRIPTION
## Summary

Tool ordering in Bedrock's `toolConfig` was non-deterministic because both reconstruction paths iterated over Go maps. Since tools appear at the start of Bedrock's prompt-cache prefix, any reordering between otherwise identical requests caused guaranteed cache misses.

## Changes

- Added insertion-order tracking (`toolNames []string`) alongside the deduplication maps in both `extractToolsFromConversationHistory` (chat path) and `extractToolsFromResponsesConversationHistory` (responses path), so the final `[]BedrockTool` slice is always built in first-seen order rather than random map iteration order.
- Updated `checkMessageForToolContent` to accept a `*[]string` parameter for tracking insertion order.
- Added `TestExtractToolsFromConversationHistory_StableOrder` which runs both the chat and responses paths 50 times each and asserts that the tool slice order never drifts from the original insertion order.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestExtractToolsFromConversationHistory_StableOrder -v -count=10
```

The test runs each path 50 iterations per invocation and fails immediately if any tool appears out of order. Prior to this fix, the test would fail intermittently due to Go's randomized map iteration.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable