### PR TITLE
fix(bedrock): preserve encrypted reasoning replay signatures

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: preserve encrypted reasoning as a Bedrock replay signature when translating Responses history [@zachgersh](https://github.com/zachgersh)
 - feat: add proxy support for WebSocket-based realtime calls, mirroring existing HTTP proxy configuration (#5788)
 - feat: add `WithFasthttpBufferSizes` option to `HTTPClientFactory` for configurable SCIM read/write buffers, fixing failures when IdP token endpoints return headers larger than the 4KB default (#5808)
 - fix: move SSE heartbeat handling into a common structure so client-disconnect detection is proactive instead of only firing on the next write attempt (#5850)

--- a/core/providers/bedrock/reasoning_replay_test.go
+++ b/core/providers/bedrock/reasoning_replay_test.go
@@ -1,0 +1,31 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertBifrostReasoningToBedrockReasoningEncryptedContent verifies that
+// encrypted reasoning replay data survives cross-provider translation into the
+// Bedrock reasoning signature field. Responses reasoning items use an empty,
+// non-nil Summary alongside EncryptedContent, so the converter must not treat
+// the empty slice as visible reasoning and silently drop the replay payload.
+func TestConvertBifrostReasoningToBedrockReasoningEncryptedContent(t *testing.T) {
+	encryptedContent := "EqQBCgIYAhIM...fixture"
+	message := &schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		ResponsesReasoning: &schemas.ResponsesReasoning{
+			Summary:          []schemas.ResponsesReasoningSummary{},
+			EncryptedContent: &encryptedContent,
+		},
+	}
+
+	blocks := convertBifrostReasoningToBedrockReasoning(message)
+	require.Len(t, blocks, 1)
+	require.NotNil(t, blocks[0].ReasoningContent)
+	require.NotNil(t, blocks[0].ReasoningContent.ReasoningText)
+	require.Nil(t, blocks[0].ReasoningContent.ReasoningText.Text)
+	require.Equal(t, encryptedContent, *blocks[0].ReasoningContent.ReasoningText.Signature)
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -4550,7 +4550,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 			}
 		}
 	} else if msg.ResponsesReasoning != nil {
-		if msg.ResponsesReasoning.Summary != nil {
+		if len(msg.ResponsesReasoning.Summary) > 0 {
 			for _, reasoningContent := range msg.ResponsesReasoning.Summary {
 				reasoningBlock := BedrockContentBlock{
 					ReasoningContent: &BedrockReasoningContent{
@@ -4561,14 +4561,11 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 				}
 				reasoningBlocks = append(reasoningBlocks, reasoningBlock)
 			}
-		} else if msg.ResponsesReasoning.EncryptedContent != nil {
-			// Bedrock doesn't have a direct equivalent to encrypted content,
-			// so we'll store it as a regular reasoning block with a special marker
-			encryptedText := fmt.Sprintf("[ENCRYPTED_REASONING: %s]", *msg.ResponsesReasoning.EncryptedContent)
+		} else if msg.ResponsesReasoning.EncryptedContent != nil && *msg.ResponsesReasoning.EncryptedContent != "" {
 			reasoningBlock := BedrockContentBlock{
 				ReasoningContent: &BedrockReasoningContent{
 					ReasoningText: &BedrockReasoningContentText{
-						Text: &encryptedText,
+						Signature: msg.ResponsesReasoning.EncryptedContent,
 					},
 				},
 			}


### PR DESCRIPTION
## Summary

Preserve encrypted reasoning replay data when a Responses API reasoning item is translated to Bedrock Converse format.

Responses reasoning items can carry `EncryptedContent` alongside an empty, non-nil `Summary`. The Bedrock converter previously treated that empty slice as visible reasoning, emitted no block, and silently dropped the replay payload. Its fallback also represented encrypted reasoning as synthetic text rather than the native Bedrock reasoning signature.

## Changes

- Treat only non-empty reasoning summaries as visible reasoning content.
- Map non-empty `EncryptedContent` to `reasoningContent.reasoningText.signature`.
- Remove the synthetic `[ENCRYPTED_REASONING: ...]` text representation.
- Add a focused regression test, committed separately before the implementation, covering the empty-summary encrypted-reasoning shape.
- Add a core changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
GOCACHE=/tmp/bifrost-go-build-cache GOPATH=/tmp/bifrost-go \
  go test ./providers/bedrock \
  -run '^TestConvertBifrostReasoningToBedrockReasoningEncryptedContent$' \
  -count=1
```

Expected result: the regression test passes and the Bedrock reasoning block contains the encrypted payload in `reasoningText.signature`, with no synthetic text.

The full Bedrock provider package was also run. It currently fails on pre-existing document-placeholder expectations (`TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_EmptyBlocks` and `TestDocumentFormatMapping`) because current `dev` emits a placeholder text block alongside document blocks. Those failures are unrelated to this change.

No new configuration or environment variables were added.

## Screenshots/Recordings

Not applicable; this change has no UI impact.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to #5638 and #5094.

## Security considerations

No new security surface. The change preserves an existing opaque provider-issued reasoning signature instead of converting it into visible synthetic text.

## Checklist

- [x] I read the current contribution and code-convention documentation and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified all builds succeed (the focused regression passes; the full Bedrock package has unrelated existing failures noted above)
- [ ] I verified the CI pipeline passes locally if applicable
