### PR TITLE
feat: adds service instance id to OTEL attributes

### DIFF
--- a/core/schemas/normalizemodelname_test.go
+++ b/core/schemas/normalizemodelname_test.go
@@ -23,8 +23,10 @@ func TestNormalizeModelName(t *testing.T) {
 		// Digit-dotted names without a vendor prefix must be preserved.
 		{"gpt-3.5-turbo", "gpt-3.5-turbo"},
 		{"gemini-1.5-pro", "gemini-1.5-pro"},
-		// OpenAI fine-tune ids must be preserved (trailing segment is an id, not a version).
+		// OpenAI fine-tune ids must be preserved (trailing segment is an id, not a version),
+		// including a date-like custom suffix BaseModelName would otherwise strip.
 		{"ft:gpt-4o-mini:acme:custom:AbCd1234", "ft:gpt-4o-mini:acme:custom:AbCd1234"},
+		{"ft:gpt-4o-mini:acme:custom-20250514", "ft:gpt-4o-mini:acme:custom-20250514"},
 		// Already-base names are unchanged.
 		{"gpt-4o-mini", "gpt-4o-mini"},
 		{"claude-opus-4", "claude-opus-4"},

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1917,10 +1917,12 @@ func NormalizeModelName(model string) string {
 		}
 		model = stripped
 	}
-	// Strip Bedrock version suffix; skip fine-tune ids (trailing segment is an id).
-	if !strings.HasPrefix(model, "ft:") {
-		model = bedrockVersionSuffixRe.ReplaceAllString(model, "")
+	// Fine-tune ids: trailing segment is an id, not a version. Return as-is so
+	// BaseModelName doesn't strip a date-like custom suffix.
+	if strings.HasPrefix(model, "ft:") {
+		return model
 	}
+	model = bedrockVersionSuffixRe.ReplaceAllString(model, "")
 	return BaseModelName(model)
 }
 

--- a/plugins/otel/entityset_test.go
+++ b/plugins/otel/entityset_test.go
@@ -1,0 +1,33 @@
+package otel
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestGetStringSliceAttr_AnyPreservesIndex(t *testing.T) {
+	got := getStringSliceAttr(map[string]any{"k": []any{"a", 1, "c"}}, "k")
+	want := []string{"a", "", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// A non-string ID element must not shift the aligned names: the entry with the
+// bad ID is dropped along with its name, and remaining ids keep their own names.
+func TestEntitySetFromAttrs_MixedAnyKeepsAlignment(t *testing.T) {
+	attrs := map[string]any{
+		schemas.AttrBifrostTeamIDs:   []any{"a1", 42, "c3"},
+		schemas.AttrBifrostTeamNames: []any{"Alpha", "Bogus", "Gamma"},
+	}
+	ids, names := entitySetFromAttrs(attrs, schemas.AttrBifrostTeamIDs, schemas.AttrBifrostTeamNames, schemas.AttrTeamID, schemas.AttrTeamName)
+	if ids != "a1,c3" || names != "Alpha,Gamma" {
+		t.Errorf("got (%q,%q), want (\"a1,c3\",\"Alpha,Gamma\")", ids, names)
+	}
+}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -848,11 +848,10 @@ func getStringSliceAttr(attrs map[string]any, key string) []string {
 	case []string:
 		return v
 	case []any:
-		out := make([]string, 0, len(v))
-		for _, e := range v {
-			if s, ok := e.(string); ok {
-				out = append(out, s)
-			}
+		// Preserve index so id/name arrays stay aligned; non-strings become "".
+		out := make([]string, len(v))
+		for i, e := range v {
+			out[i], _ = e.(string)
 		}
 		return out
 	}
@@ -1063,6 +1062,12 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 	var finalSpan *schemas.Span
 	for _, span := range trace.Spans {
 		if span.Kind != schemas.SpanKindLLMCall && span.Kind != schemas.SpanKindRetry {
+			continue
+		}
+		// Skip spans with no provider and no model (avoid empty-label series); also
+		// excludes them from final-span selection below.
+		if getStringAttr(span.Attributes, schemas.AttrProviderName) == "" &&
+			strings.TrimSpace(getStringAttr(span.Attributes, schemas.AttrRequestModel)) == "" {
 			continue
 		}
 

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -198,18 +198,12 @@ func (h *syncFloat64Histogram) Record(ctx context.Context, value float64, opts .
 
 // NewMetricsExporter creates a new OTEL metrics exporter
 func NewMetricsExporter(ctx context.Context, config *MetricsConfig) (*MetricsExporter, error) {
-	// Generate a unique instance ID for this node
-	instanceID, err := os.Hostname()
-	if err != nil {
-		instanceID = fmt.Sprintf("bifrost-%d", time.Now().UnixNano())
-	}
-
-	// Create resource with service info
+	// Resource attrs; serviceInstanceID is also emitted as a datapoint label.
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewSchemaless(
 			semconv.ServiceName(config.ServiceName),
-			semconv.ServiceInstanceID(instanceID),
+			semconv.ServiceInstanceID(serviceInstanceID),
 		),
 	)
 	if err != nil {
@@ -571,10 +565,20 @@ func (m *MetricsExporter) RecordHTTPResponseSize(ctx context.Context, sizeBytes 
 // Retry depth is intentionally NOT included here; it is reported via the dedicated
 // bifrost_request_retries histogram (recorded once per request) rather than as a label
 // on every per-attempt counter.
-// team/customer/businessUnit id+name args are canonical comma-joined sets (see
-// schemas.CanonicalEntitySet) so a multi-team/customer/BU request carries every
-// value; single-valued traffic is a set of one. The label names stay singular
-// (team_id, customer_id, ...) for dashboard backward-compatibility.
+// serviceInstanceID is this replica's id (hostname, timestamped fallback). Emitted
+// as both a resource attribute and a datapoint label so per-replica breakdown works
+// even when the collector drops resource attributes.
+var serviceInstanceID = resolveServiceInstanceID()
+
+func resolveServiceInstanceID() string {
+	if h, err := os.Hostname(); err == nil && h != "" {
+		return h
+	}
+	return fmt.Sprintf("bifrost-%d", time.Now().UnixNano())
+}
+
+// team/customer/businessUnit args are canonical comma-joined sets; label names stay
+// singular (team_id, ...) for dashboard compatibility.
 func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyName, selectedKeyID, selectedKeyName string, fallbackIndex int, teamIDs, teamNames, customerIDs, customerNames, businessUnitIDs, businessUnitNames string) []attribute.KeyValue {
 	return []attribute.KeyValue{
 		attribute.String("provider", provider),
@@ -591,6 +595,7 @@ func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyNam
 		attribute.String("customer_name", customerNames),
 		attribute.String("business_unit_id", businessUnitIDs),
 		attribute.String("business_unit_name", businessUnitNames),
+		attribute.String("service_instance_id", serviceInstanceID),
 	}
 }
 

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -861,8 +861,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	}
 	model = schemas.NormalizeModelName(model)
 
-	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label series.
+	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label
+	// series. Decrement ActiveRequests first, since PreLLMHook incremented it.
 	if provider == "" && model == "" {
+		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
+			p.ActiveRequests.WithLabelValues(string(method)).Dec()
+		}
 		return result, bifrostErr, nil
 	}
 
@@ -969,7 +973,7 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		for _, record := range attemptTrail {
 			if record.TriggeredRotation && record.FailReason != nil {
 				p.KeyRotationEventsTotal.WithLabelValues(
-					string(provider), originalModel, record.KeyID, record.KeyName, *record.FailReason,
+					string(provider), model, record.KeyID, record.KeyName, *record.FailReason,
 				).Inc()
 			}
 			if record.FailReason != nil {


### PR DESCRIPTION
## Summary

Several correctness fixes across model name normalization, OTel metrics alignment, and Prometheus active-request tracking. The common theme is preventing data loss or label pollution caused by edge-case inputs (fine-tune model IDs with date-like suffixes, mixed-type attribute arrays, spans with no provider/model, and pre-dispatch rejections that left active-request counters incremented).

## Changes

- **`NormalizeModelName` fine-tune short-circuit**: OpenAI fine-tune IDs prefixed with `ft:` are now returned immediately before `BaseModelName` is called, preventing a date-like custom suffix (e.g. `custom-20250514`) from being stripped as if it were a Bedrock version tag.
- **`getStringSliceAttr` index preservation**: When a `[]any` attribute value contains non-string elements, the slot is now kept as an empty string rather than being dropped. This keeps id and name arrays index-aligned so that `entitySetFromAttrs` can correctly pair and filter them.
- **OTel span filtering**: Spans with both an empty provider and an empty model are skipped before final-span selection in `recordMetricsFromTrace`, preventing empty-label metric series from being emitted.
- **`serviceInstanceID` as a package-level variable**: The hostname/fallback resolution is now computed once at startup and reused in both the resource attribute and as a `service_instance_id` datapoint label, so per-replica breakdown survives collector configurations that drop resource attributes.
- **Prometheus `ActiveRequests` decrement on pre-dispatch rejection**: `PostLLMHook` now decrements `ActiveRequests` before returning early for no-provider/no-model requests, fixing a counter leak introduced when `PreLLMHook` incremented it.
- **Key rotation event uses normalized model name**: `KeyRotationEventsTotal` now records the normalized `model` value instead of `originalModel`, keeping label values consistent with other metrics.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./plugins/otel/... ./plugins/telemetry/...
```

- `TestNormalizeModelName` covers the new `ft:gpt-4o-mini:acme:custom-20250514` case.
- `TestGetStringSliceAttr_AnyPreservesIndex` verifies that non-string elements produce an empty string at the correct index.
- `TestEntitySetFromAttrs_MixedAnyKeepsAlignment` verifies that a non-string ID element drops both that ID and its paired name without shifting remaining entries.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable