### PR TITLE
strip prefix check for openai reasoning models check (to accmodate mantle)

### DIFF
--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -125,7 +125,7 @@ func isOpenAIReasoningModel(model string) bool {
 		}
 	}
 	// Check for GPT-5 series models which support reasoning.effort
-	if strings.HasPrefix(modelLower, "gpt-5") {
+	if strings.Contains(modelLower, "gpt-5") {
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

Fixes detection of GPT-5 series models so that reasoning effort support is correctly identified regardless of where "gpt-5" appears in the model name string (e.g., fine-tuned or versioned variants like `ft:gpt-5-...`).

## Changes

- Replaced `strings.HasPrefix` with `strings.Contains` when checking if a model belongs to the GPT-5 series, allowing model names that include "gpt-5" in positions other than the start to be correctly recognized as reasoning models.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/...
```

Verify that model names such as `ft:gpt-5-mini` or other variants containing "gpt-5" not at the start of the string are correctly identified as reasoning models and have `reasoning.effort` applied.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable