### PR TITLE
refactor: extract shared MCP authorizer dialog chrome into `authorizerUi.tsx`

### DIFF
--- a/ui/app/workspace/mcp-registry/views/authorizerUi.tsx
+++ b/ui/app/workspace/mcp-registry/views/authorizerUi.tsx
@@ -1,0 +1,71 @@
+// Shared visual building blocks for the MCP-client verification/
+// authorization dialogs: OAuth2Authorizer (shared + per-user OAuth),
+// MCPHeadersAuthorizer (per-user headers), and the token_exchange
+// "Re-verify as me" dialog in mcpClientsTable.tsx. All three walk an admin
+// through the same shape of flow (confirm intent, wait on a check, land on
+// success/failure), so they share one dialog chrome: a bordered icon
+// header, tinted info boxes for body copy, and step-progress dots. Keeping
+// this in one place is what stops the flows drifting apart the way
+// per-user-headers previously did from the OAuth dialog.
+
+import { cn } from "@/lib/utils";
+import React from "react";
+
+export type UiVariant = "muted" | "info" | "success" | "danger" | "warning";
+
+const ICON_TINTS: Record<UiVariant, string> = {
+	muted: "bg-muted text-muted-foreground",
+	info: "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-300",
+	success: "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300",
+	danger: "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300",
+	warning: "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300",
+};
+
+// ── Icon slot ────────────────────────────────────────────────────────────────
+// The tinted square in the dialog header, next to the title/subtitle.
+
+export function IconWrap({ variant, icon }: { variant: UiVariant; icon: React.ReactNode }) {
+	return <div className={cn("flex size-9 shrink-0 items-center justify-center rounded-md", ICON_TINTS[variant])}>{icon}</div>;
+}
+
+// ── Info box ──────────────────────────────────────────────────────────────────
+// The bordered, tinted callout used for body copy in every step.
+
+const BOX_TINTS: Record<UiVariant, string> = {
+	muted: "border-border bg-muted/40 text-muted-foreground",
+	info: "border-blue-200/60 bg-blue-50/70 text-blue-800 dark:border-blue-800/40 dark:bg-blue-950/40 dark:text-blue-200",
+	success: "border-green-200/60 bg-green-50/70 text-green-800 dark:border-green-800/40 dark:bg-green-950/40 dark:text-green-200",
+	danger: "border-red-200/60 bg-red-50/70 text-red-800 dark:border-red-800/40 dark:bg-red-950/40 dark:text-red-200",
+	warning: "border-amber-200/60 bg-amber-50/70 text-amber-800 dark:border-amber-800/40 dark:bg-amber-950/40 dark:text-amber-200",
+};
+
+export function InfoBox({
+	variant = "muted",
+	icon,
+	children,
+}: {
+	variant?: UiVariant;
+	icon: React.ReactNode;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className={cn("flex gap-3 rounded-md border p-3.5 text-sm", BOX_TINTS[variant])}>
+			<span className="mt-0.5 shrink-0">{icon}</span>
+			<div className="space-y-1 leading-relaxed">{children}</div>
+		</div>
+	);
+}
+
+// ── Step dots ─────────────────────────────────────────────────────────────────
+// Progress indicator shown while a step is waiting on something external
+// (a popup redirect, a background verification call).
+
+export function StepDots({ active, total }: { active: number; total: number }) {
+	return (
+		<div className="flex items-center gap-1">
+			{Array.from({ length: total }).map((_, i) => (
+				<div key={i} className={cn("size-1.5 rounded-full transition-colors", i < active ? "bg-blue-500" : "bg-border")} />
+			))}
+		</div>
+	);
+}

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -49,6 +49,7 @@ import {
 	X,
 } from "lucide-react";
 import { ReactNode, useEffect, useMemo, useState } from "react";
+import { IconWrap, InfoBox } from "./authorizerUi";
 import MCPClientSheet from "./mcpClientSheet";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
@@ -99,9 +100,9 @@ function MCPClientActionsMenu({
 					className="h-8 w-8"
 					aria-label="MCP server actions"
 					data-testid={`mcp-client-actions-${client.config.client_id}-btn`}
-					disabled={isReconnecting || isReauthorizing}
+					disabled={isReconnecting || isReauthorizing || isVerifyingExchange}
 				>
-					{isReconnecting || isAuthorizing || isReauthorizing ? (
+					{isReconnecting || isAuthorizing || isReauthorizing || isVerifyingExchange ? (
 						<Loader2 className="h-4 w-4 animate-spin" />
 					) : (
 						<MoreHorizontal className="h-4 w-4" />
@@ -692,13 +693,32 @@ export default function MCPClientsTable({
 			    info box, outline-cancel + default-continue footer) so token_exchange
 			    reverification reads as the same kind of admin-credential action,
 			    not a destructive one. */}
-			<Dialog open={!!exchangeVerifyClient} onOpenChange={(next) => !next && setExchangeVerifyClient(null)}>
+			<Dialog
+					open={!!exchangeVerifyClient}
+					onOpenChange={(next) => {
+						// Keep the dialog open (with a spinner) for the duration of the
+						// verify call itself, so there's visible feedback while the
+						// backend does the token exchange + live connect + tools/list
+						// round trip, instead of closing immediately on "Continue" and
+						// leaving nothing on screen until the toast lands.
+						if (!next && !(exchangeVerifyClient && verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id))) {
+							setExchangeVerifyClient(null);
+						}
+					}}
+				>
 				<DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-md">
 					<DialogHeader className="border-b px-5 py-4 text-left">
 						<div className="flex items-start gap-3">
-							<div className="bg-muted text-muted-foreground flex size-9 shrink-0 items-center justify-center rounded-md">
-								<KeyRound className="size-4" />
-							</div>
+							<IconWrap
+								variant={exchangeVerifyClient && verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id) ? "info" : "muted"}
+								icon={
+									exchangeVerifyClient && verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id) ? (
+										<Loader2 className="size-4 animate-spin" />
+									) : (
+										<KeyRound className="size-4" />
+									)
+								}
+							/>
 							<div className="min-w-0 space-y-0.5">
 								<DialogTitle className="text-sm leading-snug font-medium">Re-verify as me</DialogTitle>
 								<DialogDescription className="text-xs leading-relaxed">
@@ -708,26 +728,22 @@ export default function MCPClientsTable({
 						</div>
 					</DialogHeader>
 					<div className="space-y-3 px-5 py-4">
-						<div className="border-border bg-muted/40 text-muted-foreground flex gap-3 rounded-md border p-3.5 text-sm">
-							<span className="mt-0.5 shrink-0">
-								<KeyRound className="size-4" />
-							</span>
-							<div className="space-y-1 leading-relaxed">
-								<p>
-									This exchanges your own signed-in identity to renew Bifrost&apos;s discovery credential for{" "}
-									<strong>{exchangeVerifyClient?.config.name}</strong>.
-								</p>
-								<p className="text-muted-foreground/80 text-xs">
-									That credential is only used to periodically fetch this server&apos;s tool list, not for real user requests,
-									whose tokens are exchanged automatically on every request. You only need this if the credential badge shows
-									it&apos;s expired, but running it any time is safe.
-								</p>
-							</div>
-						</div>
+						<InfoBox icon={<KeyRound className="size-4" />}>
+							<p>
+								This exchanges your own signed-in identity to renew Bifrost&apos;s discovery credential for{" "}
+								<strong>{exchangeVerifyClient?.config.name}</strong>.
+							</p>
+							<p className="text-muted-foreground/80 text-xs">
+								That credential is only used to periodically fetch this server&apos;s tool list, not for real user requests,
+								whose tokens are exchanged automatically on every request. You only need this if the credential badge shows
+								it&apos;s expired, but running it any time is safe.
+							</p>
+						</InfoBox>
 						<div className="flex justify-end gap-2">
 							<Button
 								size="sm"
 								variant="outline"
+								disabled={exchangeVerifyClient ? verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id) : false}
 								onClick={() => setExchangeVerifyClient(null)}
 								data-testid="verify-exchange-cancel-btn"
 							>
@@ -735,12 +751,18 @@ export default function MCPClientsTable({
 							</Button>
 							<Button
 								size="sm"
-								onClick={() => {
-									if (exchangeVerifyClient) void handleVerifyExchange(exchangeVerifyClient);
+								disabled={exchangeVerifyClient ? verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id) : false}
+								onClick={async () => {
+									if (!exchangeVerifyClient) return;
+									const client = exchangeVerifyClient;
+									await handleVerifyExchange(client);
 									setExchangeVerifyClient(null);
 								}}
 								data-testid="verify-exchange-confirm-btn"
 							>
+								{exchangeVerifyClient && verifyingExchangeClients.includes(exchangeVerifyClient.config.client_id) ? (
+									<Loader2 className="size-3.5 animate-spin" />
+								) : null}
 								Continue
 							</Button>
 						</div>
@@ -944,8 +966,10 @@ export default function MCPClientsTable({
 													</Link>
 												) : isPerUserAuth ? (
 													// Token exchange: no stored sessions to link to, and not in an
-													// actionable state — nothing to surface here.
-													null
+													// actionable state (pending_verification/needs_reauth handled
+													// above), so nothing meaningful to surface: render the same
+													// blank placeholder other empty cells in this table use.
+													<span className="text-muted-foreground">-</span>
 												) : (
 													<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state.replace(/_/g, " ")}</Badge>
 												)}

--- a/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpHeadersAuthorizer.tsx
@@ -1,9 +1,10 @@
-// MCPHeadersAuthorizer mirrors OAuth2Authorizer's UI/UX for the per-user-
-// headers create flow: same Dialog shell, same wording structure, same
-// state machine (confirm → input → testing → success/failed), same Cancel /
-// Continue affordances. The divergence is that the verify step is a values
-// form filled inline (no upstream redirect/popup), and the create call is
-// a single POST /api/mcp/client where the server runs verify + discover +
+// MCPHeadersAuthorizer mirrors OAuth2Authorizer's dialog chrome for the
+// per-user-headers create/refresh flow: same bordered icon header, same
+// InfoBox body copy, same Cancel / Continue footer, built from the shared
+// pieces in authorizerUi.tsx. The divergence is that the verify step is a
+// values form filled inline (no upstream redirect/popup), so there's an
+// extra "input" step between confirm and testing, and the create call is a
+// single POST /api/mcp/client where the server runs verify + discover +
 // persist atomically. Mirrors per-user OAuth where the admin's temp access
 // token plays the analogous role.
 
@@ -11,8 +12,9 @@ import HeadersForm from "@/components/headersForm";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { getErrorMessage } from "@/lib/store";
-import { Loader2 } from "lucide-react";
+import { CheckCircle2, KeyRound, Loader2, RefreshCw, ShieldCheck, XCircle } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
+import { IconWrap, InfoBox, StepDots, UiVariant } from "./authorizerUi";
 
 interface MCPHeadersAuthorizerProps {
 	open: boolean;
@@ -22,14 +24,38 @@ interface MCPHeadersAuthorizerProps {
 	onConflict?: (error: string) => void;
 	// Required key schema, rendered as the form's input fields.
 	perUserHeaderKeys: string[];
-	// Called with the collected sample values once the admin clicks "Run
-	// Test". The handler decides what endpoint to hit (Create flow's
+	// Called with the collected sample values once the admin submits the
+	// form. The handler decides what endpoint to hit (Create flow's
 	// /api/mcp/client vs bootstrap's /api/mcp/client/{id}/verify-headers).
 	// Throw to surface a failure in the dialog.
 	submitHandler: (values: Record<string, string>) => Promise<void>;
 }
 
 type Status = "confirm" | "input" | "testing" | "success" | "failed";
+
+const STATUS_ICON: Record<Status, { variant: UiVariant; icon: React.ReactNode }> = {
+	confirm: { variant: "muted", icon: <ShieldCheck className="size-4" /> },
+	input: { variant: "muted", icon: <KeyRound className="size-4" /> },
+	testing: { variant: "info", icon: <Loader2 className="size-4 animate-spin" /> },
+	success: { variant: "success", icon: <CheckCircle2 className="size-4" /> },
+	failed: { variant: "danger", icon: <XCircle className="size-4" /> },
+};
+
+const titles: Record<Status, string> = {
+	confirm: "Test header configuration",
+	input: "Enter sample values",
+	testing: "Verifying connection",
+	success: "Connection verified",
+	failed: "Verification failed",
+};
+
+const subtitles: Record<Status, string> = {
+	confirm: "Verify your header setup to discover available tools.",
+	input: "Enter sample values to verify the connection.",
+	testing: "Checking your headers and discovering available tools.",
+	success: "Header verification completed successfully.",
+	failed: "The verification did not complete.",
+};
 
 export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 	open,
@@ -97,13 +123,11 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 		<Dialog
 			open={open}
 			onOpenChange={(nextOpen) => {
-				if (!nextOpen) {
-					handleCancel();
-				}
+				if (!nextOpen) handleCancel();
 			}}
 		>
 			<DialogContent
-				className="sm:max-w-md"
+				className="gap-0 overflow-hidden p-0 sm:max-w-md"
 				onPointerDownOutside={(e) => {
 					e.preventDefault();
 					handleCancel();
@@ -113,47 +137,53 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 					handleCancel();
 				}}
 			>
-				<DialogHeader>
-					<DialogTitle>{status === "confirm" ? "Test Header Configuration" : "Header Authorization"}</DialogTitle>
-					<DialogDescription>
-						{status === "confirm" && "Verify your header setup to discover available tools."}
-						{status === "input" && "Enter sample values to verify the connection."}
-						{status === "testing" && "Verifying connection..."}
-						{status === "success" && "Verification successful!"}
-						{status === "failed" && "Verification failed"}
-					</DialogDescription>
+				{/* Header */}
+				<DialogHeader className="border-b px-5 py-4 text-left">
+					<div className="flex items-start gap-3">
+						<IconWrap variant={STATUS_ICON[status].variant} icon={STATUS_ICON[status].icon} />
+						<div className="min-w-0 space-y-0.5">
+							<DialogTitle className="text-sm leading-snug font-medium">{titles[status]}</DialogTitle>
+							<DialogDescription className="text-xs leading-relaxed">{subtitles[status]}</DialogDescription>
+						</div>
+					</div>
 				</DialogHeader>
 
-				<div className="flex flex-col space-y-4">
+				{/* Body */}
+				<div className="space-y-3 px-5 py-4">
+					{/* Confirm */}
 					{status === "confirm" && (
 						<>
-							<div className="text-muted-foreground space-y-3 text-sm">
+							<InfoBox icon={<KeyRound className="size-4" />}>
 								<p>
-									To set up this MCP server, we need to verify that your header configuration is correct and discover the available tools.
+									To set up this MCP server, we need to verify that your header configuration is correct and discover the
+									available tools.
 								</p>
-								<p>
-									You will be asked to provide sample values for the required headers. Bifrost keeps these values on file
-									to periodically refresh the available tool list; they are never used for real end-user requests.
+								<p className="text-muted-foreground/80 text-xs">
+									You will be asked to provide sample values for the required headers. Bifrost keeps these values on file to
+									periodically refresh the available tool list; they are never used for real end-user requests. Once verified,
+									each user will submit their own header values when they use this MCP server.
 								</p>
-								<p>Once verified, each user will submit their own header values when they use this MCP server.</p>
-							</div>
-							<div className="flex w-full justify-end space-x-2">
-								<Button onClick={handleCancel} variant="outline" data-testid="per-user-headers-cancel">
+							</InfoBox>
+							<div className="flex justify-end gap-2">
+								<Button size="sm" variant="outline" onClick={handleCancel} data-testid="per-user-headers-cancel">
 									Cancel
 								</Button>
-								<Button onClick={handleConfirm} data-testid="per-user-headers-confirm">
-									Continue with Test
+								<Button size="sm" onClick={handleConfirm} data-testid="per-user-headers-confirm">
+									Continue
 								</Button>
 							</div>
 						</>
 					)}
 
+					{/* Input */}
 					{status === "input" && (
 						<>
-							<p className="text-muted-foreground text-sm">
-								These values verify the connection now and are kept on file so Bifrost can periodically refresh the
-								available tool list. Each user still submits their own values when they use this server.
-							</p>
+							<InfoBox icon={<KeyRound className="size-4" />}>
+								<p>
+									These values verify the connection now and are kept on file so Bifrost can periodically refresh the available
+									tool list. Each user still submits their own values when they use this server.
+								</p>
+							</InfoBox>
 							<HeadersForm
 								requiredKeys={perUserHeaderKeys}
 								onSubmit={handleRunTest}
@@ -164,38 +194,44 @@ export const MCPHeadersAuthorizer: React.FC<MCPHeadersAuthorizerProps> = ({
 						</>
 					)}
 
+					{/* Testing */}
 					{status === "testing" && (
 						<>
-							<div className="flex flex-col items-center space-y-2">
-								<Loader2 className="text-secondary-foreground h-4 w-4 animate-spin" />
-								<p className="text-muted-foreground text-sm">Verifying connection and discovering tools...</p>
+							<InfoBox icon={<Loader2 className="size-4 animate-spin" />}>
+								<p>Checking your headers against the server and discovering available tools.</p>
+								<p className="text-muted-foreground/80 text-xs">This only takes a moment.</p>
+							</InfoBox>
+							<div className="flex items-center justify-end">
+								<StepDots active={2} total={3} />
 							</div>
 						</>
 					)}
 
+					{/* Success */}
 					{status === "success" && (
-						<div className="flex flex-col items-center space-y-2">
-							<div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-								<svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-								</svg>
-							</div>
-							<p className="text-sm text-green-600">MCP server connected successfully!</p>
-						</div>
+						<InfoBox variant="success" icon={<CheckCircle2 className="size-4" />}>
+							<p className="font-medium">Header configuration verified.</p>
+							<p className="text-xs opacity-80">You can close this dialog.</p>
+						</InfoBox>
 					)}
 
+					{/* Failed */}
 					{status === "failed" && (
-						<div className="flex flex-col items-center space-y-2">
-							<div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
-								<svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-								</svg>
+						<>
+							<InfoBox variant="danger" icon={<XCircle className="size-4" />}>
+								<p className="font-medium">Verification did not complete.</p>
+								<p className="text-xs opacity-80">{errorMessage ?? "Check your header values and try again."}</p>
+							</InfoBox>
+							<div className="flex justify-end gap-2">
+								<Button size="sm" variant="outline" onClick={handleCancel} data-testid="mcp-headers-authorizer-close-btn">
+									Close
+								</Button>
+								<Button size="sm" onClick={handleRetry} data-testid="mcp-headers-authorizer-retry-btn">
+									<RefreshCw className="size-3.5" />
+									Retry
+								</Button>
 							</div>
-							<p className="text-sm text-red-600">{errorMessage || "An error occurred"}</p>
-							<Button onClick={handleRetry} variant="outline" data-testid="mcp-headers-authorizer-retry-btn">
-								Retry
-							</Button>
-						</div>
+						</>
 					)}
 				</div>
 			</DialogContent>

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -2,9 +2,9 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { getErrorMessage } from "@/lib/store/apis/baseApi";
 import { useCompleteOAuthFlowMutation, useLazyGetOAuthConfigStatusQuery } from "@/lib/store/apis/mcpApi";
-import { cn } from "@/lib/utils";
 import { AlertTriangle, CheckCircle2, ExternalLink, KeyRound, Loader2, RefreshCw, ShieldCheck, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { IconWrap, InfoBox, StepDots, UiVariant } from "./authorizerUi";
 
 interface OAuth2AuthorizerProps {
 	open: boolean;
@@ -30,86 +30,13 @@ interface OAuth2AuthorizerProps {
 
 type Status = "confirm" | "polling" | "blocked" | "success" | "failed";
 
-// ── Icon slot ────────────────────────────────────────────────────────────────
-
-function IconWrap({ status }: { status: Status }) {
-	const base = "flex size-9 shrink-0 items-center justify-center rounded-md";
-
-	if (status === "polling") {
-		return (
-			<div className={cn(base, "bg-blue-50 text-blue-600 dark:bg-blue-950 dark:text-blue-300")}>
-				<Loader2 className="size-4 animate-spin" />
-			</div>
-		);
-	}
-	if (status === "success") {
-		return (
-			<div className={cn(base, "bg-green-50 text-green-700 dark:bg-green-950 dark:text-green-300")}>
-				<CheckCircle2 className="size-4" />
-			</div>
-		);
-	}
-	if (status === "failed") {
-		return (
-			<div className={cn(base, "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300")}>
-				<XCircle className="size-4" />
-			</div>
-		);
-	}
-	if (status === "blocked") {
-		return (
-			<div className={cn(base, "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300")}>
-				<AlertTriangle className="size-4" />
-			</div>
-		);
-	}
-	// confirm (default)
-	return (
-		<div className={cn(base, "bg-muted text-muted-foreground")}>
-			<ShieldCheck className="size-4" />
-		</div>
-	);
-}
-
-// ── Info box ──────────────────────────────────────────────────────────────────
-
-function InfoBox({
-	variant = "default",
-	icon,
-	children,
-}: {
-	variant?: "default" | "success" | "danger" | "warning";
-	icon: React.ReactNode;
-	children: React.ReactNode;
-}) {
-	return (
-		<div
-			className={cn("flex gap-3 rounded-md border p-3.5 text-sm", {
-				"border-border bg-muted/40 text-muted-foreground": variant === "default",
-				"border-green-200/60 bg-green-50/70 text-green-800 dark:border-green-800/40 dark:bg-green-950/40 dark:text-green-200":
-					variant === "success",
-				"border-red-200/60 bg-red-50/70 text-red-800 dark:border-red-800/40 dark:bg-red-950/40 dark:text-red-200": variant === "danger",
-				"border-amber-200/60 bg-amber-50/70 text-amber-800 dark:border-amber-800/40 dark:bg-amber-950/40 dark:text-amber-200":
-					variant === "warning",
-			})}
-		>
-			<span className="mt-0.5 shrink-0">{icon}</span>
-			<div className="space-y-1 leading-relaxed">{children}</div>
-		</div>
-	);
-}
-
-// ── Step dots ─────────────────────────────────────────────────────────────────
-
-function StepDots({ active, total }: { active: number; total: number }) {
-	return (
-		<div className="flex items-center gap-1">
-			{Array.from({ length: total }).map((_, i) => (
-				<div key={i} className={cn("size-1.5 rounded-full transition-colors", i < active ? "bg-blue-500" : "bg-border")} />
-			))}
-		</div>
-	);
-}
+const STATUS_ICON: Record<Status, { variant: UiVariant; icon: React.ReactNode }> = {
+	confirm: { variant: "muted", icon: <ShieldCheck className="size-4" /> },
+	polling: { variant: "info", icon: <Loader2 className="size-4 animate-spin" /> },
+	blocked: { variant: "warning", icon: <AlertTriangle className="size-4" /> },
+	success: { variant: "success", icon: <CheckCircle2 className="size-4" /> },
+	failed: { variant: "danger", icon: <XCircle className="size-4" /> },
+};
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -125,7 +52,11 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	initialPopup,
 	isReauthorize,
 }) => {
-	const [status, setStatus] = useState<Status>(isPerUserOauth ? "confirm" : "polling");
+	// Both auth types start on the confirm step and only open the popup from a
+	// direct onClick: window.open() called from anywhere else (e.g. an effect
+	// reacting to an async fetch resolving) loses the browser's "user
+	// activation" and gets silently popup-blocked.
+	const [status, setStatus] = useState<Status>("confirm");
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const popupRef = useRef<Window | null>(null);
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -167,7 +98,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 			if (cancelledRef.current) return;
 			const errMsg = getErrorMessage(error);
 			if ((error as any)?.status === 409 && onConflict) {
-				setStatus(isPerUserOauth ? "confirm" : "polling");
+				setStatus("confirm");
 				setErrorMessage(null);
 				isCompletingRef.current = false;
 				onConflict(errMsg);
@@ -177,7 +108,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 			setErrorMessage(errMsg);
 			onError(errMsg);
 		}
-	}, [oauthConfigId, completeOAuth, onSuccess, onError, onConflict, isPerUserOauth]);
+	}, [oauthConfigId, completeOAuth, onSuccess, onError, onConflict]);
 
 	const handleOAuthFailed = useCallback(
 		(reason: string) => {
@@ -282,15 +213,6 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		return () => window.removeEventListener("message", handleMessage);
 	}, [checkOAuthStatus, handleOAuthFailed]);
 
-	// Auto-open popup for non-per-user OAuth flows.
-	const openPopupRef = useRef(openPopup);
-	useEffect(() => {
-		openPopupRef.current = openPopup;
-	});
-	useEffect(() => {
-		if (open && !isPerUserOauth) openPopupRef.current();
-	}, [open, isPerUserOauth]);
-
 	useEffect(() => {
 		return () => {
 			stopPolling();
@@ -301,8 +223,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	const handleRetry = () => {
 		setErrorMessage(null);
 		isCompletingRef.current = false;
-		setStatus(isPerUserOauth ? "confirm" : "polling");
-		if (!isPerUserOauth) openPopup();
+		setStatus("confirm");
 	};
 
 	const handleCancel = () => {
@@ -354,7 +275,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 				{/* Header */}
 				<DialogHeader className="border-b px-5 py-4 text-left">
 					<div className="flex items-start gap-3">
-						<IconWrap status={status} />
+						<IconWrap variant={STATUS_ICON[status].variant} icon={STATUS_ICON[status].icon} />
 						<div className="min-w-0 space-y-0.5">
 							<DialogTitle className="text-sm leading-snug font-medium">{titles[status]}</DialogTitle>
 							<DialogDescription className="text-xs leading-relaxed">{subtitles[status]}</DialogDescription>


### PR DESCRIPTION
## Summary

Extracts the shared visual building blocks used across the MCP client authorization dialogs (`OAuth2Authorizer`, `MCPHeadersAuthorizer`, and the token-exchange "Re-verify as me" dialog) into a single `authorizerUi.tsx` module. Previously, `OAuth2Authorizer` had its own inline `IconWrap`, `InfoBox`, and `StepDots` components, while `MCPHeadersAuthorizer` used a divergent ad-hoc layout. This consolidation ensures all three flows share the same dialog chrome and prevents them from drifting apart visually over time.

## Changes

- Added `authorizerUi.tsx` exporting `IconWrap`, `InfoBox`, `StepDots`, and the `UiVariant` type, covering all tint variants (`muted`, `info`, `success`, `danger`, `warning`).
- Removed the duplicate inline implementations of `IconWrap`, `InfoBox`, and `StepDots` from `oauth2Authorizer.tsx` and replaced them with imports from `authorizerUi.tsx`. The `STATUS_ICON` map now drives icon and variant selection declaratively instead of via a switch-style component.
- Rebuilt `MCPHeadersAuthorizer`'s dialog layout to match the bordered icon-header + `InfoBox` body structure used by `OAuth2Authorizer`, including a `STATUS_ICON` map, `titles`/`subtitles` records, and a proper failed-state retry footer with a `Close` button alongside `Retry`.
- Removed the auto-open popup behavior for non-per-user OAuth flows. Both auth types now start on the `confirm` step and only open the popup from a direct user click, avoiding silent popup-blocking when `window.open()` is called outside a user-activation context.
- The token-exchange dialog in `mcpClientsTable.tsx` now stays open with a spinner while the verify call is in flight, rather than closing immediately on "Continue" and leaving no visible feedback until the toast arrives. The cancel and confirm buttons are disabled during the in-flight state, and the actions menu button is also disabled while a verify is pending.
- Token-exchange rows in the per-user-auth state that previously rendered `null` now render a `-` placeholder, consistent with other empty cells in the table.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open an MCP server configured with shared OAuth and trigger the authorization dialog — confirm the icon header, info box, and step dots render correctly across the confirm → polling → success/failed states.
2. Open an MCP server configured with per-user OAuth and walk through the same flow.
3. Open an MCP server configured with per-user headers and walk through confirm → input → testing → success and confirm → input → testing → failed (with retry).
4. Trigger the token-exchange "Re-verify as me" dialog, click Continue, and verify the dialog remains open with a spinner until the backend call resolves before closing.
5. Verify the cancel and confirm buttons are non-interactive while the verify call is in flight.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth paths introduced. The popup-blocking fix ensures `window.open()` is only called from a direct user gesture, which is the correct browser security model for OAuth popups.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable