### PR TITLE
feat: replace per-budget `BudgetOverrideDialog` with unified `BudgetOverrideManagerDialog` grouping provider and model budgets

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -1,4 +1,5 @@
 import { BudgetOverrideDialog } from "@/components/budgetOverrideDialog";
+import { BudgetOverrideManagerDialog, type BudgetOverrideSection } from "@/components/budgetOverrideManagerDialog";
 import { CopyableId } from "@/components/copyableId";
 import { SheetNavigationButtons } from "@/components/sheetNavigationButtons";
 import { Badge } from "@/components/ui/badge";
@@ -12,7 +13,7 @@ import { supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { useRemoveVirtualKeyBudgetOverrideMutation, useSetVirtualKeyBudgetOverrideMutation } from "@/lib/store/apis/governanceApi";
-import { BudgetOverrideRequest, VirtualKey } from "@/lib/types/governance";
+import { BudgetOverrideRequest, VirtualKey, VirtualKeyProviderConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import {
 	calculateUsagePercentage,
@@ -82,6 +83,22 @@ export default function VirtualKeyDetailSheet({
 	};
 	const clearBudgetOverride = async (budgetId: string) => {
 		await removeBudgetOverride({ vkId: virtualKey.id, budgetId }).unwrap();
+	};
+	// Provider budget + one section per model, for the provider's single override modal.
+	// Only persisted budgets (with an id) can carry an override.
+	const buildProviderOverrideSections = (config: VirtualKeyProviderConfig): BudgetOverrideSection[] => {
+		const toRows = (budgets: VirtualKeyProviderConfig["budgets"]) =>
+			(budgets ?? [])
+				.filter((b) => b.id)
+				.map((b) => ({ key: b.id, label: parseResetPeriod(b.reset_duration), budget: b, calendarAligned: virtualKey.calendar_aligned }));
+		const sections: BudgetOverrideSection[] = [];
+		const providerRows = toRows(config.budgets);
+		if (providerRows.length > 0) sections.push({ key: "provider", title: "Provider budget", rows: providerRows });
+		for (const mb of config.model_budgets ?? []) {
+			const rows = toRows(mb.budgets);
+			if (rows.length > 0) sections.push({ key: `m:${mb.model_name}`, title: `Model: ${mb.model_name}`, rows });
+		}
+		return sections;
 	};
 
 	const { prev: prevKeys, next: nextKeys } = useSheetNavigation({
@@ -229,9 +246,20 @@ export default function VirtualKeyDetailSheet({
 													<RenderProviderIcon provider={config.provider as ProviderIconType} size="sm" className="h-5 w-5" />
 													<span className="font-medium">{ProviderLabels[config.provider as ProviderName] || config.provider}</span>
 												</div>
-												<Badge variant="outline" className="font-mono text-xs">
-													Weight: {config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
-												</Badge>
+												<div className="flex items-center gap-2">
+													<Badge variant="outline" className="font-mono text-xs">
+														Weight: {config.weight != null ? config.weight : <span className="text-muted-foreground italic">Not Set</span>}
+													</Badge>
+													{!isManagedByProfile ? (
+														<BudgetOverrideManagerDialog
+															title={`${ProviderLabels[config.provider as ProviderName] || config.provider} budget overrides`}
+															sections={buildProviderOverrideSections(config)}
+															onSave={saveBudgetOverride}
+															onRemove={clearBudgetOverride}
+															disabled={!canUpdateVirtualKeys}
+														/>
+													) : null}
+												</div>
 											</div>
 
 											{/* Basic Config */}
@@ -313,17 +341,6 @@ export default function VirtualKeyDetailSheet({
 															<h4 className="text-sm font-medium">Provider Budgets</h4>
 															{config.budgets.map((b, bIdx) => (
 																<div key={bIdx} className="space-y-2">
-																	{!isManagedByProfile && b.id ? (
-																		<div className="flex justify-end">
-																			<BudgetOverrideDialog
-																				budget={b}
-																				onSave={(data) => saveBudgetOverride(b.id, data)}
-																				onRemove={() => clearBudgetOverride(b.id)}
-																				disabled={!canUpdateVirtualKeys}
-																				calendarAligned={virtualKey.calendar_aligned}
-																			/>
-																		</div>
-																	) : null}
 																	<UsageLine current={b.current_usage} max={getEffectiveBudgetLimit(b)} format={formatCurrency} />
 																	{hasActiveBudgetOverride(b) ? (
 																		<p className="text-muted-foreground text-xs">
@@ -429,17 +446,6 @@ export default function VirtualKeyDetailSheet({
 																	{mb.budgets && mb.budgets.length > 0
 																		? mb.budgets.map((b, bIdx) => (
 																				<div key={bIdx} className="space-y-2">
-																					{!isManagedByProfile && b.id ? (
-																						<div className="flex justify-end">
-																							<BudgetOverrideDialog
-																								budget={b}
-																								onSave={(data) => saveBudgetOverride(b.id, data)}
-																								onRemove={() => clearBudgetOverride(b.id)}
-																								disabled={!canUpdateVirtualKeys}
-																								calendarAligned={virtualKey.calendar_aligned}
-																							/>
-																						</div>
-																					) : null}
 																					<UsageLine current={b.current_usage} max={getEffectiveBudgetLimit(b)} format={formatCurrency} />
 																					{hasActiveBudgetOverride(b) ? (
 																						<p className="text-muted-foreground text-xs">

--- a/ui/components/budgetOverrideManagerDialog.tsx
+++ b/ui/components/budgetOverrideManagerDialog.tsx
@@ -1,0 +1,293 @@
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { getErrorMessage } from "@/lib/store/apis/baseApi";
+import type { Budget, BudgetOverrideRequest } from "@/lib/types/governance";
+import { budgetOverrideFormSchema } from "@/lib/types/schemas";
+import { formatCurrency, getBudgetOverrideValidUntil, getEffectiveBudgetLimit, hasActiveBudgetOverride } from "@/lib/utils/governance";
+import { Pencil, Plus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+// One overridable budget row. `budget` is the persisted row the override applies to;
+// `label` is scope-relative (the section already names the scope), e.g. the reset
+// duration. `calendarAligned` rides along for the finite-cycle "valid until" preview.
+export interface BudgetOverrideRow {
+	key: string;
+	label: string;
+	budget: Budget;
+	calendarAligned?: boolean;
+}
+
+// A titled group of budget rows in the modal (e.g. "Provider budget", "Model: gpt-4o").
+export interface BudgetOverrideSection {
+	key: string;
+	title: string;
+	rows: BudgetOverrideRow[];
+}
+
+interface BudgetOverrideManagerDialogProps {
+	title: string;
+	sections: BudgetOverrideSection[];
+	onSave: (budgetId: string, request: BudgetOverrideRequest) => Promise<void>;
+	onRemove: (budgetId: string) => Promise<void>;
+	disabled?: boolean;
+	triggerLabel?: string;
+}
+
+/**
+ * One "Add override" button opening a modal whose sections group a scope's budgets —
+ * e.g. a provider's own budget plus one section per model beneath it. Each row's
+ * additive override can be added, edited, or removed inline and independently.
+ */
+export function BudgetOverrideManagerDialog({ title, sections, onSave, onRemove, disabled, triggerLabel = "Add override" }: BudgetOverrideManagerDialogProps) {
+	const [open, setOpen] = useState(false);
+	const [expandedKey, setExpandedKey] = useState<string | null>(null);
+	const [amount, setAmount] = useState("");
+	const [mode, setMode] = useState<"cycles" | "forever">("cycles");
+	const [cycles, setCycles] = useState("1");
+	const [busyKey, setBusyKey] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const startEdit = (row: BudgetOverrideRow) => {
+		const b = row.budget;
+		const active = hasActiveBudgetOverride(b);
+		setAmount(active ? String(b.override_amount) : "");
+		setMode(active && b.override_mode ? b.override_mode : "cycles");
+		setCycles(active && b.override_mode === "cycles" ? String(b.override_cycles_remaining ?? 1) : "1");
+		setError(null);
+		setExpandedKey(row.key);
+	};
+
+	const closeForm = () => {
+		setExpandedKey(null);
+		setError(null);
+	};
+
+	const submit = async (row: BudgetOverrideRow) => {
+		const parsedAmount = Number(amount);
+		const parsedCycles = Number(cycles);
+		const parsed = budgetOverrideFormSchema.safeParse({
+			amount: parsedAmount,
+			mode,
+			...(mode === "cycles" ? { cycles: parsedCycles } : {}),
+		});
+		if (!parsed.success) {
+			setError(parsed.error.issues[0]?.message ?? "Invalid input");
+			return;
+		}
+		setBusyKey(row.key);
+		setError(null);
+		try {
+			const wasActive = hasActiveBudgetOverride(row.budget);
+			await onSave(row.budget.id, { amount: parsedAmount, mode, ...(mode === "cycles" ? { cycles: parsedCycles } : {}) });
+			toast.success(wasActive ? "Budget override updated" : "Budget override added");
+			setExpandedKey(null);
+		} catch (mutationError) {
+			setError(getErrorMessage(mutationError));
+		} finally {
+			setBusyKey(null);
+		}
+	};
+
+	const remove = async (row: BudgetOverrideRow) => {
+		setBusyKey(row.key);
+		setError(null);
+		try {
+			await onRemove(row.budget.id);
+			toast.success("Budget override removed");
+			if (expandedKey === row.key) setExpandedKey(null);
+		} catch (mutationError) {
+			// Remove can fire from a collapsed row where the inline error never renders,
+			// so surface the failure with a toast.
+			toast.error(getErrorMessage(mutationError));
+		} finally {
+			setBusyKey(null);
+		}
+	};
+
+	const renderRow = (row: BudgetOverrideRow) => {
+		const b = row.budget;
+		const active = hasActiveBudgetOverride(b);
+		const expanded = expandedKey === row.key;
+		const busy = busyKey === row.key;
+		// Lock every row while any mutation is in flight so two overrides can't race.
+		const locked = busyKey !== null;
+		const validUntil = mode === "cycles" ? getBudgetOverrideValidUntil(b, Number(cycles), row.calendarAligned) : null;
+
+		return (
+			<div key={row.key} className="rounded-sm border px-3 py-2" data-testid={`budget-override-row-${b.id}`}>
+				<div className="flex items-center justify-between gap-2">
+					<div className="min-w-0">
+						<p className="truncate text-sm font-medium">{row.label}</p>
+						<p className="text-muted-foreground text-xs">
+							{active
+								? `+${formatCurrency(b.override_amount ?? 0)} override · effective ${formatCurrency(getEffectiveBudgetLimit(b))}`
+								: `Base ${formatCurrency(b.max_limit)}`}
+						</p>
+					</div>
+					<div className="flex shrink-0 items-center gap-1">
+						{active ? (
+							<>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-7 gap-1 px-2 text-xs"
+									disabled={disabled || locked}
+									onClick={() => (expanded ? closeForm() : startEdit(row))}
+									data-testid={`budget-override-edit-${b.id}`}
+								>
+									<Pencil className="h-3 w-3" />
+									Edit
+								</Button>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="text-destructive h-7 px-2 text-xs"
+									disabled={disabled || locked}
+									isLoading={busy && !expanded}
+									onClick={() => remove(row)}
+									data-testid={`budget-override-remove-${b.id}`}
+								>
+									Remove
+								</Button>
+							</>
+						) : (
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="h-7 gap-1 px-2 text-xs"
+								disabled={disabled || locked}
+								onClick={() => (expanded ? closeForm() : startEdit(row))}
+								data-testid={`budget-override-add-${b.id}`}
+							>
+								<Plus className="h-3 w-3" />
+								Add override
+							</Button>
+						)}
+					</div>
+				</div>
+
+				{expanded ? (
+					<div className="mt-3 space-y-3 border-t pt-3">
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label className="text-xs" htmlFor={`override-amount-${b.id}`}>
+									Additional budget
+								</Label>
+								<div className="relative">
+									<span className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-sm" aria-hidden="true">
+										$
+									</span>
+									<Input
+										id={`override-amount-${b.id}`}
+										type="number"
+										min="0.01"
+										step="0.01"
+										value={amount}
+										onChange={(event) => setAmount(event.target.value)}
+										placeholder="0.00"
+										className="rounded-sm pl-7"
+										disabled={busy}
+										data-testid="budget-override-amount"
+									/>
+								</div>
+							</div>
+							<div className="space-y-1.5">
+								<Label className="text-xs">Duration</Label>
+								<Select value={mode} onValueChange={(value) => setMode(value as "cycles" | "forever")} disabled={busy}>
+									<SelectTrigger className="w-full rounded-sm" data-testid="budget-override-mode">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent className="rounded-sm">
+										<SelectItem value="cycles">For a number of reset cycles</SelectItem>
+										<SelectItem value="forever">Until removed</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+						</div>
+
+						{mode === "cycles" ? (
+							<div className="space-y-1.5">
+								<Label className="text-xs" htmlFor={`override-cycles-${b.id}`}>
+									Reset cycles
+								</Label>
+								<Input
+									id={`override-cycles-${b.id}`}
+									type="number"
+									min="1"
+									step="1"
+									value={cycles}
+									onChange={(event) => setCycles(event.target.value)}
+									className="rounded-sm"
+									disabled={busy}
+									data-testid="budget-override-cycles"
+								/>
+								{validUntil ? (
+									<p className="text-muted-foreground text-xs">
+										Valid until <span className="text-foreground font-medium">{validUntil.toLocaleString()}</span>
+									</p>
+								) : null}
+							</div>
+						) : null}
+
+						{error ? (
+							<p className="text-destructive text-xs" data-testid="budget-override-error">
+								{error}
+							</p>
+						) : null}
+
+						<div className="flex justify-end gap-2">
+							<Button type="button" variant="ghost" size="sm" className="rounded-sm" onClick={closeForm} disabled={busy} data-testid={`budget-override-cancel-${b.id}`}>
+								Cancel
+							</Button>
+							<Button type="button" size="sm" className="rounded-sm" onClick={() => submit(row)} isLoading={busy} data-testid="budget-override-save">
+								{active ? "Update" : "Add"}
+							</Button>
+						</div>
+					</div>
+				) : null}
+			</div>
+		);
+	};
+
+	const visibleSections = sections.filter((s) => s.rows.length > 0);
+	if (visibleSections.length === 0) return null;
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next);
+				if (!next) closeForm();
+			}}
+		>
+			<DialogTrigger asChild>
+				<Button type="button" variant="ghost" size="sm" className="h-7 gap-1.5 rounded-sm px-2 text-xs" disabled={disabled} data-testid="budget-override-open">
+					<Plus className="h-3 w-3" />
+					{triggerLabel}
+				</Button>
+			</DialogTrigger>
+			<DialogContent className="rounded-sm sm:max-w-lg" data-testid="budget-override-manager-dialog">
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>Temporarily add spending capacity to a budget without changing its base limit.</DialogDescription>
+				</DialogHeader>
+
+				<div className="max-h-[60vh] space-y-4 overflow-y-auto py-2">
+					{visibleSections.map((section) => (
+						<div key={section.key} className="space-y-2">
+							<p className="text-muted-foreground text-xs font-medium tracking-wider uppercase">{section.title}</p>
+							<div className="space-y-2">{section.rows.map(renderRow)}</div>
+						</div>
+					))}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary

Replaces the per-budget inline `BudgetOverrideDialog` buttons scattered throughout the virtual key detail sheet with a single consolidated `BudgetOverrideManagerDialog` per provider. Instead of one override button per budget row, a single "Add override" button on the provider header opens a modal that groups all overridable budgets — the provider's own budgets and each model's budgets — into labeled sections, allowing them to be managed in one place.

## Changes

- Introduced `BudgetOverrideManagerDialog`, a new dialog component that accepts a `title`, a list of `BudgetOverrideSection` groups (each containing `BudgetOverrideRow` entries), and `onSave`/`onRemove` callbacks. Each row can independently add, edit, or remove its override inline within the modal.
- Added `buildProviderOverrideSections` in the virtual key detail sheet to construct the section/row structure from a provider config, filtering to only persisted budgets (those with an `id`).
- Removed the individual `BudgetOverrideDialog` buttons that previously appeared inside each provider budget and model budget row in the sheet.
- The new trigger button is placed in the provider header row alongside the weight badge, and is hidden when the virtual key is managed by a profile (matching the previous per-row behavior).
- Form state (amount, mode, cycles) is shared across rows within a single open modal but resets when switching between rows, keeping the UX predictable without requiring per-row state instances.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open a virtual key detail sheet for a key that has provider configs with budgets.
2. Verify that individual override buttons no longer appear inline within each budget row.
3. Click the "Add override" button in the provider header to open the manager dialog.
4. Confirm that provider-level budgets appear under a "Provider budget" section and model budgets appear under their respective "Model: <name>" sections.
5. Add, edit, and remove overrides for individual rows and confirm toast notifications and UI state update correctly.
6. Verify the button does not appear for virtual keys managed by a profile.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Each budget row had its own override button rendered inline beneath the usage bar.

After: A single "Add override" button on the provider header opens a consolidated modal grouping all provider and model budgets into labeled sections.

## Breaking changes

- [x] No

## Related issues

## Security considerations

No new auth surfaces. Override actions continue to respect the existing `canUpdateVirtualKeys` permission check, and the dialog trigger is disabled when the user lacks that permission.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable