### PR TITLE
docs

### DIFF
--- a/docs/changelogs/ent-v1.5.8.mdx
+++ b/docs/changelogs/ent-v1.5.8.mdx
@@ -1,0 +1,490 @@
+---
+title: "v1.5.8"
+description: "v1.5.8 changelog - 2026-08-05"
+---
+
+<Update label="Bifrost Enterprise" description="v1.5.8">
+
+## Changelog
+
+This release adds JIT provisioning for first-time SSO users hitting inference endpoints directly, an `order` role-resolution strategy for SCIM/OIDC role mapping conflicts, and AWS ALB as a selectable Identity-Aware Proxy option in the SCIM wizard. It also fixes access-profile budget propagation gaps (calendar-aligned resets, large profiles), a soft-deleted-user reactivation inconsistency between the proxy and OAuth login paths, and isolates cluster peer-liveness tracking from bulk sync backlog.
+
+## ✨ Features
+
+- **Inference JIT Provisioning for First-Time SSO Users** - A first-time SSO user hitting an inference endpoint directly (no prior interactive login) is now JIT-provisioned from their IdP bearer JWT instead of receiving a flat 401, with claims enriched from the provider's userinfo endpoint so group/role mappings resolve the same way they would through the login flow. Resurrection of a deliberately deprovisioned identity is blocked; a user with no matching role mapping is denied with a 403.
+- **`order` Role-Resolution Strategy for SCIM/OIDC** - When a user matches multiple attribute-role mappings at once, admins can now choose `order` (first-listed mapping wins, by list position) as an alternative to the default `highestPermissionCount`. Role sync from SCIM group and attribute pushes is also unified into a single `RecomputeUserRole` path, so a role granted by one signal (e.g. a group) is no longer cleared by an unrelated push that only carries a different signal (e.g. an attribute).
+- **AWS ALB as a Selectable IAP Option** - AWS ALB is now exposed as a selectable Identity-Aware Proxy provider in the SCIM setup wizard, alongside Cloudflare Access and Generic OIDC.
+- **Configurable Outbound HTTP Buffer Sizes** - `ClientReadBufferSize` and `ClientWriteBufferSize` in the `config.json` server block now control the outbound HTTP client's fasthttp buffer sizes, for workloads that need to tune beyond the 64KB default.
+- **AP-Managed VK Quota Visibility Without Access-Profile Permission** - The managed-virtual-key notice now renders for users without access-profile view permissions, using a dedicated `isManagedByProfile` signal instead of depending on the full profile object. The underlying VK quota endpoint also now surfaces the access profile's rate limit alongside its budgets, so AP-managed keys no longer show stale or zeroed-out rate limit data.
+
+## 🌎 Open Source Features
+
+- **WebSocket Proxy Support** - Realtime and Responses WebSocket connections now route through the configured provider-level proxy (HTTP, SOCKS5, env-based) instead of always dialing direct.
+- **Configurable SCIM Buffer Sizes** - `WithFasthttpBufferSizes` on the HTTP client factory lets IdP token endpoints returning headers larger than the 4KB default work without failing SCIM/OAuth clients.
+
+## 🐞 Fixed
+
+- **Calendar-Aligned Budget Resets Not Reaching Existing Users** - Toggling `calendar_aligned` on an access profile now propagates to user copies that already exist, not just newly assigned users. Previously, existing users' budgets kept resetting on a rolling 30-day window instead of the calendar boundary, permanently, with no self-healing restart or re-save.
+- **Access-Profile Propagation Failing on Large Profiles** - Propagating changes from an access profile template to its user copies no longer fails when the profile is large.
+- **Soft-Deleted User Reactivation via Proxy/Inference JWT** - The auth-proxy and inference bearer-JWT paths now reactivate a soft-deleted user when their claims resolve to a valid role, matching the existing behavior of the interactive OAuth login flow instead of permanently blocking with a deprovisioned error.
+- **SCIM Provisioning vs. Periodic Role/Team Sync** - The periodic OIDC pull-based role/team sync now skips itself when SCIM provisioning is configured, since the IdP is already pushing changes in real time; the Okta API token field (only used by the pull sync) is hidden from the wizard in that mode.
+- **Cluster Peer Liveness Isolated from Bulk Sync Backlog** - Peer liveness pings now travel on a dedicated gRPC stream, separate from the bulk config-sync stream, so a slow or backed-up sync no longer delays or masks whether a peer is actually reachable.
+- **Role Conflict Resolution Copy** - Clarified the "order" strategy's label and hint text in the SCIM role-mapping UI.
+- **Proactive SSE Disconnect Detection** - SSE heartbeat handling now detects a client disconnect during streaming proactively instead of only when a producer loop attempts a write, fixing false-success logging on fast/bursty upstreams like Vertex.
+- **Closed Channel Panic on Stream Shutdown** - Fixed a race where a heartbeat goroutine mid-send on the event channel at shutdown could panic with "send on closed channel".
+- **Budget Pruning Crash with `config.json` Source of Truth** - Budget/config pruning now tolerates a not-found error on cascade-deleted rows, fixing a startup crash for API-created model configs absent from `config.json`.
+- **Bedrock Header Signing Denylist** - Caller headers stored for Anthropic OAuth passthrough are no longer forwarded to other providers, preventing SigV4 signature mismatches on Bedrock.
+- **Deterministic Bedrock Tool Ordering** - Fixed non-deterministic tool ordering in `toolConfig` caused by map iteration, which was breaking Bedrock prompt-cache hits.
+- **Bedrock `cache_control` Translation** - `cache_control` markers on Anthropic-format content blocks, system blocks, and tools are now correctly translated through the Bedrock invoke and Converse paths instead of being silently dropped.
+- **Bedrock Adaptive Thinking Fixes** - Reasoning/thinking `max_tokens` validation errors now return HTTP 400 instead of 500; `tool.defer_loading` is gated on its own beta header; Nova2 web search and code execution tools are handled correctly.
+- **Encrypted Reasoning Content Mismatch** - Replaying OpenAI Responses API reasoning items through the Anthropic surface no longer mints a fresh item id while forwarding the original encrypted content, which OpenAI was rejecting.
+- **Bedrock Invoke Content Retention** - Bedrock's InvokeModel route now correctly decodes Anthropic's type-discriminated image/tool_use/tool_result blocks instead of silently dropping them.
+- **Bedrock Document Message Placeholder** - Messages containing a document block without accompanying text no longer get rejected by Bedrock's Converse API.
+- **VK Provider Bulk Replace** - Virtual key provider config replacement is now a single bulk operation instead of per-provider round trips, fixing a hot-path slowdown at scale.
+
+## 🗄️ Database Migrations
+
+No new database migrations in this release, in either the OSS transports layer or the enterprise repo.
+
+## 🐙 Closed OSS Issues
+
+- [#5010](https://github.com/maximhq/bifrost/issues/5010) - Server-side SSE keepalive (comment heartbeat) to keep long-idle streams alive through intermediaries
+- [#5186](https://github.com/maximhq/bifrost/issues/5186) - Anthropic-surface replay of OpenAI encrypted reasoning mints a fresh item id, OpenAI 400s with "Encrypted content item_id did not match the target item id"
+
+## 📀 Base OSS version
+
+`transports/v1.6.8`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```go
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.5
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	cloud.google.com/go/pubsub/v2 v2.4.0
+	cloud.google.com/go/secretmanager v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.14
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.2
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.1
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/cel-go v0.29.0
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.28.2
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/hashicorp/vault/api v1.23.0
+	github.com/klauspost/compress v1.18.6
+	github.com/maximhq/bifrost/core v1.7.6
+	github.com/maximhq/bifrost/framework v1.5.6
+	github.com/maximhq/bifrost/plugins/governance v1.6.10
+	github.com/maximhq/bifrost/plugins/logging v1.6.6
+	github.com/maximhq/bifrost/plugins/prompts v1.0.33
+	github.com/maximhq/bifrost/plugins/semanticcache v1.5.33
+	github.com/maximhq/bifrost/transports v1.6.8
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.71.0
+	github.com/zricethezav/gitleaks/v8 v8.30.1
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.52.0
+	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
+	google.golang.org/api v0.282.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68
+	google.golang.org/grpc v1.82.1
+	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+
+require (
+	cel.dev/expr v0.25.1 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/storage v1.62.1 // indirect
+	dario.cat/mergo v1.0.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
+	github.com/BobuSumisu/aho-corasick v1.0.3 // indirect
+	github.com/ClickHouse/ch-go v0.65.0 // indirect
+	github.com/ClickHouse/clickhouse-go/v2 v2.32.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/attributes v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/proto v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.73.0-rc.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.71.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.71.0 // indirect
+	github.com/DataDog/go-libddwaf/v4 v4.6.1 // indirect
+	github.com/DataDog/go-runtime-metrics-internal v0.0.4-0.20250721125240-fdf1ef85b633 // indirect
+	github.com/DataDog/go-sqllexer v0.1.8 // indirect
+	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
+	github.com/DataDog/sketches-go v1.4.7 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/ProtonMail/go-crypto v1.1.6 // indirect
+	github.com/STARRY-S/zip v0.2.1 // indirect
+	github.com/andybalholm/brotli v1.2.2 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
+	github.com/apache/arrow/go/v15 v15.0.2 // indirect
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
+	github.com/aws/smithy-go v1.27.1 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
+	github.com/bodgit/plumbing v1.3.0 // indirect
+	github.com/bodgit/sevenzip v1.6.0 // indirect
+	github.com/bodgit/windows v1.0.1 // indirect
+	github.com/buger/jsonparser v1.2.0 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/charmbracelet/lipgloss v0.5.0 // indirect
+	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
+	github.com/cloudflare/circl v1.6.3 // indirect
+	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/containerd/log v0.1.0 // indirect
+	github.com/containerd/platforms v0.2.1 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/go-connections v0.6.0 // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/fasthttp/websocket v1.5.12 // indirect
+	github.com/fatih/color v1.18.0 // indirect
+	github.com/fatih/semgroup v1.2.0 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/gitleaks/go-gitdiff v0.9.1 // indirect
+	github.com/go-faster/city v1.0.1 // indirect
+	github.com/go-faster/errors v0.7.1 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.9.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.1 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-openapi/analysis v0.24.2 // indirect
+	github.com/go-openapi/errors v0.22.5 // indirect
+	github.com/go-openapi/jsonpointer v0.22.4 // indirect
+	github.com/go-openapi/jsonreference v0.21.4 // indirect
+	github.com/go-openapi/loads v0.23.2 // indirect
+	github.com/go-openapi/runtime v0.29.2 // indirect
+	github.com/go-openapi/spec v0.22.3 // indirect
+	github.com/go-openapi/strfmt v0.25.0 // indirect
+	github.com/go-openapi/swag v0.25.4 // indirect
+	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
+	github.com/go-openapi/swag/conv v0.25.4 // indirect
+	github.com/go-openapi/swag/fileutils v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
+	github.com/go-openapi/swag/jsonutils v0.25.4 // indirect
+	github.com/go-openapi/swag/loading v0.25.4 // indirect
+	github.com/go-openapi/swag/mangling v0.25.4 // indirect
+	github.com/go-openapi/swag/netutils v0.25.4 // indirect
+	github.com/go-openapi/swag/stringutils v0.25.4 // indirect
+	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
+	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
+	github.com/go-openapi/validate v0.25.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/btree v1.1.3 // indirect
+	github.com/google/flatbuffers v23.5.26+incompatible // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.6.3 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-metrics v0.5.4 // indirect
+	github.com/hashicorp/go-msgpack/v2 v2.1.5 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/go-version v1.8.0 // indirect
+	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jaswdr/faker/v2 v2.8.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/klauspost/pgzip v1.2.6 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.9.1 // indirect
+	github.com/mark3labs/mcp-go v0.43.2 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.32 // indirect
+	github.com/maximhq/bifrost/plugins/compat v0.1.32 // indirect
+	github.com/maximhq/bifrost/plugins/maxim v1.6.33 // indirect
+	github.com/maximhq/bifrost/plugins/mocker v1.5.33 // indirect
+	github.com/maximhq/bifrost/plugins/modelcatalogresolver v1.0.14 // indirect
+	github.com/maximhq/bifrost/plugins/otel v1.4.5 // indirect
+	github.com/maximhq/bifrost/plugins/telemetry v1.5.33 // indirect
+	github.com/maximhq/maxim-go v0.2.1 // indirect
+	github.com/mholt/archives v0.1.2 // indirect
+	github.com/miekg/dns v1.1.68 // indirect
+	github.com/minio/minlz v1.0.0 // indirect
+	github.com/minio/simdjson-go v0.4.5 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/moby/api v1.54.1 // indirect
+	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/moby/patternmatcher v0.6.1 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
+	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/userns v0.1.0 // indirect
+	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode/v2 v2.2.2 // indirect
+	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/onsi/ginkgo/v2 v2.25.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/outcaste-io/ristretto v0.2.3 // indirect
+	github.com/paulmach/orb v0.11.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/philhofer/fwd v1.2.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pinecone-io/go-pinecone/v5 v5.3.0 // indirect
+	github.com/pion/datachannel v1.6.0 // indirect
+	github.com/pion/dtls/v3 v3.1.5 // indirect
+	github.com/pion/ice/v4 v4.2.1 // indirect
+	github.com/pion/interceptor v0.1.44 // indirect
+	github.com/pion/logging v0.2.4 // indirect
+	github.com/pion/mdns/v2 v2.1.0 // indirect
+	github.com/pion/randutil v0.1.0 // indirect
+	github.com/pion/rtcp v1.2.16 // indirect
+	github.com/pion/rtp v1.10.1 // indirect
+	github.com/pion/sctp v1.9.2 // indirect
+	github.com/pion/sdp/v3 v3.0.18 // indirect
+	github.com/pion/srtp/v3 v3.0.10 // indirect
+	github.com/pion/stun/v3 v3.1.6 // indirect
+	github.com/pion/transport/v4 v4.0.2 // indirect
+	github.com/pion/turn/v4 v4.1.4 // indirect
+	github.com/pion/webrtc/v4 v4.2.9 // indirect
+	github.com/pjbgf/sha1cd v0.6.0 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/prometheus/procfs v0.19.2 // indirect
+	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
+	github.com/qdrant/go-client v1.16.2 // indirect
+	github.com/redis/go-redis/v9 v9.17.2 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rs/zerolog v1.34.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
+	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
+	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.9.0 // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/sergi/go-diff v1.4.0 // indirect
+	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/sorairolake/lzip-go v0.3.5 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.15.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/spf13/viper v1.19.0 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/theckman/httpforwarded v0.4.0 // indirect
+	github.com/therootcompany/xz v1.0.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tinylib/msgp v1.3.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.16 // indirect
+	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/wasilibs/go-re2 v1.9.0 // indirect
+	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
+	github.com/weaviate/weaviate v1.38.0 // indirect
+	github.com/weaviate/weaviate-go-client/v5 v5.7.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/wlynxg/anet v0.0.5 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/xxh3 v1.1.0 // indirect
+	go.einride.tech/aip v0.83.0 // indirect
+	go.etcd.io/etcd/api/v3 v3.6.6 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.6.6 // indirect
+	go.mongodb.org/mongo-driver v1.17.7 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/collector/component v1.39.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.39.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v0.133.0 // indirect
+	go.opentelemetry.io/collector/pdata v1.39.0 // indirect
+	go.opentelemetry.io/contrib/bridges/otelzap v0.12.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0 // indirect
+	go.opentelemetry.io/otel/log v0.14.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go4.org v0.0.0-20230225012048-214862532bf5 // indirect
+	golang.org/x/arch v0.23.0 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
+	golang.org/x/term v0.43.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/tools v0.44.0 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/clickhouse v0.7.0 // indirect
+	gorm.io/driver/postgres v1.6.0 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
+)
+```
+
+</Update>

--- a/docs/changelogs/v1.6.8.mdx
+++ b/docs/changelogs/v1.6.8.mdx
@@ -1,0 +1,117 @@
+---
+title: "v1.6.8"
+description: "v1.6.8 changelog - 2026-08-05"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.6.8
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.6.8
+    docker run -p 8080:8080 maximhq/bifrost:v1.6.8
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.6.8">
+## ✨ Features
+
+- **WebSocket Proxy Support**: Realtime and Responses WebSocket connections now route through the configured provider-level proxy (HTTP, SOCKS5, env-based) instead of always dialing direct
+- **Configurable SCIM Buffer Sizes**: Added `WithFasthttpBufferSizes` option to `HTTPClientFactory` so IdP token endpoints returning headers larger than the 4KB default no longer fail SCIM/OAuth clients
+
+## 🐞 Fixed
+
+- **Proactive SSE Disconnect Detection**: Moved SSE heartbeat handling into a shared structure so client disconnects during streaming are detected proactively instead of only when a producer loop attempts a write, fixing false-success logging on fast/bursty upstreams like Vertex
+- **Closed Channel Panic on Stream Shutdown**: Fixed a race where a heartbeat goroutine mid-send on `eventCh` at shutdown could panic with "send on closed channel"
+- **Budget Pruning Crash with `config.json` Source of Truth**: Tolerate `ErrNotFound` when pruning cascade-deleted budgets and configs, fixing a startup crash for API-created model configs absent from `config.json`
+- **Bedrock Header Signing Denylist**: Fixed credential isolation so caller headers stored for Anthropic OAuth passthrough are no longer forwarded to other providers, preventing SigV4 signature mismatches on Bedrock
+- **Deterministic Bedrock Tool Ordering**: Fixed non-deterministic tool ordering in `toolConfig` caused by map iteration, which was breaking Bedrock prompt-cache hits
+- **Bedrock `cache_control` Translation**: `cache_control` markers on Anthropic-format content blocks, system blocks, and tools are now correctly translated through the Bedrock invoke and Converse paths instead of being silently dropped
+- **Bedrock Adaptive Thinking Fixes**: Reasoning/thinking `max_tokens` validation errors now return HTTP 400 instead of 500; `tool.defer_loading` is gated on its own beta header; Nova2 web search and code execution tools handled correctly
+- **Encrypted Reasoning Content Mismatch**: Fixed a mismatch where replaying OpenAI Responses API reasoning items through the Anthropic surface minted a fresh item id while forwarding the original encrypted content, which OpenAI rejected
+- **Bedrock Invoke Content Retention**: Bedrock's InvokeModel route now correctly decodes Anthropic's type-discriminated image/tool_use/tool_result blocks instead of silently dropping them
+- **Bedrock Document Message Placeholder**: Messages containing a document block without accompanying text no longer get rejected by Bedrock's Converse API
+- **VK Provider Bulk Replace**: Virtual key provider config replacement is now a single bulk operation instead of per-provider round trips, fixing a hot-path slowdown at scale
+
+## 🗄️ Database Migrations
+
+- No new database migrations in this release.
+
+## 🐙 Closed GitHub Issues
+
+- [#5010](https://github.com/maximhq/bifrost/issues/5010): Server-side SSE keepalive (comment heartbeat) to keep long-idle streams alive through intermediaries
+- [#5186](https://github.com/maximhq/bifrost/issues/5186): Anthropic-surface replay of OpenAI encrypted reasoning mints a fresh item id, OpenAI 400s with "Encrypted content item_id did not match the target item id"
+
+## 🔧 Maintenance
+
+- **Dependency Upgrades**: Bumped core to v1.7.6, framework to v1.5.6, and governance to v1.6.10; all other plugins bumped to pick up the cascade (compat v0.1.32, jsonparser v1.5.33, logging v1.6.6, maxim v1.6.33, mocker v1.5.33, modelcatalogresolver v1.0.14, otel v1.4.5, prompts v1.0.33, semanticcache v1.5.33, telemetry v1.5.33)
+
+</Update>
+<Update label="Core" description="1.7.6">
+- feat: added proxy support for WebSocket-based realtime calls, mirroring existing HTTP proxy configuration (#5788)
+- feat: added `WithFasthttpBufferSizes` option to `HTTPClientFactory` for configurable SCIM read/write buffers, fixing failures when IdP token endpoints return headers larger than the 4KB default (#5808)
+- fix: moved SSE heartbeat handling into a common structure so client-disconnect detection is proactive instead of only firing on the next write attempt (#5850)
+- fix: bedrock headers signing denylist to prevent credential/header leakage across providers and SigV4 signature mismatches (#5833)
+- fix: corrected tool ordering in `extractToolsFromResponsesConversationHistory`, which was non-deterministic due to map iteration and caused Bedrock prompt-cache misses (#5828)
+- fix: translated `cache_control` on Anthropic-format content blocks through the Bedrock invoke path, which previously silently dropped it (#5824)
+- fix: bedrock + anthropic patches for adaptive thinking correctness bugs across reasoning validation and tool-search-tool gating (#5821)
+- fix: fixed encrypted reasoning content mismatch when the Anthropic surface replays OpenAI Responses API reasoning items back to OpenAI (#5819)
+- fix: bedrock invoke flow now retains image/tool_use/tool_return content blocks that were previously dropped by the decoder (#5814)
+- fix: injected placeholder text block for document-only messages on Bedrock, which otherwise rejected the request (#5817)
+- fix: retained tool `cache_control` markers through Bedrock Converse invoke requests so prompt caching applies to system blocks and tools (#5811)
+
+</Update>
+<Update label="Framework" description="1.5.6">
+- feat: added proxy support for WebSocket-based realtime calls, mirroring existing HTTP proxy configuration (#5788)
+- perf: bulk virtual key provider replacement and direct VK lookup to eliminate per-provider round trips in the config store (#5844)
+- chore: upgraded core to v1.7.6
+
+</Update>
+<Update label="compat" description="0.1.32">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="governance" description="1.6.10">
+- perf: bulk virtual key provider replacement and direct VK lookup to eliminate per-provider round trips in the governance store (#5844)
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="jsonparser" description="1.5.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="logging" description="1.6.6">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="maxim" description="1.6.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="mocker" description="1.5.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="modelcatalogresolver" description="1.0.14">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="otel" description="1.4.5">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="prompts" description="1.0.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="semanticcache" description="1.5.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>
+<Update label="telemetry" description="1.5.33">
+- chore: upgraded core to v1.7.6 and framework to v1.5.6
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -751,6 +751,7 @@
             "item": "Open Source",
             "icon": "rocket",
             "pages": [
+              "changelogs/v1.6.8",
               "changelogs/v1.6.7",
               "changelogs/v1.6.6",
               "changelogs/v1.6.5",
@@ -951,6 +952,7 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.5.8",
               "changelogs/ent-v1.5.7",
               "changelogs/ent-v1.5.6",
               "changelogs/ent-v1.5.5",


### PR DESCRIPTION
## Summary

Adds changelog documentation for Bifrost OSS `v1.6.8` and Enterprise `v1.5.8` releases, and registers both pages in the docs navigation.

## Changes

- Added `docs/changelogs/v1.6.8.mdx` covering OSS transport features (WebSocket proxy support, configurable SCIM buffer sizes), bug fixes (proactive SSE disconnect detection, closed-channel panic on stream shutdown, Bedrock header signing denylist, deterministic Bedrock tool ordering, `cache_control` translation, adaptive thinking fixes, encrypted reasoning content mismatch, Bedrock invoke content retention, document message placeholder, VK provider bulk replace), and dependency bumps across core, framework, governance, and all plugins.
- Added `docs/changelogs/ent-v1.5.8.mdx` covering enterprise-only features (inference JIT provisioning for first-time SSO users, `order` role-resolution strategy for SCIM/OIDC, AWS ALB as a selectable IAP option, configurable outbound HTTP buffer sizes, AP-managed VK quota visibility without access-profile permission), additional enterprise bug fixes (calendar-aligned budget reset propagation, access-profile propagation on large profiles, soft-deleted user reactivation via proxy/inference JWT, SCIM vs. periodic role sync conflict, cluster peer liveness isolation from bulk sync backlog), and the full plugin dependency manifest for compiling against this release.
- Registered both new changelog pages at the top of their respective navigation groups (`Open Source` and `Enterprise`) in `docs/docs.json`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the docs site and confirm:
- The `v1.6.8` OSS changelog page renders correctly under the Open Source changelogs section.
- The `ent-v1.5.8` Enterprise changelog page renders correctly under the Enterprise changelogs section.
- Both pages appear at the top of their respective navigation groups.

## Breaking changes

- [x] No

## Related issues

- Closes #5010
- Closes #5186

## Security considerations

None. This PR contains only documentation changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable