### PR TITLE
nil delta with non-nil finish reason doesnt bail out anymore

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1192,6 +1192,11 @@ func HandleOpenAIChatCompletionStreaming(
 		// Defer final completed/incomplete event until usage chunk arrives (fallback path only).
 		var pendingFinalEvent *schemas.BifrostResponsesStreamResponse
 		usageSeen := false
+		// Fallback path only: tracks whether the upstream ever sent a finish_reason,
+		// so a finish_reason that fails to produce a terminal event (e.g. a future
+		// regression in ToBifrostResponsesStreamResponse) is treated as truncation
+		// instead of a silent stream close.
+		fallbackFinishReasonSeen := false
 
 		for {
 			// If context was cancelled/timed out, let defer handle it
@@ -1254,6 +1259,10 @@ func HandleOpenAIChatCompletionStreaming(
 			}
 
 			if isResponsesToChatCompletionsFallback {
+				if len(response.Choices) > 0 && response.Choices[0].FinishReason != nil && *response.Choices[0].FinishReason != "" {
+					fallbackFinishReasonSeen = true
+				}
+
 				// Accumulate usage across chunks; attached to final event below.
 				if response.Usage != nil {
 					usageSeen = true
@@ -1428,7 +1437,10 @@ func HandleOpenAIChatCompletionStreaming(
 		// that is indistinguishable from a provider that generated zero tokens.
 		terminalSignalSeen := providerUtils.SSEStreamEndedOnMarker(sseReader)
 		if isResponsesToChatCompletionsFallback {
-			terminalSignalSeen = terminalSignalSeen || pendingFinalEvent != nil
+			// A finish_reason without a resulting terminal event means the conversion
+			// path failed to synthesize Completed/Incomplete — treat that as truncation
+			// rather than a silent stream close, even though [DONE] may have arrived.
+			terminalSignalSeen = pendingFinalEvent != nil || (terminalSignalSeen && !fallbackFinishReasonSeen)
 		} else {
 			terminalSignalSeen = terminalSignalSeen || finishReason != nil
 		}

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -323,6 +323,70 @@ func TestResponsesStreamTruncatedBeforeCompleted(t *testing.T) {
 	assertTruncationError(t, chunks[len(chunks)-1].BifrostError)
 }
 
+// chatChunkNullDeltaFinish reproduces the terminal-chunk shape some OpenAI-compatible
+// upstreams send: "delta" is null (or absent) alongside "finish_reason", rather than
+// an empty object. ToBifrostResponsesStreamResponse must not discard finish_reason
+// just because delta is nil, or the Responses->Chat-Completions fallback below never
+// produces a Completed event and the stream closes with no usage/stop_reason at all.
+func chatChunkNullDeltaFinish(finishReason string) string {
+	return `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":null,"finish_reason":"` + finishReason + `"}],` +
+		`"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}` + "\n\n"
+}
+
+// A Responses request that falls back to Chat Completions (because the custom
+// provider config disables native Responses but allows Chat Completions) must still
+// produce a completed Responses stream event with usage/stop_reason, even when the
+// upstream's terminal chunk carries "delta":null alongside "finish_reason".
+func TestResponsesStreamFallbackNullDeltaFinishStillCompletes(t *testing.T) {
+	server := completeSSEServer(t, chatChunk("hello", nil)+chatChunkNullDeltaFinish("stop")+"data: [DONE]\n\n")
+	defer server.Close()
+
+	provider := NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			AllowedRequests: &schemas.AllowedRequests{
+				ChatCompletionStream: true,
+				ResponsesStream:      false,
+			},
+		},
+	}, testNoopLogger{})
+
+	request := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input: []schemas.ResponsesMessage{{
+			Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+	stream, bifrostErr := provider.ResponsesStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	var completed *schemas.BifrostResponsesStreamResponse
+	for _, chunk := range collectChunks(t, stream) {
+		if chunk.BifrostError != nil {
+			t.Fatalf("unexpected error chunk: %+v", chunk.BifrostError)
+		}
+		if chunk.BifrostResponsesStreamResponse != nil && chunk.BifrostResponsesStreamResponse.Type == schemas.ResponsesStreamResponseTypeCompleted {
+			completed = chunk.BifrostResponsesStreamResponse
+		}
+	}
+
+	if completed == nil {
+		t.Fatal("expected a completed Responses stream event; stream closed silently instead")
+	}
+	if completed.Response == nil || completed.Response.Usage == nil {
+		t.Fatal("expected completed event to carry usage")
+	}
+	if completed.Response.StopReason == nil || *completed.Response.StopReason != "stop" {
+		t.Fatalf("expected stop_reason stop, got %+v", completed.Response.StopReason)
+	}
+}
+
 // A non-EOF read error is already a reported failure. The truncation guard that
 // follows the read loop must not fire a second time for the same dead stream, or
 // the client sees two errors for one request and the retryable 502 synthesized by

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1662,11 +1662,21 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 	// Convert first streaming choice to BifrostResponsesStreamResponse
 	// Note: Chat API typically has one choice per chunk in streaming
 	choice := cr.Choices[0]
-	if choice.ChatStreamResponseChoice == nil || choice.ChatStreamResponseChoice.Delta == nil {
-		return nil
+	var delta *ChatStreamResponseChoiceDelta
+	if choice.ChatStreamResponseChoice != nil {
+		delta = choice.ChatStreamResponseChoice.Delta
+	}
+	if delta == nil {
+		if choice.FinishReason == nil {
+			return nil
+		}
+		// Some OpenAI-compatible upstreams send their terminal chunk as
+		// {"delta":null,"finish_reason":"stop"} (or omit "delta" entirely).
+		// Fall through with an empty delta so the finish_reason handling below
+		// still runs and emits the Completed/Incomplete event with usage/stop_reason.
+		delta = &ChatStreamResponseChoiceDelta{}
 	}
 
-	delta := choice.ChatStreamResponseChoice.Delta
 	var responses []*BifrostResponsesStreamResponse
 
 	// Store message ID and model from first chunk

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -477,6 +477,110 @@ func TestToBifrostResponsesStreamResponse_PopulatesFinalDoneTextAndCompletedOutp
 	}
 }
 
+func TestToBifrostResponsesStreamResponse_NilDeltaWithFinishReasonStillCompletes(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	part := "Hello"
+	roleChunk := &BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{ChatStreamResponseChoice: &ChatStreamResponseChoice{Delta: &ChatStreamResponseChoiceDelta{Role: &role}}},
+		},
+	}
+	contentChunk := &BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{ChatStreamResponseChoice: &ChatStreamResponseChoice{Delta: &ChatStreamResponseChoiceDelta{Content: &part}}},
+		},
+	}
+
+	// Reproduces the real wire shape many OpenAI-compatible upstreams send on their
+	// terminal chunk: {"choices":[{"delta":null,"finish_reason":"stop"}],"usage":{...}}
+	var terminalChunk BifrostChatResponse
+	terminalJSON := `{"id":"chatcmpl-test","model":"test-model","choices":[{"index":0,"delta":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`
+	if err := json.Unmarshal([]byte(terminalJSON), &terminalChunk); err != nil {
+		t.Fatalf("failed to unmarshal terminal chunk fixture: %v", err)
+	}
+
+	var all []*BifrostResponsesStreamResponse
+	all = append(all, roleChunk.ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, contentChunk.ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, terminalChunk.ToBifrostResponsesStreamResponse(state)...)
+
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt != nil && evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+
+	if completed == nil {
+		t.Fatal("expected a Completed event even though the terminal chunk had delta:null")
+	}
+	if completed.Response == nil || completed.Response.Usage == nil {
+		t.Fatal("expected Completed event to carry usage")
+	}
+	if completed.Response.Usage.InputTokens != 5 || completed.Response.Usage.OutputTokens != 2 {
+		t.Fatalf("unexpected usage: %+v", completed.Response.Usage)
+	}
+	if completed.Response.StopReason == nil || *completed.Response.StopReason != "stop" {
+		t.Fatalf("expected stop_reason stop, got %+v", completed.Response.StopReason)
+	}
+}
+
+func TestToBifrostResponsesStreamResponse_MissingDeltaKeyWithFinishReasonStillCompletes(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	part := "Hi"
+	roleChunk := &BifrostChatResponse{
+		ID:    "chatcmpl-test2",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{ChatStreamResponseChoice: &ChatStreamResponseChoice{Delta: &ChatStreamResponseChoiceDelta{Role: &role}}},
+		},
+	}
+	contentChunk := &BifrostChatResponse{
+		ID:    "chatcmpl-test2",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{ChatStreamResponseChoice: &ChatStreamResponseChoice{Delta: &ChatStreamResponseChoiceDelta{Content: &part}}},
+		},
+	}
+
+	// Some upstreams omit the "delta" key entirely on the terminal chunk rather than
+	// sending it as null, leaving ChatStreamResponseChoice itself nil after unmarshal.
+	var terminalChunk BifrostChatResponse
+	terminalJSON := `{"id":"chatcmpl-test2","model":"test-model","choices":[{"index":0,"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`
+	if err := json.Unmarshal([]byte(terminalJSON), &terminalChunk); err != nil {
+		t.Fatalf("failed to unmarshal terminal chunk fixture: %v", err)
+	}
+
+	var all []*BifrostResponsesStreamResponse
+	all = append(all, roleChunk.ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, contentChunk.ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, terminalChunk.ToBifrostResponsesStreamResponse(state)...)
+
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt != nil && evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+
+	if completed == nil {
+		t.Fatal("expected a Completed event even though the terminal chunk omitted the delta key")
+	}
+	if completed.Response == nil || completed.Response.Usage == nil {
+		t.Fatal("expected Completed event to carry usage")
+	}
+}
+
 func TestToBifrostResponsesResponse_MapsLengthToIncomplete(t *testing.T) {
 	length := string(BifrostFinishReasonLength)
 	resp := (&BifrostChatResponse{


### PR DESCRIPTION
## Summary

Some OpenAI-compatible upstreams send their terminal streaming chunk with `"delta": null` (or omit the `"delta"` key entirely) alongside `"finish_reason"`. The Responses→Chat Completions fallback path was silently dropping these terminal chunks because `ToBifrostResponsesStreamResponse` returned early when `delta` was `nil`, meaning no `Completed` event was ever emitted and the stream closed without usage or stop reason.

## Changes

- `ToBifrostResponsesStreamResponse` now distinguishes between a missing `delta` with no `finish_reason` (skip, as before) and a missing `delta` that accompanies a `finish_reason` (fall through with an empty delta so the completion/incomplete event is still synthesized with usage and stop reason).
- The fallback path in `HandleOpenAIChatCompletionStreaming` now tracks whether a `finish_reason` was seen upstream. If a `finish_reason` arrived but no terminal event was produced (e.g. due to a future regression in the conversion path), the stream is treated as truncated rather than silently closed — even if `[DONE]` was received.
- The `terminalSignalSeen` logic for the fallback path was corrected: previously `[DONE]` alone could mask a missing `Completed` event; now a pending final event is required, or `[DONE]` must have arrived without any `finish_reason` having been seen.
- Tests were added covering `delta: null`, omitted `delta` key, and the full end-to-end fallback path producing a `Completed` event with correct usage and stop reason.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... ./core/schemas/...
```

The new tests cover:
- `TestResponsesStreamFallbackNullDeltaFinishStillCompletes` — full streaming round-trip through the fallback path with a `delta: null` terminal chunk; asserts a `Completed` event with usage and `stop_reason: stop`.
- `TestToBifrostResponsesStreamResponse_NilDeltaWithFinishReasonStillCompletes` — unit test for `ToBifrostResponsesStreamResponse` with a JSON-unmarshalled `delta: null` terminal chunk.
- `TestToBifrostResponsesStreamResponse_MissingDeltaKeyWithFinishReasonStillCompletes` — same but with the `delta` key omitted entirely.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable