### PR TITLE
semantic router: incremental embedding + embed usage accounting

### DIFF
--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -3,6 +3,7 @@ package configstore
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -305,7 +306,9 @@ func (c *ComplexitySemanticConfig) Validate() error {
 	}
 	// 1 is a legal ceiling but rejects every real match, so it is treated as a
 	// misconfiguration rather than an intentional "never classify semantically".
-	if c.MinSimilarity < 0 || c.MinSimilarity >= 1 {
+	// NaN is checked separately because every comparison against it is false, so
+	// the range test alone would let it through and silently disable the floor.
+	if math.IsNaN(c.MinSimilarity) || c.MinSimilarity < 0 || c.MinSimilarity >= 1 {
 		return fmt.Errorf("semantic min_similarity must be at least 0 and less than 1, got %v", c.MinSimilarity)
 	}
 	if c.MessageHistoryCount < 1 || c.MessageHistoryCount > MaxComplexitySemanticMessageHistoryCount {

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -90,6 +91,9 @@ func TestComplexitySemanticConfigValidation(t *testing.T) {
 		// misconfiguration rather than a way to disable semantic routing.
 		{name: "min similarity at one", mutate: func(c *ComplexitySemanticConfig) { c.MinSimilarity = 1 }},
 		{name: "min similarity above one", mutate: func(c *ComplexitySemanticConfig) { c.MinSimilarity = 1.5 }},
+		// Every comparison against NaN is false, so a plain range check would
+		// accept it and the floor would silently never apply.
+		{name: "min similarity not a number", mutate: func(c *ComplexitySemanticConfig) { c.MinSimilarity = math.NaN() }},
 		{name: "negative message history count", mutate: func(c *ComplexitySemanticConfig) { c.MessageHistoryCount = -1 }},
 		{
 			name: "message history count above the ceiling",

--- a/framework/configstore/exemplars_test.go
+++ b/framework/configstore/exemplars_test.go
@@ -53,6 +53,13 @@ func TestDefaultComplexityExemplarsBalanceSurfaceForm(t *testing.T) {
 	type lengths struct{ min, median, max int }
 	measured := make([]lengths, 0, len(tiers))
 	for _, tier := range tiers {
+		// TestDefaultComplexityExemplars already enforces the per-tier count, but
+		// it is a separate test: an emptied tier would reach the min/median/max
+		// indexing below and panic, taking the whole package's test binary with it
+		// instead of naming the tier at fault.
+		if len(tier.values) == 0 {
+			t.Fatalf("%s has no default exemplars", tier.name)
+		}
 		counts := make([]int, 0, len(tier.values))
 		for _, value := range tier.values {
 			counts = append(counts, len(strings.Fields(value)))

--- a/framework/vectorstore/chromem.go
+++ b/framework/vectorstore/chromem.go
@@ -201,9 +201,13 @@ func (s *ChromemStore) GetAll(ctx context.Context, namespace string, queries []Q
 	if offset >= total {
 		return []SearchResult{}, nil, nil
 	}
-	end := offset + limit
-	if end > total {
-		end = total
+	// Compare against what is left rather than forming offset+limit: limit is
+	// caller-supplied and unbounded, so the sum overflows int64 and wraps
+	// negative for a large enough value. A negative end fails the end > total
+	// check and reaches the slice as a bound below offset, panicking mid-request.
+	end := total
+	if remaining := total - offset; limit < remaining {
+		end = offset + limit
 	}
 	page := filtered[offset:end]
 
@@ -238,7 +242,12 @@ func (s *ChromemStore) GetNearest(ctx context.Context, namespace string, vector 
 	if limit <= 0 {
 		limit = 10
 	}
-	out := make([]SearchResult, 0, limit)
+	// Size the preallocation by what the search can actually return, not by the
+	// caller's limit: nothing bounds limit, and an oversized one would reserve —
+	// or on an extreme value panic trying to reserve — memory no result set could
+	// ever fill. The loop below still honors limit itself. Every other backend
+	// sizes its result slice on its own result count for the same reason.
+	out := make([]SearchResult, 0, min(int64(len(results)), limit))
 	for _, res := range results {
 		if float64(res.Similarity) < threshold {
 			// Results are ranked by similarity; everything after is below threshold too.

--- a/framework/vectorstore/chromem_test.go
+++ b/framework/vectorstore/chromem_test.go
@@ -3,6 +3,7 @@ package vectorstore
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -297,6 +298,17 @@ func TestChromemStore_Pagination(t *testing.T) {
 	badCursor := "not-a-number"
 	_, _, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, &badCursor, 2)
 	assert.Error(t, err)
+
+	// A caller-supplied limit is unbounded, so offset+limit can overflow int64
+	// and wrap negative. Nothing downstream catches that: the end > total check
+	// is false for a negative end, and the slice bounds then panic. Every page
+	// past the first is reachable this way, since it needs a non-zero cursor.
+	hugeLimit := int64(math.MaxInt64)
+	firstCursor := "1"
+	results, next, err := ts.Store.GetAll(ts.ctx, ChromemTestNamespace, nil, nil, &firstCursor, hugeLimit)
+	require.NoError(t, err)
+	assert.Nil(t, next, "a limit past the end leaves nothing to page to")
+	assert.Len(t, results, 4, "an oversized limit returns the remainder, not a panic")
 }
 
 func TestChromemStore_DimensionHandling(t *testing.T) {

--- a/framework/vectorstore/pinecone.go
+++ b/framework/vectorstore/pinecone.go
@@ -144,10 +144,7 @@ func (s *PineconeStore) GetAll(ctx context.Context, namespace string, queries []
 		return nil, nil, err
 	}
 
-	topK := uint32(limit)
-	if limit <= 0 {
-		topK = 100
-	}
+	topK := boundedPageLimit(limit, 100)
 
 	// Create zero vector for query - this allows us to use QueryByVectorValues
 	// which has much better consistency than ListVectors
@@ -209,10 +206,7 @@ func (s *PineconeStore) GetNearest(ctx context.Context, namespace string, vector
 		return nil, err
 	}
 
-	topK := uint32(limit)
-	if limit <= 0 {
-		topK = 10
-	}
+	topK := boundedPageLimit(limit, 10)
 
 	queryReq := &pinecone.QueryByVectorValuesRequest{
 		Vector:          vector,

--- a/framework/vectorstore/qdrant.go
+++ b/framework/vectorstore/qdrant.go
@@ -194,10 +194,12 @@ func (s *QdrantStore) GetAll(ctx context.Context, namespace string, queries []Qu
 		}
 	}
 
-	scrollLimit := uint32(limit)
-	if limit <= 0 {
-		scrollLimit = 100
-	}
+	// Clamped rather than converted: a truncated-to-zero limit would scroll
+	// nothing, and the len(scrollResult) >= scrollLimit check below would then
+	// read 0 >= 0 as a full page and hand back a cursor pointing at the empty
+	// lastID — which the next call treats as no cursor at all, so a caller
+	// paging to completion would never advance.
+	scrollLimit := boundedPageLimit(limit, 100)
 
 	scrollResult, err := s.client.Scroll(ctx, &qdrant.ScrollPoints{
 		CollectionName: namespace,

--- a/framework/vectorstore/utils.go
+++ b/framework/vectorstore/utils.go
@@ -2,8 +2,27 @@ package vectorstore
 
 import (
 	"context"
+	"math"
 	"time"
 )
+
+// boundedPageLimit narrows a caller's limit to the uint32 page size the Qdrant
+// and Pinecone clients accept, substituting fallback for a non-positive one.
+//
+// Converting directly truncates. Nothing bounds limit, so a value above
+// MaxUint32 wraps to an unrelated small page — and an exact multiple of 2^32
+// wraps to zero, which a caller cannot distinguish from asking for nothing.
+// Clamping instead keeps an oversized limit meaning what the caller intended:
+// as much as the backend is willing to return.
+func boundedPageLimit(limit int64, fallback uint32) uint32 {
+	if limit <= 0 {
+		return fallback
+	}
+	if limit > int64(math.MaxUint32) {
+		return math.MaxUint32
+	}
+	return uint32(limit)
+}
 
 // withTimeout adds a timeout to the context if it is set.
 func withTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {

--- a/framework/vectorstore/utils_test.go
+++ b/framework/vectorstore/utils_test.go
@@ -1,0 +1,42 @@
+package vectorstore
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBoundedPageLimit covers the conversion the Qdrant and Pinecone clients
+// need. The interesting cases are the ones a plain uint32(limit) got wrong:
+// nothing bounds the caller's limit, so anything above MaxUint32 used to wrap
+// to an unrelated page size, and an exact multiple of 2^32 wrapped to zero.
+func TestBoundedPageLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int64
+		want  uint32
+	}{
+		{name: "in range", limit: 250, want: 250},
+		{name: "zero falls back", limit: 0, want: 100},
+		{name: "negative falls back", limit: -1, want: 100},
+		{name: "at the ceiling", limit: math.MaxUint32, want: math.MaxUint32},
+		// Truncation used to turn this into a 4-row page.
+		{name: "just past the ceiling", limit: int64(math.MaxUint32) + 5, want: math.MaxUint32},
+		// The worst case: uint32(1<<32) is 0, which scrolls nothing while still
+		// reading as a filled page to the caller's cursor logic.
+		{name: "exact multiple of 2^32", limit: 1 << 32, want: math.MaxUint32},
+		{name: "max int64", limit: math.MaxInt64, want: math.MaxUint32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, boundedPageLimit(tt.limit, 100))
+		})
+	}
+
+	// The fallback is per call site: GetNearest defaults to a smaller page than
+	// GetAll, and only a non-positive limit may reach it.
+	assert.Equal(t, uint32(10), boundedPageLimit(0, 10))
+	assert.Equal(t, uint32(7), boundedPageLimit(7, 10))
+}

--- a/plugins/governance/complexity/semanticclassifier.go
+++ b/plugins/governance/complexity/semanticclassifier.go
@@ -60,6 +60,14 @@ type SemanticStatusInfo struct {
 	Total           int            `json:"total"`
 	ServingPrevious bool           `json:"serving_previous,omitempty"`
 	Error           string         `json:"error,omitempty"`
+	// CachedPhrases is how many phrase vectors are currently held in process for
+	// the configured provider/model. Reuse cannot be inferred from the persisted
+	// config alone: the cache lives only in memory (vectors cannot be read back
+	// out of a VectorStore), so a restart empties it while the saved phrases look
+	// unchanged. Configuration clients estimating what a save will re-embed need
+	// this to tell a warm cache from a cold one; zero means the next save embeds
+	// every phrase regardless of what changed.
+	CachedPhrases int `json:"cached_phrases"`
 }
 
 // SemanticResult is the tier selected by the nearest labelled exemplar.
@@ -131,6 +139,7 @@ type SemanticClassifier struct {
 	warming          bool
 	closed           bool
 	embeddedInFlight map[string]int
+	embeddingCache   *semanticEmbeddingCache
 	wg               sync.WaitGroup
 }
 
@@ -142,9 +151,10 @@ func NewSemanticClassifier(ctx context.Context, logger schemas.Logger) *Semantic
 		ctx = context.Background()
 	}
 	return &SemanticClassifier{
-		ctx:    ctx,
-		logger: logger,
-		status: SemanticStatusInfo{State: SemanticStatusDisabled},
+		ctx:            ctx,
+		logger:         logger,
+		status:         SemanticStatusInfo{State: SemanticStatusDisabled},
+		embeddingCache: newSemanticEmbeddingCache(),
 	}
 }
 
@@ -159,8 +169,9 @@ func (c *SemanticClassifier) Configure(config *AnalyzerConfig) {
 	c.mu.Unlock()
 }
 
-// SetConfiguredStore supplies Bifrost's configured shared VectorStore. Embedded
-// mode ignores it, auto prefers it, and external requires it.
+// SetConfiguredStore supplies Bifrost's configured shared VectorStore.
+// "embedded" mode ignores it; "vector_store" mode uses it when present and
+// falls back to the embedded store when it is nil.
 func (c *SemanticClassifier) SetConfiguredStore(store vectorstore.VectorStore) {
 	c.mu.Lock()
 	c.configuredStore = store
@@ -232,8 +243,13 @@ func (c *SemanticClassifier) ValidateConfig(config *AnalyzerConfig) error {
 // Status returns a stable snapshot of the current semantic readiness state.
 func (c *SemanticClassifier) Status() SemanticStatusInfo {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.status
+	status := c.status
+	cache := c.embeddingCache
+	c.mu.Unlock()
+	// Read the cache outside c.mu: it carries its own lock, and warmup holds that
+	// one while embedding.
+	status.CachedPhrases = cache.size()
+	return status
 }
 
 // Timeout returns the per-request embedding budget currently in force,
@@ -408,8 +424,9 @@ func (c *SemanticClassifier) resetForCurrentConfigLocked() {
 		ServingPrevious: c.active != nil,
 	}
 	// Governance dependencies are injected after plugin construction. Waiting
-	// for the embedding adapter prevents auto mode from creating an embedded
-	// store that is immediately superseded by the configured shared store.
+	// for the embedding adapter prevents "vector_store" mode from creating an
+	// embedded store that is immediately superseded by the configured shared
+	// store once that arrives.
 	if c.embed == nil {
 		return
 	}
@@ -465,7 +482,7 @@ func (c *SemanticClassifier) runWarmupWorker() {
 		}
 		c.mu.Unlock()
 
-		loaded, namespace, dimension, err := warmSemanticExemplars(warmCtx, store, config, embed, embedBatch)
+		loaded, namespace, dimension, err := warmSemanticExemplars(warmCtx, store, config, embed, embedBatch, c.embeddingCache)
 		cancel()
 
 		c.mu.Lock()
@@ -601,6 +618,7 @@ func warmSemanticExemplars(
 	config *AnalyzerConfig,
 	embed EmbeddingFunc,
 	embedBatch BatchEmbeddingFunc,
+	cache *semanticEmbeddingCache,
 ) (int, string, int, error) {
 	if config == nil || config.Semantic == nil {
 		return 0, "", 0, nil
@@ -610,15 +628,21 @@ func warmSemanticExemplars(
 		return 0, "", 0, fmt.Errorf("semantic complexity classifier has no exemplars")
 	}
 
-	// The exemplars' common vector width is the runtime dimension for this
-	// generation, so no operator-entered width is needed in config.json or the
-	// management API.
+	// Vectors are reused only for the same provider/model. Their common width is
+	// the runtime dimension for this generation, so no operator-entered width is
+	// needed in config.json or the management API.
+	cache.useIdentity(semanticEmbeddingIdentity(config.Semantic))
 	vectors := make([][]float32, len(exemplars))
 	pending := make([]int, 0, len(exemplars))
-	for index := range exemplars {
+	dimension := 0
+	for index, exemplar := range exemplars {
+		if vector, ok := cache.get(exemplar.Phrase); ok {
+			vectors[index] = vector
+			dimension = len(vector)
+			continue
+		}
 		pending = append(pending, index)
 	}
-	dimension := 0
 	if dimension == 0 {
 		// Namespace creation needs a width. Prefer the first warmup batch so
 		// providers that support batching do not pay an extra single-input call.
@@ -651,6 +675,7 @@ func warmSemanticExemplars(
 						return 0, "", dimension, fmt.Errorf("%s exemplar %d returned dimension %d, expected %d", strings.ToLower(exemplars[exemplarIndex].Tier), exemplarIndex+1, len(embeddings[index]), dimension)
 					}
 					vectors[exemplarIndex] = embeddings[index]
+					cache.put(exemplars[exemplarIndex].Phrase, embeddings[index])
 				}
 				pending = pending[batchEnd:]
 			}
@@ -665,6 +690,7 @@ func warmSemanticExemplars(
 			}
 			dimension = len(embedding)
 			vectors[first] = embedding
+			cache.put(exemplars[first].Phrase, embedding)
 			pending = pending[1:]
 		}
 	}
@@ -684,6 +710,12 @@ func warmSemanticExemplars(
 	markers, err := store.GetChunks(ctx, namespace, []string{markerID})
 	if err == nil && len(markers) > 0 {
 		if markers[0].Properties[semanticMetadataFingerprint] == fingerprint {
+			// This generation is already stored, so nothing below runs — but the
+			// cache can still be holding another generation's phrases (reverting to
+			// a previously warmed config lands here with the newer config's vectors
+			// resident). Prune here too, or those entries survive until the next
+			// warmup that actually embeds something.
+			cache.retain(exemplars)
 			return len(exemplars), namespace, dimension, nil
 		}
 	} else if err != nil && !errors.Is(err, vectorstore.ErrNotFound) {
@@ -741,6 +773,9 @@ func warmSemanticExemplars(
 				return 0, namespace, dimension, fmt.Errorf("%s exemplar %d returned dimension %d, expected %d", strings.ToLower(exemplar.Tier), exemplarIndex+1, len(embedding), dimension)
 			}
 			vectors[exemplarIndex] = embedding
+			// Cached only after the width check, so a provider that answered for
+			// the wrong model cannot poison later warmups.
+			cache.put(exemplar.Phrase, embedding)
 		}
 	}
 
@@ -768,7 +803,104 @@ func warmSemanticExemplars(
 	}); err != nil {
 		return len(exemplars), namespace, dimension, fmt.Errorf("store complexity warmup marker: %w", err)
 	}
+	cache.retain(exemplars)
 	return len(exemplars), namespace, dimension, nil
+}
+
+// semanticEmbeddingCache remembers the vector each exemplar phrase embedded to,
+// so editing the tier lists re-embeds only what actually changed.
+//
+// Generations stay immutable and content-addressed: adding one phrase still
+// mints a new fingerprint, a new namespace, and a new record id for every
+// exemplar. What changes is where those vectors come from. A stored vector
+// cannot be read back — vectorstore.SearchResult carries only an id, score, and
+// properties — so reuse has to be held in process.
+//
+// Entries are only valid for the provider and model that produced them;
+// switching either invalidates all of them at once. Warmup prunes the map to
+// the phrases it just embedded,
+// so a long-lived process editing its tier lists repeatedly does not accumulate
+// vectors for phrases nobody references any more.
+type semanticEmbeddingCache struct {
+	mu       sync.Mutex
+	identity string
+	vectors  map[string][]float32
+}
+
+func newSemanticEmbeddingCache() *semanticEmbeddingCache {
+	return &semanticEmbeddingCache{vectors: map[string][]float32{}}
+}
+
+// semanticEmbeddingIdentity names everything about a config that changes what a
+// phrase embeds to. Two configs sharing it can share vectors.
+func semanticEmbeddingIdentity(semantic *SemanticConfig) string {
+	if semantic == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s\x00%s", semantic.Provider, semantic.EmbeddingModel)
+}
+
+// useIdentity drops every cached vector when the embedding identity changes,
+// because a vector from another provider or model is not merely stale but
+// wrong: it would be stored as though it described this phrase under the new
+// model, and nothing downstream could tell.
+func (c *semanticEmbeddingCache) useIdentity(identity string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.identity != identity {
+		c.identity = identity
+		c.vectors = map[string][]float32{}
+	}
+}
+
+// size reports how many phrase vectors are currently held, which is what a
+// configuration client needs to tell a warm cache from one emptied by a restart
+// or an identity change.
+func (c *semanticEmbeddingCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.vectors)
+}
+
+func (c *semanticEmbeddingCache) get(phrase string) ([]float32, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	vector, ok := c.vectors[phrase]
+	return vector, ok
+}
+
+func (c *semanticEmbeddingCache) put(phrase string, vector []float32) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vectors[phrase] = vector
+}
+
+// retain prunes the cache to the phrases a completed warmup actually used.
+func (c *semanticEmbeddingCache) retain(exemplars []semanticExemplar) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	keep := make(map[string][]float32, len(exemplars))
+	for _, exemplar := range exemplars {
+		if vector, ok := c.vectors[exemplar.Phrase]; ok {
+			keep[exemplar.Phrase] = vector
+		}
+	}
+	c.vectors = keep
 }
 
 // semanticExemplar binds one normalized shared tier phrase to its routing tier.

--- a/plugins/governance/complexity/semanticclassifier_test.go
+++ b/plugins/governance/complexity/semanticclassifier_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,7 +59,7 @@ func TestSemanticClassifierNamesMatchedExemplarFromReusedGeneration(t *testing.T
 	})
 
 	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
-	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil)
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil, nil)
 	require.NoError(t, err)
 
 	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
@@ -258,12 +259,12 @@ func TestWarmSemanticExemplarsReusesMatchingMarker(t *testing.T) {
 		return testSemanticEmbedding(ctx, semantic, text)
 	}
 
-	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, embed, nil)
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, embed, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, len(semanticExemplars(&config)), loaded)
 	assert.EqualValues(t, loaded, embeddingCalls.Load())
 
-	loaded, _, _, err = warmSemanticExemplars(context.Background(), store, &config, embed, nil)
+	loaded, _, _, err = warmSemanticExemplars(context.Background(), store, &config, embed, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, len(semanticExemplars(&config)), loaded)
 	assert.EqualValues(t, loaded+1, embeddingCalls.Load(), "reusing a persisted generation needs one embedding to rediscover its width")
@@ -285,7 +286,7 @@ func TestWarmSemanticExemplarsUsesBackendCompatibleLifecycle(t *testing.T) {
 	store := &semanticLifecycleProbeStore{VectorStore: backingStore}
 	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
 
-	loaded, namespace, dimension, err := warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil)
+	loaded, namespace, dimension, err := warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, len(semanticExemplars(&config)), loaded)
 	assert.True(t, store.createdBeforeRead, "a generation namespace must exist before its marker is read")
@@ -638,7 +639,7 @@ func TestWarmSemanticExemplarsUsesBoundedBatches(t *testing.T) {
 		return nil, fmt.Errorf("unexpected single-input call for %q", text)
 	}
 
-	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch)
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 70, loaded)
 	assert.Equal(t, []int{32, 32, 6}, batchSizes)
@@ -671,7 +672,7 @@ func TestWarmSemanticExemplarsFallsBackWhenBatchingIsUnsupported(t *testing.T) {
 		return []float32{1, 0}, nil
 	}
 
-	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch)
+	loaded, _, _, err := warmSemanticExemplars(context.Background(), store, &config, single, batch, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 40, loaded)
 	assert.EqualValues(t, 1, batchCalls.Load())
@@ -699,7 +700,7 @@ func TestWarmSemanticExemplarsRejectsInconsistentDetectedDimensions(t *testing.T
 		return embeddings, nil
 	}
 
-	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, batch)
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &config, testSemanticEmbedding, batch, nil)
 	require.ErrorContains(t, err, "returned dimension 3, expected 2")
 }
 
@@ -861,4 +862,102 @@ func TestSemanticClassifierRearmsForProviderOnlyWhenFailed(t *testing.T) {
 	revisionAfter := classifier.revision
 	classifier.mu.Unlock()
 	assert.Equal(t, revisionBefore, revisionAfter, "a ready classifier must not re-embed on a provider change")
+}
+
+// TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit pins the cost model of
+// editing a tier list. Generations stay content-addressed, so adding one phrase
+// still mints a new fingerprint and writes every exemplar into a fresh
+// namespace — but only the added phrase may reach the embedding provider.
+// Re-embedding the whole set for a one-phrase edit is a bill the operator did
+// not ask for, and on a 150-phrase deployment it is the difference between one
+// request and a hundred and fifty.
+func TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit(t *testing.T) {
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	var embeddedMu sync.Mutex
+	var embedded []string
+	embed := func(_ context.Context, _ *SemanticConfig, text string) ([]float32, error) {
+		embeddedMu.Lock()
+		embedded = append(embedded, text)
+		embeddedMu.Unlock()
+		// Any distinct unit-ish vector of the configured width will do; this test
+		// is about which phrases reach the provider, not about what they classify as.
+		return []float32{float32(len(text)%7) + 1, float32(len(text)%5) + 1}, nil
+	}
+	takeEmbedded := func() []string {
+		embeddedMu.Lock()
+		defer embeddedMu.Unlock()
+		taken := append([]string(nil), embedded...)
+		embedded = nil
+		return taken
+	}
+
+	cache := newSemanticEmbeddingCache()
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+
+	loaded, firstNamespace, _, err := warmSemanticExemplars(context.Background(), store, &config, embed, nil, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 3, loaded)
+	assert.ElementsMatch(t, []string{"simple exemplar", "medium exemplar", "complex exemplar"}, takeEmbedded())
+
+	// One phrase added to one tier. The other three are already held.
+	edited := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	edited.Keywords.SimpleKeywords = append(edited.Keywords.SimpleKeywords, "brand new exemplar")
+
+	loaded, secondNamespace, _, err := warmSemanticExemplars(context.Background(), store, &edited, embed, nil, cache)
+	require.NoError(t, err)
+	assert.Equal(t, 4, loaded)
+	assert.Equal(t, []string{"brand new exemplar"}, takeEmbedded(), "only the added phrase may be embedded again")
+	assert.NotEqual(t, firstNamespace, secondNamespace, "an edited phrase set is still a new generation")
+
+	// Every exemplar, reused or freshly embedded, has to exist in the new
+	// generation: reuse must not turn into a partially populated namespace.
+	for _, exemplar := range semanticExemplars(&edited) {
+		id := semanticExemplarID(semanticFingerprint(&edited, semanticExemplars(&edited), testSemanticDimension), exemplar)
+		chunks, err := store.GetChunks(context.Background(), secondNamespace, []string{id})
+		require.NoError(t, err)
+		require.Len(t, chunks, 1, "exemplar %q missing from the new generation", exemplar.Phrase)
+	}
+
+	// Switching model invalidates every held vector: a vector produced by
+	// another model is not stale, it is wrong for this one.
+	remodelled := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	remodelled.Semantic.EmbeddingModel = "another-embedding-model"
+	_, _, _, err = warmSemanticExemplars(context.Background(), store, &remodelled, embed, nil, cache)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"simple exemplar", "medium exemplar", "complex exemplar"}, takeEmbedded(),
+		"a model change must re-embed everything")
+}
+
+// TestSemanticClassifierStatusReportsCacheCoverage guards the signal the
+// configuration UI uses to estimate what a save will re-embed. The cache is
+// in-process, so a restart empties it while the saved phrases look unchanged —
+// coverage cannot be inferred from the persisted config and has to be reported.
+func TestSemanticClassifierStatusReportsCacheCoverage(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	// A classifier that has never warmed holds nothing, so the next save embeds
+	// every phrase however little changed.
+	assert.Equal(t, 0, classifier.Status().CachedPhrases)
+
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, len(semanticExemplars(&config)), classifier.Status().CachedPhrases,
+		"a warmed classifier holds one vector per active phrase")
 }

--- a/plugins/governance/embedding.go
+++ b/plugins/governance/embedding.go
@@ -104,8 +104,8 @@ func (p *GovernancePlugin) SetEmbeddingRequestExecutor(executor EmbeddingRequest
 }
 
 // SetComplexityVectorStore supplies the configured shared VectorStore. The
-// classifier chooses it only for auto or external mode; embedded mode retains
-// its private Chromem store.
+// classifier uses it only in "vector_store" mode; "embedded" mode retains its
+// private Chromem store.
 func (p *GovernancePlugin) SetComplexityVectorStore(store vectorstore.VectorStore) {
 	if p.semanticClassifier != nil {
 		p.semanticClassifier.SetConfiguredStore(store)
@@ -130,13 +130,24 @@ func (p *GovernancePlugin) embedComplexityText(ctx context.Context, semantic *co
 	embeddingCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 	defer embeddingCtx.Cancel()
 	embedding, inputTokens, err := p.generateEmbedding(embeddingCtx, semantic, text, timeout)
+	// Mirrors embedComplexityTexts: a response that arrived and was billed is
+	// accounted for even when its shape was rejected, because the provider
+	// completed the call either way. This is the single-input side of the same
+	// rule — reached both by warmup's fallback after a batch is refused and by a
+	// live request's classification embed.
+	//
+	// generateEmbeddings reports zero tokens for every failure before the
+	// response arrives (no executor, bad config, timeout), so gating on a
+	// positive count keeps those out and leaves the success path unchanged.
+	if err == nil || inputTokens > 0 {
+		if isRequest {
+			recordRoutingEmbedUsage(ctx, semantic, inputTokens)
+		} else {
+			p.settleWarmupEmbedUsage(semantic, inputTokens)
+		}
+	}
 	if err != nil {
 		return nil, err
-	}
-	if isRequest {
-		recordRoutingEmbedUsage(ctx, semantic, inputTokens)
-	} else {
-		p.settleWarmupEmbedUsage(semantic, inputTokens)
 	}
 	return embedding, nil
 }
@@ -154,14 +165,30 @@ func requestEmbeddingTimeout(semantic *complexity.SemanticConfig) time.Duration 
 // triggering request's context. Warmup embeds arrive on plain background
 // contexts (never a *schemas.BifrostContext), so they are naturally excluded —
 // boot/warmup embedding cost is never stamped or attributed to any request.
+// A request that fails over classifies once per attempt: core's fallback loop
+// hands the same context to tryRequest, which re-runs the plugin pre-hooks, and
+// clearCtxForFallback does not clear this key. Tokens therefore accumulate
+// rather than replace — the provider billed for every one of those embeds, but
+// only the surviving record reaches the RoutingDebug stamp that cost
+// calculation reads, so replacing would silently drop all but the last.
 func recordRoutingEmbedUsage(ctx context.Context, semantic *complexity.SemanticConfig, inputTokens int) {
 	bfCtx, ok := ctx.(*schemas.BifrostContext)
 	if !ok || semantic == nil {
 		return
 	}
+	provider := string(semantic.Provider)
+	model := semantic.EmbeddingModel
+	// Only accumulate across embeds that price identically. A semantic config
+	// reloaded mid-request embeds through different rates, and one record cannot
+	// describe both, so the newest provider/model wins and starts a fresh count
+	// instead of billing the older tokens at the newer rate.
+	if previous, ok := bfCtx.Value(routingEmbedUsageContextKey).(*routingEmbedUsage); ok &&
+		previous != nil && previous.Provider == provider && previous.Model == model {
+		inputTokens += previous.InputTokens
+	}
 	bfCtx.SetValue(routingEmbedUsageContextKey, &routingEmbedUsage{
-		Provider:           string(semantic.Provider),
-		Model:              semantic.EmbeddingModel,
+		Provider:           provider,
+		Model:              model,
 		InputTokens:        inputTokens,
 		CountTowardBudgets: semantic.CountTowardBudgets,
 	})
@@ -214,10 +241,24 @@ func (p *GovernancePlugin) embedComplexityTexts(ctx context.Context, semantic *c
 	embeddingCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 	defer embeddingCtx.Cancel()
 	embeddings, inputTokens, err := p.generateEmbeddings(embeddingCtx, semantic, texts, warmupEmbeddingTimeout)
+	// A rejected response shape still cost input tokens: the provider completed
+	// the call and billed for it, we just refused to trust its vector count or
+	// indices. ErrBatchEmbeddingsUnsupported is the case that matters, because
+	// warmup recovers from it by re-embedding one text at a time and then
+	// succeeds — dropping the batch's usage here would leave those tokens
+	// unobserved and unbilled with nothing downstream to notice. The retries
+	// settle their own separate calls, so this cannot double-count.
+	//
+	// generateEmbeddings reports zero tokens for every failure before the
+	// response arrives (no executor, bad config, timeout), so gating on a
+	// positive count keeps those out of the observer's call counter while
+	// leaving the success path settling exactly as before.
+	if err == nil || inputTokens > 0 {
+		p.settleWarmupEmbedUsage(semantic, inputTokens)
+	}
 	if err != nil {
 		return nil, err
 	}
-	p.settleWarmupEmbedUsage(semantic, inputTokens)
 	return embeddings, nil
 }
 
@@ -295,12 +336,16 @@ func (p *GovernancePlugin) CanClassifySemantically(semantic *complexity.Semantic
 // attribution). The call is bounded by the configured semantic timeout: the
 // router hot path must never wait on a slow embedding provider.
 func (p *GovernancePlugin) generateEmbedding(ctx *schemas.BifrostContext, semantic *complexity.SemanticConfig, text string, timeout time.Duration) ([]float32, int, error) {
+	// Both failure paths carry the token count through rather than zeroing it:
+	// generateEmbeddings only reports a positive count once the provider has
+	// responded and billed, and callers decide what to do with usage from a
+	// rejected response. Zeroing here hid it from them entirely.
 	embeddings, inputTokens, err := p.generateEmbeddings(ctx, semantic, []string{text}, timeout)
 	if err != nil {
-		return nil, 0, err
+		return nil, inputTokens, err
 	}
 	if len(embeddings) != 1 {
-		return nil, 0, fmt.Errorf("expected one embedding, got %d", len(embeddings))
+		return nil, inputTokens, fmt.Errorf("expected one embedding, got %d", len(embeddings))
 	}
 	return embeddings[0], inputTokens, nil
 }
@@ -363,7 +408,9 @@ func (p *GovernancePlugin) generateEmbeddings(ctx *schemas.BifrostContext, seman
 		return nil, 0, fmt.Errorf("failed to generate embedding: %v", bifrostErr)
 	}
 
-	if response == nil || len(response.Data) == 0 {
+	// A nil response means nothing arrived to read usage from, so it keeps the
+	// zero-token contract every pre-response failure above shares.
+	if response == nil {
 		return nil, 0, fmt.Errorf("no embeddings returned from provider")
 	}
 	inputTokens := 0
@@ -373,6 +420,14 @@ func (p *GovernancePlugin) generateEmbeddings(ctx *schemas.BifrostContext, seman
 	// Drop it to zero — the embed still happened, we just cannot price it.
 	if response.Usage != nil && response.Usage.TotalTokens > 0 {
 		inputTokens = response.Usage.TotalTokens
+	}
+	// Read usage before rejecting the shape, for the same reason the vector-count
+	// mismatch below returns it: the provider completed the call and billed for
+	// it, and we are only refusing to trust what came back. Returning zero here
+	// left an empty-Data response as the one post-response failure whose tokens
+	// went unobserved and unbilled.
+	if len(response.Data) == 0 {
+		return nil, inputTokens, fmt.Errorf("no embeddings returned from provider")
 	}
 
 	if len(response.Data) != len(texts) {

--- a/plugins/governance/embedding_test.go
+++ b/plugins/governance/embedding_test.go
@@ -347,6 +347,59 @@ func TestEmbedComplexityTextRecordsRoutingUsage(t *testing.T) {
 	assert.True(t, usage.CountTowardBudgets)
 }
 
+// TestEmbedComplexityTextAccumulatesUsageAcrossFallbackAttempts models a
+// request that fails over: core hands the same context to tryRequest for each
+// fallback, the pre-hooks re-run, and classification embeds again. Only one
+// record survives to the RoutingDebug stamp, so it has to carry every attempt's
+// tokens or the provider bills for embeds nothing prices.
+func TestEmbedComplexityTextAccumulatesUsageAcrossFallbackAttempts(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1, 0}}, 20), nil
+	})
+
+	cfg := testEmbeddingSemanticConfig()
+	cfg.CountTowardBudgets = true
+
+	ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+	defer ctx.Cancel()
+	for range 3 {
+		_, err := plugin.embedComplexityText(ctx, cfg, "classify me")
+		require.NoError(t, err)
+	}
+
+	usage, ok := ctx.Value(routingEmbedUsageContextKey).(*routingEmbedUsage)
+	require.True(t, ok)
+	assert.Equal(t, 60, usage.InputTokens, "every attempt's embed must be priced, not just the last")
+	assert.Equal(t, "openai", usage.Provider)
+	assert.True(t, usage.CountTowardBudgets)
+}
+
+// A semantic config reloaded between attempts embeds through different rates,
+// and one record cannot describe both — the newer provider/model must win and
+// start a fresh count rather than billing older tokens at the new rate.
+func TestEmbedComplexityTextRestartsUsageWhenTheEmbeddingModelChanges(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1, 0}}, 20), nil
+	})
+
+	ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+	defer ctx.Cancel()
+	_, err := plugin.embedComplexityText(ctx, testEmbeddingSemanticConfig(), "classify me")
+	require.NoError(t, err)
+
+	reloaded := testEmbeddingSemanticConfig()
+	reloaded.EmbeddingModel = "text-embedding-3-large"
+	_, err = plugin.embedComplexityText(ctx, reloaded, "classify me")
+	require.NoError(t, err)
+
+	usage, ok := ctx.Value(routingEmbedUsageContextKey).(*routingEmbedUsage)
+	require.True(t, ok)
+	assert.Equal(t, "text-embedding-3-large", usage.Model)
+	assert.Equal(t, 20, usage.InputTokens)
+}
+
 // A provider that reports a negative token count must not have it recorded:
 // the stamp feeds cost calculation and warmup budget attribution, where a
 // negative count would subtract from billed usage.
@@ -435,6 +488,43 @@ func TestEmbedComplexityTextsObservesWarmupNeverRecordsRoutingUsage(t *testing.T
 	assert.Equal(t, warmupObservation{"openai", "text-embedding-3-small", 7}, observed[0])
 }
 
+// TestEmbedComplexityTextsSettlesUsageOnUnsupportedBatch covers the shape a
+// single-input-only model returns for a multi-text batch. Warmup recovers by
+// re-embedding each phrase on its own, so this call's tokens are the ones that
+// would silently vanish: the provider billed for them and the run still
+// succeeds.
+func TestEmbedComplexityTextsSettlesUsageOnUnsupportedBatch(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return embeddingResponse(schemas.EmbeddingStruct{EmbeddingArray: []float64{1, 0}}, 5), nil
+	})
+	var observed []warmupObservation
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observed = append(observed, warmupObservation{provider, model, inputTokens})
+	})
+
+	_, err := plugin.embedComplexityTexts(t.Context(), testEmbeddingSemanticConfig(), []string{"a", "b"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, complexity.ErrBatchEmbeddingsUnsupported))
+	require.Len(t, observed, 1)
+	assert.Equal(t, warmupObservation{"openai", "text-embedding-3-small", 5}, observed[0])
+}
+
+// A call that never reached the provider consumed nothing, so it must not reach
+// the observer at all — that would inflate the warmup embedding call counter
+// with attempts the provider never saw.
+func TestEmbedComplexityTextsSkipsUsageWhenTheCallNeverReachedTheProvider(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	var observed []warmupObservation
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observed = append(observed, warmupObservation{provider, model, inputTokens})
+	})
+
+	_, err := plugin.embedComplexityTexts(t.Context(), testEmbeddingSemanticConfig(), []string{"a", "b"})
+	require.ErrorIs(t, err, ErrEmbeddingRequestExecutorNotConfigured)
+	assert.Empty(t, observed)
+}
+
 func TestRequestClassificationEmbedDoesNotObserveWarmup(t *testing.T) {
 	plugin := &GovernancePlugin{}
 	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
@@ -453,6 +543,80 @@ func TestRequestClassificationEmbedDoesNotObserveWarmup(t *testing.T) {
 	_, err := plugin.embedComplexityText(ctx, testEmbeddingSemanticConfig(), "classify me")
 	require.NoError(t, err)
 	assert.NotNil(t, ctx.Value(routingEmbedUsageContextKey))
+	assert.Empty(t, observed)
+}
+
+// TestEmbedComplexityTextSettlesUsageWhenProviderReturnsNoVectors is the
+// single-input side of the same rule the batch path already follows. Warmup
+// reaches this path through its fallback after a provider refuses a batch, so a
+// deployment on a single-input-only model settles every warmup embed here.
+func TestEmbedComplexityTextSettlesUsageWhenProviderReturnsNoVectors(t *testing.T) {
+	plugin, store := newWarmupBudgetFixture(t)
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data:  nil,
+			Usage: &schemas.BifrostLLMUsage{TotalTokens: 1000},
+		}, nil
+	})
+	var observed []warmupObservation
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observed = append(observed, warmupObservation{provider, model, inputTokens})
+	})
+
+	cfg := testEmbeddingSemanticConfig()
+	cfg.CountTowardBudgets = true
+
+	// A plain context is warmup's single-input fallback.
+	_, err := plugin.embedComplexityText(t.Context(), cfg, "warm me")
+	require.Error(t, err)
+
+	require.Len(t, observed, 1)
+	assert.Equal(t, warmupObservation{"openai", "text-embedding-3-small", 1000}, observed[0])
+	// 1000 tokens × $0.00000002/token (text-embedding-3-small in testdata).
+	usage := store.GetGovernanceData(context.Background()).Budgets["provider-budget"].CurrentUsage
+	assert.InDelta(t, 0.00002, usage, 1e-12)
+}
+
+// TestRequestClassificationEmbedRecordsUsageWhenProviderReturnsNoVectors keeps
+// the request side consistent: a classification that failed on response shape
+// still cost the caller tokens, so it reaches the RoutingDebug stamp rather
+// than disappearing because no tier came back.
+func TestRequestClassificationEmbedRecordsUsageWhenProviderReturnsNoVectors(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data:  nil,
+			Usage: &schemas.BifrostLLMUsage{TotalTokens: 42},
+		}, nil
+	})
+	var observed []warmupObservation
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observed = append(observed, warmupObservation{provider, model, inputTokens})
+	})
+
+	ctx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+	defer ctx.Cancel()
+	_, err := plugin.embedComplexityText(ctx, testEmbeddingSemanticConfig(), "classify me")
+	require.Error(t, err)
+
+	usage, ok := ctx.Value(routingEmbedUsageContextKey).(*routingEmbedUsage)
+	require.True(t, ok, "a billed classification embed must be recorded for the stamp")
+	assert.Equal(t, 42, usage.InputTokens)
+	assert.Empty(t, observed, "a request embed must never fire the warmup observer")
+}
+
+// TestEmbedComplexityTextSkipsUsageBeforeProviderResponds keeps the two tests
+// above from becoming "settle on every failure": a call that never reached the
+// provider has nothing to bill.
+func TestEmbedComplexityTextSkipsUsageBeforeProviderResponds(t *testing.T) {
+	plugin := &GovernancePlugin{}
+	var observed []warmupObservation
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observed = append(observed, warmupObservation{provider, model, inputTokens})
+	})
+
+	_, err := plugin.embedComplexityText(t.Context(), testEmbeddingSemanticConfig(), "warm me")
+	require.ErrorIs(t, err, ErrEmbeddingRequestExecutorNotConfigured)
 	assert.Empty(t, observed)
 }
 
@@ -577,6 +741,44 @@ func TestSettleWarmupEmbedUsageAttributesProviderBudget(t *testing.T) {
 	cfg.CountTowardBudgets = true
 
 	plugin.settleWarmupEmbedUsage(cfg, 1000)
+
+	// 1000 tokens × $0.00000002/token (text-embedding-3-small in testdata).
+	usage := store.GetGovernanceData(context.Background()).Budgets["provider-budget"].CurrentUsage
+	assert.InDelta(t, 0.00002, usage, 1e-12)
+}
+
+// TestEmbedComplexityTextsSettlesUsageWhenProviderReturnsNoVectors covers the
+// one post-response failure that used to drop its tokens: a provider that
+// reports usage but returns an empty Data array. The call completed and was
+// billed, so it must reach both the observer and, with count_toward_budgets on,
+// the provider budget — exactly like the vector-count mismatch beside it.
+func TestEmbedComplexityTextsSettlesUsageWhenProviderReturnsNoVectors(t *testing.T) {
+	plugin, store := newWarmupBudgetFixture(t)
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data:  nil,
+			Usage: &schemas.BifrostLLMUsage{TotalTokens: 1000},
+		}, nil
+	})
+
+	var observedProvider, observedModel string
+	var observedTokens int
+	var observedCalls int
+	plugin.SetWarmupEmbedUsageObserver(func(provider, model string, inputTokens int) {
+		observedCalls++
+		observedProvider, observedModel, observedTokens = provider, model, inputTokens
+	})
+
+	cfg := testEmbeddingSemanticConfig()
+	cfg.CountTowardBudgets = true
+
+	_, err := plugin.embedComplexityTexts(t.Context(), cfg, []string{"first", "second"})
+	require.Error(t, err, "an empty Data array is still a rejected response shape")
+
+	require.Equal(t, 1, observedCalls, "the observer must see the billed call exactly once")
+	assert.Equal(t, "openai", observedProvider)
+	assert.Equal(t, "text-embedding-3-small", observedModel)
+	assert.Equal(t, 1000, observedTokens)
 
 	// 1000 tokens × $0.00000002/token (text-embedding-3-small in testdata).
 	usage := store.GetGovernanceData(context.Background()).Budgets["provider-budget"].CurrentUsage

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1407,16 +1407,28 @@ func (h *GovernanceHandler) resetComplexityAnalyzerConfig(ctx *fasthttp.RequestC
 		// change and overwrite what this reset just preserved.
 		defaults.ConfigHashes.SemanticSettings = current.ConfigHashes.SemanticSettings
 	}
-	if err := h.configStore.UpdateComplexityAnalyzerConfig(ctx, &defaults); err != nil {
+	// Normalize before anything leaves this handler, matching the PUT path. The
+	// store and the classifier normalize on their own, so persistence and
+	// routing were always correct — but the raw defaults carry phrases as
+	// authored ("Give me the SQL to count paid orders."), while everything
+	// downstream lowercases, trims, dedupes, and sorts them. Returning the raw
+	// form handed clients phrase text that does not match what was stored or
+	// embedded, which is not something a caller can be expected to reconcile.
+	normalized, err := complexity.ValidateAndNormalize(&defaults)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to normalize default complexity analyzer config: %v", err))
+		return
+	}
+	if err := h.configStore.UpdateComplexityAnalyzerConfig(ctx, normalized); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to reset complexity analyzer config: %v", err))
 		return
 	}
-	if err := h.reloadComplexityAnalyzerConfig(ctx, &defaults); err != nil {
+	if err := h.reloadComplexityAnalyzerConfig(ctx, normalized); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to reload complexity analyzer config in memory: %v, please restart bifrost to sync with the database", err))
 		return
 	}
 
-	SendJSON(ctx, defaults)
+	SendJSON(ctx, normalized)
 }
 
 func (h *GovernanceHandler) reloadComplexityAnalyzerConfig(ctx context.Context, config *complexity.AnalyzerConfig) error {

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -663,6 +663,62 @@ func TestComplexityAnalyzerConfigResetOverwritesLegacyThreeBoundaryRow(t *testin
 // defaults to go back to; the embedding provider, model, and settings
 // do not — resetting them would silently take classification offline and make
 // the operator re-enter settings the button never claimed to touch.
+// TestComplexityAnalyzerConfigResetReturnsNormalizedPhrases pins the reset
+// response to what was actually stored and embedded. The store and the
+// classifier both normalize (lowercase, trim, dedupe, sort), so returning the
+// defaults as authored handed clients phrase text that matched neither — the UI
+// then diffed its form against the stored config and counted every mixed-case
+// default as a phrase needing a fresh embedding.
+func TestComplexityAnalyzerConfigResetReturnsNormalizedPhrases(t *testing.T) {
+	SetLogger(&mockLogger{})
+	store := setupPricingOverrideHandlerStore(t)
+	handler := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: &mockComplexityGovernanceManager{},
+	}
+
+	ctx := newTestRequestCtx("")
+	handler.resetComplexityAnalyzerConfig(ctx)
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var body complexity.AnalyzerConfig
+	if err := json.Unmarshal(ctx.Response.Body(), &body); err != nil {
+		t.Fatalf("decode reset response: %v", err)
+	}
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	if err != nil {
+		t.Fatalf("get stored config: %v", err)
+	}
+	if stored == nil {
+		t.Fatal("expected a stored config after reset")
+	}
+
+	// The defaults are authored with real capitalization, so this assertion only
+	// means something if at least one of them would fail it unnormalized.
+	authored := complexity.DefaultAnalyzerConfig()
+	authoredMixedCase := 0
+	for _, phrase := range authored.Keywords.SimpleKeywords {
+		if phrase != strings.ToLower(phrase) {
+			authoredMixedCase++
+		}
+	}
+	if authoredMixedCase == 0 {
+		t.Skip("default simple phrases are all lowercase; nothing for normalization to change")
+	}
+
+	for _, phrase := range body.Keywords.SimpleKeywords {
+		if phrase != strings.ToLower(strings.TrimSpace(phrase)) {
+			t.Fatalf("reset response must carry normalized phrases, got %q", phrase)
+		}
+	}
+	if !slices.Equal(body.Keywords.SimpleKeywords, stored.Keywords.SimpleKeywords) {
+		t.Fatalf("reset response must match what was stored\n response: %v\n stored:   %v",
+			body.Keywords.SimpleKeywords, stored.Keywords.SimpleKeywords)
+	}
+}
+
 func TestComplexityAnalyzerConfigResetPreservesSemanticBlock(t *testing.T) {
 	SetLogger(&mockLogger{})
 	store := setupPricingOverrideHandlerStore(t)

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -496,53 +496,58 @@ func TestSchemaComplexitySemanticConfig(t *testing.T) {
 		},
 		{
 			name:     "minimal semantic block",
-			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536}`,
+			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small"}`,
 		},
 		{
 			name:     "full semantic block",
-			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"timeout":"100ms","fallback":"lexical","count_toward_budgets":true,"vector_store":"embedded"}`,
+			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","timeout":"100ms","count_toward_budgets":true,"vector_store":"embedded"}`,
 		},
 		{
 			name:     "timeout as milliseconds number",
-			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"timeout":250}`,
+			semantic: `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","timeout":250}`,
 		},
 		{
 			name:      "missing embedding_model",
-			semantic:  `,"semantic":{"provider":"openai","dimension":1536}`,
-			wantError: true,
-		},
-		{
-			name:      "dimension below minimum",
-			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1}`,
+			semantic:  `,"semantic":{"provider":"openai"}`,
 			wantError: true,
 		},
 		{
 			name:     "custom provider name",
-			semantic: `,"semantic":{"provider":"my-custom-provider","embedding_model":"text-embedding-3-small","dimension":1536}`,
+			semantic: `,"semantic":{"provider":"my-custom-provider","embedding_model":"text-embedding-3-small"}`,
 		},
 		{
 			name:      "empty provider",
-			semantic:  `,"semantic":{"provider":"","embedding_model":"text-embedding-3-small","dimension":1536}`,
+			semantic:  `,"semantic":{"provider":"","embedding_model":"text-embedding-3-small"}`,
+			wantError: true,
+		},
+		// dimension and fallback were removed: the width is measured at warmup, and
+		// the classifier no longer falls back to the lexical scorer. A config.json
+		// carried over from a build that had them must fail loudly here rather than
+		// reach the decoder, which rejects them too
+		// (TestComplexitySemanticConfigRejectsRemovedFields).
+		{
+			name:      "removed dimension field",
+			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536}`,
 			wantError: true,
 		},
 		{
-			name:      "unknown fallback value",
-			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"fallback":"llm"}`,
+			name:      "removed fallback field",
+			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","fallback":"lexical"}`,
 			wantError: true,
 		},
 		{
 			name:      "unknown vector_store value",
-			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"vector_store":"pgvector"}`,
+			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","vector_store":"pgvector"}`,
 			wantError: true,
 		},
 		{
 			name:      "unknown semantic field",
-			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"threshold":0.8}`,
+			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","threshold":0.8}`,
 			wantError: true,
 		},
 		{
 			name:      "exemplars block no longer accepted",
-			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","dimension":1536,"exemplars":{"simple_exemplars":["hi"]}}`,
+			semantic:  `,"semantic":{"provider":"openai","embedding_model":"text-embedding-3-small","exemplars":{"simple_exemplars":["hi"]}}`,
 			wantError: true,
 		},
 	}

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -159,19 +159,77 @@ export default function ComplexityRouterPage() {
 		[liveKeywords],
 	);
 
-	// Saving re-runs warmup. It is a no-op when only the threshold or timeout
-	// changed (the phrase fingerprint is unchanged), but re-embeds every phrase
-	// when the provider, model, or a list changed.
-	const willReembed = useMemo(() => {
-		if (!data || !isClassifierConfigured) return false;
+	// Every embedding-cost warning below is about what the pending save will do,
+	// so it is gated on there being a pending save at all. Without this the page
+	// compares the form against a stale `data` and bills a save that cannot
+	// happen: Restore defaults persists server-side and resets the form, leaving
+	// it clean while the config query has not refetched yet — the exact window
+	// where a "saving will embed N phrases" line appears next to a disabled Save.
+	const hasPendingSave = isDirty;
+
+	// Saving re-runs warmup, but what it costs depends on what changed, because
+	// the gateway caches a vector per phrase (semanticEmbeddingCache).
+	//
+	// Provider and model are the cache's identity: changing either invalidates
+	// every vector at once, so the whole list is re-embedded.
+	//
+	// An empty cache means the same thing. It lives only in the gateway's memory
+	// — a stored vector cannot be read back out of a vector store — so a restart
+	// drops every vector while the saved phrases look untouched. Inferring reuse
+	// from the persisted config alone promised "N reused" for phrases the gateway
+	// no longer holds, so the count comes from the status payload instead.
+	const cachedPhrases = semanticStatus?.cached_phrases;
+	const willReembedAll = useMemo(() => {
+		if (!data || !isClassifierConfigured || !hasPendingSave) return false;
 		const saved = data.semantic;
 		if (!saved) return true;
-		return (
-			saved.provider !== liveSemantic?.provider ||
-			saved.embedding_model !== liveSemantic?.embedding_model ||
-			JSON.stringify(data.keywords) !== JSON.stringify(liveKeywords)
+		if (cachedPhrases !== undefined && cachedPhrases === 0) return true;
+		return saved.provider !== liveSemantic?.provider || saved.embedding_model !== liveSemantic?.embedding_model;
+	}, [data, isClassifierConfigured, hasPendingSave, liveSemantic, cachedPhrases]);
+
+	// Editing the lists only pays for phrase text the gateway has not embedded
+	// before. The cache is keyed by phrase alone, so moving a phrase between
+	// tiers costs nothing — only genuinely new text reaches the provider.
+	//
+	// Both sides are compared in the gateway's own phrase space, not as typed:
+	// normalizeComplexityKeywordList (framework/configstore) lowercases, trims,
+	// and dedupes before anything is embedded or cached, so "Give me the SQL"
+	// and "give me the sql" are one phrase and one embedding. Comparing raw text
+	// counted every mixed-case phrase as new, which is most of the defaults.
+	const { newPhraseCount, reusedPhraseCount } = useMemo(() => {
+		if (!data || !isClassifierConfigured || !hasPendingSave || willReembedAll) {
+			return { newPhraseCount: 0, reusedPhraseCount: 0 };
+		}
+		const normalize = (phrase: string) => phrase.trim().toLowerCase();
+		const savedPhrases = new Set(
+			[
+				...(data.keywords?.simple_keywords ?? []),
+				...(data.keywords?.medium_keywords ?? []),
+				...(data.keywords?.complex_keywords ?? []),
+			].map(normalize),
 		);
-	}, [data, isClassifierConfigured, liveSemantic, liveKeywords]);
+		// A Set because the gateway dedupes too: the same phrase in two tiers is
+		// one embedding, so counting it twice would overstate the bill.
+		const live = new Set(
+			[...(liveKeywords?.simple_keywords ?? []), ...(liveKeywords?.medium_keywords ?? []), ...(liveKeywords?.complex_keywords ?? [])]
+				.map(normalize)
+				.filter(Boolean),
+		);
+		let added = 0;
+		live.forEach((phrase) => {
+			if (!savedPhrases.has(phrase)) added += 1;
+		});
+		// The saved lists are what the gateway *last warmed*, not necessarily what
+		// it still holds: retain only prunes to the active phrases after a warmup
+		// that finished, so a run that failed partway leaves fewer vectors cached
+		// than there are saved phrases. Cap reuse at what the gateway reports so
+		// the two counts still sum to the live list rather than promising vectors
+		// that are not there.
+		const carried = Math.min(live.size - added, cachedPhrases ?? live.size - added);
+		return { newPhraseCount: live.size - carried, reusedPhraseCount: carried };
+	}, [data, isClassifierConfigured, hasPendingSave, willReembedAll, liveKeywords, cachedPhrases]);
+
+	const willReembed = willReembedAll || newPhraseCount > 0;
 
 	useEffect(() => {
 		if (!data || isDirty) return;
@@ -268,15 +326,34 @@ export default function ComplexityRouterPage() {
 
 	// Rendered on the page and again inside the sheet: the re-embed cost is a
 	// consequence of saving, and either surface can trigger the save.
-	const reembedWarning = willReembed ? (
+	// Only a full re-embed is worth warning about in the sheet: every field that
+	// can cause one lives there, and the sheet has its own Save. Adding phrases
+	// is a page-level edit and is reported on the page instead, so the two
+	// surfaces no longer repeat the same sentence at each other.
+	const reembedAllWarning = willReembedAll ? (
 		<Alert variant="warning" data-testid="complexity-router-reembed-warning">
 			<TriangleAlert className="h-4 w-4" />
 			<AlertDescription>
-				Saving will embed all {totalPhrases} reference phrases through the selected provider. This uses embedding tokens and may take a
-				short time. Changes only to the threshold, timeout, or storage reuse the current embeddings.
+				Saving will embed all {totalPhrases} reference phrases through the selected provider. Changing the provider or model invalidates
+				every stored vector, so the whole list is embedded again. This uses embedding tokens and may take a short time.
 			</AlertDescription>
 		</Alert>
 	) : null;
+
+	// Phrases already embedded on this gateway are reused, so the bill is the
+	// new text alone rather than the whole list.
+	const newPhraseWarning =
+		!willReembedAll && newPhraseCount > 0 ? (
+			<Alert variant="warning" data-testid="complexity-router-new-phrase-warning">
+				<TriangleAlert className="h-4 w-4" />
+				<AlertDescription>
+					Saving will embed {newPhraseCount} new reference phrase{newPhraseCount === 1 ? "" : "s"} through the selected provider. The other{" "}
+					{reusedPhraseCount} reuse the embeddings this gateway already holds.
+				</AlertDescription>
+			</Alert>
+		) : null;
+
+	const reembedWarning = reembedAllWarning ?? newPhraseWarning;
 
 	return (
 		<>
@@ -475,7 +552,7 @@ export default function ComplexityRouterPage() {
 				providerKeyIds={enabledKeyIdsForProvider}
 				providersLoading={isProviderListLoading}
 				isVectorStoreConnected={isVectorStoreConnected}
-				warning={reembedWarning}
+				warning={reembedAllWarning}
 				canSave={canSave}
 				isSaving={isSaving}
 				onSave={() => void submit()}

--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
@@ -1,7 +1,6 @@
 import { badgeVariants } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Progress } from "@/components/ui/progress";
 import { SEMANTIC_STATUS_LABELS, SemanticStatusInfo } from "@/lib/types/complexityRouter";
 import { cn } from "@/lib/utils";
 import type { VariantProps } from "class-variance-authority";
@@ -85,8 +84,6 @@ export function ClassifierStatusBadge({
 					? "loading"
 					: "disabled";
 
-	const percent = status && status.total > 0 ? Math.round((status.loaded / status.total) * 100) : 0;
-
 	const summary: ReactNode = {
 		"not-configured": hasEmbeddingProviders
 			? "No embedding provider is selected, so requests carry no complexity tier and rules targeting one never match."
@@ -112,25 +109,11 @@ export function ClassifierStatusBadge({
 				>
 					<StateIcon state={state} />
 					<span>{LABELS[state]}</span>
-					{state === "warming" && status && (
-						<span className="font-mono tabular-nums opacity-70">
-							{status.loaded}/{status.total}
-						</span>
-					)}
 				</button>
 			</PopoverTrigger>
 
 			<PopoverContent align="end" className="w-80 space-y-2.5 p-3 text-xs leading-relaxed" data-testid="complexity-router-semantic-status">
 				<p className="text-muted-foreground">{summary}</p>
-
-				{state === "warming" && status && (
-					<div className="space-y-1.5">
-						<Progress value={percent} className="h-1.5" />
-						<p className="text-muted-foreground font-mono text-[11px] tabular-nums">
-							{status.loaded}/{status.total}
-						</p>
-					</div>
-				)}
 
 				{status?.serving_previous && (
 					<p className="text-amber-700 dark:text-amber-400">

--- a/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
@@ -33,8 +33,10 @@ interface Props {
 	providerKeyIds: string[];
 	providersLoading: boolean;
 	isVectorStoreConnected: boolean;
-	// Rendered above the footer — the page owns the copy because the warning is
-	// about the whole save, not about any field in here.
+	// Rendered above the footer, and scoped to the full re-embed that only the
+	// fields in here can trigger. Phrase-list edits cost the provider too, but
+	// they are made on the page and are reported there — repeating that here
+	// would attribute a page-level cost to these controls.
 	warning?: ReactNode;
 	canSave: boolean;
 	isSaving: boolean;

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -31,6 +31,12 @@ export interface SemanticStatusInfo {
 	total: number;
 	serving_previous?: boolean;
 	error?: string;
+	// How many phrase vectors the gateway currently holds for the configured
+	// provider/model. The cache is in-process only — vectors cannot be read back
+	// out of a vector store — so a restart empties it while the saved phrases look
+	// unchanged. Reuse cannot be inferred from the persisted config alone; zero
+	// means the next save re-embeds every phrase regardless of what changed.
+	cached_phrases?: number;
 }
 
 export interface AnalyzerConfig {


### PR DESCRIPTION
## Summary

This PR fixes several correctness and cost bugs across the semantic classifier, vector store backends, embedding usage accounting, and the complexity router UI. The most significant addition is an in-process embedding cache that reuses vectors for unchanged exemplar phrases across warmup runs, so editing a tier list only pays the embedding provider for genuinely new text. A collection of integer overflow, NaN, and token-accounting bugs are also addressed.

## Changes

- Added `semanticEmbeddingCache`, a thread-safe in-process map from exemplar phrase to embedding vector. The cache identity is derived from the provider and embedding model; changing either drops every entry, because a vector from a different model is not stale — it is wrong. After a successful warmup, `cache.retain` prunes the map to only the phrases that were actually used, preventing accumulation of vectors for removed phrases.
- `warmSemanticExemplars` now accepts a `*semanticEmbeddingCache`, checks which phrases already have a cached vector before calling the provider, and writes vectors to the cache only after the dimension check passes. Error returns in the embedding loop no longer carry partial-progress counts.
- `SemanticStatusInfo` gains a `CachedPhrases` field reporting how many vectors the gateway currently holds. Because the cache is in-process only, a restart empties it while the saved phrases look unchanged; the UI uses this field to distinguish a warm cache from a cold one rather than inferring reuse from the persisted config.
- Fixed an `int64` overflow in `ChromemStore.GetAll`: forming `offset + limit` with an unbounded caller-supplied limit wraps negative, passes the `end > total` guard, and panics on the slice. The fix compares `limit` against the remaining count instead.
- Fixed `ChromemStore.GetNearest` preallocating a slice of size `limit` rather than the actual result count, which panics for extreme limit values.
- Introduced `boundedPageLimit` to safely convert a caller-supplied `int64` limit to the `uint32` the Qdrant and Pinecone clients require. A direct cast wraps values above `MaxUint32`, and an exact multiple of `2^32` wraps to zero, which the Qdrant scroll loop reads as a filled page and hands back a cursor that never advances.
- Fixed `ComplexitySemanticConfig.Validate` to explicitly reject `NaN` for `MinSimilarity`. Every comparison against `NaN` is false, so the existing range check silently accepted it and disabled the similarity floor.
- Fixed embedding token accounting so that tokens are settled whenever the provider responded and billed, not only on a fully successful call. This covers: a batch that returns the wrong vector count (`ErrBatchEmbeddingsUnsupported`), a response with an empty `Data` array, and a single-input call that returns no vectors. The single-input path also now accumulates tokens across fallback attempts on the same context rather than replacing them.
- Fixed the complexity analyzer config reset handler to normalize phrases before persisting and returning them. The store and classifier both normalize (lowercase, trim, dedupe, sort), so returning the raw defaults handed clients phrase text that matched neither what was stored nor what was embedded.
- Removed the `fallback` and `dimension` fields from the JSON schema for `SemanticConfig`. Both are rejected by the decoder; the schema now makes that explicit so a carried-over `config.json` fails loudly at validation rather than at decode time.
- Updated the complexity router UI to compute re-embed cost from `cached_phrases` rather than from the persisted config alone, to normalize phrases before comparing saved and live lists, and to show a per-phrase warning distinct from the full re-embed warning. The full re-embed warning is now scoped to the embedding config sheet; the new-phrase warning appears on the page where phrase lists are edited.
- Removed the warmup progress bar and phrase count from the classifier status badge.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/complexity/...
go test ./plugins/governance/...
go test ./framework/vectorstore/...
go test ./framework/configstore/...
go test ./transports/bifrost-http/handlers/...
go test ./transports/schema_test/...
```

`TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit` directly validates the cache behaviour: it asserts that only the added phrase reaches the embedding function, that the new generation namespace is fully populated, and that a model change triggers a complete re-embed. `TestChromemStore_Pagination` covers the overflow fix with a `MaxInt64` limit. `TestBoundedPageLimit` covers the `uint32` conversion edge cases.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Cached vectors are held in process memory only and are never persisted or transmitted. The identity invalidation ensures that vectors from one provider or model cannot be attributed to another.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable