### PR TITLE
fix: base provider resolution

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6505,6 +6505,8 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			baseProvider = cfg.BaseProviderType
 		}
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
+		// Lets downstream converters resolve a custom provider key back to the built-in provider it wraps.
+		req.Context.SetValue(schemas.BifrostContextKeyBaseProviderType, baseProvider)
 
 		// Disable Anthropic raw-body passthrough when this attempt's provider isn't Anthropic-native (e.g. Bedrock).
 		clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider)

--- a/core/providers/anthropic/reasoningid_test.go
+++ b/core/providers/anthropic/reasoningid_test.go
@@ -144,7 +144,7 @@ func TestConvertBifrostReasoning_BothSummaryAndEncryptedContentEmitBothBlocks(t 
 		},
 	}
 
-	blocks := convertBifrostReasoningToAnthropicThinking(msg, schemas.OpenAI, "gpt-5")
+	blocks := convertBifrostReasoningToAnthropicThinking(schemas.NewBifrostContext(nil, schemas.NoDeadline), msg, schemas.OpenAI, "gpt-5")
 
 	var sawThinking, sawRedacted bool
 	for _, b := range blocks {
@@ -202,7 +202,7 @@ func TestBifrostAnthropicToOpenAI_RedactedThinkingReplayPreservesID(t *testing.T
 	}
 
 	// 2. Egress: convert to the Anthropic block Claude Code receives.
-	blocks := convertBifrostReasoningToAnthropicThinking(original, schemas.OpenAI, "gpt-5")
+	blocks := convertBifrostReasoningToAnthropicThinking(schemas.NewBifrostContext(nil, schemas.NoDeadline), original, schemas.OpenAI, "gpt-5")
 	if len(blocks) != 1 || blocks[0].Type != AnthropicContentBlockTypeRedactedThinking {
 		t.Fatalf("expected 1 redacted_thinking block, got %+v", blocks)
 	}

--- a/core/providers/anthropic/reasoningstream_test.go
+++ b/core/providers/anthropic/reasoningstream_test.go
@@ -125,7 +125,7 @@ func TestConvertBifrostReasoning_SignaturePresent(t *testing.T) {
 
 	t.Run("DeepSeek does not embed the id", func(t *testing.T) {
 		msg := newMsg()
-		blocks := convertBifrostReasoningToAnthropicThinking(msg, schemas.DeepSeek, "deepseek-chat")
+		blocks := convertBifrostReasoningToAnthropicThinking(schemas.NewBifrostContext(nil, schemas.NoDeadline), msg, schemas.DeepSeek, "deepseek-chat")
 		if len(blocks) != 1 {
 			t.Fatalf("expected 1 thinking block, got %d", len(blocks))
 		}
@@ -145,7 +145,7 @@ func TestConvertBifrostReasoning_SignaturePresent(t *testing.T) {
 
 	t.Run("OpenAI embeds the id", func(t *testing.T) {
 		msg := newMsg()
-		blocks := convertBifrostReasoningToAnthropicThinking(msg, schemas.OpenAI, "gpt-5")
+		blocks := convertBifrostReasoningToAnthropicThinking(schemas.NewBifrostContext(nil, schemas.NoDeadline), msg, schemas.OpenAI, "gpt-5")
 		if len(blocks) != 1 {
 			t.Fatalf("expected 1 thinking block, got %d", len(blocks))
 		}
@@ -155,6 +155,23 @@ func TestConvertBifrostReasoning_SignaturePresent(t *testing.T) {
 		id, _, ok := providerUtils.ExtractReasoningItemID(*blocks[0].Signature)
 		if !ok || id == nil || *id != *msg.ID {
 			t.Errorf("OpenAI-sourced signature = %q, want an embedded id %q", *blocks[0].Signature, *msg.ID)
+		}
+	})
+
+	// A custom provider reports its own key, so the gate has to resolve it back to
+	// the base provider type Bifrost recorded on the context -- otherwise OpenAI
+	// models served through an openai-based custom provider silently lose the id.
+	t.Run("openai-based custom provider embeds the id", func(t *testing.T) {
+		msg := newMsg()
+		ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyBaseProviderType, schemas.OpenAI)
+		blocks := convertBifrostReasoningToAnthropicThinking(ctx, msg, schemas.ModelProvider("my-openai"), "my-gpt-deployment")
+		if len(blocks) != 1 {
+			t.Fatalf("expected 1 thinking block, got %d", len(blocks))
+		}
+		id, _, ok := providerUtils.ExtractReasoningItemID(*blocks[0].Signature)
+		if !ok || id == nil || *id != *msg.ID {
+			t.Errorf("custom-provider signature = %q, want an embedded id %q", *blocks[0].Signature, *msg.ID)
 		}
 	})
 }

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2640,7 +2640,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 						// embedID gates smuggling the real OpenAI reasoning item id into
 						// signature/data (see providerUtils.ShouldEmbedReasoningItemID and
 						// convertBifrostReasoningToAnthropicThinking for why).
-						embedID := providerUtils.ShouldEmbedReasoningItemID(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+						embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
 						contentBlock.Type = AnthropicContentBlockTypeThinking
 						contentBlock.Thinking = schemas.Ptr("")
 						signature := ""
@@ -2665,7 +2665,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 						// When thinking is enabled, reasoning content might be incorrectly classified as FunctionCall
 						if bifrostResp.Item.ResponsesReasoning != nil {
 							// This is actually reasoning content, not a function call
-							embedID := providerUtils.ShouldEmbedReasoningItemID(bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
+							embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, bifrostResp.ExtraFields.Provider, bifrostResp.ExtraFields.RoutingInfo.Model)
 							contentBlock.Type = AnthropicContentBlockTypeThinking
 							contentBlock.Thinking = schemas.Ptr("")
 							signature := ""
@@ -4597,7 +4597,7 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 			flushPendingToolResults()
 
 			// Handle reasoning as thinking content
-			reasoningBlocks := convertBifrostReasoningToAnthropicThinking(&msg, provider, model)
+			reasoningBlocks := convertBifrostReasoningToAnthropicThinking(ctx, &msg, provider, model)
 			pendingReasoningContentBlocks = append(pendingReasoningContentBlocks, reasoningBlocks...)
 
 		case schemas.ResponsesMessageTypeFunctionCall:
@@ -6103,9 +6103,9 @@ func convertBifrostMessageToAnthropicMessage(msg *schemas.ResponsesMessage, pend
 // echoes the block back on a later turn, a fresh random id gets minted and paired
 // with the original (still real) encrypted_content -- a mismatch OpenAI rejects
 // with "Encrypted content item_id did not match the target item id."
-func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage, sourceProvider schemas.ModelProvider, model string) []AnthropicContentBlock {
+func convertBifrostReasoningToAnthropicThinking(ctx *schemas.BifrostContext, msg *schemas.ResponsesMessage, sourceProvider schemas.ModelProvider, model string) []AnthropicContentBlock {
 	var thinkingBlocks []AnthropicContentBlock
-	embedID := providerUtils.ShouldEmbedReasoningItemID(sourceProvider, model)
+	embedID := providerUtils.ShouldEmbedReasoningItemID(ctx, sourceProvider, model)
 
 	if msg.Content != nil && msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {

--- a/core/providers/utils/reasoningid_test.go
+++ b/core/providers/utils/reasoningid_test.go
@@ -81,33 +81,60 @@ func TestExtractReasoningItemID_UnmarkedPayloadFallsThrough(t *testing.T) {
 // (Llama/Mistral/DeepSeek on Azure, Claude on Bedrock Mantle, Gemini/Claude on Vertex) --
 // so those three must additionally check the resolved model, while plain OpenAI (which by
 // definition only ever serves OpenAI models) and every other provider stay unconditional.
+//
+// The baseProvider cases cover custom providers, which report their own key rather than the
+// built-in provider they wrap: without resolving through the base type Bifrost records on the
+// context, OpenAI models served via an openai-based custom provider fall to the default arm
+// and lose the id.
 func TestShouldEmbedReasoningItemID(t *testing.T) {
 	cases := []struct {
-		name     string
-		provider schemas.ModelProvider
-		model    string
-		want     bool
+		name         string
+		provider     schemas.ModelProvider
+		model        string
+		baseProvider schemas.ModelProvider // set on the context when non-empty
+		want         bool
 	}{
-		{"OpenAI is always true regardless of model", schemas.OpenAI, "gpt-5", true},
-		{"OpenAI is true even for an unusual model string", schemas.OpenAI, "some-future-model", true},
-		{"Azure with an OpenAI model", schemas.Azure, "o3", true},
-		{"Azure with a non-OpenAI Foundry model", schemas.Azure, "Meta-Llama-3.1-70B-Instruct", false},
-		{"Azure with Mistral", schemas.Azure, "mistral-large", false},
-		{"Bedrock Mantle with an OpenAI model", schemas.BedrockMantle, "openai.gpt-oss-120b", true},
-		{"Bedrock Mantle with a Claude model", schemas.BedrockMantle, "anthropic.claude-opus-4-8", false},
-		{"Vertex with an OpenAI model", schemas.Vertex, "openai/gpt-oss-120b", true},
-		{"Vertex with Gemini", schemas.Vertex, "gemini-2.5-pro", false},
-		{"Vertex with Claude", schemas.Vertex, "claude-sonnet-4-6", false},
-		{"DeepSeek is never true", schemas.DeepSeek, "deepseek-chat", false},
-		{"Anthropic is never true", schemas.Anthropic, "claude-sonnet-4-6", false},
-		{"Bedrock is never true", schemas.Bedrock, "anthropic.claude-opus-4-8", false},
+		{"OpenAI is always true regardless of model", schemas.OpenAI, "gpt-5", "", true},
+		{"OpenAI is true even for an unusual model string", schemas.OpenAI, "some-future-model", "", true},
+		{"Azure with an OpenAI model", schemas.Azure, "o3", "", true},
+		{"Azure with a non-OpenAI Foundry model", schemas.Azure, "Meta-Llama-3.1-70B-Instruct", "", false},
+		{"Azure with Mistral", schemas.Azure, "mistral-large", "", false},
+		{"Bedrock Mantle with an OpenAI model", schemas.BedrockMantle, "openai.gpt-oss-120b", "", true},
+		{"Bedrock Mantle with a Claude model", schemas.BedrockMantle, "anthropic.claude-opus-4-8", "", false},
+		{"Vertex with an OpenAI model", schemas.Vertex, "openai/gpt-oss-120b", "", true},
+		{"Vertex with Gemini", schemas.Vertex, "gemini-2.5-pro", "", false},
+		{"Vertex with Claude", schemas.Vertex, "claude-sonnet-4-6", "", false},
+		{"DeepSeek is never true", schemas.DeepSeek, "deepseek-chat", "", false},
+		{"Anthropic is never true", schemas.Anthropic, "claude-sonnet-4-6", "", false},
+		{"Bedrock is never true", schemas.Bedrock, "anthropic.claude-opus-4-8", "", false},
+		{"custom provider on base OpenAI, deployment-style model", "my-openai", "my-gpt-deployment", schemas.OpenAI, true},
+		{"custom provider on base OpenAI, OpenAI model", "my-openai", "gpt-5", schemas.OpenAI, true},
+		{"custom provider on base Anthropic", "my-claude", "claude-sonnet-4-6", schemas.Anthropic, false},
+		{"custom provider with no base type on the context", "my-openai", "gpt-5", "", false},
+		{"base type overrides a standard-looking provider key", schemas.Vertex, "gemini-2.5-pro", schemas.OpenAI, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := ShouldEmbedReasoningItemID(tc.provider, tc.model); got != tc.want {
+			ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+			if tc.baseProvider != "" {
+				ctx.SetValue(schemas.BifrostContextKeyBaseProviderType, tc.baseProvider)
+			}
+			if got := ShouldEmbedReasoningItemID(ctx, tc.provider, tc.model); got != tc.want {
 				t.Errorf("ShouldEmbedReasoningItemID(%q, %q) = %v, want %v", tc.provider, tc.model, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestShouldEmbedReasoningItemID_NilContext pins the fallback: converters called
+// outside a request (and tests) pass no context, so the provider key must still
+// be matched directly rather than panicking or resolving to empty.
+func TestShouldEmbedReasoningItemID_NilContext(t *testing.T) {
+	if !ShouldEmbedReasoningItemID(nil, schemas.OpenAI, "gpt-5") {
+		t.Error("ShouldEmbedReasoningItemID(nil, OpenAI, gpt-5) = false, want true")
+	}
+	if ShouldEmbedReasoningItemID(nil, schemas.Anthropic, "claude-sonnet-4-6") {
+		t.Error("ShouldEmbedReasoningItemID(nil, Anthropic, claude-sonnet-4-6) = true, want false")
 	}
 }
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -139,8 +139,16 @@ const ReasoningItemIDSeparator = ":"
 // resolved model itself to be OpenAI-family -- stamping a Bifrost-synthetic id
 // onto a non-OpenAI reasoning item's signature/data would mark data that never
 // needed it and was never bound to any id in the first place.
-func ShouldEmbedReasoningItemID(provider schemas.ModelProvider, model string) bool {
-	switch provider {
+//
+// provider is matched after schemas.ResolveBaseProvider, so a custom provider
+// (which reports its own key, e.g. "my-openai") is gated by the built-in
+// provider it wraps. A custom provider on base type OpenAI therefore qualifies
+// unconditionally like native OpenAI: OpenAI-compatible endpoints are commonly
+// configured with deployment-style model names that no OpenAI-family check would
+// match, and embedding stays a no-op anyway unless the upstream issued a real
+// reasoning item id for EmbedReasoningItemID to carry.
+func ShouldEmbedReasoningItemID(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) bool {
+	switch schemas.ResolveBaseProvider(ctx, provider) {
 	case schemas.OpenAI:
 		return true
 	case schemas.Azure, schemas.BedrockMantle, schemas.Vertex:

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -462,6 +462,20 @@ func ResolveCanonicalModel(ctx *BifrostContext, fallbackModel string) string {
 	return fallbackModel
 }
 
+// ResolveBaseProvider returns the built-in provider that actually served this
+// attempt. Custom providers surface their own key (e.g. "my-openai") wherever a
+// ModelProvider is reported, so provider-family gating must resolve through the
+// base type Bifrost records on the context. Falls back to provider when the
+// context carries none (direct converter calls, tests).
+func ResolveBaseProvider(ctx *BifrostContext, provider ModelProvider) ModelProvider {
+	if ctx != nil {
+		if base, ok := ctx.Value(BifrostContextKeyBaseProviderType).(ModelProvider); ok && base != "" {
+			return base
+		}
+	}
+	return provider
+}
+
 // IsAnthropicModelFamily reports whether the current attempt resolves to the
 // Anthropic model family. Thin wrapper over ResolveFamily so provider code
 // reads uniformly at the many call sites that branch on Anthropic vs

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -313,6 +313,7 @@ const (
 	BifrostContextKeyShouldStoreRawInLogs                BifrostContextKey = "bifrost-should-store-raw-in-logs"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request/response should be persisted in log records
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyBaseProviderType                    BifrostContextKey = "bifrost-base-provider-type"                       // ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY) — built-in provider backing this attempt (custom providers resolve to their BaseProviderType)
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyHTTPRoute                           BifrostContextKey = "bifrost-http-route"                               // string (set by bifrost - DO NOT SET THIS MANUALLY — matched route template, set by HTTP transport; used as the low-cardinality metrics `path` label)
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool


### PR DESCRIPTION
## Summary

OpenAI models served through a custom provider (e.g. an `openai`-based custom provider with its own key like `"my-openai"`) were silently losing the reasoning item ID when converting to Anthropic thinking blocks. Because `ShouldEmbedReasoningItemID` matched against the raw provider key, custom providers never matched the `OpenAI` case and fell through to the default `false` arm — causing a mismatch OpenAI rejects with `"Encrypted content item_id did not match the target item id."`.

## Changes

- Added `BifrostContextKeyBaseProviderType` context key, set during `requestWorker` to record the built-in provider backing each attempt. Custom providers surface their own key everywhere a `ModelProvider` is reported, so this gives downstream converters a way to resolve back to the underlying provider type.
- Added `ResolveBaseProvider(ctx, provider)` helper in `schemas/account.go` that reads `BifrostContextKeyBaseProviderType` from the context and falls back to the raw provider key when the context carries none (direct converter calls, tests).
- Updated `ShouldEmbedReasoningItemID` to accept a `*BifrostContext` and resolve through `ResolveBaseProvider` before switching on provider family. A custom provider wrapping OpenAI now qualifies unconditionally, matching native OpenAI behaviour — deployment-style model names used on OpenAI-compatible endpoints would never match an OpenAI-family model name check anyway.
- Propagated the new `ctx` parameter through all call sites of `ShouldEmbedReasoningItemID` and `convertBifrostReasoningToAnthropicThinking`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/utils/... ./core/schemas/...
```

The new test `"openai-based custom provider embeds the id"` in `reasoningstream_test.go` directly covers the fixed path: it sets `BifrostContextKeyBaseProviderType` to `schemas.OpenAI` on the context while passing a custom provider key, and asserts the reasoning item ID is correctly embedded in the signature.

`TestShouldEmbedReasoningItemID_NilContext` pins the nil-context fallback to ensure converters called outside a request context neither panic nor regress.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The change only affects how a reasoning item ID is embedded into an opaque signature field passed between Anthropic-compatible clients and OpenAI backends. No auth, secrets, or PII are involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable