### PR TITLE
fix: fixes normalization and whitespace trimming for metrics exporting

### DIFF
--- a/core/schemas/normalizemodelname_test.go
+++ b/core/schemas/normalizemodelname_test.go
@@ -1,0 +1,43 @@
+package schemas
+
+import "testing"
+
+func TestNormalizeModelName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Bedrock cross-region inference profiles: strip region + vendor + version + date.
+		{"us.anthropic.claude-opus-4-20250101-v1:0", "claude-opus-4"},
+		{"eu.anthropic.claude-3-5-sonnet-20241022-v1:0", "claude-3-5-sonnet"},
+		{"anthropic.claude-3-5-sonnet-20241022", "claude-3-5-sonnet"},
+		{"anthropic.claude-opus-4-6-v1", "claude-opus-4-6"},
+		// Plain Bedrock ids for other vendors.
+		{"meta.llama3-70b-instruct-v1:0", "llama3-70b-instruct"},
+		{"cohere.command-r-v1:0", "command-r"},
+		// OpenAI dated resolved names collapse to the base.
+		{"gpt-4o-mini-2024-07-18", "gpt-4o-mini"},
+		{"gpt-4o-2024-08-06", "gpt-4o"},
+		// Anthropic dated (non-Bedrock) collapses to the base.
+		{"claude-sonnet-4-20250514", "claude-sonnet-4"},
+		// Digit-dotted names without a vendor prefix must be preserved.
+		{"gpt-3.5-turbo", "gpt-3.5-turbo"},
+		{"gemini-1.5-pro", "gemini-1.5-pro"},
+		// OpenAI fine-tune ids must be preserved (trailing segment is an id, not a version).
+		{"ft:gpt-4o-mini:acme:custom:AbCd1234", "ft:gpt-4o-mini:acme:custom:AbCd1234"},
+		// Already-base names are unchanged.
+		{"gpt-4o-mini", "gpt-4o-mini"},
+		{"claude-opus-4", "claude-opus-4"},
+		// Whitespace is trimmed; blank/whitespace-only collapses to "".
+		{"  gpt-4o-mini  ", "gpt-4o-mini"},
+		{"   ", ""},
+		{"\t\n", ""},
+		// Empty stays empty.
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := NormalizeModelName(c.in); got != c.want {
+			t.Errorf("NormalizeModelName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1855,6 +1855,54 @@ func BaseModelName(id string) string {
 	return base
 }
 
+// modelVendorPrefixRe matches one leading "<token>." segment whose token is
+// lowercase letters/hyphens only (e.g. "us.", "anthropic.", "eu."). It never
+// matches a token containing a digit, so digit-dotted names such as
+// "gpt-3.5-turbo" or "gemini-1.5-pro" are left untouched.
+var modelVendorPrefixRe = regexp.MustCompile(`^[a-z][a-z-]*\.`)
+
+// bedrockVersionSuffixRe matches a trailing Bedrock version suffix like ":0" or
+// "-v1:0" so it can be stripped from an inference-profile id.
+var bedrockVersionSuffixRe = regexp.MustCompile(`(-v\d+)?:\d+$`)
+
+// NormalizeModelName reduces a provider-specific model id to a stable base name
+// for metric aggregation, so the same logical model does not split across series.
+// It strips Bedrock cross-region / vendor inference-profile prefixes, Bedrock
+// version suffixes, and any trailing date/version suffix. Digit-dotted names
+// without a vendor prefix (e.g. "gpt-3.5-turbo", "gemini-1.5-pro") and OpenAI
+// fine-tune ids ("ft:...") are preserved.
+//
+// Examples:
+//
+//	"us.anthropic.claude-opus-4-20250101-v1:0" → "claude-opus-4"
+//	"anthropic.claude-3-5-sonnet-20241022"     → "claude-3-5-sonnet"
+//	"gpt-4o-mini-2024-07-18"                    → "gpt-4o-mini"
+//	"gpt-3.5-turbo"                             → "gpt-3.5-turbo"
+func NormalizeModelName(model string) string {
+	// Trim surrounding whitespace so a blank/whitespace-only model collapses to ""
+	// (rather than a garbage label) and stray spaces around a real name are dropped.
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return model
+	}
+	// Strip vendor/region prefixes (Bedrock inference profiles). Loop so both the
+	// region and vendor segments come off (e.g. "us.anthropic.").
+	for {
+		stripped := modelVendorPrefixRe.ReplaceAllString(model, "")
+		if stripped == model || stripped == "" {
+			break
+		}
+		model = stripped
+	}
+	// Strip the Bedrock version suffix. Skip OpenAI fine-tune ids, whose trailing
+	// segment is an id, not a version.
+	if !strings.HasPrefix(model, "ft:") {
+		model = bedrockVersionSuffixRe.ReplaceAllString(model, "")
+	}
+	// Strip any trailing date/version suffix.
+	return BaseModelName(model)
+}
+
 // SameBaseModel reports whether two model ids refer to the same base model,
 // ignoring any recognized version suffixes.
 //

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -882,7 +882,7 @@ func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	}
 	return BuildBifrostAttributes(
 		getStringAttr(attrs, schemas.AttrProviderName),
-		getStringAttr(attrs, schemas.AttrRequestModel),
+		schemas.NormalizeModelName(getStringAttr(attrs, schemas.AttrRequestModel)),
 		method,
 		getStringAttr(attrs, schemas.AttrVirtualKeyID),
 		getStringAttr(attrs, schemas.AttrVirtualKeyName),
@@ -907,7 +907,7 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 	}
 	return BuildBifrostAttributes(
 		string(provider),
-		model,
+		schemas.NormalizeModelName(model),
 		string(requestType),
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID),
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName),
@@ -1042,6 +1042,13 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 	}
 
 	attrs := finalSpan.Attributes
+
+	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label series.
+	if getStringAttr(attrs, schemas.AttrProviderName) == "" &&
+		strings.TrimSpace(getStringAttr(attrs, schemas.AttrRequestModel)) == "" {
+		return
+	}
+
 	otelAttrs := buildSpanAttrs(finalSpan)
 
 	// Record retries used for this request. Read off the final span (the last attempt's

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -835,7 +835,9 @@ func extractProviderCacheTokens(result *schemas.BifrostResponse) (read, write, w
 func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	requestType, provider, originalModel, resolvedModel := bifrost.GetResponseFields(result, bifrostErr)
 
-	// Determine effective model label and alias label (mirrors applyModelAlias logic in logging)
+	// Determine effective model label and alias label (mirrors applyModelAlias logic in logging).
+	// The model label is normalized (prefix/version/date stripped) so the same logical model
+	// does not split across series; alias keeps the raw requested name.
 	model := originalModel
 	alias := ""
 	if resolvedModel != "" {
@@ -843,6 +845,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		if resolvedModel != originalModel {
 			alias = originalModel
 		}
+	}
+	model = schemas.NormalizeModelName(model)
+
+	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label series.
+	if provider == "" && model == "" {
+		return result, bifrostErr, nil
 	}
 
 	startTime, ok := ctx.Value(startTimeKey).(time.Time)


### PR DESCRIPTION
## Summary

Provider-specific model IDs (e.g. Bedrock cross-region inference profiles, dated OpenAI/Anthropic snapshots) were creating separate metric series for what is logically the same model. This PR introduces a `NormalizeModelName` function that strips vendor/region prefixes, Bedrock version suffixes, and trailing date/version segments before model names are used as metric labels, preventing cardinality explosion in Prometheus and OTel metrics.

Additionally, pre-dispatch rejections where both provider and model are empty are now skipped entirely to avoid polluting metric series with empty labels.

## Changes

- Added `NormalizeModelName` in `core/schemas/utils.go` that:
  - Strips Bedrock region and vendor prefixes (e.g. `us.anthropic.`, `anthropic.`) using a regex that only matches letter/hyphen tokens, leaving digit-dotted names like `gpt-3.5-turbo` and `gemini-1.5-pro` untouched
  - Strips Bedrock version suffixes (e.g. `-v1:0`)
  - Delegates to the existing `BaseModelName` to strip trailing date/version segments
  - Preserves OpenAI fine-tune IDs (`ft:...`) as-is
  - Trims surrounding whitespace, collapsing blank input to `""`
- Applied `NormalizeModelName` to the model label in both the Prometheus plugin (`PostLLMHook`) and the OTel plugin (`buildSpanAttrs`, `buildContextAttrs`)
- Added early-return guards in both plugins when provider and model are both empty, skipping metric recording for pre-dispatch rejections
- Added a comprehensive test suite for `NormalizeModelName` covering Bedrock inference profiles, OpenAI dated snapshots, Anthropic dated names, digit-dotted names, fine-tune IDs, whitespace, and empty input

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestNormalizeModelName -v
go test ./plugins/otel/...
go test ./plugins/telemetry/...
go test ./...
```

Expected: all tests pass, and metrics emitted for Bedrock inference profile model IDs (e.g. `us.anthropic.claude-opus-4-20250101-v1:0`) use the normalized label `claude-opus-4` rather than the full provider-specific string.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. This change only affects metric label values and does not touch auth, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable