### PR TITLE
fix: return informative message when model list is disabled for provider

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3602,13 +3602,39 @@ func reorderAtomicSlice[T pluginWithName](ptr *atomic.Pointer[[]T], pos map[stri
 //	}
 //	fmt.Println(providers)
 func (bifrost *Bifrost) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
-	providers := bifrost.providers.Load()
-	if providers == nil {
-		return nil, fmt.Errorf("no providers configured")
+	providerKeys, err := bifrost.account.GetConfiguredProviders()
+	if err != nil {
+		return nil, err
 	}
-	modelProviders := make([]schemas.ModelProvider, len(*providers))
-	for i, provider := range *providers {
-		modelProviders[i] = provider.GetProviderKey()
+
+	initializedProviders := make(map[schemas.ModelProvider]struct{})
+	if providers := bifrost.providers.Load(); providers != nil {
+		for _, provider := range *providers {
+			initializedProviders[provider.GetProviderKey()] = struct{}{}
+		}
+	}
+
+	modelProviders := make([]schemas.ModelProvider, 0, len(providerKeys))
+	for _, providerKey := range providerKeys {
+		if strings.TrimSpace(string(providerKey)) == "" {
+			continue
+		}
+
+		config, err := bifrost.account.GetConfigForProvider(providerKey)
+		if err != nil {
+			bifrost.logger.Warn("failed to get config for provider %s while listing configured providers: %v", providerKey, err)
+			continue
+		}
+		if config == nil {
+			continue
+		}
+		if config.CustomProviderConfig != nil && config.CustomProviderConfig.AllowedRequests != nil && !config.CustomProviderConfig.IsOperationAllowed(schemas.ListModelsRequest) {
+			continue
+		}
+		if _, initialized := initializedProviders[providerKey]; !initialized {
+			continue
+		}
+		modelProviders = append(modelProviders, providerKey)
 	}
 	return modelProviders, nil
 }

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -895,6 +895,92 @@ func TestFilterProvidersByContext(t *testing.T) {
 	})
 }
 
+func TestGetConfiguredProvidersRespectsListModelsAllowlist(t *testing.T) {
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 1, 1)
+	account.AddProvider(schemas.Anthropic, 1, 1)
+
+	account.configs[schemas.OpenAI].CustomProviderConfig = &schemas.CustomProviderConfig{
+		BaseProviderType: schemas.OpenAI,
+		AllowedRequests:  &schemas.AllowedRequests{ListModels: false},
+	}
+	account.configs[schemas.Anthropic].CustomProviderConfig = &schemas.CustomProviderConfig{
+		BaseProviderType: schemas.Anthropic,
+		AllowedRequests:  &schemas.AllowedRequests{ListModels: true},
+	}
+
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Error initializing Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	providers, err := client.GetConfiguredProviders()
+	if err != nil {
+		t.Fatalf("GetConfiguredProviders returned error: %v", err)
+	}
+	if len(providers) != 1 || providers[0] != schemas.Anthropic {
+		t.Fatalf("expected only anthropic provider, got %v", providers)
+	}
+}
+
+func TestListAllModelsExcludesProviderWithFailedPrepare(t *testing.T) {
+	account := NewMockAccount()
+	brokenProvider := schemas.ModelProvider("broken-provider")
+
+	account.mu.Lock()
+	account.configs[brokenProvider] = &schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			DefaultRequestTimeoutInSeconds: 300,
+			MaxRetries:                     3,
+			RetryBackoffInitial:            500 * time.Millisecond,
+			RetryBackoffMax:                5 * time.Second,
+		},
+		ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+			Concurrency: 1,
+			BufferSize:  1,
+		},
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.ModelProvider("unsupported-base-provider"),
+		},
+	}
+	account.keys[brokenProvider] = []schemas.Key{{
+		ID:     "broken-key",
+		Value:  *schemas.NewSecretVar("sk-broken"),
+		Weight: 100,
+	}}
+	account.mu.Unlock()
+
+	client, err := Init(context.Background(), schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Error initializing Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{brokenProvider})
+
+	resp, bifrostErr := client.ListAllModels(ctx, &schemas.BifrostListModelsRequest{})
+	if bifrostErr != nil {
+		t.Fatalf("expected failed-init provider to be excluded from ListAllModels, got error: %v", bifrostErr)
+	}
+	if resp == nil {
+		t.Fatalf("expected non-nil list models response")
+	}
+	if len(resp.Data) != 0 {
+		t.Fatalf("expected no models when only failed-init provider is available, got %d", len(resp.Data))
+	}
+}
+
 func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	account := NewMockAccount()


### PR DESCRIPTION
**fix: respect list_models disabled setting in /v1/models fan-out**

## Summary

When a provider had `list_models` disabled via `AllowedRequests`, the `GET /v1/models` endpoint would still fan out to that provider and include its models in the response (or return an error). Two separate code paths were affected:

1. **Fan-out (no provider specified)** — `GetConfiguredProviders()` returned all providers regardless of their `AllowedRequests` config, causing disabled providers to be included in the aggregate model list.
2. **Single-provider query** — `GET /v1/models?provider=<name>` did not check `AllowedRequests` before making the request, resulting in an `unsupported_operation` error being surfaced to the caller.

## Changes

- **bifrost.go** — `GetConfiguredProviders()` now filters out providers where `list_models` is explicitly disabled in their `CustomProviderConfig.AllowedRequests`. Providers with no `AllowedRequests` config (i.e. all operations allowed) are unaffected.
- **models.go** — Added an optional `message` field to `BifrostListModelsResponse` to convey informational messages (e.g. disabled notice) without breaking the response shape.
- **inference.go** — Added a pre-flight check in `listModels`: if a specific provider is requested and its `list_models` is disabled, return an empty model list with a human-readable message (`"The model_list request is disabled for this provider."`) instead of forwarding the request.
- **bifrost_test.go** and **`inference_list_models_test.go`** — Added unit tests covering both fan-out filtering and single-provider disabled behavior.
## Type of change

-  Bug fix

## Affected areas

- Core (Go)
- Transports (HTTP)

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.
<img width="1385" height="725" alt="image" src="https://github.com/user-attachments/assets/b0835a32-ef88-498b-a863-951cf3c3b611" />
<img width="1385" height="725" alt="image" src="https://github.com/user-attachments/assets/b52e9d92-1009-4367-94e0-25c5a0894770" />
## Screenshots/Recordings

Previously, requests to providers with model_list disabled resulted in error logs. This change ensures those providers are excluded from model_list fan-out, eliminating the unnecessary errors.

<img width="1738" height="832" alt="image" src="https://github.com/user-attachments/assets/492c2789-e336-4085-b3be-ad8956f2299d" />

## Breaking changes

- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


