### PR TITLE
feat: add team / customer / bu ids and names to OTEL metrics

### DIFF
--- a/core/schemas/canonicalentityset_test.go
+++ b/core/schemas/canonicalentityset_test.go
@@ -1,0 +1,41 @@
+package schemas
+
+import "testing"
+
+func TestCanonicalEntitySet(t *testing.T) {
+	cases := []struct {
+		name              string
+		ids, names        []string
+		wantIDs, wantName string
+	}{
+		{"empty", nil, nil, "", ""},
+		{"single", []string{"a1"}, []string{"Alpha"}, "a1", "Alpha"},
+		{
+			"sorted and aligned",
+			[]string{"c3", "a1", "b2"},
+			[]string{"Gamma", "Alpha", "Beta"},
+			"a1,b2,c3", "Alpha,Beta,Gamma",
+		},
+		{
+			"deterministic regardless of input order",
+			[]string{"b2", "c3", "a1"},
+			[]string{"Beta", "Gamma", "Alpha"},
+			"a1,b2,c3", "Alpha,Beta,Gamma",
+		},
+		{
+			"dedupe by id keeps first name",
+			[]string{"a1", "a1", "b2"},
+			[]string{"Alpha", "AlphaDup", "Beta"},
+			"a1,b2", "Alpha,Beta",
+		},
+		{"drops empty ids", []string{"", "a1"}, []string{"", "Alpha"}, "a1", "Alpha"},
+		{"missing names tolerated", []string{"a1", "b2"}, []string{"Alpha"}, "a1,b2", "Alpha,"},
+	}
+	for _, c := range cases {
+		gotIDs, gotNames := CanonicalEntitySet(c.ids, c.names)
+		if gotIDs != c.wantIDs || gotNames != c.wantName {
+			t.Errorf("%s: CanonicalEntitySet(%v,%v) = (%q,%q), want (%q,%q)",
+				c.name, c.ids, c.names, gotIDs, gotNames, c.wantIDs, c.wantName)
+		}
+	}
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1855,38 +1856,60 @@ func BaseModelName(id string) string {
 	return base
 }
 
-// modelVendorPrefixRe matches one leading "<token>." segment whose token is
-// lowercase letters/hyphens only (e.g. "us.", "anthropic.", "eu."). It never
-// matches a token containing a digit, so digit-dotted names such as
-// "gpt-3.5-turbo" or "gemini-1.5-pro" are left untouched.
+// CanonicalEntitySet returns id/name arrays as deduped, id-sorted, comma-joined
+// strings so the same set always yields the same pair. Empty set → "","". For
+// low-count dimensions (a user's teams), not unbounded sets.
+func CanonicalEntitySet(ids, names []string) (idsCSV, namesCSV string) {
+	if len(ids) == 0 {
+		return "", ""
+	}
+	type pair struct{ id, name string }
+	seen := make(map[string]struct{}, len(ids))
+	pairs := make([]pair, 0, len(ids))
+	for i, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		name := ""
+		if i < len(names) {
+			name = names[i]
+		}
+		pairs = append(pairs, pair{id, name})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].id < pairs[j].id })
+	idList := make([]string, len(pairs))
+	nameList := make([]string, len(pairs))
+	for i, p := range pairs {
+		idList[i] = p.id
+		nameList[i] = p.name
+	}
+	return strings.Join(idList, ","), strings.Join(nameList, ",")
+}
+
+// modelVendorPrefixRe matches a leading "<letters>." segment (us., anthropic.),
+// never a digit-dotted one, so "gpt-3.5-turbo" is left intact.
 var modelVendorPrefixRe = regexp.MustCompile(`^[a-z][a-z-]*\.`)
 
-// bedrockVersionSuffixRe matches a trailing Bedrock version suffix like ":0" or
-// "-v1:0" so it can be stripped from an inference-profile id.
+// bedrockVersionSuffixRe matches a trailing Bedrock version suffix (":0", "-v1:0").
 var bedrockVersionSuffixRe = regexp.MustCompile(`(-v\d+)?:\d+$`)
 
-// NormalizeModelName reduces a provider-specific model id to a stable base name
-// for metric aggregation, so the same logical model does not split across series.
-// It strips Bedrock cross-region / vendor inference-profile prefixes, Bedrock
-// version suffixes, and any trailing date/version suffix. Digit-dotted names
-// without a vendor prefix (e.g. "gpt-3.5-turbo", "gemini-1.5-pro") and OpenAI
-// fine-tune ids ("ft:...") are preserved.
-//
-// Examples:
+// NormalizeModelName strips Bedrock vendor/region prefixes, version suffixes, and
+// trailing date suffixes so the same model doesn't split across series. Preserves
+// digit-dotted names ("gpt-3.5-turbo") and fine-tune ids ("ft:...").
 //
 //	"us.anthropic.claude-opus-4-20250101-v1:0" → "claude-opus-4"
-//	"anthropic.claude-3-5-sonnet-20241022"     → "claude-3-5-sonnet"
 //	"gpt-4o-mini-2024-07-18"                    → "gpt-4o-mini"
-//	"gpt-3.5-turbo"                             → "gpt-3.5-turbo"
 func NormalizeModelName(model string) string {
-	// Trim surrounding whitespace so a blank/whitespace-only model collapses to ""
-	// (rather than a garbage label) and stray spaces around a real name are dropped.
+	// Trim so blank/whitespace-only collapses to "" and stray spaces are dropped.
 	model = strings.TrimSpace(model)
 	if model == "" {
 		return model
 	}
-	// Strip vendor/region prefixes (Bedrock inference profiles). Loop so both the
-	// region and vendor segments come off (e.g. "us.anthropic.").
+	// Strip vendor/region prefixes; loop to remove both (e.g. "us.anthropic.").
 	for {
 		stripped := modelVendorPrefixRe.ReplaceAllString(model, "")
 		if stripped == model || stripped == "" {
@@ -1894,12 +1917,10 @@ func NormalizeModelName(model string) string {
 		}
 		model = stripped
 	}
-	// Strip the Bedrock version suffix. Skip OpenAI fine-tune ids, whose trailing
-	// segment is an id, not a version.
+	// Strip Bedrock version suffix; skip fine-tune ids (trailing segment is an id).
 	if !strings.HasPrefix(model, "ft:") {
 		model = bedrockVersionSuffixRe.ReplaceAllString(model, "")
 	}
-	// Strip any trailing date/version suffix.
 	return BaseModelName(model)
 }
 

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -839,6 +839,53 @@ func getStringAttr(attrs map[string]any, key string) string {
 	return ""
 }
 
+// getStringSliceAttr reads an array-valued span attribute ([]string or []any).
+func getStringSliceAttr(attrs map[string]any, key string) []string {
+	if attrs == nil {
+		return nil
+	}
+	switch v := attrs[key].(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// entitySetFromAttrs resolves one entity dimension from span attrs: plural arrays,
+// else scalar as a set of one, canonicalized.
+func entitySetFromAttrs(attrs map[string]any, idsKey, namesKey, scalarIDKey, scalarNameKey string) (idsCSV, namesCSV string) {
+	ids := getStringSliceAttr(attrs, idsKey)
+	names := getStringSliceAttr(attrs, namesKey)
+	if len(ids) == 0 {
+		if id := getStringAttr(attrs, scalarIDKey); id != "" {
+			ids = []string{id}
+			names = []string{getStringAttr(attrs, scalarNameKey)}
+		}
+	}
+	return schemas.CanonicalEntitySet(ids, names)
+}
+
+// entitySetFromContext is entitySetFromAttrs for the request context path.
+func entitySetFromContext(ctx context.Context, idsKey, namesKey, scalarIDKey, scalarNameKey schemas.BifrostContextKey) (idsCSV, namesCSV string) {
+	ids, _ := ctx.Value(idsKey).([]string)
+	names, _ := ctx.Value(namesKey).([]string)
+	if len(ids) == 0 {
+		if id := bifrost.GetStringFromContext(ctx, scalarIDKey); id != "" {
+			ids = []string{id}
+			names = []string{bifrost.GetStringFromContext(ctx, scalarNameKey)}
+		}
+	}
+	return schemas.CanonicalEntitySet(ids, names)
+}
+
 func getIntAttr(attrs map[string]any, key string) int {
 	if attrs == nil {
 		return 0
@@ -880,6 +927,9 @@ func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 	if method == "" {
 		method = span.Name
 	}
+	teamIDs, teamNames := entitySetFromAttrs(attrs, schemas.AttrBifrostTeamIDs, schemas.AttrBifrostTeamNames, schemas.AttrTeamID, schemas.AttrTeamName)
+	customerIDs, customerNames := entitySetFromAttrs(attrs, schemas.AttrBifrostCustomerIDs, schemas.AttrBifrostCustomerNames, schemas.AttrCustomerID, schemas.AttrCustomerName)
+	buIDs, buNames := entitySetFromAttrs(attrs, schemas.AttrBifrostBusinessUnitIDs, schemas.AttrBifrostBusinessUnitNames, schemas.AttrBifrostBusinessUnitID, schemas.AttrBifrostBusinessUnitName)
 	return BuildBifrostAttributes(
 		getStringAttr(attrs, schemas.AttrProviderName),
 		schemas.NormalizeModelName(getStringAttr(attrs, schemas.AttrRequestModel)),
@@ -889,10 +939,12 @@ func buildSpanAttrs(span *schemas.Span) []attribute.KeyValue {
 		getStringAttr(attrs, schemas.AttrSelectedKeyID),
 		getStringAttr(attrs, schemas.AttrSelectedKeyName),
 		getIntAttr(attrs, schemas.AttrFallbackIndex),
-		getStringAttr(attrs, schemas.AttrTeamID),
-		getStringAttr(attrs, schemas.AttrTeamName),
-		getStringAttr(attrs, schemas.AttrCustomerID),
-		getStringAttr(attrs, schemas.AttrCustomerName),
+		teamIDs,
+		teamNames,
+		customerIDs,
+		customerNames,
+		buIDs,
+		buNames,
 	)
 }
 
@@ -905,6 +957,9 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 	if resolvedModel != "" {
 		model = resolvedModel
 	}
+	teamIDs, teamNames := entitySetFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamIDs, schemas.BifrostContextKeyGovernanceTeamNames, schemas.BifrostContextKeyGovernanceTeamID, schemas.BifrostContextKeyGovernanceTeamName)
+	customerIDs, customerNames := entitySetFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerNames, schemas.BifrostContextKeyGovernanceCustomerID, schemas.BifrostContextKeyGovernanceCustomerName)
+	buIDs, buNames := entitySetFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitIDs, schemas.BifrostContextKeyGovernanceBusinessUnitNames, schemas.BifrostContextKeyGovernanceBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitName)
 	return BuildBifrostAttributes(
 		string(provider),
 		schemas.NormalizeModelName(model),
@@ -914,10 +969,12 @@ func buildContextAttrs(ctx context.Context, resp *schemas.BifrostResponse, bifro
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyID),
 		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedKeyName),
 		bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyFallbackIndex),
-		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID),
-		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName),
-		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID),
-		bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName),
+		teamIDs,
+		teamNames,
+		customerIDs,
+		customerNames,
+		buIDs,
+		buNames,
 	)
 }
 

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -571,7 +571,11 @@ func (m *MetricsExporter) RecordHTTPResponseSize(ctx context.Context, sizeBytes 
 // Retry depth is intentionally NOT included here; it is reported via the dedicated
 // bifrost_request_retries histogram (recorded once per request) rather than as a label
 // on every per-attempt counter.
-func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyName, selectedKeyID, selectedKeyName string, fallbackIndex int, teamID, teamName, customerID, customerName string) []attribute.KeyValue {
+// team/customer/businessUnit id+name args are canonical comma-joined sets (see
+// schemas.CanonicalEntitySet) so a multi-team/customer/BU request carries every
+// value; single-valued traffic is a set of one. The label names stay singular
+// (team_id, customer_id, ...) for dashboard backward-compatibility.
+func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyName, selectedKeyID, selectedKeyName string, fallbackIndex int, teamIDs, teamNames, customerIDs, customerNames, businessUnitIDs, businessUnitNames string) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("provider", provider),
 		attribute.String("model", model),
@@ -581,10 +585,12 @@ func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyNam
 		attribute.String("selected_key_id", selectedKeyID),
 		attribute.String("selected_key_name", selectedKeyName),
 		attribute.Int("fallback_index", fallbackIndex),
-		attribute.String("team_id", teamID),
-		attribute.String("team_name", teamName),
-		attribute.String("customer_id", customerID),
-		attribute.String("customer_name", customerName),
+		attribute.String("team_id", teamIDs),
+		attribute.String("team_name", teamNames),
+		attribute.String("customer_id", customerIDs),
+		attribute.String("customer_name", customerNames),
+		attribute.String("business_unit_id", businessUnitIDs),
+		attribute.String("business_unit_name", businessUnitNames),
 	}
 }
 

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -832,12 +832,25 @@ func extractProviderCacheTokens(result *schemas.BifrostResponse) (read, write, w
 // It records:
 //   - Request latency
 //   - Total request count
+// canonicalEntitySet resolves one entity dimension from context: plural arrays,
+// else scalar as a set of one, canonicalized.
+func canonicalEntitySet(ctx context.Context, idsKey, namesKey, scalarIDKey, scalarNameKey schemas.BifrostContextKey) (idsCSV, namesCSV string) {
+	ids, _ := ctx.Value(idsKey).([]string)
+	names, _ := ctx.Value(namesKey).([]string)
+	if len(ids) == 0 {
+		if id := bifrost.GetStringFromContext(ctx, scalarIDKey); id != "" {
+			ids = []string{id}
+			names = []string{bifrost.GetStringFromContext(ctx, scalarNameKey)}
+		}
+	}
+	return schemas.CanonicalEntitySet(ids, names)
+}
+
 func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	requestType, provider, originalModel, resolvedModel := bifrost.GetResponseFields(result, bifrostErr)
 
-	// Determine effective model label and alias label (mirrors applyModelAlias logic in logging).
-	// The model label is normalized (prefix/version/date stripped) so the same logical model
-	// does not split across series; alias keeps the raw requested name.
+	// Effective model + alias (mirrors logging's applyModelAlias). model is normalized
+	// so it doesn't split across series; alias keeps the raw requested name.
 	model := originalModel
 	alias := ""
 	if resolvedModel != "" {
@@ -877,12 +890,11 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	}
 	routingEngineUsed := strings.Join(routingEngines, ",")
 
-	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
-	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)
-	customerID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerID)
-	customerName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceCustomerName)
-	businessUnitID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitID)
-	businessUnitName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitName)
+	// Team/customer/BU sets: plural arrays, else scalar as a set of one. Emitted
+	// under the singular label names for dashboard compatibility.
+	teamIDs, teamNames := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceTeamIDs, schemas.BifrostContextKeyGovernanceTeamNames, schemas.BifrostContextKeyGovernanceTeamID, schemas.BifrostContextKeyGovernanceTeamName)
+	customerID, customerName := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerNames, schemas.BifrostContextKeyGovernanceCustomerID, schemas.BifrostContextKeyGovernanceCustomerName)
+	businessUnitID, businessUnitName := canonicalEntitySet(ctx, schemas.BifrostContextKeyGovernanceBusinessUnitIDs, schemas.BifrostContextKeyGovernanceBusinessUnitNames, schemas.BifrostContextKeyGovernanceBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitName)
 
 	// Extract ALL context values BEFORE spawning the goroutine.
 	labelValues := map[string]string{
@@ -898,8 +910,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		"selected_key_id":     selectedKeyID,
 		"selected_key_name":   selectedKeyName,
 		"fallback_index":      strconv.Itoa(fallbackIndex),
-		"team_id":             teamID,
-		"team_name":           teamName,
+		"team_id":             teamIDs,
+		"team_name":           teamNames,
 		"customer_id":         customerID,
 		"customer_name":       customerName,
 		"business_unit_id":    businessUnitID,


### PR DESCRIPTION
## Summary

Adds support for multi-valued team, customer, and business unit identity dimensions in telemetry and metrics. Previously, only a single scalar value per dimension was recorded. This PR introduces a `CanonicalEntitySet` utility that deduplicates, sorts, and comma-joins parallel id/name arrays into stable strings, ensuring the same set of entities always produces the same metric label value regardless of input ordering.

## Changes

- Added `CanonicalEntitySet` in `core/schemas/utils.go` that accepts index-aligned id/name slices, drops empty ids, deduplicates by id (keeping the first name), sorts by id, and returns comma-joined `(idsCSV, namesCSV)` strings.
- Added `canonicalentityset_test.go` covering empty input, single values, sorted/deduped sets, duplicate ids, missing names, and empty id filtering.
- Added `getStringSliceAttr` in the otel plugin to tolerate both `[]string` and `[]any` encodings of array-valued span attributes.
- Added `entitySetFromAttrs` and `entitySetFromContext` helpers in the otel plugin that resolve a dimension from the plural governance arrays when present, falling back to the scalar as a set of one.
- Added `canonicalEntitySet` helper in the telemetry plugin with the same fallback logic for the Prometheus path.
- Extended `BuildBifrostAttributes` to accept and emit `business_unit_id`/`business_unit_name` attributes alongside the existing team and customer dimensions.
- All label names remain singular (`team_id`, `customer_id`, `business_unit_id`) for dashboard backward-compatibility; the values are now canonical comma-joined sets.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run TestCanonicalEntitySet -v
go test ./plugins/otel/... ./plugins/telemetry/...
go test ./...
```

Verify that a request carrying multiple team ids (e.g. `["t1","t2"]`) produces a `team_id` label of `"t1,t2"` (sorted) in both Prometheus metrics and OTel span attributes, and that a single-team request continues to produce the same label format as before.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The `BuildBifrostAttributes` function signature has changed (two new parameters added for `businessUnitIDs`/`businessUnitNames`, and scalar team/customer args replaced with their CSV equivalents). Any direct callers outside this repo will need to update their call sites.

## Related issues

N/A

## Security considerations

Label values are derived from governance context keys set server-side. No user-supplied PII is introduced beyond what was already present in the scalar team/customer labels.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable