### PR TITLE
chore: adds docs for github copilot cli, app and vscode extension

### DIFF
--- a/docs/cli-agents/claude-desktop.mdx
+++ b/docs/cli-agents/claude-desktop.mdx
@@ -139,6 +139,122 @@ The Chat tab supports MCP servers configured in `claude_desktop_config.json`. Co
 MCP servers in `claude_desktop_config.json` are for the **Chat tab only**. For MCP in the Code tab, configure servers in `~/.claude.json` or your project's `.mcp.json` file. See [MCP Gateway](/mcp/gateway) for full setup details.
 </Note>
 
+### Behind a VPN or Private Network (MCPB)
+
+The `mcpServers` config above only works if Claude Desktop's connector infrastructure can reach your Bifrost host directly. If Bifrost's `/mcp` endpoint is only reachable from inside a VPN or private network, a direct connection won't work - Claude Desktop's remote connectors are proxied through Anthropic's server-side infrastructure, which has no route into your private network.
+
+The fix is to package a local proxy as an [MCPB (MCP Bundle)](https://claude.com/docs/connectors/building/mcpb) extension. Unlike remote connectors, an MCPB runs locally on your machine via stdio, so it has the same network access as any other process on your laptop - including your VPN. It bridges Claude Desktop to Bifrost's MCP endpoint using [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a stdio-to-HTTP proxy, handling the OAuth login and token refresh against Bifrost for you.
+
+**1. Install the MCPB CLI:**
+
+```bash
+npm install -g @anthropic-ai/mcpb
+```
+
+**2. Create a project** which includes a `manifest.json` describing the extension and a `package.json` pulling in `mcp-remote`:
+
+```json manifest.json
+{
+  "manifest_version": "0.3",
+  "name": "bifrost-mcp",
+  "display_name": "Bifrost MCP",
+  "version": "1.0.0",
+  "description": "Connects Claude Desktop to a VPN-only Bifrost MCP server over a local proxy.",
+  "author": { "name": "Your Name" },
+  "server": {
+    "type": "node",
+    "entry_point": "node_modules/mcp-remote/dist/proxy.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/node_modules/mcp-remote/dist/proxy.js",
+        "${user_config.server_url}",
+        "3335"
+      ]
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32"],
+    "runtimes": { "node": ">=18.0.0" }
+  },
+  "user_config": {
+    "server_url": {
+      "type": "string",
+      "title": "Bifrost MCP URL",
+      "description": "The Streamable HTTP MCP endpoint of your Bifrost instance. Must use HTTPS.",
+      "default": "<BIFROST_BASE_URL>/mcp",
+      "required": true
+    }
+  }
+}
+```
+
+```json package.json
+{
+  "name": "bifrost-mcpb",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "mcp-remote": "0.1.38"
+  }
+}
+```
+
+<Note>
+`mcp-remote` refuses to connect to any non-HTTPS, non-local URL unless you explicitly opt out.
+
+If your Bifrost deployment is only reachable over plain `http://` (e.g. a trusted, network-isolated VPN segment) and you still need to point at it, add `--allow-http` to `mcp_config.args` in `manifest.json`:
+
+```json
+"args": [
+  "${__dirname}/node_modules/mcp-remote/dist/proxy.js",
+  "${user_config.server_url}",
+  "3335",
+  "--allow-http"
+]
+```
+</Note>
+
+**3. Install dependencies and pack:**
+
+```bash
+npm install --omit=dev
+npx @anthropic-ai/mcpb pack .
+```
+
+This produces a `bifrost-mcp.mcpb` file - a single portable archive.
+
+**4. Install it in Claude Desktop** by double-clicking the `.mcpb` file (or via Settings → Extensions → Advanced settings → Install Extension…). Confirm the `server_url`, then grant permissions. On first use it opens your browser to complete OAuth login against Bifrost; tokens are cached locally under `~/.mcp-auth`.
+
+<Note>
+To skip the OAuth browser flow entirely and authenticate with a Bifrost virtual key instead, pass it as a static header using `mcp-remote`'s `--header` flag. Add a `virtual_key` field to `user_config` and reference it from `mcp_config.args`:
+
+```json
+"user_config": {
+  "server_url": { "...": "..." },
+  "virtual_key": {
+    "type": "string",
+    "title": "Bifrost Virtual Key",
+    "description": "Bifrost virtual key sent as a Bearer token.",
+    "sensitive": true,
+    "required": true
+  }
+}
+```
+
+```json
+"args": [
+  "${__dirname}/node_modules/mcp-remote/dist/proxy.js",
+  "${user_config.server_url}",
+  "3335",
+  "--header",
+  "Authorization:Bearer ${user_config.virtual_key}"
+]
+```
+
+Marking the field `sensitive: true` masks it in the Claude Desktop extension settings UI. With a valid `Authorization` header present, `mcp-remote` connects directly and never opens a browser for OAuth.
+</Note>
+
 ## Enterprise Deployment
 
 For organization-wide Bifrost routing, deploy a `managed-settings.json` file via MDM (Jamf, Kandji, Intune):

--- a/docs/cli-agents/github-copilot.mdx
+++ b/docs/cli-agents/github-copilot.mdx
@@ -1,0 +1,246 @@
+---
+title: "GitHub Copilot"
+description: "Route GitHub Copilot App, Copilot CLI, and the VS Code Copilot Chat extension through Bifrost using each surface's Bring Your Own Key (BYOK) support."
+icon: "github"
+---
+
+GitHub Copilot ships **Bring Your Own Key (BYOK)** support across all three of its surfaces - the standalone [Copilot app](https://docs.github.com/en/copilot/how-tos/github-copilot-app), [Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli), and the [Copilot Chat extension for VS Code](https://code.visualstudio.com/docs/agent-customization/language-models).
+
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Copilot, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
+<Note>
+BYOK is a recent addition to all three surfaces and menu labels can shift between releases. If a step below doesn't match what you see, update to the latest version of the app/CLI/extension first.
+</Note>
+
+## GitHub Copilot App
+
+The [GitHub Copilot app](https://docs.github.com/en/copilot/how-tos/github-copilot-app) is the standalone desktop client for running agentic coding sessions outside an editor. It supports BYOK, so you can run sessions entirely against Bifrost - you still sign in with a GitHub account, but you don't need an active Copilot plan if you're only using your own provider.
+
+1. Open the Copilot app and go to **Settings → Model Providers → Add Provider**.
+2. Choose the **OpenAI-compatible** provider type (Anthropic is also listed if you'd rather point at Bifrost's native Anthropic surface - see the alternative below).
+3. Fill in the provider details:
+
+   | Field | Value |
+   |-------|-------|
+   | **Name** | `Bifrost` (or anything you'll recognize in the model picker) |
+   | **Base URL** | `http://localhost:8080/openai/v1/chat/completions` (or your deployed Bifrost host, e.g. `https://bifrost.example.com/openai/v1/chat/completions`) |
+   | **API Key** | Your Bifrost virtual key |
+
+4. Save. Bifrost-routed models now appear in the app's model picker alongside any GitHub-hosted models, and you choose which one to use per session.
+
+<Note>
+To use Bifrost's native Anthropic-compatible surface instead, add an **Anthropic** provider with base URL `http://localhost:8080/anthropic` and your Bifrost virtual key as the API key.
+</Note>
+
+Provider credentials are stored in your OS's credential store and are never displayed back in the UI.
+
+## GitHub Copilot CLI
+
+[Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) is GitHub's agentic terminal coding agent - it inspects your repo, edits files, runs commands, and reviews diffs from the shell.
+
+### Installing Copilot CLI
+
+```bash
+npm install -g @github/copilot
+```
+
+Requires Node.js 22 or later. WinGet, Homebrew, and standalone binary installs are also available - see the [installation docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli).
+
+### Configuring Copilot CLI with Bifrost
+
+Copilot CLI reads its model provider from environment variables, set before launching:
+
+```bash
+export COPILOT_PROVIDER_TYPE=openai
+export COPILOT_PROVIDER_BASE_URL=http://localhost:8080/openai/v1
+export COPILOT_PROVIDER_API_KEY=<bifrost_virtual_key>
+export COPILOT_MODEL=openai/gpt-5
+```
+
+```bash
+copilot
+```
+
+Always launch `copilot` from the same terminal session where you exported these variables, or add them to your shell profile - GUI-launched terminals and IDE-integrated shells won't pick up an interactive export unless the environment is configured there too.
+
+You can also switch models per run with the `--model` flag:
+
+```bash
+copilot --model anthropic/claude-sonnet-4-5-20250929
+```
+
+<Note>
+Set `COPILOT_PROVIDER_TYPE=anthropic` and `COPILOT_PROVIDER_BASE_URL=http://localhost:8080/anthropic` to route Copilot CLI through Bifrost's native Anthropic-compatible surface instead.
+</Note>
+
+<Warning>
+Models used with Copilot CLI must support tool calling and streaming - Copilot CLI relies on both for file edits, command execution, and multi-step tasks. GitHub recommends a minimum 128k context window.
+</Warning>
+
+## GitHub Copilot Chat (VS Code Extension)
+
+The Copilot Chat extension's current BYOK path is the **Custom Endpoint** model provider (the older `github.copilot.chat.customOAIModels` setting still works but is deprecated).
+
+1. Open the Command Palette and run **Chat: Manage Language Models** (or click the gear icon in the chat model picker).
+2. Choose **Add Models → Custom Endpoint**. VS Code creates/opens a `chatLanguageModels.json` file.
+3. Add an entry pointing at Bifrost:
+
+```json
+[
+  {
+    "name": "Bifrost",
+    "vendor": "customendpoint",
+    "apiKey": "${input:bifrostApiKey}",
+    "apiType": "chat-completions",
+    "models": [
+      {
+        "id": "anthropic/claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5 (Bifrost)",
+        "url": "http://localhost:8080/openai/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "maxInputTokens": 200000,
+        "maxOutputTokens": 8192
+      },
+      {
+        "id": "openai/gpt-5",
+        "name": "GPT-5 (Bifrost)",
+        "url": "http://localhost:8080/openai/v1/chat/completions",
+        "toolCalling": true,
+        "vision": true,
+        "maxInputTokens": 400000,
+        "maxOutputTokens": 128000
+      }
+    ]
+  }
+]
+```
+
+4. Save the file. VS Code will prompt you to enter the API key securely on first use - enter your Bifrost virtual key; it's stored in VS Code's secret storage, not in `chatLanguageModels.json`.
+5. Open the chat model picker and select one of your Bifrost models.
+
+Add one `models` entry per Bifrost model you want selectable, using the `provider/model-name` format for `id`.
+
+<Note>
+`apiType` also accepts `"messages"` (Anthropic's Messages API) and `"responses"` (OpenAI's Responses API). To use Bifrost's native Anthropic surface instead, set `"apiType": "messages"` and point `url` at `http://localhost:8080/anthropic/v1/messages`.
+</Note>
+
+## Using Virtual Keys
+
+Bifrost [Virtual Keys](/features/governance/virtual-keys) work as the API key in all three surfaces - the Copilot app's provider API key, Copilot CLI's `COPILOT_PROVIDER_API_KEY`, and the VS Code extension's Custom Endpoint API key. Virtual keys let you enforce budgets, rate limits, and provider access controls per user or team without sharing raw provider credentials.
+
+## Adding MCP Servers via Bifrost
+
+<Note>
+This feature is only available on `v1.4.0-prerelease1` and above.
+</Note>
+
+Bifrost exposes every MCP tool you've configured through a single aggregated MCP server endpoint at `/mcp`. Instead of wiring each individual MCP server into Copilot, connect Copilot to Bifrost once and it gets every tool Bifrost has access to - with virtual keys controlling which tools each client is allowed to see.
+
+### GitHub Copilot CLI
+
+Add Bifrost with `copilot mcp add`.
+
+**Header auth** (`headers` or `both` mode) - send a virtual key as a `Bearer` token or under `x-bf-vk` header:
+
+```bash
+copilot mcp add --transport http \
+  --header "x-bf-vk: <BIFROST_VIRTUAL_KEY>" \
+  bifrost http://localhost:8080/mcp
+```
+
+**OAuth** (`oauth` or `both` mode) - omit `--header` entirely:
+
+```bash
+copilot mcp add --transport http bifrost http://localhost:8080/mcp
+```
+
+This writes the server into `~/.copilot/mcp-config.json`, which you can also edit directly:
+
+```json
+{
+  "mcpServers": {
+    "bifrost": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "x-bf-vk": "<BIFROST_VIRTUAL_KEY>"
+      },
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+Replace `<BIFROST_VIRTUAL_KEY>` with your actual Bifrost virtual key, or drop the `headers` block entirely for OAuth. Copilot CLI will only have access to the MCP tools permitted by that key's configuration.
+
+### GitHub Copilot Chat (VS Code Extension)
+
+Add Bifrost to `.vscode/mcp.json` (to share with your team via version control) or your user MCP config (Command Palette → **MCP: Open User Configuration**, for a personal connection).
+
+**Header auth** (`headers` or `both` mode) - send a virtual key as a `Bearer` token or under `x-bf-vk` header:
+
+```json
+{
+  "servers": {
+    "bifrost": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "x-bf-vk": "<BIFROST_VIRTUAL_KEY>"
+      }
+    }
+  }
+}
+```
+
+**OAuth** (`oauth` or `both` mode) - omit `headers` entirely.
+
+```json
+{
+  "servers": {
+    "bifrost": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}
+```
+
+Save the file and click **Start** next to the `bifrost` entry, then switch Copilot Chat to **Agent** mode. Click the tools icon (**Configure your MCP server**) at the bottom of the chat window to see Bifrost's tools listed and available to the agent.
+
+### GitHub Copilot App
+
+**Header auth** (`headers` or `both` mode) - send a virtual key as a `Bearer` token or under `x-bf-vk` header:
+
+1. Open **Settings → MCP Servers → Add Server**.
+2. Set **Type** to **HTTP**, **URL** to `http://localhost:8080/mcp`, and add an `x-bf-vk: <BIFROST_VIRTUAL_KEY>` header.
+3. Save. Bifrost's tools become available to agent sessions in the app.
+
+**OAuth** (`oauth` or `both` mode) - leave the headers section empty:
+
+1. Open **Settings → MCP Servers → Add Server**.
+2. Set **Type** to **HTTP**, **URL** to `http://localhost:8080/mcp`, and add no headers.
+3. Save. The app opens a browser consent page against Bifrost on first connect.
+
+<Note>
+The MCP settings screen is newer than BYOK support and menu labels may differ slightly by app version. If you don't see **MCP Servers** in Settings, update to the latest release.
+</Note>
+
+### Tool Access Control
+
+Control which tools each Copilot surface can see using [Virtual Keys](/features/governance/virtual-keys):
+
+- Create a separate virtual key per surface (or per user/team)
+- Configure which MCP servers and tools that key can access in the Bifrost dashboard
+- Bifrost enforces these permissions automatically on every `/mcp` request
+
+For complete setup instructions and tool filtering options, see [MCP Gateway](/mcp/gateway).
+
+## Next Steps
+
+- [Provider Configuration](/quickstart/gateway/provider-configuration) - Configure AI providers in Bifrost
+- [Virtual Keys](/features/governance/virtual-keys) - Set up usage limits and access control
+- [MCP Gateway](/mcp/gateway) - Full MCP server setup and tool filtering

--- a/docs/cli-agents/overview.mdx
+++ b/docs/cli-agents/overview.mdx
@@ -36,6 +36,9 @@ If your Allowed Headers are already set to `*`, you can skip this note. If not a
   <Card title="Claude Desktop" icon="desktop" href="/cli-agents/claude-desktop">
     Route Claude Desktop App's Code tab through any provider
   </Card>
+  <Card title="GitHub Copilot" icon="github" href="/cli-agents/github-copilot">
+    Route the Copilot App, CLI, and VS Code extension through any provider
+  </Card>
   <Card title="Codex CLI" icon="code" href="/cli-agents/codex-cli">
     OpenAI's powerful code generation CLI
   </Card>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -425,6 +425,7 @@
               "cli-agents/claude-code",
               "cli-agents/claude-desktop",
               "cli-agents/claude-for-office",
+              "cli-agents/github-copilot",
               "cli-agents/codex-cli",
               "cli-agents/gemini-cli",
               "cli-agents/qwen-code",


### PR DESCRIPTION
## Summary

Adds a new documentation page covering how to route GitHub Copilot through Bifrost using each surface's Bring Your Own Key (BYOK) support. This gives users a clear reference for integrating Bifrost with the Copilot App, Copilot CLI, and the VS Code Copilot Chat extension.

## Changes

- Added `docs/cli-agents/github-copilot.mdx` with full setup instructions for:
  - GitHub Copilot App (OpenAI-compatible and Anthropic-compatible provider configuration)
  - Copilot CLI (environment variable-based configuration, model switching, and Anthropic surface alternative)
  - VS Code Copilot Chat extension (Custom Endpoint `chatLanguageModels.json` configuration)
  - Virtual Keys usage across all three surfaces
  - MCP server integration via Bifrost's `/mcp` endpoint for all three surfaces, including tool access control via Virtual Keys
- Added a card for the new GitHub Copilot page to `docs/cli-agents/overview.mdx`
- Registered `cli-agents/github-copilot` in `docs/docs.json` navigation

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the `cli-agents/github-copilot` page in the docs site and verify:
- All three surface sections render correctly (Copilot App, Copilot CLI, VS Code extension)
- Code blocks and tables display as expected
- Notes and warnings render properly
- The GitHub Copilot card appears on the CLI Agents overview page
- Navigation order in the sidebar places GitHub Copilot between Claude for Office and Codex CLI

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The documentation advises users to store Bifrost virtual keys via each surface's secure credential storage (OS credential store, VS Code secret storage, environment variables) rather than hardcoding them in config files. No secrets are introduced by this change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable