### PR TITLE
refactor: extract TLS, OAuth, and token exchange fields into shared components and reorganize MCP client sheet into tabs

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -21,7 +21,10 @@ import { Info } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
+import { OAuthAdvancedFields } from "./oauthAdvancedFields";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
+import { TLSConfigFields } from "./tlsConfigFields";
+import { TokenExchangeFields } from "./tokenExchangeFields";
 
 interface ClientFormProps {
 	open: boolean;
@@ -269,36 +272,36 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			stdio_config:
 				connectionType === "stdio"
 					? {
-						command: data.stdio_config?.command || "",
-						args: parseArrayFromText(argsText),
-						// Each row becomes KEY=value, or a bare KEY when no value is given
-						// (read from Bifrost's host environment). Rows without a name are skipped.
-						envs: Object.entries(envVars)
-							.filter(([name]) => name.trim() !== "")
-							.map(([name, value]) => {
-								const v = value.trim();
-								return v ? `${name}=${v}` : name;
-							}),
-					}
+							command: data.stdio_config?.command || "",
+							args: parseArrayFromText(argsText),
+							// Each row becomes KEY=value, or a bare KEY when no value is given
+							// (read from Bifrost's host environment). Rows without a name are skipped.
+							envs: Object.entries(envVars)
+								.filter(([name]) => name.trim() !== "")
+								.map(([name, value]) => {
+									const v = value.trim();
+									return v ? `${name}=${v}` : name;
+								}),
+						}
 					: undefined,
 			tls_config: connectionType === "http" || connectionType === "sse" ? buildTLSConfigPayload(data.tls_config) : undefined,
 			oauth_config:
 				authType === "oauth" || authType === "per_user_oauth"
 					? {
-						client_id: data.oauth_config?.client_id ?? emptySecretVar,
-						client_secret:
-							data.oauth_config?.client_secret?.value ||
+							client_id: data.oauth_config?.client_id ?? emptySecretVar,
+							client_secret:
+								data.oauth_config?.client_secret?.value ||
 								data.oauth_config?.client_secret?.type === "env" ||
 								data.oauth_config?.client_secret?.type === "vault"
-								? data.oauth_config.client_secret
-								: undefined,
-						authorize_url: data.oauth_config?.authorize_url || undefined,
-						token_url: data.oauth_config?.token_url || undefined,
-						registration_url: data.oauth_config?.registration_url || undefined,
-						scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-						server_url: data.connection_string?.value || undefined,
-						resource: resourceText.trim() || undefined,
-					}
+									? data.oauth_config.client_secret
+									: undefined,
+							authorize_url: data.oauth_config?.authorize_url || undefined,
+							token_url: data.oauth_config?.token_url || undefined,
+							registration_url: data.oauth_config?.registration_url || undefined,
+							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
+							server_url: data.connection_string?.value || undefined,
+							resource: resourceText.trim() || undefined,
+						}
 					: undefined,
 			// "headers" and "per_user_headers" both can carry static admin
 			// headers on data.headers (per-user values are submitted
@@ -311,17 +314,17 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			token_exchange:
 				authType === "token_exchange"
 					? {
-						audience: data.token_exchange?.audience?.trim() || "",
-						client_id: data.token_exchange?.client_id ?? emptySecretVar,
-						client_secret:
-							data.token_exchange?.client_secret?.value ||
+							audience: data.token_exchange?.audience?.trim() || "",
+							client_id: data.token_exchange?.client_id ?? emptySecretVar,
+							client_secret:
+								data.token_exchange?.client_secret?.value ||
 								data.token_exchange?.client_secret?.type === "env" ||
 								data.token_exchange?.client_secret?.type === "vault"
-								? data.token_exchange.client_secret
-								: undefined,
-						scopes: tokenExchangeScopesText.trim() ? parseArrayFromText(tokenExchangeScopesText) : undefined,
-						authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
-					}
+									? data.token_exchange.client_secret
+									: undefined,
+							scopes: tokenExchangeScopesText.trim() ? parseArrayFromText(tokenExchangeScopesText) : undefined,
+							authorization_server_url: data.token_exchange?.authorization_server_url?.trim() || undefined,
+						}
 					: undefined,
 			tools_to_execute: ["*"],
 		};
@@ -610,7 +613,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											    tool use via the inline auth landing page. */}
 											<div className="space-y-1">
 												<div className="space-y-0.5">
-													<div className="text-sm font-medium">Required Headers</div>
+													<Label htmlFor="per-user-header-keys">Required Headers</Label>
 													<p className="text-muted-foreground text-sm">
 														Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
 														<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user - never stored on this server config.
@@ -657,151 +660,66 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									)}
 
 									{authType === "token_exchange" && (
-										<div className="space-y-4" data-testid="token-exchange-fields">
-											<p className="text-muted-foreground text-sm">
-												Each caller's identity token is exchanged automatically for a short-lived token scoped to this server - users never
-												authenticate to it individually, and this server connects per tool call instead of holding a shared connection.
-												Callers must authenticate with their identity provider token; virtual keys alone cannot use this server. Creating
-												the server verifies it as you, using your own signed-in identity.
-											</p>
-											<FormField
+										<div data-testid="token-exchange-fields">
+											<TokenExchangeFields
 												control={control}
-												name="token_exchange.audience"
-												render={({ field }) => (
-													<FormItem>
-														<div className="flex items-center gap-2">
-															<FormLabel>Audience</FormLabel>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			The resource identifier this server is registered as at your identity provider. Exchanged tokens are
-																			scoped to it.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<FormControl>
-															<Input
-																data-testid="token-exchange-audience-input"
-																placeholder="api://my-mcp-server"
-																value={field.value || ""}
-																onChange={(e) => {
-																	field.onChange(e.target.value);
-																	clearErrors("token_exchange.audience");
-																}}
-															/>
-														</FormControl>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-											<FormField
-												control={control}
-												name="token_exchange.client_id"
-												render={({ field }) => (
-													<FormItem>
-														<div className="flex items-center gap-2">
-															<FormLabel>Exchange Client ID</FormLabel>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			A dedicated application at your identity provider with the token exchange (or on-behalf-of) grant
-																			enabled and permission to request this audience. Not the SSO login application.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<SecretVarInput
-															value={field.value}
-															onChange={(value) => {
-																field.onChange(value);
-																clearErrors("token_exchange.client_id");
-															}}
-															placeholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
-															data-testid="token-exchange-client-id-input"
-														/>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-											<FormField
-												control={control}
-												name="token_exchange.client_secret"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel>Exchange Client Secret (optional)</FormLabel>
-														<SecretVarInput
-															value={field.value}
-															onChange={field.onChange}
-															placeholder="env.EXCHANGE_CLIENT_SECRET"
-															maskNonEnvValue
-															data-testid="token-exchange-client-secret-input"
-														/>
-														<p className="text-muted-foreground text-xs">Omit for public clients.</p>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-											<FormField
-												control={control}
-												name="token_exchange.authorization_server_url"
-												render={({ field }) => (
-													<FormItem>
-														<div className="flex items-center gap-2">
-															<FormLabel>Authorization Server URL (optional)</FormLabel>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			Only needed when the audience above is registered on a different authorization server than the one
-																			your SSO login uses - for example, Okta&apos;s per-resource Custom Authorization Servers. Leave blank
-																			to use your SSO login&apos;s issuer, which is correct for most providers.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<FormControl>
-															<Input
-																data-testid="token-exchange-authorization-server-url-input"
-																placeholder="https://your-domain.okta.com/oauth2/your-auth-server-id"
-																value={field.value || ""}
-																onChange={(e) => field.onChange(e.target.value)}
-															/>
-														</FormControl>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-											<div className="space-y-1">
-												<div className="space-y-0.5">
-													<div className="text-sm font-medium">Scopes (optional)</div>
+												beforeFields={
 													<p className="text-muted-foreground text-sm">
-														Comma-separated scopes to request on exchanged tokens. Include <code>offline_access</code> (where your identity
-														provider supports it) so the retained discovery credential can renew itself in the background.
+														Each caller's identity token is exchanged automatically for a short-lived token scoped to this server - users
+														never authenticate to it individually, and this server connects per tool call instead of holding a shared
+														connection. Callers must authenticate with their identity provider token; virtual keys alone cannot use this
+														server. Creating the server verifies it as you, using your own signed-in identity.
 													</p>
-												</div>
-												<Textarea
-													data-testid="token-exchange-scopes-textarea"
-													className="h-20"
-													placeholder="jira.read, jira.write, offline_access"
-													value={tokenExchangeScopesText}
-													onChange={(e) => setTokenExchangeScopesText(e.target.value)}
-												/>
-											</div>
+												}
+												gridClassName="space-y-4"
+												audienceLabel={
+													<>
+														Audience <span className="text-destructive">*</span>
+													</>
+												}
+												audienceTooltip="The resource identifier this server is registered as at your identity provider. Exchanged tokens are scoped to it."
+												audienceTestId="token-exchange-audience-input"
+												onAudienceTouched={() => clearErrors("token_exchange.audience")}
+												clientIdLabel={
+													<>
+														Exchange Client ID <span className="text-destructive">*</span>
+													</>
+												}
+												clientIdTooltip="A dedicated application at your identity provider with the token exchange (or on-behalf-of) grant enabled and permission to request this audience. Not the SSO login application."
+												clientIdPlaceholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
+												clientIdTestId="token-exchange-client-id-input"
+												onClientIdTouched={() => clearErrors("token_exchange.client_id")}
+												clientIdRedactNonEnvValue={false}
+												clientSecretLabel="Exchange Client Secret (optional)"
+												clientSecretPlaceholder="env.EXCHANGE_CLIENT_SECRET"
+												clientSecretHelperText="Omit for public clients."
+												clientSecretTestId="token-exchange-client-secret-input"
+												clientSecretHideValueWhenEnv={false}
+												clientSecretMaskNonEnvValue={true}
+												clientSecretRedactNonEnvValue={false}
+												authServerUrlLabel="Authorization Server URL (optional)"
+												authServerUrlTooltip={
+													<>
+														Only needed when the audience above is registered on a different authorization server than the one your SSO
+														login uses - for example, Okta&apos;s per-resource Custom Authorization Servers. Leave blank to use your SSO
+														login&apos;s issuer, which is correct for most providers.
+													</>
+												}
+												authServerUrlTestId="token-exchange-authorization-server-url-input"
+												scopes={{
+													variant: "textarea",
+													value: tokenExchangeScopesText,
+													onChange: setTokenExchangeScopesText,
+													label: "Scopes (optional)",
+													helperText: (
+														<>
+															Comma-separated scopes to request on exchanged tokens. Include <code>offline_access</code> (where your
+															identity provider supports it) so the retained discovery credential can renew itself in the background.
+														</>
+													),
+													testId: "token-exchange-scopes-textarea",
+												}}
+											/>
 										</div>
 									)}
 
@@ -811,161 +729,33 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 												<AccordionTrigger className="py-0" data-testid="oauth-advanced-trigger">
 													<span className="text-sm font-medium">OAuth Client Advanced Settings</span>
 												</AccordionTrigger>
-												<AccordionContent className="space-y-4 pt-4 pb-0">
-													{/* OAuth Client ID */}
-													<FormField
+												<AccordionContent className="pt-4 pb-0">
+													<OAuthAdvancedFields
 														control={control}
-														name="oauth_config.client_id"
-														render={({ field }) => (
-															<FormItem>
-																<div className="flex items-center gap-2">
-																	<FormLabel>OAuth Client ID (optional)</FormLabel>
-																	<TooltipProvider>
-																		<Tooltip>
-																			<TooltipTrigger asChild>
-																				<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																			</TooltipTrigger>
-																			<TooltipContent className="max-w-xs">
-																				<p>
-																					Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register
-																					with the OAuth provider if supported.
-																				</p>
-																			</TooltipContent>
-																		</Tooltip>
-																	</TooltipProvider>
-																</div>
-																<FormControl>
-																	<SecretVarInput
-																		value={field.value}
-																		onChange={field.onChange}
-																		placeholder="your-client-id (auto-generated if empty)"
-																		data-testid="mcp-oauth-client-id"
-																	/>
-																</FormControl>
-																<p className="text-muted-foreground text-xs">
-																	Will be auto-generated via dynamic registration if left empty and provider supports it
-																</p>
-																<FormMessage />
-															</FormItem>
-														)}
+														scopesRaw={scopesText}
+														onScopesRawChange={setScopesText}
+														scopesLabel="Scopes (optional, comma-separated)"
+														scopesTestId="mcp-oauth-scopes-input"
+														resource={{ mode: "raw", value: resourceText, onChange: setResourceText }}
+														resourceLabel="Resource"
+														resourceTestId="mcp-oauth-resource-input"
+														clientIdLabel="OAuth Client ID (optional)"
+														clientIdPlaceholder="your-client-id (auto-generated if empty)"
+														clientIdHelperText="Will be auto-generated via dynamic registration if left empty and provider supports it"
+														clientIdTooltip="Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with the OAuth provider if supported."
+														clientIdTestId="mcp-oauth-client-id"
+														clientSecretLabel="OAuth Client Secret (optional for PKCE)"
+														clientSecretPlaceholder="your-client-secret"
+														clientSecretHelperText="Leave empty for public clients using PKCE"
+														clientSecretTestId="mcp-oauth-client-secret"
+														authorizeUrlLabel="Authorization URL (optional, auto-discovered)"
+														authorizeUrlTestId="mcp-oauth-authorize-url"
+														tokenUrlLabel="Token URL (optional, auto-discovered)"
+														tokenUrlTestId="mcp-oauth-token-url"
+														registrationUrlLabel="Registration URL (optional, auto-discovered)"
+														registrationUrlTestId="mcp-oauth-registration-url"
+														onFieldTouched={(field) => clearErrors(`oauth_config.${field}`)}
 													/>
-
-													{/* OAuth Client Secret */}
-													<FormField
-														control={control}
-														name="oauth_config.client_secret"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>OAuth Client Secret (optional for PKCE)</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		value={field.value}
-																		onChange={field.onChange}
-																		placeholder="your-client-secret"
-																		hideValueWhenEnv
-																		maskNonEnvValue
-																		data-testid="mcp-oauth-client-secret"
-																	/>
-																</FormControl>
-																<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-
-													{/* OAuth Authorize URL */}
-													<FormField
-														control={control}
-														name="oauth_config.authorize_url"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>Authorization URL (optional, auto-discovered)</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		onChange={(e) => {
-																			field.onChange(e);
-																			clearErrors("oauth_config.authorize_url");
-																		}}
-																		placeholder="https://provider.com/oauth/authorize"
-																		data-testid="mcp-oauth-authorize-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-
-													{/* OAuth Token URL */}
-													<FormField
-														control={control}
-														name="oauth_config.token_url"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>Token URL (optional, auto-discovered)</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		onChange={(e) => {
-																			field.onChange(e);
-																			clearErrors("oauth_config.token_url");
-																		}}
-																		placeholder="https://provider.com/oauth/token"
-																		data-testid="mcp-oauth-token-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-
-													{/* OAuth Registration URL */}
-													<FormField
-														control={control}
-														name="oauth_config.registration_url"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>Registration URL (optional, auto-discovered)</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		onChange={(e) => {
-																			field.onChange(e);
-																			clearErrors("oauth_config.registration_url");
-																		}}
-																		placeholder="https://provider.com/oauth/register"
-																		data-testid="mcp-oauth-registration-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-
-													{/* Scopes (local state, not RHF field) */}
-													<div className="space-y-2">
-														<Label>Scopes (optional, comma-separated)</Label>
-														<Input
-															value={scopesText}
-															onChange={(e) => setScopesText(e.target.value)}
-															placeholder="read, write, admin"
-															data-testid="mcp-oauth-scopes-input"
-														/>
-													</div>
-
-													{/* OAuth Resource Indicator (local state, not RHF field) */}
-													<div className="space-y-2">
-														<Label>Resource</Label>
-														<Input
-															value={resourceText}
-															onChange={(e) => setResourceText(e.target.value)}
-															placeholder="https://provider.example.com/mcp or urn:example:mcp"
-															data-testid="mcp-oauth-resource-input"
-														/>
-													</div>
 												</AccordionContent>
 											</AccordionItem>
 										</Accordion>
@@ -978,54 +768,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 												<span className="text-sm font-medium">TLS / Certificate</span>
 											</AccordionTrigger>
 											<AccordionContent className="space-y-4 pt-4 pb-0">
-												<FormField
-													control={control}
-													name="tls_config.insecure_skip_verify"
-													render={({ field }) => (
-														<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-															<div className="space-y-0.5">
-																<FormLabel>Skip TLS verification</FormLabel>
-																<p className="text-muted-foreground text-sm">
-																	Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
-																	certificate.
-																</p>
-															</div>
-															<FormControl>
-																<Switch
-																	checked={field.value ?? false}
-																	onCheckedChange={field.onChange}
-																	data-testid="mcp-tls-insecure-skip-verify"
-																/>
-															</FormControl>
-														</FormItem>
-													)}
-												/>
-												<FormField
-													control={control}
-													name="tls_config.ca_cert_pem"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-															<FormControl>
-																<SecretVarInput
-																	variant="textarea"
-																	placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
-																	className="font-mono text-xs"
-																	rows={6}
-																	hideValueWhenEnv
-																	redactNonEnvValue
-																	{...field}
-																	value={field.value}
-																	data-testid="mcp-tls-ca-cert-pem"
-																/>
-															</FormControl>
-															<p className="text-muted-foreground text-sm">
-																PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
-															</p>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
+												<TLSConfigFields control={control} />
 											</AccordionContent>
 										</AccordionItem>
 									</Accordion>
@@ -1074,8 +817,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 									{/* Args (local state) */}
 									<div className="space-y-2">
-										<Label>Arguments (comma-separated)</Label>
+										<Label htmlFor="stdio-args-input">Arguments (comma-separated)</Label>
 										<Input
+											id="stdio-args-input"
 											value={argsText}
 											onChange={(e) => setArgsText(e.target.value)}
 											placeholder="--port, 3000, --config, config.json"
@@ -1084,9 +828,9 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 									</div>
 
 									{/* Envs (local state) */}
-									<div className="space-y-2">
+									<div className="space-y-2" role="group" aria-labelledby="stdio-envs-label">
 										<div className="flex items-center gap-2">
-											<Label>Environment Variables</Label>
+											<Label id="stdio-envs-label">Environment Variables</Label>
 											<TooltipProvider>
 												<Tooltip>
 													<TooltipTrigger asChild>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -1,4 +1,3 @@
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -15,14 +14,16 @@ import { Fragment } from "react";
 
 import { SheetNavigationButtons } from "@/components/sheetNavigationButtons";
 import { CodeEditor } from "@/components/ui/codeEditor";
-import { SecretVarInput } from "@/components/ui/secretVarInput";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multiSelect";
+import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { TriStateCheckbox } from "@/components/ui/tristateCheckbox";
@@ -39,7 +40,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ChevronDown, ChevronRight, Info, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { OAuthAdvancedFields } from "./oauthAdvancedFields";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
+import { TLSConfigFields } from "./tlsConfigFields";
+import { TokenExchangeFields } from "./tokenExchangeFields";
 
 interface MCPClientSheetProps {
 	mcpClient: MCPClient;
@@ -94,6 +98,38 @@ function toolExecutionTimeoutToSeconds(v: string | number | undefined | null): n
 	return Math.ceil(total);
 }
 
+/** Consistent title + one-line description used for every subsection across all tabs. */
+function SectionHeader({
+	title,
+	description,
+	testId,
+	action,
+}: {
+	title: string;
+	description: string;
+	testId?: string;
+	/** Optional trailing action (e.g. an "Add X" button) rendered right-aligned on the same row as the title. */
+	action?: React.ReactNode;
+}) {
+	const header = (
+		<div className="space-y-1">
+			<Label className="text-sm font-medium" data-testid={testId}>
+				{title}
+			</Label>
+			<p className="text-muted-foreground text-xs">{description}</p>
+		</div>
+	);
+
+	if (!action) return header;
+
+	return (
+		<div className="flex items-start justify-between gap-4">
+			{header}
+			{action}
+		</div>
+	);
+}
+
 export default function MCPClientSheet({
 	mcpClient,
 	onClose,
@@ -112,6 +148,12 @@ export default function MCPClientSheet({
 	const { toast } = useToast();
 
 	const [pendingNavDirection, setPendingNavDirection] = useState<"prev" | "next" | null>(null);
+	const [selectedTab, setSelectedTab] = useState("general");
+
+	// Land back on the General tab whenever a different client is opened (e.g. via prev/next navigation).
+	useEffect(() => {
+		setSelectedTab("general");
+	}, [mcpClient.config.client_id]);
 
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const globalToolSyncInterval = bifrostConfig?.client_config?.mcp_tool_sync_interval ?? 10;
@@ -597,398 +639,36 @@ export default function MCPClientSheet({
 						</div>
 					</SheetHeader>
 					<Form {...form}>
-						<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col">
-							<div className="gap-6 space-y-6 px-8">
-								{/* Name and Header Section */}
-								<div className="space-y-4">
-									<h3 className="font-semibold">Basic Information</h3>
-									<FormField
-										control={form.control}
-										name="name"
-										render={({ field }) => (
-											<FormItem className="flex flex-col gap-3">
-												<div className="flex items-center gap-2">
-													<FormLabel>Name</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>
-																	Use a descriptive, meaningful name that clearly identifies the server. For example, use "google_drive"
-																	instead of "gdrive", or "hacker_news" instead of "hn". This name is used as the Python module name in code
-																	mode.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<div>
-													<FormControl>
-														<Input placeholder="Client name" {...field} value={field.value || ""} />
-													</FormControl>
-													<FormMessage />
-												</div>
-											</FormItem>
-										)}
-									/>
-									{/* Read-only connection summary. Connection type and target
-								    can't be changed after create — surface them here for
-								    visibility without exposing edit controls. */}
-									<div className="flex flex-col gap-2">
-										<div className="text-sm font-medium">Connection</div>
-										<div className="bg-muted/40 text-muted-foreground rounded-md border px-3 py-2 text-sm">
-											<span className="text-foreground font-mono text-xs uppercase">
-												{mcpClient.config.connection_type === "stdio"
-													? "STDIO"
-													: mcpClient.config.connection_type === "sse"
-														? "SSE"
-														: "HTTP"}
-											</span>
-											<span className="mx-2">·</span>
-											<span className="font-mono break-all">
-												{mcpClient.config.connection_type === "stdio"
-													? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
-													"-"
-													: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
-														? mcpClient.config.connection_string.ref
-														: mcpClient.config.connection_string?.value || "-"}
-											</span>
-										</div>
+						<form onSubmit={form.handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+							<div className="min-h-0 flex-1 overflow-y-auto px-8">
+								<Tabs value={selectedTab} onValueChange={setSelectedTab} className="w-full">
+									<div className="bg-card sticky top-0 z-10 pb-4">
+										<TabsList>
+											<TabsTrigger value="general" data-testid="mcpclient-tab-general">
+												General
+											</TabsTrigger>
+											<TabsTrigger value="authentication" data-testid="mcpclient-tab-authentication">
+												Authentication
+											</TabsTrigger>
+											<TabsTrigger value="tools" data-testid="mcpclient-tab-tools">
+												Tools
+											</TabsTrigger>
+											<TabsTrigger value="access" data-testid="mcpclient-tab-access">
+												Access
+											</TabsTrigger>
+										</TabsList>
 									</div>
-									{mcpClient.config.connection_type === "stdio" &&
-										mcpClient.config.stdio_config?.envs &&
-										mcpClient.config.stdio_config.envs.length > 0 && (
-											<div className="space-y-2">
-												<div className="text-sm font-medium">Environment Variables</div>
-												<HeadersTable
-													value={Object.fromEntries(
-														mcpClient.config.stdio_config.envs.map((env) => {
-															const [name, ...valueParts] = env.split("=");
-															return [name, valueParts.join("=")];
-														}),
-													)}
-													onChange={() => { }}
-													fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
-													valuePlaceholder="—"
-													label=""
-													disabled
-												/>
-											</div>
-										)}
-									<FormField
-										control={form.control}
-										name="is_code_mode_client"
-										render={({ field }) => (
-											<FormItem className="flex items-center justify-between rounded-lg border p-4">
-												<div className="flex items-center gap-2">
-													<FormLabel>Code Mode Server</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<a
-																	href="https://docs.getbifrost.ai/mcp/code-mode"
-																	target="_blank"
-																	rel="noopener noreferrer"
-																	data-testid="code-mode-link-help"
-																	className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
-																	aria-label="Learn more about Code Mode"
-																>
-																	<Info className="h-4 w-4 cursor-help" />
-																</a>
-															</TooltipTrigger>
-															<TooltipContent>
-																<p>Click to learn more about Code Mode</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
 
-												<FormControl>
-													<Switch checked={field.value || false} onCheckedChange={field.onChange} />
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="is_ping_available"
-										render={({ field }) => (
-											<FormItem className="flex items-center justify-between rounded-lg border p-4">
-												<div className="flex items-center gap-2">
-													<FormLabel>Ping Available for Health Check</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>
-																	Enable to use lightweight ping method for health checks. Disable if your MCP server doesn't support ping -
-																	will use listTools instead.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Switch checked={field.value === true} onCheckedChange={field.onChange} />
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="allow_on_all_virtual_keys"
-										render={({ field }) => (
-											<FormItem className="flex items-center justify-between rounded-lg border p-4">
-												<div className="flex items-center gap-2">
-													<FormLabel>Allow on All Virtual Keys</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>
-																	When enabled, this MCP server is accessible to all virtual keys without requiring explicit per-key
-																	assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this server,
-																	that config takes precedence and overrides this behaviour.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Switch
-														checked={field.value === true}
-														onCheckedChange={field.onChange}
-														data-testid="mcpclient-allow-on-all-virtual-keys-switch"
-													/>
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									<FormField
-										control={form.control}
-										name="disabled"
-										render={({ field }) => (
-											<FormItem className="flex items-center justify-between rounded-lg border p-4">
-												<div className="flex items-center gap-2">
-													<FormLabel>Disable Client</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>
-																	When enabled, the client's connection, health monitor, and tool syncer are shut down. Tools from this
-																	client will not be available for inference until it is re-enabled.
-																</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Switch
-														checked={field.value === true}
-														onCheckedChange={(checked) => {
-															field.onChange(checked);
-														}}
-														data-testid="mcpclient-disabled-switch"
-													/>
-												</FormControl>
-											</FormItem>
-										)}
-									/>
-									{(mcpClient.config.connection_type === "http" || mcpClient.config.connection_type === "sse") && (
-										<Accordion type="single" collapsible className="w-full">
-											<AccordionItem value="tls-config" className="border-b-0">
-												<AccordionTrigger className="py-0" data-testid="tls-config-trigger">
-													<span className="text-sm font-medium">TLS / Certificate</span>
-												</AccordionTrigger>
-												<AccordionContent className="space-y-4 pt-4 pb-0">
-													<FormField
-														control={form.control}
-														name="tls_config.insecure_skip_verify"
-														render={({ field }) => (
-															<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-																<div className="space-y-0.5">
-																	<FormLabel>Skip TLS verification</FormLabel>
-																	<p className="text-muted-foreground text-sm">
-																		Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA
-																		certificate.
-																	</p>
-																</div>
-																<FormControl>
-																	<Switch
-																		checked={field.value ?? false}
-																		onCheckedChange={field.onChange}
-																		disabled={!hasUpdateMCPClientAccess}
-																		data-testid="mcp-tls-insecure-skip-verify"
-																	/>
-																</FormControl>
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="tls_config.ca_cert_pem"
-														render={({ field }) => (
-															<FormItem>
-																<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		variant="textarea"
-																		placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
-																		className="font-mono text-xs"
-																		rows={6}
-																		hideValueWhenEnv
-																		redactNonEnvValue
-																		{...field}
-																		value={field.value}
-																		disabled={!hasUpdateMCPClientAccess}
-																		data-testid="mcp-tls-ca-cert-pem"
-																	/>
-																</FormControl>
-																<p className="text-muted-foreground text-sm">
-																	PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
-																</p>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-												</AccordionContent>
-											</AccordionItem>
-										</Accordion>
-									)}
-									<FormField
-										control={form.control}
-										name="tool_sync_interval"
-										render={({ field }) => {
-											const isUsingGlobal = field.value === undefined || field.value === null || field.value === 0;
-											return (
-												<FormItem className="flex items-center justify-between rounded-lg border px-4 py-2">
-													<div className="flex flex-col items-start gap-0.5">
-														<div className="flex items-start gap-2">
-															<div>
-																<FormLabel>Tool Sync Interval (minutes)</FormLabel>
-															</div>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			Override the global tool sync interval for this server. Leave empty to use global setting. Set to -1
-																			to disable sync for this server.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<div>{isUsingGlobal && <p className="text-muted-foreground text-xs">Using global setting</p>}</div>
-													</div>
-													<FormControl>
-														<Input
-															type="number"
-															className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
-															placeholder={String(globalToolSyncInterval)}
-															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
-															onChange={(e) => {
-																const val = e.target.value === "" ? undefined : parseInt(e.target.value);
-																field.onChange(val);
-															}}
-															min="-1"
-														/>
-													</FormControl>
-												</FormItem>
-											);
-										}}
-									/>
-									<FormField
-										control={form.control}
-										name="tool_execution_timeout"
-										render={({ field }) => {
-											const isUsingGlobal = field.value === undefined || field.value === null || field.value === 0;
-											return (
-												<FormItem className="flex items-center justify-between rounded-lg border px-4 py-2">
-													<div className="flex flex-col items-start gap-0.5">
-														<div className="flex items-start gap-2">
-															<div>
-																<FormLabel>Tool Execution Timeout (seconds)</FormLabel>
-															</div>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-xs">
-																		<p>
-																			Override the global tool execution timeout for this server. Leave empty or set to 0 to use the global
-																			setting.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<div>{isUsingGlobal && <p className="text-muted-foreground text-xs">Using global setting</p>}</div>
-													</div>
-													<FormControl>
-														<Input
-															type="number"
-															className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
-															placeholder={String(globalToolExecutionTimeout)}
-															value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
-															onChange={(e) => {
-																if (e.target.value === "") {
-																	field.onChange(undefined);
-																	return;
-																}
-																const n = Number(e.target.value);
-																if (!Number.isInteger(n)) return;
-																field.onChange(n);
-															}}
-															min="0"
-															step="1"
-															data-testid="mcp-tool-execution-timeout"
-														/>
-													</FormControl>
-												</FormItem>
-											);
-										}}
-									/>
-									<FormField
-										control={form.control}
-										name="headers"
-										render={({ field }) => (
-											<FormItem className="flex flex-col gap-3">
-												<FormControl>
-													<HeadersTable
-														value={field.value || {}}
-														onChange={field.onChange}
-														keyPlaceholder="Header name"
-														valuePlaceholder="Header value"
-														label="Headers"
-														useSecretVarInput
-													/>
-												</FormControl>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-									{mcpClient.config.auth_type === "per_user_headers" && (
-										<FormField
-											control={form.control}
-											name="per_user_header_keys"
-											render={({ field }) => (
-												<FormItem className="space-y-1">
-													<div className="space-y-0.5">
+									<TabsContent value="general" className="space-y-6 pb-10">
+										<div className="space-y-4">
+											<SectionHeader title="Basic Information" description="Identify this server and review its connection details." />
+											<FormField
+												control={form.control}
+												name="name"
+												render={({ field }) => (
+													<FormItem className="flex flex-col gap-3">
 														<div className="flex items-center gap-2">
-															<FormLabel>Required Headers</FormLabel>
+															<FormLabel>Name</FormLabel>
 															<TooltipProvider>
 																<Tooltip>
 																	<TooltipTrigger asChild>
@@ -996,673 +676,885 @@ export default function MCPClientSheet({
 																	</TooltipTrigger>
 																	<TooltipContent className="max-w-xs">
 																		<p>
-																			Changing this list marks existing per-user header submissions as needing an update, so callers
-																			resubmit values on next use.
+																			Use a descriptive, meaningful name that clearly identifies the server. For example, use "google_drive"
+																			instead of "gdrive", or "hacker_news" instead of "hn". This name is used as the Python module name in
+																			code mode.
 																		</p>
 																	</TooltipContent>
 																</Tooltip>
 															</TooltipProvider>
 														</div>
-														<p className="text-muted-foreground text-sm">
-															Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
-															<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user, not stored on this server config.
-														</p>
-													</div>
-													<FormControl>
-														<Textarea
-															id="mcpclient-per-user-header-keys"
-															data-testid="mcpclient-per-user-header-keys-textarea"
-															className="h-24"
-															placeholder="X-API-Key, X-Tenant-ID"
-															name={field.name}
-															ref={field.ref}
-															value={perUserHeaderKeysRaw}
-															onChange={(e) => {
-																const value = e.target.value;
-																setPerUserHeaderKeysRaw(value);
-																form.setValue("per_user_header_keys", parseArrayFromText(value), {
-																	shouldDirty: true,
-																	shouldValidate: true,
-																});
-															}}
-															onBlur={field.onBlur}
-														/>
-													</FormControl>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									)}
-									<FormField
-										control={form.control}
-										name="allowed_extra_headers"
-										render={({ field }) => (
-											<FormItem className="flex flex-col gap-2">
-												<div className="flex items-center gap-2">
-													<FormLabel>Allowed Extra Headers</FormLabel>
-													<TooltipProvider>
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-															</TooltipTrigger>
-															<TooltipContent className="max-w-xs">
-																<p>Allowlist of headers that callers can forward to this MCP server at request time.</p>
-															</TooltipContent>
-														</Tooltip>
-													</TooltipProvider>
-												</div>
-												<FormControl>
-													<Input
-														data-testid="mcpclient-input-allowed-extra-headers"
-														placeholder="*, or: authorization, x-user-id"
-														name={field.name}
-														ref={field.ref}
-														value={allowedExtraHeadersRaw}
-														onChange={(e) => {
-															setAllowedExtraHeadersRaw(e.target.value);
-														}}
-														onBlur={() => {
-															const parsed = allowedExtraHeadersRaw.trim()
-																? allowedExtraHeadersRaw
-																	.split(",")
-																	.map((h) => h.trim())
-																	.filter(Boolean)
-																: [];
-															field.onChange(parsed);
-															field.onBlur();
-														}}
-													/>
-												</FormControl>
-												<p className="text-muted-foreground text-xs">
-													Comma-separated header names, or <code>*</code> to allow all. Leave empty to block all extra headers.
-												</p>
-												<FormMessage />
-											</FormItem>
-										)}
-									/>
-								</div>
-								{supportsOAuthCredentialUpdate ? (
-									<Accordion type="single" collapsible className="w-full">
-										<AccordionItem value="oauth-advanced" className="border-b-0">
-											<AccordionTrigger className="py-0" data-testid="oauth-advanced-trigger">
-												<span className="text-sm font-medium">OAuth Client Advanced Settings</span>
-											</AccordionTrigger>
-											<AccordionContent className="space-y-4 pt-4 pb-0">
-												{isDisabled ? (
-													<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-														<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-														<p>OAuth config cannot be rotated while the client is disabled. Re-enable the client to update it.</p>
-													</div>
-												) : (
-													<>
-														<p className="text-muted-foreground text-sm">
-															Connection type, auth type, and connection URL cannot be changed. Leave any field empty to keep its stored
-															value.
-														</p>
-														{oauthCredentialsDirty && (
-															<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-																<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-																<p>
-																	Changing any OAuth config field immediately signs out every current session on this MCP client, shared and
-																	per-user alike. Everyone will need to re-authenticate.
-																</p>
-															</div>
-														)}
-													</>
-												)}
-												<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-													<FormField
-														control={form.control}
-														name="oauth_config.client_id"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Client ID</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		data-testid="mcpclient-input-oauth-client-id"
-																		placeholder="Enter new OAuth client ID"
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		value={field.value}
-																		onChange={field.onChange}
-																	/>
-																</FormControl>
-																{!isDisabled && (
-																	<p className="text-muted-foreground text-xs">Leave empty to keep existing credentials unchanged.</p>
-																)}
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="oauth_config.client_secret"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Client Secret</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		data-testid="mcpclient-input-oauth-client-secret"
-																		placeholder="Enter new OAuth client secret"
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		hideValueWhenEnv
-																		maskNonEnvValue
-																		value={field.value}
-																		onChange={field.onChange}
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="oauth_config.authorize_url"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Authorization URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		placeholder="https://provider.com/oauth/authorize"
-																		data-testid="mcpclient-input-oauth-authorize-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="oauth_config.token_url"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Token URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		placeholder="https://provider.com/oauth/token"
-																		data-testid="mcpclient-input-oauth-token-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="oauth_config.registration_url"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Registration URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		placeholder="https://provider.com/oauth/register"
-																		data-testid="mcpclient-input-oauth-registration-url"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormItem className="flex flex-col gap-2">
-														<FormLabel>Scopes</FormLabel>
-														<FormControl>
-															<Input
-																value={oauthScopesRaw}
-																disabled={isDisabled || !hasUpdateMCPClientAccess}
-																onChange={(e) => setOauthScopesRaw(e.target.value)}
-																placeholder="read, write, admin"
-																data-testid="mcpclient-input-oauth-scopes"
-															/>
-														</FormControl>
-														<p className="text-muted-foreground text-xs">Comma-separated.</p>
+														<div>
+															<FormControl>
+																<Input placeholder="Client name" {...field} value={field.value || ""} />
+															</FormControl>
+															<FormMessage />
+														</div>
 													</FormItem>
-													<FormField
-														control={form.control}
-														name="oauth_config.resource"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Resource</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={isDisabled || !hasUpdateMCPClientAccess}
-																		placeholder="https://provider.example.com/mcp or urn:example:mcp"
-																		data-testid="mcpclient-input-oauth-resource"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-												</div>
-											</AccordionContent>
-										</AccordionItem>
-									</Accordion>
-								) : null}
-								{supportsTokenExchangeCredentialUpdate ? (
-									<Accordion type="single" collapsible className="w-full">
-										<AccordionItem value="token-exchange-advanced" className="border-b-0">
-											<AccordionTrigger className="py-0" data-testid="token-exchange-advanced-trigger">
-												<span className="text-sm font-medium">Token Exchange Advanced Settings</span>
-											</AccordionTrigger>
-											<AccordionContent className="space-y-4 pt-4 pb-0">
-												<p className="text-muted-foreground text-sm">
-													Connection type and auth type cannot be changed. Every field here is resent on save, so update the ones you mean
-													to change and leave the rest as shown.
-												</p>
-												{tokenExchangeCredentialsDirty && (
-													<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-														<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-														<p>
-															Changing any token exchange field immediately evicts every cached exchanged token for this server. The next
-															tool call for each caller re-exchanges a fresh token.
-														</p>
-													</div>
 												)}
-												<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-													<FormField
-														control={form.control}
-														name="token_exchange.audience"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Audience</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={!hasUpdateMCPClientAccess}
-																		placeholder="api://my-mcp-server"
-																		data-testid="mcpclient-input-token-exchange-audience"
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="token_exchange.client_id"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Exchange Client ID</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		data-testid="mcpclient-input-token-exchange-client-id"
-																		placeholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
-																		disabled={!hasUpdateMCPClientAccess}
-																		redactNonEnvValue
-																		value={field.value}
-																		onChange={field.onChange}
-																	/>
-																</FormControl>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="token_exchange.client_secret"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Exchange Client Secret</FormLabel>
-																<FormControl>
-																	<SecretVarInput
-																		data-testid="mcpclient-input-token-exchange-client-secret"
-																		placeholder="env.EXCHANGE_CLIENT_SECRET"
-																		disabled={!hasUpdateMCPClientAccess}
-																		hideValueWhenEnv
-																		redactNonEnvValue
-																		value={field.value}
-																		onChange={field.onChange}
-																	/>
-																</FormControl>
-																<p className="text-muted-foreground text-xs">Omit for public clients.</p>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormField
-														control={form.control}
-														name="token_exchange.authorization_server_url"
-														render={({ field }) => (
-															<FormItem className="flex flex-col gap-2">
-																<FormLabel>Authorization Server URL</FormLabel>
-																<FormControl>
-																	<Input
-																		{...field}
-																		value={field.value ?? ""}
-																		disabled={!hasUpdateMCPClientAccess}
-																		placeholder="https://your-domain.okta.com/oauth2/your-auth-server-id"
-																		data-testid="mcpclient-input-token-exchange-authorization-server-url"
-																	/>
-																</FormControl>
-																<p className="text-muted-foreground text-xs">
-																	Leave blank to use the deployment's SSO login issuer.
-																</p>
-																<FormMessage />
-															</FormItem>
-														)}
-													/>
-													<FormItem className="flex flex-col gap-2">
-														<FormLabel>Scopes</FormLabel>
-														<FormControl>
-															<Input
-																value={tokenExchangeScopesRaw}
-																disabled={!hasUpdateMCPClientAccess}
-																onChange={(e) => setTokenExchangeScopesRaw(e.target.value)}
-																placeholder="jira.read, jira.write, offline_access"
-																data-testid="mcpclient-input-token-exchange-scopes"
-															/>
-														</FormControl>
-														<p className="text-muted-foreground text-xs">Comma-separated.</p>
-													</FormItem>
+											/>
+											{/* Read-only connection summary. Connection type and target
+										    can't be changed after create — surface them here for
+										    visibility without exposing edit controls. */}
+											<div className="flex flex-col gap-2">
+												<div className="text-sm font-medium">Connection</div>
+												<div className="bg-muted/40 text-muted-foreground rounded-md border px-3 py-2 text-sm">
+													<span className="text-foreground font-mono text-xs uppercase">
+														{mcpClient.config.connection_type === "stdio"
+															? "STDIO"
+															: mcpClient.config.connection_type === "sse"
+																? "SSE"
+																: "HTTP"}
+													</span>
+													<span className="mx-2">·</span>
+													<span className="font-mono break-all">
+														{mcpClient.config.connection_type === "stdio"
+															? `${mcpClient.config.stdio_config?.command ?? ""} ${(mcpClient.config.stdio_config?.args ?? []).join(" ")}`.trim() ||
+															"-"
+															: mcpClient.config.connection_string?.type === "env" || mcpClient.config.connection_string?.type === "vault"
+																? mcpClient.config.connection_string.ref
+																: mcpClient.config.connection_string?.value || "-"}
+													</span>
 												</div>
-											</AccordionContent>
-										</AccordionItem>
-									</Accordion>
-								) : null}
-								{/* Tools Section */}
-								<div className="space-y-4 pb-10">
-									<div className="flex items-center justify-between">
-										<h3 className="font-semibold">Available Tools ({mcpClient.tools?.length || 0})</h3>
-										{mcpClient.tools && mcpClient.tools.length > 0 && (
-											<div className="flex items-center gap-4">
-												{/* Enable All */}
-												<FormField
-													control={form.control}
-													name="tools_to_execute"
-													render={() => {
-														const currentTools = form.watch("tools_to_execute") || [];
-														const allToolNames = mcpClient.tools?.map((tool) => tool.name) || [];
-														const isAllEnabled = currentTools.includes("*");
-														const isNoneEnabled = currentTools.length === 0;
-														const selectedIds = isAllEnabled ? allToolNames : currentTools;
-
-														return (
-															<FormItem>
-																<FormControl>
-																	<div className="flex items-center gap-2">
-																		<span className="text-muted-foreground text-sm">
-																			{isAllEnabled ? "All enabled" : isNoneEnabled ? "None enabled" : `${currentTools.length} enabled`}
-																		</span>
-																		<TriStateCheckbox
-																			allIds={allToolNames}
-																			selectedIds={selectedIds}
-																			onChange={(nextSelectedIds) => {
-																				if (nextSelectedIds.length === 0) {
-																					form.setValue("tools_to_execute", [], { shouldDirty: true });
-																					// Also clear auto-execute when disabling all
-																					form.setValue("tools_to_auto_execute", [], { shouldDirty: true });
-																				} else if (nextSelectedIds.length === allToolNames.length) {
-																					form.setValue("tools_to_execute", ["*"], { shouldDirty: true });
-																				} else {
-																					form.setValue("tools_to_execute", nextSelectedIds, { shouldDirty: true });
-																				}
-																			}}
-																		/>
-																	</div>
-																</FormControl>
-															</FormItem>
-														);
-													}}
-												/>
-												{/* Auto-execute All */}
-												<FormField
-													control={form.control}
-													name="tools_to_auto_execute"
-													render={() => {
-														const currentTools = form.watch("tools_to_execute") || [];
-														const currentAutoExecute = form.watch("tools_to_auto_execute") || [];
-														const allToolNames = mcpClient.tools?.map((tool) => tool.name) || [];
-
-														// Get the list of enabled tools
-														const enabledToolNames = currentTools.includes("*") ? allToolNames : currentTools;
-														const isAllAutoExecute = currentAutoExecute.includes("*");
-														const isNoneAutoExecute = currentAutoExecute.length === 0;
-
-														// For TriStateCheckbox, we need the selected auto-execute tools that are also enabled
-														const selectedAutoExecuteIds = isAllAutoExecute
-															? enabledToolNames
-															: currentAutoExecute.filter((t) => enabledToolNames.includes(t));
-
-														const autoExecuteCount = isAllAutoExecute ? enabledToolNames.length : selectedAutoExecuteIds.length;
-
-														return (
-															<FormItem>
-																<FormControl>
-																	<div className="flex items-center gap-2">
-																		<span className="text-muted-foreground text-sm">
-																			{isAllAutoExecute
-																				? "All auto-execute"
-																				: isNoneAutoExecute
-																					? "None auto-execute"
-																					: `${autoExecuteCount} auto-execute`}
-																		</span>
-																		<TriStateCheckbox
-																			allIds={enabledToolNames}
-																			selectedIds={selectedAutoExecuteIds}
-																			disabled={enabledToolNames.length === 0}
-																			onChange={(nextSelectedIds) => {
-																				if (nextSelectedIds.length === 0) {
-																					form.setValue("tools_to_auto_execute", [], { shouldDirty: true });
-																				} else if (nextSelectedIds.length === enabledToolNames.length) {
-																					form.setValue("tools_to_auto_execute", ["*"], { shouldDirty: true });
-																				} else {
-																					form.setValue("tools_to_auto_execute", nextSelectedIds, { shouldDirty: true });
-																				}
-																			}}
-																		/>
-																	</div>
-																</FormControl>
-															</FormItem>
-														);
-													}}
-												/>
 											</div>
-										)}
-									</div>
+											{mcpClient.config.connection_type === "stdio" &&
+												mcpClient.config.stdio_config?.envs &&
+												mcpClient.config.stdio_config.envs.length > 0 && (
+													<div className="space-y-2">
+														<div className="text-sm font-medium">Environment Variables</div>
+														<HeadersTable
+															value={Object.fromEntries(
+																mcpClient.config.stdio_config.envs.map((env) => {
+																	const [name, ...valueParts] = env.split("=");
+																	return [name, valueParts.join("=")];
+																}),
+															)}
+															onChange={() => { }}
+															fixedKeys={mcpClient.config.stdio_config.envs.map((env) => env.split("=")[0])}
+															valuePlaceholder="—"
+															label=""
+															disabled
+														/>
+													</div>
+												)}
+										</div>
 
-									{mcpClient.tools && mcpClient.tools.length > 0 ? (
-										<div className="rounded-md border">
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead className="w-10"></TableHead>
-														<TableHead className="max-w-[300px]">Tool Name</TableHead>
-														<TableHead className="w-24 text-center">Enabled</TableHead>
-														<TableHead className="w-28 text-center">
-															<div className="flex items-center justify-center gap-1.5">
-																<span>Auto-execute</span>
+										<DottedSeparator />
+
+										<div className="space-y-4">
+											<SectionHeader
+												title="Server Behavior"
+												description="Control how this server participates in code mode and health checks."
+											/>
+											<div className="divide-y rounded-md border">
+												<FormField
+													control={form.control}
+													name="is_code_mode_client"
+													render={({ field }) => (
+														<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+															<div className="flex items-center gap-2">
+																<FormLabel>Code Mode Server</FormLabel>
 																<TooltipProvider>
 																	<Tooltip>
 																		<TooltipTrigger asChild>
 																			<a
-																				href="https://docs.getbifrost.ai/mcp/agent-mode"
+																				href="https://docs.getbifrost.ai/mcp/code-mode"
 																				target="_blank"
 																				rel="noopener noreferrer"
-																				aria-label="Learn more about Auto-execute and Agent Mode"
-																				className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex rounded focus-visible:ring-2 focus-visible:outline-none"
+																				data-testid="code-mode-link-help"
+																				className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
+																				aria-label="Learn more about Code Mode"
 																			>
-																				<Info className="h-3.5 w-3.5 cursor-help" />
+																				<Info className="h-4 w-4 cursor-help" />
 																			</a>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			<p>Click to learn more about Code Mode</p>
+																		</TooltipContent>
+																	</Tooltip>
+																</TooltipProvider>
+															</div>
+															<FormControl>
+																<Switch checked={field.value || false} onCheckedChange={field.onChange} />
+															</FormControl>
+														</FormItem>
+													)}
+												/>
+												<FormField
+													control={form.control}
+													name="is_ping_available"
+													render={({ field }) => (
+														<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+															<div className="flex items-center gap-2">
+																<FormLabel>Ping Available for Health Check</FormLabel>
+																<TooltipProvider>
+																	<Tooltip>
+																		<TooltipTrigger asChild>
+																			<Info className="text-muted-foreground h-4 w-4 cursor-help" />
 																		</TooltipTrigger>
 																		<TooltipContent className="max-w-xs">
 																			<p>
-																				Applies only when Bifrost runs the LLM loop in Agent Mode. In MCP Gateway mode, the connected client
-																				(Claude Desktop, Cursor, etc.) controls tool approval and this setting is ignored. Click to learn
-																				more.
+																				Enable to use lightweight ping method for health checks. Disable if your MCP server doesn't support
+																				ping - will use listTools instead.
 																			</p>
 																		</TooltipContent>
 																	</Tooltip>
 																</TooltipProvider>
 															</div>
-														</TableHead>
-														<TableHead className="w-32 text-center">Cost (USD)</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{mcpClient.tools.map((tool, index) => {
-														const currentTools = form.watch("tools_to_execute") || [];
-														const currentAutoExecute = form.watch("tools_to_auto_execute") || [];
-														const isToolEnabled = currentTools?.includes("*") || currentTools?.includes(tool.name);
-														const isAutoExecuteEnabled =
-															(currentAutoExecute?.includes("*") && isToolEnabled) ||
-															(currentAutoExecute?.includes(tool.name) && isToolEnabled);
-														const isExpanded = expandedTools.has(tool.name);
+															<FormControl>
+																<Switch checked={field.value === true} onCheckedChange={field.onChange} />
+															</FormControl>
+														</FormItem>
+													)}
+												/>
+											</div>
+										</div>
 
+										<DottedSeparator />
+
+										<div className="space-y-4">
+											<SectionHeader
+												title="Sync & Timeouts"
+												description="Override the global tool sync interval and execution timeout for this server."
+											/>
+											<div className="divide-y rounded-md border">
+												<FormField
+													control={form.control}
+													name="tool_sync_interval"
+													render={({ field }) => {
+														const isUsingGlobal = field.value === undefined || field.value === null || field.value === 0;
 														return (
-															<Fragment key={index}>
-																<TableRow className="group">
-																	<TableCell className="p-2">
-																		<button
-																			type="button"
-																			className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-md transition-colors"
-																			onClick={() => toggleToolExpanded(tool.name)}
-																		>
-																			{isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-																		</button>
-																	</TableCell>
-																	<TableCell className="max-w-[300px]">
-																		<div className="min-w-0">
-																			<div className="text-foreground truncate text-sm font-medium">{tool.name}</div>
-																			{tool.description && (
-																				<p className="text-muted-foreground mt-0.5 truncate text-xs">{tool.description}</p>
-																			)}
+															<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+																<div className="flex flex-col items-start gap-0.5">
+																	<div className="flex items-start gap-2">
+																		<div>
+																			<FormLabel>Tool Sync Interval (minutes)</FormLabel>
 																		</div>
-																	</TableCell>
-																	<TableCell className="text-center">
-																		<FormField
-																			control={form.control}
-																			name="tools_to_execute"
-																			render={() => (
-																				<FormItem>
-																					<FormControl>
-																						<Switch
-																							size="md"
-																							checked={isToolEnabled}
-																							onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
-																						/>
-																					</FormControl>
-																				</FormItem>
-																			)}
-																		/>
-																	</TableCell>
-																	<TableCell className="text-center">
-																		<FormField
-																			control={form.control}
-																			name="tools_to_auto_execute"
-																			render={() => (
-																				<FormItem>
-																					<FormControl>
-																						<Switch
-																							size="md"
-																							checked={isAutoExecuteEnabled}
-																							disabled={!isToolEnabled}
-																							onCheckedChange={(checked) => handleAutoExecuteToggle(tool.name, checked)}
-																						/>
-																					</FormControl>
-																				</FormItem>
-																			)}
-																		/>
-																	</TableCell>
-																	<TableCell className="text-center">
-																		<FormField
-																			control={form.control}
-																			name="tool_pricing"
-																			render={({ field }) => (
-																				<FormItem>
-																					<FormControl>
-																						<Input
-																							type="number"
-																							step="0.000001"
-																							min="0"
-																							placeholder="0.00"
-																							className="h-8 w-24"
-																							disabled={!isToolEnabled}
-																							value={field.value?.[tool.name] ?? ""}
-																							onChange={(e) => {
-																								const value = e.target.value === "" ? undefined : parseFloat(e.target.value);
-																								const newPricing = { ...field.value };
-																								if (value === undefined || isNaN(value)) {
-																									delete newPricing[tool.name];
-																								} else {
-																									newPricing[tool.name] = value;
-																								}
-																								field.onChange(newPricing);
-																							}}
-																						/>
-																					</FormControl>
-																				</FormItem>
-																			)}
-																		/>
-																	</TableCell>
-																</TableRow>
-																{isExpanded && (
-																	<tr>
-																		<td colSpan={5} className="p-0">
-																			<div className="bg-muted/30 border-b px-4 py-3">
-																				<div className="text-muted-foreground mb-2 text-xs font-medium">Parameters Schema</div>
-																				{tool.parameters ? (
-																					<CodeEditor
-																						className="z-0 w-full rounded-sm border"
-																						shouldAdjustInitialHeight={true}
-																						maxHeight={300}
-																						wrap={true}
-																						code={JSON.stringify(tool.parameters, null, 2)}
-																						lang="json"
-																						readonly={true}
-																						options={{
-																							scrollBeyondLastLine: false,
-																							collapsibleBlocks: true,
-																							lineNumbers: "off",
-																							alwaysConsumeMouseWheel: false,
-																						}}
-																					/>
-																				) : (
-																					<div className="text-muted-foreground text-sm">No parameters defined</div>
-																				)}
-																			</div>
-																		</td>
-																	</tr>
-																)}
-															</Fragment>
+																		<TooltipProvider>
+																			<Tooltip>
+																				<TooltipTrigger asChild>
+																					<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																				</TooltipTrigger>
+																				<TooltipContent className="max-w-xs">
+																					<p>
+																						Override the global tool sync interval for this server. Leave empty to use global setting. Set
+																						to -1 to disable sync for this server.
+																					</p>
+																				</TooltipContent>
+																			</Tooltip>
+																		</TooltipProvider>
+																	</div>
+																	<div>{isUsingGlobal && <p className="text-muted-foreground text-xs">Using global setting</p>}</div>
+																</div>
+																<FormControl>
+																	<Input
+																		type="number"
+																		className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
+																		placeholder={String(globalToolSyncInterval)}
+																		value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
+																		onChange={(e) => {
+																			const val = e.target.value === "" ? undefined : parseInt(e.target.value);
+																			field.onChange(val);
+																		}}
+																		min="-1"
+																	/>
+																</FormControl>
+															</FormItem>
 														);
-													})}
-												</TableBody>
-											</Table>
+													}}
+												/>
+												<FormField
+													control={form.control}
+													name="tool_execution_timeout"
+													render={({ field }) => {
+														const isUsingGlobal = field.value === undefined || field.value === null || field.value === 0;
+														return (
+															<FormItem className="flex flex-row items-center justify-between gap-4 px-4 py-3">
+																<div className="flex flex-col items-start gap-0.5">
+																	<div className="flex items-start gap-2">
+																		<div>
+																			<FormLabel>Tool Execution Timeout (seconds)</FormLabel>
+																		</div>
+																		<TooltipProvider>
+																			<Tooltip>
+																				<TooltipTrigger asChild>
+																					<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																				</TooltipTrigger>
+																				<TooltipContent className="max-w-xs">
+																					<p>
+																						Override the global tool execution timeout for this server. Leave empty or set to 0 to use the
+																						global setting.
+																					</p>
+																				</TooltipContent>
+																			</Tooltip>
+																		</TooltipProvider>
+																	</div>
+																	<div>{isUsingGlobal && <p className="text-muted-foreground text-xs">Using global setting</p>}</div>
+																</div>
+																<FormControl>
+																	<Input
+																		type="number"
+																		className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
+																		placeholder={String(globalToolExecutionTimeout)}
+																		value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
+																		onChange={(e) => {
+																			if (e.target.value === "") {
+																				field.onChange(undefined);
+																				return;
+																			}
+																			const n = Number(e.target.value);
+																			if (!Number.isInteger(n)) return;
+																			field.onChange(n);
+																		}}
+																		min="0"
+																		step="1"
+																		data-testid="mcp-tool-execution-timeout"
+																	/>
+																</FormControl>
+															</FormItem>
+														);
+													}}
+												/>
+											</div>
 										</div>
-									) : (
-										<div className="text-muted-foreground rounded-sm border p-6 text-center">
-											<p className="text-sm">No tools available</p>
-										</div>
-									)}
 
-									{mcpClient.tools && mcpClient.tools.length > 0 && (
-										<div className="mt-6 space-y-4">
-											<div className="flex flex-col gap-2">
-												<div className="flex items-center justify-between">
+										<DottedSeparator />
+
+										<FormField
+											control={form.control}
+											name="disabled"
+											render={({ field }) => (
+												<FormItem className="border-destructive/30 bg-destructive/5 flex flex-row items-center justify-between gap-4 rounded-md border p-4">
 													<div className="flex items-center gap-2">
-														<div className="text-md font-semibold">Virtual Key Access</div>
+														<FormLabel>Disable Client</FormLabel>
 														<TooltipProvider>
 															<Tooltip>
 																<TooltipTrigger asChild>
 																	<Info className="text-muted-foreground h-4 w-4 cursor-help" />
 																</TooltipTrigger>
 																<TooltipContent className="max-w-xs">
-																	<p>Control which virtual keys can use this MCP server and which specific tools they can call.</p>
+																	<p>
+																		When enabled, the client's connection, health monitor, and tool syncer are shut down. Tools from this
+																		client will not be available for inference until it is re-enabled.
+																	</p>
 																</TooltipContent>
 															</Tooltip>
 														</TooltipProvider>
 													</div>
+													<FormControl>
+														<Switch
+															checked={field.value === true}
+															onCheckedChange={(checked) => {
+																field.onChange(checked);
+															}}
+															data-testid="mcpclient-disabled-switch"
+														/>
+													</FormControl>
+												</FormItem>
+											)}
+										/>
+									</TabsContent>
+
+									<TabsContent value="authentication" className="space-y-6 pb-10">
+										<div className="space-y-4">
+											<SectionHeader
+												title="Headers"
+												description="Static headers and header-based access rules sent with every request to this server."
+											/>
+											<FormField
+												control={form.control}
+												name="headers"
+												render={({ field }) => (
+													<FormItem className="flex flex-col gap-3">
+														<FormControl>
+															<HeadersTable
+																value={field.value || {}}
+																onChange={field.onChange}
+																keyPlaceholder="Header name"
+																valuePlaceholder="Header value"
+																label=""
+																useSecretVarInput
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											{mcpClient.config.auth_type === "per_user_headers" && (
+												<FormField
+													control={form.control}
+													name="per_user_header_keys"
+													render={({ field }) => (
+														<FormItem className="space-y-1">
+															<div className="space-y-0.5">
+																<div className="flex items-center gap-2">
+																	<FormLabel>Required Headers</FormLabel>
+																	<TooltipProvider>
+																		<Tooltip>
+																			<TooltipTrigger asChild>
+																				<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																			</TooltipTrigger>
+																			<TooltipContent className="max-w-xs">
+																				<p>
+																					Changing this list marks existing per-user header submissions as needing an update, so callers
+																					resubmit values on next use.
+																				</p>
+																			</TooltipContent>
+																		</Tooltip>
+																	</TooltipProvider>
+																</div>
+																<p className="text-muted-foreground text-sm">
+																	Comma-separated list of header names each caller must supply when they first use this server (e.g.{" "}
+																	<code>X-API-Key, X-Tenant-ID</code>). Values are submitted per user, not stored on this server config.
+																</p>
+															</div>
+															<FormControl>
+																<Textarea
+																	id="mcpclient-per-user-header-keys"
+																	data-testid="mcpclient-per-user-header-keys-textarea"
+																	className="h-24"
+																	placeholder="X-API-Key, X-Tenant-ID"
+																	name={field.name}
+																	ref={field.ref}
+																	value={perUserHeaderKeysRaw}
+																	onChange={(e) => {
+																		const value = e.target.value;
+																		setPerUserHeaderKeysRaw(value);
+																		form.setValue("per_user_header_keys", parseArrayFromText(value), {
+																			shouldDirty: true,
+																			shouldValidate: true,
+																		});
+																	}}
+																	onBlur={field.onBlur}
+																/>
+															</FormControl>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											)}
+											<SectionHeader
+												title="Allowed Extra Headers"
+												description="Comma-separated dynamic request header names, or * to allow all. Leave empty to block all extra headers."
+											/>
+											<FormField
+												control={form.control}
+												name="allowed_extra_headers"
+												render={({ field }) => (
+													<FormItem className="flex flex-col gap-2">
+														<FormControl>
+															<Input
+																data-testid="mcpclient-input-allowed-extra-headers"
+																placeholder="*, or: authorization, x-user-id"
+																name={field.name}
+																ref={field.ref}
+																value={allowedExtraHeadersRaw}
+																onChange={(e) => {
+																	setAllowedExtraHeadersRaw(e.target.value);
+																}}
+																onBlur={() => {
+																	const parsed = allowedExtraHeadersRaw.trim()
+																		? allowedExtraHeadersRaw
+																			.split(",")
+																			.map((h) => h.trim())
+																			.filter(Boolean)
+																		: [];
+																	field.onChange(parsed);
+																	field.onBlur();
+																}}
+															/>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</div>
+
+										{(() => {
+											const showTLS = mcpClient.config.connection_type === "http" || mcpClient.config.connection_type === "sse";
+											const showOAuth = supportsOAuthCredentialUpdate;
+											const showTokenExchange = supportsTokenExchangeCredentialUpdate;
+											if (!showTLS && !showOAuth && !showTokenExchange) return null;
+
+											return (
+												<>
+													{showTLS && (
+														<>
+															<DottedSeparator />
+															<div className="space-y-4">
+																<SectionHeader
+																	title="TLS / Certificate"
+																	description="Configure certificate verification for HTTPS connections to this server."
+																	testId="tls-config-heading"
+																/>
+																<div className="space-y-4 rounded-md border p-4">
+																	<TLSConfigFields control={form.control} disabled={!hasUpdateMCPClientAccess} />
+																</div>
+															</div>
+														</>
+													)}
+
+													{showOAuth && (
+														<>
+															<DottedSeparator />
+															<div className="space-y-4">
+																<SectionHeader
+																	title="OAuth Configuration"
+																	description="Credentials and endpoints this server uses to authenticate via OAuth."
+																	testId="oauth-advanced-heading"
+																/>
+																<div className="space-y-4 rounded-md border p-4">
+																	<OAuthAdvancedFields
+																		control={form.control}
+																		disabled={isDisabled || !hasUpdateMCPClientAccess}
+																		beforeFields={
+																			isDisabled ? (
+																				<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+																					<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+																					<p>
+																						OAuth config cannot be rotated while the client is disabled. Re-enable the client to update it.
+																					</p>
+																				</div>
+																			) : (
+																				oauthCredentialsDirty && (
+																					<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+																						<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+																						<p>
+																							Changing any OAuth config field immediately signs out every current session on this MCP
+																							client, shared and per-user alike. Everyone will need to re-authenticate.
+																						</p>
+																					</div>
+																				)
+																			)
+																		}
+																		scopesRaw={oauthScopesRaw}
+																		onScopesRawChange={setOauthScopesRaw}
+																		scopesLabel="Scopes"
+																		scopesTestId="mcpclient-input-oauth-scopes"
+																		resource={{ mode: "field" }}
+																		resourceLabel="Resource"
+																		resourceTestId="mcpclient-input-oauth-resource"
+																		clientIdLabel="Client ID"
+																		clientIdPlaceholder="Enter new OAuth client ID"
+																		clientIdHelperText={!isDisabled ? "Leave empty to keep existing credentials unchanged." : undefined}
+																		clientIdTestId="mcpclient-input-oauth-client-id"
+																		clientSecretLabel="Client Secret"
+																		clientSecretPlaceholder="Enter new OAuth client secret"
+																		clientSecretTestId="mcpclient-input-oauth-client-secret"
+																		authorizeUrlLabel="Authorization URL"
+																		authorizeUrlTestId="mcpclient-input-oauth-authorize-url"
+																		tokenUrlLabel="Token URL"
+																		tokenUrlTestId="mcpclient-input-oauth-token-url"
+																		registrationUrlLabel="Registration URL"
+																		registrationUrlTestId="mcpclient-input-oauth-registration-url"
+																	/>
+																</div>
+															</div>
+														</>
+													)}
+
+													{showTokenExchange && (
+														<>
+															<DottedSeparator />
+															<div className="space-y-4">
+																<SectionHeader
+																	title="Token Exchange Configuration"
+																	description="Credentials and scopes used to exchange caller identity tokens for access to this server."
+																	testId="token-exchange-advanced-heading"
+																/>
+																<div className="space-y-4 rounded-md border p-4">
+																	<TokenExchangeFields
+																		control={form.control}
+																		disabled={!hasUpdateMCPClientAccess}
+																		beforeFields={
+																			tokenExchangeCredentialsDirty && (
+																				<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+																					<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+																					<p>
+																						Changing any token exchange field immediately evicts every cached exchanged token for this
+																						server. The next tool call for each caller re-exchanges a fresh token.
+																					</p>
+																				</div>
+																			)
+																		}
+																		audienceLabel="Audience"
+																		audienceTestId="mcpclient-input-token-exchange-audience"
+																		clientIdLabel="Exchange Client ID"
+																		clientIdPlaceholder="bifrost-exchange or env.EXCHANGE_CLIENT_ID"
+																		clientIdTestId="mcpclient-input-token-exchange-client-id"
+																		clientIdRedactNonEnvValue={false}
+																		clientSecretLabel="Exchange Client Secret"
+																		clientSecretPlaceholder="env.EXCHANGE_CLIENT_SECRET"
+																		clientSecretHelperText="Omit for public clients."
+																		clientSecretTestId="mcpclient-input-token-exchange-client-secret"
+																		clientSecretMaskNonEnvValue={true}
+																		clientSecretRedactNonEnvValue={false}
+																		authServerUrlLabel="Authorization Server URL"
+																		authServerUrlHelperText="Leave blank to use the deployment's SSO login issuer."
+																		authServerUrlTestId="mcpclient-input-token-exchange-authorization-server-url"
+																		scopes={{
+																			variant: "input",
+																			value: tokenExchangeScopesRaw,
+																			onChange: setTokenExchangeScopesRaw,
+																			label: "Scopes",
+																			helperText: "Comma-separated.",
+																			testId: "mcpclient-input-token-exchange-scopes",
+																			disabled: !hasUpdateMCPClientAccess,
+																		}}
+																	/>
+																</div>
+															</div>
+														</>
+													)}
+												</>
+											);
+										})()}
+									</TabsContent>
+
+									<TabsContent value="tools" className="space-y-6 pb-10">
+										<div className="space-y-4">
+											<div className="flex items-start justify-between gap-4">
+												<SectionHeader
+													title={`Available Tools (${mcpClient.tools?.length || 0})`}
+													description="Enable, auto-execute, and price individual tools exposed by this server."
+												/>
+												{mcpClient.tools && mcpClient.tools.length > 0 && (
+													<div className="flex items-center gap-4">
+														{/* Enable All */}
+														<FormField
+															control={form.control}
+															name="tools_to_execute"
+															render={() => {
+																const currentTools = form.watch("tools_to_execute") || [];
+																const allToolNames = mcpClient.tools?.map((tool) => tool.name) || [];
+																const isAllEnabled = currentTools.includes("*");
+																const isNoneEnabled = currentTools.length === 0;
+																const selectedIds = isAllEnabled ? allToolNames : currentTools;
+																const statusLabel = isAllEnabled
+																	? "All enabled"
+																	: isNoneEnabled
+																		? "None enabled"
+																		: `${currentTools.length} enabled`;
+
+																return (
+																	<FormItem>
+																		<FormControl>
+																			<div className="flex items-center gap-2">
+																				<span id="mcpclient-tools-enable-status" className="text-muted-foreground text-sm">
+																					{statusLabel}
+																				</span>
+																				<TriStateCheckbox
+																					allIds={allToolNames}
+																					selectedIds={selectedIds}
+																					ariaLabel={`Enable all tools (${statusLabel})`}
+																					data-testid="mcpclient-tools-enable-all"
+																					onChange={(nextSelectedIds) => {
+																						if (nextSelectedIds.length === 0) {
+																							form.setValue("tools_to_execute", [], { shouldDirty: true });
+																							// Also clear auto-execute when disabling all
+																							form.setValue("tools_to_auto_execute", [], { shouldDirty: true });
+																						} else if (nextSelectedIds.length === allToolNames.length) {
+																							form.setValue("tools_to_execute", ["*"], { shouldDirty: true });
+																						} else {
+																							form.setValue("tools_to_execute", nextSelectedIds, { shouldDirty: true });
+																						}
+																					}}
+																				/>
+																			</div>
+																		</FormControl>
+																	</FormItem>
+																);
+															}}
+														/>
+														{/* Auto-execute All */}
+														<FormField
+															control={form.control}
+															name="tools_to_auto_execute"
+															render={() => {
+																const currentTools = form.watch("tools_to_execute") || [];
+																const currentAutoExecute = form.watch("tools_to_auto_execute") || [];
+																const allToolNames = mcpClient.tools?.map((tool) => tool.name) || [];
+
+																// Get the list of enabled tools
+																const enabledToolNames = currentTools.includes("*") ? allToolNames : currentTools;
+																const isAllAutoExecute = currentAutoExecute.includes("*");
+																const isNoneAutoExecute = currentAutoExecute.length === 0;
+
+																// For TriStateCheckbox, we need the selected auto-execute tools that are also enabled
+																const selectedAutoExecuteIds = isAllAutoExecute
+																	? enabledToolNames
+																	: currentAutoExecute.filter((t) => enabledToolNames.includes(t));
+
+																const autoExecuteCount = isAllAutoExecute ? enabledToolNames.length : selectedAutoExecuteIds.length;
+																const statusLabel = isAllAutoExecute
+																	? "All auto-execute"
+																	: isNoneAutoExecute
+																		? "None auto-execute"
+																		: `${autoExecuteCount} auto-execute`;
+
+																return (
+																	<FormItem>
+																		<FormControl>
+																			<div className="flex items-center gap-2">
+																				<span id="mcpclient-tools-autoexecute-status" className="text-muted-foreground text-sm">
+																					{statusLabel}
+																				</span>
+																				<TriStateCheckbox
+																					allIds={enabledToolNames}
+																					selectedIds={selectedAutoExecuteIds}
+																					disabled={enabledToolNames.length === 0}
+																					ariaLabel={`Auto-execute all tools (${statusLabel})`}
+																					data-testid="mcpclient-tools-autoexecute-all"
+																					onChange={(nextSelectedIds) => {
+																						if (nextSelectedIds.length === 0) {
+																							form.setValue("tools_to_auto_execute", [], { shouldDirty: true });
+																						} else if (nextSelectedIds.length === enabledToolNames.length) {
+																							form.setValue("tools_to_auto_execute", ["*"], { shouldDirty: true });
+																						} else {
+																							form.setValue("tools_to_auto_execute", nextSelectedIds, { shouldDirty: true });
+																						}
+																					}}
+																				/>
+																			</div>
+																		</FormControl>
+																	</FormItem>
+																);
+															}}
+														/>
+													</div>
+												)}
+											</div>
+
+											{mcpClient.tools && mcpClient.tools.length > 0 ? (
+												<div className="rounded-md border">
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead className="w-10"></TableHead>
+																<TableHead className="max-w-[300px]">Tool Name</TableHead>
+																<TableHead className="w-24 text-center">Enabled</TableHead>
+																<TableHead className="w-28 text-center">
+																	<div className="flex items-center justify-center gap-1.5">
+																		<span>Auto-execute</span>
+																		<TooltipProvider>
+																			<Tooltip>
+																				<TooltipTrigger asChild>
+																					<a
+																						href="https://docs.getbifrost.ai/mcp/agent-mode"
+																						target="_blank"
+																						rel="noopener noreferrer"
+																						aria-label="Learn more about Auto-execute and Agent Mode"
+																						className="text-muted-foreground hover:text-foreground focus-visible:ring-ring inline-flex rounded focus-visible:ring-2 focus-visible:outline-none"
+																					>
+																						<Info className="h-3.5 w-3.5 cursor-help" />
+																					</a>
+																				</TooltipTrigger>
+																				<TooltipContent className="max-w-xs">
+																					<p>
+																						Applies only when Bifrost runs the LLM loop in Agent Mode. In MCP Gateway mode, the connected
+																						client (Claude Desktop, Cursor, etc.) controls tool approval and this setting is ignored. Click
+																						to learn more.
+																					</p>
+																				</TooltipContent>
+																			</Tooltip>
+																		</TooltipProvider>
+																	</div>
+																</TableHead>
+																<TableHead className="w-32 text-center">Cost (USD)</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															{mcpClient.tools.map((tool, index) => {
+																const currentTools = form.watch("tools_to_execute") || [];
+																const currentAutoExecute = form.watch("tools_to_auto_execute") || [];
+																const isToolEnabled = currentTools?.includes("*") || currentTools?.includes(tool.name);
+																const isAutoExecuteEnabled =
+																	(currentAutoExecute?.includes("*") && isToolEnabled) ||
+																	(currentAutoExecute?.includes(tool.name) && isToolEnabled);
+																const isExpanded = expandedTools.has(tool.name);
+
+																return (
+																	<Fragment key={index}>
+																		<TableRow className="group">
+																			<TableCell className="p-2">
+																				<button
+																					type="button"
+																					className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-md transition-colors"
+																					onClick={() => toggleToolExpanded(tool.name)}
+																				>
+																					{isExpanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+																				</button>
+																			</TableCell>
+																			<TableCell className="max-w-[300px]">
+																				<div className="min-w-0">
+																					<div className="text-foreground truncate text-sm font-medium">{tool.name}</div>
+																					{tool.description && (
+																						<p className="text-muted-foreground mt-0.5 truncate text-xs">{tool.description}</p>
+																					)}
+																				</div>
+																			</TableCell>
+																			<TableCell className="text-center">
+																				<FormField
+																					control={form.control}
+																					name="tools_to_execute"
+																					render={() => (
+																						<FormItem>
+																							<FormControl>
+																								<div className="flex h-11 w-11 items-center justify-center">
+																									<Switch
+																										size="md"
+																										checked={isToolEnabled}
+																										aria-label={`${isToolEnabled ? "Disable" : "Enable"} ${tool.name}`}
+																										onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
+																									/>
+																								</div>
+																							</FormControl>
+																						</FormItem>
+																					)}
+																				/>
+																			</TableCell>
+																			<TableCell className="text-center">
+																				<FormField
+																					control={form.control}
+																					name="tools_to_auto_execute"
+																					render={() => (
+																						<FormItem>
+																							<FormControl>
+																								<div className="flex h-11 w-11 items-center justify-center">
+																									<Switch
+																										size="md"
+																										checked={isAutoExecuteEnabled}
+																										disabled={!isToolEnabled}
+																										aria-label={`${isAutoExecuteEnabled ? "Disable" : "Enable"} auto-execute for ${tool.name}`}
+																										onCheckedChange={(checked) => handleAutoExecuteToggle(tool.name, checked)}
+																									/>
+																								</div>
+																							</FormControl>
+																						</FormItem>
+																					)}
+																				/>
+																			</TableCell>
+																			<TableCell className="text-center">
+																				<FormField
+																					control={form.control}
+																					name="tool_pricing"
+																					render={({ field }) => (
+																						<FormItem>
+																							<FormControl>
+																								<Input
+																									type="number"
+																									step="0.000001"
+																									min="0"
+																									placeholder="0.00"
+																									className="h-8 w-24"
+																									disabled={!isToolEnabled}
+																									value={field.value?.[tool.name] ?? ""}
+																									onChange={(e) => {
+																										const value = e.target.value === "" ? undefined : parseFloat(e.target.value);
+																										const newPricing = { ...field.value };
+																										if (value === undefined || isNaN(value)) {
+																											delete newPricing[tool.name];
+																										} else {
+																											newPricing[tool.name] = value;
+																										}
+																										field.onChange(newPricing);
+																									}}
+																								/>
+																							</FormControl>
+																						</FormItem>
+																					)}
+																				/>
+																			</TableCell>
+																		</TableRow>
+																		{isExpanded && (
+																			<tr>
+																				<td colSpan={5} className="p-0">
+																					<div className="bg-muted/30 border-b px-4 py-3">
+																						<div className="text-muted-foreground mb-2 text-xs font-medium">Parameters Schema</div>
+																						{tool.parameters ? (
+																							<CodeEditor
+																								className="z-0 w-full rounded-sm border"
+																								shouldAdjustInitialHeight={true}
+																								maxHeight={300}
+																								wrap={true}
+																								code={JSON.stringify(tool.parameters, null, 2)}
+																								lang="json"
+																								readonly={true}
+																								options={{
+																									scrollBeyondLastLine: false,
+																									collapsibleBlocks: true,
+																									lineNumbers: "off",
+																									alwaysConsumeMouseWheel: false,
+																								}}
+																							/>
+																						) : (
+																							<div className="text-muted-foreground text-sm">No parameters defined</div>
+																						)}
+																					</div>
+																				</td>
+																			</tr>
+																		)}
+																	</Fragment>
+																);
+															})}
+														</TableBody>
+													</Table>
+												</div>
+											) : (
+												<div className="text-muted-foreground rounded-sm border p-6 text-center">
+													<p className="text-sm">No tools available</p>
+												</div>
+											)}
+										</div>
+									</TabsContent>
+
+									<TabsContent value="access" className="space-y-6 pb-10">
+										<div className="space-y-4">
+											<SectionHeader
+												title="Access Control"
+												description="Control whether this server is reachable by all virtual keys without explicit per-key assignment."
+											/>
+											<FormField
+												control={form.control}
+												name="allow_on_all_virtual_keys"
+												render={({ field }) => (
+													<FormItem className="flex flex-row items-center justify-between gap-4 rounded-md border p-4">
+														<div className="flex items-center gap-2">
+															<FormLabel>Allow on All Virtual Keys</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			When enabled, this MCP server is accessible to all virtual keys without requiring explicit per-key
+																			assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this
+																			server, that config takes precedence and overrides this behaviour.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<FormControl>
+															<Switch
+																checked={field.value === true}
+																onCheckedChange={field.onChange}
+																data-testid="mcpclient-allow-on-all-virtual-keys-switch"
+															/>
+														</FormControl>
+													</FormItem>
+												)}
+											/>
+										</div>
+
+										<DottedSeparator />
+
+										<div className="space-y-4">
+											<SectionHeader
+												title="Virtual Key Access"
+												description="Control which virtual keys can use this server and which tools they're allowed to call."
+												action={
 													<VirtualKeySelector
 														mode="add"
 														onSelect={addVKConfig}
@@ -1680,7 +1572,9 @@ export default function MCPClientSheet({
 															</Button>
 														}
 													/>
-												</div>
+												}
+											/>
+											<div className="flex flex-col gap-2">
 												{form.watch("allow_on_all_virtual_keys") && (
 													<p className="text-muted-foreground flex items-center gap-1 text-xs">
 														<Info className="h-3 w-3 shrink-0" />
@@ -1761,21 +1655,35 @@ export default function MCPClientSheet({
 												</div>
 											)}
 										</div>
-									)}
-								</div>
+									</TabsContent>
+								</Tabs>
 							</div>
 
 							<div className="bg-card sticky bottom-0 z-10 flex justify-end gap-2 border-t px-8 py-4">
 								<Button type="button" variant="outline" onClick={onClose}>
 									Cancel
 								</Button>
-								<Button
-									type="submit"
-									disabled={isUpdating || !isDirty || !hasUpdateMCPClientAccess}
-									isLoading={isUpdating}
-								>
-									Save Changes
-								</Button>
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="inline-block">
+												<Button
+													type="submit"
+													disabled={isUpdating || !isDirty || !hasUpdateMCPClientAccess}
+													isLoading={isUpdating}
+													data-testid="mcpclient-save-btn"
+												>
+													Save Changes
+												</Button>
+											</span>
+										</TooltipTrigger>
+										{(!hasUpdateMCPClientAccess || !isDirty) && (
+											<TooltipContent>
+												<p>{!hasUpdateMCPClientAccess ? "You don't have permission to perform this action" : "No changes to save"}</p>
+											</TooltipContent>
+										)}
+									</Tooltip>
+								</TooltipProvider>
 							</div>
 						</form>
 					</Form>

--- a/ui/app/workspace/mcp-registry/views/oauthAdvancedFields.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauthAdvancedFields.tsx
@@ -1,0 +1,260 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import type { Control } from "react-hook-form";
+
+interface OAuthAdvancedFieldsProps {
+	// Loosely typed on purpose: shared between the create form (CreateMCPClientRequest)
+	// and the edit sheet (MCPClientUpdateSchema), which use identical oauth_config.* field
+	// names but different surrounding form types.
+	control: Control<any>;
+	disabled?: boolean;
+	/** Prose / dirty-state warning banners rendered above the field grid. */
+	beforeFields?: React.ReactNode;
+
+	scopesRaw: string;
+	onScopesRawChange: (value: string) => void;
+	scopesLabel: React.ReactNode;
+	scopesTestId: string;
+
+	// The Resource field is a real RHF field in the edit sheet (control has an
+	// oauth_config.resource entry) but raw local state in the create form
+	// (resolved only at submit time, alongside its own URI validation).
+	resource: { mode: "field" } | { mode: "raw"; value: string; onChange: (value: string) => void };
+	resourceLabel: React.ReactNode;
+	resourceTestId?: string;
+
+	clientIdLabel: React.ReactNode;
+	clientIdPlaceholder: string;
+	clientIdHelperText?: React.ReactNode;
+	clientIdTooltip?: React.ReactNode;
+	clientIdTestId: string;
+
+	clientSecretLabel: React.ReactNode;
+	clientSecretPlaceholder: string;
+	clientSecretHelperText?: React.ReactNode;
+	clientSecretTestId: string;
+
+	authorizeUrlLabel: React.ReactNode;
+	authorizeUrlTestId: string;
+	tokenUrlLabel: React.ReactNode;
+	tokenUrlTestId: string;
+	registrationUrlLabel: React.ReactNode;
+	registrationUrlTestId: string;
+
+	/** Called after a URL/client-id field changes, e.g. so the create form can clear a submit-time error for that field. */
+	onFieldTouched?: (field: "authorize_url" | "token_url" | "registration_url") => void;
+}
+
+/** OAuth Client ID/Secret/Authorize URL/Token URL/Registration URL/Scopes/Resource fields, shared by the MCP create form and edit sheet. */
+export function OAuthAdvancedFields({
+	control,
+	disabled,
+	beforeFields,
+	scopesRaw,
+	onScopesRawChange,
+	scopesLabel,
+	scopesTestId,
+	resource,
+	resourceLabel,
+	resourceTestId,
+	clientIdLabel,
+	clientIdPlaceholder,
+	clientIdHelperText,
+	clientIdTooltip,
+	clientIdTestId,
+	clientSecretLabel,
+	clientSecretPlaceholder,
+	clientSecretHelperText,
+	clientSecretTestId,
+	authorizeUrlLabel,
+	authorizeUrlTestId,
+	tokenUrlLabel,
+	tokenUrlTestId,
+	registrationUrlLabel,
+	registrationUrlTestId,
+	onFieldTouched,
+}: OAuthAdvancedFieldsProps) {
+	return (
+		<>
+			{beforeFields}
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<FormField
+					control={control}
+					name="oauth_config.client_id"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<div className="flex items-center gap-2">
+								<FormLabel>{clientIdLabel}</FormLabel>
+								{clientIdTooltip && (
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">{clientIdTooltip}</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								)}
+							</div>
+							<FormControl>
+								<SecretVarInput
+									data-testid={clientIdTestId}
+									placeholder={clientIdPlaceholder}
+									disabled={disabled}
+									maskNonEnvValue
+									value={field.value}
+									onChange={field.onChange}
+								/>
+							</FormControl>
+							{clientIdHelperText && <p className="text-muted-foreground text-xs">{clientIdHelperText}</p>}
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="oauth_config.client_secret"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<FormLabel>{clientSecretLabel}</FormLabel>
+							<FormControl>
+								<SecretVarInput
+									data-testid={clientSecretTestId}
+									placeholder={clientSecretPlaceholder}
+									disabled={disabled}
+									hideValueWhenEnv
+									maskNonEnvValue
+									value={field.value}
+									onChange={field.onChange}
+								/>
+							</FormControl>
+							{clientSecretHelperText && <p className="text-muted-foreground text-xs">{clientSecretHelperText}</p>}
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="oauth_config.authorize_url"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<FormLabel>{authorizeUrlLabel}</FormLabel>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value ?? ""}
+									disabled={disabled}
+									onChange={(e) => {
+										field.onChange(e);
+										onFieldTouched?.("authorize_url");
+									}}
+									placeholder="https://provider.com/oauth/authorize"
+									data-testid={authorizeUrlTestId}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="oauth_config.token_url"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<FormLabel>{tokenUrlLabel}</FormLabel>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value ?? ""}
+									disabled={disabled}
+									onChange={(e) => {
+										field.onChange(e);
+										onFieldTouched?.("token_url");
+									}}
+									placeholder="https://provider.com/oauth/token"
+									data-testid={tokenUrlTestId}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="oauth_config.registration_url"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<FormLabel>{registrationUrlLabel}</FormLabel>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value ?? ""}
+									disabled={disabled}
+									onChange={(e) => {
+										field.onChange(e);
+										onFieldTouched?.("registration_url");
+									}}
+									placeholder="https://provider.com/oauth/register"
+									data-testid={registrationUrlTestId}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormItem className="flex flex-col gap-2">
+					<FormLabel htmlFor="mcp-oauth-scopes-field">{scopesLabel}</FormLabel>
+					<FormControl>
+						<Input
+							id="mcp-oauth-scopes-field"
+							value={scopesRaw}
+							disabled={disabled}
+							onChange={(e) => onScopesRawChange(e.target.value)}
+							placeholder="read, write, admin"
+							data-testid={scopesTestId}
+						/>
+					</FormControl>
+					<p className="text-muted-foreground text-xs">Comma-separated.</p>
+				</FormItem>
+				{resource.mode === "field" ? (
+					<FormField
+						control={control}
+						name="oauth_config.resource"
+						render={({ field }) => (
+							<FormItem className="flex flex-col gap-2">
+								<FormLabel>{resourceLabel}</FormLabel>
+								<FormControl>
+									<Input
+										{...field}
+										value={field.value ?? ""}
+										disabled={disabled}
+										placeholder="https://provider.example.com/mcp or urn:example:mcp"
+										data-testid={resourceTestId}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				) : (
+					<FormItem className="flex flex-col gap-2">
+						<FormLabel htmlFor="mcp-oauth-resource-field">{resourceLabel}</FormLabel>
+						<FormControl>
+							<Input
+								id="mcp-oauth-resource-field"
+								value={resource.value}
+								disabled={disabled}
+								onChange={(e) => resource.onChange(e.target.value)}
+								placeholder="https://provider.example.com/mcp or urn:example:mcp"
+								data-testid={resourceTestId}
+							/>
+						</FormControl>
+					</FormItem>
+				)}
+			</div>
+		</>
+	);
+}

--- a/ui/app/workspace/mcp-registry/views/tlsConfigFields.tsx
+++ b/ui/app/workspace/mcp-registry/views/tlsConfigFields.tsx
@@ -1,0 +1,69 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Switch } from "@/components/ui/switch";
+import type { Control } from "react-hook-form";
+
+interface TLSConfigFieldsProps {
+	// Loosely typed on purpose: this fragment is shared between the create form
+	// (CreateMCPClientRequest) and the edit sheet (MCPClientUpdateSchema), which
+	// both carry an identical tls_config.{insecure_skip_verify,ca_cert_pem} shape.
+	control: Control<any>;
+	disabled?: boolean;
+}
+
+/** Skip TLS Verification switch + CA Certificate PEM input, shared by the MCP create form and edit sheet. */
+export function TLSConfigFields({ control, disabled }: TLSConfigFieldsProps) {
+	return (
+		<>
+			<FormField
+				control={control}
+				name="tls_config.insecure_skip_verify"
+				render={({ field }) => (
+					<FormItem className="flex flex-row items-center justify-between gap-4">
+						<div className="space-y-0.5">
+							<FormLabel>Skip TLS verification</FormLabel>
+							<p className="text-muted-foreground text-sm">
+								Disable TLS certificate verification. Use only in trusted isolated environments. Takes priority over CA certificate.
+							</p>
+						</div>
+						<FormControl>
+							<Switch
+								checked={field.value ?? false}
+								onCheckedChange={field.onChange}
+								disabled={disabled}
+								data-testid="mcp-tls-insecure-skip-verify"
+							/>
+						</FormControl>
+					</FormItem>
+				)}
+			/>
+			<FormField
+				control={control}
+				name="tls_config.ca_cert_pem"
+				render={({ field }) => (
+					<FormItem>
+						<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+						<p className="text-muted-foreground text-xs">
+							PEM-encoded CA certificate to trust for MCP server connections (e.g. self-signed or private CA).
+						</p>
+						<FormControl>
+							<SecretVarInput
+								variant="textarea"
+								placeholder={`-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.MCP_CA_CERT_PEM`}
+								className="font-mono text-xs"
+								rows={6}
+								hideValueWhenEnv
+								redactNonEnvValue
+								{...field}
+								value={field.value}
+								disabled={disabled}
+								data-testid="mcp-tls-ca-cert-pem"
+							/>
+						</FormControl>
+						<FormMessage />
+					</FormItem>
+				)}
+			/>
+		</>
+	);
+}

--- a/ui/app/workspace/mcp-registry/views/tokenExchangeFields.tsx
+++ b/ui/app/workspace/mcp-registry/views/tokenExchangeFields.tsx
@@ -1,0 +1,256 @@
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import type { Control } from "react-hook-form";
+
+interface TokenExchangeScopesFieldProps {
+	variant: "input" | "textarea";
+	value: string;
+	onChange: (value: string) => void;
+	label: React.ReactNode;
+	helperText?: React.ReactNode;
+	testId: string;
+	disabled?: boolean;
+}
+
+interface TokenExchangeFieldsProps {
+	// Loosely typed on purpose: shared between the create form (CreateMCPClientRequest)
+	// and the edit sheet (MCPClientUpdateSchema), which use identical token_exchange.*
+	// field names but different surrounding form types.
+	control: Control<any>;
+	disabled?: boolean;
+	/** Prose / dirty-state warning banners rendered above the field grid. */
+	beforeFields?: React.ReactNode;
+
+	audienceLabel: React.ReactNode;
+	audienceTooltip?: React.ReactNode;
+	audienceTestId: string;
+	onAudienceTouched?: () => void;
+
+	clientIdLabel: React.ReactNode;
+	clientIdTooltip?: React.ReactNode;
+	clientIdPlaceholder: string;
+	clientIdTestId: string;
+	onClientIdTouched?: () => void;
+	/** SecretVarInput masking mode for the exchange client ID; create and edit differ here. */
+	clientIdRedactNonEnvValue?: boolean;
+
+	clientSecretLabel: React.ReactNode;
+	clientSecretPlaceholder: string;
+	clientSecretHelperText?: React.ReactNode;
+	clientSecretTestId: string;
+	/** SecretVarInput masking mode for the exchange client secret; create and edit differ here. */
+	clientSecretHideValueWhenEnv?: boolean;
+	clientSecretMaskNonEnvValue?: boolean;
+	clientSecretRedactNonEnvValue?: boolean;
+
+	authServerUrlLabel: React.ReactNode;
+	authServerUrlTooltip?: React.ReactNode;
+	authServerUrlHelperText?: React.ReactNode;
+	authServerUrlTestId: string;
+
+	scopes: TokenExchangeScopesFieldProps;
+
+	/** Wrap the whole field set (e.g. in a grid) — defaults to a 2-column grid like the edit sheet. */
+	gridClassName?: string;
+}
+
+/** Audience/Exchange Client ID/Exchange Client Secret/Authorization Server URL/Scopes fields, shared by the MCP create form and edit sheet. */
+export function TokenExchangeFields({
+	control,
+	disabled,
+	beforeFields,
+	audienceLabel,
+	audienceTooltip,
+	audienceTestId,
+	onAudienceTouched,
+	clientIdLabel,
+	clientIdTooltip,
+	clientIdPlaceholder,
+	clientIdTestId,
+	onClientIdTouched,
+	clientIdRedactNonEnvValue = true,
+	clientSecretLabel,
+	clientSecretPlaceholder,
+	clientSecretHelperText,
+	clientSecretTestId,
+	clientSecretHideValueWhenEnv = true,
+	clientSecretMaskNonEnvValue = false,
+	clientSecretRedactNonEnvValue = true,
+	authServerUrlLabel,
+	authServerUrlTooltip,
+	authServerUrlHelperText,
+	authServerUrlTestId,
+	scopes,
+	gridClassName = "grid grid-cols-1 gap-4 md:grid-cols-2",
+}: TokenExchangeFieldsProps) {
+	return (
+		<>
+			{beforeFields}
+			<div className={gridClassName}>
+				<FormField
+					control={control}
+					name="token_exchange.audience"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<div className="flex items-center gap-2">
+								<FormLabel>{audienceLabel}</FormLabel>
+								{audienceTooltip && (
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">{audienceTooltip}</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								)}
+							</div>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value ?? ""}
+									disabled={disabled}
+									onChange={(e) => {
+										field.onChange(e);
+										onAudienceTouched?.();
+									}}
+									placeholder="api://my-mcp-server"
+									data-testid={audienceTestId}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="token_exchange.client_id"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<div className="flex items-center gap-2">
+								<FormLabel>{clientIdLabel}</FormLabel>
+								{clientIdTooltip && (
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">{clientIdTooltip}</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								)}
+							</div>
+							<FormControl>
+								<SecretVarInput
+									data-testid={clientIdTestId}
+									placeholder={clientIdPlaceholder}
+									disabled={disabled}
+									redactNonEnvValue={clientIdRedactNonEnvValue}
+									value={field.value}
+									onChange={(value) => {
+										field.onChange(value);
+										onClientIdTouched?.();
+									}}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="token_exchange.client_secret"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<FormLabel>{clientSecretLabel}</FormLabel>
+							<FormControl>
+								<SecretVarInput
+									data-testid={clientSecretTestId}
+									placeholder={clientSecretPlaceholder}
+									disabled={disabled}
+									hideValueWhenEnv={clientSecretHideValueWhenEnv}
+									maskNonEnvValue={clientSecretMaskNonEnvValue}
+									redactNonEnvValue={clientSecretRedactNonEnvValue}
+									value={field.value}
+									onChange={field.onChange}
+								/>
+							</FormControl>
+							{clientSecretHelperText && <p className="text-muted-foreground text-xs">{clientSecretHelperText}</p>}
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				<FormField
+					control={control}
+					name="token_exchange.authorization_server_url"
+					render={({ field }) => (
+						<FormItem className="flex flex-col gap-2">
+							<div className="flex items-center gap-2">
+								<FormLabel>{authServerUrlLabel}</FormLabel>
+								{authServerUrlTooltip && (
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+											</TooltipTrigger>
+											<TooltipContent className="max-w-xs">{authServerUrlTooltip}</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								)}
+							</div>
+							<FormControl>
+								<Input
+									{...field}
+									value={field.value ?? ""}
+									disabled={disabled}
+									placeholder="https://your-domain.okta.com/oauth2/your-auth-server-id"
+									data-testid={authServerUrlTestId}
+								/>
+							</FormControl>
+							{authServerUrlHelperText && <p className="text-muted-foreground text-xs">{authServerUrlHelperText}</p>}
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+				{scopes.variant === "input" ? (
+					<FormItem className="flex flex-col gap-2">
+						<FormLabel htmlFor="mcp-token-exchange-scopes-field">{scopes.label}</FormLabel>
+						<FormControl>
+							<Input
+								id="mcp-token-exchange-scopes-field"
+								value={scopes.value}
+								disabled={scopes.disabled ?? disabled}
+								onChange={(e) => scopes.onChange(e.target.value)}
+								placeholder="jira.read, jira.write, offline_access"
+								data-testid={scopes.testId}
+							/>
+						</FormControl>
+						{scopes.helperText && <p className="text-muted-foreground text-xs">{scopes.helperText}</p>}
+					</FormItem>
+				) : (
+					<div className="space-y-1 md:col-span-2">
+						<div className="space-y-0.5">
+							<div className="text-sm font-medium" id="mcp-token-exchange-scopes-label">
+								{scopes.label}
+							</div>
+							{scopes.helperText && <p className="text-muted-foreground text-sm">{scopes.helperText}</p>}
+						</div>
+						<Textarea
+							aria-labelledby="mcp-token-exchange-scopes-label"
+							className="h-20"
+							placeholder="jira.read, jira.write, offline_access"
+							value={scopes.value}
+							disabled={scopes.disabled ?? disabled}
+							onChange={(e) => scopes.onChange(e.target.value)}
+							data-testid={scopes.testId}
+						/>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1097,124 +1097,139 @@ export const prometheusFormSchema = z
 	});
 
 // MCP Client update schema
-export const mcpClientUpdateSchema = z.object({
-	is_code_mode_client: z.boolean().optional(),
-	is_ping_available: z.boolean().optional(),
-	allow_on_all_virtual_keys: z.boolean().optional(),
-	disabled: z.boolean().optional(),
-	name: z
-		.string()
-		.min(1, "Name is required")
-		.refine((val) => !val.includes("-"), {
-			message: "Client name cannot contain hyphens",
-		})
-		.refine((val) => !val.includes(" "), {
-			message: "Client name cannot contain spaces",
-		})
-		.refine((val) => !/^[0-9]/.test(val), {
-			message: "Client name cannot start with a number",
-		}),
-	headers: z.record(z.string(), secretVarSchema).optional().nullable(),
-	per_user_header_keys: z
-		.array(z.string().trim().min(1, "Header name cannot be empty"))
-		.optional()
-		.refine(
-			(headers) => {
-				if (!headers) return true;
-				const normalized = headers.map((h) => h.trim().toLowerCase());
-				return normalized.length === new Set(normalized).size;
-			},
-			{ message: "Duplicate header names are not allowed" },
-		),
-	tools_to_execute: z
-		.array(z.string())
-		.optional()
-		.refine(
-			(tools) => {
-				if (!tools || tools.length === 0) return true;
-				const hasWildcard = tools.includes("*");
-				return !hasWildcard || tools.length === 1;
-			},
-			{ message: "Wildcard '*' cannot be combined with other tool names" },
-		)
-		.refine(
-			(tools) => {
-				if (!tools) return true;
-				return tools.length === new Set(tools).size;
-			},
-			{ message: "Duplicate tool names are not allowed" },
-		),
-	tools_to_auto_execute: z
-		.array(z.string())
-		.optional()
-		.refine(
-			(tools) => {
-				if (!tools || tools.length === 0) return true;
-				const hasWildcard = tools.includes("*");
-				return !hasWildcard || tools.length === 1;
-			},
-			{ message: "Wildcard '*' cannot be combined with other tool names" },
-		)
-		.refine(
-			(tools) => {
-				if (!tools) return true;
-				return tools.length === new Set(tools).size;
-			},
-			{ message: "Duplicate tool names are not allowed" },
-		),
-	tool_pricing: z.record(z.string(), z.number().min(0, "Cost must be non-negative")).optional(),
-	tool_sync_interval: z.number().optional(), // -1 = disabled, 0 = use global, >0 = custom interval in minutes
-	tool_execution_timeout: z.number().int().min(0).optional(), // 0 = use global, >0 = per-server timeout in seconds
-	allowed_extra_headers: z
-		.array(z.string())
-		.optional()
-		.refine(
-			(headers) => {
-				if (!headers || headers.length === 0) return true;
-				const hasWildcard = headers.includes("*");
-				return !hasWildcard || headers.length === 1;
-			},
-			{ message: "Wildcard '*' cannot be combined with specific header names" },
-		),
-	oauth_config: z
-		.object({
-			client_id: secretVarSchema.optional(),
-			client_secret: secretVarSchema.optional(),
-			authorize_url: z
-				.string()
-				.optional()
-				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Authorize URL must start with http:// or https://" }),
-			token_url: z
-				.string()
-				.optional()
-				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Token URL must start with http:// or https://" }),
-			registration_url: z
-				.string()
-				.optional()
-				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Registration URL must start with http:// or https://" }),
-			scopes: z.array(z.string()).optional(),
-			resource: z.string().optional(),
-		})
-		.optional(),
-	token_exchange: z
-		.object({
-			audience: z.string().trim().min(1, "Audience is required"),
-			client_id: secretVarSchema.optional(),
-			client_secret: secretVarSchema.optional(),
-			authorization_server_url: z
-				.string()
-				.optional()
-				.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Authorization Server URL must start with http:// or https://" }),
-			scopes: z.array(z.string()).optional(),
-		})
-		.optional(),
-	tls_config: z
-		.object({
-			insecure_skip_verify: z.boolean().optional(),
-			ca_cert_pem: secretVarSchema.optional(),
-		})
-		.optional(),
-});
+export const mcpClientUpdateSchema = z
+	.object({
+		is_code_mode_client: z.boolean().optional(),
+		is_ping_available: z.boolean().optional(),
+		allow_on_all_virtual_keys: z.boolean().optional(),
+		disabled: z.boolean().optional(),
+		name: z
+			.string()
+			.min(1, "Name is required")
+			.refine((val) => !val.includes("-"), {
+				message: "Client name cannot contain hyphens",
+			})
+			.refine((val) => !val.includes(" "), {
+				message: "Client name cannot contain spaces",
+			})
+			.refine((val) => !/^[0-9]/.test(val), {
+				message: "Client name cannot start with a number",
+			}),
+		headers: z.record(z.string(), secretVarSchema).optional().nullable(),
+		per_user_header_keys: z
+			.array(z.string().trim().min(1, "Header name cannot be empty"))
+			.optional()
+			.refine(
+				(headers) => {
+					if (!headers) return true;
+					const normalized = headers.map((h) => h.trim().toLowerCase());
+					return normalized.length === new Set(normalized).size;
+				},
+				{ message: "Duplicate header names are not allowed" },
+			),
+		tools_to_execute: z
+			.array(z.string())
+			.optional()
+			.refine(
+				(tools) => {
+					if (!tools || tools.length === 0) return true;
+					const hasWildcard = tools.includes("*");
+					return !hasWildcard || tools.length === 1;
+				},
+				{ message: "Wildcard '*' cannot be combined with other tool names" },
+			)
+			.refine(
+				(tools) => {
+					if (!tools) return true;
+					return tools.length === new Set(tools).size;
+				},
+				{ message: "Duplicate tool names are not allowed" },
+			),
+		tools_to_auto_execute: z
+			.array(z.string())
+			.optional()
+			.refine(
+				(tools) => {
+					if (!tools || tools.length === 0) return true;
+					const hasWildcard = tools.includes("*");
+					return !hasWildcard || tools.length === 1;
+				},
+				{ message: "Wildcard '*' cannot be combined with other tool names" },
+			)
+			.refine(
+				(tools) => {
+					if (!tools) return true;
+					return tools.length === new Set(tools).size;
+				},
+				{ message: "Duplicate tool names are not allowed" },
+			),
+		tool_pricing: z.record(z.string(), z.number().min(0, "Cost must be non-negative")).optional(),
+		tool_sync_interval: z.number().optional(), // -1 = disabled, 0 = use global, >0 = custom interval in minutes
+		tool_execution_timeout: z.number().int().min(0).optional(), // 0 = use global, >0 = per-server timeout in seconds
+		allowed_extra_headers: z
+			.array(z.string())
+			.optional()
+			.refine(
+				(headers) => {
+					if (!headers || headers.length === 0) return true;
+					const hasWildcard = headers.includes("*");
+					return !hasWildcard || headers.length === 1;
+				},
+				{ message: "Wildcard '*' cannot be combined with specific header names" },
+			),
+		oauth_config: z
+			.object({
+				client_id: secretVarSchema.optional(),
+				client_secret: secretVarSchema.optional(),
+				authorize_url: z
+					.string()
+					.optional()
+					.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Authorize URL must start with http:// or https://" }),
+				token_url: z
+					.string()
+					.optional()
+					.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Token URL must start with http:// or https://" }),
+				registration_url: z
+					.string()
+					.optional()
+					.refine((val) => !val || /^https?:\/\/.+$/.test(val), { message: "Registration URL must start with http:// or https://" }),
+				scopes: z.array(z.string()).optional(),
+				resource: z.string().optional(),
+			})
+			.optional(),
+		token_exchange: z
+			.object({
+				audience: z.string().trim().min(1, "Audience is required"),
+				client_id: secretVarSchema.optional(),
+				client_secret: secretVarSchema.optional(),
+				authorization_server_url: z
+					.string()
+					.optional()
+					.refine((val) => !val || /^https?:\/\/.+$/.test(val), {
+						message: "Authorization Server URL must start with http:// or https://",
+					}),
+				scopes: z.array(z.string()).optional(),
+			})
+			.optional(),
+		tls_config: z
+			.object({
+				insecure_skip_verify: z.boolean().optional(),
+				ca_cert_pem: secretVarSchema.optional(),
+			})
+			.optional(),
+	})
+	.superRefine((data, ctx) => {
+		// per_user_header_keys is only ever set on the form for per_user_headers
+		// auth clients (undefined otherwise), so an empty array here means the
+		// admin cleared every entry, not that the field doesn't apply.
+		if (data.per_user_header_keys !== undefined && data.per_user_header_keys.length === 0) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["per_user_header_keys"],
+				message: "Declare at least one header name users must supply.",
+			});
+		}
+	});
 
 // Global proxy type schema
 export const globalProxyTypeSchema = z.enum(["http", "socks5", "tcp"]);


### PR DESCRIPTION
## Summary

The MCP client create form and edit sheet previously duplicated large blocks of JSX for OAuth advanced settings, token exchange settings, and TLS configuration. This PR extracts those repeated field groups into three shared components (`OAuthAdvancedFields`, `TokenExchangeFields`, `TLSConfigFields`) and restructures the edit sheet into a tabbed layout to reduce visual clutter and improve navigability.

## Changes

- Extracted `OAuthAdvancedFields` component covering OAuth client ID/secret, authorize/token/registration URLs, scopes, and resource indicator — used by both the create form and edit sheet with per-callsite label and placeholder customization.
- Extracted `TokenExchangeFields` component covering audience, exchange client ID/secret, authorization server URL, and scopes — supports both `input` and `textarea` variants for the scopes field to match the different UX needs of create vs. edit.
- Extracted `TLSConfigFields` component covering the skip-TLS-verification switch and CA certificate PEM input.
- Replaced the single-scroll edit sheet layout with a four-tab layout: **General**, **Authentication**, **Tools**, and **Access**. The sheet resets to the General tab whenever a different client is opened via prev/next navigation.
- Moved server behavior toggles (Code Mode, Ping), sync/timeout overrides, and the Disable Client control into the General tab with `SectionHeader` dividers for visual grouping.
- Moved headers, per-user header keys, allowed extra headers, TLS config, OAuth config, and token exchange config into the Authentication tab.
- Moved the tools table (enable, auto-execute, pricing) into the Tools tab.
- Moved allow-on-all-virtual-keys and virtual key access assignments into the Access tab.
- Added a `superRefine` rule to `mcpClientUpdateSchema` that rejects an empty `per_user_header_keys` array when the field is present, ensuring at least one header name is declared for per-user-headers auth clients.
- Added a tooltip to the Save Changes button that surfaces a reason when the button is disabled (no permission or no unsaved changes).
- Added `aria-label` attributes to tool enable/auto-execute switches and `ariaLabel`/`data-testid` props to `TriStateCheckbox` instances for accessibility.
- Fixed label associations (`htmlFor`/`id`) on Arguments, Environment Variables, and Required Headers inputs in the create form.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Open the MCP Registry and create a new HTTP/SSE client with OAuth auth — verify the OAuth advanced fields render and submit correctly.
2. Create a client with token exchange auth — verify all token exchange fields render and submit correctly.
3. Create a client with an HTTP/SSE connection — verify the TLS fields appear and save correctly.
4. Open an existing client's edit sheet and navigate through the General, Authentication, Tools, and Access tabs — verify all fields are present and editable.
5. Navigate between clients using prev/next — verify the sheet resets to the General tab each time.
6. On a per-user-headers client, clear all required header keys and attempt to save — verify the validation error appears.
7. Hover over a disabled Save Changes button — verify the tooltip explains why it is disabled.

## Screenshots/Recordings

Before: All MCP client edit fields in a single scrollable panel with accordion sections.

After: Fields organized across General / Authentication / Tools / Access tabs with consistent section headers and shared field components.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets handling introduced. Existing `SecretVarInput` masking and redaction behavior is preserved and explicitly threaded through the new shared components via props.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable