### PR TITLE
move complexity exemplars to configstore with backfill migration

### DIFF
--- a/framework/configstore/exemplars.go
+++ b/framework/configstore/exemplars.go
@@ -1,4 +1,4 @@
-package complexity
+package configstore
 
 // Default semantic-routing exemplars are balanced along two axes at once.
 //
@@ -241,8 +241,17 @@ var defaultComplexExemplars = []string{
 	"Unfamiliar repo, flaky tests: decide what to run, when to stop, and what to hand back.",
 }
 
-func sharedTierDefaults(keywords, exemplars []string) []string {
-	combined := make([]string, 0, len(keywords)+len(exemplars))
-	combined = append(combined, keywords...)
-	return append(combined, exemplars...)
+// DefaultComplexityExemplars returns independent copies of the curated
+// semantic-routing exemplars. The configstore migration and governance runtime
+// share this source so existing and new installations receive the same phrases.
+func DefaultComplexityExemplars() ComplexityEditableKeywordConfig {
+	return ComplexityEditableKeywordConfig{
+		SimpleKeywords:  cloneComplexityExemplars(defaultSimpleExemplars),
+		MediumKeywords:  cloneComplexityExemplars(defaultMediumExemplars),
+		ComplexKeywords: cloneComplexityExemplars(defaultComplexExemplars),
+	}
+}
+
+func cloneComplexityExemplars(values []string) []string {
+	return append([]string(nil), values...)
 }

--- a/framework/configstore/exemplars_test.go
+++ b/framework/configstore/exemplars_test.go
@@ -1,0 +1,124 @@
+package configstore
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestDefaultComplexityExemplars(t *testing.T) {
+	exemplars := DefaultComplexityExemplars()
+	tiers := []struct {
+		name   string
+		values []string
+	}{
+		{name: "simple", values: exemplars.SimpleKeywords},
+		{name: "medium", values: exemplars.MediumKeywords},
+		{name: "complex", values: exemplars.ComplexKeywords},
+	}
+
+	seen := make(map[string]string, 150)
+	for _, tier := range tiers {
+		if len(tier.values) != 50 {
+			t.Fatalf("%s has %d default exemplars, want 50", tier.name, len(tier.values))
+		}
+		for index, value := range tier.values {
+			normalized := strings.ToLower(strings.Join(strings.Fields(value), " "))
+			if normalized == "" {
+				t.Fatalf("%s exemplar %d is empty", tier.name, index)
+			}
+			if previous, ok := seen[normalized]; ok {
+				t.Fatalf("%s exemplar %d duplicates %s: %q", tier.name, index, previous, value)
+			}
+			seen[normalized] = tier.name
+		}
+	}
+}
+
+// TestDefaultComplexityExemplarsBalanceSurfaceForm guards the property that
+// makes the exemplars classify on requested work: no surface feature may
+// concentrate in one tier. The bounds catch drift without blocking deliberate
+// wording changes.
+func TestDefaultComplexityExemplarsBalanceSurfaceForm(t *testing.T) {
+	exemplars := DefaultComplexityExemplars()
+	tiers := []struct {
+		name   string
+		values []string
+	}{
+		{name: "simple", values: exemplars.SimpleKeywords},
+		{name: "medium", values: exemplars.MediumKeywords},
+		{name: "complex", values: exemplars.ComplexKeywords},
+	}
+
+	type lengths struct{ min, median, max int }
+	measured := make([]lengths, 0, len(tiers))
+	for _, tier := range tiers {
+		counts := make([]int, 0, len(tier.values))
+		for _, value := range tier.values {
+			counts = append(counts, len(strings.Fields(value)))
+		}
+		slices.Sort(counts)
+		measured = append(measured, lengths{min: counts[0], median: counts[len(counts)/2], max: counts[len(counts)-1]})
+	}
+	for index := 1; index < len(measured); index++ {
+		lower, upper := measured[index-1], measured[index]
+		if lower.max < upper.min {
+			t.Errorf("%s (max %d words) and %s (min %d words) do not overlap in length; length alone would separate the tiers",
+				tiers[index-1].name, lower.max, tiers[index].name, upper.min)
+		}
+		if upper.median > 2*lower.median {
+			t.Errorf("%s median is %d words against %s's %d; a gradient that steep teaches the classifier that verbosity means difficulty",
+				tiers[index].name, upper.median, tiers[index-1].name, lower.median)
+		}
+	}
+
+	features := []struct {
+		name    string
+		matches func(string) bool
+		minimum int
+	}{
+		{name: "question-form", matches: func(s string) bool { return strings.HasSuffix(strings.TrimSpace(s), "?") }, minimum: 5},
+		{name: "all-lowercase", matches: func(s string) bool { return s == strings.ToLower(s) }, minimum: 5},
+		{name: "embedded code", matches: func(s string) bool { return strings.Contains(s, "`") }, minimum: 2},
+	}
+	for _, feature := range features {
+		perTier := make([]int, len(tiers))
+		total := 0
+		for index, tier := range tiers {
+			for _, value := range tier.values {
+				if feature.matches(value) {
+					perTier[index]++
+				}
+			}
+			total += perTier[index]
+		}
+		for index, tier := range tiers {
+			if perTier[index] < feature.minimum {
+				t.Errorf("%s has %d %s exemplars, want at least %d: the feature would identify the other tiers",
+					tier.name, perTier[index], feature.name, feature.minimum)
+			}
+			if perTier[index]*10 > total*6 {
+				t.Errorf("%s holds %d of %d %s exemplars; concentrating one that heavily makes it a tier signal",
+					tier.name, perTier[index], total, feature.name)
+			}
+		}
+	}
+}
+
+func TestDefaultComplexityExemplarsReturnsDeepCopy(t *testing.T) {
+	first := DefaultComplexityExemplars()
+	first.SimpleKeywords[0] = "changed"
+	first.MediumKeywords[0] = "changed"
+	first.ComplexKeywords[0] = "changed"
+
+	second := DefaultComplexityExemplars()
+	if second.SimpleKeywords[0] == "changed" {
+		t.Fatal("simple exemplars expose mutable backing storage")
+	}
+	if second.MediumKeywords[0] == "changed" {
+		t.Fatal("medium exemplars expose mutable backing storage")
+	}
+	if second.ComplexKeywords[0] == "changed" {
+		t.Fatal("complex exemplars expose mutable backing storage")
+	}
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -457,6 +457,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_budget_override_anchor_columns"}, run: migrationAddBudgetOverrideAnchorColumns},
 	{IDs: []string{"add_live_models_sync_interval_column"}, run: migrationAddLiveModelsSyncIntervalColumn},
 	{IDs: []string{"add_pricing_override_user_id_column"}, run: migrationAddPricingOverrideUserIDColumn},
+	{IDs: []string{"backfill_default_complexity_exemplars"}, run: migrationBackfillDefaultComplexityExemplars},
 	{IDs: []string{"add_budget_reset_config_column"}, run: migrationAddBudgetResetConfigColumn},
 	{IDs: []string{"add_mcp_client_pending_oauth_config_json_column"}, run: migrationAddMCPClientPendingOAuthConfigJSONColumn},
 	{IDs: []string{"merge_oauth_token_tables"}, run: migrationMergeOauthTokenTables},
@@ -11312,6 +11313,116 @@ func migrationAddPricingOverrideUserIDColumn(ctx context.Context, db *gorm.DB, l
 		return fmt.Errorf("error while running pricing override user_id column migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationBackfillDefaultComplexityExemplars appends the curated semantic
+// exemplars to persisted complexity configurations created before those
+// defaults existed. Existing phrases and tier assignments always win.
+func migrationBackfillDefaultComplexityExemplars(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "backfill_default_complexity_exemplars"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			var entry tables.TableGovernanceConfig
+			err := tx.First(&entry, "key = ?", tables.ConfigComplexityAnalyzerConfigKey).Error
+			if err == gorm.ErrRecordNotFound {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("query persisted complexity analyzer config: %w", err)
+			}
+			if strings.TrimSpace(entry.Value) == "" {
+				return nil
+			}
+
+			config, err := DecodeComplexityAnalyzerConfig([]byte(entry.Value))
+			if err != nil {
+				return fmt.Errorf("decode persisted complexity analyzer config: %w", err)
+			}
+			if config == nil {
+				return nil
+			}
+
+			added := appendMissingDefaultComplexityExemplars(config, DefaultComplexityExemplars())
+			if added == 0 {
+				return nil
+			}
+
+			config.EmbeddingFingerprint = ""
+			normalized := config.Normalized()
+			if err := normalized.Validate(); err != nil {
+				return fmt.Errorf("validate complexity analyzer config after exemplar backfill: %w", err)
+			}
+			raw, err := encodeComplexityAnalyzerConfig(normalized)
+			if err != nil {
+				return fmt.Errorf("encode complexity analyzer config after exemplar backfill: %w", err)
+			}
+
+			result := tx.Model(&tables.TableGovernanceConfig{}).
+				Where("key = ?", tables.ConfigComplexityAnalyzerConfigKey).
+				Update("value", string(raw))
+			if result.Error != nil {
+				return fmt.Errorf("persist complexity analyzer exemplar backfill: %w", result.Error)
+			}
+			if result.RowsAffected != 1 {
+				return fmt.Errorf("persist complexity analyzer exemplar backfill: updated %d rows, want 1", result.RowsAffected)
+			}
+
+			logger.Info("[configstore] %s: added %d default complexity exemplars", migrationName, added)
+			return nil
+		},
+		Rollback: func(*gorm.DB) error {
+			// Removing phrases later would also remove administrator-owned data
+			// that happens to match a default exemplar.
+			return fmt.Errorf("%s is non-rollbackable: appended default phrases cannot be distinguished safely from administrator-owned phrases", migrationName)
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running %s migration: %w", migrationName, err)
+	}
+	return nil
+}
+
+func appendMissingDefaultComplexityExemplars(config *ComplexityAnalyzerConfig, defaults ComplexityEditableKeywordConfig) int {
+	type tierPhrases struct {
+		values   *[]string
+		defaults []string
+	}
+	tiers := []tierPhrases{
+		{values: &config.Keywords.SimpleKeywords, defaults: defaults.SimpleKeywords},
+		{values: &config.Keywords.MediumKeywords, defaults: defaults.MediumKeywords},
+		{values: &config.Keywords.ComplexKeywords, defaults: defaults.ComplexKeywords},
+	}
+
+	seen := make(map[string]struct{})
+	for _, tier := range tiers {
+		for _, phrase := range *tier.values {
+			seen[normalizeComplexityExemplarKey(phrase)] = struct{}{}
+		}
+	}
+
+	added := 0
+	for _, tier := range tiers {
+		for _, phrase := range tier.defaults {
+			key := normalizeComplexityExemplarKey(phrase)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			*tier.values = append(*tier.values, phrase)
+			seen[key] = struct{}{}
+			added++
+		}
+	}
+	return added
+}
+
+func normalizeComplexityExemplarKey(phrase string) string {
+	return strings.ToLower(strings.Join(strings.Fields(phrase), " "))
 }
 
 // migrationMergeOauthTokenTables introduces mcp_oauth_tokens, a new table

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -2938,6 +2938,177 @@ func TestMigrationAddBudgetOverrideAnchorColumns(t *testing.T) {
 	assert.True(t, anchor.UTC().Equal(lastReset))
 }
 
+func setupComplexityExemplarMigrationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&tables.TableGovernanceConfig{}))
+	require.NoError(t, db.Exec(`CREATE TABLE migrations (id VARCHAR(255) PRIMARY KEY)`).Error)
+	return db
+}
+
+func seedComplexityAnalyzerConfig(t *testing.T, db *gorm.DB, value string) {
+	t.Helper()
+	require.NoError(t, db.Create(&tables.TableGovernanceConfig{
+		Key:   tables.ConfigComplexityAnalyzerConfigKey,
+		Value: value,
+	}).Error)
+}
+
+func readRawComplexityAnalyzerConfig(t *testing.T, db *gorm.DB) string {
+	t.Helper()
+	var entry tables.TableGovernanceConfig
+	require.NoError(t, db.First(&entry, "key = ?", tables.ConfigComplexityAnalyzerConfigKey).Error)
+	return entry.Value
+}
+
+func TestMigrationBackfillDefaultComplexityExemplars(t *testing.T) {
+	ctx := context.Background()
+	defaults := DefaultComplexityExemplars()
+
+	t.Run("backfills persisted config and preserves administrator state", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		config := testSemanticAnalyzerConfig()
+		config.Keywords = ComplexityEditableKeywordConfig{
+			SimpleKeywords:  []string{"custom simple"},
+			MediumKeywords:  []string{"custom medium", defaults.SimpleKeywords[0]},
+			ComplexKeywords: []string{"custom complex"},
+		}
+		config.ConfigHashes = ComplexityAnalyzerConfigHashes{
+			TierBoundaries:   "tier-hash",
+			SimpleKeywords:   "simple-hash",
+			MediumKeywords:   "medium-hash",
+			ComplexKeywords:  "complex-hash",
+			SemanticSettings: "semantic-hash",
+		}
+		config.EmbeddingFingerprint = "old-fingerprint"
+		expectedSemantic := config.Normalized().Semantic
+
+		raw, err := encodeComplexityAnalyzerConfig(config.Normalized())
+		require.NoError(t, err)
+		seedComplexityAnalyzerConfig(t, db, string(raw))
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+
+		got, err := DecodeComplexityAnalyzerConfig([]byte(readRawComplexityAnalyzerConfig(t, db)))
+		require.NoError(t, err)
+		assert.Equal(t, expectedSemantic, got.Semantic)
+		assert.Equal(t, config.ConfigHashes, got.ConfigHashes)
+		assert.Empty(t, got.EmbeddingFingerprint)
+		assert.Contains(t, got.Keywords.SimpleKeywords, "custom simple")
+		assert.Contains(t, got.Keywords.MediumKeywords, "custom medium")
+		assert.Contains(t, got.Keywords.ComplexKeywords, "custom complex")
+
+		crossTierDefault := normalizeComplexityExemplarKey(defaults.SimpleKeywords[0])
+		assert.NotContains(t, got.Keywords.SimpleKeywords, crossTierDefault)
+		assert.Contains(t, got.Keywords.MediumKeywords, crossTierDefault)
+
+		for _, phrase := range defaults.SimpleKeywords[1:] {
+			assert.Contains(t, got.Keywords.SimpleKeywords, normalizeComplexityExemplarKey(phrase))
+		}
+		for _, phrase := range defaults.MediumKeywords {
+			assert.Contains(t, got.Keywords.MediumKeywords, normalizeComplexityExemplarKey(phrase))
+		}
+		for _, phrase := range defaults.ComplexKeywords {
+			assert.Contains(t, got.Keywords.ComplexKeywords, normalizeComplexityExemplarKey(phrase))
+		}
+	})
+
+	t.Run("canonicalizes legacy keyword fields", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		seedComplexityAnalyzerConfig(t, db, `{
+			"tier_boundaries":{"simple_medium":0.2,"medium_complex":0.4},
+			"keywords":{
+				"simple_keywords":["legacy simple"],
+				"code_keywords":["legacy code"],
+				"technical_keywords":["legacy technical"],
+				"reasoning_keywords":["legacy reasoning"]
+			}
+		}`)
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+
+		raw := readRawComplexityAnalyzerConfig(t, db)
+		assert.NotContains(t, raw, `"code_keywords"`)
+		assert.NotContains(t, raw, `"technical_keywords"`)
+		assert.NotContains(t, raw, `"reasoning_keywords"`)
+		got, err := DecodeComplexityAnalyzerConfig([]byte(raw))
+		require.NoError(t, err)
+		assert.Contains(t, got.Keywords.SimpleKeywords, "legacy simple")
+		assert.Contains(t, got.Keywords.MediumKeywords, "legacy code")
+		assert.Contains(t, got.Keywords.MediumKeywords, "legacy technical")
+		assert.Contains(t, got.Keywords.ComplexKeywords, "legacy reasoning")
+	})
+
+	t.Run("does not create or replace an absent config", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+
+		var count int64
+		require.NoError(t, db.Model(&tables.TableGovernanceConfig{}).
+			Where("key = ?", tables.ConfigComplexityAnalyzerConfigKey).
+			Count(&count).Error)
+		assert.Zero(t, count)
+	})
+
+	t.Run("leaves an empty config unchanged", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		seedComplexityAnalyzerConfig(t, db, "")
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+		assert.Empty(t, readRawComplexityAnalyzerConfig(t, db))
+	})
+
+	t.Run("does not overwrite malformed config", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		seedComplexityAnalyzerConfig(t, db, `{`)
+
+		err := migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger)
+		require.ErrorContains(t, err, "decode persisted complexity analyzer config")
+		assert.Equal(t, `{`, readRawComplexityAnalyzerConfig(t, db))
+	})
+
+	t.Run("keeps a complete config byte-for-byte unchanged", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		config := testComplexityAnalyzerConfig()
+		config.Keywords = defaults
+		config.EmbeddingFingerprint = "keep-fingerprint"
+		raw, err := encodeComplexityAnalyzerConfig(config.Normalized())
+		require.NoError(t, err)
+		seedComplexityAnalyzerConfig(t, db, string(raw))
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+
+		assert.Equal(t, string(raw), readRawComplexityAnalyzerConfig(t, db))
+	})
+
+	t.Run("allows more than 500 phrases", func(t *testing.T) {
+		db := setupComplexityExemplarMigrationDB(t)
+		config := testSemanticAnalyzerConfig()
+		config.Keywords.SimpleKeywords = make([]string, 501)
+		for index := range config.Keywords.SimpleKeywords {
+			config.Keywords.SimpleKeywords[index] = fmt.Sprintf("existing simple %d", index)
+		}
+		config.Keywords.MediumKeywords = []string{"existing medium"}
+		config.Keywords.ComplexKeywords = []string{"existing complex"}
+		raw, err := encodeComplexityAnalyzerConfig(config.Normalized())
+		require.NoError(t, err)
+		seedComplexityAnalyzerConfig(t, db, string(raw))
+
+		require.NoError(t, migrationBackfillDefaultComplexityExemplars(ctx, db, testMigrationLogger))
+
+		got, err := DecodeComplexityAnalyzerConfig([]byte(readRawComplexityAnalyzerConfig(t, db)))
+		require.NoError(t, err)
+		total := len(got.Keywords.SimpleKeywords) + len(got.Keywords.MediumKeywords) + len(got.Keywords.ComplexKeywords)
+		assert.Greater(t, total, 500)
+	})
+}
+
 // TestMigrationAddBudgetResetConfigColumn_NonRollbackable pins that rolling the
 // fiscal-quarter column back is refused rather than performed. reset_config_json
 // is the only home for a budget's quarter definition, and QuarterStartMonth

--- a/plugins/governance/complexity/config.go
+++ b/plugins/governance/complexity/config.go
@@ -74,10 +74,11 @@ func DefaultTierBoundaries() TierBoundaries {
 
 // DefaultEditableKeywordConfig returns the user-visible default keyword lists.
 func DefaultEditableKeywordConfig() EditableKeywordConfig {
+	exemplars := configstore.DefaultComplexityExemplars()
 	return EditableKeywordConfig{
-		SimpleKeywords:  sharedTierDefaults(simpleKeywords, defaultSimpleExemplars),
-		MediumKeywords:  sharedTierDefaults(mediumKeywords, defaultMediumExemplars),
-		ComplexKeywords: sharedTierDefaults(complexKeywords, defaultComplexExemplars),
+		SimpleKeywords:  sharedTierDefaults(simpleKeywords, exemplars.SimpleKeywords),
+		MediumKeywords:  sharedTierDefaults(mediumKeywords, exemplars.MediumKeywords),
+		ComplexKeywords: sharedTierDefaults(complexKeywords, exemplars.ComplexKeywords),
 	}
 }
 
@@ -117,12 +118,19 @@ func mergeEditableKeywordsOntoDefaults(editable EditableKeywordConfig) KeywordCo
 }
 
 func defaultFullKeywordConfig() KeywordConfig {
+	exemplars := configstore.DefaultComplexityExemplars()
 	return KeywordConfig{
-		MediumKeywords:      sharedTierDefaults(mediumKeywords, defaultMediumExemplars),
-		ComplexKeywords:     sharedTierDefaults(complexKeywords, defaultComplexExemplars),
-		SimpleKeywords:      sharedTierDefaults(simpleKeywords, defaultSimpleExemplars),
+		MediumKeywords:      sharedTierDefaults(mediumKeywords, exemplars.MediumKeywords),
+		ComplexKeywords:     sharedTierDefaults(complexKeywords, exemplars.ComplexKeywords),
+		SimpleKeywords:      sharedTierDefaults(simpleKeywords, exemplars.SimpleKeywords),
 		ContinuationPhrases: cloneStringSlice(continuationPhrases),
 	}
+}
+
+func sharedTierDefaults(keywords, exemplars []string) []string {
+	combined := make([]string, 0, len(keywords)+len(exemplars))
+	combined = append(combined, keywords...)
+	return append(combined, exemplars...)
 }
 
 func cloneStringSlice(values []string) []string {

--- a/plugins/governance/complexity/exemplars_test.go
+++ b/plugins/governance/complexity/exemplars_test.go
@@ -4,19 +4,22 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore"
 )
 
 func TestDefaultEditableKeywordConfigIncludesSemanticExemplars(t *testing.T) {
 	cfg := DefaultEditableKeywordConfig()
+	exemplars := configstore.DefaultComplexityExemplars()
 	tiers := []struct {
 		name      string
 		values    []string
 		keywords  []string
 		exemplars []string
 	}{
-		{name: TierSimple, values: cfg.SimpleKeywords, keywords: simpleKeywords, exemplars: defaultSimpleExemplars},
-		{name: TierMedium, values: cfg.MediumKeywords, keywords: mediumKeywords, exemplars: defaultMediumExemplars},
-		{name: TierComplex, values: cfg.ComplexKeywords, keywords: complexKeywords, exemplars: defaultComplexExemplars},
+		{name: TierSimple, values: cfg.SimpleKeywords, keywords: simpleKeywords, exemplars: exemplars.SimpleKeywords},
+		{name: TierMedium, values: cfg.MediumKeywords, keywords: mediumKeywords, exemplars: exemplars.MediumKeywords},
+		{name: TierComplex, values: cfg.ComplexKeywords, keywords: complexKeywords, exemplars: exemplars.ComplexKeywords},
 	}
 
 	for _, tier := range tiers {


### PR DESCRIPTION
## Summary

Moves the curated semantic-routing exemplars out of the `complexity` plugin and into `configstore` so that both the governance runtime and the database migration layer share a single authoritative source. A new migration backfills those exemplars into persisted complexity configurations that were created before the defaults existed, without overwriting any administrator-owned phrases or tier assignments.

## Changes

- Relocated `exemplars.go` from `plugins/governance/complexity` to `framework/configstore`, changing its package and replacing the private `sharedTierDefaults` helper with a public `DefaultComplexityExemplars()` function that returns independent copies of all three tier slices via `cloneComplexityExemplars`.
- `sharedTierDefaults` moved back into `plugins/governance/complexity/config.go` where it is still needed to combine static keywords with exemplars.
- `DefaultEditableKeywordConfig` and `defaultFullKeywordConfig` in the complexity plugin now call `configstore.DefaultComplexityExemplars()` instead of referencing the package-local exemplar slices directly.
- Added `migrationBackfillDefaultComplexityExemplars`, which reads the persisted `ComplexityAnalyzerConfig`, appends any missing default exemplars per tier (existing phrases always win, cross-tier duplicates are not re-added), clears `EmbeddingFingerprint` to trigger re-embedding, validates, and writes back. The rollback is intentionally a no-op to avoid removing administrator data.
- `appendMissingDefaultComplexityExemplars` deduplicates by normalized key (lowercased, collapsed whitespace) across all tiers before appending, so a phrase already present in any tier is never duplicated.
- Added `framework/configstore/exemplars_test.go` covering: exact count per tier (50 each), global uniqueness, deep-copy isolation, word-length overlap between adjacent tiers, and surface-feature balance (question form, all-lowercase, embedded code) to prevent the classifier from learning tier identity from formatting alone.
- Added `TestMigrationBackfillDefaultComplexityExemplars` covering: backfill with preserved administrator state, legacy keyword field canonicalization, absent config, empty config, malformed config, idempotency on a complete config, and configs exceeding 500 phrases.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./plugins/governance/complexity/...
```

The exemplar tests assert count, uniqueness, deep-copy safety, length-overlap between tiers, and surface-feature distribution. The migration tests run against an in-memory SQLite database and cover all edge cases including idempotency and legacy field canonicalization.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII involved. The migration only appends to existing rows and never creates new configuration entries.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable