### PR TITLE
[fix]: Anthropic - container param no longer dropped on /v1/messages, container reuse works

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3891,6 +3891,9 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	if req.Diagnostics != nil {
 		params.ExtraParams["diagnostics"] = req.Diagnostics
 	}
+	if req.Container != nil {
+		params.ExtraParams["container"] = req.Container
+	}
 	if req.TopK != nil {
 		params.ExtraParams["top_k"] = *req.TopK
 	}
@@ -4331,6 +4334,30 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				}
 				if parsed {
 					delete(anthropicReq.ExtraParams, "diagnostics")
+				}
+			}
+			if containerRaw, exists := anthropicReq.ExtraParams["container"]; exists {
+				parsed := false
+				switch v := containerRaw.(type) {
+				case *AnthropicContainer:
+					anthropicReq.Container = v
+					parsed = true
+				case AnthropicContainer:
+					anthropicReq.Container = &v
+					parsed = true
+				default:
+					// Raw forms from other surfaces: a bare string id or an
+					// object map both decode via the AnthropicContainer union.
+					if data, err := providerUtils.MarshalSorted(v); err == nil {
+						var c AnthropicContainer
+						if sonic.Unmarshal(data, &c) == nil {
+							anthropicReq.Container = &c
+							parsed = true
+						}
+					}
+				}
+				if parsed {
+					delete(anthropicReq.ExtraParams, "container")
 				}
 			}
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])

--- a/core/providers/anthropic/responses_test.go
+++ b/core/providers/anthropic/responses_test.go
@@ -27,6 +27,71 @@ func makeResponsesTextFormat(schemaName string) *schemas.ResponsesTextConfig {
 	}
 }
 
+// TestAnthropicContainerRoundTrip covers issue #5707: the "container" request
+// param (string id for container reuse, or object with skills[]) must survive
+// the /v1/messages ingress-to-egress round trip. Both forms were silently
+// dropped: ToBifrostResponsesRequest never read req.Container, so a client
+// requesting container reuse got HTTP 200 with a fresh container and all
+// previously staged files missing.
+func TestAnthropicContainerRoundTrip(t *testing.T) {
+	t.Run("StringForm", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model:     "claude-sonnet-4-5",
+			MaxTokens: 100,
+			Container: &AnthropicContainer{ContainerStr: schemas.Ptr("container_011CPQ2vNi9wkjJdrCFJNkCq")},
+		}
+
+		bifrostReq := req.ToBifrostResponsesRequest(nil)
+		out, err := ToAnthropicResponsesRequest(nil, bifrostReq)
+		if err != nil {
+			t.Fatalf("egress error: %v", err)
+		}
+
+		if out.Container == nil || out.Container.ContainerStr == nil {
+			t.Fatalf("string-form container dropped in round trip: %+v", out.Container)
+		}
+		if *out.Container.ContainerStr != "container_011CPQ2vNi9wkjJdrCFJNkCq" {
+			t.Errorf("container id = %q, want %q", *out.Container.ContainerStr, "container_011CPQ2vNi9wkjJdrCFJNkCq")
+		}
+		// Consumed onto the typed field, so it must not also linger in
+		// ExtraParams and serialize twice.
+		if _, ok := out.ExtraParams["container"]; ok {
+			t.Errorf("container left in ExtraParams after promotion: %#v", out.ExtraParams["container"])
+		}
+	})
+
+	t.Run("ObjectForm", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model:     "claude-sonnet-4-5",
+			MaxTokens: 100,
+			Container: &AnthropicContainer{ContainerObject: &AnthropicContainerObject{
+				ID:     schemas.Ptr("container_011CPQ2vNi9wkjJdrCFJNkCq"),
+				Skills: []AnthropicContainerSkill{{SkillID: "pdf", Type: "anthropic"}},
+			}},
+		}
+
+		bifrostReq := req.ToBifrostResponsesRequest(nil)
+		out, err := ToAnthropicResponsesRequest(nil, bifrostReq)
+		if err != nil {
+			t.Fatalf("egress error: %v", err)
+		}
+
+		if out.Container == nil || out.Container.ContainerObject == nil {
+			t.Fatalf("object-form container dropped in round trip: %+v", out.Container)
+		}
+		obj := out.Container.ContainerObject
+		if obj.ID == nil || *obj.ID != "container_011CPQ2vNi9wkjJdrCFJNkCq" {
+			t.Errorf("container object id = %v, want container_011CPQ2vNi9wkjJdrCFJNkCq", obj.ID)
+		}
+		if len(obj.Skills) != 1 || obj.Skills[0].SkillID != "pdf" || obj.Skills[0].Type != "anthropic" {
+			t.Errorf("container skills not preserved: %+v", obj.Skills)
+		}
+		if _, ok := out.ExtraParams["container"]; ok {
+			t.Errorf("container left in ExtraParams after promotion: %#v", out.ExtraParams["container"])
+		}
+	})
+}
+
 // TestToAnthropicResponsesRequest_StructuredOutput_ToolConversion verifies that,
 // mirroring the Chat Completions path, providers whose native Anthropic endpoint
 // rejects output_config.format get structured output converted into a synthetic


### PR DESCRIPTION
## Summary

On `/anthropic/v1/messages`, the `container` request param was silently dropped during the ingress/egress conversion: `ToBifrostResponsesRequest` never read `req.Container`, and `ToAnthropicResponsesRequest` had no way to restore it. A client sending `"container": "container_..."` to reuse a code-execution sandbox got HTTP 200 with a fresh container id and all staged files missing. Both union arms were affected (string id and object-with-skills); requests via the Claude Code raw-passthrough path were unaffected, which masked the object-form case.

## Changes

- Ingress: `ToBifrostResponsesRequest` carries `req.Container` in `ExtraParams["container"]`, matching the existing pattern for `cache_control`/`diagnostics`/`context_management`
- Egress: `ToAnthropicResponsesRequest` promotes it back onto the typed `AnthropicContainer` field (typed values directly, raw string/map values via the union's decoder) and deletes the ExtraParams entry so it cannot serialize twice
- Test: `TestAnthropicContainerRoundTrip` asserts both forms survive the round trip with id and skills intact; both subtests fail on current dev


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

`cd core && go test ./providers/anthropic/ -run TestAnthropicContainerRoundTrip -v`

Both subtests fail on dev without the fix. Full `go test ./providers/anthropic/` green.

## Breaking changes

- [x] No


## Related issues

Closes #5707 

## Security considerations

None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


