### PR TITLE
`refactor: replace OAuth2 token-expired text matching with errors.Is and preserve last-known tool map on disconnect`

### DIFF
--- a/core/mcp/auth_retry_test.go
+++ b/core/mcp/auth_retry_test.go
@@ -64,17 +64,14 @@ func TestIsAuthFailureErrorText_OpposesIsTransientErrorOnAuthText(t *testing.T) 
 
 // isAuthFailureErrorText must NOT match Bifrost's own internal
 // ErrOAuth2TokenExpired sentinel text (schemas.ErrOAuth2TokenExpired says
-// "oauth2 token expired") — that's isOAuth2TokenExpiredErrorText's job, a
-// genuinely different detector for a genuinely different failure class (a
-// connect-time failure already classified by Bifrost's own refresh logic,
-// vs. a raw unclassified upstream rejection here).
+// "oauth2 token expired") — that sentinel is a genuinely different failure
+// class (a connect-time failure already classified by Bifrost's own refresh
+// logic via errors.Is, not text matching — see connectToMCPClient) vs. a raw
+// unclassified upstream rejection here.
 func TestIsAuthFailureErrorText_DoesNotOverlapOAuth2TokenExpiredSentinel(t *testing.T) {
 	sentinelText := schemas.ErrOAuth2TokenExpired.Error()
 	if isAuthFailureErrorText(sentinelText) {
 		t.Fatalf("isAuthFailureErrorText unexpectedly matched Bifrost's own %q sentinel text", sentinelText)
-	}
-	if !isOAuth2TokenExpiredErrorText(sentinelText) {
-		t.Fatalf("isOAuth2TokenExpiredErrorText should still match its own sentinel text")
 	}
 }
 

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1100,7 +1100,35 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s is not disabled (current state: %s)", clientState.ExecutionConfig.Name, clientState.State)
 	}
+	m.mu.Unlock()
 
+	// Guard against concurrent reconnects for the same client from any caller
+	// (health monitor, manual API call, etc.) BEFORE mutating Disabled, not
+	// after: connectToMCPClient's own Disabled guard only bails out while
+	// State is Disabled AND config.Disabled is still true (see its call
+	// site), so flipping Disabled first and only losing this guard
+	// afterwards would let a concurrent ReconnectClient read Disabled=false,
+	// sail past that guard, and connect the entry while its State is still
+	// Disabled — silently enabling the client out from under an EnableClient
+	// call that then reports "already in progress" as if nothing happened.
+	// Registration is atomic: whichever caller arrives second gets the error
+	// immediately.
+	finish, ok := m.beginExclusiveClientOp(id)
+	if !ok {
+		return fmt.Errorf("reconnect already in progress for this client")
+	}
+	defer func() { finish(retErr) }()
+
+	m.mu.Lock()
+	clientState, ok = m.clientMap[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s not found", id)
+	}
+	if clientState.State != schemas.MCPConnectionStateDisabled {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s is not disabled (current state: %s)", clientState.ExecutionConfig.Name, clientState.State)
+	}
 	clientState.ExecutionConfig.Disabled = false
 	configCopy := clientState.ExecutionConfig
 	m.mu.Unlock()
@@ -1123,15 +1151,6 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 		m.logger.Debug("%s Per-user auth MCP client '%s' enabled (no persistent connection)", MCPLogPrefix, configCopy.Name)
 		return nil
 	}
-
-	// Guard against concurrent reconnects for the same client from any caller
-	// (health monitor, manual API call, etc.). Registration is atomic: whichever
-	// caller arrives second gets the "already in progress" error immediately.
-	finish, ok := m.beginExclusiveClientOp(id)
-	if !ok {
-		return fmt.Errorf("reconnect already in progress for this client")
-	}
-	defer func() { finish(retErr) }()
 
 	if err := m.connectToMCPClient(m.ctx, configCopy); err != nil {
 		// Connection failed — leave the entry as Disconnected so the health monitor can
@@ -1553,10 +1572,16 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 			// during connection attempts; it transitions to Connected only on
 			// success. The generation bump invalidates any late writer that
 			// captured the detached connection (tool syncer, SSE loss callback).
+			//
+			// ToolMap/ToolNameMapping are deliberately left as last-known-good,
+			// not cleared here: the success path below replaces both wholesale
+			// after discovery regardless, and failConnectAttempt relies on
+			// finding the previous maps still in place if this dial fails —
+			// clearing them here would make a second consecutive failed
+			// close-first reconnect (STDIO, in-process, or no live connection)
+			// lose its last-known tools instead of just the first one.
 			existingClient.State = schemas.MCPConnectionStateDisconnected
 			existingClient.Conn = nil
-			existingClient.ToolMap = make(map[string]schemas.ChatTool)
-			existingClient.ToolNameMapping = make(map[string]string)
 			existingClient.ConnectionInfo = &schemas.MCPClientConnectionInfo{
 				Type: config.ConnectionType,
 			}
@@ -1797,7 +1822,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		// carries that signal. Never clobber Disabled (DisableClient is
 		// authoritative, same invariant the health monitor's updateClientState
 		// guard preserves).
-		needsReauth := isOAuth2TokenExpiredErrorText(gateErr.GetErrorString())
+		needsReauth := gateErr.Error != nil && errors.Is(gateErr.Error.Error, schemas.ErrOAuth2TokenExpired)
 		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, needsReauth)
 		return fmt.Errorf("failed to connect MCP client %s: %s", config.Name, gateErr.GetErrorString())
 	}
@@ -1984,11 +2009,11 @@ func (m *MCPManager) closeConnHandles(cancel context.CancelFunc, conn *client.Cl
 // failConnectAttempt is the shared teardown for every failure exit of
 // connectToMCPClient after the client entry has been prepared. It first
 // writes the standard post-failure entry state under m.mu: no connection,
-// cleared tool maps, connection info reduced to the bare type, a generation
-// bump, and State Disconnected (or NeedsReauth when the failure was
-// classified as a dead OAuth2 credential). Only then are the half-built new
-// connection handles and the previous connection captured for
-// make-before-break closed, outside the lock.
+// last-known tool maps left intact, connection info reduced to the bare
+// type, a generation bump, and State Disconnected (or NeedsReauth when the
+// failure was classified as a dead OAuth2 credential). Only then are the
+// half-built new connection handles and the previous connection captured
+// for make-before-break closed, outside the lock.
 //
 // The order is load-bearing: during a make-before-break dial the map entry
 // still references the old connection, and other closers (RemoveClient)
@@ -1997,8 +2022,9 @@ func (m *MCPManager) closeConnHandles(cancel context.CancelFunc, conn *client.Cl
 // the transport's own idempotence check suffices; closing first would race
 // it. The generation bump invalidates late writers that captured the old
 // connection: a tool-sync tick whose list_tools succeeded on the old
-// connection mid-dial must not repopulate the cleared tool map of a
-// Disconnected or NeedsReauth entry, and a late SSE loss callback from the
+// connection mid-dial must not write its results over this entry (toolsync.go
+// compares the generation it captured before running against the current one
+// and drops the write on mismatch), and a late SSE loss callback from the
 // torn-down connection must not overwrite the failure state.
 //
 // Disabled entries keep the state DisableClient wrote, and an entry removed
@@ -2011,8 +2037,15 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 	if clientState, exists := m.clientMap[config.ID]; exists && clientState == entry && clientState.State != schemas.MCPConnectionStateDisabled {
 		clientState.Conn = nil
 		clientState.CancelFunc = nil
-		clientState.ToolMap = make(map[string]schemas.ChatTool)
-		clientState.ToolNameMapping = make(map[string]string)
+		// ToolMap/ToolNameMapping are deliberately left as last-known-good, not
+		// cleared: GetClientForTool resolves by tool name against this map, and
+		// wiping it here made a dead connection indistinguishable from a tool
+		// that never existed ("not available or not permitted" instead of
+		// "client needs re-authorization" — see prepareToolExecution's
+		// State-specific checks, which now give the real reason). Callers that
+		// build the advertised tool list (GetToolPerClient) filter on State
+		// directly rather than relying on an empty map, so this doesn't cause
+		// a disconnected client's tools to keep being offered.
 		clientState.ConnectionInfo = &schemas.MCPClientConnectionInfo{
 			Type: config.ConnectionType,
 		}

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -166,3 +166,42 @@ func TestCloseAndMarkNeedsReauth_Disabled_IsNoOp(t *testing.T) {
 	m.mu.RUnlock()
 	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State)
 }
+
+// TestEnableClient_GuardLostLeavesDisabledUntouched pins the ordering
+// CodeRabbit flagged: EnableClient must acquire the exclusive per-client
+// operation guard (beginExclusiveClientOp) before flipping
+// ExecutionConfig.Disabled, not after. Flipping it first and only then
+// losing the guard to a concurrent operation (e.g. ReconnectClient) would
+// leave the entry looking enabled to that other caller's connectToMCPClient
+// call while State is still Disabled, letting it dial the entry out from
+// under this failed EnableClient — which then returns "already in progress"
+// even though the client was actually just connected by the race winner.
+func TestEnableClient_GuardLostLeavesDisabledUntouched(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-enable-race")
+	config.Disabled = true
+
+	m.mu.Lock()
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		Name:            config.Name,
+		ExecutionConfig: config,
+		State:           schemas.MCPConnectionStateDisabled,
+	}
+	m.mu.Unlock()
+
+	// Simulate a concurrent operation (e.g. ReconnectClient) already holding
+	// the exclusive guard for this client when EnableClient is called.
+	finish, ok := m.beginExclusiveClientOp(config.ID)
+	require.True(t, ok)
+	defer finish(nil)
+
+	err := m.EnableClient(config.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in progress")
+
+	m.mu.RLock()
+	state := *m.clientMap[config.ID]
+	m.mu.RUnlock()
+	assert.True(t, state.ExecutionConfig.Disabled, "a failed EnableClient (guard already held elsewhere) must not have flipped Disabled — otherwise a concurrent connectToMCPClient could dial the still-Disabled-State entry")
+	assert.Equal(t, schemas.MCPConnectionStateDisabled, state.State)
+}

--- a/core/mcp/exec.go
+++ b/core/mcp/exec.go
@@ -168,6 +168,23 @@ func (m *MCPManager) prepareToolExecution(ctx *schemas.BifrostContext, request *
 	if shouldSkipToolForRequest(ctx, clientName, toolName) {
 		return nil, nil, nil, fmt.Errorf("tool '%s' is not permitted (filtered by request context)", toolName)
 	}
+	// NeedsReauth/Disconnected clients keep their last-known ToolMap (see
+	// failConnectAttempt) so the tool stays visible in discovery instead of
+	// silently vanishing, but there's no live connection to actually run it
+	// on. Say so explicitly here rather than falling through to
+	// AcquireClientConn's generic "no active connection", which doesn't tell
+	// the caller whether this is transient or needs an admin to act. Checked
+	// only after the authorization filters above: a caller not permitted to
+	// see this client/tool in the first place must get the same generic
+	// "not permitted" error whether it's disconnected or not — surfacing
+	// client name and reauth state to an unauthorized caller would leak
+	// existence/state information the filters exist to hide.
+	if state.State == schemas.MCPConnectionStateNeedsReauth {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is unavailable: client %s needs re-authorization (its admin credential expired or was revoked)", toolName, clientName)
+	}
+	if state.State == schemas.MCPConnectionStateDisconnected {
+		return nil, nil, nil, fmt.Errorf("tool '%s' is unavailable: client %s is disconnected", toolName, clientName)
+	}
 	conn, release, err := m.AcquireClientConn(ctx, state)
 	if err != nil {
 		return nil, nil, nil, err

--- a/core/mcp/makebeforebreak_test.go
+++ b/core/mcp/makebeforebreak_test.go
@@ -357,8 +357,14 @@ func TestConnectToMCPClient_MakeBeforeBreak_DialFailure_ResetsStateAndClosesOldC
 			assert.Equal(t, tc.wantState, after.State)
 			assert.Nil(t, after.Conn, "a failed re-dial must leave no connection on the entry")
 			assert.Nil(t, after.CancelFunc)
-			assert.Empty(t, after.ToolMap, "a failed re-dial must leave the tool map empty")
-			assert.Empty(t, after.ToolNameMapping)
+			// The tool map is deliberately left as last-known-good, not cleared:
+			// a dead connection stays distinguishable from a tool that never
+			// existed (GetClientForTool still resolves it, and
+			// prepareToolExecution's State-specific checks give the real
+			// "needs re-authorization" / "disconnected" reason instead of a
+			// generic "not available").
+			assert.NotEmpty(t, after.ToolMap, "a failed re-dial must keep the last-known tool map")
+			assert.NotEmpty(t, after.ToolNameMapping)
 
 			// The captured old connection must have been torn down too.
 			callCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -368,6 +374,21 @@ func TestConnectToMCPClient_MakeBeforeBreak_DialFailure_ResetsStateAndClosesOldC
 				Params:  mcpgo.CallToolParams{Name: "echo", Arguments: map[string]interface{}{"message": "ping"}},
 			})
 			require.Error(t, oldErr, "the old connection must be closed on a failed re-dial")
+
+			// A second consecutive failure takes the close-first path (Conn is
+			// already nil after the first failure above, so this attempt no
+			// longer qualifies for make-before-break) — exactly where a pre-dial
+			// clear of the tool maps would go unnoticed by the make-before-break
+			// assertions above, since those only exercise the make-before-break
+			// branch on its first failure.
+			require.Error(t, m.connectToMCPClient(context.Background(), config))
+
+			afterSecondFailure, ok := snapshotClientState(m, config.ID)
+			require.True(t, ok, "the entry must survive a second failed re-dial")
+			assert.Equal(t, tc.wantState, afterSecondFailure.State)
+			assert.Nil(t, afterSecondFailure.Conn)
+			assert.Equal(t, before.ToolMap, afterSecondFailure.ToolMap, "a second failed re-dial (close-first path) must keep the original last-known tool map")
+			assert.Equal(t, before.ToolNameMapping, afterSecondFailure.ToolNameMapping)
 		})
 	}
 }

--- a/core/mcp/pluginpipeline.go
+++ b/core/mcp/pluginpipeline.go
@@ -347,7 +347,10 @@ func (m *MCPManager) runConnectWithPluginPipeline(
 		if opErr != nil {
 			return resp, &schemas.BifrostError{
 				IsBifrostError: false,
-				Error:          &schemas.ErrorField{Message: opErr.Error()},
+				// Error kept alongside Message (json:"-", same as
+				// runWithPluginPipeline) so callers can classify via
+				// errors.Is/errors.As instead of string-matching.
+				Error: &schemas.ErrorField{Message: opErr.Error(), Error: opErr},
 			}
 		}
 		return resp, nil
@@ -402,7 +405,10 @@ func (m *MCPManager) runConnectWithPluginPipeline(
 	if opErr != nil {
 		bErr = &schemas.BifrostError{
 			IsBifrostError: false,
-			Error:          &schemas.ErrorField{Message: opErr.Error()},
+			// Error kept alongside Message (json:"-", same as
+			// runWithPluginPipeline) so callers can classify via
+			// errors.Is/errors.As instead of string-matching.
+			Error: &schemas.ErrorField{Message: opErr.Error(), Error: opErr},
 		}
 	}
 

--- a/core/mcp/reauth_state_test.go
+++ b/core/mcp/reauth_state_test.go
@@ -11,37 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIsOAuth2TokenExpiredErrorText covers the substring-matching fallback
-// connectToMCPClient relies on to recognize schemas.ErrOAuth2TokenExpired at
-// the failure site: runConnectWithPluginPipeline flattens the underlying Go
-// error to a string (see the doc comment on isOAuth2TokenExpiredErrorText),
-// so errors.Is/As isn't usable there, and text matching is the only option
-// left, mirroring isTransientError.
-func TestIsOAuth2TokenExpiredErrorText(t *testing.T) {
-	wrappedOnce := fmt.Errorf("refresh token rejected by upstream OAuth server, re-authentication required: %w", schemas.ErrOAuth2TokenExpired)
-	wrappedTwice := fmt.Errorf("token expired and refresh failed: %w", wrappedOnce)
-
-	tests := []struct {
-		name   string
-		errStr string
-		want   bool
-	}{
-		{"exact sentinel text", schemas.ErrOAuth2TokenExpired.Error(), true},
-		{"single %w wrap (RefreshAccessToken permanent-rejection path)", wrappedOnce.Error(), true},
-		{"double %w wrap (GetAccessToken's refresh-failed wrapper)", wrappedTwice.Error(), true},
-		{"token-not-active wrap (GetAccessToken's inactive-status path)", fmt.Errorf("oauth token is not active, status: orphaned: %w", schemas.ErrOAuth2TokenExpired).Error(), true},
-		{"unrelated connectivity error", "connection refused", false},
-		{"unrelated config error", "oauth2 config not found", false},
-		{"empty string", "", false},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isOAuth2TokenExpiredErrorText(tc.errStr))
-		})
-	}
-}
-
 // expiredOAuthCredStore simulates a shared OAuth2 credential store whose
 // refresh has permanently failed: every ConnectionHeaders call returns the
 // same error shape framework/oauth2's RefreshAccessToken/GetAccessToken

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -238,26 +238,6 @@ func isTransientError(err error) bool {
 	return true
 }
 
-// isOAuth2TokenExpiredErrorText reports whether a connect-failure message
-// indicates the underlying failure was schemas.ErrOAuth2TokenExpired — a
-// shared client's OAuth2 credential that has permanently died (refresh
-// rejected/expired, no way to silently recover) and needs a human to
-// reauthorize it — as opposed to a generic connectivity failure that a
-// routine reconnect can resolve on its own.
-//
-// connectToMCPClient's op closure returns this sentinel (wrapped via %w by
-// framework/oauth2) as a plain Go error, but runConnectWithPluginPipeline
-// (unlike RunWithPluginPipeline, used for tool/ping/list_tools calls) only
-// carries opErr.Error() as a string on the *schemas.BifrostError it returns —
-// it does not also preserve the original error on ErrorField.Error — so
-// errors.Is/errors.As is not usable on the gateErr the caller receives.
-// Same substring-matching technique as isTransientError above, for the same
-// structural reason: the typed error info was already flattened to a string
-// by the time it gets here.
-func isOAuth2TokenExpiredErrorText(errStr string) bool {
-	return strings.Contains(errStr, schemas.ErrOAuth2TokenExpired.Error())
-}
-
 // isAuthFailureErrorText reports whether a raw upstream tool-call error looks
 // like an auth rejection (401/403/unauthorized/forbidden). mcp-go flattens
 // HTTP status codes into a plain error string by the time a CallTool error
@@ -265,24 +245,20 @@ func isOAuth2TokenExpiredErrorText(errStr string) bool {
 // isTransientError above, substring matching on the same class of text is
 // the only option.
 //
-// This is deliberately a separate function from both of the above, not a
-// reuse of either:
+// This is deliberately not a reuse of isTransientError: that function matches
+// this exact substring class too, but as a PERMANENT signal (don't retry) for
+// its connection-establishment callers — the opposite polarity needed here,
+// where the same text is the POSITIVE trigger for a forced-refresh-and-retry.
+// A tool call that reaches this point already has a live, previously-healthy
+// connection (AcquireClientConn already succeeded once), so a 401/403 here
+// means the upstream server is actively rejecting a credential Bifrost's own
+// bookkeeping still considers valid — worth reacting to, not giving up on.
 //
-//   - isTransientError matches this exact substring class too, but as a
-//     PERMANENT signal (don't retry) for its connection-establishment
-//     callers — the opposite polarity needed here, where the same text is
-//     the POSITIVE trigger for a forced-refresh-and-retry. A tool call that
-//     reaches this point already has a live, previously-healthy connection
-//     (AcquireClientConn already succeeded once), so a 401/403 here means
-//     the upstream server is actively rejecting a credential Bifrost's own
-//     bookkeeping still considers valid — worth reacting to, not giving up
-//     on.
-//   - isOAuth2TokenExpiredErrorText matches Bifrost's OWN internal sentinel
-//     text (schemas.ErrOAuth2TokenExpired), surfaced only after Bifrost's
-//     own refresh logic already ran and classified a credential as
-//     permanently dead. A raw CallTool error never goes through that
-//     classification at all — it's the upstream server's rejection text
-//     verbatim, not Bifrost's.
+// This is also distinct from schemas.ErrOAuth2TokenExpired-based
+// classification (see connectToMCPClient), which fires only after Bifrost's
+// own refresh logic already ran and classified a credential as permanently
+// dead. A raw CallTool error never goes through that classification at all —
+// it's the upstream server's rejection text verbatim, not Bifrost's.
 func isAuthFailureErrorText(errStr string) bool {
 	lower := strings.ToLower(errStr)
 	for _, needle := range []string{"401", "403", "unauthorized", "forbidden"} {


### PR DESCRIPTION
## Summary

When an MCP client connection fails, the tool map was being cleared, making a dead connection indistinguishable from a tool that never existed. This caused callers to receive a generic "not available or not permitted" error rather than an actionable "client needs re-authorization" or "client is disconnected" message. Additionally, the OAuth2 token expiry detection relied on fragile substring matching against a flattened error string because `runConnectWithPluginPipeline` was not preserving the original Go error on `ErrorField.Error`. This PR fixes both issues.

## Changes

- **Preserve last-known tool map on connection failure**: `failConnectAttempt` no longer clears `ToolMap`/`ToolNameMapping` when a connection fails. The maps are left as last-known-good so `GetClientForTool` can still resolve the tool and route it to the correct client. `GetToolPerClient` already filters on `State` directly, so disconnected clients' tools are not re-advertised.

- **Add explicit state checks in `prepareToolExecution`**: Before falling through to `AcquireClientConn`, the execution path now checks for `NeedsReauth` and `Disconnected` states and returns specific, actionable error messages rather than a generic "no active connection" error.

- **Preserve the original error on `BifrostError` in `runConnectWithPluginPipeline`**: Both early-return and late-return error paths now set `ErrorField.Error` alongside `ErrorField.Message`, enabling `errors.Is`/`errors.As` classification by callers.

- **Replace text-matching OAuth2 expiry detection with `errors.Is`**: `connectToMCPClient` now uses `errors.Is(gateErr.Error.Error, schemas.ErrOAuth2TokenExpired)` instead of the `isOAuth2TokenExpiredErrorText` substring matcher, which was only necessary because the original error was being discarded.

- **Remove `isOAuth2TokenExpiredErrorText` and its tests**: The function and its associated test coverage are deleted now that the typed error is preserved through the pipeline. The `TestIsAuthFailureErrorText_DoesNotOverlapOAuth2TokenExpiredSentinel` test is simplified to only assert the negative case, since there is no longer a separate text-matching function to validate the positive case for.

- **Update make-before-break test assertions**: The reconnect failure test now asserts that the tool map is retained (`NotEmpty`) rather than cleared (`Empty`), reflecting the new intended behavior.

## Type of change

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Core (Go)

## How to test

```sh
go version
go test ./...
```

The `makebeforebreak_test.go` and `reauth_state_test.go` tests directly cover the changed behavior. After a simulated dial failure, verify that:
- The client entry retains its tool map.
- Attempting to execute a tool on a `NeedsReauth` client returns a message containing "needs re-authorization".
- Attempting to execute a tool on a `Disconnected` client returns a message containing "is disconnected".

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. The change improves error message clarity for expired OAuth2 credentials but does not alter authentication logic or expose new information externally.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable