### PR TITLE
feat: add `-jwt` flag for JWT bearer auth to mcp-test-client

### DIFF
--- a/examples/mcps/mcp-test-client/README.md
+++ b/examples/mcps/mcp-test-client/README.md
@@ -6,8 +6,8 @@ under any inbound-auth configuration. It speaks streamable HTTP via
 credential styles the Bifrost MCP server accepts:
 
 - **header credentials** — a virtual key (`x-bf-vk`, `Authorization: Bearer`, or
-  `x-api-key`) or a session id (`x-bf-mcp-session-id`). Use with server auth
-  mode `headers` or `both`.
+  `x-api-key`), a JWT (`Authorization: Bearer`), or a session id
+  (`x-bf-mcp-session-id`). Use with server auth mode `headers` or `both`.
 - **OAuth** — full discovery (RFC 9728/8414) + dynamic client registration +
   PKCE authorization-code flow, with a local browser-callback. Use with server
   auth mode `both` or `oauth`.
@@ -38,6 +38,12 @@ Same VK as a bearer, or as `x-api-key`:
 ```bash
 GOWORK=off go run . -auth headers -bearer sk-bf-xxxxx
 GOWORK=off go run . -auth headers -api-key sk-bf-xxxxx
+```
+
+JWT as bearer (mutually exclusive with `-bearer`, both set `Authorization`):
+
+```bash
+GOWORK=off go run . -auth headers -jwt eyJhbGciOi...
 ```
 
 Session id (only accepted while `enforce_auth_on_inference=false`):

--- a/examples/mcps/mcp-test-client/main.go
+++ b/examples/mcps/mcp-test-client/main.go
@@ -5,8 +5,9 @@
 // MCP server accepts:
 //
 //   - header credentials: a virtual key (x-bf-vk / Authorization: Bearer /
-//     x-api-key) or a session id (x-bf-mcp-session-id), used for the
-//     `headers` and `both` server auth modes; and
+//     x-api-key), a JWT (Authorization: Bearer), or a session id
+//     (x-bf-mcp-session-id), used for the `headers` and `both` server auth
+//     modes; and
 //   - OAuth: full RFC 9728/8414 discovery + dynamic client registration + PKCE
 //     authorization-code flow, used for the `both` and `oauth` server modes.
 //
@@ -75,6 +76,7 @@ func main() {
 	vk := flag.String("vk", "", "virtual key, sent as x-bf-vk (auth=headers)")
 	bearer := flag.String("bearer", "", "virtual key sent as Authorization: Bearer (auth=headers)")
 	apiKey := flag.String("api-key", "", "virtual key sent as x-api-key (auth=headers)")
+	jwt := flag.String("jwt", "", "JWT sent as Authorization: Bearer (auth=headers; mutually exclusive with -bearer)")
 	session := flag.String("session", "", "session id, sent as x-bf-mcp-session-id (auth=headers)")
 	flag.Var(extra, "header", "extra header \"Key: Value\" (repeatable, any auth)")
 	scope := flag.String("scope", "mcp", "comma-separated OAuth scopes (auth=oauth)")
@@ -89,6 +91,13 @@ func main() {
 	}
 	if *bearer != "" {
 		headers["Authorization"] = "Bearer " + *bearer
+	}
+	if *jwt != "" {
+		if *bearer != "" {
+			fmt.Fprintln(os.Stderr, "error: -bearer and -jwt both set Authorization: Bearer and are mutually exclusive")
+			os.Exit(1)
+		}
+		headers["Authorization"] = "Bearer " + *jwt
 	}
 	if *apiKey != "" {
 		headers["x-api-key"] = *apiKey


### PR DESCRIPTION
## Summary

Adds a `-jwt` flag to the MCP test client, allowing a JWT to be passed as the `Authorization: Bearer` credential. This provides a distinct flag for JWT-based authentication separate from the existing `-bearer` flag (which is intended for virtual keys), making the client's credential options more explicit and self-documenting.

## Changes

- Added a `-jwt` CLI flag that sets `Authorization: Bearer <jwt>` on outbound requests
- Added a mutual exclusivity check between `-bearer` and `-jwt`, since both write to the same `Authorization` header — the client exits with an error if both are provided
- Updated the README and package-level doc comment to reflect JWT as a supported credential style under `headers` auth mode

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the test client with a JWT against a Bifrost MCP server configured for `headers` or `both` auth mode:

```sh
cd examples/mcps/mcp-test-client
GOWORK=off go run . -auth headers -jwt eyJhbGciOi...
```

Verify that passing both `-bearer` and `-jwt` together exits with an error:

```sh
GOWORK=off go run . -auth headers -bearer sk-bf-xxxxx -jwt eyJhbGciOi...
# Expected: error: -bearer and -jwt both set Authorization: Bearer and are mutually exclusive
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `-jwt` flag transmits a JWT as a bearer token over HTTP. Users should ensure the MCP server endpoint is served over TLS in any non-local environment to prevent token exposure in transit.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
