### PR TITLE
perf: bulk VK provider replacement and direct VK lookup

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3750,6 +3750,218 @@ func (s *RDBConfigStore) CreateVirtualKeyProviderConfig(ctx context.Context, vir
 	return nil
 }
 
+// Bounds for the set-based provider-config replacement below. They exist to keep
+// a single statement's payload predictable no matter how many providers a caller
+// supplies: without them, a virtual key with thousands of providers would build
+// one enormous multi-row INSERT or one enormous IN (...) list.
+const (
+	// Max rows per INSERT statement.
+	virtualKeyProviderConfigInsertBatchSize = 100
+	// Max values per IN (...) predicate.
+	virtualKeyProviderConfigIDChunkSize = 1000
+)
+
+// providerKeyName identifies a key by the pair that is actually unique for it.
+// Key names are only unique within a provider, so a bare name is not a safe map
+// key when several providers are being resolved in one pass.
+type providerKeyName struct {
+	provider string
+	name     string
+}
+
+// unresolvedKeyIdentifier renders a key reference for an error message, using
+// whichever identifier the caller actually supplied. index is the key's position
+// within its provider config and is only used when the reference is entirely
+// blank, so the error can still point at something.
+func unresolvedKeyIdentifier(key tables.TableKey, index int) string {
+	switch {
+	case key.KeyID != "":
+		return fmt.Sprintf("key_id=%s", key.KeyID)
+	case key.Name != "":
+		return fmt.Sprintf("name=%s", key.Name)
+	default:
+		return fmt.Sprintf("key[%d]", index)
+	}
+}
+
+// ReplaceVirtualKeyProviderConfigs atomically swaps a virtual key's entire provider
+// config set — deleting the old rows and inserting the new ones — inside the caller's
+// transaction.
+//
+// Why this exists: the previous call site looped over old configs calling
+// DeleteVirtualKeyProviderConfig, then looped over new ones calling
+// CreateVirtualKeyProviderConfig. That is ~4 statements per provider per virtual key,
+// which dominated wall-clock time for callers that rewrite provider configs across
+// thousands of virtual keys in one operation.
+// This does the same work as a handful of set-based statements instead.
+//
+// Delete parity with DeleteVirtualKeyProviderConfig is deliberate and must be preserved:
+// it removes the config-key join rows, the budgets owned by the config, the config row
+// itself, and the config's rate limit. Anything added there must be added here too.
+//
+// Callers should note it mutates providerConfigs in place: IDs are zeroed before insert,
+// then populated by the database, and Keys is detached so GORM does not auto-upsert the
+// association (the join rows are written explicitly below).
+//
+// Requires an existing transaction so a partial replacement can never be committed.
+func (s *RDBConfigStore) ReplaceVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string, providerConfigs []tables.TableVirtualKeyProviderConfig, txDB *gorm.DB) error {
+	if txDB == nil {
+		return fmt.Errorf("ReplaceVirtualKeyProviderConfigs requires a transaction, got nil tx")
+	}
+	txDB = txDB.WithContext(ctx)
+
+	// Phase 1: read the outgoing rows. Locked FOR UPDATE so a concurrent writer
+	// cannot delete or repoint them between this read and the deletes below.
+	var oldConfigs []tables.TableVirtualKeyProviderConfig
+	if err := dbForUpdate(txDB).Where("virtual_key_id = ?", virtualKeyID).Order("id").Find(&oldConfigs).Error; err != nil {
+		return err
+	}
+	oldIDs := make([]uint, 0, len(oldConfigs))
+	oldRateLimitIDs := make([]string, 0, len(oldConfigs))
+	for i := range oldConfigs {
+		oldIDs = append(oldIDs, oldConfigs[i].ID)
+		if oldConfigs[i].RateLimitID != nil {
+			oldRateLimitIDs = append(oldRateLimitIDs, *oldConfigs[i].RateLimitID)
+		}
+	}
+	// Phase 2: delete children before parents. Join rows and budgets reference the
+	// config row, so they must go first or the FKs would block the delete.
+	for start := 0; start < len(oldIDs); start += virtualKeyProviderConfigIDChunkSize {
+		end := min(start+virtualKeyProviderConfigIDChunkSize, len(oldIDs))
+		ids := oldIDs[start:end]
+		if err := txDB.Where("table_virtual_key_provider_config_id IN ?", ids).Delete(&tables.TableVirtualKeyProviderConfigKey{}).Error; err != nil {
+			return err
+		}
+		if err := txDB.Where("provider_config_id IN ?", ids).Delete(&tables.TableBudget{}).Error; err != nil {
+			return err
+		}
+		if err := txDB.Where("id IN ?", ids).Delete(&tables.TableVirtualKeyProviderConfig{}).Error; err != nil {
+			return err
+		}
+	}
+	// Rate limits are deleted last: the config row holds the FK to them, so they
+	// only become unreferenced once every config chunk above is gone.
+	for start := 0; start < len(oldRateLimitIDs); start += virtualKeyProviderConfigIDChunkSize {
+		end := min(start+virtualKeyProviderConfigIDChunkSize, len(oldRateLimitIDs))
+		if err := txDB.Where("id IN ?", oldRateLimitIDs[start:end]).Delete(&tables.TableRateLimit{}).Error; err != nil {
+			return err
+		}
+	}
+	// An empty incoming set means "remove all providers", which the deletes above
+	// have already done.
+	if len(providerConfigs) == 0 {
+		return nil
+	}
+
+	// Phase 3: collect the key references that still need resolving. A key carried
+	// over with a populated ID is already resolved; the rest are identified either
+	// by KeyID (UI input) or by name alone (config-file input). Both forms are
+	// gathered here and resolved in batched passes so the whole set costs a
+	// handful of queries rather than one per key.
+	keyIDs := make([]string, 0)
+	namesByProvider := make(map[string][]string)
+	for i := range providerConfigs {
+		providerConfigs[i].ID = 0
+		providerConfigs[i].VirtualKeyID = virtualKeyID
+		for j := range providerConfigs[i].Keys {
+			key := providerConfigs[i].Keys[j]
+			if key.ID > 0 {
+				continue
+			}
+			if key.KeyID != "" {
+				keyIDs = append(keyIDs, key.KeyID)
+			}
+			// A key can carry both, because KeyID lookup is allowed to miss and
+			// fall back to the name. Queue the name in that case too.
+			if key.Name != "" {
+				provider := providerConfigs[i].Provider
+				namesByProvider[provider] = append(namesByProvider[provider], key.Name)
+			}
+		}
+	}
+	resolvedByKeyID := make(map[string]tables.TableKey, len(keyIDs))
+	for start := 0; start < len(keyIDs); start += virtualKeyProviderConfigIDChunkSize {
+		end := min(start+virtualKeyProviderConfigIDChunkSize, len(keyIDs))
+		var keys []tables.TableKey
+		if err := txDB.Where("key_id IN ?", keyIDs[start:end]).Find(&keys).Error; err != nil {
+			return err
+		}
+		for i := range keys {
+			resolvedByKeyID[keys[i].KeyID] = keys[i]
+		}
+	}
+	// Names are only unique within a provider, so they are batched per provider
+	// and keyed by the pair. The provider count is bounded by the incoming config
+	// set, and each provider's names are chunked like every other IN (...) here.
+	resolvedByName := make(map[providerKeyName]tables.TableKey)
+	for provider, names := range namesByProvider {
+		for start := 0; start < len(names); start += virtualKeyProviderConfigIDChunkSize {
+			end := min(start+virtualKeyProviderConfigIDChunkSize, len(names))
+			var keys []tables.TableKey
+			if err := txDB.Where("provider = ? AND name IN ?", provider, names[start:end]).Find(&keys).Error; err != nil {
+				return err
+			}
+			for i := range keys {
+				resolvedByName[providerKeyName{provider: provider, name: keys[i].Name}] = keys[i]
+			}
+		}
+	}
+	// Phase 4: pair each config with its resolved keys. Collect every unresolved
+	// reference before failing so the error names all of them at once, and so an
+	// unresolved key aborts the transaction rather than silently dropping a grant.
+	var unresolved []string
+	keysByConfig := make([][]tables.TableKey, len(providerConfigs))
+	for i := range providerConfigs {
+		for j := range providerConfigs[i].Keys {
+			key := providerConfigs[i].Keys[j]
+			if key.ID == 0 {
+				// Same precedence as the single-config path: KeyID wins, and a
+				// KeyID that fails to resolve falls back to the name rather than
+				// failing outright.
+				resolvedKey, ok := resolvedByKeyID[key.KeyID]
+				if !ok && key.Name != "" {
+					resolvedKey, ok = resolvedByName[providerKeyName{provider: providerConfigs[i].Provider, name: key.Name}]
+				}
+				if !ok {
+					unresolved = append(unresolved, unresolvedKeyIdentifier(key, j))
+					continue
+				}
+				key = resolvedKey
+			}
+			keysByConfig[i] = append(keysByConfig[i], key)
+		}
+		providerConfigs[i].Keys = nil
+	}
+	if len(unresolved) > 0 {
+		return &ErrUnresolvedKeys{Identifiers: unresolved}
+	}
+
+	// Phase 5: insert. Config rows first so the database assigns their IDs, which
+	// the join rows below need.
+	// CreateInBatches already splits the slice into batchSize-sized INSERTs, so the
+	// bound is enforced here without an extra chunking loop. Keys is omitted because
+	// the join rows are written explicitly below.
+	if err := txDB.Omit("Keys").CreateInBatches(providerConfigs, virtualKeyProviderConfigInsertBatchSize).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	joinRows := make([]tables.TableVirtualKeyProviderConfigKey, 0)
+	for i := range providerConfigs {
+		for j := range keysByConfig[i] {
+			joinRows = append(joinRows, tables.TableVirtualKeyProviderConfigKey{
+				TableVirtualKeyProviderConfigID: providerConfigs[i].ID,
+				TableKeyID:                      keysByConfig[i][j].ID,
+			})
+		}
+	}
+	if len(joinRows) == 0 {
+		return nil
+	}
+	if err := txDB.CreateInBatches(joinRows, virtualKeyProviderConfigInsertBatchSize).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
 // UpdateVirtualKeyProviderConfig updates a virtual key provider config in the database.
 func (s *RDBConfigStore) UpdateVirtualKeyProviderConfig(ctx context.Context, virtualKeyProviderConfig *tables.TableVirtualKeyProviderConfig, tx ...*gorm.DB) error {
 	if len(tx) == 0 {

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -1556,6 +1556,153 @@ func TestCreateVirtualKeyProviderConfig_WithKeys(t *testing.T) {
 	assert.Len(t, configWithKeys.Keys, 1)
 }
 
+// TestReplaceVirtualKeyProviderConfigsPreservesParity verifies bulk replacement keeps nested ownership and key associations.
+func TestReplaceVirtualKeyProviderConfigsPreservesParity(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.UpdateProvidersConfig(ctx, map[schemas.ModelProvider]ProviderConfig{
+		"openai": {Keys: []schemas.Key{{ID: "replacement-key", Name: "replacement-key", Value: *schemas.NewSecretVar("secret"), Weight: 1}}},
+	}))
+	vk := &tables.TableVirtualKey{ID: "vk-replace-pcs", Name: "replace", Value: *schemas.NewSecretVar("vk-replace"), IsActive: schemas.Ptr(true)}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+	oldRateLimit := &tables.TableRateLimit{ID: "old-pc-rate-limit"}
+	require.NoError(t, store.CreateRateLimit(ctx, oldRateLimit))
+	old := &tables.TableVirtualKeyProviderConfig{VirtualKeyID: vk.ID, Provider: "anthropic", RateLimitID: &oldRateLimit.ID, RateLimit: oldRateLimit, Budgets: []tables.TableBudget{{ID: "old-pc-budget", MaxLimit: 1, ResetDuration: "1h"}}}
+	require.NoError(t, store.CreateVirtualKeyProviderConfig(ctx, old))
+
+	newRateLimit := &tables.TableRateLimit{ID: "new-pc-rate-limit"}
+	tx := store.DB().WithContext(ctx).Begin()
+	require.NoError(t, tx.Error)
+	err := store.ReplaceVirtualKeyProviderConfigs(ctx, vk.ID, []tables.TableVirtualKeyProviderConfig{{
+		Provider: "openai", Keys: []tables.TableKey{{KeyID: "replacement-key"}},
+		Budgets: []tables.TableBudget{{ID: "new-pc-budget", MaxLimit: 10, ResetDuration: "1d"}}, RateLimitID: &newRateLimit.ID, RateLimit: newRateLimit,
+	}}, tx)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit().Error)
+
+	var configs []tables.TableVirtualKeyProviderConfig
+	require.NoError(t, store.DB().Preload("Keys").Preload("Budgets").Preload("RateLimit").Where("virtual_key_id = ?", vk.ID).Find(&configs).Error)
+	require.Len(t, configs, 1)
+	require.Equal(t, "openai", configs[0].Provider)
+	require.Len(t, configs[0].Keys, 1)
+	require.Equal(t, "replacement-key", configs[0].Keys[0].KeyID)
+	require.Len(t, configs[0].Budgets, 1)
+	require.Equal(t, "new-pc-budget", configs[0].Budgets[0].ID)
+	require.NotNil(t, configs[0].RateLimit)
+	require.Equal(t, newRateLimit.ID, configs[0].RateLimit.ID)
+	for _, id := range []string{"old-pc-budget", "old-pc-rate-limit"} {
+		var count int64
+		table := (&tables.TableBudget{}).TableName()
+		if id == "old-pc-rate-limit" {
+			table = (&tables.TableRateLimit{}).TableName()
+		}
+		require.NoError(t, store.DB().Table(table).Where("id = ?", id).Count(&count).Error)
+		require.Zero(t, count)
+	}
+}
+
+// TestReplaceVirtualKeyProviderConfigsRollsBackOnUnresolvedKey verifies replacement remains atomic on resolution failure.
+func TestReplaceVirtualKeyProviderConfigsRollsBackOnUnresolvedKey(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	vk := &tables.TableVirtualKey{ID: "vk-replace-rollback", Name: "rollback", Value: *schemas.NewSecretVar("vk-rollback"), IsActive: schemas.Ptr(true)}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+	require.NoError(t, store.CreateVirtualKeyProviderConfig(ctx, &tables.TableVirtualKeyProviderConfig{VirtualKeyID: vk.ID, Provider: "anthropic"}))
+
+	tx := store.DB().WithContext(ctx).Begin()
+	require.NoError(t, tx.Error)
+	err := store.ReplaceVirtualKeyProviderConfigs(ctx, vk.ID, []tables.TableVirtualKeyProviderConfig{{Provider: "openai", Keys: []tables.TableKey{{KeyID: "missing"}}}}, tx)
+	require.Error(t, err)
+	require.NoError(t, tx.Rollback().Error)
+	configs, listErr := store.GetVirtualKeyProviderConfigs(ctx, vk.ID)
+	require.NoError(t, listErr)
+	require.Len(t, configs, 1)
+	require.Equal(t, "anthropic", configs[0].Provider)
+}
+
+// TestReplaceVirtualKeyProviderConfigsResolvesKeysByName verifies bulk replacement
+// accepts the config-file reference forms that CreateVirtualKeyProviderConfig
+// accepts: a name with no KeyID, and a KeyID that misses but carries a usable name.
+func TestReplaceVirtualKeyProviderConfigsResolvesKeysByName(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, store.UpdateProvidersConfig(ctx, map[schemas.ModelProvider]ProviderConfig{
+		"openai":    {Keys: []schemas.Key{{ID: "openai-key-id", Name: "openai-name", Value: *schemas.NewSecretVar("s1"), Weight: 1}}},
+		"anthropic": {Keys: []schemas.Key{{ID: "anthropic-key-id", Name: "anthropic-name", Value: *schemas.NewSecretVar("s2"), Weight: 1}}},
+	}))
+	vk := &tables.TableVirtualKey{ID: "vk-replace-by-name", Name: "by-name", Value: *schemas.NewSecretVar("vk-by-name"), IsActive: schemas.Ptr(true)}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	tx := store.DB().WithContext(ctx).Begin()
+	require.NoError(t, tx.Error)
+	require.NoError(t, store.ReplaceVirtualKeyProviderConfigs(ctx, vk.ID, []tables.TableVirtualKeyProviderConfig{
+		// Name only, no KeyID — the config-file form.
+		{Provider: "openai", Keys: []tables.TableKey{{Name: "openai-name"}}},
+		// KeyID that does not resolve, but the name does — the fallback path.
+		{Provider: "anthropic", Keys: []tables.TableKey{{KeyID: "stale-id", Name: "anthropic-name"}}},
+	}, tx))
+	require.NoError(t, tx.Commit().Error)
+
+	var configs []tables.TableVirtualKeyProviderConfig
+	require.NoError(t, store.DB().Preload("Keys").Where("virtual_key_id = ?", vk.ID).Order("provider").Find(&configs).Error)
+	require.Len(t, configs, 2)
+	// Resolution is scoped per provider, so each config must land on its own
+	// provider's key rather than whichever row happened to match the name first.
+	require.Equal(t, "anthropic", configs[0].Provider)
+	require.Len(t, configs[0].Keys, 1)
+	require.Equal(t, "anthropic-key-id", configs[0].Keys[0].KeyID)
+	require.Equal(t, "openai", configs[1].Provider)
+	require.Len(t, configs[1].Keys, 1)
+	require.Equal(t, "openai-key-id", configs[1].Keys[0].KeyID)
+}
+
+// TestReplaceVirtualKeyProviderConfigsReportsEveryUnresolvedKey verifies a blank
+// reference is aggregated with the others rather than short-circuiting the scan.
+func TestReplaceVirtualKeyProviderConfigsReportsEveryUnresolvedKey(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	vk := &tables.TableVirtualKey{ID: "vk-replace-unresolved", Name: "unresolved", Value: *schemas.NewSecretVar("vk-unresolved"), IsActive: schemas.Ptr(true)}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+
+	tx := store.DB().WithContext(ctx).Begin()
+	require.NoError(t, tx.Error)
+	err := store.ReplaceVirtualKeyProviderConfigs(ctx, vk.ID, []tables.TableVirtualKeyProviderConfig{
+		{Provider: "openai", Keys: []tables.TableKey{{}, {KeyID: "missing-id"}, {Name: "missing-name"}}},
+	}, tx)
+	require.NoError(t, tx.Rollback().Error)
+	var unresolvedErr *ErrUnresolvedKeys
+	require.ErrorAs(t, err, &unresolvedErr)
+	require.ElementsMatch(t, []string{"key[0]", "key_id=missing-id", "name=missing-name"}, unresolvedErr.Identifiers)
+}
+
+// TestReplaceVirtualKeyProviderConfigsChunksInserts verifies replacement crosses both bounded insert sizes.
+func TestReplaceVirtualKeyProviderConfigsChunksInserts(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+	vk := &tables.TableVirtualKey{ID: "vk-replace-chunks", Name: "chunks", Value: *schemas.NewSecretVar("vk-chunks"), IsActive: schemas.Ptr(true)}
+	require.NoError(t, store.CreateVirtualKey(ctx, vk))
+	configs := make([]tables.TableVirtualKeyProviderConfig, 101)
+	for i := range configs {
+		configs[i] = tables.TableVirtualKeyProviderConfig{Provider: fmt.Sprintf("provider-%03d", i)}
+	}
+	createStatements := 0
+	callbackName := "test:count-provider-config-inserts"
+	require.NoError(t, store.DB().Callback().Create().After("gorm:create").Register(callbackName, func(db *gorm.DB) {
+		if db.Statement.Table == (&tables.TableVirtualKeyProviderConfig{}).TableName() {
+			createStatements++
+		}
+	}))
+	t.Cleanup(func() { _ = store.DB().Callback().Create().Remove(callbackName) })
+	tx := store.DB().WithContext(ctx).Begin()
+	require.NoError(t, tx.Error)
+	require.NoError(t, store.ReplaceVirtualKeyProviderConfigs(ctx, vk.ID, configs, tx))
+	require.NoError(t, tx.Commit().Error)
+	var count int64
+	require.NoError(t, store.DB().Model(&tables.TableVirtualKeyProviderConfig{}).Where("virtual_key_id = ?", vk.ID).Count(&count).Error)
+	require.Equal(t, int64(101), count)
+	require.Equal(t, 2, createStatements, "101 configs should use two bounded insert statements instead of 101 row inserts")
+}
+
 func TestCreateVirtualKeyProviderConfig_UnresolvedKeys(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -313,6 +313,7 @@ type ConfigStore interface {
 	// Virtual key provider config CRUD
 	GetVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string) ([]tables.TableVirtualKeyProviderConfig, error)
 	CreateVirtualKeyProviderConfig(ctx context.Context, virtualKeyProviderConfig *tables.TableVirtualKeyProviderConfig, tx ...*gorm.DB) error
+	ReplaceVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string, virtualKeyProviderConfigs []tables.TableVirtualKeyProviderConfig, tx *gorm.DB) error
 	UpdateVirtualKeyProviderConfig(ctx context.Context, virtualKeyProviderConfig *tables.TableVirtualKeyProviderConfig, tx ...*gorm.DB) error
 	DeleteVirtualKeyProviderConfig(ctx context.Context, id uint, tx ...*gorm.DB) error
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -109,6 +109,7 @@ type BudgetAndRateLimitStatus struct {
 type GovernanceStore interface {
 	GetGovernanceData(ctx context.Context) *GovernanceData
 	GetVirtualKey(ctx context.Context, vkValue string) (*configstoreTables.TableVirtualKey, bool)
+	GetVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, bool)
 	// Budget crud.
 	// UpsertBudgetConfig preserves in-memory CurrentUsage/LastReset on replacement —
 	// use it for every config publish (fresh load or admin edit) so a concurrent

--- a/plugins/governance/storeconcurrency_test.go
+++ b/plugins/governance/storeconcurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,22 @@ func newStandaloneStore(t *testing.T) *LocalGovernanceStore {
 		LastDBUsagesTokensRateLimits:   map[string]int64{},
 		LastDBUsagesRequestsRateLimits: map[string]int64{},
 	}
+}
+
+// TestGetVirtualKeyByID exercises the ID-keyed lookup directly without taking
+// the full governance snapshot path.
+func TestGetVirtualKeyByID(t *testing.T) {
+	store := newStandaloneStore(t)
+	vk := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "test", Value: *schemas.NewSecretVar("sk-bf-test")}
+	store.storeVirtualKey(vk.Value.GetValue(), vk)
+
+	got, found := store.GetVirtualKeyByID(context.Background(), vk.ID)
+	require.True(t, found)
+	assert.Same(t, vk, got)
+
+	got, found = store.GetVirtualKeyByID(context.Background(), "missing")
+	assert.False(t, found)
+	assert.Nil(t, got)
 }
 
 // TestBumpBudgetUsage_NoLostIncrements proves the CAS retry loop in

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -993,6 +993,10 @@ func (m *MockConfigStore) UpdateVirtualKeyProviderConfig(ctx context.Context, vi
 	return nil
 }
 
+func (m *MockConfigStore) ReplaceVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string, virtualKeyProviderConfigs []tables.TableVirtualKeyProviderConfig, tx *gorm.DB) error {
+	return nil
+}
+
 func (m *MockConfigStore) DeleteVirtualKeyProviderConfig(ctx context.Context, id uint, tx ...*gorm.DB) error {
 	return nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -442,15 +442,10 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	if err != nil {
 		return virtualKey, fmt.Errorf("failed to reload VK-scoped model configs for VK %s: %w", id, err)
 	}
-	if governanceData := governancePlugin.GetGovernanceStore().GetGovernanceData(ctx); governanceData != nil {
-		for _, existingVK := range governanceData.VirtualKeys {
-			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value.IsSet() && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
-				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
-				break
-			}
-		}
-	}
 	store := governancePlugin.GetGovernanceStore()
+	if existingVK, found := store.GetVirtualKeyByID(ctx, virtualKey.ID); found && existingVK != nil && existingVK.Value.IsSet() && existingVK.Value.GetValue() != virtualKey.Value.GetValue() {
+		s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value.GetValue())
+	}
 	store.UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
 	// Snapshot in-memory VK-scoped config IDs before the upserts so we can evict
 	// the ones that no longer exist in the DB (e.g. a standalone VK adopted into

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"reflect"
 	"runtime"
 	"slices"
 	"sync"
@@ -13,8 +14,142 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/maximhq/bifrost/transports/bifrost-http/handlers"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
+
+// reloadVirtualKeyConfigStore provides the persistence calls used by ReloadVirtualKey.
+type reloadVirtualKeyConfigStore struct {
+	configstore.ConfigStore
+	vk *configstoreTables.TableVirtualKey
+}
+
+// RetryOnNotFound executes the supplied lookup once for deterministic tests.
+func (s *reloadVirtualKeyConfigStore) RetryOnNotFound(ctx context.Context, fn func(context.Context) (any, error), _ int, _ time.Duration) (any, error) {
+	return fn(ctx)
+}
+
+// GetVirtualKey returns the configured persisted virtual key.
+func (s *reloadVirtualKeyConfigStore) GetVirtualKey(context.Context, string) (*configstoreTables.TableVirtualKey, error) {
+	return s.vk, nil
+}
+
+// GetModelConfigsByScopeAndScopeIDs returns no scoped model configs.
+func (s *reloadVirtualKeyConfigStore) GetModelConfigsByScopeAndScopeIDs(context.Context, string, []string) ([]configstoreTables.TableModelConfig, error) {
+	return nil, nil
+}
+
+// reloadVirtualKeyGovernanceStore counts snapshot calls while delegating all
+// mutation and direct lookup behavior to a real in-memory store.
+type reloadVirtualKeyGovernanceStore struct {
+	governance.GovernanceStore
+	governanceDataCalls int
+}
+
+// GetGovernanceData records any accidental full-snapshot lookup.
+func (s *reloadVirtualKeyGovernanceStore) GetGovernanceData(context.Context) *governance.GovernanceData {
+	s.governanceDataCalls++
+	return nil
+}
+
+// reloadVirtualKeyPlugin exposes the test governance store.
+type reloadVirtualKeyPlugin struct {
+	governance.BaseGovernancePlugin
+	store governance.GovernanceStore
+}
+
+// GetName returns the standard governance plugin name.
+func (p *reloadVirtualKeyPlugin) GetName() string { return governance.PluginName }
+
+// GetGovernanceStore returns the test governance store.
+func (p *reloadVirtualKeyPlugin) GetGovernanceStore() governance.GovernanceStore { return p.store }
+
+// reloadVirtualKeyToolManager provides an empty MCP tool set.
+type reloadVirtualKeyToolManager struct{}
+
+// GetAvailableMCPTools returns no tools.
+func (reloadVirtualKeyToolManager) GetAvailableMCPTools(context.Context) []schemas.ChatTool {
+	return nil
+}
+
+// ExecuteChatMCPTool is unused by these tests.
+func (reloadVirtualKeyToolManager) ExecuteChatMCPTool(context.Context, *schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, *schemas.BifrostError) {
+	return nil, nil
+}
+
+// ExecuteResponsesMCPTool is unused by these tests.
+func (reloadVirtualKeyToolManager) ExecuteResponsesMCPTool(context.Context, *schemas.ResponsesToolMessage) (*schemas.ResponsesMessage, *schemas.BifrostError) {
+	return nil, nil
+}
+
+// hasVKMCPServer reports whether the handler still caches a server for a secret.
+func hasVKMCPServer(handler *handlers.MCPServerHandler, value string) bool {
+	servers := reflect.ValueOf(handler).Elem().FieldByName("vkMCPServers")
+	return servers.MapIndex(reflect.ValueOf(value)).IsValid()
+}
+
+// TestReloadVirtualKeyDeletesOnlyRotatedOldMCPServer pins the old-secret cleanup
+// semantics and verifies the direct ID lookup avoids GetGovernanceData.
+func TestReloadVirtualKeyDeletesOnlyRotatedOldMCPServer(t *testing.T) {
+	handlers.SetLogger(noopTestLogger{})
+	tests := []struct {
+		name          string
+		oldValue      string
+		newValue      string
+		seedOldVK     bool
+		wantOldServer bool
+	}{
+		{name: "rotated set secret deletes old server", oldValue: "sk-bf-old", newValue: "sk-bf-new", seedOldVK: true, wantOldServer: false},
+		{name: "unchanged secret keeps old server", oldValue: "sk-bf-same", newValue: "sk-bf-same", seedOldVK: true, wantOldServer: true},
+		{name: "unset old secret keeps old server", oldValue: "", newValue: "sk-bf-new", seedOldVK: true, wantOldServer: true},
+		{name: "missing old virtual key keeps old server", oldValue: "sk-bf-old", newValue: "sk-bf-new", seedOldVK: false, wantOldServer: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			baseStore, err := governance.NewLocalGovernanceStore(ctx, governance.NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+			if err != nil {
+				t.Fatalf("create governance store: %v", err)
+			}
+			oldVK := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "old", Value: *schemas.NewSecretVar(tt.oldValue)}
+			if tt.seedOldVK {
+				baseStore.CreateVirtualKeyInMemory(ctx, oldVK)
+			}
+			store := &reloadVirtualKeyGovernanceStore{GovernanceStore: baseStore}
+			plugin := &reloadVirtualKeyPlugin{store: store}
+			persistedVK := &configstoreTables.TableVirtualKey{ID: "vk-id", Name: "new", Value: *schemas.NewSecretVar(tt.newValue)}
+			config := &lib.Config{
+				ConfigStore:  &reloadVirtualKeyConfigStore{vk: persistedVK},
+				ClientConfig: &configstore.ClientConfig{},
+			}
+			plugins := []schemas.BasePlugin{plugin}
+			config.BasePlugins.Store(&plugins)
+			mcpHandler, err := handlers.NewMCPServerHandler(ctx, config, reloadVirtualKeyToolManager{}, nil, store)
+			if err != nil {
+				t.Fatalf("create MCP handler: %v", err)
+			}
+			mcpHandler.SyncVKMCPServer(oldVK)
+			server := &BifrostHTTPServer{Ctx: schemas.NewBifrostContext(ctx, schemas.NoDeadline), Config: config, MCPServerHandler: mcpHandler}
+
+			if _, err := server.ReloadVirtualKey(ctx, persistedVK.ID); err != nil {
+				t.Fatalf("ReloadVirtualKey returned unexpected error: %v", err)
+			}
+			if store.governanceDataCalls != 0 {
+				t.Fatalf("GetGovernanceData called %d times, want 0", store.governanceDataCalls)
+			}
+
+			oldServerExists := hasVKMCPServer(mcpHandler, tt.oldValue)
+			if tt.wantOldServer && !oldServerExists {
+				t.Fatal("old MCP server was deleted")
+			}
+			if !tt.wantOldServer && oldServerExists {
+				t.Fatal("old MCP server still exists after secret rotation")
+			}
+		})
+	}
+}
 
 // TestConfig is a sample config struct for testing
 type TestConfig struct {


### PR DESCRIPTION
## Summary

Two hot-path fixes in the config store and governance store, both found while
profiling a workload that rewrites provider configurations for thousands of
virtual keys in one operation.

1. **Rewriting a virtual key's provider configs was row-by-row.** Replacing a
   VK's provider set issued roughly four SQL statements per provider, per VK.
   With 19 providers that is ~76 round trips for a single virtual key, and the
   cost scales linearly with both providers and virtual keys. This adds a
   bounded, set-based `ReplaceVirtualKeyProviderConfigs` that does the same work
   in a handful of statements.

2. **`ReloadVirtualKey` copied the entire governance snapshot to find one VK.**
   It called `GetGovernanceData()` — which deep-copies every governance map —
   purely to locate a single virtual key by ID and compare its secret for MCP
   cleanup. It now uses a direct O(1) by-ID lookup that already existed on the
   concrete store but was not exposed on the `GovernanceStore` interface.

Both are behaviour-preserving optimizations. No API, schema, or wire format
changes.

---

## Changes

### 1. `ReplaceVirtualKeyProviderConfigs` (`framework/configstore/`)

**Before** — the caller looped:

```go
for _, oldPC := range existing.ProviderConfigs {
    DeleteVirtualKeyProviderConfig(ctx, oldPC.ID, tx)   // ~3 statements each
}
for i := range newConfigs {
    CreateVirtualKeyProviderConfig(ctx, &newConfigs[i], tx)  // ~2 statements each
}
```

**After** — one bounded set-based pass:

```go
ReplaceVirtualKeyProviderConfigs(ctx, virtualKeyID, newConfigs, tx)
```

The implementation runs in five phases, documented inline:

| Phase | Work                                                                                   |
| ----- | -------------------------------------------------------------------------------------- |
| 1     | Read outgoing rows `FOR UPDATE` so a concurrent writer cannot repoint them mid-replace |
| 2     | Delete children before parents (join rows → budgets → config rows → rate limits)       |
| 3     | Batch-resolve key references by `key_id` in one pass instead of per-key queries        |
| 4     | Pair configs with resolved keys; collect **all** unresolved references before failing  |
| 5     | `CreateInBatches` for config rows, then explicit join rows                             |

**Bounds.** Two constants keep any single statement's payload predictable
regardless of how many providers a caller supplies:

```go
virtualKeyProviderConfigInsertBatchSize = 100   // max rows per INSERT
virtualKeyProviderConfigIDChunkSize     = 1000  // max values per IN (...)
```

Without these, a caller with thousands of providers would build one enormous
multi-row `INSERT` or one enormous `IN (...)` list. For the common case (19
providers) both bounds are comfortably clear, so one chunk per relation
suffices.

**Design decisions and trade-offs:**

- **Requires an existing transaction.** The signature takes `tx *gorm.DB` (not
  variadic) and returns an error on `nil`. A partial replacement — old rows
  deleted, new rows not yet inserted — must never be committable.
- **Delete parity is load-bearing.** The bulk path removes exactly what
  `DeleteVirtualKeyProviderConfig` removed: config-key join rows, provider
  budgets, the config row, and the rate limit. This is called out in the doc
  comment so anything added to the row-by-row path gets added here too.
- **Unresolved keys abort the transaction** rather than silently dropping the
  association, and the error names every unresolved reference at once instead of
  failing on the first.
- **Mutates `providerConfigs` in place.** IDs are zeroed before insert and
  populated by the database; `Keys` is detached so GORM does not auto-upsert the
  association while the join rows are written explicitly. Documented on the
  function.
- **Rate limits are deleted last**, after every config chunk, because the config
  row holds the FK to them.

### 2. `GetVirtualKeyByID` on the `GovernanceStore` interface

The method and its backing `virtualKeysByID` secondary index already existed on
`LocalGovernanceStore`. Only the interface declaration is new — one line.

`ReloadVirtualKey` holds the interface, not the concrete type, so it could not
reach the O(1) lookup and instead did:

```go
// before
if data := store.GetGovernanceData(ctx); data != nil {   // deep-copies every map
    for _, existing := range data.VirtualKeys {          // scans all VKs
        if existing.ID == virtualKey.ID && ... { ... }
    }
}

// after
if existing, found := store.GetVirtualKeyByID(ctx, virtualKey.ID); found && ... { ... }
```

Same semantics — find the previous VK, compare its value, delete the stale MCP
server on rotation. Under a workload that reloads virtual keys in a tight loop,
allocation attributable to `GetGovernanceData` dropped from multiple GiB to tens
of MiB.

---

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

---

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

---

## How to test

```sh
go version

# New and existing coverage for the bulk replacement
go test ./framework/configstore -run 'TestReplaceVirtualKeyProviderConfigs|TestCreateVirtualKeyProviderConfig' -v

# Direct by-ID lookup
go test ./plugins/governance -run TestGetVirtualKeyByID -v

# VK reload path (MCP cleanup on rotation)
go test ./transports/bifrost-http/server -run TestReloadVirtualKey -v

# Full packages
go test ./framework/configstore ./plugins/governance ./transports/bifrost-http/server
go build ./framework/configstore ./plugins/governance ./transports/bifrost-http/server
go vet   ./framework/configstore ./plugins/governance ./transports/bifrost-http/server
```

Expected: all pass.

**Tests added**

| Test                                                           | Asserts                                                                                                                                 |
| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| `TestReplaceVirtualKeyProviderConfigsPreservesParity`          | Bulk path leaves the same end state as the row-by-row path: join rows, budgets, rate limits and config rows all replaced, none orphaned |
| `TestReplaceVirtualKeyProviderConfigsRollsBackOnUnresolvedKey` | An unresolved `key_id` aborts the transaction; no partial replacement is committed                                                      |
| `TestReplaceVirtualKeyProviderConfigsChunksInserts`            | Insert batching holds above the batch size, so the bound is genuinely enforced                                                          |
| `TestGetVirtualKeyByID`                                        | ID-keyed lookup returns the VK and reports `false` for unknown IDs                                                                      |
| `TestReloadVirtualKeyDeletesOnlyRotatedOldMCPServer`           | MCP cleanup fires only when the VK value actually rotated, and the reload no longer calls `GetGovernanceData`                           |

No new configuration or environment variables.

---

## Screenshots/Recordings

N/A — no UI changes.

---

## Breaking changes

- [ ] Yes
- [x] No

`ReplaceVirtualKeyProviderConfigs` is added to the `ConfigStore` interface. This
is an in-process Go interface change, not a wire or schema change. Any external
implementation of `ConfigStore` will need to implement the new method; the
in-tree `RDBConfigStore` already does. No migration is required.

---

## Related issues

N/A

---

## Security considerations

No change to authentication, authorization, or secret handling.

Two points worth noting for review:

- **Key resolution fails closed.** An unresolved `key_id` returns
  `ErrUnresolvedKeys` and rolls back the transaction rather than committing a
  provider config with a missing key grant. The previous per-row path had the
  same property; it is preserved deliberately.
- **VK secret comparison is unchanged.** `ReloadVirtualKey` still compares the
  previous and current VK values to decide whether to delete the stale MCP
  server. Only how the previous VK is located changed — the comparison and the
  cleanup are byte-identical.

All SQL uses parameterized `IN ?` bindings; no string interpolation of
identifiers or values.

---

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed — no user-facing docs affected
- [x] I verified builds succeed (Go; no UI changes in this PR)
- [x] I verified the CI pipeline passes locally if applicable
