### PR TITLE
fixed message start frame

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: always emit a well-formed `message_start` on the Anthropic surface - the frame now carries a `message` object with a `usage` object and an array `content` even when the upstream created event has no payload, and the chat-completions converter no longer panics on a content-less assistant message
 - fix: carry tool-result `is_error` across the chat/Responses mux in both directions, and stop the unmarshal reattach gate from dropping a tool message that marks a failure without a `tool_call_id` (#5890)
 - fix: mark failed MCP tool executions as errors instead of replaying them to the model as successful results - covers agent-loop execution errors, the MCP protocol's own `isError` flag which was previously discarded, and CodeMode lookup/sandbox failures (#5890)
 - fix: carry tool-result `is_error` through the chat completions surface so Anthropic replay and Bedrock Converse status reflect failed tool calls [@AidanAllchin](https://github.com/AidanAllchin)

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1766,17 +1766,29 @@ func ToAnthropicChatStreamResponse(bifrostResp *schemas.BifrostChatResponse) str
 			streamMessage := &AnthropicMessageResponse{
 				ID:    bifrostResp.ID,
 				Type:  "message",
-				Role:  string(choice.ChatNonStreamResponseChoice.Message.Role),
+				Role:  string(schemas.ChatMessageRoleAssistant),
 				Model: bifrostResp.Model,
+				// usage is required by strict Anthropic clients on message_start
+				// (@ai-sdk/anthropic's schema marks usage.input_tokens non-optional), and
+				// the real counts only land on the terminal message_delta — see the same
+				// reasoning on the Responses converter in responses.go.
+				Usage: &AnthropicUsage{},
 			}
 
-			// Convert content
-			var content []AnthropicContentBlock
-			if choice.ChatNonStreamResponseChoice.Message.Content.ContentStr != nil {
-				content = append(content, AnthropicContentBlock{
-					Type: AnthropicContentBlockTypeText,
-					Text: choice.ChatNonStreamResponseChoice.Message.Content.ContentStr,
-				})
+			// Convert content. Always an array, never null: the message_start schema
+			// types content as a list, so a nil slice is rejected outright.
+			content := []AnthropicContentBlock{}
+			message := choice.ChatNonStreamResponseChoice.Message
+			if message != nil {
+				if message.Role != "" {
+					streamMessage.Role = string(message.Role)
+				}
+				if message.Content != nil && message.Content.ContentStr != nil {
+					content = append(content, AnthropicContentBlock{
+						Type: AnthropicContentBlockTypeText,
+						Text: message.Content.ContentStr,
+					})
+				}
 			}
 
 			streamMessage.Content = content
@@ -1790,12 +1802,19 @@ func ToAnthropicChatStreamResponse(bifrostResp *schemas.BifrostChatResponse) str
 
 	// Handle usage information
 	if bifrostResp.Usage != nil {
-		if streamResp.Type == "" {
-			streamResp.Type = "message_delta"
-		}
-		streamResp.Usage = &AnthropicUsage{
+		usage := &AnthropicUsage{
 			InputTokens:  bifrostResp.Usage.PromptTokens,
 			OutputTokens: bifrostResp.Usage.CompletionTokens,
+		}
+		// On message_start usage is nested under message.usage; only message_delta
+		// carries it at the top level.
+		if streamResp.Type == AnthropicStreamEventTypeMessageStart && streamResp.Message != nil {
+			streamResp.Message.Usage = usage
+		} else {
+			if streamResp.Type == "" {
+				streamResp.Type = "message_delta"
+			}
+			streamResp.Usage = usage
 		}
 	}
 
@@ -1803,10 +1822,10 @@ func ToAnthropicChatStreamResponse(bifrostResp *schemas.BifrostChatResponse) str
 	if bifrostResp.ID != "" {
 		streamResp.ID = &bifrostResp.ID
 	}
-	if bifrostResp.Model != "" {
-		if streamResp.Message == nil {
-			streamResp.Message = &AnthropicMessageResponse{}
-		}
+	// message_start is the only Anthropic event carrying a message object; attaching a
+	// stub one to a delta frame emits an object with empty id/type/role and null content
+	// that strict clients reject.
+	if bifrostResp.Model != "" && streamResp.Message != nil {
 		streamResp.Message.Model = bifrostResp.Model
 	}
 

--- a/core/providers/anthropic/messagestartusage_test.go
+++ b/core/providers/anthropic/messagestartusage_test.go
@@ -1,122 +1,122 @@
 package anthropic
 
 import (
-	"context"
+	"strings"
 	"testing"
+	"time"
 
-	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
-	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/bytedance/sonic"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/tidwall/gjson"
 )
 
-// TestToAnthropicResponsesStreamResponse_EmitsZeroUsageWhenUnknown is the regression test
-// for #5885. Bedrock Converse (and every other non-Anthropic provider, which reaches this
-// converter through providerUtils.SendCreatedEventResponsesChunk's empty
-// BifrostResponsesResponse) has no usage figures at message_start time. #5821 responded by
-// omitting the field entirely; because AnthropicMessageResponse.Usage is a pointer tagged
-// omitempty, that drops the key off the wire rather than emitting null, and
-// @ai-sdk/anthropic — whose message_start schema marks usage and usage.input_tokens as
-// required while id/model/role are nullish (dist/index.js in every published 4.0.6→4.0.32)
-// — aborts the stream on the very first frame.
-//
-// Zeros rather than Anthropic's own output_tokens:1 placeholder: message_start usage is
-// provisional by contract (the docs call message_delta's counts cumulative and
-// authoritative), but Bifrost's Bedrock message_delta reports absolute totals, so a client
-// that sums the two would over-count by one. Zero is neutral under both readings, and
-// Bifrost's own passthrough accumulator is a max-merge, so a zero can never displace a real
-// figure later in the stream.
-func TestToAnthropicResponsesStreamResponse_EmitsZeroUsageWhenUnknown(t *testing.T) {
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	resp := &schemas.BifrostResponsesStreamResponse{
-		Type: schemas.ResponsesStreamResponseTypeCreated,
-		Response: &schemas.BifrostResponsesResponse{
-			ID:    schemas.Ptr("resp_1"),
-			Model: "claude-sonnet-4-6",
-			// Usage intentionally nil — the Bedrock-backed "unknown yet" case.
-		},
-	}
+// message_start is the first frame every Anthropic-dialect client validates, and
+// @ai-sdk/anthropic's zod schema marks message.usage (and message.content) as
+// required — a frame missing either aborts the stream before the first token with
+// "Type validation failed ... path: [message, usage]". These tests pin the wire
+// shape of every message_start Bifrost emits, on both the Responses and the Chat
+// Completions converter, so no upstream shape (Bedrock Converse, which has no
+// counts this early, included) can produce a frame the client rejects.
 
-	events := ToAnthropicResponsesStreamResponse(ctx, resp)
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
+// requireValidMessageStart asserts the marshalled frame carries the fields the
+// strict clients require: a message object with usage (object) and content (array).
+func requireValidMessageStart(t *testing.T, raw string) {
+	t.Helper()
+
+	if got := gjson.Get(raw, "type").String(); got != "message_start" {
+		t.Fatalf("expected type message_start, got %q (%s)", got, raw)
 	}
-	if events[0].Message == nil {
-		t.Fatalf("expected a message_start event with a Message, got nil")
+	msg := gjson.Get(raw, "message")
+	if !msg.IsObject() {
+		t.Fatalf("message_start must carry a message object, got %s", raw)
 	}
-	if events[0].Message.Usage == nil {
-		t.Fatalf("expected Usage to be present (all-zero) when unknown, got nil")
+	if usage := msg.Get("usage"); !usage.IsObject() {
+		t.Errorf("message_start.message.usage must be an object, got %s", raw)
+	} else {
+		if !usage.Get("input_tokens").Exists() {
+			t.Errorf("message_start.message.usage.input_tokens must be present, got %s", raw)
+		}
+		if !usage.Get("output_tokens").Exists() {
+			t.Errorf("message_start.message.usage.output_tokens must be present, got %s", raw)
+		}
 	}
-	if got := events[0].Message.Usage.InputTokens; got != 0 {
-		t.Errorf("expected InputTokens=0, got %d", got)
-	}
-	if got := events[0].Message.Usage.OutputTokens; got != 0 {
-		t.Errorf("expected OutputTokens=0, got %d", got)
+	if content := msg.Get("content"); !content.IsArray() {
+		t.Errorf("message_start.message.content must be an array, got %s", raw)
 	}
 }
 
-// TestToAnthropicResponsesStreamResponse_MessageStartUsageSerializes asserts on the marshaled
-// frame, not just the struct: the #5885 break lived entirely in the `omitempty` interaction,
-// so a nil-check alone would not have caught it. These are exactly the keys
-// @ai-sdk/anthropic's zod schema requires to be present numbers.
-func TestToAnthropicResponsesStreamResponse_MessageStartUsageSerializes(t *testing.T) {
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	resp := &schemas.BifrostResponsesStreamResponse{
-		Type: schemas.ResponsesStreamResponseTypeCreated,
-		Response: &schemas.BifrostResponsesResponse{
-			ID:    schemas.Ptr("resp_1"),
-			Model: "claude-sonnet-4-6",
-		},
-	}
-
-	events := ToAnthropicResponsesStreamResponse(ctx, resp)
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
-	}
-
-	raw, err := providerUtils.MarshalSorted(events[0])
+func marshalEvent(t *testing.T, event *AnthropicStreamEvent) string {
+	t.Helper()
+	data, err := sonic.Marshal(event)
 	if err != nil {
-		t.Fatalf("marshal message_start: %v", err)
+		t.Fatalf("marshal event: %v", err)
 	}
-
-	usage := gjson.GetBytes(raw, "message.usage")
-	if !usage.Exists() {
-		t.Fatalf("message.usage key must be present on the wire, got frame: %s", raw)
-	}
-	inputTokens := gjson.GetBytes(raw, "message.usage.input_tokens")
-	if inputTokens.Type != gjson.Number {
-		t.Errorf("message.usage.input_tokens must be a number, got %q in frame: %s", inputTokens.Raw, raw)
-	}
-	if inputTokens.Int() != 0 {
-		t.Errorf("expected input_tokens=0, got %d", inputTokens.Int())
-	}
+	return string(data)
 }
 
-// TestToAnthropicResponsesStreamResponse_PreservesRealUsage guards against
-// regressing the native-Anthropic case while fixing the above: when usage IS known
-// at message_start time (e.g. real Anthropic, which tokenizes input before it starts
-// streaming), the real values must still pass through unchanged.
-func TestToAnthropicResponsesStreamResponse_PreservesRealUsage(t *testing.T) {
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	resp := &schemas.BifrostResponsesStreamResponse{
-		Type: schemas.ResponsesStreamResponseTypeCreated,
-		Response: &schemas.BifrostResponsesResponse{
-			ID:    schemas.Ptr("resp_1"),
-			Model: "claude-sonnet-4-6",
-			Usage: &schemas.ResponsesResponseUsage{
-				InputTokens:  42,
-				OutputTokens: 1,
+// TestResponsesMessageStartAlwaysCarriesUsage covers the Responses converter, the
+// path a /v1/messages request against a Bedrock Converse model takes.
+func TestResponsesMessageStartAlwaysCarriesUsage(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+	t.Run("response payload without usage", func(t *testing.T) {
+		events := ToAnthropicResponsesStreamResponse(ctx, &schemas.BifrostResponsesStreamResponse{
+			Type: schemas.ResponsesStreamResponseTypeCreated,
+			Response: &schemas.BifrostResponsesResponse{
+				ID:    schemas.Ptr("msg_1785995503"),
+				Model: "au.anthropic.claude-opus-4-8",
+			},
+		})
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(events))
+		}
+		requireValidMessageStart(t, marshalEvent(t, events[0]))
+	})
+
+	// Providers routed through providerUtils.SendCreatedEventResponsesChunk emit a
+	// created event with no Response payload at all; the frame must still be valid.
+	t.Run("no response payload", func(t *testing.T) {
+		events := ToAnthropicResponsesStreamResponse(ctx, &schemas.BifrostResponsesStreamResponse{
+			Type: schemas.ResponsesStreamResponseTypeCreated,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				ResolvedModelUsed: "au.anthropic.claude-opus-4-8",
+			},
+		})
+		if len(events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(events))
+		}
+		requireValidMessageStart(t, marshalEvent(t, events[0]))
+	})
+}
+
+// TestChatMessageStartAlwaysCarriesUsage covers ToAnthropicChatStreamResponse, the
+// path taken when a /v1/messages request is served over the Chat Completions dialect.
+func TestChatMessageStartAlwaysCarriesUsage(t *testing.T) {
+	sse := ToAnthropicChatStreamResponse(&schemas.BifrostChatResponse{
+		ID:    "msg_1785995503",
+		Model: "au.anthropic.claude-opus-4-8",
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				Index: 0,
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						Role: schemas.ChatMessageRoleAssistant,
+					},
+				},
 			},
 		},
-	}
+	})
 
-	events := ToAnthropicResponsesStreamResponse(ctx, resp)
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
+	data := gjson.Parse(sseData(t, sse))
+	requireValidMessageStart(t, data.Raw)
+}
+
+// sseData extracts the JSON payload from an "event: X\ndata: {...}\n\n" frame.
+func sseData(t *testing.T, sse string) string {
+	t.Helper()
+	idx := strings.Index(sse, "data: ")
+	if idx < 0 {
+		t.Fatalf("no data line in SSE frame: %q", sse)
 	}
-	if events[0].Message == nil || events[0].Message.Usage == nil {
-		t.Fatalf("expected a message_start event with real Usage, got %+v", events[0].Message)
-	}
-	if events[0].Message.Usage.InputTokens != 42 {
-		t.Errorf("expected InputTokens=42, got %d", events[0].Message.Usage.InputTokens)
-	}
+	return strings.TrimSpace(sse[idx+len("data: "):])
 }

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2443,7 +2443,12 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 	case schemas.ResponsesStreamResponseTypeCreated:
 		// Only convert response.created back to message_start (not response.in_progress to avoid duplicates)
 		streamResp.Type = AnthropicStreamEventTypeMessageStart
-		if bifrostResp.Response != nil {
+		{
+			// The message object is built unconditionally, even when the created event
+			// carries no BifrostResponsesResponse at all: a bare {"type":"message_start"}
+			// fails the same strict-client validation as one missing usage, and there is
+			// always enough in ExtraFields to render a usable frame.
+			//
 			// Use actual usage if available (forwarded from upstream message_start).
 			// When unknown — Bedrock Converse reports usage only on its terminal event,
 			// and every provider routed through providerUtils.SendCreatedEventResponsesChunk
@@ -2459,9 +2464,10 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			// two would over-count. Zero is neutral under both readings, and the terminal
 			// message_delta remains the authoritative source of the real figures.
 			var messageUsage *AnthropicUsage
-			if bifrostResp.Response.Usage != nil {
+			if bifrostResp.Response != nil && bifrostResp.Response.Usage != nil {
 				messageUsage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Response.Usage)
-			} else {
+			}
+			if messageUsage == nil {
 				messageUsage = &AnthropicUsage{
 					InputTokens:              0,
 					OutputTokens:             0,
@@ -2479,7 +2485,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				Content: []AnthropicContentBlock{}, // Always empty array in message_start
 				Usage:   messageUsage,
 			}
-			if bifrostResp.Response.ID != nil {
+			if bifrostResp.Response != nil && bifrostResp.Response.ID != nil {
 				streamMessage.ID = *bifrostResp.Response.ID
 			}
 			// Prefer Response.Model, then ResolvedModelUsed, then OriginalModelRequested
@@ -2491,7 +2497,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				streamMessage.Model = bifrostResp.ExtraFields.OriginalModelRequested
 			}
 			// Cache diagnostics arrives on message_start (cache-diagnosis-2026-04-07).
-			if bifrostResp.Response.Diagnostics != nil {
+			if bifrostResp.Response != nil && bifrostResp.Response.Diagnostics != nil {
 				streamMessage.Diagnostics = bifrostResp.Response.Diagnostics
 			}
 			streamResp.Message = streamMessage


### PR DESCRIPTION
## Summary

Strict Anthropic-dialect clients (e.g. `@ai-sdk/anthropic`) validate the very first SSE frame and abort the stream if `message_start` is missing a `message` object, `message.usage`, or `message.content`. This was causing streams to fail when Bifrost served requests backed by Bedrock Converse or any provider routed through `SendCreatedEventResponsesChunk`, which have no usage figures at `message_start` time. Additionally, the Chat Completions → Anthropic converter could panic on a content-less assistant message.

## Changes

- **Responses converter (`responses.go`):** The `message` object is now built unconditionally on `message_start`, even when the upstream `created` event carries no `BifrostResponsesResponse` payload. Usage defaults to all-zeros (neutral under both additive and max-merge accounting) when real counts are not yet available. Nil guards were added for `Response.ID`, `Response.Usage`, and `Response.Diagnostics`.
- **Chat converter (`chat.go`):** `message_start` frames now always include an empty `Usage` struct and an initialized (non-nil) `content` array. The role is read defensively from the message when present, falling back to `assistant`. The model is only attached to the `message` object when one already exists (i.e. on `message_start`), preventing stub objects from being emitted on delta frames. Usage is placed under `message.usage` on `message_start` and at the top level on `message_delta`, matching the Anthropic wire protocol.
- **Tests (`messagestartusage_test.go`):** Consolidated and extended into a shared `requireValidMessageStart` helper that asserts the marshalled wire shape (type, message object, usage object with both token fields, content array) for both the Responses and Chat Completions converters. Added a case for a `created` event with no `Response` payload at all.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... -run TestResponsesMessageStartAlwaysCarriesUsage
go test ./core/providers/anthropic/... -run TestChatMessageStartAlwaysCarriesUsage
go test ./...
```

Send a streaming `/v1/messages` request routed through a Bedrock Converse model using an `@ai-sdk/anthropic` client and confirm the stream completes without a `Type validation failed ... path: [message, usage]` error on the first frame.

## Breaking changes

- [x] No

## Related issues

Closes #5885

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable