### PR TITLE
fixes generateContent to keep safetyRatings and avgLogprobs

### DIFF
--- a/.claude/skills/investigate-issue/SKILL.md
+++ b/.claude/skills/investigate-issue/SKILL.md
@@ -33,7 +33,7 @@ If any section is missing, go back and complete it before presenting the report.
 4. **Analyze impact** -- Cross-reference codebase findings with documentation to identify side effects, dependencies, and breaking changes
 5. **Suggest tests** -- If changes touch `core/`, recommend specific LLM and MCP test additions
 6. **Present the plan** -- Show findings and recommended changes to the user
-7. **Implement with approval** -- After plan approval, make changes one at a time with user confirmation
+7. **Implement with approval** -- After plan approval, make changes one at a time with user confirmation. For Bug issues, tests are written and confirmed failing (red) before the fix is implemented (green), per AGENTS.md's "Bug fixes: red before green" rule
 
 ## Step 1: Fetch the Issue
 
@@ -511,18 +511,29 @@ Copy the research table from Step 3e here. If you skipped Step 3e, go back and d
 
 Once the user approves the plan:
 
-### 7a. Create a Todo List
+### 7a. Bug issues: red before green (per AGENTS.md "Testing" section)
 
-Create a todo item for each change in the plan:
+If the issue was classified as **Bug** in Step 2a, tests are written and confirmed failing *before* any fix code is written:
+
+1. Write (or extend) the test(s) from the Test Plan first, targeting the actual root cause identified in Step 3/4 -- not a placeholder.
+2. Run them and confirm they fail **for the expected reason** (the missing behavior/field/branch) -- not a compile error, typo, or unrelated panic.
+3. Only then implement the fix changes from the plan (Step 7c below).
+4. Re-run the same tests and confirm they now pass. Do not consider the change complete until red-then-green is shown for each new/extended test.
+
+This does not apply to Feature or Docs-classified issues -- AGENTS.md scopes "red before green" to bug fixes specifically, not all work. For those, tests are still added per the Test Plan, but there's no requirement to write them before the implementation.
+
+### 7b. Create a Todo List
+
+Create a todo item for each change in the plan. For Bug issues, order test-writing before the corresponding fix so the red-before-green sequence in 7a is reflected in the todo list itself:
 ```
-1. Change 1: <description> -- pending
-2. Change 2: <description> -- pending
-3. Update test: <description> -- pending
-4. Add new test: <description> -- pending
+1. Write failing test: <description> -- pending      (Bug issues only; confirm red before continuing)
+2. Change 1: <description> -- pending
+3. Change 2: <description> -- pending
+4. Update existing test: <description> -- pending
 5. Verify all tests pass -- pending
 ```
 
-### 7b. For Each Change
+### 7c. For Each Change
 
 Before making any edit, present the change to the user:
 
@@ -542,7 +553,7 @@ Before making any edit, present the change to the user:
 
 Wait for user approval before applying. If user says "no", skip and move to the next change. If user says "modify", discuss and adjust.
 
-### 7c. After All Changes
+### 7d. After All Changes
 
 Once all approved changes are applied:
 
@@ -561,7 +572,7 @@ Once all approved changes are applied:
    make run-e2e FLOW=<feature>
    ```
 
-2. Report results to the user
+2. Report results to the user, including the red-then-green transcript/summary for Bug issues (what failed before, what passes now)
 3. If tests fail, investigate and propose fixes (with approval)
 
 ## Error Handling

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3978,6 +3978,61 @@ func TestGenAIFinishReasonMaxTokens_PersistsThroughBifrostRoundTrip(t *testing.T
 	assert.Equal(t, gemini.FinishReasonMaxTokens, out.Candidates[0].FinishReason)
 }
 
+// Regression: candidates[0].safetyRatings, candidates[0].avgLogprobs, and the native
+// responseId must survive Gemini/Vertex → Bifrost → Gemini on the GenAI generateContent
+// path. These fields have no home in Bifrost's OpenAI-shaped Responses schema, so they
+// must be preserved via ProviderExtraFields rather than silently dropped.
+// See https://github.com/maximhq/bifrost/issues/5843
+func TestGenAISafetyRatingsAvgLogprobsResponseID_PersistThroughBifrostRoundTrip(t *testing.T) {
+	geminiResp := &gemini.GenerateContentResponse{
+		ResponseID:   "abcd1234",
+		ModelVersion: "gemini-2.5-flash",
+		Candidates: []*gemini.Candidate{
+			{
+				Index:        0,
+				FinishReason: gemini.FinishReasonStop,
+				AvgLogprobs:  -0.1234,
+				Content: &gemini.Content{
+					Role: "model",
+					Parts: []*gemini.Part{
+						{Text: "hello there"},
+					},
+				},
+				SafetyRatings: []*gemini.SafetyRating{
+					{
+						Category:    "HARM_CATEGORY_HARASSMENT",
+						Probability: "NEGLIGIBLE",
+					},
+					{
+						Category:    "HARM_CATEGORY_DANGEROUS_CONTENT",
+						Probability: "LOW",
+						Blocked:     false,
+					},
+				},
+			},
+		},
+	}
+
+	bifrostResp := geminiResp.ToResponsesBifrostResponsesResponse()
+	require.NotNil(t, bifrostResp)
+	require.NotNil(t, bifrostResp.ProviderExtraFields, "safetyRatings/avgLogprobs/responseId must be captured in ProviderExtraFields since Bifrost's Responses schema has no field for them")
+	assert.Equal(t, "abcd1234", bifrostResp.ProviderExtraFields["responseId"])
+	assert.NotNil(t, bifrostResp.ProviderExtraFields["safetyRatings"])
+	assert.Equal(t, -0.1234, bifrostResp.ProviderExtraFields["avgLogprobs"])
+
+	out := gemini.ToGeminiResponsesResponse(bifrostResp)
+	require.NotNil(t, out)
+	require.Len(t, out.Candidates, 1)
+
+	assert.Equal(t, "abcd1234", out.ResponseID, "native responseId must be restored, not the synthesized resp_... internal ID")
+	assert.InDelta(t, -0.1234, out.Candidates[0].AvgLogprobs, 0.0001)
+	require.Len(t, out.Candidates[0].SafetyRatings, 2)
+	assert.Equal(t, "HARM_CATEGORY_HARASSMENT", out.Candidates[0].SafetyRatings[0].Category)
+	assert.Equal(t, "NEGLIGIBLE", out.Candidates[0].SafetyRatings[0].Probability)
+	assert.Equal(t, "HARM_CATEGORY_DANGEROUS_CONTENT", out.Candidates[0].SafetyRatings[1].Category)
+	assert.Equal(t, "LOW", out.Candidates[0].SafetyRatings[1].Probability)
+}
+
 // Regression: GenAI usageMetadata modality details must include tokenCount even when zero.
 // Some clients (e.g. @ai-sdk/google) validate tokenCount as required and reject missing fields.
 func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T) {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -279,6 +280,23 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 		if len(outputMessages) > 0 {
 			bifrostResp.Output = outputMessages
 		}
+
+		// safetyRatings, avgLogprobs, and the native responseId have no field in Bifrost's
+		// OpenAI-shaped Responses schema. Preserve them here so ToGeminiResponsesResponse
+		// can restore them on the GenAI generateContent egress path.
+		extraFields := map[string]interface{}{}
+		if response.ResponseID != "" {
+			extraFields["responseId"] = response.ResponseID
+		}
+		if len(candidate.SafetyRatings) > 0 {
+			extraFields["safetyRatings"] = candidate.SafetyRatings
+		}
+		if candidate.AvgLogprobs != 0 {
+			extraFields["avgLogprobs"] = candidate.AvgLogprobs
+		}
+		if len(extraFields) > 0 {
+			bifrostResp.ProviderExtraFields = extraFields
+		}
 	}
 
 	return bifrostResp
@@ -545,10 +563,29 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 				candidate.GroundingMetadata = buildGroundingMetadataFromWebSearch(lastWebSearchCall, webSearchAnnotations, lastRenderedContent)
 			}
 
+			// Restore safetyRatings/avgLogprobs preserved by ToResponsesBifrostResponsesResponse
+			// (they have no field in Bifrost's OpenAI-shaped Responses schema).
+			if bifrostResp.ProviderExtraFields != nil {
+				if ratings := extractGeminiSafetyRatings(bifrostResp.ProviderExtraFields["safetyRatings"]); ratings != nil {
+					candidate.SafetyRatings = ratings
+				}
+				if avgLogprobs, ok := extractGeminiAvgLogprobs(bifrostResp.ProviderExtraFields["avgLogprobs"]); ok {
+					candidate.AvgLogprobs = avgLogprobs
+				}
+			}
+
 			candidates = append(candidates, candidate)
 		}
 
 		geminiResp.Candidates = candidates
+	}
+
+	// Restore the native provider responseId (rather than the synthesized resp_... internal ID)
+	// when this response originated from a Gemini/Vertex candidate that carried one.
+	if bifrostResp.ProviderExtraFields != nil {
+		if responseID, ok := bifrostResp.ProviderExtraFields["responseId"].(string); ok && responseID != "" {
+			geminiResp.ResponseID = responseID
+		}
 	}
 
 	// Convert usage metadata
@@ -567,6 +604,49 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 	}
 
 	return geminiResp
+}
+
+// extractGeminiSafetyRatings recovers []*SafetyRating from ProviderExtraFields["safetyRatings"].
+// Handles both the in-memory pointer (normal non-streaming path) and a JSON-decoded
+// []interface{}/map form (e.g. if the response was round-tripped through JSON).
+func extractGeminiSafetyRatings(v interface{}) []*SafetyRating {
+	if v == nil {
+		return nil
+	}
+	if ratings, ok := v.([]*SafetyRating); ok {
+		return ratings
+	}
+	b, err := sonic.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var ratings []*SafetyRating
+	if err := sonic.Unmarshal(b, &ratings); err != nil {
+		return nil
+	}
+	return ratings
+}
+
+// extractGeminiAvgLogprobs recovers a float64 from ProviderExtraFields["avgLogprobs"].
+func extractGeminiAvgLogprobs(v interface{}) (float64, bool) {
+	switch val := v.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	default:
+		b, err := sonic.Marshal(v)
+		if err != nil {
+			return 0, false
+		}
+		var f float64
+		if err := sonic.Unmarshal(b, &f); err != nil {
+			return 0, false
+		}
+		return f, true
+	}
 }
 
 // BifrostToGeminiStreamState tracks state when converting Bifrost streams to Gemini format
@@ -840,6 +920,20 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 			if state.HasWebSearch && state.WebSearchCall != nil {
 				candidate.GroundingMetadata = buildGroundingMetadataFromWebSearch(state.WebSearchCall, state.Annotations, state.RenderedContent)
 			}
+
+			// Restore safetyRatings/avgLogprobs/responseId preserved by closeGeminiOpenItems
+			// (they have no field in Bifrost's OpenAI-shaped Responses schema).
+			if bifrostResp.Response.ProviderExtraFields != nil {
+				if ratings := extractGeminiSafetyRatings(bifrostResp.Response.ProviderExtraFields["safetyRatings"]); ratings != nil {
+					candidate.SafetyRatings = ratings
+				}
+				if avgLogprobs, ok := extractGeminiAvgLogprobs(bifrostResp.Response.ProviderExtraFields["avgLogprobs"]); ok {
+					candidate.AvgLogprobs = avgLogprobs
+				}
+				if responseID, ok := bifrostResp.Response.ProviderExtraFields["responseId"].(string); ok && responseID != "" {
+					streamResp.ResponseID = responseID
+				}
+			}
 		}
 
 	// Response failed
@@ -902,6 +996,12 @@ type GeminiResponsesStreamState struct {
 	Model      *string // Model version
 	CreatedAt  int     // Timestamp for consistency
 	ResponseID *string // Gemini's responseId
+
+	// Candidate metadata that only arrives on the terminal chunk (alongside finishReason).
+	// Preserved here so closeGeminiOpenItems can stash them onto the response.completed
+	// event's ProviderExtraFields for the reverse (Bifrost -> Gemini) conversion to restore.
+	SafetyRatings []*SafetyRating
+	AvgLogprobs   float64
 
 	// Content tracking
 	HasStartedText     bool            // Whether we've started text content
@@ -976,6 +1076,8 @@ func (state *GeminiResponsesStreamState) flush() {
 	state.MessageID = nil
 	state.Model = nil
 	state.ResponseID = nil
+	state.SafetyRatings = nil
+	state.AvgLogprobs = 0
 	state.CreatedAt = int(time.Now().Unix())
 	state.HasEmittedCreated = false
 	state.HasEmittedCompleted = false
@@ -1072,6 +1174,14 @@ func (response *GenerateContentResponse) ToBifrostResponsesStream(sequenceNumber
 				partResponses := processGeminiPart(part, state, sequenceNumber+len(responses))
 				responses = append(responses, partResponses...)
 			}
+		}
+
+		// safetyRatings/avgLogprobs only arrive on the terminal chunk, alongside finishReason.
+		if len(candidate.SafetyRatings) > 0 {
+			state.SafetyRatings = candidate.SafetyRatings
+		}
+		if candidate.AvgLogprobs != 0 {
+			state.AvgLogprobs = candidate.AvgLogprobs
 		}
 
 		// Check for finish reason (indicates end of generation)
@@ -1954,6 +2064,23 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 			failedStatus := "failed"
 			completedResp.Status = &failedStatus
 		}
+	}
+
+	// safetyRatings, avgLogprobs, and the native responseId have no field in Bifrost's
+	// OpenAI-shaped Responses schema. Preserve them here so ToGeminiResponsesStreamResponse
+	// can restore them on the GenAI streamGenerateContent egress path.
+	extraFields := map[string]interface{}{}
+	if state.ResponseID != nil && *state.ResponseID != "" {
+		extraFields["responseId"] = *state.ResponseID
+	}
+	if len(state.SafetyRatings) > 0 {
+		extraFields["safetyRatings"] = state.SafetyRatings
+	}
+	if state.AvgLogprobs != 0 {
+		extraFields["avgLogprobs"] = state.AvgLogprobs
+	}
+	if len(extraFields) > 0 {
+		completedResp.ProviderExtraFields = extraFields
 	}
 
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{

--- a/core/providers/gemini/safetyratingsstream_test.go
+++ b/core/providers/gemini/safetyratingsstream_test.go
@@ -1,0 +1,89 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// safetyRatingsStreamChunks mirrors how Gemini/Vertex deliver a streamed answer: a text
+// chunk followed by a final chunk carrying finishReason plus per-candidate safetyRatings
+// and avgLogprobs, which only ever appear on the terminal chunk.
+func safetyRatingsStreamChunks() []*GenerateContentResponse {
+	return []*GenerateContentResponse{
+		{
+			ResponseID:   "resp-safety",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				Content: &Content{
+					Role:  "model",
+					Parts: []*Part{{Text: "hello there"}},
+				},
+			}},
+		},
+		{
+			ResponseID:   "resp-safety",
+			ModelVersion: "gemini-2.5-flash",
+			Candidates: []*Candidate{{
+				FinishReason: FinishReasonStop,
+				AvgLogprobs:  -0.1234,
+				SafetyRatings: []*SafetyRating{
+					{Category: "HARM_CATEGORY_HARASSMENT", Probability: "NEGLIGIBLE"},
+					{Category: "HARM_CATEGORY_DANGEROUS_CONTENT", Probability: "LOW"},
+				},
+			}},
+			UsageMetadata: &GenerateContentResponseUsageMetadata{
+				PromptTokenCount:     4,
+				CandidatesTokenCount: 3,
+				TotalTokenCount:      7,
+			},
+		},
+	}
+}
+
+// TestGeminiSafetyRatingsAvgLogprobsResponseIDStreamRoundTrip drives the genai
+// streamGenerateContent passthrough loop -- Gemini stream -> Bifrost Responses stream ->
+// Gemini stream -- and asserts candidates[0].safetyRatings, avgLogprobs, and the native
+// responseId survive, matching the non-streaming fix for
+// https://github.com/maximhq/bifrost/issues/5843.
+func TestGeminiSafetyRatingsAvgLogprobsResponseIDStreamRoundTrip(t *testing.T) {
+	forward := &GeminiResponsesStreamState{}
+	forward.flush()
+	reverse := NewBifrostToGeminiStreamState()
+
+	var restored *Candidate
+	var restoredResponseID string
+	seq := 0
+	for _, chunk := range safetyRatingsStreamChunks() {
+		events, bifrostErr := chunk.ToBifrostResponsesStream(seq, forward)
+		require.Nil(t, bifrostErr, "unexpected forward conversion error")
+		seq += len(events)
+
+		for _, event := range events {
+			out := ToGeminiResponsesStreamResponse(event, reverse)
+			if out == nil {
+				continue
+			}
+			if out.ResponseID != "" {
+				restoredResponseID = out.ResponseID
+			}
+			for _, candidate := range out.Candidates {
+				if len(candidate.SafetyRatings) > 0 || candidate.AvgLogprobs != 0 {
+					restored = candidate
+				}
+			}
+		}
+	}
+
+	require.NotNil(t, restored, "safetyRatings/avgLogprobs must be rebuilt on the response.completed chunk")
+	assert.InDelta(t, -0.1234, restored.AvgLogprobs, 0.0001)
+	require.Len(t, restored.SafetyRatings, 2)
+	assert.Equal(t, "HARM_CATEGORY_HARASSMENT", restored.SafetyRatings[0].Category)
+	assert.Equal(t, "NEGLIGIBLE", restored.SafetyRatings[0].Probability)
+	assert.Equal(t, "HARM_CATEGORY_DANGEROUS_CONTENT", restored.SafetyRatings[1].Category)
+	assert.Equal(t, "LOW", restored.SafetyRatings[1].Probability)
+
+	assert.Equal(t, "resp-safety", restoredResponseID,
+		"native responseId must be restored on the streamed response.completed chunk, not a synthesized internal ID")
+}


### PR DESCRIPTION
## Summary

`candidates[0].safetyRatings`, `candidates[0].avgLogprobs`, and the native Gemini `responseId` were silently dropped when a Gemini/Vertex response passed through Bifrost's OpenAI-shaped Responses schema. Because Bifrost's schema has no fields for these values, they need to be round-tripped via `ProviderExtraFields` and restored on egress. This fix covers both the non-streaming (`generateContent`) and streaming (`streamGenerateContent`) paths.

Closes #5843

## Changes

- **`responses.go`** **— non-streaming path**: `ToResponsesBifrostResponsesResponse` now stashes `responseId`, `safetyRatings`, and `avgLogprobs` into `ProviderExtraFields` when converting inbound Gemini responses to Bifrost format. `ToGeminiResponsesResponse` reads them back out and restores them onto the outbound `GenerateContentResponse`.
- **`responses.go`** **— streaming path**: `GeminiResponsesStreamState` gains `SafetyRatings` and `AvgLogprobs` fields. `ToBifrostResponsesStream` captures these from the terminal chunk (the only chunk that carries them, alongside `finishReason`). `closeGeminiOpenItems` writes them into `ProviderExtraFields` on the `response.completed` event. `ToGeminiResponsesStreamResponse` restores them onto the outbound stream chunk.
- **`extractGeminiSafetyRatings`** **/** **`extractGeminiAvgLogprobs`**: Two helper functions handle both the in-memory pointer form (normal path) and the JSON-decoded `[]interface{}`/`map` form that can appear after a JSON round-trip.
- **`gemini_test.go`**: Regression test `TestGenAISafetyRatingsAvgLogprobsResponseIDStreamRoundTrip` covers the non-streaming round-trip, asserting all three fields survive `ToResponsesBifrostResponsesResponse` → `ToGeminiResponsesResponse`.
- **`safetyratingsstream_test.go`**: New test file with `TestGeminiSafetyRatingsAvgLogprobsResponseIDStreamRoundTrip`, which drives a two-chunk stream through the full forward (`ToBifrostResponsesStream`) and reverse (`ToGeminiResponsesStreamResponse`) conversion loop and asserts `safetyRatings`, `avgLogprobs`, and `responseId` are present on the terminal chunk.
- **`SKILL.md`**: The investigate-issue skill now enforces AGENTS.md's "red before green" rule for Bug-classified issues — tests are written and confirmed failing before any fix code is applied, and the todo list ordering reflects this sequence.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/gemini/... -run TestGenAISafetyRatingsAvgLogprobsResponseIDStreamRoundTrip
go test ./core/providers/gemini/... -run TestGeminiSafetyRatingsAvgLogprobsResponseIDStreamRoundTrip
go test ./core/providers/gemini/...
```

Both new tests should pass. The streaming test validates that `safetyRatings`, `avgLogprobs`, and `responseId` appear on the `response.completed` chunk after a two-chunk stream round-trip. The non-streaming test validates the same fields survive a single `GenerateContentResponse` → Bifrost → `GenerateContentResponse` round-trip.

## Breaking changes

- [x] No

## Related issues

Closes #5843

## Security considerations

None. The change only preserves existing provider-supplied metadata through an internal schema boundary; no new data is introduced or exposed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable