### PR TITLE
fix(modelcatalogresolver): honor SkipKeySelection before catalog-based provider resolution

### DIFF
--- a/plugins/modelcatalogresolver/main.go
+++ b/plugins/modelcatalogresolver/main.go
@@ -61,6 +61,9 @@ func (p *Plugin) Cleanup() error { return nil }
 //
 // If the catalog returns zero providers, the resolver leaves req.Provider empty — the
 // empty-provider validation in handleRequest/handleStreamRequest then returns a clear error.
+// Exception: key-selection-bypass requests (BifrostContextKeySkipKeySelection) are pinned to
+// the integration's canonical provider regardless of catalog contents — see
+// ResolveProviderFromCatalog for why a zero-key OAuth-passthrough provider needs this.
 func (p *Plugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
 	if req.RequestType == schemas.PassthroughRequest || req.RequestType == schemas.PassthroughStreamRequest {
 		return nil
@@ -145,7 +148,26 @@ func (p *Plugin) PreRequestHook(ctx *schemas.BifrostContext, req *schemas.Bifros
 // selection — emitting routing-engine logs visible to callers when the allowlist prunes
 // candidates. Side effect: routing-engine logs are written to ctx when allowlist filtering
 // is applied (nil ctx skips logging).
+//
+// Key-selection-bypass requests (BifrostContextKeySkipKeySelection — currently set only by
+// checkAnthropicPassthrough for Claude Code OAuth/Max-mode passthrough) are pinned to the
+// integration's canonical provider unconditionally, before any catalog lookup: the OAuth
+// credential such a request carries is only ever valid against that one provider, and a
+// zero-key passthrough provider (e.g. `anthropic` configured with `"keys": []`) by design
+// contributes nothing to the catalog, so it could otherwise never be resolved this way. This
+// restores, at this consolidated layer, the behavior the now-removed core/providers/utils.
+// CheckAndSetDefaultProvider used to provide for every ToBifrost*Request converter before #4177.
 func ResolveProviderFromCatalog(ctx *schemas.BifrostContext, catalog *modelcatalog.ModelCatalog, model string) (schemas.ModelProvider, []schemas.ModelProvider) {
+	if ctx != nil {
+		if skip, ok := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skip {
+			if integrationType, ok := ctx.Value(schemas.BifrostContextKeyIntegrationType).(string); ok {
+				if integrationDefault, mapped := integrationTypeToDefaultProvider[integrationType]; mapped && integrationDefault != "" {
+					return integrationDefault, nil
+				}
+			}
+		}
+	}
+
 	if catalog == nil || model == "" {
 		return "", nil
 	}


### PR DESCRIPTION
## Summary

Anthropic OAuth passthrough (Claude Code / Max mode) is rejected with HTTP 400 `could not auto resolve a provider` whenever the request uses a bare, unprefixed model name such as `claude-sonnet-5`. Prefixing the model (`anthropic/claude-sonnet-5`) works, so the failure is purely in provider resolution, not in the passthrough dispatch itself.

The cause is a gap in `ResolveProviderFromCatalog`: it resolves an unprefixed model exclusively through the model catalog. A zero-key OAuth-passthrough provider — `anthropic` configured with `"keys": []`, which is the documented way to run Claude Code Max mode — contributes nothing to the catalog by design. The catalog therefore returns zero candidates, `req.Provider` stays empty, and the empty-provider validation rejects the request before the passthrough dispatch code that would have recognized it (`IsClaudeCodeMaxMode`) is ever reached.

This is a regression from #4177, which removed `core/providers/utils.CheckAndSetDefaultProvider`. That helper short-circuited on `SkipKeySelection` unconditionally, ahead of any catalog lookup, for every `ToBifrost*Request` converter. Its replacement, `ResolveProviderFromCatalog`, has no equivalent for this one case. This PR restores that short-circuit at the layer that now owns provider resolution.

Closes #5792.

## Changes

- `plugins/modelcatalogresolver/main.go`: add an early return at the top of `ResolveProviderFromCatalog`, before the `catalog == nil || model == ""` guard. When `BifrostContextKeySkipKeySelection` is set and `BifrostContextKeyIntegrationType` maps to a known canonical provider via the existing `integrationTypeToDefaultProvider` map, return that provider immediately with a `nil` candidate list — the catalog is not consulted at all.
- Doc comments on `ResolveProviderFromCatalog` and `PreRequestHook` record the exception and why it exists.

Design notes:

- **Placed before the catalog lookup, not after.** The whole point is that the catalog cannot answer for a zero-key provider. Consulting it first and falling back would leave the bug in place.
- **Reuses `integrationTypeToDefaultProvider`** rather than hardcoding `schemas.Anthropic`. The invariant being expressed is general — a key-selection-bypass request carries a credential valid against exactly one provider, the integration's canonical one — so it is written once for all integrations rather than special-cased for the only one that currently sets the flag.
- **Returns a `nil` candidate list deliberately.** A passthrough request must not acquire cross-provider fallbacks: the OAuth credential it carries is not valid anywhere else, so any fallback attempt would fail on authentication.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure an `anthropic` provider with no keys, so it is passthrough-only:

```json
{ "providers": { "anthropic": { "keys": [] } } }
```

Send a request with Anthropic OAuth credentials (no `x-api-key`) and a bare model name:

```sh
curl -X POST http://localhost:8080/anthropic/v1/messages \
  -H "authorization: Bearer $ANTHROPIC_OAUTH_TOKEN" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"claude-sonnet-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
```

- **Before:** HTTP 400, `could not auto resolve a provider`.
- **After:** the request is routed to the `anthropic` provider and dispatched through OAuth passthrough.

Regression checks that must remain unchanged:

- The same request with an explicit `anthropic/claude-sonnet-5` prefix — already worked, still works (an explicit provider short-circuits earlier, in `PreRequestHook`).
- A normal API-key request for a bare model name served by several providers — still resolves through the catalog with its usual candidate list and fallbacks; `SkipKeySelection` is not set on that path.
- A request with `SkipKeySelection` set but an unmapped or absent integration type — falls through to the existing catalog logic exactly as before.

Build and static checks:

```sh
go version                       # go1.26.5
cd plugins/modelcatalogresolver
gofmt -l main.go                 # no output
go build ./...                   # ok
go vet ./...                     # ok
go test ./...                    # no test files in this package
```

No new configuration or environment variables.

## Screenshots/Recordings

Not applicable — no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

The new branch is reachable only when `BifrostContextKeySkipKeySelection` is `true`. That flag is written in exactly one place in the tree — `transports/bifrost-http/integrations/anthropic.go`, inside the passthrough branch, and only when the request is *not* API-key authenticated and targets the `anthropic` provider (or none). Every other request path reaches `ResolveProviderFromCatalog` with the flag unset and takes the identical code path it takes today. Requests that already carry an explicit provider never reach the resolver at all.

## Related issues

Closes #5792. Regression introduced by #4177 (removal of `core/providers/utils.CheckAndSetDefaultProvider`).

## Security considerations

No change to authentication, authorization, or secret handling.

Worth noting explicitly, because the change bypasses a lookup: the early return decides only *which provider* handles the request, not *whether the caller may skip key selection*. That authorization decision is made upstream, where `SkipKeySelection` is set, and enforced downstream by `isKeySkippingAllowed` in `core/bifrost.go`. Both are untouched. The provider returned is the integration's own canonical provider, so a request cannot be steered to a provider other than the one its credential was issued for.

The governance/VK routing allowlist is not consulted on this path, which is correct and consistent with how the flag already behaves: the request carries its own end-user OAuth credential, consumes no configured key, and the provider is fixed by the credential rather than chosen from candidates. There is no selection left for an allowlist to constrain.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

Notes on the unchecked items: the package has no existing test files, and reaching this branch requires a `BifrostContext` carrying passthrough flags — happy to add a table test for `ResolveProviderFromCatalog` covering the bypass, unmapped-integration, and flag-unset cases if maintainers would like one alongside the fix. Only `plugins/modelcatalogresolver` was built (`go build`, `go vet`, both clean); the UI was not built, as the change does not touch it. The full CI pipeline was not run locally, and the `curl` reproduction above is written from the code path rather than from an executed run against a live gateway.
