### PR TITLE
template fixes

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -902,6 +902,11 @@
                 "minimum": 1,
                 "description": "Associated access profile ID for direct access profile assignment (mutually exclusive with team_id and customer_id)"
               },
+              "is_access_profile_managed": {
+                "type": "boolean",
+                "description": "Read-only, server-computed flag: true when the virtual key is governed by an access profile. Never persisted and ignored if set in config.json.",
+                "readOnly": true
+              },
               "rate_limit_id": {
                 "type": "string",
                 "description": "Associated rate limit ID"


### PR DESCRIPTION
## Summary

Adds a read-only `is_access_profile_managed` field to the virtual key schema to expose whether a virtual key is governed by an access profile. This field is server-computed and never persisted, providing consumers of the config schema with a clear, documented signal for access profile governance state.

## Changes

- Added `is_access_profile_managed` as a `boolean` field in the virtual key section of `config.schema.json`, marked as `readOnly: true`
- The field is intentionally non-persistent — it is ignored if present in `config.json` and is only meaningful as a server-computed value returned at runtime

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify the schema is valid and the new field appears correctly:

```sh
# Validate the JSON schema
cat transports/config.schema.json | python3 -m json.tool > /dev/null && echo "Schema is valid"
```

Confirm that setting `is_access_profile_managed` in `config.json` has no effect on persisted state, and that the field is only populated by the server at runtime.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This field exposes access profile governance state for virtual keys. It is read-only and server-computed, so there is no risk of clients manipulating access profile assignment through this field.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable