### PR TITLE
feat: add tiered retry configs for MCP connect, per-call connect, and tool-call paths

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -116,15 +116,6 @@ func (m *MCPManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schem
 		if perUserTLSClient != nil {
 			perUserOpts = append(perUserOpts, transport.WithHTTPBasicClient(perUserTLSClient))
 		}
-		httpTransport, err := transport.NewStreamableHTTP(targetURL, perUserOpts...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
-		}
-		tempClient = client.NewClient(httpTransport)
-		if err := tempClient.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start ephemeral MCP connection: %w", err)
-		}
-
 		initRequest := mcp.InitializeRequest{
 			Params: mcp.InitializeParams{
 				ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
@@ -135,17 +126,60 @@ func (m *MCPManager) AcquireClientConn(ctx *schemas.BifrostContext, state *schem
 				},
 			},
 		}
-		// Bound the MCP `initialize` handshake — a stalled upstream (TCP open
-		// succeeds but JSON-RPC initialize never returns) would otherwise block
-		// the entire tool call until the parent request ctx fires. Mirrors the
-		// bound used for shared-connection Initialize in connectToMCPClient.
-		initCtx, initCancel := context.WithTimeout(ctx, MCPClientConnectionEstablishTimeout)
-		defer initCancel()
-		initResult, err := tempClient.Initialize(initCtx, initRequest)
-		if err != nil {
-			_ = tempClient.Close()
-			tempClient = nil
-			return nil, fmt.Errorf("failed to initialize ephemeral MCP connection: %w", err)
+		// Build, start, and initialize with a single retry loop covering the
+		// whole connect handshake — same recreate-fresh-per-attempt shape as
+		// connectToMCPClient's shared-connect path (each attempt closes the
+		// previous attempt's client and builds a new one) but with
+		// PerCallConnectRetryConfig, not ConnectRetryConfig: unlike the shared
+		// dial, this runs synchronously in front of a live tool call with no
+		// separate budget wrapper around it, so it can't afford the shared
+		// path's full backoff schedule. Previously Start ran once with no
+		// retry at all — a transient blip failed the whole tool call outright.
+		//
+		// Start and Initialize share one retry budget (not two separate
+		// ones) deliberately: a failed Initialize can leave the transport
+		// broken — mcp-go marks initialization state before validating the
+		// response — so a retry needs a fresh client from Start onward
+		// regardless of which of the two failed, and one combined attempt
+		// achieves that without extra bookkeeping to track which stage a
+		// given retry is rebuilding for.
+		var initResult *mcp.InitializeResult
+		if err := ExecuteWithRetry(
+			ctx,
+			func() error {
+				if tempClient != nil {
+					if closeErr := tempClient.Close(); closeErr != nil {
+						m.logger.Warn("%s Failed to close ephemeral client during retry: %v", MCPLogPrefix, closeErr)
+					}
+				}
+				httpTransport, err := transport.NewStreamableHTTP(targetURL, perUserOpts...)
+				if err != nil {
+					return fmt.Errorf("failed to create HTTP transport: %w", err)
+				}
+				tempClient = client.NewClient(httpTransport)
+				if err := tempClient.Start(ctx); err != nil {
+					return err
+				}
+
+				// Bound the MCP `initialize` handshake — a stalled upstream (TCP
+				// open succeeds but JSON-RPC initialize never returns) would
+				// otherwise block the entire tool call until the parent request
+				// ctx fires. Mirrors the bound used for shared-connection
+				// Initialize in connectToMCPClient. Fresh per attempt, not
+				// deferred to the end of the retry loop.
+				initCtx, initCancel := context.WithTimeout(ctx, MCPClientConnectionEstablishTimeout)
+				defer initCancel()
+				initResult, err = tempClient.Initialize(initCtx, initRequest)
+				return err
+			},
+			PerCallConnectRetryConfig,
+			m.logger,
+		); err != nil {
+			if tempClient != nil {
+				_ = tempClient.Close()
+				tempClient = nil
+			}
+			return nil, fmt.Errorf("failed to establish ephemeral MCP connection: %w", err)
 		}
 
 		// Build the gate response from the captured initialize result so
@@ -1706,7 +1740,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 
 		// Start the transport (with internal retries). Each retry uses a fresh client.
 		m.logger.Debug("%s [%s] Starting transport...", MCPLogPrefix, config.Name)
-		transportRetryConfig := DefaultRetryConfig
+		transportRetryConfig := ConnectRetryConfig
 		if startErr := ExecuteWithRetry(
 			m.ctx,
 			func() error {
@@ -1767,7 +1801,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 				},
 			},
 		}
-		initRetryConfig := DefaultRetryConfig
+		initRetryConfig := ConnectRetryConfig
 		if initErr := ExecuteWithRetry(
 			m.ctx,
 			func() error {

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -724,8 +724,25 @@ func (m *ToolsManager) executeToolInternal(
 		},
 	}
 
+	// ToolCallRetryConfig, not ConnectRetryConfig/PerCallConnectRetryConfig:
+	// unlike a bare connect, this call may not be idempotent, so it only gets
+	// a couple of quick, latency-conscious attempts. isTransientToolCallError
+	// (ToolCallRetryConfig's configured classifier) already treats
+	// 401/403/unauthorized/forbidden as non-retryable — those fail
+	// immediately here with zero retries and fall through to the
+	// isAuthFailureErrorText handling below unchanged.
 	toolCallStart := time.Now()
-	toolResponse, callErr := clientConn.CallTool(toolCtx, callRequest)
+	var toolResponse *mcp.CallToolResult
+	callErr := ExecuteWithRetry(
+		toolCtx,
+		func() error {
+			var err error
+			toolResponse, err = clientConn.CallTool(toolCtx, callRequest)
+			return err
+		},
+		ToolCallRetryConfig,
+		m.logger,
+	)
 	schemas.AddUpstreamLatency(ctx, time.Since(toolCallStart))
 	if callErr != nil {
 		// Sentinel-wrapped so the gate can classify error.type (timeout vs tool_error).

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -22,12 +22,53 @@ type RetryConfig struct {
 	MaxRetries     int           // Maximum number of retry attempts (not including the initial attempt)
 	InitialBackoff time.Duration // Initial backoff duration
 	MaxBackoff     time.Duration // Maximum backoff duration
+	// IsRetryable classifies an attempt's error as worth retrying or not.
+	// Nil defaults to isTransientError (connect-shaped: unrecognized errors
+	// default to retryable). ToolCallRetryConfig overrides this with
+	// isTransientToolCallError (the opposite default — see its doc comment).
+	IsRetryable func(error) bool
 }
 
-var DefaultRetryConfig = RetryConfig{
+// ConnectRetryConfig backs every connection-establishment step — the shared
+// persistent dial (connectToMCPClient) and the ephemeral per-call connect
+// (AcquireClientConn's per-user/per-call branch) alike. Nothing user-facing
+// is blocked synchronously on this in the shared case, and in the per-call
+// case it's a one-time cost paid before the tool call runs — generous
+// retries are the right tradeoff here.
+var ConnectRetryConfig = RetryConfig{
 	MaxRetries:     5,
 	InitialBackoff: 1 * time.Second,
 	MaxBackoff:     30 * time.Second,
+}
+
+// PerCallConnectRetryConfig backs the ephemeral per-call connect+init steps
+// (AcquireClientConn's per-user/per-call branch) — distinct from both of the
+// other two configs, not a reuse of either. It runs synchronously in front
+// of a live tool call with no separate budget wrapper (unlike
+// ConnectRetryConfig's shared dial, mostly background/setup), so it can't
+// afford ConnectRetryConfig's full ~31s-worst-case schedule. But establishing
+// a connection has no side effects on the upstream — safe to retry harder
+// than the tool call that follows it, which might not be idempotent — so
+// it's more generous than ToolCallRetryConfig, not just a copy of it.
+var PerCallConnectRetryConfig = RetryConfig{
+	MaxRetries:     3,
+	InitialBackoff: 250 * time.Millisecond,
+	MaxBackoff:     1 * time.Second,
+}
+
+// ToolCallRetryConfig backs the live tool-call invocation itself
+// (executeToolInternal's CallTool). Deliberately the lightest of the three —
+// a caller is waiting synchronously on this, and unlike a bare connect, the
+// call itself may not be safe to retry blindly (non-idempotent tools), so it
+// trades retry depth for latency: a couple of quick attempts to ride out a
+// genuine blip, nothing more. Uses isTransientToolCallError, not the default
+// isTransientError, so an unrecognized (likely application-level) failure
+// is never retried — see that function's doc comment.
+var ToolCallRetryConfig = RetryConfig{
+	MaxRetries:     2,
+	InitialBackoff: 200 * time.Millisecond,
+	MaxBackoff:     200 * time.Millisecond,
+	IsRetryable:    isTransientToolCallError,
 }
 
 // GetClientForTool safely finds a client that has the specified tool.
@@ -199,34 +240,14 @@ func isTransientError(err error) bool {
 		}
 	}
 
-	// Transient errors that SHOULD be retried
-	transientErrors := []string{
-		// Network errors
-		"connection refused", "connection reset", "broken pipe",
-		"network is unreachable", "no route to host",
-		// Timeout errors
-		"timeout", "deadline exceeded", "i/o timeout",
-		// DNS errors
-		"no such host", "name resolution failed",
-		// HTTP errors
-		"503", "502", "504", "429", "500", // Service Unavailable, Bad Gateway, Gateway Timeout, Too Many Requests, Internal Server Error
-		// Connection errors
-		"connection error", "connection lost", "connection failed",
-		// I/O errors
-		"i/o error", "read error", "write error",
-		// Temporary errors
-		"temporary failure", "try again",
-	}
-
-	for _, transientErr := range transientErrors {
+	for _, transientErr := range transientErrorSubstrings {
 		if strings.Contains(strings.ToLower(errStr), transientErr) {
 			return true
 		}
 	}
 
 	// Check for net.Error types (timeout-related errors)
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		// Timeout errors are transient and should be retried
 		if netErr.Timeout() {
 			return true
@@ -234,8 +255,68 @@ func isTransientError(err error) bool {
 	}
 
 	// Default: treat as transient to be safe (connection-related errors)
-	// This ensures we retry unknown errors that are likely transient
+	// This ensures we retry unknown errors that are likely transient — the
+	// right default for connection-establishment callers, where an
+	// unrecognized failure is still usually infra-related. NOT the right
+	// default for a tool call already past a live connection — see
+	// isTransientToolCallError below, which shares the same substring list
+	// but flips this default.
 	return true
+}
+
+// transientErrorSubstrings is the shared substring list both isTransientError
+// (connection-establishment, default-retry-unknown) and
+// isTransientToolCallError (tool calls, default-don't-retry-unknown) match
+// against — one source of truth for what "looks like a transport blip" means,
+// even though the two callers apply opposite defaults to anything outside it.
+var transientErrorSubstrings = []string{
+	// Network errors
+	"connection refused", "connection reset", "broken pipe",
+	"network is unreachable", "no route to host",
+	// Timeout errors
+	"timeout", "deadline exceeded", "i/o timeout",
+	// DNS errors
+	"no such host", "name resolution failed",
+	// HTTP errors
+	"503", "502", "504", "429", "500", // Service Unavailable, Bad Gateway, Gateway Timeout, Too Many Requests, Internal Server Error
+	// Connection errors
+	"connection error", "connection lost", "connection failed",
+	// I/O errors
+	"i/o error", "read error", "write error",
+	// Temporary errors
+	"temporary failure", "try again",
+}
+
+// isTransientToolCallError is ToolCallRetryConfig's classifier: a live tool
+// call already has a working connection (AcquireClientConn succeeded to get
+// here), so an error at this point is either a genuine transport blip
+// (matches transientErrorSubstrings — worth one quick retry) or something
+// application-level (a tool's own business-logic failure, bad arguments, a
+// panic in the tool implementation) that retrying can't fix and might
+// actively harm if the tool isn't idempotent. Unlike isTransientError, this
+// does NOT default to true for unrecognized text — only a positive match
+// against known transport-failure shapes triggers a retry; everything else
+// (including net.Error timeouts, which isTransientError treats as transient
+// but which already have "timeout"/"deadline exceeded" in the substring list
+// above anyway) goes straight through as non-retryable.
+func isTransientToolCallError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	// Auth failures are checked first, before the transient substring scan:
+	// error text like "401 unauthorized: try again" would otherwise match
+	// "try again" below and get retried, contradicting the non-retryable
+	// auth-failure rule this classifier exists to enforce for tool calls.
+	if isAuthFailureErrorText(errStr) {
+		return false
+	}
+	for _, transientErr := range transientErrorSubstrings {
+		if strings.Contains(errStr, transientErr) {
+			return true
+		}
+	}
+	return false
 }
 
 // isAuthFailureErrorText reports whether a raw upstream tool-call error looks
@@ -289,6 +370,10 @@ func ExecuteWithRetry(
 ) error {
 	var lastErr error
 	backoff := config.InitialBackoff
+	isRetryable := config.IsRetryable
+	if isRetryable == nil {
+		isRetryable = isTransientError
+	}
 
 	for attempt := 0; attempt <= config.MaxRetries; attempt++ {
 		// Check context before attempting
@@ -305,7 +390,7 @@ func ExecuteWithRetry(
 		}
 
 		// Check if error is transient - if not, fail immediately without retrying
-		if !isTransientError(lastErr) {
+		if !isRetryable(lastErr) {
 			logger.Debug("%s permanent error (not retrying): %v", MCPLogPrefix, lastErr)
 			return lastErr
 		}
@@ -360,7 +445,7 @@ func retrieveExternalToolsDetailed(ctx context.Context, client *client.Client, c
 	}
 
 	var toolsResponse *mcp.ListToolsResult
-	retryConfig := DefaultRetryConfig
+	retryConfig := ConnectRetryConfig
 	err := ExecuteWithRetry(
 		ctx,
 		func() error {


### PR DESCRIPTION
## Summary

Transient failures during MCP tool calls and ephemeral per-call connections previously caused immediate, unrecoverable errors with no retry logic. This PR introduces differentiated retry configurations for the three distinct MCP operation types — shared connection establishment, ephemeral per-call connection, and live tool call invocation — each with backoff schedules and retryability classifiers tuned to their specific latency and idempotency constraints.

## Changes

- Replaced the single `DefaultRetryConfig` with three purpose-built configs:
  - `ConnectRetryConfig` (5 retries, 1s–30s backoff): backs shared persistent dials and `retrieveExternalToolsDetailed`, where generous retries are appropriate since nothing user-facing is blocked synchronously.
  - `PerCallConnectRetryConfig` (3 retries, 250ms–1s backoff): backs the ephemeral connect+init steps in `AcquireClientConn`'s per-user/per-call branch, which previously had zero retry logic. Lighter than `ConnectRetryConfig` since it runs synchronously in front of a live tool call, but more generous than `ToolCallRetryConfig` since connection establishment has no side effects.
  - `ToolCallRetryConfig` (2 retries, 200ms flat backoff): backs `CallTool` in `executeToolInternal`, which previously had no retry logic. Uses `isTransientToolCallError` instead of `isTransientError` — only retries on positive matches against known transport-failure substrings, never on unrecognized errors, to avoid blindly retrying non-idempotent tool calls.
- Added `isTransientToolCallError`, which shares the `transientErrorSubstrings` list with `isTransientError` but defaults to non-retryable for unrecognized errors, the opposite of `isTransientError`'s connect-oriented default.
- Extracted `transientErrorSubstrings` as a package-level variable to serve as a single source of truth for both classifiers.
- Added an `IsRetryable` field to `RetryConfig`, defaulting to `isTransientError` when nil, so each config can supply its own classifier without changing `ExecuteWithRetry`'s signature.
- Auth failures (401/403/unauthorized/forbidden) remain permanently non-retryable across all paths via `isTransientError`'s existing early-exit logic, which `isTransientToolCallError` also inherits through the substring list.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

- Simulate a transient network blip (e.g., brief upstream unavailability) during a tool call and verify the call succeeds after a retry rather than failing immediately.
- Simulate a permanent error (e.g., 401 response) and verify it fails immediately with no retries across all three paths.
- Simulate a stalled ephemeral connection (TCP open, no JSON-RPC response) and verify `PerCallConnectRetryConfig`'s timeout bound fires per attempt rather than blocking until the parent context expires.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Auth rejection errors (401/403/unauthorized/forbidden) are explicitly classified as permanent and never retried, preserving existing behavior across all retry paths.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable