### PR TITLE
docs: add user scopes, pagination, and extended pricing fields to pricing overrides OpenAPI spec

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -47593,15 +47593,15 @@
             "in": "query",
             "description": "Filter by scope kind",
             "schema": {
-              "type": "string",
-              "enum": [
-                "global",
-                "provider",
-                "provider_key",
-                "virtual_key",
-                "virtual_key_provider",
-                "virtual_key_provider_key"
-              ]
+              "$ref": "#/components/schemas/PricingOverrideScopeKind"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by user ID (for user* scopes)",
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -47626,6 +47626,32 @@
             "description": "Filter by provider key ID",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive substring match against the pricing override name. A non-empty value switches the response to the paginated shape.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return. A non-empty `limit`, `offset`, or `search` value switches the response to the paginated shape.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of results to skip",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         ],
@@ -83438,6 +83464,21 @@
           }
         }
       },
+      "PricingOverrideScopeKind": {
+        "type": "string",
+        "description": "Scope that determines which requests a pricing override applies to. The virtual_key* family is checked before the user* family during cost resolution, which is checked before the provider/global scopes; within a family, more identifiers present means a more specific match.\n",
+        "enum": [
+          "global",
+          "provider",
+          "provider_key",
+          "virtual_key",
+          "virtual_key_provider",
+          "virtual_key_provider_key",
+          "user",
+          "user_provider",
+          "user_provider_key"
+        ]
+      },
       "PricingOverrideRequestType": {
         "type": "string",
         "description": "Request type for pricing override filtering. Stream variants are treated identically to their base type - specifying `chat_completion` covers both streaming and non-streaming chat requests.\n",
@@ -83484,11 +83525,41 @@
             "type": "number",
             "minimum": 0
           },
+          "input_cost_per_token_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering."
+          },
+          "output_cost_per_token_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering."
+          },
           "input_cost_per_character": {
             "type": "number",
             "minimum": 0
           },
           "input_cost_per_token_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_image_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_video_per_second_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_audio_per_second_above_128k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83500,7 +83571,39 @@
             "type": "number",
             "minimum": 0
           },
+          "input_cost_per_token_above_200k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
           "output_cost_per_token_above_200k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_200k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_flex_above_272k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83520,11 +83623,15 @@
             "type": "number",
             "minimum": 0
           },
-          "cache_read_input_token_cost_priority": {
+          "cache_read_input_token_cost_above_200k_tokens_priority": {
             "type": "number",
             "minimum": 0
           },
-          "cache_read_input_image_token_cost": {
+          "cache_creation_input_token_cost_above_1hr": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_above_1hr_above_200k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83532,11 +83639,62 @@
             "type": "number",
             "minimum": 0
           },
-          "input_cost_per_image": {
+          "cache_read_input_token_cost_priority": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image": {
+          "cache_read_input_token_cost_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_image_token_cost": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "cache_creation_input_token_cost_above_1hr_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "cache_read_input_token_cost_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "input_cost_per_image": {
             "type": "number",
             "minimum": 0
           },
@@ -83544,15 +83702,39 @@
             "type": "number",
             "minimum": 0
           },
+          "output_cost_per_image": {
+            "type": "number",
+            "minimum": 0
+          },
           "output_cost_per_pixel": {
             "type": "number",
             "minimum": 0
           },
-          "input_cost_per_image_token": {
+          "output_cost_per_image_premium_image": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_token": {
+          "output_cost_per_image_above_512_and_512_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_512_and_512_pixels_and_premium_image": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_2048_and_2048_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_4096_and_4096_pixels": {
             "type": "number",
             "minimum": 0
           },
@@ -83572,31 +83754,15 @@
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_premium_image": {
+          "input_cost_per_image_token": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_above_512_and_512_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_1024_and_1024_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_2048_and_2048_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_4096_and_4096_pixels": {
+          "output_cost_per_image_token": {
             "type": "number",
             "minimum": 0
           },
           "input_cost_per_audio_token": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_audio_token": {
             "type": "number",
             "minimum": 0
           },
@@ -83609,6 +83775,10 @@
             "minimum": 0
           },
           "input_cost_per_video_per_second": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_audio_token": {
             "type": "number",
             "minimum": 0
           },
@@ -83627,6 +83797,19 @@
           "code_interpreter_cost_per_session": {
             "type": "number",
             "minimum": 0
+          },
+          "inference_geo_us_multiplier": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Anthropic data-residency multiplier applied when usage.inference_geo == \"us\"."
+          },
+          "ocr_cost_per_page": {
+            "type": "number",
+            "minimum": 0
+          },
+          "annotation_cost_per_page": {
+            "type": "number",
+            "minimum": 0
           }
         }
       },
@@ -83643,16 +83826,14 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
-            "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
+            "type": [
+              "string",
+              "null"
             ],
-            "description": "Scope that determines which requests this override applies to"
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": [
@@ -83666,14 +83847,14 @@
               "string",
               "null"
             ],
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83736,15 +83917,11 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
             "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
-            ]
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": "string",
@@ -83752,11 +83929,11 @@
           },
           "provider_id": {
             "type": "string",
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": "string",
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83791,15 +83968,11 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
             "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
-            ]
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": "string",
@@ -83807,11 +83980,11 @@
           },
           "provider_id": {
             "type": "string",
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": "string",
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83850,6 +84023,7 @@
       },
       "ListPricingOverridesResponse": {
         "type": "object",
+        "description": "When `limit`, `offset`, or `search` is supplied, `count` reflects the returned page while `total_count` reflects the full matching set. Otherwise (backward-compatible, non-paginated path) `total_count` equals `count` and `limit`/`offset` describe the full unpaged result.\n",
         "properties": {
           "pricing_overrides": {
             "type": "array",
@@ -83859,7 +84033,19 @@
           },
           "count": {
             "type": "integer",
-            "description": "Total number of overrides returned"
+            "description": "Number of overrides in this response"
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "Total number of overrides matching the filters"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Page size used for this response"
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset used for this response"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1612,6 +1612,8 @@ components:
       $ref: './schemas/management/governance.yaml#/UpdateProviderGovernanceRequest'
 
     # Governance - Pricing Overrides
+    PricingOverrideScopeKind:
+      $ref: './schemas/management/governance.yaml#/PricingOverrideScopeKind'
     PricingOverrideRequestType:
       $ref: './schemas/management/governance.yaml#/PricingOverrideRequestType'
     PricingPatch:

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -1109,14 +1109,12 @@ pricing-overrides:
         in: query
         description: Filter by scope kind
         schema:
+          $ref: '../../schemas/management/governance.yaml#/PricingOverrideScopeKind'
+      - name: user_id
+        in: query
+        description: Filter by user ID (for user* scopes)
+        schema:
           type: string
-          enum:
-            - global
-            - provider
-            - provider_key
-            - virtual_key
-            - virtual_key_provider
-            - virtual_key_provider_key
       - name: virtual_key_id
         in: query
         description: Filter by virtual key ID (for virtual_key* scopes)
@@ -1132,6 +1130,23 @@ pricing-overrides:
         description: Filter by provider key ID
         schema:
           type: string
+      - name: search
+        in: query
+        description: Case-insensitive substring match against the pricing override name. A non-empty value switches the response to the paginated shape.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Maximum number of results to return. A non-empty `limit`, `offset`, or `search` value switches the response to the paginated shape.
+        schema:
+          type: integer
+          minimum: 0
+      - name: offset
+        in: query
+        description: Number of results to skip
+        schema:
+          type: integer
+          minimum: 0
     security:
       - ManagementBearerAuth: []
     responses:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -1477,6 +1477,24 @@ UpdateProviderGovernanceRequest:
 
 # Pricing Overrides
 
+PricingOverrideScopeKind:
+  type: string
+  description: >
+    Scope that determines which requests a pricing override applies to. The
+    virtual_key* family is checked before the user* family during cost
+    resolution, which is checked before the provider/global scopes; within a
+    family, more identifiers present means a more specific match.
+  enum:
+    - global
+    - provider
+    - provider_key
+    - virtual_key
+    - virtual_key_provider
+    - virtual_key_provider_key
+    - user
+    - user_provider
+    - user_provider_key
+
 PricingOverrideRequestType:
   type: string
   description: >
@@ -1503,6 +1521,7 @@ PricingPatch:
     Pricing fields to override. Only non-zero/non-null fields are applied.
     All values are cost per unit in USD.
   properties:
+    # Costs - Text
     input_cost_per_token:
       type: number
       minimum: 0
@@ -1521,21 +1540,72 @@ PricingPatch:
     output_cost_per_token_priority:
       type: number
       minimum: 0
+    input_cost_per_token_flex:
+      type: number
+      minimum: 0
+    output_cost_per_token_flex:
+      type: number
+      minimum: 0
+    input_cost_per_token_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering.
+    output_cost_per_token_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering.
     input_cost_per_character:
       type: number
       minimum: 0
+    # Costs - 128k Tier
     input_cost_per_token_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_image_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_video_per_second_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_audio_per_second_above_128k_tokens:
       type: number
       minimum: 0
     output_cost_per_token_above_128k_tokens:
       type: number
       minimum: 0
+    # Costs - 200k Tier
     input_cost_per_token_above_200k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_token_above_200k_tokens_priority:
       type: number
       minimum: 0
     output_cost_per_token_above_200k_tokens:
       type: number
       minimum: 0
+    output_cost_per_token_above_200k_tokens_priority:
+      type: number
+      minimum: 0
+    # Costs - 272k Tier
+    input_cost_per_token_above_272k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_token_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    input_cost_per_token_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    output_cost_per_token_above_272k_tokens:
+      type: number
+      minimum: 0
+    output_cost_per_token_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    output_cost_per_token_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    # Costs - Cache
     cache_creation_input_token_cost:
       type: number
       minimum: 0
@@ -1548,31 +1618,92 @@ PricingPatch:
     cache_read_input_token_cost_above_200k_tokens:
       type: number
       minimum: 0
-    cache_read_input_token_cost_priority:
+    cache_read_input_token_cost_above_200k_tokens_priority:
       type: number
       minimum: 0
-    cache_read_input_image_token_cost:
+    cache_creation_input_token_cost_above_1hr:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_above_1hr_above_200k_tokens:
       type: number
       minimum: 0
     cache_creation_input_audio_token_cost:
       type: number
       minimum: 0
-    input_cost_per_image:
+    cache_read_input_token_cost_priority:
       type: number
       minimum: 0
-    output_cost_per_image:
+    cache_read_input_token_cost_flex:
+      type: number
+      minimum: 0
+    cache_read_input_image_token_cost:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_flex:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_priority:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    cache_creation_input_token_cost_above_1hr_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    cache_read_input_token_cost_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    # Costs - Image
+    input_cost_per_image:
       type: number
       minimum: 0
     input_cost_per_pixel:
       type: number
       minimum: 0
+    output_cost_per_image:
+      type: number
+      minimum: 0
     output_cost_per_pixel:
       type: number
       minimum: 0
-    input_cost_per_image_token:
+    output_cost_per_image_premium_image:
       type: number
       minimum: 0
-    output_cost_per_image_token:
+    output_cost_per_image_above_512_and_512_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_512_and_512_pixels_and_premium_image:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_and_premium_image:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_2048_and_2048_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_4096_and_4096_pixels:
       type: number
       minimum: 0
     output_cost_per_image_low_quality:
@@ -1587,25 +1718,14 @@ PricingPatch:
     output_cost_per_image_auto_quality:
       type: number
       minimum: 0
-    output_cost_per_image_premium_image:
+    input_cost_per_image_token:
       type: number
       minimum: 0
-    output_cost_per_image_above_512_and_512_pixels:
+    output_cost_per_image_token:
       type: number
       minimum: 0
-    output_cost_per_image_above_1024_and_1024_pixels:
-      type: number
-      minimum: 0
-    output_cost_per_image_above_2048_and_2048_pixels:
-      type: number
-      minimum: 0
-    output_cost_per_image_above_4096_and_4096_pixels:
-      type: number
-      minimum: 0
+    # Costs - Audio/Video
     input_cost_per_audio_token:
-      type: number
-      minimum: 0
-    output_cost_per_audio_token:
       type: number
       minimum: 0
     input_cost_per_audio_per_second:
@@ -1617,16 +1737,31 @@ PricingPatch:
     input_cost_per_video_per_second:
       type: number
       minimum: 0
+    output_cost_per_audio_token:
+      type: number
+      minimum: 0
     output_cost_per_video_per_second:
       type: number
       minimum: 0
     output_cost_per_second:
       type: number
       minimum: 0
+    # Costs - Other
     search_context_cost_per_query:
       type: number
       minimum: 0
     code_interpreter_cost_per_session:
+      type: number
+      minimum: 0
+    inference_geo_us_multiplier:
+      type: number
+      minimum: 0
+      description: Anthropic data-residency multiplier applied when usage.inference_geo == "us".
+    # Costs - OCR
+    ocr_cost_per_page:
+      type: number
+      minimum: 0
+    annotation_cost_per_page:
       type: number
       minimum: 0
 
@@ -1641,24 +1776,19 @@ PricingOverride:
       type: string
       description: Human-readable label
     scope_kind:
-      type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
-      description: Scope that determines which requests this override applies to
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
+      type: [string, 'null']
+      description: Required for user* scopes
     virtual_key_id:
       type: [string, 'null']
       description: Required for virtual_key* scopes
     provider_id:
       type: [string, 'null']
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: [string, 'null']
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1704,23 +1834,19 @@ CreatePricingOverrideRequest:
       type: string
       description: Human-readable label
     scope_kind:
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
       type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
+      description: Required for user* scopes
     virtual_key_id:
       type: string
       description: Required for virtual_key* scopes
     provider_id:
       type: string
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: string
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1749,23 +1875,19 @@ UpdatePricingOverrideRequest:
       type: string
       description: Human-readable label
     scope_kind:
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
       type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
+      description: Required for user* scopes
     virtual_key_id:
       type: string
       description: Required for virtual_key* scopes
     provider_id:
       type: string
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: string
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1793,6 +1915,11 @@ PricingOverrideResponse:
 
 ListPricingOverridesResponse:
   type: object
+  description: >
+    When `limit`, `offset`, or `search` is supplied, `count` reflects the
+    returned page while `total_count` reflects the full matching set.
+    Otherwise (backward-compatible, non-paginated path) `total_count` equals
+    `count` and `limit`/`offset` describe the full unpaged result.
   properties:
     pricing_overrides:
       type: array
@@ -1800,7 +1927,16 @@ ListPricingOverridesResponse:
         $ref: '#/PricingOverride'
     count:
       type: integer
-      description: Total number of overrides returned
+      description: Number of overrides in this response
+    total_count:
+      type: integer
+      description: Total number of overrides matching the filters
+    limit:
+      type: integer
+      description: Page size used for this response
+    offset:
+      type: integer
+      description: Offset used for this response
 
 # Complexity Tier Boundaries
 


### PR DESCRIPTION
## Summary

Extends the Pricing Overrides API with user-scoped override support, pagination/search on the list endpoint, and a significantly expanded set of priceable fields covering new token tiers, cache variants, image quality/size tiers, and OCR costs.

## Changes

- Introduced a shared `PricingOverrideScopeKind` schema component, replacing inline enum definitions across `PricingOverride`, `CreatePricingOverrideRequest`, `UpdatePricingOverrideRequest`, and the list query parameter. The enum now includes three new `user*` scopes: `user`, `user_provider`, and `user_provider_key`. Resolution priority is documented: `virtual_key*` > `user*` > `provider`/`global`, with more-specific matches winning within a family.
- Added `user_id` field to override request/response schemas and as a query filter on the list endpoint, required when using `user*` scopes.
- Updated `provider_id` and `provider_key_id` descriptions to reflect their applicability to the new `user_provider` and `user_provider_key` scopes.
- Added pagination and search to the list endpoint via `limit`, `offset`, and `search` query parameters. When any of these are present, the response switches to a paginated shape with `total_count`, `limit`, and `offset` fields alongside the existing `count`. The non-paginated path remains backward-compatible.
- Expanded `PricingPatch` with many new pricing fields, organized into logical sections:
  - **Text**: `input/output_cost_per_token_flex`, `input/output_cost_per_token_fast` (Anthropic research preview, flat rate with no tiering)
  - **128k tier**: `input_cost_per_image/video/audio_above_128k_tokens`
  - **200k tier**: priority variants for input and output
  - **272k tier**: standard, priority, and flex variants for input and output
  - **Cache**: flex, priority, fast, and 272k-tier variants; `cache_creation_input_token_cost_above_1hr` and its 200k/fast variants
  - **Image**: `premium_image` combined tiers at 512px and 1024px, `input_cost_per_image_token`
  - **Other**: `inference_geo_us_multiplier` (Anthropic data-residency), `ocr_cost_per_page`, `annotation_cost_per_page`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the updated OpenAPI spec is valid and that the new fields and parameters appear correctly:

```sh
# Validate the OpenAPI spec
npx @redocly/cli lint docs/openapi/openapi.yaml

# Confirm new scope kinds are present
grep -E "user|user_provider|user_provider_key" docs/openapi/openapi.yaml

# Confirm pagination parameters are present on the list endpoint
grep -E "limit|offset|search" docs/openapi/paths/management/governance.yaml
```

## Breaking changes

- [ ] Yes
- [x] No

The list endpoint response gains new optional fields (`total_count`, `limit`, `offset`) and the non-paginated path continues to behave as before. Existing `scope_kind` enum values are unchanged; new values are additive.

## Related issues

## Security considerations

The new `user_id` scoping field allows pricing overrides to be applied per user. Ensure that `user_id` values are validated against authenticated session context server-side and are not accepted from untrusted input without authorization checks.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable