### PR TITLE
stream cancel fix

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1897,6 +1897,12 @@ func (h *CompletionHandler) handleStreamingTranscriptionRequest(ctx *fasthttp.Re
 	h.handleStreamingResponse(ctx, bifrostCtx, schemas.TranscriptionStreamRequest, getStream, cancel)
 }
 
+// streamHeartbeatInterval is how often handleStreamingResponse's heartbeat goroutine
+// probes the downstream connection with a no-op SSE comment. See that goroutine's
+// comment for why this exists: disconnect detection is otherwise purely reactive to
+// real-data write failures, which a fast/bursty upstream can outrun entirely.
+const streamHeartbeatInterval = 100 * time.Millisecond
+
 // handleStreamingResponse is a generic function to handle streaming responses using Server-Sent Events (SSE)
 // The cancel function is called ONLY when client disconnects are detected via write errors.
 // Bifrost handles cleanup internally for normal completion and errors, so we only cancel
@@ -2003,7 +2009,12 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 			transportLogs = logs
 		}
 
+		// heartbeatDone stops the keep-alive goroutine below once this producer
+		// goroutine exits, via any path (normal completion, disconnect, interceptor error).
+		heartbeatDone := make(chan struct{})
+
 		defer func() {
+			close(heartbeatDone)
 			schemas.ReleaseHTTPRequest(httpReq)
 			// Fallback: on early-return paths (client disconnect, interceptor error)
 			// we never reached the pre-[DONE] invocation, so run it now. Any error is
@@ -2014,6 +2025,32 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL.
 			if traceCompleter != nil {
 				traceCompleter(transportLogs)
+			}
+		}()
+
+		// Client-disconnect detection above is purely reactive: cancel() only fires when
+		// a downstream SendEvent write actually fails, which only happens when this loop
+		// attempts one. If the upstream provider delivers its whole response in a few
+		// large/fast chunks, this loop may never attempt another write during the window
+		// where the client has already disconnected, so the disconnect goes undetected and
+		// the request logs as a false success (observed live: Vertex's streamGenerateContent
+		// delivers fewer, larger deltas than direct Gemini for the same prompt, giving the
+		// write-failure detector too few chances to fire before the stream finished).
+		// A periodic no-op heartbeat forces an extra write attempt during otherwise-idle
+		// gaps, closing that window without touching fasthttp's connection internals.
+		go func() {
+			ticker := time.NewTicker(streamHeartbeatInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if !reader.SendHeartbeat() {
+						cancel() // Disconnect discovered via the heartbeat, not real data.
+						return
+					}
+				case <-heartbeatDone:
+					return
+				}
 			}
 		}()
 

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -107,6 +107,24 @@ func (r *SSEStreamReader) SendDone() bool {
 	return r.Send([]byte("data: [DONE]\n\n"))
 }
 
+// sseHeartbeatFrame is an SSE comment line -- per the WHATWG SSE spec, a line
+// beginning with ':' is a comment that every compliant client ignores. It never
+// surfaces to application code as a real event.
+var sseHeartbeatFrame = []byte(": heartbeat\n\n")
+
+// SendHeartbeat sends a no-op SSE comment line purely to force an additional
+// downstream write attempt. Client-disconnect detection in this reader is
+// reactive: fasthttp only calls Close() when a write actually fails, and a
+// write only happens when the producer calls Send/SendEvent/SendError/SendDone.
+// If the upstream provider finishes fast enough (few large chunks) that the
+// producer never attempts another write during a disconnect window, the
+// disconnect goes undetected and the stream completes as if nothing happened.
+// A caller sending this periodically (independent of real data) closes that
+// window. Returns false if the reader has been closed (client disconnected).
+func (r *SSEStreamReader) SendHeartbeat() bool {
+	return r.Send(sseHeartbeatFrame)
+}
+
 // Done closes the event channel, signaling to Read that the stream is finished.
 // Must be called exactly once by the producer goroutine when streaming is complete.
 func (r *SSEStreamReader) Done() {

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -682,6 +682,42 @@ func TestSSEStreamReaderConcurrentSendEvent(t *testing.T) {
 	}
 }
 
+// TestSSEStreamReaderSendHeartbeat verifies the heartbeat frame is a valid SSE
+// comment line (starts with ':', per the WHATWG SSE spec every compliant client
+// ignores a comment line) so it can be sent as a disconnect-detection probe
+// without ever surfacing to application code as a real event.
+func TestSSEStreamReaderSendHeartbeat(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		r.SendHeartbeat()
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := string(buf[:n])
+	if len(got) == 0 || got[0] != ':' {
+		t.Errorf("heartbeat frame = %q, want a line starting with ':' (SSE comment)", got)
+	}
+	if got[len(got)-2:] != "\n\n" {
+		t.Errorf("heartbeat frame = %q, want it terminated by a blank line", got)
+	}
+}
+
+// TestSSEStreamReaderSendHeartbeatAfterClose verifies the same disconnect
+// contract as the other Send* wrappers: false once the reader is closed.
+func TestSSEStreamReaderSendHeartbeatAfterClose(t *testing.T) {
+	r := NewSSEStreamReader()
+	r.Close()
+
+	if r.SendHeartbeat() {
+		t.Error("SendHeartbeat should return false after Close")
+	}
+}
+
 func TestSSEStreamReaderCloseUnblocksProducer(t *testing.T) {
 	r := NewSSEStreamReader()
 


### PR DESCRIPTION
## Summary

Client-disconnect detection during SSE streaming was purely reactive: `cancel()` only fired when a downstream `SendEvent` write failed, and a write only happened when the producer loop attempted one. For providers like Vertex AI's `streamGenerateContent` that deliver fewer, larger chunks than direct Gemini for the same prompt, the upstream could finish delivering its entire response before the producer ever attempted another write after a client disconnect — causing the stream to log as a false success with no disconnect recorded.

This PR adds a periodic heartbeat goroutine that sends a no-op SSE comment frame (`: heartbeat\n\n`) every 100ms independently of real data. Because SSE comment lines are ignored by every spec-compliant client, the heartbeat is invisible to application code but forces a write attempt during otherwise-idle gaps, closing the detection window.

## Changes

- Added `SendHeartbeat()` to `SSEStreamReader`, which writes an SSE comment frame (`: heartbeat\n\n`) and returns `false` if the reader is already closed, matching the contract of the other `Send*` wrappers.
- Added a `streamHeartbeatInterval` constant (100ms) and a heartbeat goroutine inside `handleStreamingResponse` that ticks at that interval, calls `SendHeartbeat()`, and invokes `cancel()` if a disconnect is detected. The goroutine is stopped via a `heartbeatDone` channel that is closed in the producer's `defer`.
- Added tests verifying the heartbeat frame starts with `:` and ends with `\n\n` (valid SSE comment), and that `SendHeartbeat` returns `false` after `Close`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/...
```

To validate end-to-end: send a streaming request through a Vertex AI provider, disconnect the client mid-stream (e.g. close the browser tab or kill the curl process), and confirm the request is logged as a client disconnect rather than a successful completion.

## Breaking changes

- [x] No

## Security considerations

The heartbeat frame is a standard SSE comment and is never forwarded to upstream providers — it only touches the downstream client connection. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable