### PR TITLE
fix(transports): drop trailing blank line from SSE heartbeat frame

### DIFF
--- a/transports/bifrost-http/integrations/router_heartbeat_test.go
+++ b/transports/bifrost-http/integrations/router_heartbeat_test.go
@@ -54,7 +54,8 @@ func Test_handleStreamingSSESendsHeartbeatDuringIdleGap(t *testing.T) {
 
 		result := <-readDone
 		require.NoError(t, result.err)
-		assert.Contains(t, result.body, ": heartbeat\n\n", "expected at least one heartbeat comment frame during the idle gap")
+		assert.Contains(t, result.body, ": heartbeat\n", "expected at least one heartbeat comment frame during the idle gap")
+		assert.NotContains(t, result.body, ": heartbeat\n\n", "heartbeat must not carry a blank line, which non-conforming decoders dispatch as an empty event (#5874)")
 	})
 }
 

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -108,10 +108,12 @@ func (r *SSEStreamReader) SendDone() bool {
 	return r.Send([]byte("data: [DONE]\n\n"))
 }
 
-// sseHeartbeatFrame is an SSE comment line -- per the WHATWG SSE spec, a line
-// beginning with ':' is a comment that every compliant client ignores. It never
-// surfaces to application code as a real event.
-var sseHeartbeatFrame = []byte(": heartbeat\n\n")
+// sseHeartbeatFrame is an SSE comment line that every compliant client ignores.
+// Deliberately no trailing blank line: that's the event-dispatch signal, and
+// some deployed decoders (e.g. openai-go ssestream < v3.43.0) dispatch an empty
+// event on it and abort the stream (#5874). A bare comment line is still a real
+// socket write, which is all the disconnect probe needs.
+var sseHeartbeatFrame = []byte(": heartbeat\n")
 
 // SendHeartbeat sends a no-op SSE comment line purely to force an additional
 // downstream write attempt. Client-disconnect detection in this reader is

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -420,9 +420,9 @@ func TestSSEStreamReaderRawAndWrapperMixed(t *testing.T) {
 	}
 
 	go func() {
-		r.Send(bedrockBinary)                       // raw binary passthrough
-		r.Send(preformattedSSE)                     // pre-formatted SSE string
-		r.SendEvent("", []byte(`{"final":true}`))   // wrapper method
+		r.Send(bedrockBinary)                     // raw binary passthrough
+		r.Send(preformattedSSE)                   // pre-formatted SSE string
+		r.SendEvent("", []byte(`{"final":true}`)) // wrapper method
 		r.Done()
 	}()
 
@@ -685,10 +685,11 @@ func TestSSEStreamReaderConcurrentSendEvent(t *testing.T) {
 	}
 }
 
-// TestSSEStreamReaderSendHeartbeat verifies the heartbeat frame is a valid SSE
+// TestSSEStreamReaderSendHeartbeat verifies the heartbeat frame is a bare SSE
 // comment line (starts with ':', per the WHATWG SSE spec every compliant client
-// ignores a comment line) so it can be sent as a disconnect-detection probe
-// without ever surfacing to application code as a real event.
+// ignores a comment line) with no trailing blank line, so it never dispatches
+// an event in any decoder -- including non-conforming ones that dispatch empty
+// events on a blank line (#5874).
 func TestSSEStreamReaderSendHeartbeat(t *testing.T) {
 	r := NewSSEStreamReader()
 	go func() {
@@ -701,12 +702,8 @@ func TestSSEStreamReaderSendHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	got := string(buf[:n])
-	if len(got) == 0 || got[0] != ':' {
-		t.Errorf("heartbeat frame = %q, want a line starting with ':' (SSE comment)", got)
-	}
-	if got[len(got)-2:] != "\n\n" {
-		t.Errorf("heartbeat frame = %q, want it terminated by a blank line", got)
+	if got, want := string(buf[:n]), ": heartbeat\n"; got != want {
+		t.Errorf("heartbeat frame = %q, want %q", got, want)
 	}
 }
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -5,6 +5,7 @@
 
 ## 🐞 Fixed
 
+- **SSE Heartbeat Frame Compatibility** — Dropped the trailing blank line from the heartbeat comment frame so non-conforming SSE decoders (e.g. openai-go ssestream before v3.43.0) no longer dispatch an empty event and abort mid-stream with "unexpected end of JSON input"
 - **Proactive SSE Disconnect Detection** — Moved SSE heartbeat handling into a shared structure so client disconnects during streaming are detected proactively instead of only when a producer loop attempts a write, fixing false-success logging on fast/bursty upstreams like Vertex
 - **Closed Channel Panic on Stream Shutdown** — Fixed a race where a heartbeat goroutine mid-send on `eventCh` at shutdown could panic with "send on closed channel"
 - **Budget Pruning Crash with `config.json` Source of Truth** — Tolerate `ErrNotFound` when pruning cascade-deleted budgets and configs, fixing a startup crash for API-created model configs absent from `config.json`
@@ -24,6 +25,7 @@
 ## 🐙 Closed GitHub Issues
 
 - [#5010](https://github.com/maximhq/bifrost/issues/5010) — Server-side SSE keepalive (comment heartbeat) to keep long-idle streams alive through intermediaries
+- [#5874](https://github.com/maximhq/bifrost/issues/5874) — SSE heartbeat frame aborts streams for openai-go ssestream consumers (< v3.43.0) with "unexpected end of JSON input"
 - [#5186](https://github.com/maximhq/bifrost/issues/5186) — Anthropic-surface replay of OpenAI encrypted reasoning mints a fresh item id, OpenAI 400s with "Encrypted content item_id did not match the target item id"
 
 ## 🔧 Maintenance


### PR DESCRIPTION
## Summary

The SSE heartbeat introduced in #5850 is emitted as `": heartbeat\n\n"`. The trailing blank line is the SSE event-dispatch signal, and some widely-deployed decoders dispatch an empty event on it: openai-go's `ssestream` (before v3.43.0, fixed in openai/openai-go#621) falls into its untyped branch, calls `json.Unmarshal` on the empty payload, and aborts the stream with `unexpected end of JSON input`. Net effect: for those consumers, any streaming request outliving the 1s heartbeat interval dies at the first heartbeat. Fast streams are unaffected, which makes this easy to miss.

## Changes

- `lib/streamreader.go`: `sseHeartbeatFrame` drops its trailing blank line (`": heartbeat\n"`). A bare comment line accumulates nothing and dispatches nothing in every decoder — conforming or not — while still being a real write on the socket, which is all the disconnect probe (and intermediary idle timers, per #5010's original goal) needs. Doc comment explains why the blank line must not come back.
- `lib/streamreader_test.go`: `TestSSEStreamReaderSendHeartbeat` now pins the frame as a single newline-terminated comment line with no blank line.
- `integrations/router_heartbeat_test.go`: asserts the heartbeat appears during idle gaps and never carries a blank line.
- `transports/changelog.md`: entry under Fixed + closed-issue link.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd transports
go test ./bifrost-http/lib/... -count=1
go test ./bifrost-http/integrations/ -run 'Heartbeat|heartbeat' -count=1
```

Expected: all pass. `TestSSEStreamReaderSendHeartbeat` fails on the old frame; `Test_handleStreamingSSESendsHeartbeatDuringIdleGap` confirms heartbeats still flow during idle gaps.

To reproduce the original failure end-to-end: run bifrost-http at `transports/v1.6.8` with any streaming provider and issue a streaming request lasting more than ~1s using openai-go < v3.43.0 (e.g. v3.15.0); the stream aborts at the first heartbeat with `unexpected end of JSON input`. With this fix, the same client streams to completion (verified with both openai-go v3.15.0 and v3.43.0).

No new configs or environment variables.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #5874

## Security considerations

None — one byte removed from a server-emitted SSE comment frame.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
