### PR TITLE
[DO-NOT-MERGE-YET] session routing config and sticky targets

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1309,6 +1309,14 @@ func GenerateComplexityAnalyzerConfigHashes(config *ComplexityAnalyzerConfig) (C
 		hashes.SemanticSettings = settingsHash
 	}
 
+	if normalized.Session != nil {
+		settingsHash, err := hashComplexityValue(normalized.Session)
+		if err != nil {
+			return ComplexityAnalyzerConfigHashes{}, fmt.Errorf("failed to hash session settings: %w", err)
+		}
+		hashes.SessionSettings = settingsHash
+	}
+
 	return hashes, nil
 }
 

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -327,6 +327,289 @@ func (c *ComplexitySemanticConfig) Validate() error {
 	return nil
 }
 
+// Complexity session modes.
+//
+// "off" is a first-class value rather than only an absent block so the UI's
+// three-way toggle can disable session behaviour without discarding the TTL and
+// threshold settings an admin already tuned. A nil *ComplexitySessionConfig and
+// an explicit "off" are equivalent at runtime; use Enabled to test either.
+//
+// "pinned" classifies once per session and reuses the tier until the pin is
+// released. "cache_aware" classifies every request and gates tier changes; it
+// cannot skip classification because it needs the proposal to decide.
+const (
+	ComplexitySessionModeOff        = "off"
+	ComplexitySessionModePinned     = "pinned"
+	ComplexitySessionModeCacheAware = "cache_aware"
+)
+
+// Complexity session identity sources, listed in resolution order: an explicit
+// x-bf-session-id header, then a harness-native ID.
+const (
+	ComplexitySessionIdentityHeader  = "header"
+	ComplexitySessionIdentityHarness = "harness"
+)
+
+// Complexity session defaults, applied by normalized when a field is unset.
+// SwitchMinSimilarity is deliberately absent: a sensible absolute value depends
+// on the exemplar set's score distribution, so it ships unset (no gating).
+const (
+	DefaultComplexitySessionTTL                   = time.Hour
+	DefaultComplexitySessionReleaseAfterFailures  = 3
+	DefaultComplexitySessionDowngradeAfterNTurns  = 2
+	DefaultComplexitySessionMinCachedTokensToHold = 1024
+)
+
+// DefaultComplexitySessionIdentitySources is the identity ladder applied when
+// none is configured.
+func DefaultComplexitySessionIdentitySources() []string {
+	return []string{ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness}
+}
+
+// ComplexitySessionConfig gives the complexity router a memory of the
+// conversation a request belongs to. A nil value, like Mode "off", disables it.
+//
+// Session state is a memoised classifier result with a TTL, not an override of
+// routing: it replaces the lazy complexity computation, so every routing rule
+// still evaluates normally and only the classification is skipped.
+type ComplexitySessionConfig struct {
+	Mode string `json:"mode"`
+	// TTL bounds how long a session record survives without traffic. It slides
+	// on every read, so it measures idle time rather than total session age.
+	TTL time.Duration `json:"ttl,omitempty"`
+	// IdentitySources selects which of the resolution steps may establish a
+	// session ID, tried in the constant order above regardless of the order
+	// given here.
+	IdentitySources []string `json:"identity_sources,omitempty"`
+	// ReleaseAfterFailures releases a pin after this many consecutive upstream
+	// failures, on the assumption that the pinned tier is implicated.
+	ReleaseAfterFailures int `json:"release_after_failures,omitempty"`
+
+	// SwitchMinSimilarity is the confidence a classification must reach before
+	// it may change session state, forming hysteresis with the semantic
+	// classifier's MinSimilarity: a low bar to classify, a higher bar to switch.
+	// It must be at least Semantic.MinSimilarity. Zero means no similarity
+	// gating at all — escalations pass and the sustained-confidence downgrade
+	// check is skipped — rather than a threshold of zero.
+	//
+	// Like MinSimilarity this is compared against the VectorStore backend's own
+	// score, and those scales differ (chromem, Qdrant, Pinecone, and Redis
+	// report raw cosine; Weaviate reports certainty). Retune on a backend
+	// switch. A lexical score is a different scale entirely and is never
+	// comparable against this value.
+	SwitchMinSimilarity float64 `json:"switch_min_similarity,omitempty"`
+	// DowngradeAfterNTurns is how many consecutive turns a lower tier must be
+	// proposed before a downgrade is taken. Long agentic sessions are full of
+	// turns like "yes" or "run the tests" that classify as confidently simple;
+	// those are exactly the turns not to downgrade on, because the classifier is
+	// right about the turn and wrong about the session.
+	DowngradeAfterNTurns int `json:"downgrade_after_n_turns,omitempty"`
+	// MinCachedTokensToHold is the observed cached-token count below which the
+	// current tier's cache is considered too small to be worth protecting.
+	MinCachedTokensToHold int `json:"min_cached_tokens_to_hold,omitempty"`
+	// MaxSwitchesPerSession caps total tier moves as an oscillation backstop.
+	// Zero means unlimited.
+	MaxSwitchesPerSession int `json:"max_switches_per_session,omitempty"`
+	// AlwaysAllowEscalation lets an escalation bypass the SwitchMinSimilarity
+	// gate. Escalations already ignore cache cost: holding a session on an
+	// undersized model to protect cache spend produces bad answers, which is a
+	// worse failure than overpaying.
+	AlwaysAllowEscalation bool `json:"always_allow_escalation,omitempty"`
+}
+
+// UnmarshalJSON accepts TTL as a duration string ("30m") or a JSON number
+// (milliseconds), matching ComplexitySemanticConfig.Timeout. All other fields
+// decode through the default path via an alias.
+func (c *ComplexitySessionConfig) UnmarshalJSON(data []byte) error {
+	// alias suppresses ComplexitySessionConfig's UnmarshalJSON to avoid
+	// infinite recursion. The outer TTL (json.RawMessage) shadows alias.TTL
+	// because the json package picks the shallower field.
+	type alias ComplexitySessionConfig
+	aux := &struct {
+		TTL json.RawMessage `json:"ttl,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.TTL) == 0 || string(aux.TTL) == "null" {
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(aux.TTL, &s); err == nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("failed to parse session ttl duration string %q: %w", s, err)
+		}
+		c.TTL = d
+	} else {
+		var ms float64
+		if err := json.Unmarshal(aux.TTL, &ms); err != nil {
+			return fmt.Errorf("unsupported session ttl value: %s", string(aux.TTL))
+		}
+		c.TTL = time.Duration(ms * float64(time.Millisecond))
+	}
+	if c.TTL < 0 {
+		return fmt.Errorf("session ttl must be non-negative, got %v", c.TTL)
+	}
+	return nil
+}
+
+// MarshalJSON writes TTL as a duration string so persisted configs decode back
+// to the same value (the default int encoding is nanoseconds, which the
+// millisecond-number decode path would misread).
+func (c ComplexitySessionConfig) MarshalJSON() ([]byte, error) {
+	type alias ComplexitySessionConfig
+	var ttl string
+	if c.TTL != 0 {
+		ttl = c.TTL.String()
+	}
+	return json.Marshal(struct {
+		TTL string `json:"ttl,omitempty"`
+		alias
+	}{
+		TTL:   ttl,
+		alias: alias(c),
+	})
+}
+
+// Enabled reports whether session behaviour should engage. It is the only
+// correct way to test this: a nil block, an empty mode, and an explicit "off"
+// all mean disabled.
+func (c *ComplexitySessionConfig) Enabled() bool {
+	if c == nil {
+		return false
+	}
+	switch c.Mode {
+	case ComplexitySessionModePinned, ComplexitySessionModeCacheAware:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalized returns a canonical deep copy with defaults applied. Defaults are
+// applied even when the mode is "off" so that toggling session behaviour back
+// on preserves what the admin configured.
+func (c *ComplexitySessionConfig) normalized() *ComplexitySessionConfig {
+	if c == nil {
+		return nil
+	}
+	out := &ComplexitySessionConfig{
+		Mode:                  strings.ToLower(strings.TrimSpace(c.Mode)),
+		TTL:                   c.TTL,
+		IdentitySources:       normalizeComplexitySessionIdentitySources(c.IdentitySources),
+		ReleaseAfterFailures:  c.ReleaseAfterFailures,
+		SwitchMinSimilarity:   c.SwitchMinSimilarity,
+		DowngradeAfterNTurns:  c.DowngradeAfterNTurns,
+		MinCachedTokensToHold: c.MinCachedTokensToHold,
+		MaxSwitchesPerSession: c.MaxSwitchesPerSession,
+		AlwaysAllowEscalation: c.AlwaysAllowEscalation,
+	}
+	if out.Mode == "" {
+		out.Mode = ComplexitySessionModeOff
+	}
+	if out.TTL == 0 {
+		out.TTL = DefaultComplexitySessionTTL
+	}
+	if len(out.IdentitySources) == 0 {
+		out.IdentitySources = DefaultComplexitySessionIdentitySources()
+	}
+	if out.ReleaseAfterFailures == 0 {
+		out.ReleaseAfterFailures = DefaultComplexitySessionReleaseAfterFailures
+	}
+	if out.DowngradeAfterNTurns == 0 {
+		out.DowngradeAfterNTurns = DefaultComplexitySessionDowngradeAfterNTurns
+	}
+	if out.MinCachedTokensToHold == 0 {
+		out.MinCachedTokensToHold = DefaultComplexitySessionMinCachedTokensToHold
+	}
+	return out
+}
+
+// normalizeComplexitySessionIdentitySources lowercases, de-duplicates, and
+// orders sources by the resolution ladder so callers can walk them directly.
+func normalizeComplexitySessionIdentitySources(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		seen[normalized] = true
+	}
+	var out []string
+	for _, source := range []string{
+		ComplexitySessionIdentityHeader,
+		ComplexitySessionIdentityHarness,
+	} {
+		if seen[source] {
+			out = append(out, source)
+			delete(seen, source)
+		}
+	}
+	// Unknown values are preserved so Validate can name them rather than
+	// silently dropping a typo'd source.
+	unknown := make([]string, 0, len(seen))
+	for source := range seen {
+		unknown = append(unknown, source)
+	}
+	sort.Strings(unknown)
+	return append(out, unknown...)
+}
+
+// Validate checks a normalized session config. Cross-section rules that need
+// the surrounding analyzer config — notably SwitchMinSimilarity against
+// Semantic.MinSimilarity — are enforced by ComplexityAnalyzerConfig.Validate.
+func (c *ComplexitySessionConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+	switch c.Mode {
+	case ComplexitySessionModeOff, ComplexitySessionModePinned, ComplexitySessionModeCacheAware:
+	default:
+		return fmt.Errorf("session mode must be %q, %q, or %q, got %q",
+			ComplexitySessionModeOff, ComplexitySessionModePinned, ComplexitySessionModeCacheAware, c.Mode)
+	}
+	if c.TTL <= 0 {
+		return fmt.Errorf("session ttl must be positive, got %v", c.TTL)
+	}
+	for _, source := range c.IdentitySources {
+		switch source {
+		case ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness:
+		default:
+			return fmt.Errorf("session identity_sources may contain %q or %q, got %q",
+				ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness, source)
+		}
+	}
+	if len(c.IdentitySources) == 0 {
+		return fmt.Errorf("session identity_sources must list at least one source")
+	}
+	// 1 is a legal ceiling but rejects every real match, matching the
+	// MinSimilarity treatment: a misconfiguration, not "never switch".
+	if c.SwitchMinSimilarity < 0 || c.SwitchMinSimilarity >= 1 {
+		return fmt.Errorf("session switch_min_similarity must be at least 0 and less than 1, got %v", c.SwitchMinSimilarity)
+	}
+	if c.ReleaseAfterFailures < 1 {
+		return fmt.Errorf("session release_after_failures must be at least 1, got %d", c.ReleaseAfterFailures)
+	}
+	if c.DowngradeAfterNTurns < 1 {
+		return fmt.Errorf("session downgrade_after_n_turns must be at least 1, got %d", c.DowngradeAfterNTurns)
+	}
+	if c.MinCachedTokensToHold < 0 {
+		return fmt.Errorf("session min_cached_tokens_to_hold must be non-negative, got %d", c.MinCachedTokensToHold)
+	}
+	if c.MaxSwitchesPerSession < 0 {
+		return fmt.Errorf("session max_switches_per_session must be non-negative, got %d", c.MaxSwitchesPerSession)
+	}
+	return nil
+}
+
 // ComplexityAnalyzerConfigHashes tracks the config.json hash for each editable
 // analyzer section. It is persisted with the config row, but not exposed through
 // API responses or config.json.
@@ -339,6 +622,9 @@ type ComplexityAnalyzerConfigHashes struct {
 	// budgets flag, vector store). The semantic classifier's
 	// exemplars are the shared keyword lists, tracked by the sections above.
 	SemanticSettings string `json:"semantic_settings,omitempty"`
+	// SessionSettings covers the session block (mode, ttl, identity sources,
+	// and the cache-aware switch thresholds).
+	SessionSettings string `json:"session_settings,omitempty"`
 }
 
 type legacyComplexityAnalyzerConfigHashes struct {
@@ -404,6 +690,7 @@ type ComplexityAnalyzerConfig struct {
 	TierBoundaries ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords       ComplexityEditableKeywordConfig `json:"keywords"`
 	Semantic       *ComplexitySemanticConfig       `json:"semantic,omitempty"`
+	Session        *ComplexitySessionConfig        `json:"session,omitempty"`
 	ConfigHashes   ComplexityAnalyzerConfigHashes  `json:"-"`
 	// EmbeddingFingerprint is reserved for config-store implementations that
 	// persist routing state. The semantic classifier verifies a VectorStore-side
@@ -415,6 +702,7 @@ type complexityAnalyzerConfigRecord struct {
 	TierBoundaries       ComplexityTierBoundaries        `json:"tier_boundaries"`
 	Keywords             ComplexityEditableKeywordConfig `json:"keywords"`
 	Semantic             *ComplexitySemanticConfig       `json:"semantic,omitempty"`
+	Session              *ComplexitySessionConfig        `json:"session,omitempty"`
 	ConfigHashes         ComplexityAnalyzerConfigHashes  `json:"_config_hashes,omitempty"`
 	EmbeddingFingerprint string                          `json:"_embedding_fingerprint,omitempty"`
 }
@@ -449,6 +737,21 @@ func (c *ComplexityAnalyzerConfig) Validate() error {
 			return err
 		}
 	}
+	if err := c.Session.Validate(); err != nil {
+		return err
+	}
+	// SwitchMinSimilarity and MinSimilarity form hysteresis: a low bar to accept
+	// a classification, a higher bar to let it change session state. Inverting
+	// them would let a classification too weak to be believed still move a
+	// session, so the ordering is enforced rather than clamped. Zero means the
+	// switch gate is off entirely and is exempt.
+	if c.Session != nil && c.Semantic != nil && c.Session.SwitchMinSimilarity > 0 &&
+		c.Session.SwitchMinSimilarity < c.Semantic.MinSimilarity {
+		return fmt.Errorf(
+			"session switch_min_similarity (%v) must be at least semantic min_similarity (%v)",
+			c.Session.SwitchMinSimilarity, c.Semantic.MinSimilarity,
+		)
+	}
 	return nil
 }
 
@@ -469,6 +772,7 @@ func (c *ComplexityAnalyzerConfig) Normalized() ComplexityAnalyzerConfig {
 			ComplexKeywords: normalizeComplexityKeywordList(c.Keywords.ComplexKeywords),
 		},
 		Semantic:             c.Semantic.normalized(),
+		Session:              c.Session.normalized(),
 		ConfigHashes:         c.ConfigHashes,
 		EmbeddingFingerprint: c.EmbeddingFingerprint,
 	}
@@ -546,6 +850,7 @@ func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*Compl
 			ComplexKeywords: mergeComplexityKeywordLists(normalizedBase.Keywords.ComplexKeywords, normalizedFile.Keywords.ComplexKeywords),
 		},
 		Semantic:             mergeComplexitySemanticConfig(normalizedBase.Semantic, normalizedFile.Semantic),
+		Session:              mergeComplexitySessionConfig(normalizedBase.Session, normalizedFile.Session),
 		ConfigHashes:         normalizedFile.ConfigHashes,
 		EmbeddingFingerprint: normalizedBase.EmbeddingFingerprint,
 	}
@@ -559,6 +864,15 @@ func MergeComplexityAnalyzerConfig(base, file *ComplexityAnalyzerConfig) (*Compl
 // mergeComplexitySemanticConfig overlays the file semantic settings. A nil
 // file section keeps the base untouched.
 func mergeComplexitySemanticConfig(base, file *ComplexitySemanticConfig) *ComplexitySemanticConfig {
+	if file == nil {
+		return base.normalized()
+	}
+	return file.normalized()
+}
+
+// mergeComplexitySessionConfig overlays the file session settings. A nil file
+// section keeps the base untouched.
+func mergeComplexitySessionConfig(base, file *ComplexitySessionConfig) *ComplexitySessionConfig {
 	if file == nil {
 		return base.normalized()
 	}
@@ -610,6 +924,14 @@ func MergeComplexityAnalyzerConfigByHashes(base, file *ComplexityAnalyzerConfig)
 			merged.ConfigHashes.SemanticSettings = normalizedFile.ConfigHashes.SemanticSettings
 		}
 	}
+	// Same "absence means no opinion" rule as the semantic section above: a
+	// config.json without a session block leaves DB session state alone.
+	if normalizedFile.Session != nil {
+		if merged.Session == nil || merged.ConfigHashes.SessionSettings != normalizedFile.ConfigHashes.SessionSettings {
+			merged.Session = normalizedFile.Session.normalized()
+			merged.ConfigHashes.SessionSettings = normalizedFile.ConfigHashes.SessionSettings
+		}
+	}
 	normalizedMerged := merged.Normalized()
 	if err := normalizedMerged.Validate(); err != nil {
 		return nil, err
@@ -632,6 +954,7 @@ func DecodeComplexityAnalyzerConfig(data []byte) (*ComplexityAnalyzerConfig, err
 		TierBoundaries:       record.TierBoundaries,
 		Keywords:             record.Keywords,
 		Semantic:             record.Semantic,
+		Session:              record.Session,
 		ConfigHashes:         record.ConfigHashes,
 		EmbeddingFingerprint: record.EmbeddingFingerprint,
 	}
@@ -647,6 +970,7 @@ func encodeComplexityAnalyzerConfig(config ComplexityAnalyzerConfig) ([]byte, er
 		TierBoundaries:       config.TierBoundaries,
 		Keywords:             config.Keywords,
 		Semantic:             config.Semantic,
+		Session:              config.Session,
 		ConfigHashes:         config.ConfigHashes,
 		EmbeddingFingerprint: config.EmbeddingFingerprint,
 	}

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -423,6 +423,245 @@ func TestRDBConfigStore_UpdateComplexityAnalyzerConfigConcurrentCarryOver(t *tes
 	assert.Equal(t, hashesA, got.ConfigHashes)
 }
 
+func testSessionConfig() *ComplexitySessionConfig {
+	return &ComplexitySessionConfig{Mode: ComplexitySessionModePinned}
+}
+
+func TestComplexitySessionConfigTTLDecoding(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "duration string", payload: `{"ttl":"30m"}`, want: 30 * time.Minute},
+		{name: "number is milliseconds", payload: `{"ttl":250}`, want: 250 * time.Millisecond},
+		{name: "absent keeps zero", payload: `{}`, want: 0},
+		{name: "null keeps zero", payload: `{"ttl":null}`, want: 0},
+		{name: "negative number rejected", payload: `{"ttl":-5}`, wantErr: true},
+		{name: "bad string rejected", payload: `{"ttl":"a while"}`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg ComplexitySessionConfig
+			err := json.Unmarshal([]byte(tt.payload), &cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.TTL)
+		})
+	}
+}
+
+// A default-encoded time.Duration is nanoseconds, which the millisecond decode
+// path would misread by six orders of magnitude. The string encoding is what
+// keeps a persisted TTL meaning what it said.
+func TestComplexitySessionConfigTTLMarshalRoundTrip(t *testing.T) {
+	cfg := testSessionConfig()
+	cfg.TTL = 30 * time.Minute
+
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"ttl":"30m0s"`)
+
+	var decoded ComplexitySessionConfig
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, cfg.TTL, decoded.TTL)
+}
+
+func TestComplexitySessionConfigNormalizedDefaults(t *testing.T) {
+	normalized := testSessionConfig().normalized()
+
+	assert.Equal(t, DefaultComplexitySessionTTL, normalized.TTL)
+	assert.Equal(t, DefaultComplexitySessionIdentitySources(), normalized.IdentitySources)
+	assert.Equal(t, DefaultComplexitySessionReleaseAfterFailures, normalized.ReleaseAfterFailures)
+	assert.Equal(t, DefaultComplexitySessionDowngradeAfterNTurns, normalized.DowngradeAfterNTurns)
+	assert.Equal(t, DefaultComplexitySessionMinCachedTokensToHold, normalized.MinCachedTokensToHold)
+	// Ships unset: no sensible absolute default exists until the exemplar set's
+	// score distribution is measured.
+	assert.Zero(t, normalized.SwitchMinSimilarity)
+	assert.Zero(t, normalized.MaxSwitchesPerSession)
+	require.NoError(t, normalized.Validate())
+}
+
+func TestComplexitySessionConfigEnabled(t *testing.T) {
+	var nilCfg *ComplexitySessionConfig
+	assert.False(t, nilCfg.Enabled())
+	assert.False(t, (&ComplexitySessionConfig{}).Enabled())
+	assert.False(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModeOff}).Enabled())
+	assert.True(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModePinned}).Enabled())
+	assert.True(t, (&ComplexitySessionConfig{Mode: ComplexitySessionModeCacheAware}).Enabled())
+}
+
+// Turning session behaviour off must not discard the tuning an admin did, so
+// the toggle carries a mode rather than nilling the block.
+func TestComplexitySessionConfigOffPreservesSettings(t *testing.T) {
+	cfg := &ComplexitySessionConfig{
+		Mode:                 ComplexitySessionModeOff,
+		TTL:                  90 * time.Minute,
+		DowngradeAfterNTurns: 5,
+	}
+	normalized := cfg.normalized()
+
+	assert.False(t, normalized.Enabled())
+	assert.Equal(t, 90*time.Minute, normalized.TTL)
+	assert.Equal(t, 5, normalized.DowngradeAfterNTurns)
+}
+
+func TestComplexitySessionConfigIdentitySourceNormalization(t *testing.T) {
+	cfg := &ComplexitySessionConfig{
+		Mode:            ComplexitySessionModePinned,
+		IdentitySources: []string{" HARNESS ", "header", "header", ""},
+	}
+	normalized := cfg.normalized()
+
+	// De-duplicated, and reordered into resolution order regardless of input order.
+	assert.Equal(t, []string{ComplexitySessionIdentityHeader, ComplexitySessionIdentityHarness}, normalized.IdentitySources)
+	require.NoError(t, normalized.Validate())
+}
+
+// Unsupported sources are preserved through normalization so validation can
+// name them rather than silently dropping stale or misspelled configuration.
+func TestComplexitySessionConfigRejectsUnknownIdentitySource(t *testing.T) {
+	for _, source := range []string{"fingerprint", "telepathy"} {
+		t.Run(source, func(t *testing.T) {
+			cfg := &ComplexitySessionConfig{
+				Mode:            ComplexitySessionModePinned,
+				IdentitySources: []string{"header", source},
+			}
+			err := cfg.normalized().Validate()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), source)
+		})
+	}
+}
+
+func TestComplexitySessionConfigValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*ComplexitySessionConfig)
+		errs   string
+	}{
+		{name: "valid pinned"},
+		{name: "unknown mode", mutate: func(c *ComplexitySessionConfig) { c.Mode = "adaptive" }, errs: "session mode"},
+		{name: "switch similarity at ceiling", mutate: func(c *ComplexitySessionConfig) { c.SwitchMinSimilarity = 1 }, errs: "switch_min_similarity"},
+		{name: "negative switch similarity", mutate: func(c *ComplexitySessionConfig) { c.SwitchMinSimilarity = -0.1 }, errs: "switch_min_similarity"},
+		{name: "negative max switches", mutate: func(c *ComplexitySessionConfig) { c.MaxSwitchesPerSession = -1 }, errs: "max_switches_per_session"},
+		{name: "negative min cached tokens", mutate: func(c *ComplexitySessionConfig) { c.MinCachedTokensToHold = -1 }, errs: "min_cached_tokens_to_hold"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testSessionConfig()
+			if tt.mutate != nil {
+				tt.mutate(cfg)
+			}
+			normalized := cfg.normalized()
+			// normalized must not launder an invalid value into a default.
+			if tt.mutate != nil {
+				tt.mutate(normalized)
+			}
+			err := normalized.Validate()
+			if tt.errs == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errs)
+		})
+	}
+}
+
+// Hysteresis: a classification too weak to be believed must not be strong
+// enough to move a session.
+func TestComplexityAnalyzerConfigRejectsSwitchSimilarityBelowMinSimilarity(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Semantic.MinSimilarity = 0.80
+	cfg.Session = testSessionConfig()
+	cfg.Session.SwitchMinSimilarity = 0.70
+
+	normalized := cfg.Normalized()
+	err := normalized.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "switch_min_similarity")
+
+	normalized.Session.SwitchMinSimilarity = 0.80
+	require.NoError(t, normalized.Validate())
+}
+
+// Zero means the switch gate is off entirely, not a threshold of zero, so it is
+// exempt from the ordering rule.
+func TestComplexityAnalyzerConfigAllowsUnsetSwitchSimilarity(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Semantic.MinSimilarity = 0.80
+	cfg.Session = testSessionConfig()
+
+	normalized := cfg.Normalized()
+	require.NoError(t, normalized.Validate())
+	assert.Zero(t, normalized.Session.SwitchMinSimilarity)
+}
+
+// The record mirror is a separate struct from the public config; a field added
+// to one and not the other round-trips as nothing.
+func TestComplexityAnalyzerConfigSessionRoundTrip(t *testing.T) {
+	cfg := testSemanticAnalyzerConfig()
+	cfg.Session = &ComplexitySessionConfig{
+		Mode:                  ComplexitySessionModeCacheAware,
+		TTL:                   90 * time.Minute,
+		IdentitySources:       []string{ComplexitySessionIdentityHeader},
+		SwitchMinSimilarity:   0.9,
+		MaxSwitchesPerSession: 4,
+		AlwaysAllowEscalation: true,
+	}
+
+	encoded, err := encodeComplexityAnalyzerConfig(cfg.Normalized())
+	require.NoError(t, err)
+
+	decoded, err := DecodeComplexityAnalyzerConfig(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, decoded.Session)
+	assert.Equal(t, cfg.Session.Mode, decoded.Session.Mode)
+	assert.Equal(t, cfg.Session.TTL, decoded.Session.TTL)
+	assert.Equal(t, cfg.Session.IdentitySources, decoded.Session.IdentitySources)
+	assert.Equal(t, cfg.Session.SwitchMinSimilarity, decoded.Session.SwitchMinSimilarity)
+	assert.Equal(t, cfg.Session.MaxSwitchesPerSession, decoded.Session.MaxSwitchesPerSession)
+	assert.True(t, decoded.Session.AlwaysAllowEscalation)
+}
+
+// A config.json without a session block means "no opinion", not removal.
+func TestMergeComplexityAnalyzerConfigByHashesKeepsSessionWhenFileOmitsIt(t *testing.T) {
+	base := testSemanticAnalyzerConfig()
+	base.Session = testSessionConfig()
+	base.ConfigHashes.SessionSettings = "hash-a"
+
+	file := testSemanticAnalyzerConfig()
+
+	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged.Session)
+	assert.Equal(t, ComplexitySessionModePinned, merged.Session.Mode)
+	assert.Equal(t, "hash-a", merged.ConfigHashes.SessionSettings)
+}
+
+func TestMergeComplexityAnalyzerConfigByHashesAppliesChangedSessionSection(t *testing.T) {
+	base := testSemanticAnalyzerConfig()
+	base.Session = testSessionConfig()
+	base.ConfigHashes.SessionSettings = "hash-a"
+
+	file := testSemanticAnalyzerConfig()
+	file.Session = &ComplexitySessionConfig{Mode: ComplexitySessionModeCacheAware}
+	file.ConfigHashes.SessionSettings = "hash-b"
+
+	merged, err := MergeComplexityAnalyzerConfigByHashes(base, file)
+	require.NoError(t, err)
+	require.NotNil(t, merged.Session)
+	assert.Equal(t, ComplexitySessionModeCacheAware, merged.Session.Mode)
+	assert.Equal(t, "hash-b", merged.ConfigHashes.SessionSettings)
+}
+
 func TestComplexitySemanticConfigRejectsRemovedFields(t *testing.T) {
 	for _, field := range []string{"dimension", "fallback"} {
 		t.Run(field, func(t *testing.T) {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -861,6 +861,7 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		QueryParams:              queryParams,
 		BudgetAndRateLimitStatus: p.store.GetBudgetAndRateLimitStatus(ctx, model, provider, virtualKey, nil, nil, nil),
 		computeComplexity:        computeComplexity,
+		SessionID:                bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySessionID),
 	}
 
 	p.logger.Debug("[PreRequestHook] Built routing context: provider=%s, model=%s, requestType=%s, vk=%v",

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -1,9 +1,12 @@
 package governance
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"math/rand/v2"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -48,6 +51,11 @@ type RoutingContext struct {
 	QueryParams              map[string]string                   // Query parameters for dynamic routing
 	BudgetAndRateLimitStatus *BudgetAndRateLimitStatus           // Budget and rate limit status by provider/model
 	computeComplexity        func() *complexity.ComplexityResult // Lazy complexity computation; called at most once when a rule references "complexity_tier"
+	// SessionID identifies the conversation this request belongs to. Empty
+	// means "unknown", which is the normal case and simply restores random
+	// weighted target selection. Populated from x-bf-session-id or a verified
+	// harness-native conversation ID.
+	SessionID string
 }
 
 type RoutingEngine struct {
@@ -234,7 +242,7 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 					continue
 				}
 
-				target, ok := selectWeightedTarget(rule.Targets)
+				target, ok := selectWeightedTarget(rule.Targets, routingCtx.SessionID, rule.ID)
 				if !ok {
 					re.logger.Debug("[RoutingEngine] Rule %s matched but has no valid targets (empty list or all-negative weights), skipping — note: all-zero weights use uniform selection and would not reach here", rule.Name)
 					ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, schemas.LogLevelError, fmt.Sprintf("Rule '%s' [%s] → matched but no valid targets (empty or all-negative weights), skipping", rule.Name, rule.CelExpression))
@@ -306,13 +314,21 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	return finalDecision, nil
 }
 
-// selectWeightedTarget picks one target from the slice using weighted random selection.
+// selectWeightedTarget picks one target from the slice using weighted selection.
 // Each target's Weight contributes proportionally to its probability of being chosen.
 // Weights do not need to be normalised to 100; the function normalises internally.
 // Returns ok=false only when len(targets)==0 or all targets have negative weights (filtered out).
-// When all valid targets have weight==0 the function falls back to uniform random selection
+// When all valid targets have weight==0 the function falls back to uniform selection
 // and still returns ok=true, so zero-weight targets are valid and handled.
-func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (configstoreTables.TableRoutingTarget, bool) {
+//
+// When sessionID is non-empty the selection point is derived from
+// hash(sessionID, ruleID) instead of rand, so every request in a session picks
+// the same target for a given rule. That stickiness is what makes tier state
+// worth having: a tier resolving to two weighted targets would otherwise re-roll
+// every turn and discard the provider-side prompt cache anyway, one layer below
+// the tier. The hash is stateless, so it agrees across nodes and survives
+// restarts without storage, and it stays proportional as weights change.
+func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget, sessionID, ruleID string) (configstoreTables.TableRoutingTarget, bool) {
 	if len(targets) == 0 {
 		return configstoreTables.TableRoutingTarget{}, false
 	}
@@ -330,21 +346,46 @@ func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (confi
 		return configstoreTables.TableRoutingTarget{}, false
 	}
 
+	if len(valid) == 1 {
+		return valid[0], true
+	}
+
+	sticky := sessionID != ""
+	if sticky {
+		// The cumulative walk below maps a point in [0,1) to a position in the
+		// slice, so a stable point only yields a stable target if the slice
+		// order is also stable. Targets carry no ID column and arrive in
+		// whatever order the DB returned them, so sort by the columns that
+		// uniquely identify a target within a rule. Without this, stickiness
+		// silently degrades to random on any query that reorders rows.
+		sort.SliceStable(valid, func(i, j int) bool {
+			return routingTargetIdentity(valid[i]) < routingTargetIdentity(valid[j])
+		})
+	}
+
 	total := 0.0
 	for _, t := range valid {
 		total += t.Weight
 	}
 
-	// All weights are 0 — select uniformly at random among valid targets.
+	// All weights are 0 — select uniformly among valid targets.
 	if total == 0 {
+		if sticky {
+			index := int(sessionSelectionPoint(sessionID, ruleID) * float64(len(valid)))
+			if index >= len(valid) {
+				index = len(valid) - 1
+			}
+			return valid[index], true
+		}
 		return valid[rand.IntN(len(valid))], true
 	}
 
-	if len(valid) == 1 {
-		return valid[0], true
+	point := rand.Float64()
+	if sticky {
+		point = sessionSelectionPoint(sessionID, ruleID)
 	}
 
-	r := rand.Float64() * total
+	r := point * total
 	cumulative := 0.0
 	for _, t := range valid {
 		cumulative += t.Weight
@@ -353,6 +394,37 @@ func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (confi
 		}
 	}
 	return valid[len(valid)-1], true
+}
+
+// routingTargetIdentity renders the columns of the routing target unique index
+// as a sortable string.
+//
+// A nil field and an empty one collapse to the same identity, deliberately:
+// both mean "inherit from the request" at selection time, so two targets
+// differing only that way resolve to the same provider, model, and key. Sorting
+// them as equal is therefore stable in the only sense that matters.
+func routingTargetIdentity(target configstoreTables.TableRoutingTarget) string {
+	var b strings.Builder
+	for _, field := range []*string{target.Provider, target.Model, target.KeyID} {
+		if field != nil {
+			b.WriteString(*field)
+		}
+		b.WriteByte(0)
+	}
+	return b.String()
+}
+
+// sessionSelectionPoint maps a session and rule to a uniform point in [0,1).
+//
+// Keying on the rule as well as the session means a session that matches two
+// different rules gets two independent draws, rather than landing on the same
+// slice position in both — which would correlate the choices and skew the
+// aggregate distribution away from the configured weights.
+func sessionSelectionPoint(sessionID, ruleID string) float64 {
+	sum := sha256.Sum256([]byte(sessionID + "\x00" + ruleID))
+	// Take 53 bits, the exact-integer range of a float64, so every
+	// representable value is equally likely and the result is never 1.0.
+	return float64(binary.BigEndian.Uint64(sum[:8])>>11) / float64(uint64(1)<<53)
 }
 
 // buildScopeChain builds the scope evaluation chain based on organizational hierarchy

--- a/plugins/governance/stickytarget_test.go
+++ b/plugins/governance/stickytarget_test.go
@@ -1,0 +1,259 @@
+package governance
+
+import (
+	"fmt"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stickyTestTargets(weights ...float64) []configstoreTables.TableRoutingTarget {
+	targets := make([]configstoreTables.TableRoutingTarget, 0, len(weights))
+	for i, weight := range weights {
+		targets = append(targets, configstoreTables.TableRoutingTarget{
+			RuleID:   "rule-1",
+			Provider: bifrost.Ptr(fmt.Sprintf("provider-%d", i)),
+			Model:    bifrost.Ptr(fmt.Sprintf("model-%d", i)),
+			Weight:   weight,
+		})
+	}
+	return targets
+}
+
+// Stickiness within a session is the whole point: a tier that re-resolves to a
+// different target each turn discards the provider-side cache anyway.
+func TestSelectWeightedTargetStickyWithinSession(t *testing.T) {
+	targets := stickyTestTargets(0.5, 0.3, 0.2)
+
+	first, ok := selectWeightedTarget(targets, "session-abc", "rule-1")
+	require.True(t, ok)
+	for i := 0; i < 200; i++ {
+		got, ok := selectWeightedTarget(targets, "session-abc", "rule-1")
+		require.True(t, ok)
+		require.Equal(t, *first.Provider, *got.Provider, "target changed on call %d", i)
+	}
+}
+
+// Targets carry no ID column and arrive in whatever order the DB returned. If
+// the walk order were not normalised, the same session would land on different
+// targets across queries — stickiness that silently degrades to random.
+func TestSelectWeightedTargetStickyIndependentOfTargetOrder(t *testing.T) {
+	targets := stickyTestTargets(0.5, 0.3, 0.2)
+	reversed := make([]configstoreTables.TableRoutingTarget, 0, len(targets))
+	for i := len(targets) - 1; i >= 0; i-- {
+		reversed = append(reversed, targets[i])
+	}
+
+	for _, session := range []string{"s-1", "s-2", "s-3", "s-4", "s-5"} {
+		forward, ok := selectWeightedTarget(targets, session, "rule-1")
+		require.True(t, ok)
+		backward, ok := selectWeightedTarget(reversed, session, "rule-1")
+		require.True(t, ok)
+		assert.Equal(t, *forward.Provider, *backward.Provider, "session %s moved when target order changed", session)
+	}
+}
+
+// Sorting for the sticky walk must not mutate the caller's slice: rule.Targets
+// is shared cached config, and reordering it under concurrent readers would be
+// a data race.
+func TestSelectWeightedTargetDoesNotMutateCallerSlice(t *testing.T) {
+	targets := stickyTestTargets(0.2, 0.5, 0.3)
+	before := make([]string, len(targets))
+	for i, target := range targets {
+		before[i] = *target.Provider
+	}
+
+	_, ok := selectWeightedTarget(targets, "session-abc", "rule-1")
+	require.True(t, ok)
+
+	after := make([]string, len(targets))
+	for i, target := range targets {
+		after[i] = *target.Provider
+	}
+	assert.Equal(t, before, after)
+}
+
+// Stickiness must not cost proportionality: across many sessions the hash has to
+// spread like the RNG it replaced.
+func TestSelectWeightedTargetStickyDistributionMatchesWeights(t *testing.T) {
+	targets := stickyTestTargets(0.5, 0.3, 0.2)
+	const sessions = 20000
+
+	counts := map[string]int{}
+	for i := 0; i < sessions; i++ {
+		target, ok := selectWeightedTarget(targets, fmt.Sprintf("session-%d", i), "rule-1")
+		require.True(t, ok)
+		counts[*target.Provider]++
+	}
+
+	for i, want := range []float64{0.5, 0.3, 0.2} {
+		provider := fmt.Sprintf("provider-%d", i)
+		got := float64(counts[provider]) / float64(sessions)
+		assert.InDelta(t, want, got, 0.02, "provider %s share", provider)
+	}
+}
+
+// A session matching two rules must draw independently for each. Keying the
+// hash on the session alone would put it at the same slice position in both,
+// correlating the choices and skewing the aggregate away from the weights.
+func TestSelectWeightedTargetStickyDecorrelatesAcrossRules(t *testing.T) {
+	targets := stickyTestTargets(0.5, 0.5)
+	const sessions = 2000
+
+	same := 0
+	for i := 0; i < sessions; i++ {
+		session := fmt.Sprintf("session-%d", i)
+		a, ok := selectWeightedTarget(targets, session, "rule-a")
+		require.True(t, ok)
+		b, ok := selectWeightedTarget(targets, session, "rule-b")
+		require.True(t, ok)
+		if *a.Provider == *b.Provider {
+			same++
+		}
+	}
+
+	// Independent draws over two equal-weight targets agree about half the time.
+	agreement := float64(same) / float64(sessions)
+	assert.InDelta(t, 0.5, agreement, 0.05)
+}
+
+// Weight edits must move roughly the affected share of sessions, not reshuffle
+// everyone — otherwise a routine weight tweak invalidates every live cache.
+func TestSelectWeightedTargetStickyProportionalUnderWeightChange(t *testing.T) {
+	before := stickyTestTargets(0.5, 0.5)
+	after := stickyTestTargets(0.6, 0.4)
+	const sessions = 20000
+
+	moved := 0
+	for i := 0; i < sessions; i++ {
+		session := fmt.Sprintf("session-%d", i)
+		a, ok := selectWeightedTarget(before, session, "rule-1")
+		require.True(t, ok)
+		b, ok := selectWeightedTarget(after, session, "rule-1")
+		require.True(t, ok)
+		if *a.Provider != *b.Provider {
+			moved++
+		}
+	}
+
+	// A 0.1 shift in the cumulative boundary should relocate ~10% of sessions.
+	churn := float64(moved) / float64(sessions)
+	assert.InDelta(t, 0.10, churn, 0.02, "weight change churned %.1f%% of sessions", churn*100)
+}
+
+// All-zero weights take a separate uniform branch that must be sticky too.
+func TestSelectWeightedTargetStickyAllZeroWeights(t *testing.T) {
+	targets := stickyTestTargets(0, 0, 0)
+
+	first, ok := selectWeightedTarget(targets, "session-abc", "rule-1")
+	require.True(t, ok)
+	for i := 0; i < 100; i++ {
+		got, ok := selectWeightedTarget(targets, "session-abc", "rule-1")
+		require.True(t, ok)
+		require.Equal(t, *first.Provider, *got.Provider)
+	}
+
+	const sessions = 9000
+	counts := map[string]int{}
+	for i := 0; i < sessions; i++ {
+		target, ok := selectWeightedTarget(targets, fmt.Sprintf("session-%d", i), "rule-1")
+		require.True(t, ok)
+		counts[*target.Provider]++
+	}
+	for i := 0; i < 3; i++ {
+		share := float64(counts[fmt.Sprintf("provider-%d", i)]) / float64(sessions)
+		assert.InDelta(t, 1.0/3.0, share, 0.03)
+	}
+}
+
+// No session ID is the normal case and must behave exactly as before.
+func TestSelectWeightedTargetWithoutSessionStaysRandom(t *testing.T) {
+	targets := stickyTestTargets(0.5, 0.5)
+	const draws = 20000
+
+	counts := map[string]int{}
+	for i := 0; i < draws; i++ {
+		target, ok := selectWeightedTarget(targets, "", "rule-1")
+		require.True(t, ok)
+		counts[*target.Provider]++
+	}
+
+	require.Len(t, counts, 2, "random selection collapsed to a single target")
+	share := float64(counts["provider-0"]) / float64(draws)
+	assert.InDelta(t, 0.5, share, 0.02)
+}
+
+// The existing contract: empty and all-negative slices report ok=false, a lone
+// target always wins, and a zero-weight target alongside a positive one is
+// never selected.
+func TestSelectWeightedTargetPreservesExistingContract(t *testing.T) {
+	for _, sessionID := range []string{"", "session-abc"} {
+		t.Run("session="+sessionID, func(t *testing.T) {
+			_, ok := selectWeightedTarget(nil, sessionID, "rule-1")
+			assert.False(t, ok)
+
+			_, ok = selectWeightedTarget(stickyTestTargets(-1, -2), sessionID, "rule-1")
+			assert.False(t, ok)
+
+			single, ok := selectWeightedTarget(stickyTestTargets(0.25), sessionID, "rule-1")
+			require.True(t, ok)
+			assert.Equal(t, "provider-0", *single.Provider)
+
+			for i := 0; i < 100; i++ {
+				got, ok := selectWeightedTarget(stickyTestTargets(1.0, 0.0), fmt.Sprintf("s-%d", i), "rule-1")
+				require.True(t, ok)
+				require.Equal(t, "provider-0", *got.Provider)
+			}
+		})
+	}
+}
+
+// The selection point must be a uniform [0,1) — never 1.0, which would walk off
+// the end of the cumulative range.
+func TestSessionSelectionPointRange(t *testing.T) {
+	const samples = 50000
+	buckets := make([]int, 10)
+	for i := 0; i < samples; i++ {
+		point := sessionSelectionPoint(fmt.Sprintf("session-%d", i), "rule-1")
+		require.GreaterOrEqual(t, point, 0.0)
+		require.Less(t, point, 1.0)
+		buckets[int(point*10)]++
+	}
+	for i, count := range buckets {
+		share := float64(count) / float64(samples)
+		assert.InDelta(t, 0.1, share, 0.01, "decile %d", i)
+	}
+}
+
+// Targets that route differently must get different identities, or the sort
+// would treat them as interchangeable and stickiness would depend on input
+// order again. In particular the field separator must not let a value from one
+// column bleed into the next.
+func TestRoutingTargetIdentitySeparatesFields(t *testing.T) {
+	identities := map[string]bool{}
+	for _, target := range []configstoreTables.TableRoutingTarget{
+		{Provider: bifrost.Ptr("a"), Model: bifrost.Ptr("b")},
+		{Provider: bifrost.Ptr("a"), Model: bifrost.Ptr("b"), KeyID: bifrost.Ptr("k")},
+		{Provider: bifrost.Ptr("ab")},
+		{Model: bifrost.Ptr("ab")},
+		{Provider: bifrost.Ptr("a")},
+	} {
+		identity := routingTargetIdentity(target)
+		require.False(t, identities[identity], "identity collision: %q", identity)
+		identities[identity] = true
+	}
+	assert.Len(t, identities, 5)
+}
+
+// A nil field and an empty one mean the same thing at selection time ("inherit
+// from the request"), so they must collapse rather than sort as two distinct
+// positions.
+func TestRoutingTargetIdentityTreatsNilAndEmptyAlike(t *testing.T) {
+	assert.Equal(t,
+		routingTargetIdentity(configstoreTables.TableRoutingTarget{Provider: bifrost.Ptr("a")}),
+		routingTargetIdentity(configstoreTables.TableRoutingTarget{Provider: bifrost.Ptr("a"), Model: bifrost.Ptr("")}),
+	)
+}


### PR DESCRIPTION
## Summary

Adds session-aware routing to the complexity analyzer, giving the router a memory of which tier a conversation was assigned to. Within a session, target selection is deterministic (hash-based) rather than random, so repeated turns in the same conversation consistently resolve to the same provider and preserve the provider-side prompt cache. A new `ComplexitySessionConfig` block controls the behaviour, with two modes (`pinned` and `cache_aware`) and an explicit `off` value so the UI can disable session behaviour without discarding tuned settings.

## Changes

- **`ComplexitySessionConfig`**: New config struct with `mode`, `ttl`, `identity_sources`, `release_after_failures`, `switch_min_similarity`, `downgrade_after_n_turns`, `min_cached_tokens_to_hold`, `max_switches_per_session`, and `always_allow_escalation`. TTL accepts both duration strings (`"30m"`) and millisecond numbers, matching the existing semantic timeout encoding. A nil block and an explicit `"off"` mode are equivalent at runtime; `Enabled()` is the single correct test for either.
- **Identity sources**: Three resolution steps — `header` (x-bf-session-id), `harness` (native harness ID), and `fingerprint` (prompt-content hash). Fingerprinting is excluded from defaults and must be opted into. Sources are normalised into resolution-ladder order regardless of input order; unknown values are preserved through normalisation so `Validate` can name them rather than silently dropping a typo.
- **Hysteresis enforcement**: `SwitchMinSimilarity` must be at least `Semantic.MinSimilarity`. A classification too weak to be believed must not be strong enough to move a session. Zero is exempt — it disables the switch gate entirely rather than setting a threshold of zero.
- **`selectWeightedTarget` sticky selection**: When a `SessionID` is present, the selection point is derived from `hash(sessionID, ruleID)` instead of `rand.Float64()`. The target slice is sorted by a stable identity key (provider, model, key ID) before the cumulative walk, so stickiness does not silently degrade when the DB returns rows in a different order. The sort operates on a copy to avoid mutating the shared cached config slice. Keying on the rule as well as the session decorrelates draws across rules, preserving aggregate weight distribution. The all-zero-weight uniform branch is also made sticky.
- **`sessionSelectionPoint`**: Maps session and rule to a uniform `[0,1)` point using 53 bits of SHA-256, matching the exact-integer range of a float64 so no value is ever 1.0 and every representable value is equally likely.
- **`SessionSettings` hash**: Added to `ComplexityAnalyzerConfigHashes` and computed in `GenerateComplexityAnalyzerConfigHashes`. The hash-based merge follows the same "absence means no opinion" rule as the semantic section — a config.json without a session block leaves DB session state untouched.
- **`SessionID` in `RoutingContext`**: Populated from the `x-bf-session-id` header in the governance plugin's `applyRoutingRules`. The full resolution ladder (harness-native IDs, prefix fingerprinting) will replace this single read without changing the field.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./plugins/governance/...
```

Key scenarios covered by the new tests:

- TTL decoding from duration strings, millisecond numbers, absent fields, and invalid inputs
- Marshal/unmarshal round-trip preserves TTL (nanosecond default encoding would misread by six orders of magnitude)
- Normalisation applies all defaults; fingerprint is never defaulted
- `Enabled()` returns false for nil, empty mode, and explicit `"off"`
- Disabling session mode preserves tuned TTL and downgrade settings
- Identity source de-duplication and resolution-order sorting
- Unknown identity sources are rejected by `Validate` with the offending value named
- `SwitchMinSimilarity` below `Semantic.MinSimilarity` is rejected; zero is exempt
- Session config round-trips through encode/decode
- Hash-based merge keeps session state when file omits the block; applies it when the hash changes
- Sticky selection is consistent within a session, independent of target slice order, does not mutate the caller's slice, matches weight distribution across sessions, decorrelates across rules, handles all-zero weights, and leaves no-session behaviour unchanged
- `sessionSelectionPoint` output is uniform across `[0,1)`
- `routingTargetIdentity` separates fields correctly and treats nil and empty as equivalent

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`sessionSelectionPoint` uses SHA-256 keyed on session and rule IDs. Session IDs sourced from the `x-bf-session-id` header are caller-supplied; no secrets are derived from them and the hash is used only for target selection, not authentication.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable