### PR TITLE
feat: add `is_access_profile_managed` server-computed flag to VK for RBAC-independent managed-key UI

### DIFF
--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -238,6 +238,12 @@ type TableVirtualKey struct {
 	RateLimit *TableRateLimit `gorm:"foreignKey:RateLimitID;onDelete:CASCADE" json:"rate_limit,omitempty"`
 	Budgets   []TableBudget   `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"budgets,omitempty"` // Multiple budgets with different reset intervals
 
+	// IsAccessProfileManaged is a read-only, computed flag (never persisted): true when
+	// the VK is governed by an access profile, so the UI can lock edits and show the
+	// managed-key notice without a separate, differently-gated access-profile lookup.
+	// Populated on the governance read paths from the external resolver; false in OSS.
+	IsAccessProfileManaged bool `gorm:"-" json:"is_access_profile_managed,omitempty"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -118,6 +118,10 @@ type ExternalQuotaBudgetResult struct {
 	// RateLimit, when non-nil, replaces the VK's own rate-limit row (enterprise:
 	// the access-profile rate limit that carries the real usage for an AP-managed VK).
 	RateLimit *configstoreTables.TableRateLimit
+	// Managed reports that the VK is access-profile-managed. Set independently of
+	// Budgets/RateLimit so the flag reaches the response even when the profile has
+	// neither — it drives the managed-key UI (lock + notice).
+	Managed bool
 	// UsageUserID, when non-empty, scopes the per_model_usage query to this user id
 	// instead of the VK id.
 	UsageUserID string
@@ -949,6 +953,7 @@ func (h *GovernanceHandler) applyExternalBudgets(ctx context.Context, vk *config
 	// AP's governance verbatim. An empty budget slice or nil rate limit means the AP has
 	// none — we must NOT fall back to the misleading VK rows. This mirrors the UI's
 	// managing-profile branch and getVirtualKeyQuota, so all read paths agree.
+	vk.IsAccessProfileManaged = ext.Managed
 	vk.Budgets = ext.Budgets
 	vk.RateLimit = ext.RateLimit
 }

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1757,6 +1757,7 @@ func TestGetVirtualKeyQuota_ExternalResolverReplacesWithAccessProfileBudgets(t *
 				Budgets: []configstoreTables.TableBudget{
 					{ID: "b-ap", MaxLimit: 500, CurrentUsage: 42, ResetDuration: "1d", LastReset: cycleStart},
 				},
+				Managed:     true,
 				UsageUserID: "user-1",
 			}, nil
 		},
@@ -1838,6 +1839,7 @@ func TestGetVirtualKeyQuota_ExternalResolverRateLimitOnly(t *testing.T) {
 			// AP-managed VK whose profile carries a rate limit but no budget.
 			return &ExternalQuotaBudgetResult{
 				RateLimit:   &configstoreTables.TableRateLimit{ID: "ap-rl", TokenMaxLimit: &tokMax, TokenCurrentUsage: 250},
+				Managed:     true,
 				UsageUserID: "user-1",
 			}, nil
 		},
@@ -1877,6 +1879,7 @@ func TestApplyExternalBudgets_RateLimitOnlyDropsNativeBudgets(t *testing.T) {
 		externalQuotaBudgetResolver: func(_ context.Context, _ *configstoreTables.TableVirtualKey) (*ExternalQuotaBudgetResult, error) {
 			return &ExternalQuotaBudgetResult{
 				RateLimit: &configstoreTables.TableRateLimit{ID: "ap-rl"},
+				Managed:   true,
 			}, nil
 		},
 	}
@@ -1895,6 +1898,40 @@ func TestApplyExternalBudgets_RateLimitOnlyDropsNativeBudgets(t *testing.T) {
 	}
 	if vk.RateLimit == nil || vk.RateLimit.ID != "ap-rl" {
 		t.Fatalf("expected the AP rate limit ap-rl to replace the native rl-vk-mirror, got %#v", vk.RateLimit)
+	}
+	if !vk.IsAccessProfileManaged {
+		t.Fatalf("expected IsAccessProfileManaged=true for an AP-managed VK")
+	}
+}
+
+// TestApplyExternalBudgets_ManagedWithNoGovernanceFlagsAndClears verifies that a VK the
+// resolver reports as managed but whose profile has NO budget and NO rate limit is still
+// flagged managed (so the UI locks edits / shows the notice) and has its untracked mirror
+// budget and rate-limit rows cleared rather than shown.
+func TestApplyExternalBudgets_ManagedWithNoGovernanceFlagsAndClears(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{
+		externalQuotaBudgetResolver: func(_ context.Context, _ *configstoreTables.TableVirtualKey) (*ExternalQuotaBudgetResult, error) {
+			return &ExternalQuotaBudgetResult{Managed: true}, nil
+		},
+	}
+	vk := &configstoreTables.TableVirtualKey{
+		ID:        "vk-1",
+		Budgets:   []configstoreTables.TableBudget{{ID: "b-vk-mirror", MaxLimit: 100, CurrentUsage: 0}},
+		RateLimit: &configstoreTables.TableRateLimit{ID: "rl-vk-mirror"},
+	}
+
+	h.applyExternalBudgets(context.Background(), vk)
+
+	if !vk.IsAccessProfileManaged {
+		t.Fatalf("expected IsAccessProfileManaged=true")
+	}
+	if len(vk.Budgets) != 0 {
+		t.Fatalf("expected mirror budgets cleared for a managed VK with no AP budget, got %#v", vk.Budgets)
+	}
+	if vk.RateLimit != nil {
+		t.Fatalf("expected mirror rate limit cleared for a managed VK with no AP rate limit, got %#v", vk.RateLimit)
 	}
 }
 

--- a/ui/app/_fallbacks/enterprise/components/access-profiles/managedVirtualKeyNotice.tsx
+++ b/ui/app/_fallbacks/enterprise/components/access-profiles/managedVirtualKeyNotice.tsx
@@ -1,6 +1,7 @@
 import type { UserAccessProfile } from "@enterprise/lib/types/accessProfile";
 
 interface ManagedVirtualKeyNoticeProps {
+	isManagedByProfile: boolean;
 	managingProfile?: UserAccessProfile;
 }
 

--- a/ui/app/workspace/virtual-keys/hooks/useVirtualKeyUsage.ts
+++ b/ui/app/workspace/virtual-keys/hooks/useVirtualKeyUsage.ts
@@ -39,7 +39,11 @@ export function useVirtualKeyUsage(vk: VirtualKey | null | undefined): {
 	// Only treat the VK as AP-managed when an AP explicitly lists this VK in its virtual_key_ids.
 	// No fallback to "first active" / "first AP" — that misattributed budgets in multi-AP setups.
 	const managingProfile = vk ? userAPs.find((p) => p.virtual_key_ids?.includes(vk.id)) : undefined;
-	const isManagedByProfile = managingProfile !== undefined;
+	// The server-computed flag is the source of truth for "is this managed" — it does not
+	// depend on the RBAC-gated access-profile call. managingProfile still resolves the profile
+	// name/actions when the caller can view access profiles; without that permission the VK is
+	// still known to be managed (lock + notice), just without the profile name.
+	const isManagedByProfile = (vk?.is_access_profile_managed ?? false) || managingProfile !== undefined;
 
 	const displayBudgets: Budget[] | undefined = managingProfile
 		? (managingProfile.budgets ?? []).map((line) => ({

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -139,7 +139,7 @@ export default function VirtualKeyDetailSheet({
 				</SheetHeader>
 
 				<div className="space-y-6 px-8 py-4">
-					<ManagedVirtualKeyNotice managingProfile={managingProfile} />
+					<ManagedVirtualKeyNotice isManagedByProfile={isManagedByProfile} managingProfile={managingProfile} />
 
 					{assignedUsers.length > 0 ? (
 						<div className="space-y-1">
@@ -481,7 +481,7 @@ export default function VirtualKeyDetailSheet({
 									<span className="text-muted-foreground ml-2 text-xs font-normal">(from {managingProfile.name})</span>
 								) : null}
 							</h3>
-							{isManagedByProfile ? <ViewUserDetailsButton userId={managingProfile?.user_id} /> : null}
+							{isManagedByProfile && managingProfile?.user_id ? <ViewUserDetailsButton userId={managingProfile.user_id} /> : null}
 						</div>
 
 						{displayBudgets && displayBudgets.length > 0 ? (

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -106,6 +106,10 @@ export interface VirtualKey {
 	customer?: Customer;
 	budgets?: Budget[];
 	rate_limit?: RateLimit;
+	// Read-only, server-computed: true when the VK is governed by an access profile.
+	// Lets the UI lock edits and show the managed-key notice without the separately
+	// RBAC-gated access-profile lookup.
+	is_access_profile_managed?: boolean;
 	config_hash?: string; // Present when config is synced from config.json
 }
 


### PR DESCRIPTION
## Summary

Users without access-profile RBAC permissions were not seeing the managed-key lock and notice on virtual keys governed by an access profile. Because the managed state was derived solely from the client-side access-profile lookup (which is RBAC-gated), users lacking that permission saw the key as unmanaged and could attempt edits that should be locked.

This PR introduces a server-computed `is_access_profile_managed` flag on the `VirtualKey` response that is populated during the governance read path, independent of any access-profile permission check. The UI uses this flag as the authoritative source for "is this key managed," falling back to the existing profile lookup only for resolving the profile name and actions.

## Changes

- Added `IsAccessProfileManaged bool` to `TableVirtualKey` as a non-persisted, computed field (`gorm:"-"`) that is set by `applyExternalBudgets` from the external resolver result.
- Added a `Managed bool` field to `ExternalQuotaBudgetResult` so resolvers can signal managed status independently of whether the profile carries any budget or rate-limit rows.
- `applyExternalBudgets` now sets `vk.IsAccessProfileManaged = ext.Managed` before overwriting budgets and rate limit, ensuring the flag is present even when the profile has neither.
- Updated `useVirtualKeyUsage` so `isManagedByProfile` is `true` when either the server flag is set or the client-side profile lookup finds a match. This means users without access-profile permissions still see the lock and notice.
- Fixed a potential nil-dereference in `virtualKeyDetailsSheet` where `managingProfile.user_id` was accessed without first checking that `managingProfile` is non-nil.
- `ManagedVirtualKeyNotice` now receives `isManagedByProfile` directly so it renders correctly even when `managingProfile` is undefined.
- Added `is_access_profile_managed?: boolean` to the `VirtualKey` TypeScript interface.
- Added a new test `TestApplyExternalBudgets_ManagedWithNoGovernanceFlagsAndClears` verifying that a resolver-managed VK with no AP budget and no AP rate limit is still flagged managed and has its mirror rows cleared.
- Updated the existing `TestApplyExternalBudgets_RateLimitOnlyDropsNativeBudgets` test to assert `IsAccessProfileManaged=true`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a virtual key governed by an access profile.
2. Log in as a user who does **not** have RBAC permission to list access profiles.
3. Navigate to the virtual key detail sheet — the managed-key notice and edit lock should be visible.
4. Log in as a user who **does** have access-profile permissions and confirm the profile name still appears alongside the notice.

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/... -run TestApplyExternalBudgets

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `is_access_profile_managed` flag is read-only and never persisted (`gorm:"-"`). It is populated only on governance read paths and carries no sensitive data — it is a boolean indicator used solely to drive UI state. No auth or secret handling is affected.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable