### PR TITLE
fix update passthrough docs

### DIFF
--- a/docs/integrations/passthrough.mdx
+++ b/docs/integrations/passthrough.mdx
@@ -29,8 +29,17 @@ When you use passthrough endpoints, the request still flows through Bifrost core
 
 1. Send your request to a passthrough endpoint (OpenAI, Anthropic, Azure, or GenAI passthrough).
 2. The integration strips the passthrough prefix and forwards the remaining provider-native path/body.
-3. Bifrost handles provider execution through core inference and plugin pipelines.
-4. Response status, headers, and body are returned as passthrough output (for both stream and non-stream requests).
+3. **Bifrost picks the provider key.** Client-supplied provider credentials (`authorization`, `api-key`, `x-api-key`, `x-goog-api-key`) are stripped from the request, and Bifrost selects a key from its own key config for the resolved provider and model.
+4. Bifrost handles provider execution through core inference and plugin pipelines.
+5. Response status, headers, and body are returned as passthrough output (for both stream and non-stream requests).
+
+<Warning>
+**Authenticate to Bifrost with your Bifrost virtual key, not your provider API key.** Passthrough is not a credential proxy — provider keys in the incoming request are never forwarded upstream. Bifrost always injects the key it selects from its configured keys.
+</Warning>
+
+<Note>
+Claude Code OAuth sign-in (`Authorization: Bearer sk-ant-oat…`) is handled separately on the regular `/anthropic` route, where Bifrost forwards the caller's token instead of selecting a key. Point Claude Code there — no passthrough endpoint needed. See [Claude Code authentication](../cli-agents/claude-code#anthropic_custom_headers-alternative).
+</Note>
 
 ---
 
@@ -128,7 +137,7 @@ print(response.content[0].text)
 ```bash
 curl -X POST "http://localhost:8080/anthropic_passthrough/v1/messages" \
   -H "content-type: application/json" \
-  -H "x-api-key: <YOUR-ANTHROPIC-API-KEY>" \
+  -H "x-api-key: <YOUR-BIFROST-VIRTUAL-KEY>" \
   -H "anthropic-version: 2023-06-01" \
   -d '{
     "model": "claude-sonnet-4-20250514",
@@ -207,6 +216,7 @@ print(response.content[0].text)
 ```bash
 curl -X POST "http://localhost:8080/azure_passthrough/openai/deployments/gpt-4o/chat/completions?api-version=2025-04-01-preview" \
   -H "content-type: application/json" \
+  -H "api-key: <YOUR-BIFROST-VIRTUAL-KEY>" \
   -d '{
     "messages": [{"role": "user", "content": "hello from azure passthrough"}]
   }'
@@ -243,7 +253,7 @@ print(response.text)
 ```bash
 curl -X POST "http://localhost:8080/genai_passthrough/v1beta/models/gemini-2.5-flash:generateContent" \
   -H "content-type: application/json" \
-  -H "x-goog-api-key: <YOUR-GEMINI-API-KEY>" \
+  -H "x-goog-api-key: <YOUR-BIFROST-VIRTUAL-KEY>" \
   -d '{
     "contents":[{"parts":[{"text":"hello from passthrough"}]}]
   }'
@@ -281,7 +291,7 @@ print(response.text)
 ```bash
 curl -X POST "http://localhost:8080/genai_passthrough/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent" \
   -H "content-type: application/json" \
-  -H "authorization: Bearer ya29.your-vertex-token" \
+  -H "authorization: Bearer <YOUR-BIFROST-VIRTUAL-KEY>" \
   -d '{
     "contents":[{"parts":[{"text":"hello from vertex passthrough"}]}]
   }'
@@ -295,5 +305,6 @@ curl -X POST "http://localhost:8080/genai_passthrough/v1/projects/my-project/loc
 ## Notes
 
 - Use passthrough when you need a provider endpoint that is not directly supported by Bifrost integration routes yet.
-- For Azure passthrough, auth headers (`api-key`, `x-api-key`, OAuth token) are always sourced from the Bifrost key config and never forwarded from the client request.
+- **Provider key selection is done by Bifrost, not by the caller.** On every passthrough endpoint, the client's `authorization`, `api-key`, `x-api-key`, and `x-goog-api-key` headers are dropped before the request leaves Bifrost, and the upstream auth header (including Azure's `api-key` / OAuth token) is set from the Bifrost key config.
+- The only exception is [direct API keys](../providers/request-options#direct-api-key), which need both the server-side `allow_direct_keys` setting and a per-request `x-bf-direct-key: true` header. Without both, a raw provider key in the request is ignored.
 - For Azure `/openai/deployments/` routes, Bifrost injects `api-version=2025-04-01-preview` when the caller does not supply one. Supply your own `api-version` query parameter to use a different version (e.g. `2024-10-21` for the latest GA, or a newer preview).


### PR DESCRIPTION
## Summary

Clarifies that passthrough endpoints are not credential proxies — Bifrost always selects and injects its own provider key, and any provider credentials supplied by the caller are stripped before the request is forwarded upstream.

## Changes

- Added a `Warning` callout making it explicit that callers must authenticate with a Bifrost virtual key, not a provider API key, and that provider keys in the request are never forwarded.
- Added a `Note` callout explaining that Claude Code OAuth tokens (`sk-ant-oat…`) are handled on the regular `/anthropic` route, not via passthrough.
- Updated the "How it works" numbered steps to explicitly describe Bifrost's key selection and credential-stripping behavior.
- Updated curl examples for Anthropic, GenAI (Gemini), and Vertex passthrough to use `<YOUR-BIFROST-VIRTUAL-KEY>` instead of raw provider API key placeholders.
- Replaced the Azure-specific auth note in the Notes section with a provider-agnostic statement covering all passthrough endpoints (`authorization`, `api-key`, `x-api-key`, `x-goog-api-key`).
- Added a note about the `direct API keys` exception, requiring both `allow_direct_keys` server-side and `x-bf-direct-key: true` per-request.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated passthrough documentation and verify:
- The `Warning` and `Note` callouts render correctly.
- curl examples reference `<YOUR-BIFROST-VIRTUAL-KEY>` consistently across Anthropic, GenAI, and Vertex sections.
- The Notes section accurately reflects the behavior for all passthrough endpoints, not just Azure.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change reinforces that provider API keys should never be sent by callers on passthrough requests — Bifrost strips them regardless. The documentation now makes this behavior explicit, reducing the risk of users inadvertently exposing provider credentials or expecting them to be forwarded upstream.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable