### PR TITLE
docs: add user scopes, fast-mode costs, OCR fields, and pagination to custom pricing docs

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -47593,15 +47593,15 @@
             "in": "query",
             "description": "Filter by scope kind",
             "schema": {
-              "type": "string",
-              "enum": [
-                "global",
-                "provider",
-                "provider_key",
-                "virtual_key",
-                "virtual_key_provider",
-                "virtual_key_provider_key"
-              ]
+              "$ref": "#/components/schemas/PricingOverrideScopeKind"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "description": "Filter by user ID (for user* scopes)",
+            "schema": {
+              "type": "string"
             }
           },
           {
@@ -47626,6 +47626,32 @@
             "description": "Filter by provider key ID",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Case-insensitive substring match against the pricing override name. A non-empty value switches the response to the paginated shape.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return. A non-empty `limit`, `offset`, or `search` value switches the response to the paginated shape.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Number of results to skip",
+            "schema": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         ],
@@ -83438,6 +83464,21 @@
           }
         }
       },
+      "PricingOverrideScopeKind": {
+        "type": "string",
+        "description": "Scope that determines which requests a pricing override applies to. The virtual_key* family is checked before the user* family during cost resolution, which is checked before the provider/global scopes; within a family, more identifiers present means a more specific match.\n",
+        "enum": [
+          "global",
+          "provider",
+          "provider_key",
+          "virtual_key",
+          "virtual_key_provider",
+          "virtual_key_provider_key",
+          "user",
+          "user_provider",
+          "user_provider_key"
+        ]
+      },
       "PricingOverrideRequestType": {
         "type": "string",
         "description": "Request type for pricing override filtering. Stream variants are treated identically to their base type - specifying `chat_completion` covers both streaming and non-streaming chat requests.\n",
@@ -83484,11 +83525,41 @@
             "type": "number",
             "minimum": 0
           },
+          "input_cost_per_token_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering."
+          },
+          "output_cost_per_token_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering."
+          },
           "input_cost_per_character": {
             "type": "number",
             "minimum": 0
           },
           "input_cost_per_token_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_image_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_video_per_second_above_128k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_audio_per_second_above_128k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83500,7 +83571,39 @@
             "type": "number",
             "minimum": 0
           },
+          "input_cost_per_token_above_200k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
           "output_cost_per_token_above_200k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_200k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "input_cost_per_token_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_token_flex_above_272k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83520,11 +83623,15 @@
             "type": "number",
             "minimum": 0
           },
-          "cache_read_input_token_cost_priority": {
+          "cache_read_input_token_cost_above_200k_tokens_priority": {
             "type": "number",
             "minimum": 0
           },
-          "cache_read_input_image_token_cost": {
+          "cache_creation_input_token_cost_above_1hr": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_above_1hr_above_200k_tokens": {
             "type": "number",
             "minimum": 0
           },
@@ -83532,11 +83639,62 @@
             "type": "number",
             "minimum": 0
           },
-          "input_cost_per_image": {
+          "cache_read_input_token_cost_priority": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image": {
+          "cache_read_input_token_cost_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_image_token_cost": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_above_272k_tokens_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_read_input_token_cost_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_flex": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_flex_above_272k_tokens": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_priority": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cache_creation_input_token_cost_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "cache_creation_input_token_cost_above_1hr_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "cache_read_input_token_cost_fast": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Fast mode (Anthropic) cache rate - flat across the full context window, no tiering."
+          },
+          "input_cost_per_image": {
             "type": "number",
             "minimum": 0
           },
@@ -83544,15 +83702,39 @@
             "type": "number",
             "minimum": 0
           },
+          "output_cost_per_image": {
+            "type": "number",
+            "minimum": 0
+          },
           "output_cost_per_pixel": {
             "type": "number",
             "minimum": 0
           },
-          "input_cost_per_image_token": {
+          "output_cost_per_image_premium_image": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_token": {
+          "output_cost_per_image_above_512_and_512_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_512_and_512_pixels_and_premium_image": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_2048_and_2048_pixels": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_image_above_4096_and_4096_pixels": {
             "type": "number",
             "minimum": 0
           },
@@ -83572,31 +83754,15 @@
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_premium_image": {
+          "input_cost_per_image_token": {
             "type": "number",
             "minimum": 0
           },
-          "output_cost_per_image_above_512_and_512_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_1024_and_1024_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_2048_and_2048_pixels": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_image_above_4096_and_4096_pixels": {
+          "output_cost_per_image_token": {
             "type": "number",
             "minimum": 0
           },
           "input_cost_per_audio_token": {
-            "type": "number",
-            "minimum": 0
-          },
-          "output_cost_per_audio_token": {
             "type": "number",
             "minimum": 0
           },
@@ -83609,6 +83775,10 @@
             "minimum": 0
           },
           "input_cost_per_video_per_second": {
+            "type": "number",
+            "minimum": 0
+          },
+          "output_cost_per_audio_token": {
             "type": "number",
             "minimum": 0
           },
@@ -83627,6 +83797,19 @@
           "code_interpreter_cost_per_session": {
             "type": "number",
             "minimum": 0
+          },
+          "inference_geo_us_multiplier": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Anthropic data-residency multiplier applied when usage.inference_geo == \"us\"."
+          },
+          "ocr_cost_per_page": {
+            "type": "number",
+            "minimum": 0
+          },
+          "annotation_cost_per_page": {
+            "type": "number",
+            "minimum": 0
           }
         }
       },
@@ -83643,16 +83826,14 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
-            "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
+            "type": [
+              "string",
+              "null"
             ],
-            "description": "Scope that determines which requests this override applies to"
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": [
@@ -83666,14 +83847,14 @@
               "string",
               "null"
             ],
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": [
               "string",
               "null"
             ],
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83736,15 +83917,11 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
             "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
-            ]
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": "string",
@@ -83752,11 +83929,11 @@
           },
           "provider_id": {
             "type": "string",
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": "string",
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83791,15 +83968,11 @@
             "description": "Human-readable label"
           },
           "scope_kind": {
+            "$ref": "#/components/schemas/PricingOverrideScopeKind"
+          },
+          "user_id": {
             "type": "string",
-            "enum": [
-              "global",
-              "provider",
-              "provider_key",
-              "virtual_key",
-              "virtual_key_provider",
-              "virtual_key_provider_key"
-            ]
+            "description": "Required for user* scopes"
           },
           "virtual_key_id": {
             "type": "string",
@@ -83807,11 +83980,11 @@
           },
           "provider_id": {
             "type": "string",
-            "description": "Required for provider and virtual_key_provider scopes"
+            "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
             "type": "string",
-            "description": "Required for provider_key and virtual_key_provider_key scopes"
+            "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
@@ -83850,6 +84023,7 @@
       },
       "ListPricingOverridesResponse": {
         "type": "object",
+        "description": "When `limit`, `offset`, or `search` is supplied, `count` reflects the returned page while `total_count` reflects the full matching set. Otherwise (backward-compatible, non-paginated path) `total_count` equals `count` and `limit`/`offset` describe the full unpaged result.\n",
         "properties": {
           "pricing_overrides": {
             "type": "array",
@@ -83859,7 +84033,19 @@
           },
           "count": {
             "type": "integer",
-            "description": "Total number of overrides returned"
+            "description": "Number of overrides in this response"
+          },
+          "total_count": {
+            "type": "integer",
+            "description": "Total number of overrides matching the filters"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Page size used for this response"
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset used for this response"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1612,6 +1612,8 @@ components:
       $ref: './schemas/management/governance.yaml#/UpdateProviderGovernanceRequest'
 
     # Governance - Pricing Overrides
+    PricingOverrideScopeKind:
+      $ref: './schemas/management/governance.yaml#/PricingOverrideScopeKind'
     PricingOverrideRequestType:
       $ref: './schemas/management/governance.yaml#/PricingOverrideRequestType'
     PricingPatch:

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -1109,14 +1109,12 @@ pricing-overrides:
         in: query
         description: Filter by scope kind
         schema:
+          $ref: '../../schemas/management/governance.yaml#/PricingOverrideScopeKind'
+      - name: user_id
+        in: query
+        description: Filter by user ID (for user* scopes)
+        schema:
           type: string
-          enum:
-            - global
-            - provider
-            - provider_key
-            - virtual_key
-            - virtual_key_provider
-            - virtual_key_provider_key
       - name: virtual_key_id
         in: query
         description: Filter by virtual key ID (for virtual_key* scopes)
@@ -1132,6 +1130,23 @@ pricing-overrides:
         description: Filter by provider key ID
         schema:
           type: string
+      - name: search
+        in: query
+        description: Case-insensitive substring match against the pricing override name. A non-empty value switches the response to the paginated shape.
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Maximum number of results to return. A non-empty `limit`, `offset`, or `search` value switches the response to the paginated shape.
+        schema:
+          type: integer
+          minimum: 0
+      - name: offset
+        in: query
+        description: Number of results to skip
+        schema:
+          type: integer
+          minimum: 0
     security:
       - ManagementBearerAuth: []
     responses:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -1477,6 +1477,24 @@ UpdateProviderGovernanceRequest:
 
 # Pricing Overrides
 
+PricingOverrideScopeKind:
+  type: string
+  description: >
+    Scope that determines which requests a pricing override applies to. The
+    virtual_key* family is checked before the user* family during cost
+    resolution, which is checked before the provider/global scopes; within a
+    family, more identifiers present means a more specific match.
+  enum:
+    - global
+    - provider
+    - provider_key
+    - virtual_key
+    - virtual_key_provider
+    - virtual_key_provider_key
+    - user
+    - user_provider
+    - user_provider_key
+
 PricingOverrideRequestType:
   type: string
   description: >
@@ -1503,6 +1521,7 @@ PricingPatch:
     Pricing fields to override. Only non-zero/non-null fields are applied.
     All values are cost per unit in USD.
   properties:
+    # Costs - Text
     input_cost_per_token:
       type: number
       minimum: 0
@@ -1521,21 +1540,72 @@ PricingPatch:
     output_cost_per_token_priority:
       type: number
       minimum: 0
+    input_cost_per_token_flex:
+      type: number
+      minimum: 0
+    output_cost_per_token_flex:
+      type: number
+      minimum: 0
+    input_cost_per_token_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering.
+    output_cost_per_token_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic research preview). Flat rate across the full context window - no 128k/200k/272k tiering.
     input_cost_per_character:
       type: number
       minimum: 0
+    # Costs - 128k Tier
     input_cost_per_token_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_image_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_video_per_second_above_128k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_audio_per_second_above_128k_tokens:
       type: number
       minimum: 0
     output_cost_per_token_above_128k_tokens:
       type: number
       minimum: 0
+    # Costs - 200k Tier
     input_cost_per_token_above_200k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_token_above_200k_tokens_priority:
       type: number
       minimum: 0
     output_cost_per_token_above_200k_tokens:
       type: number
       minimum: 0
+    output_cost_per_token_above_200k_tokens_priority:
+      type: number
+      minimum: 0
+    # Costs - 272k Tier
+    input_cost_per_token_above_272k_tokens:
+      type: number
+      minimum: 0
+    input_cost_per_token_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    input_cost_per_token_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    output_cost_per_token_above_272k_tokens:
+      type: number
+      minimum: 0
+    output_cost_per_token_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    output_cost_per_token_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    # Costs - Cache
     cache_creation_input_token_cost:
       type: number
       minimum: 0
@@ -1548,31 +1618,92 @@ PricingPatch:
     cache_read_input_token_cost_above_200k_tokens:
       type: number
       minimum: 0
-    cache_read_input_token_cost_priority:
+    cache_read_input_token_cost_above_200k_tokens_priority:
       type: number
       minimum: 0
-    cache_read_input_image_token_cost:
+    cache_creation_input_token_cost_above_1hr:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_above_1hr_above_200k_tokens:
       type: number
       minimum: 0
     cache_creation_input_audio_token_cost:
       type: number
       minimum: 0
-    input_cost_per_image:
+    cache_read_input_token_cost_priority:
       type: number
       minimum: 0
-    output_cost_per_image:
+    cache_read_input_token_cost_flex:
+      type: number
+      minimum: 0
+    cache_read_input_image_token_cost:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_above_272k_tokens_priority:
+      type: number
+      minimum: 0
+    cache_read_input_token_cost_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_flex:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_flex_above_272k_tokens:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_priority:
+      type: number
+      minimum: 0
+    cache_creation_input_token_cost_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    cache_creation_input_token_cost_above_1hr_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    cache_read_input_token_cost_fast:
+      type: number
+      minimum: 0
+      description: Fast mode (Anthropic) cache rate - flat across the full context window, no tiering.
+    # Costs - Image
+    input_cost_per_image:
       type: number
       minimum: 0
     input_cost_per_pixel:
       type: number
       minimum: 0
+    output_cost_per_image:
+      type: number
+      minimum: 0
     output_cost_per_pixel:
       type: number
       minimum: 0
-    input_cost_per_image_token:
+    output_cost_per_image_premium_image:
       type: number
       minimum: 0
-    output_cost_per_image_token:
+    output_cost_per_image_above_512_and_512_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_512_and_512_pixels_and_premium_image:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_1024_and_1024_pixels_and_premium_image:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_2048_and_2048_pixels:
+      type: number
+      minimum: 0
+    output_cost_per_image_above_4096_and_4096_pixels:
       type: number
       minimum: 0
     output_cost_per_image_low_quality:
@@ -1587,25 +1718,14 @@ PricingPatch:
     output_cost_per_image_auto_quality:
       type: number
       minimum: 0
-    output_cost_per_image_premium_image:
+    input_cost_per_image_token:
       type: number
       minimum: 0
-    output_cost_per_image_above_512_and_512_pixels:
+    output_cost_per_image_token:
       type: number
       minimum: 0
-    output_cost_per_image_above_1024_and_1024_pixels:
-      type: number
-      minimum: 0
-    output_cost_per_image_above_2048_and_2048_pixels:
-      type: number
-      minimum: 0
-    output_cost_per_image_above_4096_and_4096_pixels:
-      type: number
-      minimum: 0
+    # Costs - Audio/Video
     input_cost_per_audio_token:
-      type: number
-      minimum: 0
-    output_cost_per_audio_token:
       type: number
       minimum: 0
     input_cost_per_audio_per_second:
@@ -1617,16 +1737,31 @@ PricingPatch:
     input_cost_per_video_per_second:
       type: number
       minimum: 0
+    output_cost_per_audio_token:
+      type: number
+      minimum: 0
     output_cost_per_video_per_second:
       type: number
       minimum: 0
     output_cost_per_second:
       type: number
       minimum: 0
+    # Costs - Other
     search_context_cost_per_query:
       type: number
       minimum: 0
     code_interpreter_cost_per_session:
+      type: number
+      minimum: 0
+    inference_geo_us_multiplier:
+      type: number
+      minimum: 0
+      description: Anthropic data-residency multiplier applied when usage.inference_geo == "us".
+    # Costs - OCR
+    ocr_cost_per_page:
+      type: number
+      minimum: 0
+    annotation_cost_per_page:
       type: number
       minimum: 0
 
@@ -1641,24 +1776,19 @@ PricingOverride:
       type: string
       description: Human-readable label
     scope_kind:
-      type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
-      description: Scope that determines which requests this override applies to
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
+      type: [string, 'null']
+      description: Required for user* scopes
     virtual_key_id:
       type: [string, 'null']
       description: Required for virtual_key* scopes
     provider_id:
       type: [string, 'null']
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: [string, 'null']
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1704,23 +1834,19 @@ CreatePricingOverrideRequest:
       type: string
       description: Human-readable label
     scope_kind:
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
       type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
+      description: Required for user* scopes
     virtual_key_id:
       type: string
       description: Required for virtual_key* scopes
     provider_id:
       type: string
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: string
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1749,23 +1875,19 @@ UpdatePricingOverrideRequest:
       type: string
       description: Human-readable label
     scope_kind:
+      $ref: '#/PricingOverrideScopeKind'
+    user_id:
       type: string
-      enum:
-        - global
-        - provider
-        - provider_key
-        - virtual_key
-        - virtual_key_provider
-        - virtual_key_provider_key
+      description: Required for user* scopes
     virtual_key_id:
       type: string
       description: Required for virtual_key* scopes
     provider_id:
       type: string
-      description: Required for provider and virtual_key_provider scopes
+      description: Required for provider, virtual_key_provider, and user_provider scopes
     provider_key_id:
       type: string
-      description: Required for provider_key and virtual_key_provider_key scopes
+      description: Required for provider_key, virtual_key_provider_key, and user_provider_key scopes
     match_type:
       type: string
       enum:
@@ -1793,6 +1915,11 @@ PricingOverrideResponse:
 
 ListPricingOverridesResponse:
   type: object
+  description: >
+    When `limit`, `offset`, or `search` is supplied, `count` reflects the
+    returned page while `total_count` reflects the full matching set.
+    Otherwise (backward-compatible, non-paginated path) `total_count` equals
+    `count` and `limit`/`offset` describe the full unpaged result.
   properties:
     pricing_overrides:
       type: array
@@ -1800,7 +1927,16 @@ ListPricingOverridesResponse:
         $ref: '#/PricingOverride'
     count:
       type: integer
-      description: Total number of overrides returned
+      description: Number of overrides in this response
+    total_count:
+      type: integer
+      description: Total number of overrides matching the filters
+    limit:
+      type: integer
+      description: Page size used for this response
+    offset:
+      type: integer
+      description: Offset used for this response
 
 # Complexity Tier Boundaries
 

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -9,7 +9,7 @@ icon: "circle-dollar-to-slot"
 Bifrost computes request costs using a built-in pricing catalog that is automatically synced from a remote datasheet. **Custom Pricing** lets you override those catalog prices at runtime without redeploying, applying your own rates for any model across any combination of provider, key, and virtual key scopes.
 
 **Key capabilities:**
-- **Scoped overrides** - apply prices globally or narrow them to a specific provider, provider key, or virtual key
+- **Scoped overrides** - apply prices globally or narrow them to a specific provider, provider key, virtual key, or user
 - **Pattern matching** - target an exact model name or a wildcard prefix (e.g. `gpt-4*`)
 - **Request type filtering** - restrict an override to one or more specific operations (chat, embeddings, image generation, etc.); at least one request type is required
 - **Hierarchical resolution** - the most-specific matching override always wins; broader scopes act as fallbacks
@@ -63,12 +63,15 @@ Before configuring overrides, Bifrost needs a pricing catalog to work from. By d
 
 ## Scope hierarchy
 
-Every override is assigned a **scope kind** that determines which requests it applies to. When Bifrost resolves pricing for a request, it evaluates all matching overrides and selects the one with the most specific scope. More specific scopes always win over broader ones.
+Every override is assigned a **scope kind** that determines which requests it applies to. When Bifrost resolves pricing for a request, it evaluates all matching overrides and selects the one with the most specific scope. More specific scopes always win over broader ones. The virtual-key family is checked before the user family, which is checked before the provider/global scopes; within a family, more identifiers present means a more specific match.
 
 ```
 virtual_key_provider_key  (most specific)
 virtual_key_provider
 virtual_key
+user_provider_key
+user_provider
+user
 provider_key
 provider
 global                    (least specific / catch-all)
@@ -78,9 +81,12 @@ global                    (least specific / catch-all)
 
 | Scope kind | Required | Description |
 |------------|----------|-------------|
-| `global` | - | Applies to every request regardless of provider, key, or virtual key |
+| `global` | - | Applies to every request regardless of provider, key, virtual key, or user |
 | `provider` | `provider_id` | Applies to all keys under a specific provider |
 | `provider_key` | `provider_key_id` | Applies to a specific provider API key only |
+| `user` | `user_id` | Applies to all requests made by a specific user |
+| `user_provider` | `user_id` + `provider_id` | Applies when a user's request routes to a specific provider |
+| `user_provider_key` | `user_id` + `provider_key_id` | Applies when a user's request resolves to a specific provider API key |
 | `virtual_key` | `virtual_key_id` | Applies to all requests made under a virtual key |
 | `virtual_key_provider` | `virtual_key_id` + `provider_id` | Applies when a virtual key routes to a specific provider |
 | `virtual_key_provider_key` | `virtual_key_id` + `provider_key_id` | Most specific: virtual key + exact provider API key |
@@ -202,8 +208,11 @@ curl -X POST http://localhost:8080/api/governance/pricing-overrides \
 ```
 
 **Update (sparse patch):**
+
+Omitted fields are merged from the existing record. When `scope_kind` is supplied, all scope identifiers are reset first and only explicitly supplied identifiers are retained. The `patch` field is always replaced in full when provided.
+
 ```bash
-curl -X PATCH http://localhost:8080/api/governance/pricing-overrides/{id} \
+curl -X PUT http://localhost:8080/api/governance/pricing-overrides/{id} \
   -H "Content-Type: application/json" \
   -d '{
     "patch": {
@@ -224,7 +233,13 @@ curl http://localhost:8080/api/governance/pricing-overrides
 
 # Filter by scope
 curl "http://localhost:8080/api/governance/pricing-overrides?scope_kind=virtual_key&virtual_key_id=vk-abc123"
+
+# Paginated, with search - supplying limit, offset, or search switches the
+# response to the paginated shape (adds total_count, limit, offset)
+curl "http://localhost:8080/api/governance/pricing-overrides?search=gpt-4o&limit=20&offset=0"
 ```
+
+Supported query filters: `scope_kind`, `user_id`, `virtual_key_id`, `provider_id`, `provider_key_id`, `search`, `limit`, `offset`.
 
 </Tab>
 <Tab title="config.json">
@@ -263,10 +278,11 @@ Pricing overrides are defined under `governance.pricing_overrides`. Each entry r
 |-------|------|----------|-------------|
 | `id` | string | Yes | Unique override ID (UUID recommended) |
 | `name` | string | Yes | Human-readable label |
-| `scope_kind` | string | Yes | One of: `global`, `provider`, `provider_key`, `virtual_key`, `virtual_key_provider`, `virtual_key_provider_key` |
+| `scope_kind` | string | Yes | One of: `global`, `provider`, `provider_key`, `user`, `user_provider`, `user_provider_key`, `virtual_key`, `virtual_key_provider`, `virtual_key_provider_key` |
+| `user_id` | string | Conditional | Required for `user*` scopes |
 | `virtual_key_id` | string | Conditional | Required for `virtual_key*` scopes |
-| `provider_id` | string | Conditional | Required for `provider` and `virtual_key_provider` scopes |
-| `provider_key_id` | string | Conditional | Required for `provider_key` and `virtual_key_provider_key` scopes |
+| `provider_id` | string | Conditional | Required for `provider`, `virtual_key_provider`, and `user_provider` scopes |
+| `provider_key_id` | string | Conditional | Required for `provider_key`, `virtual_key_provider_key`, and `user_provider_key` scopes |
 | `match_type` | string | Yes | `exact` or `wildcard` |
 | `pattern` | string | Yes | Model name or wildcard prefix ending with `*` |
 | `request_types` | array | Yes | Request types this override applies to. At least one value required. |
@@ -280,7 +296,7 @@ Pricing overrides are defined under `governance.pricing_overrides`. Each entry r
 
 ## Pricing fields reference
 
-Only fields with non-zero values are applied. All values are cost **per unit** in USD.
+Only fields with non-zero values are applied. Cost fields are per unit in USD; multiplier fields are dimensionless.
 
 ### Token costs
 
@@ -294,6 +310,8 @@ Only fields with non-zero values are applied. All values are cost **per unit** i
 | `output_cost_per_token_priority` | Output token cost for priority requests |
 | `input_cost_per_token_flex` | Input token cost for flex requests |
 | `output_cost_per_token_flex` | Output token cost for flex requests |
+| `input_cost_per_token_fast` | Input token cost for fast-mode requests (flat across the full context window - no tiering) |
+| `output_cost_per_token_fast` | Output token cost for fast-mode requests (flat across the full context window - no tiering) |
 | `input_cost_per_character` | Input cost per character (character-billed models) |
 
 ### Token tier costs
@@ -308,8 +326,11 @@ Only fields with non-zero values are applied. All values are cost **per unit** i
 | `output_cost_per_token_above_200k_tokens_priority` | Output cost above 200k context for priority requests |
 | `input_cost_per_token_above_272k_tokens` | Input cost above 272k context |
 | `input_cost_per_token_above_272k_tokens_priority` | Input cost above 272k context for priority requests |
+| `input_cost_per_token_flex_above_272k_tokens` | Input cost above 272k context for flex requests |
 | `output_cost_per_token_above_272k_tokens` | Output cost above 272k context |
 | `output_cost_per_token_above_272k_tokens_priority` | Output cost above 272k context for priority requests |
+| `output_cost_per_token_flex_above_272k_tokens` | Output cost above 272k context for flex requests |
+| `input_cost_per_image_above_128k_tokens` | Input cost per image above 128k context |
 
 ### Cache costs
 
@@ -324,8 +345,18 @@ Only fields with non-zero values are applied. All values are cost **per unit** i
 | `cache_read_input_token_cost_flex` | Flex cache read cost |
 | `cache_read_input_token_cost_above_272k_tokens` | Cache read above 272k context |
 | `cache_read_input_token_cost_above_272k_tokens_priority` | Cache read above 272k context for priority requests |
+| `cache_read_input_token_cost_flex_above_272k_tokens` | Cache read above 272k context for flex requests |
 | `cache_read_input_image_token_cost` | Cache read cost for image tokens |
 | `cache_creation_input_audio_token_cost` | Cache creation cost for audio tokens |
+| `cache_creation_input_token_cost_above_1hr` | Cache creation cost for 1hr+ TTL entries |
+| `cache_creation_input_token_cost_above_1hr_above_200k_tokens` | Cache creation cost for 1hr+ TTL entries above 200k context |
+| `cache_creation_input_token_cost_above_272k_tokens` | Cache creation above 272k context |
+| `cache_creation_input_token_cost_flex` | Flex cache creation cost |
+| `cache_creation_input_token_cost_flex_above_272k_tokens` | Cache creation above 272k context for flex requests |
+| `cache_creation_input_token_cost_priority` | Priority cache creation cost |
+| `cache_creation_input_token_cost_fast` | Cache creation cost for fast-mode requests (flat across the full context window - no tiering) |
+| `cache_creation_input_token_cost_above_1hr_fast` | Cache creation cost for fast-mode requests with 1hr+ TTL entries |
+| `cache_read_input_token_cost_fast` | Cache read cost for fast-mode requests (flat across the full context window - no tiering) |
 
 ### Image costs
 
@@ -341,10 +372,13 @@ Only fields with non-zero values are applied. All values are cost **per unit** i
 | `output_cost_per_image_medium_quality` | Generated image - medium quality |
 | `output_cost_per_image_high_quality` | Generated image - high quality |
 | `output_cost_per_image_auto_quality` | Generated image - auto quality |
-| `output_cost_per_image_above_512_and_512_pixels` | Generated image > 512×512 |
-| `output_cost_per_image_above_1024_and_1024_pixels` | Generated image > 1024×1024 |
-| `output_cost_per_image_above_2048_and_2048_pixels` | Generated image > 2048×2048 |
-| `output_cost_per_image_above_4096_and_4096_pixels` | Generated image > 4096×4096 |
+| `output_cost_per_image_above_512_and_512_pixels` | Generated image at or above 512×512 |
+| `output_cost_per_image_above_1024_and_1024_pixels` | Generated image at or above 1024×1024 |
+| `output_cost_per_image_above_2048_and_2048_pixels` | Generated image at or above 2048×2048 |
+| `output_cost_per_image_above_4096_and_4096_pixels` | Generated image at or above 4096×4096 |
+| `output_cost_per_image_premium_image` | Generated image - premium image |
+| `output_cost_per_image_above_512_and_512_pixels_and_premium_image` | Generated image at or above 512×512, premium image |
+| `output_cost_per_image_above_1024_and_1024_pixels_and_premium_image` | Generated image at or above 1024×1024, premium image |
 
 ### Audio and video costs
 
@@ -366,6 +400,14 @@ Only fields with non-zero values are applied. All values are cost **per unit** i
 |-------|-------------|
 | `search_context_cost_per_query` | Cost per web search context query |
 | `code_interpreter_cost_per_session` | Cost per code interpreter session |
+| `inference_geo_us_multiplier` | Data-residency cost multiplier applied when a request is served from a US inference region |
+
+### OCR costs
+
+| Field | Description |
+|-------|-------------|
+| `ocr_cost_per_page` | Cost per page processed by OCR |
+| `annotation_cost_per_page` | Cost per annotated page |
 
 ---
 


### PR DESCRIPTION
## Summary

Expands the custom pricing documentation to cover new user-scoped overrides, additional pricing fields (fast-mode, OCR, premium images, extended cache creation/read tiers), and updated API behavior including paginated list responses and a corrected `PUT` verb for updates.

## Changes

- Added three new scope kinds — `user`, `user_provider`, and `user_provider_key` — to the scope hierarchy, table, and field reference, positioned between the virtual-key family and the provider/global scopes
- Clarified scope resolution order: virtual-key family is checked before user family, which is checked before provider/global scopes
- Updated the `scope_kind` enum in the config field reference to include all `user*` variants and added the `user_id` conditional field
- Corrected the update endpoint verb from `PATCH` to `PUT` and added a note that omitted fields are merged from the existing record
- Added pagination support to the list endpoint (`limit`, `offset`, `search` query params) with documentation of the paginated response shape and all supported query filters
- Added new pricing patch fields: `input_cost_per_token_fast`, `output_cost_per_token_fast`, and their cache counterparts (`cache_creation_input_token_cost_fast`, `cache_read_input_token_cost_fast`, `cache_creation_input_token_cost_above_1hr_fast`)
- Added extended cache creation/read tier fields for flex and 272k+ context windows, 1hr+ TTL entries, and 200k+ context with 1hr+ TTL
- Added premium image output cost fields and per-resolution premium image variants
- Added `input_cost_per_image_above_128k_tokens` for image input above 128k context
- Added `inference_geo_us_multiplier` for data-residency cost multipliers
- Added a new OCR costs section covering `ocr_cost_per_page` and `annotation_cost_per_page`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:
- The scope hierarchy diagram and table include all three `user*` scope kinds in the correct position
- The update example uses `PUT` and includes the merge-patch note
- The list example shows the paginated query and documents all supported filters
- All new pricing fields appear in their respective sections with accurate descriptions

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. This is a documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable