### PR TITLE
fix: bedrock headers signing denylist

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6185,26 +6185,25 @@ func executeRequestWithRetries[T any](
 
 		// Surface caller-supplied extra headers (from x-bf-eh-* and direct-allowlist
 		// header forwarding) as span attributes so observability backends see the
-		// same set Bifrost forwards to the upstream provider.
-		if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-			for name, values := range extraHeaders {
-				if name == "" || len(values) == 0 {
-					continue
-				}
-				// Never export credential-bearing headers verbatim. The transport
-				// layer denylists most sensitive headers, but plain authorization /
-				// set-cookie can still reach here, and core SDK callers bypass that
-				// guard entirely. Keep the key (presence is useful) but redact the value.
-				if schemas.IsSensitiveHeader(name) {
-					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, schemas.RedactedAttrValue)
-					continue
-				}
-				if len(values) == 1 {
-					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, values[0])
-				} else {
-					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, values)
+		// same set Bifrost forwards to the upstream provider. Credential-bearing values
+		// are redacted and the virtual key is dropped; see extraHeaderSpanAttribute.
+		exportHeaderAttributes := func(headers map[string][]string) {
+			for name, values := range headers {
+				if value, export := extraHeaderSpanAttribute(name, values); export {
+					tracer.SetAttribute(handle, schemas.AttrExtraHeaderPrefix+name, value)
 				}
 			}
+		}
+		if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+			exportHeaderAttributes(extraHeaders)
+		}
+		// The Anthropic OAuth passthrough set no longer reaches ExtraHeaders (only the
+		// Anthropic provider forwards it), but the caller metadata it carries — x-app,
+		// x-claude-code-session-id, x-stainless-* — is what attribution keys on, and it was
+		// traced before the split. Merge it back in so observability is unchanged. Tracing
+		// only: this does not put those headers back on any provider request.
+		if passthrough, ok := ctx.Value(schemas.BifrostContextKeyPassthroughHeaders).(map[string][]string); ok {
+			exportHeaderAttributes(passthrough)
 		}
 
 		// Populate LLM request attributes (messages, parameters, etc.)

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -222,6 +222,9 @@ func completeRequest(
 
 	// Set network-config extra headers, excluding anthropic-beta (set explicitly below).
 	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+	// OAuth passthrough: forward the caller's raw headers, whose token is the upstream
+	// credential. Skips anthropic-beta — MergeBetaHeaders below owns the final value.
+	providerUtils.SetPassthroughHeaders(ctx, req, providerName, []string{AnthropicBetaHeader})
 
 	// Force JSON content type after extra headers so network config can't override it
 	// (matches the original per-provider completeRequest ordering).
@@ -773,6 +776,9 @@ func HandleAnthropicChatCompletionStreaming(
 	req.Header.SetContentType("application/json")
 
 	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+	// OAuth passthrough: forward the caller's raw headers, whose token is the upstream
+	// credential. Skips anthropic-beta — MergeBetaHeaders below owns the final value.
+	providerUtils.SetPassthroughHeaders(ctx, req, providerName, []string{AnthropicBetaHeader})
 
 	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(ctx, extraHeaders), providerName, betaHeaderOverrides); len(betaHeaders) > 0 {
 		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))
@@ -1412,6 +1418,9 @@ func HandleAnthropicResponsesStream(
 	req.Header.SetContentType("application/json")
 
 	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+	// OAuth passthrough: forward the caller's raw headers, whose token is the upstream
+	// credential. Skips anthropic-beta — MergeBetaHeaders below owns the final value.
+	providerUtils.SetPassthroughHeaders(ctx, req, providerName, []string{AnthropicBetaHeader})
 
 	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(ctx, extraHeaders), providerName, betaHeaderOverrides); len(betaHeaders) > 0 {
 		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))

--- a/core/providers/anthropic/passthroughheaders_test.go
+++ b/core/providers/anthropic/passthroughheaders_test.go
@@ -1,0 +1,262 @@
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// clientHeaders is what Claude Code sends on the OAuth passthrough path: the caller's token
+// (the upstream credential), their beta flags, client telemetry, Bifrost's own virtual key,
+// and headers an ingress proxy injected.
+func clientHeaders() map[string][]string {
+	return map[string][]string{
+		"authorization":     {"Bearer sk-ant-oat01-caller-token"},
+		"anthropic-beta":    {"interleaved-thinking-2025-05-14"},
+		"anthropic-version": {"2023-06-01"},
+		"content-type":      {"text/plain"},
+		"x-app":             {"cli"},
+		"x-stainless-lang":  {"js"},
+		"x-bf-vk":           {"sk-bf-must-never-leave-the-gateway"},
+		"x-forwarded-for":   {"10.30.10.147"},
+		"connection":        {"keep-alive"},
+	}
+}
+
+// TestSetPassthroughHeaders_ForwardsCallerCredentialButNotInternals covers the Anthropic side:
+// the caller's OAuth token must reach Anthropic, while Bifrost-internal and hop-by-hop headers
+// must not. anthropic-beta is skipped here because MergeBetaHeaders owns the final value.
+func TestSetPassthroughHeaders_ForwardsCallerCredentialButNotInternals(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, clientHeaders())
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, []string{AnthropicBetaHeader})
+
+	forwarded := map[string]string{
+		"authorization":     "Bearer sk-ant-oat01-caller-token",
+		"anthropic-version": "2023-06-01",
+		"x-app":             "cli",
+		"x-stainless-lang":  "js",
+	}
+	for name, want := range forwarded {
+		if got := string(req.Header.Peek(name)); got != want {
+			t.Errorf("%q should reach Anthropic: got %q, want %q", name, got, want)
+		}
+	}
+	// x-bf-* is Bifrost's own credential; connection is hop-by-hop.
+	for _, name := range []string{"x-bf-vk", "connection"} {
+		if got := string(req.Header.Peek(name)); got != "" {
+			t.Errorf("%q must not be forwarded, got %q", name, got)
+		}
+	}
+	// Owned by the beta pipeline, not by raw passthrough.
+	if got := string(req.Header.Peek(AnthropicBetaHeader)); got != "" {
+		t.Errorf("anthropic-beta must be left to MergeBetaHeaders, got %q", got)
+	}
+	// Bifrost owns the body, so it owns Content-Type — a caller value must never override it,
+	// regardless of where callers invoke this relative to their own SetContentType.
+	if got := string(req.Header.Peek("Content-Type")); got != "" {
+		t.Errorf("caller Content-Type must not be forwarded, got %q", got)
+	}
+}
+
+// TestSetPassthroughHeaders_NoOpWithoutKey — providers other than Anthropic never populate the
+// key, so nothing is forwarded. This is the structural guarantee that replaced the old
+// clear-the-context-afterwards teardown.
+func TestSetPassthroughHeaders_NoOpWithoutKey(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, clientHeaders()) // wrong key on purpose
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, nil)
+
+	req.Header.VisitAll(func(k, v []byte) {
+		t.Errorf("nothing should be forwarded without the passthrough key, got %q: %q", k, v)
+	})
+}
+
+// TestMergeBetaHeaders_ReadsPassthroughKey is how Bedrock/Vertex/Azure/Mantle still receive the
+// caller's beta flags now that they no longer see the raw header set at all.
+func TestMergeBetaHeaders_ReadsPassthroughKey(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, clientHeaders())
+
+	got := MergeBetaHeaders(ctx, nil)
+	if len(got) != 1 || got[0] != "interleaved-thinking-2025-05-14" {
+		t.Fatalf("caller beta flags lost: %v", got)
+	}
+}
+
+// TestMergeBetaHeaders_DedupesAcrossBothKeys — a value present in both context keys must be
+// emitted once.
+func TestMergeBetaHeaders_DedupesAcrossBothKeys(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+		"anthropic-beta": {"interleaved-thinking-2025-05-14"},
+	})
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, map[string][]string{
+		"anthropic-beta": {"interleaved-thinking-2025-05-14,context-management-2025-06-27"},
+	})
+
+	got := MergeBetaHeaders(ctx, nil)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 deduped betas, got %v", got)
+	}
+}
+
+// TestAnthropicPassthroughHeaders_IsReserved — plugins must not be able to inject into the
+// passthrough set while restricted writes are blocked (which is how the plugin pipeline runs).
+func TestAnthropicPassthroughHeaders_IsReserved(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.BlockRestrictedWrites()
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, clientHeaders())
+	if v := ctx.Value(schemas.BifrostContextKeyPassthroughHeaders); v != nil {
+		t.Errorf("a plugin was able to set the passthrough headers: %v", v)
+	}
+}
+
+// countPrefixed counts entries in a merged beta list belonging to one beta family.
+func countPrefixed(betas []string, prefix string) int {
+	n := 0
+	for _, b := range betas {
+		if strings.HasPrefix(b, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestAddMissingBetaHeaders_HonoursCallerVersionFromPassthroughKey covers the interaction
+// between auto-injection and the OAuth passthrough split. The caller pins an older MCP beta;
+// Bifrost's default is the current one. The "passthrough wins" guard has to see the caller's
+// value — which now lives in the passthrough key, not ExtraHeaders — or it injects its own
+// version and MergeBetaHeaders (exact-token dedup, not prefix) forwards BOTH versions of the
+// same family, which Anthropic rejects.
+func TestAddMissingBetaHeaders_HonoursCallerVersionFromPassthroughKey(t *testing.T) {
+	const callerMCPBeta = "mcp-client-2025-04-04" // deliberately older than AnthropicMCPClientBetaHeader
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, map[string][]string{
+		"anthropic-beta": {callerMCPBeta},
+	})
+
+	req := &AnthropicMessageRequest{MCPServers: []AnthropicMCPServerV2{{}}}
+	if err := AddMissingBetaHeadersToContext(ctx, req, ""); err != nil {
+		t.Fatalf("AddMissingBetaHeadersToContext: %v", err)
+	}
+
+	merged := MergeBetaHeaders(ctx, nil)
+	if n := countPrefixed(merged, "mcp-client-"); n != 1 {
+		t.Fatalf("expected exactly 1 mcp-client beta, got %d: %v", n, merged)
+	}
+	if merged[0] != callerMCPBeta {
+		t.Errorf("caller's pinned version should win: got %q, want %q", merged[0], callerMCPBeta)
+	}
+}
+
+// TestAddMissingBetaHeaders_StillInjectsWhenCallerSentNone — the guard must not over-trigger:
+// with no caller beta at all, auto-injection still has to happen.
+func TestAddMissingBetaHeaders_StillInjectsWhenCallerSentNone(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	req := &AnthropicMessageRequest{MCPServers: []AnthropicMCPServerV2{{}}}
+	if err := AddMissingBetaHeadersToContext(ctx, req, ""); err != nil {
+		t.Fatalf("AddMissingBetaHeadersToContext: %v", err)
+	}
+
+	merged := MergeBetaHeaders(ctx, nil)
+	if countPrefixed(merged, "mcp-client-") != 1 || merged[0] != AnthropicMCPClientBetaHeader {
+		t.Fatalf("expected auto-injected %q, got %v", AnthropicMCPClientBetaHeader, merged)
+	}
+}
+
+// TestSetPassthroughHeaders_ContentTypeSurvivesEitherOrdering reproduces the two call
+// orderings that exist in this file. completeRequest sets the content type AFTER
+// SetPassthroughHeaders; both streaming handlers set it BEFORE. Rather than depend on call
+// order, SetPassthroughHeaders drops the caller's content-type entirely — Bifrost owns the
+// body it sends, so it owns the header. This test pins that, so a future call site added in
+// either order cannot resurrect the bug.
+func TestSetPassthroughHeaders_ContentTypeSurvivesEitherOrdering(t *testing.T) {
+	hostile := map[string][]string{
+		"content-type": {"text/plain"}, // a caller trying to override the JSON body's type
+		"x-app":        {"cli"},
+	}
+
+	t.Run("SetContentType before (streaming handlers)", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, hostile)
+
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		req.Header.SetContentType("application/json")
+		providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, []string{AnthropicBetaHeader})
+
+		if got := string(req.Header.ContentType()); got != "application/json" {
+			t.Errorf("caller overrode content type: got %q, want application/json", got)
+		}
+		if got := string(req.Header.Peek("x-app")); got != "cli" {
+			t.Errorf("other caller headers should still forward, got %q", got)
+		}
+	})
+
+	t.Run("SetContentType after (completeRequest)", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, hostile)
+
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, []string{AnthropicBetaHeader})
+		req.Header.SetContentType("application/json")
+
+		if got := string(req.Header.ContentType()); got != "application/json" {
+			t.Errorf("content type wrong: got %q, want application/json", got)
+		}
+	})
+}
+
+// TestSetPassthroughHeaders_OnlyAnthropicReceivesThem is the enforcement test for the
+// invariant. HandleAnthropicChatCompletionStreaming / HandleAnthropicResponsesStream /
+// completeRequest are shared by every Anthropic-wire-format provider, so without a gate the
+// caller's OAuth credential and client metadata would be forwarded to Azure, Vertex, Bedrock
+// Mantle, vLLM, SGL, DeepSeek and Fireworks too.
+func TestSetPassthroughHeaders_OnlyAnthropicReceivesThem(t *testing.T) {
+	sharers := []schemas.ModelProvider{
+		schemas.Azure, schemas.Vertex, schemas.BedrockMantle, schemas.Bedrock,
+		schemas.VLLM, schemas.SGL, schemas.DeepSeek, schemas.Fireworks,
+	}
+
+	for _, provider := range sharers {
+		t.Run(string(provider), func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, clientHeaders())
+
+			req := fasthttp.AcquireRequest()
+			defer fasthttp.ReleaseRequest(req)
+			providerUtils.SetPassthroughHeaders(ctx, req, provider, nil)
+
+			req.Header.VisitAll(func(k, v []byte) {
+				t.Errorf("%s must not receive caller passthrough headers, got %q: %q", provider, k, v)
+			})
+		})
+	}
+
+	t.Run("anthropic still receives them", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, clientHeaders())
+
+		req := fasthttp.AcquireRequest()
+		defer fasthttp.ReleaseRequest(req)
+		providerUtils.SetPassthroughHeaders(ctx, req, schemas.Anthropic, nil)
+
+		if got := string(req.Header.Peek("authorization")); got != "Bearer sk-ant-oat01-caller-token" {
+			t.Errorf("Anthropic must still receive the caller's OAuth token, got %q", got)
+		}
+	})
+}

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1367,19 +1367,26 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 		}
 	}
 	existing := extraHeaders[AnthropicBetaHeader]
-	if len(existing) == 0 {
-		extraHeaders[AnthropicBetaHeader] = headers
-	} else {
-		// Passthrough wins: skip auto-injected headers when a same-prefix header
-		// already exists from passthrough. This prevents conflicting versions
-		// (e.g. mcp-client-2025-04-04 + mcp-client-2025-11-20) in the same request.
-		for _, h := range headers {
-			if !betaHeaderPrefixExists(existing, h) {
-				existing = append(existing, h)
+	// Passthrough wins: skip auto-injected headers when a same-prefix header already exists
+	// from passthrough. This prevents conflicting versions (e.g. mcp-client-2025-04-04 +
+	// mcp-client-2025-11-20) in the same request. On the OAuth path the caller's own
+	// anthropic-beta lives in the passthrough key rather than here, so check both — otherwise
+	// this sees nothing, injects its own version, and MergeBetaHeaders (which dedups by exact
+	// token, not by prefix) forwards both.
+	claimed := existing
+	if passthrough, ok := ctx.Value(schemas.BifrostContextKeyPassthroughHeaders).(map[string][]string); ok {
+		for k, vals := range passthrough {
+			if strings.EqualFold(k, AnthropicBetaHeader) {
+				claimed = append(append(make([]string, 0, len(claimed)+len(vals)), claimed...), vals...)
 			}
 		}
-		extraHeaders[AnthropicBetaHeader] = existing
 	}
+	for _, h := range headers {
+		if !betaHeaderPrefixExists(claimed, h) {
+			existing = append(existing, h)
+		}
+	}
+	extraHeaders[AnthropicBetaHeader] = existing
 	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
 	return nil
 }
@@ -1822,7 +1829,15 @@ func MergeBetaHeaders(ctx context.Context, providerExtraHeaders map[string]strin
 			add(v)
 		}
 	}
-	if ctxHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+
+	for _, key := range []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyExtraHeaders,
+		schemas.BifrostContextKeyPassthroughHeaders,
+	} {
+		ctxHeaders, ok := ctx.Value(key).(map[string][]string)
+		if !ok {
+			continue
+		}
 		for k, vals := range ctxHeaders {
 			if !strings.EqualFold(k, AnthropicBetaHeader) {
 				continue

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -565,6 +565,56 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 }
 
 // Returns a BifrostError if signing fails.
+// unsignableHeaders must not be covered by the SigV4 signature: hop-by-hop and
+// proxy-managed headers that an intermediary may rewrite in transit, which invalidates the
+// signature. AWS's signing guide requires only host and x-amz-* to be signed and warns
+// against "volatile transport headers that are mutated by proxies, load balancers, and the
+// nodes in a distributed system". The AWS SDK itself skips only authorization, user-agent,
+// x-amzn-trace-id, expect and transfer-encoding, so the rest is on us. These are removed for
+// signing and restored afterwards, so what goes on the wire is unchanged.
+var unsignableHeaders = map[string]struct{}{
+	"connection":          {},
+	"keep-alive":          {},
+	"te":                  {},
+	"trailer":             {},
+	"upgrade":             {},
+	"proxy-authorization": {},
+	"proxy-authenticate":  {},
+	"x-real-ip":           {},
+	"x-request-id":        {},
+}
+
+// internalHeaderPrefix marks Bifrost's own headers. They carry the caller's virtual key, so
+// they are dropped outright rather than restored — they must never reach a provider.
+const internalHeaderPrefix = "x-bf-"
+
+// restoredHeader is a header lifted off the request for signing, to be put back after.
+type restoredHeader struct {
+	name   string
+	values []string
+}
+
+// stripHeadersForSigning removes headers that must not be signed and returns the ones to put
+// back after signing. Bifrost-internal headers are dropped and never returned. A request with
+// no volatile headers — the common case — allocates nothing and leaves the request untouched.
+func stripHeadersForSigning(header http.Header) []restoredHeader {
+	var restore []restoredHeader
+	for name, values := range header {
+		lower := strings.ToLower(name)
+		internal := strings.HasPrefix(lower, internalHeaderPrefix)
+		_, volatile := unsignableHeaders[lower]
+		if !internal && !volatile && !strings.HasPrefix(lower, "x-forwarded-") {
+			continue
+		}
+		if !internal {
+			restore = append(restore, restoredHeader{name: name, values: values})
+		}
+		// The name came straight off the map, so skip Del's redundant canonicalization.
+		delete(header, name)
+	}
+	return restore
+}
+
 func signAWSRequest(
 	ctx *schemas.BifrostContext,
 	req *http.Request,
@@ -690,6 +740,10 @@ func signAWSRequest(
 		}
 	}
 
+	// The SDK signs every header still on the request, so lift the volatile ones out for
+	// the duration of signing and put them back before the request goes out.
+	restoreHeaders := stripHeadersForSigning(req.Header)
+
 	// Create the AWS signer
 	signer := v4.NewSigner()
 
@@ -700,7 +754,11 @@ func signAWSRequest(
 	}
 
 	// Sign the request with AWS Signature V4
-	if err := signer.SignHTTP(ctx, creds, req, bodyHash, service, region, time.Now()); err != nil {
+	err = signer.SignHTTP(ctx, creds, req, bodyHash, service, region, time.Now())
+	for _, h := range restoreHeaders {
+		req.Header[h.name] = h.values
+	}
+	if err != nil {
 		return providerUtils.NewBifrostOperationError("failed to sign request", err)
 	}
 

--- a/core/providers/bedrock/convert_tool_config_test.go
+++ b/core/providers/bedrock/convert_tool_config_test.go
@@ -3,6 +3,7 @@ package bedrock
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -797,5 +798,65 @@ func glmUserMessage(text string) schemas.ResponsesMessage {
 		Content: &schemas.ResponsesMessageContent{
 			ContentStr: schemas.Ptr(text),
 		},
+	}
+}
+
+// TestExtractToolsFromConversationHistory_StableOrder locks in the fix for the
+// non-deterministic tool ordering that both reconstruction paths had: toolConfig
+// was built by ranging a Go map, so identical requests produced different tool
+// orders. Tools are the first thing in Bedrock's prompt-cache prefix, so every
+// reshuffle was a guaranteed cache miss.
+func TestExtractToolsFromConversationHistory_StableOrder(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	names := []string{"Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot"}
+
+	t.Run("responses", func(t *testing.T) {
+		input := []schemas.ResponsesMessage{}
+		for i, name := range names {
+			input = append(input, schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr(fmt.Sprintf("call_%d", i)),
+					Name:   schemas.Ptr(name),
+				},
+			})
+		}
+		for i := 0; i < 50; i++ {
+			_, tools := extractToolsFromResponsesConversationHistory(ctx, input, "us.anthropic.claude-opus-5")
+			assertToolOrder(t, tools, names)
+		}
+	})
+
+	t.Run("chat", func(t *testing.T) {
+		toolCalls := []schemas.ChatAssistantMessageToolCall{}
+		for i, name := range names {
+			toolCalls = append(toolCalls, schemas.ChatAssistantMessageToolCall{
+				ID:       schemas.Ptr(fmt.Sprintf("call_%d", i)),
+				Function: schemas.ChatAssistantMessageToolCallFunction{Name: schemas.Ptr(name)},
+			})
+		}
+		input := []schemas.ChatMessage{{
+			Role:                 schemas.ChatMessageRoleAssistant,
+			ChatAssistantMessage: &schemas.ChatAssistantMessage{ToolCalls: toolCalls},
+		}}
+		for i := 0; i < 50; i++ {
+			_, tools := extractToolsFromConversationHistory(ctx, input)
+			assertToolOrder(t, tools, names)
+		}
+	})
+}
+
+func assertToolOrder(t *testing.T, tools []BedrockTool, want []string) {
+	t.Helper()
+	if len(tools) != len(want) {
+		t.Fatalf("got %d tools, want %d", len(tools), len(want))
+	}
+	for i, tool := range tools {
+		if tool.ToolSpec == nil {
+			t.Fatalf("tools[%d] has no ToolSpec", i)
+		}
+		if tool.ToolSpec.Name != want[i] {
+			t.Fatalf("tool order drifted: got %s at index %d, want %s", tool.ToolSpec.Name, i, want[i])
+		}
 	}
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2892,6 +2892,7 @@ func ensureResponsesToolConfigForConversation(ctx context.Context, bifrostReq *s
 func extractToolsFromResponsesConversationHistory(ctx context.Context, messages []schemas.ResponsesMessage, model string) (bool, []BedrockTool) {
 	var hasToolContent bool
 	toolMap := make(map[string]*schemas.ResponsesTool) // Use map to deduplicate by name
+	var toolNames []string                             // Insertion-order tracking for toolMap
 	var hasNovaGrounding, hasNovaCodeInterpreter bool
 
 	for _, msg := range messages {
@@ -2904,6 +2905,7 @@ func extractToolsFromResponsesConversationHistory(ctx context.Context, messages 
 				if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.Name != nil {
 					toolName := *msg.ResponsesToolMessage.Name
 					if _, exists := toolMap[toolName]; !exists {
+						toolNames = append(toolNames, toolName)
 						// Create a minimal tool definition
 						toolMap[toolName] = &schemas.ResponsesTool{
 							Type: "function",
@@ -2929,7 +2931,8 @@ func extractToolsFromResponsesConversationHistory(ctx context.Context, messages 
 
 	// Convert function tool map to BedrockTool slice
 	var tools []BedrockTool
-	for _, tool := range toolMap {
+	for _, toolName := range toolNames {
+		tool := toolMap[toolName]
 		if tool.Name != nil && tool.ResponsesToolFunction != nil {
 			schemaObject := tool.ResponsesToolFunction.Parameters
 			if schemaObject == nil {

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -16,6 +16,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -723,4 +725,88 @@ func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	// TLSNextProto must be set to empty map to truly disable HTTP/2 ALPN negotiation
 	assert.NotNil(t, transport.TLSNextProto)
 	assert.Empty(t, transport.TLSNextProto)
+}
+
+// TestSignAWSRequest_ExcludesVolatileHeadersFromSignature locks in the fix for the
+// "signature we calculated does not match" 403s on Bedrock. The AWS SDK signs every header
+// left on the request, so client/proxy headers forwarded from the /anthropic integration
+// ended up in SignedHeaders. Any hop that rewrites one of them (x-forwarded-for gains the
+// NAT address in transit) then invalidates the signature. AWS's signing guide requires only
+// host and x-amz-*, and explicitly warns against signing headers "mutated by proxies, load
+// balancers, and the nodes in a distributed system". Volatile headers are lifted out for
+// signing and restored afterwards; only Bifrost-internal x-bf-* is dropped for good.
+func TestSignAWSRequest_ExcludesVolatileHeadersFromSignature(t *testing.T) {
+	volatile := map[string]string{
+		"x-forwarded-for":   "10.30.10.147",
+		"x-forwarded-proto": "https",
+		"x-real-ip":         "10.30.10.147",
+		"x-request-id":      "57bac1b7-1831-4a0a-97cb-af8e87329147",
+		"x-bf-vk":           "sk-bf-secret-should-never-reach-aws",
+		"connection":        "keep-alive",
+	}
+	kept := map[string]string{
+		"anthropic-beta":  "interleaved-thinking-2025-05-14",
+		"accept-encoding": "identity", // deliberately set for eventstream TTFB (#4542)
+		"x-amz-target":    "converse",
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse-stream", strings.NewReader(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	for k, v := range volatile {
+		req.Header.Set(k, v)
+	}
+	for k, v := range kept {
+		req.Header.Set(k, v)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	keyCfg := &schemas.BedrockKeyConfig{
+		AccessKey: *schemas.NewSecretVar("AKIAIOSFODNN7EXAMPLE"),
+		SecretKey: *schemas.NewSecretVar("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+	}
+	if bifrostErr := signAWSRequest(ctx, req, keyCfg, "us-east-1", bedrockSigningService); bifrostErr != nil {
+		t.Fatalf("signAWSRequest failed: %s", bifrostErr.Error.Message)
+	}
+
+	auth := req.Header.Get("Authorization")
+	_, signedPart, found := strings.Cut(auth, "SignedHeaders=")
+	if !found {
+		t.Fatalf("no SignedHeaders in Authorization: %q", auth)
+	}
+	signedHeadersStr, _, _ := strings.Cut(signedPart, ",")
+	signedHeaders := strings.Split(signedHeadersStr, ";")
+
+	// None of the volatile headers may be covered by the signature.
+	for name := range volatile {
+		if slices.Contains(signedHeaders, name) {
+			t.Errorf("%q is in SignedHeaders (%q) — a proxy rewriting it breaks SigV4", name, signedHeadersStr)
+		}
+	}
+
+	// Bifrost-internal headers carry the caller's virtual key and must not reach AWS at all.
+	if got := req.Header.Get("x-bf-vk"); got != "" {
+		t.Errorf("x-bf-vk was forwarded upstream with value %q", got)
+	}
+
+	// Every other volatile header is restored after signing, so the wire is unchanged.
+	for name, want := range volatile {
+		if strings.HasPrefix(name, internalHeaderPrefix) {
+			continue
+		}
+		if got := req.Header.Get(name); got != want {
+			t.Errorf("%q should be restored after signing: got %q, want %q", name, got, want)
+		}
+	}
+
+	// Headers Bifrost controls must survive untouched and stay signed where required.
+	for name, want := range kept {
+		if got := req.Header.Get(name); got != want {
+			t.Errorf("%q should survive signing: got %q, want %q", name, got, want)
+		}
+	}
+	if !slices.Contains(signedHeaders, "host") {
+		t.Errorf("host must be signed; SignedHeaders=%q", signedHeadersStr)
+	}
 }

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -2045,21 +2045,22 @@ func convertToolChoice(toolChoice schemas.ChatToolChoice) *BedrockToolChoice {
 func extractToolsFromConversationHistory(ctx context.Context, messages []schemas.ChatMessage) (bool, []BedrockTool) {
 	hasToolContent := false
 	toolsMap := make(map[string]BedrockTool)
+	var toolNames []string // Insertion-order tracking for toolsMap
 
 	for _, msg := range messages {
-		hasToolContent = checkMessageForToolContent(ctx, msg, toolsMap) || hasToolContent
+		hasToolContent = checkMessageForToolContent(ctx, msg, toolsMap, &toolNames) || hasToolContent
 	}
 
 	tools := make([]BedrockTool, 0, len(toolsMap))
-	for _, tool := range toolsMap {
-		tools = append(tools, tool)
+	for _, toolName := range toolNames {
+		tools = append(tools, toolsMap[toolName])
 	}
 
 	return hasToolContent, tools
 }
 
 // checkMessageForToolContent checks a single message for tool content and updates the tools map
-func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, toolsMap map[string]BedrockTool) bool {
+func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, toolsMap map[string]BedrockTool, toolNames *[]string) bool {
 	hasContent := false
 
 	// Check assistant tool calls
@@ -2069,6 +2070,7 @@ func checkMessageForToolContent(ctx context.Context, msg schemas.ChatMessage, to
 			if toolCall.Function.Name != nil {
 				toolName := bedrockAliasToolName(ctx, *toolCall.Function.Name)
 				if _, exists := toolsMap[toolName]; !exists {
+					*toolNames = append(*toolNames, toolName)
 					// Create a complete schema object for extracted tools
 					schemaObject := map[string]interface{}{
 						"type":       "object",

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -987,6 +987,50 @@ func SetExtraHeaders(ctx context.Context, req *fasthttp.Request, extraHeaders ma
 	}
 }
 
+// internalHeaderPrefix marks Bifrost's own request headers (x-bf-vk and friends). They carry
+// gateway credentials and must never be forwarded to a provider.
+const internalHeaderPrefix = "x-bf-"
+
+// SetPassthroughHeaders applies the caller's raw request headers captured for Anthropic OAuth
+// passthrough, where the caller's token is the upstream credential. ONLY the Anthropic provider
+// may call this: every other provider authenticates with its own configured credentials, so
+// forwarding these would leak x-bf-* upstream and, on Bedrock, break SigV4 when a hop rewrites
+// x-forwarded-for. Hop-by-hop headers are dropped by filterHeaders, x-bf-* never leaves the gateway.
+func SetPassthroughHeaders(ctx context.Context, req *fasthttp.Request, provider schemas.ModelProvider, skipHeaders []string) {
+	// Gate on the provider here rather than at the call sites: the Anthropic request handlers
+	// are shared with azure, vertex, bedrockmantle, vllm, sgl, deepseek and fireworks, so a
+	// call-site check would silently forward the caller's credential to all of them.
+	if provider != schemas.Anthropic {
+		return
+	}
+	headers, ok := (ctx).Value(schemas.BifrostContextKeyPassthroughHeaders).(map[string][]string)
+	if !ok {
+		return
+	}
+	for k, values := range filterHeaders(headers) {
+		lower := strings.ToLower(k)
+		if strings.HasPrefix(lower, internalHeaderPrefix) {
+			continue
+		}
+		// Bifrost owns the body it sends, so it owns Content-Type. Dropping it here keeps a
+		// caller value from overriding the JSON content type no matter where callers invoke
+		// this relative to their own SetContentType.
+		if lower == "content-type" {
+			continue
+		}
+		if skipHeaders != nil && slices.Contains(skipHeaders, lower) {
+			continue
+		}
+		for i, v := range values {
+			if i == 0 {
+				req.Header.Set(k, v)
+			} else {
+				req.Header.Add(k, v)
+			}
+		}
+	}
+}
+
 // GetPathFromContext gets the path from the context, if it exists, otherwise returns the default path.
 func GetPathFromContext(ctx context.Context, defaultPath string) string {
 	if pathInContext, ok := ctx.Value(schemas.BifrostContextKeyURLPath).(string); ok {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -269,6 +269,7 @@ const (
 	BifrostContextKeyStreamIdleTimeout                   BifrostContextKey = "bifrost-stream-idle-timeout"            // time.Duration (per-chunk idle timeout for streaming)
 	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"             // bool (will pass an empty key to the provider)
 	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"                  // map[string][]string
+	BifrostContextKeyPassthroughHeaders                  BifrostContextKey = "bifrost-anthropic-passthrough-headers"  // map[string][]string (the caller's raw request headers, captured for Anthropic OAuth passthrough where their token is the upstream credential; ONLY the Anthropic provider may forward these — every other provider authenticates with its own configured credentials. Reserved: set by the transport, never by a plugin)
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                 // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -23,6 +23,7 @@ var reservedKeys = []any{
 	BifrostContextKeyNumberOfRetries,
 	BifrostContextKeyFallbackIndex,
 	BifrostContextKeySkipKeySelection,
+	BifrostContextKeyPassthroughHeaders,
 	BifrostContextKeySkipBudgetAndRateLimits,
 	BifrostContextKeyURLPath,
 	BifrostContextKeyDeferTraceCompletion,

--- a/core/utils.go
+++ b/core/utils.go
@@ -376,6 +376,30 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 // should stay tied to the caller's trace) and
 // BifrostContextKeySkipPluginPipeline (whether the internal request runs the
 // plugin pipeline is the caller's decision).
+// virtualKeyHeader carries Bifrost's own virtual key. IsSensitiveHeader does not match it
+// (no api-key/authorization/secret substring, no -token suffix), so it would otherwise be
+// exported to traces verbatim.
+const virtualKeyHeader = "x-bf-vk"
+
+// extraHeaderSpanAttribute returns the span-attribute value for a caller-supplied header and
+// whether it should be exported at all. The virtual key is dropped outright; other
+// credential-bearing headers keep their key (presence is useful) with the value redacted.
+func extraHeaderSpanAttribute(name string, values []string) (any, bool) {
+	if name == "" || len(values) == 0 {
+		return nil, false
+	}
+	if strings.EqualFold(name, virtualKeyHeader) {
+		return nil, false
+	}
+	if schemas.IsSensitiveHeader(name) {
+		return schemas.RedactedAttrValue, true
+	}
+	if len(values) == 1 {
+		return values[0], true
+	}
+	return values, true
+}
+
 func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	// Key routing.
 	ctx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
@@ -392,6 +416,7 @@ func ClearContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyLargePayloadMode)
 	ctx.ClearValue(schemas.BifrostContextKeyLargeResponseMode)
 	ctx.ClearValue(schemas.BifrostContextKeyExtraHeaders)
+	ctx.ClearValue(schemas.BifrostContextKeyPassthroughHeaders)
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
 }
 

--- a/core/utils_extraheader_test.go
+++ b/core/utils_extraheader_test.go
@@ -1,0 +1,58 @@
+package bifrost
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestExtraHeaderSpanAttribute pins what reaches the tracer. The virtual key is the sharp
+// edge: IsSensitiveHeader does not match "x-bf-vk", so before this guard it was exported
+// verbatim as gen_ai.request.extra_header.x-bf-vk and shipped to the trace backend in
+// plaintext. Everything else keeps its previous behaviour — redact credentials, forward the
+// rest — so attribution headers are unaffected.
+func TestExtraHeaderSpanAttribute(t *testing.T) {
+	cases := []struct {
+		name       string
+		header     string
+		values     []string
+		wantExport bool
+		wantValue  any
+	}{
+		{"virtual key dropped entirely", "x-bf-vk", []string{"sk-bf-secret"}, false, nil},
+		{"virtual key dropped case-insensitively", "X-BF-VK", []string{"sk-bf-secret"}, false, nil},
+		{"other x-bf-* still exported", "x-bf-custom", []string{"v"}, true, "v"},
+		{"authorization redacted", "authorization", []string{"Bearer sk-ant-oat01"}, true, schemas.RedactedAttrValue},
+		{"api key redacted", "x-api-key", []string{"sk-ant-key"}, true, schemas.RedactedAttrValue},
+		{"attribution header forwarded", "x-claude-code-session-id", []string{"sess-1"}, true, "sess-1"},
+		{"client telemetry forwarded", "x-app", []string{"cli"}, true, "cli"},
+		{"beta header forwarded", "anthropic-beta", []string{"interleaved-thinking-2025-05-14"}, true, "interleaved-thinking-2025-05-14"},
+		{"empty name skipped", "", []string{"v"}, false, nil},
+		{"no values skipped", "x-app", nil, false, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, export := extraHeaderSpanAttribute(tc.header, tc.values)
+			if export != tc.wantExport {
+				t.Fatalf("export=%v, want %v", export, tc.wantExport)
+			}
+			if export && got != tc.wantValue {
+				t.Errorf("value=%v, want %v", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestExtraHeaderSpanAttribute_MultiValue — multi-value headers are exported as the slice.
+func TestExtraHeaderSpanAttribute_MultiValue(t *testing.T) {
+	values := []string{"a", "b"}
+	got, export := extraHeaderSpanAttribute("x-app", values)
+	if !export {
+		t.Fatal("expected export")
+	}
+	slice, ok := got.([]string)
+	if !ok || len(slice) != 2 {
+		t.Fatalf("expected the value slice, got %#v", got)
+	}
+}

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -333,7 +333,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 			if !strings.HasPrefix(url, "/") {
 				url = "/" + url
 			}
-			bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, headers)
+			bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughHeaders, headers)
 			bifrostCtx.SetValue(schemas.BifrostContextKeyURLPath, url)
 			// This key is also used in IsClaudeCodeMaxMode
 			// So if you are changing the behaviour of this key, make sure to change IsClaudeCodeMaxMode as well

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -2,6 +2,7 @@ package integrations
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -189,5 +190,66 @@ func TestCheckAnthropicPassthrough_OutputConfigEscapeHatch(t *testing.T) {
 				t.Errorf("expected UseRawRequestBody to stay true for %s, got false", tc.model)
 			}
 		})
+	}
+}
+
+// TestCheckAnthropicPassthrough_OAuthHeaderRouting locks in the split that stopped Bifrost
+// leaking x-bf-vk upstream and breaking Bedrock's SigV4. In OAuth mode the caller's raw
+// headers must land ONLY in the Anthropic-only passthrough key; BifrostContextKeyExtraHeaders
+// is read by every provider, so anything placed there reaches Bedrock/Vertex/Azure too.
+func TestCheckAnthropicPassthrough_OAuthHeaderRouting(t *testing.T) {
+	reqCtx := &fasthttp.RequestCtx{}
+	reqCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+	reqCtx.Request.Header.Set("user-agent", "claude-code/1.0")
+	// OAuth mode: an sk-ant-oat bearer and no x-api-key.
+	reqCtx.Request.Header.Set("Authorization", "Bearer sk-ant-oat01-caller-token")
+	reqCtx.Request.Header.Set("anthropic-beta", "interleaved-thinking-2025-05-14")
+	reqCtx.Request.Header.Set("x-bf-vk", "sk-bf-must-not-leak")
+	reqCtx.Request.Header.Set("x-forwarded-for", "10.30.10.147")
+	reqCtx.Request.Header.Set("x-claude-code-session-id", "sess-1")
+
+	bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	// Whatever x-bf-eh-* already put in ExtraHeaders must survive: the OAuth branch used to
+	// overwrite this key wholesale, silently dropping caller-requested forwarded headers.
+	bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+		"my-custom-header": {"kept"},
+	})
+
+	req := &anthropic.AnthropicMessageRequest{Model: "claude-opus-4-8", MaxTokens: 1024}
+	if err := checkAnthropicPassthrough(reqCtx, bifrostCtx, req); err != nil {
+		t.Fatalf("checkAnthropicPassthrough: %v", err)
+	}
+
+	// The transport must be able to write the reserved key (restricted writes gate plugins,
+	// not the transport). If this is empty, OAuth passthrough is dead.
+	passthrough, ok := bifrostCtx.Value(schemas.BifrostContextKeyPassthroughHeaders).(map[string][]string)
+	if !ok || len(passthrough) == 0 {
+		t.Fatalf("passthrough headers were not set — OAuth would lose the caller's credential")
+	}
+	// fasthttp canonicalizes header names, so look up case-insensitively (the product code
+	// does the same via strings.ToLower / EqualFold at every check).
+	lookup := func(m map[string][]string, name string) []string {
+		for k, v := range m {
+			if strings.EqualFold(k, name) {
+				return v
+			}
+		}
+		return nil
+	}
+	if got := lookup(passthrough, "authorization"); len(got) == 0 || got[0] != "Bearer sk-ant-oat01-caller-token" {
+		t.Errorf("caller OAuth token missing from passthrough set: %v", got)
+	}
+
+	extra, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	// x-bf-eh-* survives.
+	if got := lookup(extra, "my-custom-header"); len(got) == 0 || got[0] != "kept" {
+		t.Errorf("x-bf-eh-* header was clobbered: %v", extra)
+	}
+	// Nothing the caller sent may sit in the every-provider key.
+	for _, leaked := range []string{"authorization", "x-bf-vk", "x-forwarded-for", "x-claude-code-session-id"} {
+		if lookup(extra, leaked) != nil {
+			t.Errorf("%q reached BifrostContextKeyExtraHeaders — every provider forwards that key", leaked)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a credential isolation bug in the Anthropic OAuth passthrough path where the caller's raw request headers — originally stored under `BifrostContextKeyExtraHeaders` — were being forwarded by every provider rather than only Anthropic. This caused `x-bf-*` virtual keys to leak upstream and, on Bedrock, caused `SignatureDoesNotMatch` 403 errors when volatile headers like `x-forwarded-for` were included in the SigV4 signature and then mutated by NAT, load balancers, or proxies in transit.

## Changes

- Introduced `BifrostContextKeyAnthropicPassthroughHeaders`, a reserved context key that replaces the previous misuse of `BifrostContextKeyExtraHeaders` for storing the caller's raw OAuth headers. Plugins cannot write to this key once restricted writes are blocked.
- The Anthropic transport integration now stores passthrough headers under the new key instead of the shared extra-headers key, so no other provider ever sees them.
- Added `SetPassthroughHeaders` in provider utils, called only by the Anthropic provider (non-streaming, streaming, and responses paths), which forwards the caller's headers while dropping `x-bf-*` internals, hop-by-hop headers, and any caller-supplied `anthropic-beta` (owned by `MergeBetaHeaders`).
- Updated `MergeBetaHeaders` to read `anthropic-beta` from both `BifrostContextKeyExtraHeaders` and `BifrostContextKeyAnthropicPassthroughHeaders`, with deduplication, so Bedrock/Vertex/Azure/Mantle still receive the caller's beta flags through the correct pipeline.
- Introduced `stripHeadersForSigning` on the Bedrock path, which lifts hop-by-hop, proxy-managed, and `x-forwarded-*` headers off the request before SigV4 signing and restores them afterward so the wire payload is unchanged. `x-bf-*` headers are dropped entirely and never restored.
- The `unsignableHeaders` set covers `connection`, `keep-alive`, `te`, `trailer`, `upgrade`, `proxy-authorization`, `proxy-authenticate`, `x-real-ip`, and `x-request-id`.
- `ClearContextForInternalRequest` now also clears `BifrostContextKeyAnthropicPassthroughHeaders`.
- Added `TestSetPassthroughHeaders_ForwardsCallerCredentialButNotInternals`, `TestSetPassthroughHeaders_NoOpWithoutKey`, `TestMergeBetaHeaders_ReadsPassthroughKey`, `TestMergeBetaHeaders_DedupesAcrossBothKeys`, and `TestAnthropicPassthroughHeaders_IsReserved` in the Anthropic package.
- Added `TestSignAWSRequest_ExcludesVolatileHeadersFromSignature` in the Bedrock package, asserting volatile headers are absent from `SignedHeaders`, `x-bf-vk` is not forwarded, restored headers are present on the wire, and `host` is signed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... -run TestSetPassthroughHeaders -v
go test ./core/providers/anthropic/... -run TestMergeBetaHeaders -v
go test ./core/providers/anthropic/... -run TestAnthropicPassthroughHeaders_IsReserved -v
go test ./core/providers/bedrock/... -run TestSignAWSRequest_ExcludesVolatileHeadersFromSignature -v
go test ./core/providers/...
```

The new tests verify that:
- The caller's OAuth token and telemetry headers reach Anthropic while `x-bf-*` and hop-by-hop headers do not.
- Without the passthrough key set, nothing is forwarded regardless of what other context keys contain.
- Beta flags from the passthrough key are merged and deduplicated correctly.
- Plugins cannot inject into the passthrough header set once restricted writes are active.
- Volatile headers are excluded from `SignedHeaders` on Bedrock and restored on the wire, while `x-bf-vk` is dropped entirely.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`x-bf-*` headers carry the caller's virtual key and are now unconditionally dropped in both the Anthropic passthrough path and the Bedrock signing path, preventing accidental credential leakage to upstream providers. The passthrough header key is reserved and cannot be written by plugins.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable